### PR TITLE
Prefer static readonly string rather than const string

### DIFF
--- a/src/OpenTelemetry.Abstractions/Trace/SpanAttributeConstants.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/SpanAttributeConstants.cs
@@ -18,14 +18,14 @@ namespace OpenTelemetry.Trace
 {
     internal static class SpanAttributeConstants
     {
-        public const string HttpMethodKey = "http.method";
-        public const string HttpStatusCodeKey = "http.status_code";
-        public const string HttpUserAgentKey = "http.user_agent";
-        public const string HttpPathKey = "http.path";
-        public const string HttpHostKey = "http.host";
-        public const string HttpUrlKey = "http.url";
-        public const string HttpRequestSizeKey = "http.request.size";
-        public const string HttpResponseSizeKey = "http.response.size";
-        public const string HttpRouteKey = "http.route";
+        public static readonly string HttpMethodKey = "http.method";
+        public static readonly string HttpStatusCodeKey = "http.status_code";
+        public static readonly string HttpUserAgentKey = "http.user_agent";
+        public static readonly string HttpPathKey = "http.path";
+        public static readonly string HttpHostKey = "http.host";
+        public static readonly string HttpUrlKey = "http.url";
+        public static readonly string HttpRequestSizeKey = "http.request.size";
+        public static readonly string HttpResponseSizeKey = "http.response.size";
+        public static readonly string HttpRouteKey = "http.route";
     }
 }

--- a/src/OpenTelemetry.Collector.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Collector.AspNetCore/Implementation/HttpInListener.cs
@@ -28,7 +28,7 @@ namespace OpenTelemetry.Collector.AspNetCore.Implementation
 
     internal class HttpInListener : ListenerHandler
     {
-        private const string UnknownHostName = "UNKNOWN-HOST";
+        private static readonly string UnknownHostName = "UNKNOWN-HOST";
         private readonly PropertyFetcher startContextFetcher = new PropertyFetcher("HttpContext");
         private readonly PropertyFetcher stopContextFetcher = new PropertyFetcher("HttpContext");
         private readonly PropertyFetcher beforeActionActionDescriptorFetcher = new PropertyFetcher("actionDescriptor");

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusMetricBuilder.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusMetricBuilder.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Exporter.Prometheus.Implementation
 
     internal class PrometheusMetricBuilder
     {
-        public const string ContentType = "text/plain; version = 0.0.4";
+        public static readonly string ContentType = "text/plain; version = 0.0.4";
 
         private static char[] firstCharacterNameCharset = new char[]
         {

--- a/src/OpenTelemetry.Exporter.Stackdriver/Implementation/Constants.cs
+++ b/src/OpenTelemetry.Exporter.Stackdriver/Implementation/Constants.cs
@@ -20,30 +20,30 @@ namespace OpenTelemetry.Exporter.Stackdriver.Implementation
 
     internal class Constants
     {
-        public const string PACKAGE_VERSION_UNDEFINED = "undefined";
+        public static readonly string PACKAGE_VERSION_UNDEFINED = "undefined";
 
-        public const string LABEL_DESCRIPTION = "OpenTelemetry TagKey";
-        public const string OpenTelemetry_TASK = "OpenTelemetry_task";
-        public const string OpenTelemetry_TASK_DESCRIPTION = "OpenTelemetry task identifier";
+        public static readonly string LABEL_DESCRIPTION = "OpenTelemetry TagKey";
+        public static readonly string OpenTelemetry_TASK = "OpenTelemetry_task";
+        public static readonly string OpenTelemetry_TASK_DESCRIPTION = "OpenTelemetry task identifier";
 
-        public const string GCP_GKE_CONTAINER = "k8s_container";
-        public const string GCP_GCE_INSTANCE = "gce_instance";
-        public const string AWS_EC2_INSTANCE = "aws_ec2_instance";
-        public const string GLOBAL = "global";
+        public static readonly string GCP_GKE_CONTAINER = "k8s_container";
+        public static readonly string GCP_GCE_INSTANCE = "gce_instance";
+        public static readonly string AWS_EC2_INSTANCE = "aws_ec2_instance";
+        public static readonly string GLOBAL = "global";
 
-        public const string PROJECT_ID_LABEL_KEY = "project_id";
+        public static readonly string PROJECT_ID_LABEL_KEY = "project_id";
         public static readonly string OpenTelemetry_TASK_VALUE_DEFAULT = GenerateDefaultTaskValue();
 
-        public const string GCP_GCE_INSTANCE_TYPE = "cloud.google.com/gce/instance";
-        public const string GCP_INSTANCE_ID_KEY = "cloud.google.com/gce/instance_id";
-        public const string GCP_ACCOUNT_ID_KEY = "cloud.google.com/gce/project_id";
-        public const string GCP_ZONE_KEY = "cloud.google.com/gce/zone";
+        public static readonly string GCP_GCE_INSTANCE_TYPE = "cloud.google.com/gce/instance";
+        public static readonly string GCP_INSTANCE_ID_KEY = "cloud.google.com/gce/instance_id";
+        public static readonly string GCP_ACCOUNT_ID_KEY = "cloud.google.com/gce/project_id";
+        public static readonly string GCP_ZONE_KEY = "cloud.google.com/gce/zone";
 
-        public const string K8S_CONTAINER_TYPE = "k8s.io/container";
-        public const string K8S_CLUSTER_NAME_KEY = "k8s.io/cluster/name";
-        public const string K8S_CONTAINER_NAME_KEY = "k8s.io/container/name";
-        public const string K8S_NAMESPACE_NAME_KEY = "k8s.io/namespace/name";
-        public const string K8S_POD_NAME_KEY = "k8s.io/pod/name";
+        public static readonly string K8S_CONTAINER_TYPE = "k8s.io/container";
+        public static readonly string K8S_CLUSTER_NAME_KEY = "k8s.io/cluster/name";
+        public static readonly string K8S_CONTAINER_NAME_KEY = "k8s.io/container/name";
+        public static readonly string K8S_NAMESPACE_NAME_KEY = "k8s.io/namespace/name";
+        public static readonly string K8S_POD_NAME_KEY = "k8s.io/pod/name";
 
         private static string GenerateDefaultTaskValue()
         {

--- a/src/OpenTelemetry.Exporter.Stackdriver/Implementation/StackdriverStatsExporter.cs
+++ b/src/OpenTelemetry.Exporter.Stackdriver/Implementation/StackdriverStatsExporter.cs
@@ -46,11 +46,11 @@ namespace OpenTelemetry.Exporter.Stackdriver.Implementation
         private CancellationTokenSource tokenSource;
 
         private const int MAX_BATCH_EXPORT_SIZE = 200;
-        private const string DEFAULT_DISPLAY_NAME_PREFIX = "OpenTelemetry/";
-        private const string CUSTOM_METRIC_DOMAIN = "custom.googleapis.com/";
-        private const string CUSTOM_OpenTelemetry_DOMAIN = CUSTOM_METRIC_DOMAIN + "OpenTelemetry/";
+        private static readonly string DEFAULT_DISPLAY_NAME_PREFIX = "OpenTelemetry/";
+        private static readonly string CUSTOM_METRIC_DOMAIN = "custom.googleapis.com/";
+        private static readonly string CUSTOM_OpenTelemetry_DOMAIN = CUSTOM_METRIC_DOMAIN + "OpenTelemetry/";
 
-        private const string USER_AGENT_KEY = "user-agent";
+        private static readonly string USER_AGENT_KEY = "user-agent";
         private static string USER_AGENT;
 
         private readonly string domain;

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/TraceExporterHandler.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/TraceExporterHandler.cs
@@ -30,11 +30,13 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
 
     internal class TraceExporterHandler : IHandler
     {
-        private const string StatusCode = "census.status_code";
-        private const string StatusDescription = "census.status_description";
         private const long MillisPerSecond = 1000L;
         private const long NanosPerMillisecond = 1000 * 1000;
         private const long NanosPerSecond = NanosPerMillisecond * MillisPerSecond;
+
+        private static readonly string StatusCode = "census.status_code";
+        private static readonly string StatusDescription = "census.status_description";
+
         private readonly ZipkinTraceExporterOptions options;
         private readonly ZipkinEndpoint localEndpoint;
         private readonly HttpClient httpClient;

--- a/src/OpenTelemetry/Context/Propagation/B3Format.cs
+++ b/src/OpenTelemetry/Context/Propagation/B3Format.cs
@@ -26,21 +26,21 @@ namespace OpenTelemetry.Context.Propagation
     /// </summary>
     public sealed class B3Format : ITextFormat
     {
-        internal const string XB3TraceId = "X-B3-TraceId";
-        internal const string XB3SpanId = "X-B3-SpanId";
-        internal const string XB3ParentSpanId = "X-B3-ParentSpanId";
-        internal const string XB3Sampled = "X-B3-Sampled";
-        internal const string XB3Flags = "X-B3-Flags";
+        internal static readonly string XB3TraceId = "X-B3-TraceId";
+        internal static readonly string XB3SpanId = "X-B3-SpanId";
+        internal static readonly string XB3ParentSpanId = "X-B3-ParentSpanId";
+        internal static readonly string XB3Sampled = "X-B3-Sampled";
+        internal static readonly string XB3Flags = "X-B3-Flags";
 
         // Used as the upper TraceId.SIZE hex characters of the traceID. B3-propagation used to send
         // TraceId.SIZE hex characters (8-bytes traceId) in the past.
-        internal const string UpperTraceId = "0000000000000000";
+        internal static readonly string UpperTraceId = "0000000000000000";
 
         // Sampled value via the X_B3_SAMPLED header.
-        internal const string SampledValue = "1";
+        internal static readonly string SampledValue = "1";
 
         // "Debug" sampled value.
-        internal const string FlagsValue = "1";
+        internal static readonly string FlagsValue = "1";
 
         private static readonly HashSet<string> AllFields = new HashSet<string>() { XB3TraceId, XB3SpanId, XB3ParentSpanId, XB3Sampled, XB3Flags };
 


### PR DESCRIPTION
As per the movements in the AspNetCore repo's, we should prefer `static readonly string` so that we only allocate it once.