### PR TITLE
Mention an existent .NET Framework version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Reporting bugs is an important contribution. Please make sure to include:
 - expected and actual behavior.
 - dotnet version that application is compiled on and running with (it may be
   different - for instance target framework was set to .NET 4.6 for
-  compilation, but application is running on .NET 4.7.3).
+  compilation, but application is running on .NET 4.7.2).
 - exception call stack and other artifacts.
 - if possible - repro application and steps to reproduce.
 


### PR DESCRIPTION
.NET 4.7.2 was superseded by 4.8. There was no 4.7.3.