### PR TITLE
More Attributes improvements

### DIFF
--- a/src/OpenTelemetry.Abstractions/Trace/Export/Attributes.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/Export/Attributes.cs
@@ -18,32 +18,31 @@ namespace OpenTelemetry.Trace.Export
 {
     using System;
     using System.Collections.Generic;
-    using System.Collections.ObjectModel;
     using System.Linq;
 
-    public sealed class Attributes : IAttributes
+    public sealed class Attributes
     {
         private static readonly Attributes Empty = new Attributes(new Dictionary<string, object>(), 0);
 
-        internal Attributes(IDictionary<string, object> attributeMap, int droppedAttributesCount)
+        internal Attributes(IEnumerable<KeyValuePair<string, object>> attributeMap, int droppedAttributesCount)
         {
-            this.AttributeMap = attributeMap ?? throw new ArgumentNullException("Null attributeMap");
+            this.AttributeMap = attributeMap ?? throw new ArgumentNullException(nameof(attributeMap));
             this.DroppedAttributesCount = droppedAttributesCount;
         }
 
-        public IDictionary<string, object> AttributeMap { get; }
+        public IEnumerable<KeyValuePair<string, object>> AttributeMap { get; }
 
         public int DroppedAttributesCount { get; }
 
-        public static Attributes Create(IDictionary<string, object> attributeMap, int droppedAttributesCount)
+        public static Attributes Create(IEnumerable<KeyValuePair<string, object>> attributeMap, int droppedAttributesCount)
         {
             if (attributeMap == null)
             {
                 return Empty;
             }
 
-            IDictionary<string, object> copy = new Dictionary<string, object>(attributeMap);
-            return new Attributes(new ReadOnlyDictionary<string, object>(copy), droppedAttributesCount);
+            var copy = new List<KeyValuePair<string, object>>(attributeMap);
+            return new Attributes(copy, droppedAttributesCount);
         }
 
         /// <inheritdoc/>
@@ -55,7 +54,7 @@ namespace OpenTelemetry.Trace.Export
                 + "}";
         }
 
-    /// <inheritdoc/>
+        /// <inheritdoc/>
         public override bool Equals(object o)
         {
             if (o == this)
@@ -72,7 +71,7 @@ namespace OpenTelemetry.Trace.Export
             return false;
         }
 
-    /// <inheritdoc/>
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             var h = 1;

--- a/src/OpenTelemetry.Abstractions/Trace/Export/Attributes.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/Export/Attributes.cs
@@ -24,7 +24,7 @@ namespace OpenTelemetry.Trace.Export
     {
         private static readonly Attributes Empty = new Attributes(new Dictionary<string, object>(), 0);
 
-        internal Attributes(IEnumerable<KeyValuePair<string, object>> attributeMap, int droppedAttributesCount)
+        private Attributes(IEnumerable<KeyValuePair<string, object>> attributeMap, int droppedAttributesCount)
         {
             this.AttributeMap = attributeMap ?? throw new ArgumentNullException(nameof(attributeMap));
             this.DroppedAttributesCount = droppedAttributesCount;
@@ -34,15 +34,14 @@ namespace OpenTelemetry.Trace.Export
 
         public int DroppedAttributesCount { get; }
 
-        public static Attributes Create(IEnumerable<KeyValuePair<string, object>> attributeMap, int droppedAttributesCount)
+        public static Attributes Create(IReadOnlyCollection<KeyValuePair<string, object>> attributeMap, int droppedAttributesCount)
         {
             if (attributeMap == null)
             {
                 return Empty;
             }
 
-            var copy = new List<KeyValuePair<string, object>>(attributeMap);
-            return new Attributes(copy, droppedAttributesCount);
+            return new Attributes(attributeMap, droppedAttributesCount);
         }
 
         /// <inheritdoc/>

--- a/src/OpenTelemetry.Abstractions/Trace/SpanData.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/SpanData.cs
@@ -35,7 +35,7 @@ namespace OpenTelemetry.Trace
             Resource resource,
             string name,
             Timestamp startTimestamp,
-            IAttributes attributes,
+            Attributes attributes,
             ITimedEvents<IEvent> events,
             ILinks links,
             int? childSpanCount,
@@ -78,9 +78,9 @@ namespace OpenTelemetry.Trace
         public string Name { get; }
 
         /// <summary>
-        /// Gets the collection of <see cref="IAttributes"/> objects.
+        /// Gets the collection of <see cref="Attributes"/> objects.
         /// </summary>
-        public IAttributes Attributes { get; }
+        public Attributes Attributes { get; }
 
         /// <summary>
         /// Gets the collection of <see cref="ITimedEvents{IEvent}"/> objects.
@@ -125,7 +125,7 @@ namespace OpenTelemetry.Trace
         /// <param name="resource">The <see cref="Resource"/> this span was executed on.</param>
         /// <param name="name">The name of the <see cref="ISpan"/>.</param>
         /// <param name="startTimestamp">The start <see cref="Timestamp"/> of the <see cref="ISpan"/>.</param>
-        /// <param name="attributes">The <see cref="IAttributes"/> associated with the <see cref="ISpan"/>.</param>
+        /// <param name="attributes">The <see cref="Attributes"/> associated with the <see cref="ISpan"/>.</param>
         /// <param name="events">The <see cref="Events"/> associated with the <see cref="ISpan"/>.</param>
         /// <param name="links">The <see cref="ILinks"/> associated with the <see cref="ISpan"/>.</param>
         /// <param name="childSpanCount">The <see cref="ChildSpanCount"/> associated with the <see cref="ISpan"/>.</param>
@@ -139,7 +139,7 @@ namespace OpenTelemetry.Trace
                         Resource resource,
                         string name,
                         Timestamp startTimestamp,
-                        IAttributes attributes,
+                        Attributes attributes,
                         ITimedEvents<IEvent> events,
                         ILinks links,
                         int? childSpanCount,

--- a/src/OpenTelemetry.Exporter.Ocagent/Implementation/SpanDataExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Ocagent/Implementation/SpanDataExtensions.cs
@@ -78,7 +78,7 @@ namespace OpenTelemetry.Exporter.Ocagent.Implementation
                         },
                     SameProcessAsParentSpan = spanData.ParentSpanId != null,
                     ChildSpanCount = spanData.ChildSpanCount.HasValue ? (uint)spanData.ChildSpanCount.Value : 0,
-                    Attributes = FromIAttributes(spanData.Attributes),
+                    Attributes = FromAttributes(spanData.Attributes),
                     TimeEvents = FromITimeEvents(spanData.Events),
                     Links = new Span.Types.Links
                     {
@@ -99,7 +99,7 @@ namespace OpenTelemetry.Exporter.Ocagent.Implementation
             return null;
         }
 
-        private static Span.Types.Attributes FromIAttributes(IAttributes source)
+        private static Span.Types.Attributes FromAttributes(Attributes source)
         {
             var attributes = new Span.Types.Attributes
             {

--- a/src/OpenTelemetry/Trace/Span.cs
+++ b/src/OpenTelemetry/Trace/Span.cs
@@ -421,7 +421,7 @@ namespace OpenTelemetry.Trace
                 throw new InvalidOperationException("Getting SpanData for a Span without RECORD_EVENTS option.");
             }
 
-            var attributesSpanData = Attributes.Create(this.attributes, this.attributes?.NumberOfDroppedAttributes ?? 0);
+            var attributesSpanData = Attributes.Create(this.attributes?.AsReadOnlyCollection(), this.attributes?.NumberOfDroppedAttributes ?? 0);
 
             var annotationsSpanData = CreateTimedEvents(this.InitializedEvents, this.TimestampConverter);
             var linksSpanData = LinkList.Create(this.links?.Events, this.links?.NumberOfDroppedEvents ?? 0);

--- a/test/OpenTelemetry.Collector.AspNetCore.Tests/AttributesExtensions.cs
+++ b/test/OpenTelemetry.Collector.AspNetCore.Tests/AttributesExtensions.cs
@@ -1,0 +1,29 @@
+﻿// <copyright file="AttributesExtensions.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Collector.AspNetCore.Tests
+{
+    using System.Linq;
+    using OpenTelemetry.Trace.Export;
+
+    internal static class AttributesExtensions
+    {
+        public static object GetValue(this Attributes attributes, string key)
+        {
+            return attributes.AttributeMap.FirstOrDefault(kvp => kvp.Key == key).Value;
+        }
+    }
+}

--- a/test/OpenTelemetry.Collector.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Collector.AspNetCore.Tests/BasicTests.cs
@@ -85,7 +85,7 @@ namespace OpenTelemetry.Collector.AspNetCore.Tests
             var spanData = ((Span)startEndHandler.Invocations[1].Arguments[0]).ToSpanData();
 
             Assert.Equal(SpanKind.Server, spanData.Kind);
-            Assert.Equal("/api/values", spanData.Attributes.AttributeMap["http.path"]);
+            Assert.Equal("/api/values", spanData.Attributes.GetValue("http.path"));
         }
 
         [Fact]
@@ -143,7 +143,7 @@ namespace OpenTelemetry.Collector.AspNetCore.Tests
 
             Assert.Equal(SpanKind.Server, spanData.Kind);
             Assert.Equal("api/Values/{id}", spanData.Name);
-            Assert.Equal("/api/values/2", spanData.Attributes.AttributeMap["http.path"]);
+            Assert.Equal("/api/values/2", spanData.Attributes.GetValue("http.path"));
 
             Assert.Equal(expectedTraceId, spanData.Context.TraceId);
             Assert.Equal(expectedSpanId, spanData.ParentSpanId);

--- a/test/OpenTelemetry.Collector.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
+++ b/test/OpenTelemetry.Collector.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
@@ -96,8 +96,8 @@ namespace OpenTelemetry.Collector.AspNetCore.Tests
             var spanData = ((Span)startEndHandler.Invocations[0].Arguments[0]).ToSpanData();
 
             Assert.Equal(SpanKind.Server, spanData.Kind);
-            Assert.Equal("/api/values", spanData.Attributes.AttributeMap["http.path"]);
-            Assert.Equal(503L, spanData.Attributes.AttributeMap["http.status_code"]);
+            Assert.Equal("/api/values", spanData.Attributes.GetValue("http.path"));
+            Assert.Equal(503L, spanData.Attributes.GetValue("http.status_code"));
         }
     }
 }

--- a/test/OpenTelemetry.Collector.StackExchangeRedis.Tests/AttributesExtensions.cs
+++ b/test/OpenTelemetry.Collector.StackExchangeRedis.Tests/AttributesExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="IAttributes.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="AttributesExtensions.cs" company="OpenTelemetry Authors">
 // Copyright 2018, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,23 +14,16 @@
 // limitations under the License.
 // </copyright>
 
-namespace OpenTelemetry.Trace.Export
+namespace OpenTelemetry.Collector.StackExchangeRedis.Tests
 {
-    using System.Collections.Generic;
+    using System.Linq;
+    using OpenTelemetry.Trace.Export;
 
-    /// <summary>
-    /// Attributes collection.
-    /// </summary>
-    public interface IAttributes
+    internal static class AttributesExtensions
     {
-        /// <summary>
-        /// Gets the dictionary of attributes by name.
-        /// </summary>
-        IDictionary<string, object> AttributeMap { get; }
-
-        /// <summary>
-        /// Gets the number of attributed dropped due to the limit.
-        /// </summary>
-        int DroppedAttributesCount { get; }
+        public static object GetValue(this Attributes attributes, string key)
+        {
+            return attributes.AttributeMap.FirstOrDefault(kvp => kvp.Key == key).Value;
+        }
     }
 }

--- a/test/OpenTelemetry.Collector.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToSpanConverterTests.cs
+++ b/test/OpenTelemetry.Collector.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToSpanConverterTests.cs
@@ -14,6 +14,9 @@
 // limitations under the License.
 // </copyright>
 
+using System.Linq;
+using OpenTelemetry.Collector.StackExchangeRedis.Tests;
+
 namespace OpenTelemetry.Collector.StackExchangeRedis.Implementation
 {
     using OpenTelemetry.Trace;
@@ -56,8 +59,8 @@ namespace OpenTelemetry.Collector.StackExchangeRedis.Implementation
         {
             var profiledCommand = new Mock<IProfiledCommand>();
             var result = RedisProfilerEntryToSpanConverter.ProfiledCommandToSpanData(SpanContext.Blank, "SET", default, profiledCommand.Object);
-            Assert.Contains("db.type", result.Attributes.AttributeMap.Keys);
-            Assert.Equal("redis", result.Attributes.AttributeMap["db.type"]);
+            Assert.Contains(result.Attributes.AttributeMap, kvp => kvp.Key == "db.type");
+            Assert.Equal("redis", result.Attributes.GetValue("db.type"));
         }
 
         [Fact]
@@ -66,19 +69,22 @@ namespace OpenTelemetry.Collector.StackExchangeRedis.Implementation
             var profiledCommand = new Mock<IProfiledCommand>();
             profiledCommand.Setup(m => m.Command).Returns("SET");
             var result = RedisProfilerEntryToSpanConverter.ProfiledCommandToSpanData(SpanContext.Blank, "another name", default, profiledCommand.Object);
-            Assert.Contains("db.statement", result.Attributes.AttributeMap.Keys);
-            Assert.Equal("SET", result.Attributes.AttributeMap["db.statement"]);
+            Assert.Contains(result.Attributes.AttributeMap, kvp => kvp.Key == "db.statement");
+            Assert.Equal("SET", result.Attributes.GetValue("db.statement"));
         }
 
         [Fact]
         public void ProfiledCommandToSpanDataUsesFlagsForFlagsAttribute()
         {
             var profiledCommand = new Mock<IProfiledCommand>();
-            var expectedFlags = StackExchange.Redis.CommandFlags.FireAndForget | StackExchange.Redis.CommandFlags.NoRedirect;
+            var expectedFlags = StackExchange.Redis.CommandFlags.FireAndForget |
+                                StackExchange.Redis.CommandFlags.NoRedirect;
             profiledCommand.Setup(m => m.Flags).Returns(expectedFlags);
-            var result = RedisProfilerEntryToSpanConverter.ProfiledCommandToSpanData(SpanContext.Blank, "SET", default, profiledCommand.Object);
-            Assert.Contains("redis.flags", result.Attributes.AttributeMap.Keys);
-            Assert.Equal("None, FireAndForget, NoRedirect", result.Attributes.AttributeMap["redis.flags"]);
+            var result =
+                RedisProfilerEntryToSpanConverter.ProfiledCommandToSpanData(SpanContext.Blank, "SET", default,
+                    profiledCommand.Object);
+            Assert.Contains(result.Attributes.AttributeMap, kvp => kvp.Key == "redis.flags");
+            Assert.Equal("None, FireAndForget, NoRedirect", result.Attributes.GetValue("redis.flags"));
         }
     }
 }

--- a/test/OpenTelemetry.Exporter.ApplicationInsights.Tests/Implementation/TraceExporterHandlerTests.cs
+++ b/test/OpenTelemetry.Exporter.ApplicationInsights.Tests/Implementation/TraceExporterHandlerTests.cs
@@ -1863,7 +1863,7 @@ namespace OpenTelemetry.Exporter.ApplicationInsights.Tests
             out Resource resource,
             out string name,
             out Timestamp startTimestamp,
-            out IAttributes attributes,
+            out Attributes attributes,
             out ITimedEvents<IEvent> events,
             out ILinks links,
             out int? childSpanCount,

--- a/test/OpenTelemetry.Tests/Impl/Trace/AttributesExtensions.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/AttributesExtensions.cs
@@ -1,0 +1,44 @@
+﻿// <copyright file="AttributesExtensions.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace OpenTelemetry.Tests
+{
+    using System.Linq;
+    using OpenTelemetry.Trace.Export;
+
+    internal static class AttributesExtensions
+    {
+        public static object GetValue(this Attributes attributes, string key)
+        {
+            return attributes.AttributeMap.FirstOrDefault(kvp => kvp.Key == key).Value;
+        }
+
+        public static void AssertAreSame(this Attributes attributes,
+            IEnumerable<KeyValuePair<string, object>> expectedAttributes)
+        {
+            var keyValuePairs = expectedAttributes as KeyValuePair<string, object>[] ?? expectedAttributes.ToArray();
+            Assert.Equal(attributes.AttributeMap.Count(), keyValuePairs.Count());
+
+            foreach (var attr in attributes.AttributeMap)
+            {
+                Assert.Contains(attr, keyValuePairs);
+            }
+        }
+    }
+}

--- a/test/OpenTelemetry.Tests/Impl/Trace/Export/SpanDataTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Export/SpanDataTest.cs
@@ -43,7 +43,7 @@ namespace OpenTelemetry.Trace.Export.Test
         private readonly List<ITimedEvent<IEvent>> eventList = new List<ITimedEvent<IEvent>>();
         private readonly List<ILink> linksList = new List<ILink>();
 
-        private readonly IAttributes attributes;
+        private readonly Attributes attributes;
         private readonly ITimedEvents<IEvent> events;
         private readonly LinkList links;
 

--- a/test/OpenTelemetry.Tests/Impl/Trace/Export/SpanDataTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Export/SpanDataTest.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+using System.Collections.ObjectModel;
+
 namespace OpenTelemetry.Trace.Export.Test
 {
     using System.Collections.Generic;
@@ -54,7 +56,7 @@ namespace OpenTelemetry.Trace.Export.Test
 
             attributesMap.Add("MyAttributeKey1", 10L);
             attributesMap.Add("MyAttributeKey2", true);
-            attributes = Attributes.Create(attributesMap, 1);
+            attributes = Attributes.Create(new ReadOnlyDictionary<string, object>(attributesMap), 1);
 
             eventList.Add(TimedEvent<IEvent>.Create(eventTimestamp1, spanEvent));
             eventList.Add(TimedEvent<IEvent>.Create(eventTimestamp3, spanEvent));

--- a/test/OpenTelemetry.Tests/OpenTelemetry.Tests.csproj
+++ b/test/OpenTelemetry.Tests/OpenTelemetry.Tests.csproj
@@ -4,6 +4,11 @@
     <TargetFrameworks>net46;netcoreapp2.1</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="Impl\Trace\Internal\**" />
+    <EmbeddedResource Remove="Impl\Trace\Internal\**" />
+    <None Remove="Impl\Trace\Internal\**" />
+  </ItemGroup>
 
   <ItemGroup>
     <Content Include="xunit.runner.json">


### PR DESCRIPTION
1. IAttributes should not be in API as they are part of exporting - removed
2. Cleaned up Attributes API to avoid constant copying
3. cleaned up AttributesWithCapacity - use linked list as eviction mechanism, avoid OrderedDictionary

Depends on #148 