### PR TITLE
Fix for https://github.com/open-telemetry/opentelemetry-dotnet/issues/175

### DIFF
--- a/lib/Thrift/Thrift.csproj
+++ b/lib/Thrift/Thrift.csproj
@@ -6,7 +6,8 @@
     <PackageIconUrl>https://opentelemetry.io/img/logos/opentelemetry-icon-color.png</PackageIconUrl>
     <PackageProjectUrl>https://OpenTelemetry.io</PackageProjectUrl>
     <PackageTags>Tracing;OpenTelemetry;Management;Monitoring;Jaeger;distributed-tracing</PackageTags>
-    <IsPackable>false</IsPackable>
+    <AssemblyName>OpenTelemetry.Thrift.VendoredThrift</AssemblyName>
+    <PackageId>OpenTelemetry.Thrift.VendoredThrift</PackageId>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">


### PR DESCRIPTION
Thrift library coflicts with already existing package in nuget. Jaeger authors rename it into 'Jaeger.Thrift.VendoredThrift' (https://github.com/jaegertracing/jaeger-client-csharp/blob/master/src/Thrift/netcore/Thrift/Thrift.csproj) . Solution was is rename opentelemetry variant assembly name and package to 'OpenTelemetry.Thrift.VendoredThrift' and it solve my problem