### PR TITLE
POC - Almost complete templated solution for ASP.Net Core MVC prometheus metrics Exporter

### DIFF
--- a/samples/ASP.Net Metrics/MetricsShim/MetricsExporter.cs
+++ b/samples/ASP.Net Metrics/MetricsShim/MetricsExporter.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using OpenTelemetry.Exporter.Prometheus;
+using OpenTelemetry.Stats;
+
+namespace hellocs.MetricsShim
+{
+    public class MetricExporter
+    {
+        #region Fields for Json2Object conversion
+        public String Hostname { get; set; }
+        public String ListenOnPort { get; set; }
+        public String Path { get; set; }
+        public String AppName { get; set; }
+        public Dictionary<String, View> Views { get; set; }
+        #endregion
+        private PrometheusExporter exporter;
+
+        public void Setup()
+        {
+            IViewManager viewManager = Stats.ViewManager;
+            foreach (KeyValuePair<string, View> view in Views)
+            {
+                view.Value.Setup();
+                viewManager.RegisterView(view.Value.toRegister());
+            }
+            string s_uri = String.Format("http://{0}:{1}{2}{3}/", Hostname, ListenOnPort, Path, AppName);
+            Console.WriteLine(String.Format("Metrics listening at: {0}", s_uri));
+            exporter = new PrometheusExporter(
+            new PrometheusExporterOptions()
+            {
+                Url = s_uri
+            },
+            viewManager);
+        }
+
+        public void Start()
+        {
+            // Starting of the prometheus provider (http server)
+            exporter.Start();
+        }
+    }
+}

--- a/samples/ASP.Net Metrics/MetricsShim/MetricsExporterMeasures.cs
+++ b/samples/ASP.Net Metrics/MetricsShim/MetricsExporterMeasures.cs
@@ -1,0 +1,33 @@
+using System;
+using OpenTelemetry.Stats;
+using OpenTelemetry.Stats.Measures;
+
+namespace hellocs.MetricsShim
+{
+    public class Measure
+    {
+        #region Fields for Json2Object conversion
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string Unit { get; set; }
+        public string Type { get; set; }
+        #endregion
+        private IMeasure _reqMeasure;
+
+        public void Setup()
+        {
+            // Metric type: name, description, unit
+            if (Type == nameof(MeasureLong))
+                _reqMeasure = MeasureLong.Create(Name, Description, Unit);
+            else if (Type == nameof(MeasureDouble))
+                _reqMeasure = MeasureDouble.Create(Name, Description, Unit);
+            else
+                throw new ApplicationException(String.Format("Error Metrics#006: [Exporter/Views/Measure:Setup()] Unsupported Measure Type: {0}", Type));
+        }
+
+        public IMeasure getMeasure()
+        {
+            return _reqMeasure;
+        }
+    }
+}

--- a/samples/ASP.Net Metrics/MetricsShim/MetricsExporterViews.cs
+++ b/samples/ASP.Net Metrics/MetricsShim/MetricsExporterViews.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using OpenTelemetry.Tags;
+using OpenTelemetry.Stats;
+using OpenTelemetry.Stats.Aggregations;
+using OpenTelemetry.Stats.Measures;
+
+namespace hellocs.MetricsShim
+{
+    public class View
+    {
+        #region Fields for Json2Object conversion
+        public string Name { get; set; }
+        public string Namespace { get; set; }
+        public string Description { get; set; }
+        public Measure Measure { get; set; }
+        public string Aggregation { get; set; }
+        public IList<double> Bucket { get; set; }
+        public IList<string> TagKeys { get; set; }
+        #endregion
+        private IList<TagKey> _tags;
+        private IMeasure _reqMeasure;
+        private IStatsRecorder _statsRecorder;
+        private IView _requestView;
+
+        public void Setup()
+        {
+            _statsRecorder = Stats.StatsRecorder;
+            IViewName ReqViewName = ViewName.Create(String.Format("{0}_{1}", Namespace, Name));
+            Measure.Setup();
+            _reqMeasure = Measure.getMeasure();
+            // Counter type, default to 0 at start if wo/params
+            IAggregation ReqViewType = this.aggSelect();
+            // KeyTag creation
+            _tags = new List<TagKey>();
+            foreach (string str in TagKeys)
+            {
+                _tags.Add(TagKey.Create(str));
+            }
+            if(ReqViewType!=null)
+            {
+                // Build view: (IViewName name, string description, IMeasure measure, IAggregation aggregation, IReadOnlyList<ITagKey> columns)
+                _requestView = OpenTelemetry.Stats.View.Create(
+                    ReqViewName,
+                    Description,
+                    _reqMeasure,
+                    ReqViewType,
+                    new List<TagKey>(_tags));
+            }
+            else
+                // Build view: (IViewName name, string description, IMeasure measure, IAggregation aggregation, IReadOnlyList<ITagKey> columns)
+                _requestView = OpenTelemetry.Stats.View.Create(
+                    ReqViewName,
+                    Description,
+                    _reqMeasure,
+                    Count.Create(),
+                    new List<TagKey>(_tags));
+        }
+
+        public void UpdateView(Dictionary<string, string> dic, int value)
+        {
+            string code;
+            dic.TryGetValue("status_code", out code);
+            if (code != null)
+            {
+                int res_code = Convert.ToInt32(code);
+                if (res_code < 400)
+                {
+                    ITagContextBuilder tagMap = Tags.Tagger.EmptyBuilder;
+                    foreach (TagKey tag in _tags)
+                    {
+                        tagMap.Put(tag, TagValue.Create(dic[tag.Name]));
+                    }
+                    ITagContext tagContext = tagMap.Build();
+                    if (Measure.Type == nameof(MeasureLong))
+                        _statsRecorder.NewMeasureMap().Put((MeasureLong)_reqMeasure, value).Record(tagContext);
+                    else if (Measure.Type == nameof(MeasureDouble))
+                        _statsRecorder.NewMeasureMap().Put((MeasureDouble)_reqMeasure, value).Record(tagContext);
+                    else
+                        Console.WriteLine(String.Format("Error Metrics#000: [Exporter/Views:UpdateView()] Unsupported Measure Type: {0}", Measure.Type));
+                }
+                else
+                {
+                    Console.WriteLine(String.Format("Info Metrics#001: [Exporter/Views:UpdateView()] Response code >= 400 (bad request), not added to metricsExporter: {0}", code));
+                }
+            }
+            else
+            {
+                Console.WriteLine("Info Metrics#002: [Exporter/Views:UpdateView()] No response code in metrics dictionnary");
+                ITagContextBuilder tagMap = Tags.Tagger.EmptyBuilder;
+                foreach (TagKey tag in _tags)
+                {
+                    tagMap.Put(tag, TagValue.Create(dic[tag.Name]));
+                }
+                ITagContext tagContext = tagMap.Build();
+                if (Measure.Type == nameof(MeasureLong))
+                    _statsRecorder.NewMeasureMap().Put((MeasureLong)_reqMeasure, value).Record(tagContext);
+                else if (Measure.Type == nameof(MeasureDouble))
+                    _statsRecorder.NewMeasureMap().Put((MeasureDouble)_reqMeasure, value).Record(tagContext);
+                else
+                    Console.WriteLine(String.Format("Error Metrics#003: [Exporter/Views:UpdateView()] Unsupported Measure Type: {0}", Measure.Type));
+            }
+            
+        }
+
+        public IView toRegister()
+        {
+            return _requestView;
+        }
+
+        private IAggregation aggSelect()
+        {
+            switch (Aggregation)
+            {
+                case nameof(Count):
+                    return Count.Create();
+                case nameof(Distribution):
+                    if (Bucket != null)
+                        return Distribution.Create(BucketBoundaries.Create(new List<double>(Bucket)));
+                    else
+                        throw new ApplicationException("Error Metrics#004: [Exporter/Views:UpdateView()] Bucket parameter missing in appsettings.json");
+                case nameof(LastValue):
+                    return LastValue.Create();
+                case nameof(Mean):
+                    return Mean.Create();
+                case nameof(Sum):
+                    return Sum.Create();
+                default:
+                    throw new ApplicationException(String.Format("Error Metrics#005: [Exporter/Views:UpdateView()] Unsupported Aggregation Type: {0}", Aggregation));
+            }
+        }
+    }
+}

--- a/samples/ASP.Net Metrics/MetricsShim/MetricsShim.cs
+++ b/samples/ASP.Net Metrics/MetricsShim/MetricsShim.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Newtonsoft.Json.Linq;
+
+namespace hellocs.MetricsShim
+{
+    public class MetricShim
+    {
+        public MetricExporter MetricsExp;
+        private string _json;
+        public MetricShim(string jsonString)
+        {
+            _json = jsonString;
+        }
+
+        public void Start()
+        {
+            JObject o = JObject.Parse(_json);
+            JToken token = o.SelectToken("MetricShim.MetricsExp");
+            try
+            {
+                MetricsExp = token.ToObject<MetricExporter>();
+                MetricsExp.Setup();
+                MetricsExp.Start();
+            }
+            catch (NullReferenceException)
+            {
+                throw new ApplicationException("Don't forget to add your settings for the Metrics exporter in file 'appsettings.json'");
+            }
+        }
+    }
+}

--- a/samples/ASP.Net Metrics/Middlewares/CustomMetricsMiddleware.cs
+++ b/samples/ASP.Net Metrics/Middlewares/CustomMetricsMiddleware.cs
@@ -1,0 +1,91 @@
+﻿using hellocs.MetricsShim;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace hellocs.Middlewares
+{
+    // Sadly, I didn't figure how to template the functions that provide data to the exporter
+    public class MetricsMiddleware
+    {
+        // Handle to the next Middleware in the pipeline  
+        private readonly RequestDelegate _next;
+        // Handle to the metrics Exporter
+        private readonly MetricShim _shim;
+        private long responseTimeForCompleteRequest;
+        public MetricsMiddleware(RequestDelegate next, MetricShim shim)
+        {
+            _next = next;
+            _shim = shim;
+        }
+
+        public object HttpContext { get; private set; }
+
+        public Task InvokeAsync(HttpContext context)
+        {
+            // Start the Timer using Stopwatch  
+            var watch = new Stopwatch();
+            watch.Start();
+            context.Response.OnStarting(() =>
+            {
+                // Stop the timer information and calculate the time   
+                writeRequestsToMetrics(context);
+                watch.Stop();
+                responseTimeForCompleteRequest = watch.ElapsedMilliseconds;
+                // Add the Response time information to the metrics exporter
+                writeRequestsTimeToMetrics(context);
+                return Task.CompletedTask;
+            });
+            // Call the next delegate/middleware in the pipeline   
+            return this._next(context);
+        }
+
+        /// <summary>
+        /// This is a CUSTOM function made to fit with metrics views_requests_time view define in 
+        /// appsettings.json.
+        /// </summary>
+        private void writeRequestsTimeToMetrics(HttpContext context)
+        {
+            try
+            {
+                View vue;
+                Dictionary<string, string> dic = new Dictionary<string, string>();
+                dic.Add("route", context.Request.Path);
+                dic.Add("status_code", context.Response.StatusCode.ToString());
+                _shim.MetricsExp.Views.TryGetValue("req_time", out vue);
+
+                vue.UpdateView(dic, Convert.ToInt32(responseTimeForCompleteRequest));
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.ToString());
+            }
+
+        }
+
+        /// <summary>
+        /// This is a CUSTOM function made to fit with metrics views_requests_total view define in 
+        /// appsettings.json.
+        /// </summary>
+        private void writeRequestsToMetrics(HttpContext context)
+        {
+            try
+            {
+                View vue;
+                Dictionary<string, string> dic = new Dictionary<string, string>();
+                dic.Add("route", context.Request.Path);
+                dic.Add("status_code", context.Response.StatusCode.ToString());
+                _shim.MetricsExp.Views.TryGetValue("req_amount", out vue);
+
+                vue.UpdateView(dic, 1);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.ToString());
+            }
+        }
+    }
+}

--- a/samples/ASP.Net Metrics/Startup.cs
+++ b/samples/ASP.Net Metrics/Startup.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.IO;
+using Microsoft.Extensions.Logging;
+using System.Reflection;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+using Microsoft.AspNetCore;
+using WebMarkupMin.AspNetCore2;
+using hellocs.MetricsShim;
+using hellocs.Middlewares;
+
+namespace hellocs
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public static void Main(string[] args)
+        {
+            BuildWebHost(args).Run();
+        }
+
+        public static IWebHost BuildWebHost(string[] args)
+        {
+            return WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>()
+                .Build();
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddResponseCaching();
+            services.AddMvc();
+            // Add Single instance of the shim to access the metrics exporter
+            services.AddSingleton<MetricShim>((p) =>
+            {
+                string file = File.ReadAllText(@"appsettings.json");
+                return new MetricShim(file);
+            });
+
+            services.AddWebMarkupMin(options =>
+            {
+                options.AllowMinificationInDevelopmentEnvironment = true;
+                options.DisablePoweredByHttpHeaders = true;
+                options.DisableCompression = true;
+            })
+            .AddHtmlMinification(options =>
+            {
+                options.MinificationSettings.RemoveRedundantAttributes = true;
+                options.MinificationSettings.RemoveHttpProtocolFromAttributes = true;
+                options.MinificationSettings.RemoveHttpsProtocolFromAttributes = true;
+                options.MinificationSettings.MinifyEmbeddedCssCode = false;
+                options.MinificationSettings.RemoveOptionalEndTags = false;
+            });
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, MetricShim metricsExporter)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+            else
+            {
+                app.UseResponseCaching();
+            }
+
+            // Add the middleware to actually provide data to the exporter
+            app.UseMiddleware<MetricsMiddleware>();
+            app.UseStaticFiles(new StaticFileOptions()
+            {
+                OnPrepareResponse = (context) =>
+                {
+                    var headers = context.Context.Response.GetTypedHeaders();
+                    headers.CacheControl = new CacheControlHeaderValue()
+                    {
+                        MaxAge = TimeSpan.FromDays(365)
+                    };
+                }
+            });
+
+            app.UseWebMarkupMin();
+            // Starts the Exporter server in a thread
+            metricsExporter.Start();
+
+            // This is where the app routes are declared and would be using authentification as opposed to
+            // statusExporter, healthExporter and metricsExporter which is answering to anonymous requests.
+            // The 3 anonymous routes are exposed on other port to ensure health and metrics are only accessible
+            // from inside the cluster and status accessible by anonymous clients outside of the cluster.
+            app.UseMvc(routes =>
+            {
+                routes.MapRoute(name: "Home", template: "{controller}/{action}/{id?}/");
+            });
+        }
+    }
+}

--- a/samples/ASP.Net Metrics/Startup.cs
+++ b/samples/ASP.Net Metrics/Startup.cs
@@ -97,10 +97,6 @@ namespace hellocs
             // Starts the Exporter server in a thread
             metricsExporter.Start();
 
-            // This is where the app routes are declared and would be using authentification as opposed to
-            // statusExporter, healthExporter and metricsExporter which is answering to anonymous requests.
-            // The 3 anonymous routes are exposed on other port to ensure health and metrics are only accessible
-            // from inside the cluster and status accessible by anonymous clients outside of the cluster.
             app.UseMvc(routes =>
             {
                 routes.MapRoute(name: "Home", template: "{controller}/{action}/{id?}/");

--- a/samples/ASP.Net Metrics/appsettings.json
+++ b/samples/ASP.Net Metrics/appsettings.json
@@ -1,0 +1,57 @@
+{
+  "Logging": {
+    "IncludeScopes": false,
+    "Debug": {
+      "LogLevel": {
+        "Default": "Warning"
+      }
+    },
+    "Console": {
+      "LogLevel": {
+        "Default": "Warning"
+      }
+    }
+  },
+  "MetricShim": {
+    "MetricsExp": {
+      "Hostname": "+",
+      "ListenOnPort": "8080",
+      "Path": "/",
+      "AppName": "metrics",
+      "Views": {
+        "req_amount": {
+          "Name": "views_requests_total",
+          "Namespace": "hellocs",
+          "Description": " requests made over time",
+          "Measure": {
+            "Name": "requests_count",
+            "Description": "counter of requests",
+            "Unit": "req",
+            "Type": "MeasureLong"
+          },
+          "Aggregation": "Count",
+          "TagKeys": [
+            "status_code",
+            "route"
+          ]
+        },
+        "req_time": {
+          "Name": "views_requests_time",
+          "Namespace": "hellocs",
+          "Description": " average time to process requests",
+          "Measure": {
+            "Name": "requests_time",
+            "Description": "time to answer requests",
+            "Unit": "ms",
+            "Type": "MeasureLong"
+          },
+          "Aggregation": "LastValue",
+          "TagKeys": [
+            "status_code",
+            "route"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Is a response to the Issue #124 .
Is a proof of concept.
Am open to new ideas.

Snipped from Issue #124 : "As a dev using ASP.Net Core MVC, I mainly use the file appsettings.json to assign different settings. We could use that file to do the heavy lifting of setting-up Prometheus Exporter."

It could be generalized by being able to use more than one Exporter under the MetricsShim.