### PR TITLE
Improvements in http in and out auto-collectors

### DIFF
--- a/OpenTelemetry.sln
+++ b/OpenTelemetry.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28407.52
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.705
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry", "src\OpenTelemetry\OpenTelemetry.csproj", "{AE3E3DF5-4083-4C6E-A840-8271B0ACDE7E}"
 EndProject
@@ -80,9 +80,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LoggingTracer.Demo.ConsoleA
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LoggingTracer.Demo.AspNetCore", "samples\LoggingTracer\LoggingTracer.Demo.AspNetCore\LoggingTracer.Demo.AspNetCore.csproj", "{1EB74FCE-55C5-476A-8BB0-C46B77FE1070}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTelemetry.Exporter.Jaeger", "src\OpenTelemetry.Exporter.Jaeger\OpenTelemetry.Exporter.Jaeger.csproj", "{8D47E3CF-9AE3-42FE-9084-FEB72D9AD769}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.Exporter.Jaeger", "src\OpenTelemetry.Exporter.Jaeger\OpenTelemetry.Exporter.Jaeger.csproj", "{8D47E3CF-9AE3-42FE-9084-FEB72D9AD769}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTelemetry.Exporter.Jaeger.Tests", "test\OpenTelemetry.Exporter.Jaeger.Tests\OpenTelemetry.Exporter.Jaeger.Tests.csproj", "{21E69213-72D5-453F-BD00-75EF36AC4965}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.Exporter.Jaeger.Tests", "test\OpenTelemetry.Exporter.Jaeger.Tests\OpenTelemetry.Exporter.Jaeger.Tests.csproj", "{21E69213-72D5-453F-BD00-75EF36AC4965}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Thrift", "lib\Thrift\Thrift.csproj", "{ED179037-DDB3-4780-A24F-F56278623EBB}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "lib", "lib", "{9D2D6933-C28C-4541-9A25-FDAE0DA5A5D4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -182,6 +186,10 @@ Global
 		{21E69213-72D5-453F-BD00-75EF36AC4965}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{21E69213-72D5-453F-BD00-75EF36AC4965}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{21E69213-72D5-453F-BD00-75EF36AC4965}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ED179037-DDB3-4780-A24F-F56278623EBB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ED179037-DDB3-4780-A24F-F56278623EBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ED179037-DDB3-4780-A24F-F56278623EBB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ED179037-DDB3-4780-A24F-F56278623EBB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -193,6 +201,7 @@ Global
 		{1EEF77DF-7552-4265-B64C-FA13BC40C256} = {D9C14CDA-5182-4DEA-8606-98FF1A388BD3}
 		{607B3861-4D69-43EF-84CE-19F18CD5339A} = {D9C14CDA-5182-4DEA-8606-98FF1A388BD3}
 		{1EB74FCE-55C5-476A-8BB0-C46B77FE1070} = {D9C14CDA-5182-4DEA-8606-98FF1A388BD3}
+		{ED179037-DDB3-4780-A24F-F56278623EBB} = {9D2D6933-C28C-4541-9A25-FDAE0DA5A5D4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {55639B5C-0770-4A22-AB56-859604650521}

--- a/src/OpenTelemetry.Collector.AspNetCore/AspNetCoreCollectorEventSource.cs
+++ b/src/OpenTelemetry.Collector.AspNetCore/AspNetCoreCollectorEventSource.cs
@@ -38,16 +38,22 @@ namespace OpenTelemetry.Collector.AspNetCore
             }
         }
 
-        [Event(1, Message = "Context is NULL in end callback. Span will not be recorded.", Level = EventLevel.Warning)]
-        public void NullContext()
+        [Event(1, Message = "Http Context is NULL in '{0}' callback. Span will not be recorded.", Level = EventLevel.Warning)]
+        public void NullHttpContext(string eventName)
         {
-            this.WriteEvent(1);
+            this.WriteEvent(1, eventName);
         }
 
         [Event(2, Message = "Error getting custom sampler, the default sampler will be used. Exception : {0}", Level = EventLevel.Warning)]
         public void ExceptionInCustomSampler(string ex)
         {
             this.WriteEvent(2, ex);
+        }
+
+        [Event(3, Message = "Current Span is null or blank in '{0}' callback. Span will not be recorded.", Level = EventLevel.Warning)]
+        public void NullOrBlankSpan(string callbackName)
+        {
+            this.WriteEvent(3, callbackName);
         }
 
         /// <summary>

--- a/src/OpenTelemetry.Collector.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Collector.AspNetCore/Implementation/HttpInListener.cs
@@ -33,10 +33,12 @@ namespace OpenTelemetry.Collector.AspNetCore.Implementation
         private readonly PropertyFetcher beforeActionActionDescriptorFetcher = new PropertyFetcher("actionDescriptor");
         private readonly PropertyFetcher beforeActionAttributeRouteInfoFetcher = new PropertyFetcher("AttributeRouteInfo");
         private readonly PropertyFetcher beforeActionTemplateFetcher = new PropertyFetcher("Template");
+        private readonly bool hostingSupportsW3C = false;
 
         public HttpInListener(ITracer tracer, Func<HttpRequest, ISampler> samplerFactory)
             : base("Microsoft.AspNetCore", tracer, samplerFactory)
         {
+            this.hostingSupportsW3C = typeof(HttpRequest).Assembly.GetName().Version.Major >= 3;
         }
 
         public override void OnStartActivity(Activity activity, object payload)
@@ -51,48 +53,65 @@ namespace OpenTelemetry.Collector.AspNetCore.Implementation
 
             var request = context.Request;
 
-            var ctx = this.Tracer.TextFormat.Extract<HttpRequest>(
-                request,
-                (r, name) => r.Headers[name]);
+            SpanContext ctx = null;
+            if (!this.hostingSupportsW3C)
+            {
+                ctx = this.Tracer.TextFormat.Extract<HttpRequest>(
+                    request,
+                    (r, name) => r.Headers[name]);
+            }
 
             // see the spec https://github.com/open-telemetry/OpenTelemetry-specs/blob/master/trace/HTTP.md
-
             var path = (request.PathBase.HasValue || request.Path.HasValue) ? (request.PathBase + request.Path).ToString() : "/";
 
-            ISpan span = this.Tracer.SpanBuilder(path)
+            var spanBuilder = this.Tracer.SpanBuilder(path)
                 .SetSpanKind(SpanKind.Server)
-                .SetParent(ctx)
-                .SetSampler(this.SamplerFactory(request))
-                .StartSpan();
+                .SetSampler(this.SamplerFactory(request));
 
+            if (this.hostingSupportsW3C)
+            {
+                spanBuilder.SetCreateChild(false);
+            }
+            else
+            {
+                spanBuilder.SetParent(ctx);
+            }
+
+            var span = spanBuilder.StartSpan();
             this.Tracer.WithSpan(span);
 
-            // Note, route is missing at this stage. It will be available later
+            if (span.IsRecordingEvents)
+            {
+                // Note, route is missing at this stage. It will be available later
+                span.PutHttpHostAttribute(request.Host.Host, request.Host.Port ?? 80);
+                span.PutHttpMethodAttribute(request.Method);
+                span.PutHttpPathAttribute(path);
 
-            span.PutHttpHostAttribute(request.Host.Host, request.Host.Port ?? 80);
-            span.PutHttpMethodAttribute(request.Method);
-            span.PutHttpPathAttribute(path);
-
-            var userAgent = request.Headers["User-Agent"].FirstOrDefault();
-            span.PutHttpUserAgentAttribute(userAgent);
-            span.PutHttpRawUrlAttribute(GetUri(request));
+                var userAgent = request.Headers["User-Agent"].FirstOrDefault();
+                span.PutHttpUserAgentAttribute(userAgent);
+                span.PutHttpRawUrlAttribute(GetUri(request));
+            }
         }
 
         public override void OnStopActivity(Activity activity, object payload)
         {
-            var context = this.stopContextFetcher.Fetch(payload) as HttpContext;
+            var span = this.Tracer.CurrentSpan;
 
-            if (context == null)
+            if (span == null || span == BlankSpan.Instance)
             {
-                AspNetCoreCollectorEventSource.Log.NullContext();
+                AspNetCoreCollectorEventSource.Log.NullOrBlankSpan("HttpInListener.OnStopActivity");
                 return;
             }
 
-            var span = this.Tracer.CurrentSpan;
-
-            if (span == null)
+            if (!span.IsRecordingEvents)
             {
-                // TODO: report lost span
+                span.End();
+                return;
+            }
+
+            if (!(this.stopContextFetcher.Fetch(payload) is HttpContext context))
+            {
+                AspNetCoreCollectorEventSource.Log.NullHttpContext("HttpInListener.OnStopActivity");
                 return;
             }
 
@@ -110,30 +129,33 @@ namespace OpenTelemetry.Collector.AspNetCore.Implementation
 
                 if (span == null)
                 {
-                    // TODO: report lost span
+                    AspNetCoreCollectorEventSource.Log.NullOrBlankSpan(name);
                     return;
                 }
 
-                // See https://github.com/aspnet/Mvc/blob/2414db256f32a047770326d14d8b0e2afd49ba49/src/Microsoft.AspNetCore.Mvc.Core/MvcCoreDiagnosticSourceExtensions.cs#L36-L44
-                // Reflection accessing: ActionDescriptor.AttributeRouteInfo.Template
-                // The reason to use reflection is to avoid a reference on MVC package.
-                // This package can be used with non-MVC apps and this logic simply wouldn't run.
-                // Taking reference on MVC will increase size of deployment for non-MVC apps.
-                var actionDescriptor = this.beforeActionActionDescriptorFetcher.Fetch(payload);
-                var attributeRouteInfo = this.beforeActionAttributeRouteInfoFetcher.Fetch(actionDescriptor);
-                var template = this.beforeActionTemplateFetcher.Fetch(attributeRouteInfo) as string;
-
-                if (!string.IsNullOrEmpty(template))
+                if (span.IsRecordingEvents)
                 {
-                    // override the span name that was previously set to the path part of URL.
-                    span.UpdateName(template);
+                    // See https://github.com/aspnet/Mvc/blob/2414db256f32a047770326d14d8b0e2afd49ba49/src/Microsoft.AspNetCore.Mvc.Core/MvcCoreDiagnosticSourceExtensions.cs#L36-L44
+                    // Reflection accessing: ActionDescriptor.AttributeRouteInfo.Template
+                    // The reason to use reflection is to avoid a reference on MVC package.
+                    // This package can be used with non-MVC apps and this logic simply wouldn't run.
+                    // Taking reference on MVC will increase size of deployment for non-MVC apps.
+                    var actionDescriptor = this.beforeActionActionDescriptorFetcher.Fetch(payload);
+                    var attributeRouteInfo = this.beforeActionAttributeRouteInfoFetcher.Fetch(actionDescriptor);
+                    var template = this.beforeActionTemplateFetcher.Fetch(attributeRouteInfo) as string;
 
-                    span.PutHttpRouteAttribute(template);
+                    if (!string.IsNullOrEmpty(template))
+                    {
+                        // override the span name that was previously set to the path part of URL.
+                        span.UpdateName(template);
+
+                        span.PutHttpRouteAttribute(template);
+                    }
+
+                    // TODO: Should we get values from RouteData?
+                    // private readonly PropertyFetcher beforActionRouteDataFetcher = new PropertyFetcher("routeData");
+                    // var routeData = this.beforActionRouteDataFetcher.Fetch(payload) as RouteData;
                 }
-
-                // TODO: Should we get values from RouteData?
-                // private readonly PropertyFetcher beforActionRouteDataFetcher = new PropertyFetcher("routeData");
-                // var routeData = this.beforActionRouteDataFetcher.Fetch(payload) as RouteData;
             }
         }
 

--- a/src/OpenTelemetry.Collector.AspNetCore/RequestsCollector.cs
+++ b/src/OpenTelemetry.Collector.AspNetCore/RequestsCollector.cs
@@ -57,7 +57,7 @@ namespace OpenTelemetry.Collector.AspNetCore
                         AspNetCoreCollectorEventSource.Log.ExceptionInCustomSampler(e);
                     }
 
-                    return s == null ? sampler : s;
+                    return s ?? sampler;
                 });
             this.diagnosticSourceSubscriber.Subscribe();
         }

--- a/src/OpenTelemetry.Collector.Dependencies/DependenciesCollector.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/DependenciesCollector.cs
@@ -55,7 +55,7 @@ namespace OpenTelemetry.Collector.Dependencies
                         DependenciesCollectorEventSource.Log.ExceptionInCustomSampler(e);
                     }
 
-                    return s == null ? sampler : s;
+                    return s ?? sampler;
                     });
             this.diagnosticSourceSubscriber.Subscribe();
         }

--- a/src/OpenTelemetry.Collector.Dependencies/DependenciesCollectorEventSource.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/DependenciesCollectorEventSource.cs
@@ -38,16 +38,28 @@ namespace OpenTelemetry.Collector.Dependencies
             }
         }
 
-        [Event(1, Message = "Context is NULL in end callback. Span will not be recorded.", Level = EventLevel.Warning)]
-        public void NullContext()
+        [Event(1, Message = "Span is NULL or blank in the '{0}' callback. Span will not be recorded.", Level = EventLevel.Warning)]
+        public void NullOrBlankSpan(string eventName)
         {
-            this.WriteEvent(1);
+            this.WriteEvent(1, eventName);
         }
 
         [Event(2, Message = "Error getting custom sampler, the default sampler will be used. Exception : {0}", Level = EventLevel.Warning)]
         public void ExceptionInCustomSampler(string ex)
         {
             this.WriteEvent(2, ex);
+        }
+
+        [Event(3, Message = "Current Activity is NULL the '{0}' callback. Span will not be recorded.", Level = EventLevel.Warning)]
+        public void NullActivity(string eventName)
+        {
+            this.WriteEvent(3, eventName);
+        }
+
+        [Event(4, Message = "Unknown error processing event '{0}' from handler '{1}', Exception: {2}", Level = EventLevel.Error)]
+        public void UnknownErrorProcessingEvent(string handlerName, string eventName, Exception ex)
+        {
+            this.WriteEvent(4, handlerName, eventName, ToInvariantString(ex));
         }
 
         /// <summary>

--- a/src/OpenTelemetry.Collector.Dependencies/Implementation/OpenTelemetry.Collector.Dependencies.Common/DiagnosticSourceListener.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/Implementation/OpenTelemetry.Collector.Dependencies.Common/DiagnosticSourceListener.cs
@@ -22,12 +22,10 @@ namespace OpenTelemetry.Collector.Dependencies.Common
 
     internal class DiagnosticSourceListener : IObserver<KeyValuePair<string, object>>, IDisposable
     {
-        private readonly string sourceName;
         private readonly ListenerHandler handler;
 
-        public DiagnosticSourceListener(string sourceName, ListenerHandler handler)
+        public DiagnosticSourceListener(ListenerHandler handler)
         {
-            this.sourceName = sourceName;
             this.handler = handler;
         }
 
@@ -45,7 +43,7 @@ namespace OpenTelemetry.Collector.Dependencies.Common
         {
             if (Activity.Current == null)
             {
-                Debug.WriteLine("Activity is null " + value.Key);
+                DependenciesCollectorEventSource.Log.NullActivity(value.Key);
                 return;
             }
 
@@ -68,10 +66,9 @@ namespace OpenTelemetry.Collector.Dependencies.Common
                     this.handler.OnCustom(value.Key, Activity.Current, value.Value);
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                // Debug.WriteLine(e);
-                // TODO: make sure to output the handler name as part of error message
+                DependenciesCollectorEventSource.Log.UnknownErrorProcessingEvent(this.handler?.SourceName, value.Key, ex);
             }
         }
 

--- a/src/OpenTelemetry.Collector.Dependencies/Implementation/OpenTelemetry.Collector.Dependencies.Common/DiagnosticSourceSubscriber.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/Implementation/OpenTelemetry.Collector.Dependencies.Common/DiagnosticSourceSubscriber.cs
@@ -57,7 +57,7 @@ namespace OpenTelemetry.Collector.Dependencies.Common
                 {
                     this.subscriptions.GetOrAdd(value.Name, name =>
                     {
-                        var dl = new DiagnosticSourceListener(value.Name, this.handlers[value.Name](this.tracer, this.sampler));
+                        var dl = new DiagnosticSourceListener(this.handlers[value.Name](this.tracer, this.sampler));
                         dl.Subscription = value.Subscribe(dl);
                         return dl;
                     });

--- a/src/OpenTelemetry.Collector.Dependencies/Implementation/OpenTelemetry.Collector.Dependencies.Common/ListenerHandler.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/Implementation/OpenTelemetry.Collector.Dependencies.Common/ListenerHandler.cs
@@ -42,9 +42,9 @@ namespace OpenTelemetry.Collector.Dependencies.Common
         {
             var span = this.Tracer.CurrentSpan;
 
-            if (span == null)
+            if (span == null || span == BlankSpan.Instance)
             {
-                // TODO: Notify that span got lost
+                DependenciesCollectorEventSource.Log.NullOrBlankSpan("ListenerHandler.OnStopActivity");
                 return;
             }
 

--- a/src/OpenTelemetry/Trace/SpanBuilder.cs
+++ b/src/OpenTelemetry/Trace/SpanBuilder.cs
@@ -242,7 +242,7 @@ namespace OpenTelemetry.Trace
 
             var span = Span.StartSpan(
                         activityForSpan,
-                        childTracestate, // it is updated in CreateActivityForSpan, 
+                        childTracestate, 
                         this.kind,
                         activeTraceParams,
                         this.options.StartEndHandler,

--- a/src/OpenTelemetry/Trace/Tracer.cs
+++ b/src/OpenTelemetry/Trace/Tracer.cs
@@ -17,6 +17,7 @@
 namespace OpenTelemetry.Trace
 {
     using System;
+    using System.Diagnostics;
     using System.Threading;
     using OpenTelemetry.Context;
     using OpenTelemetry.Context.Propagation;
@@ -33,6 +34,12 @@ namespace OpenTelemetry.Trace
 
         private readonly SpanBuilderOptions spanBuilderOptions;
         private readonly SpanExporter spanExporter;
+
+        static Tracer()
+        {
+            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+            Activity.ForceDefaultIdFormat = true;
+        }
 
         /// <summary>
         /// Creates an instance of <see cref="ITracer"/>.

--- a/test/OpenTelemetry.Collector.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Collector.AspNetCore.Tests/BasicTests.cs
@@ -23,7 +23,6 @@ namespace OpenTelemetry.Collector.AspNetCore.Tests
     using Microsoft.Extensions.DependencyInjection;
     using OpenTelemetry.Trace;
     using OpenTelemetry.Trace.Config;
-    using OpenTelemetry.Trace.Internal;
     using Moq;
     using Microsoft.AspNetCore.TestHost;
     using System;
@@ -41,11 +40,10 @@ namespace OpenTelemetry.Collector.AspNetCore.Tests
         public BasicTests(WebApplicationFactory<Startup> factory)
         {
             this.factory = factory;
-            
         }
 
         [Fact]
-        public async Task SuccesfulTemplateControllerCallGeneratesASpan()
+        public async Task SuccessfulTemplateControllerCallGeneratesASpan()
         {
             var startEndHandler = new Mock<IStartEndHandler>();
             var tracer = new Tracer(startEndHandler.Object, new TraceConfig());
@@ -89,7 +87,7 @@ namespace OpenTelemetry.Collector.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task SuccesfulTemplateControllerCallUsesParentContext()
+        public async Task SuccessfulTemplateControllerCallUsesParentContext()
         {
             var startEndHandler = new Mock<IStartEndHandler>();
 

--- a/test/OpenTelemetry.Collector.Dependencies.Tests/HttpClientTests.cs
+++ b/test/OpenTelemetry.Collector.Dependencies.Tests/HttpClientTests.cs
@@ -87,7 +87,7 @@ namespace OpenTelemetry.Collector.Dependencies.Tests
 
         [Theory]
         [MemberData(nameof(TestData))]
-        public async Task HttpOutCallsAreCollectedSuccesfullyAsync(HttpOutTestCase tc)
+        public async Task HttpOutCallsAreCollectedSuccessfullyAsync(HttpOutTestCase tc)
         {
             var serverLifeTime = TestServer.RunServer(
                 (ctx) =>
@@ -194,7 +194,7 @@ namespace OpenTelemetry.Collector.Dependencies.Tests
 ]
 ")));
 
-            var t = (Task)this.GetType().InvokeMember(nameof(HttpOutCallsAreCollectedSuccesfullyAsync), BindingFlags.InvokeMethod, null, this, getArgumentsFromTestCaseObject(input).First());
+            var t = (Task)this.GetType().InvokeMember(nameof(HttpOutCallsAreCollectedSuccessfullyAsync), BindingFlags.InvokeMethod, null, this, getArgumentsFromTestCaseObject(input).First());
             await t;
         }
 


### PR DESCRIPTION
- special treatment for .NET Core 3.0 (we'll need to set up test infra after 3.0 stable rolls out) - it supports W3C in ASP.NET Core and HttpClient
- Do not create child Activity for HttpClient
- Do not set attributes on non-recorded spans
- Do not instrument outgoing HttpRequests which have 'traceparent' already - something else instrumented them
- some minor test improvements

