### PR TITLE
Fix/67 add listen all hostnames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ process content of "Unreleased" section content will generate release notes for
 the release.
 
 ## Unreleased
+- Modified Prometheus Exporter to add listening on all hostnames support.
+    1. Modified the content of PrometheusExporterOptions from `Uri()` to `String()`.
+    2. `HttpListener()` can support "+" as: hostname which listens on all ports.
+    3. Modified samples/TestPrometheus.cs to safely use the new implementation.
 
 - Copy from
   [OpenCensus](http://github.com/census-instrumentation/opencensus-csharp) at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ the release.
 
 ## Unreleased
 - Modified Prometheus Exporter to add listening on all hostnames support.
-    1. Modified the content of PrometheusExporterOptions from `Uri()` to `String()`.
+    1. Modified the content of PrometheusExporterOptions from `Uri()` to `string`.
     2. `HttpListener()` can support "+" as: hostname which listens on all ports.
     3. Modified samples/TestPrometheus.cs to safely use the new implementation.
 

--- a/samples/Exporters/TestPrometheus.cs
+++ b/samples/Exporters/TestPrometheus.cs
@@ -36,7 +36,7 @@
             var exporter = new PrometheusExporter(
                 new PrometheusExporterOptions()
                 {
-                    Url = new String("http://localhost:9184/metrics/")
+                    Url = "http://localhost:9184/metrics/"
                 },
                 Stats.ViewManager);
 

--- a/samples/Exporters/TestPrometheus.cs
+++ b/samples/Exporters/TestPrometheus.cs
@@ -36,7 +36,7 @@
             var exporter = new PrometheusExporter(
                 new PrometheusExporterOptions()
                 {
-                    Url = new Uri("http://localhost:9184/metrics/")
+                    Url = new String("http://localhost:9184/metrics/")
                 },
                 Stats.ViewManager);
 

--- a/src/OpenTelemetry.Abstractions/Trace/ISpan.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/ISpan.cs
@@ -45,7 +45,7 @@ namespace OpenTelemetry.Trace
         /// <summary>
         /// Gets a value indicating whether this span was already stopped.
         /// </summary>
-        /// <remarks>This method is not compliant with the specification. https://github.com/open-telemetry/opentelemetry-specification/issues/55</remarks>
+        /// <remarks>This method is not compliant with the specification. https://github.com/open-telemetry/opentelemetry-specification/issues/55 .</remarks>
         bool HasEnded { get; }
 
         /// <summary>

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/MetricsHttpServer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/MetricsHttpServer.cs
@@ -34,7 +34,7 @@ namespace OpenTelemetry.Exporter.Prometheus.Implementation
         {
             this.viewManager = viewManager;
             this.token = token;
-            this.httpListener.Prefixes.Add(options.Url.ToString());
+            this.httpListener.Prefixes.Add(options.Url);
         }
 
         public void WorkerThread()

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterOptions.cs
@@ -26,6 +26,6 @@ namespace OpenTelemetry.Exporter.Prometheus
         /// <summary>
         /// Gets or sets the port to listen to. Typically it ends with /metrics like http://localhost:9184/metrics/.
         /// </summary>
-        public String Url { get; set; }
+        public string Url { get; set; }
     }
 }

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterOptions.cs
@@ -26,6 +26,6 @@ namespace OpenTelemetry.Exporter.Prometheus
         /// <summary>
         /// Gets or sets the port to listen to. Typically it ends with /metrics like http://localhost:9184/metrics/.
         /// </summary>
-        public Uri Url { get; set; }
+        public String Url { get; set; }
     }
 }


### PR DESCRIPTION
Fix #67 
By removing the object Uri() in `PrometheusExporterOptions` we can directly pass a url string to the underlying HttpListener() that supports some regex to listen on all hostnames. Removes a small warning about dots at end of comment line too.