### PR TITLE
Cleaned up infrastructure. Added code coverage

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/test/OpenTelemetry.Collector.Dependencies.Tests/bin/Debug/netcoreapp2.0/OpenTelemetry.Collector.Dependencies.Tests.dll",
+            "program": "${workspaceFolder}/test/OpenTelemetry.Collector.Dependencies.Tests/bin/Debug/netcoreapp2.1/OpenTelemetry.Collector.Dependencies.Tests.dll",
             "args": [],
             "cwd": "${workspaceFolder}/test/OpenTelemetry.Collector.Dependencies.Tests",
             // For more information about the 'console' field, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#console-terminal-window

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,12 @@ To test from command line you need `dotnet` version `2.0+`.
 dotnet test OpenTelemetry.sln
 ```
 
+To see test coverage, run `dotnet test` from a console window and you will see the following output:
+
+![image](https://user-images.githubusercontent.com/20248180/59361025-1e1e7980-8d29-11e9-8449-548caf0d7823.png)
+
+Or, after running the tests, open the file `TestResults\Results\index.htm` in a browser.
+
 ### Proposing changes
 
 Create a Pull Request with your changes. Please add any user-visible changes to

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <RepositoryRoot>$(MSBuildThisFileDirectory)</RepositoryRoot>
+    <RepositoryType>git</RepositoryType>
+    <PackageProjectUrl>https://github.com/open-telemetry/opentelemetry-dotnet</PackageProjectUrl>
+  </PropertyGroup>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,5 @@
 <Project>
   <PropertyGroup>
-    <RepositoryRoot>$(MSBuildThisFileDirectory)</RepositoryRoot>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/open-telemetry/opentelemetry-dotnet</PackageProjectUrl>
   </PropertyGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,7 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -20,17 +20,23 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <!-- Optional: Declare that the Repository URL can be published to NuSpec -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-
-    <!-- Optional: Embed source files that are not tracked by the source control manager to the PDB -->
-    <!-- This is useful if you generate files during the build -->
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <PackageTags>Tracing;OpenTelemetry;Management;Monitoring</PackageTags>
+    <PackageIconUrl>https://opentelemetry.io/img/logos/opentracing-icon-color.png</PackageIconUrl>
+    <PackageProjectUrl>https://OpenTelemetry.io</PackageProjectUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <Authors>OpenTelemetry authors</Authors>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
   </PropertyGroup>
 
-  <ItemGroup>
-    <!-- Required -->
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All"/>
-  </ItemGroup>
+  <PropertyGroup Label="SourceLink">
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
 </Project>

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -21,7 +21,7 @@
 
   <PropertyGroup>
     <PackageTags>Tracing;OpenTelemetry;Management;Monitoring</PackageTags>
-    <PackageIconUrl>https://opentelemetry.io/img/logos/opentracing-icon-color.png</PackageIconUrl>
+    <PackageIconUrl>https://opentelemetry.io/img/logos/opentelemetry-icon-color.png</PackageIconUrl>
     <PackageProjectUrl>https://OpenTelemetry.io</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Authors>OpenTelemetry authors</Authors>

--- a/build/Common.test.props
+++ b/build/Common.test.props
@@ -6,6 +6,11 @@
     <DelaySign>false</DelaySign>
     <DefineConstants>$(DefineConstants);SIGNED</DefineConstants>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
   
   <PropertyGroup>
     <CodeAnalysisRuleSet>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\OpenTelemetry.test.ruleset</CodeAnalysisRuleSet>
@@ -15,4 +20,28 @@
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)/stylecop.json" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+
+  <PropertyGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
+    <IsTestProject>true</IsTestProject>
+    <CollectCoverage Condition="$(CollectCoverage) == ''">true</CollectCoverage>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <CollectCoverage Condition="$(CollectCoverage) == '' OR !$(TargetFramework.StartsWith('netcoreapp'))">false</CollectCoverage>
+  </PropertyGroup>
+
+  <PropertyGroup Label="CollectCodeCoverageResults" Condition="$(CollectCoverage)">
+    <CoverletOutputFormat>cobertura</CoverletOutputFormat>
+    <_BaseDir>..\..\TestResults\</_BaseDir>
+    <CoverletBaseDir>$(_BaseDir)Coverage\</CoverletBaseDir>
+    <CoverletResultsDir>$(_BaseDir)Results\</CoverletResultsDir>
+    <CoverletBaseDir Condition="$([MSBuild]::IsOSUnixLike())">$(CoverletBaseDir.Replace('\', '/'))</CoverletBaseDir>
+    <CoverletResultsDir Condition="$([MSBuild]::IsOSUnixLike())">$(CoverletResultsDir.Replace('\', '/'))</CoverletResultsDir>
+    <CoverletOutput>$(CoverletBaseDir)$(MSBuildProjectName).xml</CoverletOutput>
+    <Exclude>[xunit*]*,[*.Tests]*</Exclude>
+    <DebugType>pdbonly</DebugType> <!-- Coverlet needs full debug symbols -->
+  </PropertyGroup>
 </Project>

--- a/samples/Exporters/Exporters.csproj
+++ b/samples/Exporters/Exporters.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,4 @@
+<Project>
+  <Import Project="..\Directory.Build.props" Condition="Exists('..\Directory.Build.props')" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.prod.props" />
+</Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,10 @@
+<Project>
+  <Import Project="..\Directory.Build.targets" Condition="Exists('..\Directory.Build.targets')" />
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/src/OpenTelemetry.Abstractions/OpenTelemetry.Abstractions.csproj
+++ b/src/OpenTelemetry.Abstractions/OpenTelemetry.Abstractions.csproj
@@ -1,33 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.prod.props" />
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard2.0</TargetFrameworks>
     <Description>OpenTelemetry .NET API abstractions</Description>
-    <IncludeSymbols>True</IncludeSymbols>
-    <PackageTags>Tracing;OpenTelemetry;Management;Monitoring</PackageTags>
-    <PackageIconUrl>https://OpenTelemetry.io/images/OpenTelemetry-logo.png</PackageIconUrl>
-    <PackageProjectUrl>https://OpenTelemetry.io</PackageProjectUrl>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <Authors>OpenTelemetry authors</Authors>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RootNamespace>OpenTelemetry</RootNamespace>
   </PropertyGroup>
-  <PropertyGroup>
-    <CodeAnalysisRuleSet>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))/build/OpenTelemetry.prod.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Stats\" />
-  </ItemGroup>
+
   <ItemGroup>
     <Compile Remove="Utils\AttributesWithCapacity.cs" />
   </ItemGroup>

--- a/src/OpenTelemetry.Collector.AspNetCore/OpenTelemetry.Collector.AspNetCore.csproj
+++ b/src/OpenTelemetry.Collector.AspNetCore/OpenTelemetry.Collector.AspNetCore.csproj
@@ -1,27 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.prod.props" />
-
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard2.0</TargetFrameworks>
-    <IncludeSymbols>True</IncludeSymbols>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <Description>OpenTelemetry collector for ASP.NET Core requests</Description>
-    <PackageTags>Tracing;OpenTelemetry;Management;Monitoring;distributed-tracing;AspNetCore</PackageTags>
-    <PackageIconUrl>https://OpenTelemetry.io/images/OpenTelemetry-logo.png</PackageIconUrl>
-    <PackageProjectUrl>https://OpenTelemetry.io</PackageProjectUrl>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <Authors>OpenTelemetry authors</Authors>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageTags>$(PackageTags);distributed-tracing;AspNetCore</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\OpenTelemetry.Abstractions\OpenTelemetry.Abstractions.csproj" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="2.0.0" />

--- a/src/OpenTelemetry.Collector.Dependencies/OpenTelemetry.Collector.Dependencies.csproj
+++ b/src/OpenTelemetry.Collector.Dependencies/OpenTelemetry.Collector.Dependencies.csproj
@@ -1,20 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.prod.props" />
-
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard2.0</TargetFrameworks>
-    <IncludeSymbols>True</IncludeSymbols>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <Description>OpenTelemetry collector for calls to dependencies</Description>
-    <PackageTags>Tracing;OpenTelemetry;Management;Monitoring;distributed-tracing;HttpClient</PackageTags>
-    <PackageIconUrl>https://OpenTelemetry.io/images/OpenTelemetry-logo.png</PackageIconUrl>
-    <PackageProjectUrl>https://OpenTelemetry.io</PackageProjectUrl>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <Authors>OpenTelemetry authors</Authors>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageTags>$(PackageTags);distributed-tracing;HttpClient</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,9 +12,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\OpenTelemetry.Abstractions\OpenTelemetry.Abstractions.csproj" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/OpenTelemetry.Collector.StackExchangeRedis/OpenTelemetry.Collector.StackExchangeRedis.csproj
+++ b/src/OpenTelemetry.Collector.StackExchangeRedis/OpenTelemetry.Collector.StackExchangeRedis.csproj
@@ -1,25 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.prod.props" />
-
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard2.0</TargetFrameworks>
-    <IncludeSymbols>True</IncludeSymbols>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <Description>OpenTelemetry collector for Redis calls made by StackExchange.Redis library.</Description>
-    <PackageTags>Tracing;OpenTelemetry;Management;Monitoring;distributed-tracing;Redis;StackExchange.Redis</PackageTags>
-    <PackageIconUrl>https://OpenTelemetry.io/images/OpenTelemetry-logo.png</PackageIconUrl>
-    <PackageProjectUrl>https://OpenTelemetry.io</PackageProjectUrl>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <Authors>OpenTelemetry authors</Authors>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageTags>$(PackageTags);distributed-tracing;Redis;StackExchange.Redis</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\OpenTelemetry.Abstractions\OpenTelemetry.Abstractions.csproj" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
     <PackageReference Include="StackExchange.Redis" Version="2.0.519" />
   </ItemGroup>
 </Project>

--- a/src/OpenTelemetry.Exporter.ApplicationInsights/OpenTelemetry.Exporter.ApplicationInsights.csproj
+++ b/src/OpenTelemetry.Exporter.ApplicationInsights/OpenTelemetry.Exporter.ApplicationInsights.csproj
@@ -1,31 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.prod.props" />
-
   <PropertyGroup>
     <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard2.0</TargetFrameworks>
-    <IncludeSymbols>True</IncludeSymbols>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <Description>Application Insights exporter for Open Census.</Description>
-    <PackageTags>Tracing;OpenTelemetry;Management;Monitoring;application-insights;azure;distributed-tracing</PackageTags>
-    <PackageIconUrl>https://OpenTelemetry.io/images/OpenTelemetry-logo.png</PackageIconUrl>
-    <PackageProjectUrl>https://OpenTelemetry.io</PackageProjectUrl>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <Authors>OpenTelemetry authors</Authors>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageTags>$(PackageTags);application-insights;azure;distributed-tracing</PackageTags>
   </PropertyGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\stylecop.json" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\OpenTelemetry.Abstractions\OpenTelemetry.Abstractions.csproj" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0-beta1" />
   </ItemGroup>
 </Project>

--- a/src/OpenTelemetry.Exporter.Ocagent/OpenTelemetry.Exporter.Ocagent.csproj
+++ b/src/OpenTelemetry.Exporter.Ocagent/OpenTelemetry.Exporter.Ocagent.csproj
@@ -1,28 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.prod.props" />
-
   <PropertyGroup>
     <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard2.0</TargetFrameworks>
-    <IncludeSymbols>True</IncludeSymbols>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <Description>OcAgent exporter for OpenTelemetry</Description>
-    <PackageTags>Tracing;OpenTelemetry;Management;Monitoring;ocagent;distributed-tracing</PackageTags>
-    <PackageIconUrl>https://OpenTelemetry.io/images/OpenTelemetry-logo.png</PackageIconUrl>
-    <PackageProjectUrl>https://OpenTelemetry.io</PackageProjectUrl>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <Authors>OpenTelemetry authors</Authors>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageTags>$(PackageTags);ocagent;distributed-tracing</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\OpenTelemetry.Abstractions\OpenTelemetry.Abstractions.csproj" />
     <PackageReference Include="Google.Protobuf" Version="3.6.1" />
     <PackageReference Include="Grpc.Core" Version="1.16.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/OpenTelemetry.Exporter.Prometheus/OpenTelemetry.Exporter.Prometheus.csproj
+++ b/src/OpenTelemetry.Exporter.Prometheus/OpenTelemetry.Exporter.Prometheus.csproj
@@ -1,27 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.prod.props" />
-
-    <PropertyGroup>
+  <PropertyGroup>
     <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard2.0</TargetFrameworks>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <Description>OpenTelemetry to Prometheus exporter.</Description>
-    <IncludeSymbols>True</IncludeSymbols>
-    <PackageTags>OpenTelemetry;Management;Monitoring;Prometheus</PackageTags>
-    <PackageIconUrl>https://OpenTelemetry.io/images/OpenTelemetry-logo.png</PackageIconUrl>
-    <PackageProjectUrl>https://OpenTelemetry.io</PackageProjectUrl>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <Authors>OpenTelemetry authors</Authors>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageTags>$(PackageTags);Prometheus</PackageTags>
   </PropertyGroup>
-
 
   <ItemGroup>
     <ProjectReference Include="..\OpenTelemetry.Abstractions\OpenTelemetry.Abstractions.csproj" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/OpenTelemetry.Exporter.Stackdriver/OpenTelemetry.Exporter.Stackdriver.csproj
+++ b/src/OpenTelemetry.Exporter.Stackdriver/OpenTelemetry.Exporter.Stackdriver.csproj
@@ -1,24 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.prod.props" />
-  
   <PropertyGroup>
     <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard2.0</TargetFrameworks>
     <Description>Stackdriver .NET Exporter for OpenTelemetry.</Description>
     <IncludeSymbols>True</IncludeSymbols>
-    <PackageTags>Tracing;OpenTelemetry;Management;Monitoring;Stackdriver;Google;GCP;distributed-tracing</PackageTags>
-    <PackageIconUrl>https://OpenTelemetry.io/images/OpenTelemetry-logo.png</PackageIconUrl>
-    <PackageProjectUrl>https://OpenTelemetry.io</PackageProjectUrl>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <Authors>OpenTelemetry authors</Authors>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageTags>$(PackageTags);Stackdriver;Google;GCP;distributed-tracing</PackageTags>
   </PropertyGroup>
-  
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
+
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))/build/OpenTelemetry.prod.loose.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Google.Cloud.Monitoring.V3" Version="1.1.0-beta02" />
     <PackageReference Include="Google.Cloud.Trace.V2" Version="1.0.0-beta02" />

--- a/src/OpenTelemetry.Exporter.Zipkin/OpenTelemetry.Exporter.Zipkin.csproj
+++ b/src/OpenTelemetry.Exporter.Zipkin/OpenTelemetry.Exporter.Zipkin.csproj
@@ -1,27 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.prod.props" />
-
   <PropertyGroup>
     <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard2.0</TargetFrameworks>
-    <IncludeSymbols>True</IncludeSymbols>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <Description>Zipkin exporter for OpenTelemetry</Description>
-    <PackageTags>Tracing;OpenTelemetry;Management;Monitoring;Zipkin;distributed-tracing</PackageTags>
-    <PackageIconUrl>https://OpenTelemetry.io/images/OpenTelemetry-logo.png</PackageIconUrl>
-    <PackageProjectUrl>https://OpenTelemetry.io</PackageProjectUrl>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <Authors>OpenTelemetry authors</Authors>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageTags>$(PackageTags);Zipkin;distributed-tracing</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\OpenTelemetry.Abstractions\OpenTelemetry.Abstractions.csproj" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
 

--- a/src/OpenTelemetry/OpenTelemetry.csproj
+++ b/src/OpenTelemetry/OpenTelemetry.csproj
@@ -1,38 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.prod.props" />
-
   <PropertyGroup>
     <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard2.0</TargetFrameworks>
     <Description>OpenTelemetry .NET API</Description>
-    <IncludeSymbols>True</IncludeSymbols>
-    <PackageTags>Tracing;OpenTelemetry;Management;Monitoring</PackageTags>
-    <PackageIconUrl>https://OpenTelemetry.io/images/OpenTelemetry-logo.png</PackageIconUrl>
-    <PackageProjectUrl>https://OpenTelemetry.io</PackageProjectUrl>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <Authors>OpenTelemetry authors</Authors>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <PropertyGroup>
     <CodeAnalysisRuleSet>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))/build/OpenTelemetry.prod.loose.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
-
   <ItemGroup>
     <ProjectReference Include="..\OpenTelemetry.Abstractions\OpenTelemetry.Abstractions.csproj" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Stats\" />
-    <Folder Include="Tags\" />
   </ItemGroup>
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,0 +1,4 @@
+<Project>
+  <Import Project="..\Directory.Build.props" Condition="Exists('..\Directory.Build.props')" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.test.props" />
+</Project>

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -1,0 +1,18 @@
+<Project>
+  <Import Project="..\Directory.Build.targets" Condition="Exists('..\Directory.Build.targets')" />
+
+  <ItemGroup>
+    <DotNetCliToolReference Include="dotnet-reportgenerator-cli" Version="4.1.10" />
+    <PackageReference Include="coverlet.msbuild" Version="2.6.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <Target Name="CovertReportResults" AfterTargets="GenerateCoverageResult" Condition="$(CollectCoverage)">
+    <!-- Merges the reports into one -->
+    <Exec Command="dotnet reportgenerator -reports:$(CoverletBaseDir)*.xml -targetdir:$(CoverletResultsDir) -reporttypes:Cobertura -verbosity:Verbose" WorkingDirectory="$(ProjectDir)" />
+    <!-- Gives the summary in an Azure Pipelines look & feel -->
+    <Exec Command="dotnet reportgenerator -reports:$(CoverletResultsDir)Cobertura.xml -targetdir:$(CoverletResultsDir) -reporttypes:HtmlInline_AzurePipelines;Cobertura -verbosity:Verbose" WorkingDirectory="$(ProjectDir)" />
+  </Target>
+</Project>

--- a/test/OpenTelemetry.Collector.AspNetCore.Tests/OpenTelemetry.Collector.AspNetCore.Tests.csproj
+++ b/test/OpenTelemetry.Collector.AspNetCore.Tests/OpenTelemetry.Collector.AspNetCore.Tests.csproj
@@ -1,6 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.test.props" />
-
   <PropertyGroup>
     <Description>Unit test project for OpenTelemetry</Description>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
@@ -19,14 +17,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.11.0" />
-
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-      <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
@@ -42,13 +36,4 @@
   <ItemGroup>
     <Reference Include="System.Net.Http" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
-
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
 </Project>

--- a/test/OpenTelemetry.Collector.Dependencies.Tests/OpenTelemetry.Collector.Dependencies.Tests.csproj
+++ b/test/OpenTelemetry.Collector.Dependencies.Tests/OpenTelemetry.Collector.Dependencies.Tests.csproj
@@ -1,9 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.test.props" />
-
   <PropertyGroup>
     <Description>Unit test project for OpenTelemetry</Description>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,14 +17,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.11.0" />
-
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-      <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
@@ -45,13 +39,4 @@
   <ItemGroup>
     <Reference Include="System.Net.Http" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
-
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
 </Project>

--- a/test/OpenTelemetry.Collector.StackExchangeRedis.Tests/OpenTelemetry.Collector.StackExchangeRedis.Tests.csproj
+++ b/test/OpenTelemetry.Collector.StackExchangeRedis.Tests/OpenTelemetry.Collector.StackExchangeRedis.Tests.csproj
@@ -1,10 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.test.props" />
-
   <PropertyGroup>
     <Description>Unit test project for ApplicationInsights Exporter for OpenTelemetry</Description>
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,22 +13,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.11.0" />
-
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="True" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
-
-</Project>
+ </Project>

--- a/test/OpenTelemetry.Exporter.ApplicationInsights.Tests/OpenTelemetry.Exporter.ApplicationInsights.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.ApplicationInsights.Tests/OpenTelemetry.Exporter.ApplicationInsights.Tests.csproj
@@ -1,10 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.test.props" />
-
   <PropertyGroup>
     <Description>Unit test project for ApplicationInsights Exporter for OpenTelemetry</Description>
-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,7 +20,6 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.11.0" />
-
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
@@ -31,14 +28,4 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="True" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
-
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
-
 </Project>

--- a/test/OpenTelemetry.Exporter.Stackdriver.Tests/OpenTelemetry.Exporter.Stackdriver.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.Stackdriver.Tests/OpenTelemetry.Exporter.Stackdriver.Tests.csproj
@@ -1,16 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.test.props" />
-
   <PropertyGroup>
     <Description>Unit test project for Stackdriver Exporter for OpenTelemetry</Description>
-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp2.0</TargetFrameworks>
-    <AssemblyName>OpenTelemetry.Exporter.Stackdriver.Tests</AssemblyName>
-    <PackageId>OpenTelemetry.Exporter.Stackdriver.Tests</PackageId>
-    <PackageTags>OpenTelemetry;Tracing;Management;Monitoring;Stackdriver;Google;Cloud</PackageTags>
-    <PackageProjectUrl>http://OpenTelemetry.io</PackageProjectUrl>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <RootNamespace>OpenTelemetry</RootNamespace>
+    <TargetFrameworks>net46;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,25 +18,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.11.0" />
-
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
-
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
-
 </Project>

--- a/test/OpenTelemetry.Tests/OpenTelemetry.Tests.csproj
+++ b/test/OpenTelemetry.Tests/OpenTelemetry.Tests.csproj
@@ -1,16 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.test.props" />
-
   <PropertyGroup>
     <Description>Unit test project for OpenTelemetry</Description>
-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp2.0</TargetFrameworks>
-    <AssemblyName>OpenTelemetry.Tests</AssemblyName>
-    <PackageId>OpenTelemetry.Tests</PackageId>
-    <PackageTags>OpenTelemetry;Tracing;Management;Monitoring</PackageTags>
-    <PackageProjectUrl>http://OpenTelemetry.io</PackageProjectUrl>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <RootNamespace>OpenTelemetry</RootNamespace>
+    <TargetFrameworks>net46;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,25 +18,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.11.0" />
-
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
-
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
-
 </Project>

--- a/test/TestApp.AspNetCore.2.0/TestApp.AspNetCore.2.0.csproj
+++ b/test/TestApp.AspNetCore.2.0/TestApp.AspNetCore.2.0.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.test.props" />
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,9 +24,6 @@
     <ProjectReference Include="..\..\src\OpenTelemetry.Collector.Dependencies\OpenTelemetry.Collector.Dependencies.csproj" />
     <ProjectReference Include="..\..\src\OpenTelemetry.Exporter.Ocagent\OpenTelemetry.Exporter.Ocagent.csproj" />
     <ProjectReference Include="..\..\src\OpenTelemetry\OpenTelemetry.csproj" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Normalised to `netcoreapp2.1`
- Reduced redundancy in the csproj files, ie: normalising imports, package tags etc
- Fixed the logo as it 404'd
- Added code coverage (Resolving #34)
   - I haven't added it to the `.yml` files to produce code coverage in Azure DevOps because I can never actually get this to work correctly. All the files are produced to `<root>/TestResults/Results`
   - Code coverage doesn't appear to work on `net` based TFM's, but it does on the `netcoreapp` TFM's. I'll be raising a bug in coverlet and pointing them back to this PR.

Note: _I tried to prefer using the files in the `build/` directory. Let me know if you want things moved around._