### PR TITLE
Dependency collector should not be http specific

### DIFF
--- a/src/OpenTelemetry.Collector.Dependencies/DependenciesCollector.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/DependenciesCollector.cs
@@ -39,7 +39,7 @@ namespace OpenTelemetry.Collector.Dependencies
         public DependenciesCollector(DependenciesCollectorOptions options, ITracer tracer, ISampler sampler)
         {
             this.diagnosticSourceSubscriber = new DiagnosticSourceSubscriber(
-                new Dictionary<string, Func<ITracer, Func<HttpRequestMessage, ISampler>, ListenerHandler>>()
+                new Dictionary<string, Func<ITracer, Func<object, ISampler>, ListenerHandler>>()
                 { { "HttpHandlerDiagnosticListener", (t, s) => new HttpHandlerDiagnosticListener(t, s) } },
                 tracer,
                 x =>

--- a/src/OpenTelemetry.Collector.Dependencies/DependenciesCollector.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/DependenciesCollector.cs
@@ -44,7 +44,7 @@ namespace OpenTelemetry.Collector.Dependencies
                     ["HttpHandlerDiagnosticListener"] = (t, s) => new HttpHandlerDiagnosticListener(t, s),
                 },
                 tracer,
-                options.CustomSampler ?? sampler);
+                sampler);
             this.diagnosticSourceSubscriber.Subscribe();
         }
 

--- a/src/OpenTelemetry.Collector.Dependencies/DependenciesCollector.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/DependenciesCollector.cs
@@ -35,28 +35,16 @@ namespace OpenTelemetry.Collector.Dependencies
         /// </summary>
         /// <param name="options">Configuration options for dependencies collector.</param>
         /// <param name="tracer">Tracer to record traced with.</param>
-        /// <param name="sampler">Sampler to use to sample dependnecy calls.</param>
+        /// <param name="sampler">Sampler to use to sample dependency calls.</param>
         public DependenciesCollector(DependenciesCollectorOptions options, ITracer tracer, ISampler sampler)
         {
             this.diagnosticSourceSubscriber = new DiagnosticSourceSubscriber(
-                new Dictionary<string, Func<ITracer, Func<object, ISampler>, ListenerHandler>>()
-                { { "HttpHandlerDiagnosticListener", (t, s) => new HttpHandlerDiagnosticListener(t, s) } },
-                tracer,
-                x =>
+                new Dictionary<string, Func<ITracer, ISampler, ListenerHandler>>
                 {
-                    ISampler s = null;
-                    try
-                    {
-                        s = options.CustomSampler(x);
-                    }
-                    catch (Exception e)
-                    {
-                        s = null;
-                        DependenciesCollectorEventSource.Log.ExceptionInCustomSampler(e);
-                    }
-
-                    return s ?? sampler;
-                    });
+                    ["HttpHandlerDiagnosticListener"] = (t, s) => new HttpHandlerDiagnosticListener(t, s),
+                },
+                tracer,
+                options.CustomSampler ?? sampler);
             this.diagnosticSourceSubscriber.Subscribe();
         }
 

--- a/src/OpenTelemetry.Collector.Dependencies/DependenciesCollectorOptions.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/DependenciesCollectorOptions.cs
@@ -16,11 +16,6 @@
 
 namespace OpenTelemetry.Collector.Dependencies
 {
-    using System;
-    using System.Net.Http;
-    using OpenTelemetry.Trace;
-    using OpenTelemetry.Trace.Sampler;
-
     /// <summary>
     /// Options for dependencies collector.
     /// </summary>
@@ -29,16 +24,8 @@ namespace OpenTelemetry.Collector.Dependencies
         /// <summary>
         /// Initializes a new instance of the <see cref="DependenciesCollectorOptions"/> class.
         /// </summary>
-        /// <param name="sampler">Custom sampling function, if any.</param>
-        public DependenciesCollectorOptions(ISampler sampler = null)
+        public DependenciesCollectorOptions()
         {
-            this.CustomSampler = sampler;
         }
-
-        /// <summary>
-        /// Gets a hook to exclude calls based on domain
-        /// or other per-request criterion.
-        /// </summary>
-        public ISampler CustomSampler { get; private set; }
     }
 }

--- a/src/OpenTelemetry.Collector.Dependencies/DependenciesCollectorOptions.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/DependenciesCollectorOptions.cs
@@ -26,32 +26,19 @@ namespace OpenTelemetry.Collector.Dependencies
     /// </summary>
     public class DependenciesCollectorOptions
     {
-        private static readonly Func<object, ISampler> DefaultSampler = (state) =>
-        {
-            // TODO we need list of known urls NOT to instrument see https://github.com/open-telemetry/opentelemetry-dotnet/issues/166
-            if (state is HttpRequestMessage request &&
-                request.RequestUri != null &&
-                request.RequestUri.ToString().Contains("zipkin.azurewebsites.net"))
-            {
-                return Samplers.NeverSample;
-            }
-
-            return null;
-        };
-
         /// <summary>
         /// Initializes a new instance of the <see cref="DependenciesCollectorOptions"/> class.
         /// </summary>
         /// <param name="sampler">Custom sampling function, if any.</param>
-        public DependenciesCollectorOptions(Func<object, ISampler> sampler = null)
+        public DependenciesCollectorOptions(ISampler sampler = null)
         {
-            this.CustomSampler = sampler ?? DefaultSampler;
+            this.CustomSampler = sampler;
         }
 
         /// <summary>
         /// Gets a hook to exclude calls based on domain
         /// or other per-request criterion.
         /// </summary>
-        public Func<object, ISampler> CustomSampler { get; private set; }
+        public ISampler CustomSampler { get; private set; }
     }
 }

--- a/src/OpenTelemetry.Collector.Dependencies/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/Implementation/HttpHandlerDiagnosticListener.cs
@@ -35,8 +35,8 @@ namespace OpenTelemetry.Collector.Dependencies.Implementation
         private readonly PropertyFetcher stopRequestStatusFetcher = new PropertyFetcher("RequestTaskStatus");
         private readonly bool httpClientSupportsW3C = false;
 
-        public HttpHandlerDiagnosticListener(ITracer tracer, Func<object, ISampler> samplerFactory)
-            : base("HttpHandlerDiagnosticListener", tracer, samplerFactory)
+        public HttpHandlerDiagnosticListener(ITracer tracer, ISampler sampler)
+            : base("HttpHandlerDiagnosticListener", tracer, sampler)
         {
             var framework = Assembly
                 .GetEntryAssembly()?
@@ -68,7 +68,7 @@ namespace OpenTelemetry.Collector.Dependencies.Implementation
 
             var span = this.Tracer.SpanBuilder(request.RequestUri.AbsolutePath)
                 .SetSpanKind(SpanKind.Client)
-                .SetSampler(this.SamplerFactory(request))
+                .SetSampler(this.Sampler)
                 .SetCreateChild(false)
                 .StartSpan();
 

--- a/src/OpenTelemetry.Collector.Dependencies/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/Implementation/HttpHandlerDiagnosticListener.cs
@@ -35,7 +35,7 @@ namespace OpenTelemetry.Collector.Dependencies.Implementation
         private readonly PropertyFetcher stopRequestStatusFetcher = new PropertyFetcher("RequestTaskStatus");
         private readonly bool httpClientSupportsW3C = false;
 
-        public HttpHandlerDiagnosticListener(ITracer tracer, Func<HttpRequestMessage, ISampler> samplerFactory)
+        public HttpHandlerDiagnosticListener(ITracer tracer, Func<object, ISampler> samplerFactory)
             : base("HttpHandlerDiagnosticListener", tracer, samplerFactory)
         {
             var framework = Assembly

--- a/src/OpenTelemetry.Collector.Dependencies/Implementation/OpenTelemetry.Collector.Dependencies.Common/DiagnosticSourceSubscriber.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/Implementation/OpenTelemetry.Collector.Dependencies.Common/DiagnosticSourceSubscriber.cs
@@ -26,14 +26,14 @@ namespace OpenTelemetry.Collector.Dependencies.Common
 
     internal class DiagnosticSourceSubscriber : IDisposable, IObserver<DiagnosticListener>
     {
-        private readonly Dictionary<string, Func<ITracer, Func<HttpRequestMessage, ISampler>, ListenerHandler>> handlers;
+        private readonly Dictionary<string, Func<ITracer, Func<object, ISampler>, ListenerHandler>> handlers;
         private readonly ITracer tracer;
-        private readonly Func<HttpRequestMessage, ISampler> sampler;
+        private readonly Func<object, ISampler> sampler;
         private ConcurrentDictionary<string, DiagnosticSourceListener> subscriptions;
         private bool disposing;
         private IDisposable subscription;
 
-        public DiagnosticSourceSubscriber(Dictionary<string, Func<ITracer, Func<HttpRequestMessage, ISampler>, ListenerHandler>> handlers, ITracer tracer, Func<HttpRequestMessage, ISampler> sampler)
+        public DiagnosticSourceSubscriber(Dictionary<string, Func<ITracer, Func<object, ISampler>, ListenerHandler>> handlers, ITracer tracer, Func<object, ISampler> sampler)
         {
             this.subscriptions = new ConcurrentDictionary<string, DiagnosticSourceListener>();
             this.handlers = handlers;

--- a/src/OpenTelemetry.Collector.Dependencies/Implementation/OpenTelemetry.Collector.Dependencies.Common/DiagnosticSourceSubscriber.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/Implementation/OpenTelemetry.Collector.Dependencies.Common/DiagnosticSourceSubscriber.cs
@@ -26,14 +26,14 @@ namespace OpenTelemetry.Collector.Dependencies.Common
 
     internal class DiagnosticSourceSubscriber : IDisposable, IObserver<DiagnosticListener>
     {
-        private readonly Dictionary<string, Func<ITracer, Func<object, ISampler>, ListenerHandler>> handlers;
+        private readonly Dictionary<string, Func<ITracer, ISampler, ListenerHandler>> handlers;
         private readonly ITracer tracer;
-        private readonly Func<object, ISampler> sampler;
+        private readonly ISampler sampler;
         private ConcurrentDictionary<string, DiagnosticSourceListener> subscriptions;
         private bool disposing;
         private IDisposable subscription;
 
-        public DiagnosticSourceSubscriber(Dictionary<string, Func<ITracer, Func<object, ISampler>, ListenerHandler>> handlers, ITracer tracer, Func<object, ISampler> sampler)
+        public DiagnosticSourceSubscriber(Dictionary<string, Func<ITracer, ISampler, ListenerHandler>> handlers, ITracer tracer, ISampler sampler)
         {
             this.subscriptions = new ConcurrentDictionary<string, DiagnosticSourceListener>();
             this.handlers = handlers;

--- a/src/OpenTelemetry.Collector.Dependencies/Implementation/OpenTelemetry.Collector.Dependencies.Common/ListenerHandler.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/Implementation/OpenTelemetry.Collector.Dependencies.Common/ListenerHandler.cs
@@ -25,9 +25,9 @@ namespace OpenTelemetry.Collector.Dependencies.Common
     {
         protected readonly ITracer Tracer;
 
-        protected readonly Func<HttpRequestMessage, ISampler> SamplerFactory;
+        protected readonly Func<object, ISampler> SamplerFactory;
 
-        public ListenerHandler(string sourceName, ITracer tracer, Func<HttpRequestMessage, ISampler> samplerFactory)
+        public ListenerHandler(string sourceName, ITracer tracer, Func<object, ISampler> samplerFactory)
         {
             this.SourceName = sourceName;
             this.Tracer = tracer;

--- a/src/OpenTelemetry.Collector.Dependencies/Implementation/OpenTelemetry.Collector.Dependencies.Common/ListenerHandler.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/Implementation/OpenTelemetry.Collector.Dependencies.Common/ListenerHandler.cs
@@ -25,13 +25,13 @@ namespace OpenTelemetry.Collector.Dependencies.Common
     {
         protected readonly ITracer Tracer;
 
-        protected readonly Func<object, ISampler> SamplerFactory;
+        protected readonly ISampler Sampler;
 
-        public ListenerHandler(string sourceName, ITracer tracer, Func<object, ISampler> samplerFactory)
+        public ListenerHandler(string sourceName, ITracer tracer, ISampler sampler)
         {
             this.SourceName = sourceName;
             this.Tracer = tracer;
-            this.SamplerFactory = samplerFactory;
+            this.Sampler = sampler;
         }
 
         public string SourceName { get; }


### PR DESCRIPTION
Today DependenciesCollector uses sampler factory like Func<HttpRequestMessage, ISampler>. The goal is to sample out all calls to internal endpoints.

This is not the right way to do it - the proper way is through DiagnosticSource.IsEnabled callback. 

If we use sampler for it, we should create builder, span and do a lot of things before we can discard call that we do want not track.

So this mechanism now requires every custom listener to work with Http message and it must change in future. 
I'm removing it now and we'll address url filtering in #166 using DiagnostiSource.IsEnabled.