### PR TITLE
Multiple calls to DiagnosticSourceSubscriber::Dispose would throw nullrefs

### DIFF
--- a/src/OpenTelemetry.Collector.AspNetCore/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Collector.AspNetCore/AssemblyInfo.cs
@@ -13,3 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("OpenTelemetry.Collector.AspNetCore.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010051c1562a090fb0c9f391012a32198b5e5d9a60e9b80fa2d7b434c9e5ccb7259bd606e66f9660676afc6692b8cdc6793d190904551d2103b7b22fa636dcbb8208839785ba402ea08fc00c8f1500ccef28bbf599aa64ffb1e1d5dc1bf3420a3777badfe697856e9d52070a50c3ea5821c80bef17ca3acffa28f89dd413f096f898")]

--- a/src/OpenTelemetry.Collector.AspNetCore/Implementation/OpenTelemetry.Collector.AspNetCore.Common/DiagnosticSourceSubscriber.cs
+++ b/src/OpenTelemetry.Collector.AspNetCore/Implementation/OpenTelemetry.Collector.AspNetCore.Common/DiagnosticSourceSubscriber.cs
@@ -30,15 +30,15 @@ namespace OpenTelemetry.Collector.AspNetCore.Common
         private readonly ITracer tracer;
         private readonly Func<HttpRequest, ISampler> sampler;
         private ConcurrentDictionary<string, DiagnosticSourceListener> subscriptions;
-        private bool disposing;
+        private long disposed;
         private IDisposable subscription;
 
         public DiagnosticSourceSubscriber(Dictionary<string, Func<ITracer, Func<HttpRequest, ISampler>, ListenerHandler>> handlers, ITracer tracer, Func<HttpRequest, ISampler> sampler)
         {
             this.subscriptions = new ConcurrentDictionary<string, DiagnosticSourceListener>();
-            this.handlers = handlers;
-            this.tracer = tracer;
-            this.sampler = sampler;
+            this.handlers = handlers ?? throw new ArgumentNullException(nameof(handlers));
+            this.tracer = tracer ?? throw new ArgumentNullException(nameof(tracer));
+            this.sampler = sampler ?? throw new ArgumentNullException(nameof(sampler));
         }
 
         public void Subscribe()
@@ -51,7 +51,7 @@ namespace OpenTelemetry.Collector.AspNetCore.Common
 
         public void OnNext(DiagnosticListener value)
         {
-            if (!Volatile.Read(ref this.disposing) && this.subscriptions != null)
+            if ((Interlocked.Read(ref this.disposed) == 0) && this.subscriptions != null)
             {
                 if (this.handlers.ContainsKey(value.Name))
                 {
@@ -75,7 +75,10 @@ namespace OpenTelemetry.Collector.AspNetCore.Common
 
         public void Dispose()
         {
-            Volatile.Write(ref this.disposing, true);
+            if (Interlocked.CompareExchange(ref this.disposed, 1, 0) == 1)
+            {
+                return;
+            }
 
             var subsCopy = this.subscriptions;
             this.subscriptions = null;

--- a/test/OpenTelemetry.Collector.AspNetCore.Tests/DiagnosticsSourceSubscriberTests.cs
+++ b/test/OpenTelemetry.Collector.AspNetCore.Tests/DiagnosticsSourceSubscriberTests.cs
@@ -1,0 +1,43 @@
+﻿// <copyright file="DiagnosticsSourceSubscriberTests.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Collector.AspNetCore.Tests
+{
+    using Xunit;
+    using OpenTelemetry.Collector.AspNetCore.Common;
+    using System.Collections.Generic;
+    using System;
+    using Moq;
+    using OpenTelemetry.Trace;
+
+    public class DiagnosticsSourceSubscriberTests
+    {
+        [Fact]
+        public void DisposeIsIdempotent()
+        {
+            var subject = new DiagnosticSourceSubscriber(
+                new Dictionary<string, Func<ITracer, Func<Microsoft.AspNetCore.Http.HttpRequest, ISampler>, ListenerHandler>>
+                {
+                    { "unused", (tracer, samplerFunc) => new Mock<ListenerHandler>().Object },
+                },
+                new Mock<ITracer>().Object,
+                request => new Mock<ISampler>().Object);
+
+            subject.Dispose();
+            subject.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
All Dispose methods should be idempotent.

- Switched the dispose flag check(s) from using Volatile to using Interlocked.CompareExchange and Interlocked.Read
- Add null checks to the arguments
- Added a simple unit test class for this internal class