### PR TITLE
Disable code coverage in CI: reportgenerator does not work

### DIFF
--- a/build/Common.test.props
+++ b/build/Common.test.props
@@ -26,7 +26,7 @@
 
   <PropertyGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
     <IsTestProject>true</IsTestProject>
-    <CollectCoverage Condition="$(CollectCoverage) == ''">true</CollectCoverage>
+    <!--CollectCoverage Condition="$(CollectCoverage) == ''">true</CollectCoverage-->
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Reportgenerator tool sometimes fails to  generate report with following  error (e.g. in #155 )

```
/home/vsts/work/1/s/test/Directory.Build.targets(16,5): error MSB3073: The command "dotnet reportgenerator -reports:../../TestResults/Results/Cobertura.xml -targetdir:../../TestResults/Results/ -reporttypes:HtmlInline_AzurePipelines;Cobertura -verbosity:Verbose" exited with code 127. [/home/vsts/work/1/s/test/OpenTelemetry.Exporter.ApplicationInsights.Tests/OpenTelemetry.Exporter.ApplicationInsights.Tests.csproj]
##[error]Error: The process '/opt/hostedtoolcache/dncs/2.2.101/x64/dotnet' failed with exit code 1
```

Disabling coverage for now as CI does not validate it anyway. We'll need to get back to it when we decide to use coverage information.