### PR TITLE
Better Assert (with error message) for timestamp range

### DIFF
--- a/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
@@ -699,8 +699,7 @@ namespace OpenTelemetry.Trace.Test
         private void AssertApproxSameTimestamp(DateTime one, DateTime two)
         {
             var timeShift = Math.Abs((one - two).TotalMilliseconds);
-            Assert.True(timeShift > 0);
-            Assert.True(timeShift < 10);
+            Assert.InRange(timeShift, double.Epsilon, 10);
         }
     }
 }


### PR DESCRIPTION
GoSpanData_EndedSpan test became flaky after timestamp changes, this PR only improves assert to generate error message and does nothing to fix the test

```Assert.True() Failure
Expected: True
Actual: False

Stack trace
   at OpenTelemetry.Trace.Test.SpanTest.AssertApproxSameTimestamp(DateTime one, DateTime two) in D:\a\1\s\test\OpenTelemetry.Tests\Impl\Trace\SpanTest.cs:line 703
   at OpenTelemetry.Trace.Test.SpanTest.<GoSpanData_EndedSpan>d__11.MoveNext() in D:\a\1\s\test\OpenTelemetry.Tests\Impl\Trace\SpanTest.cs:line 303
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
```

https://dev.azure.com/opentelemetry/pipelines/_test/analytics?definitionId=1&contextType=build