### PR TITLE
Extend the OpenTelemetry public API slightly to support the OpenTracing->OpenTelemetry shim.

### DIFF
--- a/samples/LoggingTracer/LoggingTracer/CurrentSpanUtils.cs
+++ b/samples/LoggingTracer/LoggingTracer/CurrentSpanUtils.cs
@@ -6,23 +6,24 @@
 
     public static class CurrentSpanUtils
     {
-        private static AsyncLocal<ISpan> asyncLocalContext = new AsyncLocal<ISpan>();
+        private static AsyncLocal<LoggingScope> asyncLocalContext = new AsyncLocal<LoggingScope>();
 
-        public static ISpan CurrentSpan => asyncLocalContext.Value;
+        public static IScope CurrentScope => asyncLocalContext.Value;
 
         public class LoggingScope : IScope
         {
-            private readonly ISpan origContext;
-            private readonly ISpan span;
+            private readonly LoggingScope origContext;
             private readonly bool endSpan;
 
             public LoggingScope(ISpan span, bool endSpan = true)
             {
-                this.span = span;
+                this.Span = span;
                 this.endSpan = endSpan;
                 this.origContext = CurrentSpanUtils.asyncLocalContext.Value;
-                CurrentSpanUtils.asyncLocalContext.Value = span;
+                CurrentSpanUtils.asyncLocalContext.Value = this;
             }
+
+            public ISpan Span { get; }
 
             public void Dispose()
             {
@@ -37,7 +38,7 @@
 
                 if (this.endSpan)
                 {
-                    this.span.End();
+                    this.Span.End();
                 }
             }
         }

--- a/samples/LoggingTracer/LoggingTracer/LoggingTracer.cs
+++ b/samples/LoggingTracer/LoggingTracer/LoggingTracer.cs
@@ -6,7 +6,9 @@
 
     public class LoggingTracer : ITracer
     {
-        public ISpan CurrentSpan => CurrentSpanUtils.CurrentSpan;
+        public ISpan CurrentSpan => this.CurrentScope.Span;
+
+        public IScope CurrentScope => CurrentSpanUtils.CurrentScope;
 
         public IBinaryFormat BinaryFormat => new LoggingBinaryFormat();
 
@@ -32,7 +34,9 @@
             return new LoggingSpanBuilder(spanName, spanKind, remoteParentSpanContext);
         }
 
-        public IScope WithSpan(ISpan span)
+        public IScope WithSpan(ISpan span) => this.WithSpan(span, true);
+
+        public IScope WithSpan(ISpan span, bool endOnDispose)
         {
             Logger.Log("Tracer.WithSpan");
             return new CurrentSpanUtils.LoggingScope(span);

--- a/src/OpenTelemetry.Abstractions/Context/IScope.cs
+++ b/src/OpenTelemetry.Abstractions/Context/IScope.cs
@@ -17,6 +17,7 @@
 namespace OpenTelemetry.Context
 {
     using System;
+    using OpenTelemetry.Trace;
 
     /// <summary>
     /// Scope marker. Used as a syntactic sugar in methods like StartScopedSpan so it can be
@@ -24,5 +25,6 @@ namespace OpenTelemetry.Context
     /// </summary>
     public interface IScope : IDisposable
     {
+        ISpan Span { get; }
     }
 }

--- a/src/OpenTelemetry.Abstractions/Context/Propagation/ITextFormat.cs
+++ b/src/OpenTelemetry.Abstractions/Context/Propagation/ITextFormat.cs
@@ -22,7 +22,7 @@ namespace OpenTelemetry.Context.Propagation
 
     /// <summary>
     /// Text format wire context propagator. Helps to extract and inject context from textual
-    /// representation (typically http headers or metadata colleciton).
+    /// representation (typically http headers or metadata collection).
     /// </summary>
     public interface ITextFormat
     {

--- a/src/OpenTelemetry.Abstractions/Context/Propagation/TraceContextFormat.cs
+++ b/src/OpenTelemetry.Abstractions/Context/Propagation/TraceContextFormat.cs
@@ -54,7 +54,7 @@ namespace OpenTelemetry.Context.Propagation
                     return SpanContext.Blank;
                 }
 
-                var traceparent = traceparentCollection.First();
+                var traceparent = traceparentCollection?.First();
                 var traceparentParsed = this.TryExtractTraceparent(traceparent, out var traceId, out var spanId, out var traceoptions);
 
                 if (!traceparentParsed)

--- a/src/OpenTelemetry.Abstractions/OpenTelemetry.Abstractions.csproj
+++ b/src/OpenTelemetry.Abstractions/OpenTelemetry.Abstractions.csproj
@@ -9,8 +9,4 @@
   <ItemGroup>
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.6.0-preview7.19362.9" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Trace\Internal\" />
-  </ItemGroup>
 </Project>

--- a/src/OpenTelemetry.Abstractions/Tags/ITagContextBuilder.cs
+++ b/src/OpenTelemetry.Abstractions/Tags/ITagContextBuilder.cs
@@ -16,7 +16,7 @@
 
 namespace OpenTelemetry.Tags
 {
-    using OpenTelemetry.Context;
+    using System;
 
     /// <summary>
     /// Tags context builder.
@@ -48,6 +48,6 @@ namespace OpenTelemetry.Tags
         /// Builds tag context and save it as current.
         /// </summary>
         /// <returns>Scope control object. Dispose it to close a scope.</returns>
-        IScope BuildScoped();
+        IDisposable BuildScoped();
     }
 }

--- a/src/OpenTelemetry.Abstractions/Tags/ITagger.cs
+++ b/src/OpenTelemetry.Abstractions/Tags/ITagger.cs
@@ -16,7 +16,7 @@
 
 namespace OpenTelemetry.Tags
 {
-    using OpenTelemetry.Context;
+    using System;
 
     /// <summary>
     /// Tags API configuraiton.
@@ -50,7 +50,7 @@ namespace OpenTelemetry.Tags
         /// </summary>
         /// <param name="tags">Tags to set as current.</param>
         /// <returns>Scope object. Dispose to dissassociate tags context from the current context.</returns>
-        IScope WithTagContext(ITagContext tags);
+        IDisposable WithTagContext(ITagContext tags);
 
         /// <summary>
         /// Gets the builder from the tags context.

--- a/src/OpenTelemetry.Abstractions/Trace/ITracer.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/ITracer.cs
@@ -30,6 +30,11 @@ namespace OpenTelemetry.Trace
         ISpan CurrentSpan { get; }
 
         /// <summary>
+        /// Gets the current scope from the context.
+        /// </summary>
+        IScope CurrentScope { get; }
+
+        /// <summary>
         /// Gets the <see cref="IBinaryFormat"/> for this implementation.
         /// </summary>
         IBinaryFormat BinaryFormat { get; }
@@ -40,11 +45,19 @@ namespace OpenTelemetry.Trace
         ITextFormat TextFormat { get; }
 
         /// <summary>
-        /// Associates the span with the current context.
+        /// Associates the span with the current context. Shorthand for WithSpan(span, true).
         /// </summary>
         /// <param name="span">Span to associate with the current context.</param>
         /// <returns>Scope object to control span to current context association.</returns>
         IScope WithSpan(ISpan span);
+
+        /// <summary>
+        /// Associates the span with the current context.
+        /// </summary>
+        /// <param name="span">Span to associate with the current context.</param>
+        /// <param name="endOnDispose">If true, the span will end when the returned scope is disposed.</param>
+        /// <returns>Scope object to control span to current context association.</returns>
+        IScope WithSpan(ISpan span, bool endOnDispose);
 
         /// <summary>
         /// Gets the span builder for the span with the given name.

--- a/src/OpenTelemetry.Abstractions/Trace/NoopDisposable.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/NoopDisposable.cs
@@ -1,0 +1,40 @@
+﻿// <copyright file="NoopDisposable.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Trace
+{
+    using System;
+
+    /// <summary>
+    /// An implmentation of IDisposable that does nothing.
+    /// </summary>
+    public class NoopDisposable : IDisposable
+    {
+        /// <summary>
+        /// Prevents a default instance of the <see cref="NoopDisposable"/> class from being created.
+        /// </summary>
+        private NoopDisposable()
+        {
+        }
+
+        public static IDisposable Instance { get; } = new NoopDisposable();
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/OpenTelemetry.Abstractions/Trace/NoopScope.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/NoopScope.cs
@@ -32,6 +32,8 @@ namespace OpenTelemetry.Trace
         {
         }
 
+        public ISpan Span => BlankSpan.Instance;
+
         /// <inheritdoc />
         public void Dispose()
         {

--- a/src/OpenTelemetry.Abstractions/Trace/NoopTracer.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/NoopTracer.cs
@@ -35,7 +35,9 @@ namespace OpenTelemetry.Trace
         }
 
         /// <inheritdoc/>
-        public ISpan CurrentSpan => BlankSpan.Instance;
+        public ISpan CurrentSpan => this.CurrentScope.Span;
+
+        public IScope CurrentScope => NoopScope.Instance;
 
         /// <inheritdoc/>
         public IBinaryFormat BinaryFormat => new BinaryFormat();
@@ -44,10 +46,10 @@ namespace OpenTelemetry.Trace
         public ITextFormat TextFormat => new TraceContextFormat();
 
         /// <inheritdoc/>
-        public IScope WithSpan(ISpan span)
-        {
-            return NoopScope.Instance;
-        }
+        public IScope WithSpan(ISpan span) => this.WithSpan(span, true);
+
+                /// <inheritdoc/>
+        public IScope WithSpan(ISpan span, bool endOnDispose) => NoopScope.Instance;
 
         /// <inheritdoc/>
         public ISpanBuilder SpanBuilder(string spanName)

--- a/src/OpenTelemetry/Tags/CurrentTagContextUtils.cs
+++ b/src/OpenTelemetry/Tags/CurrentTagContextUtils.cs
@@ -16,6 +16,7 @@
 
 namespace OpenTelemetry.Tags
 {
+    using System;
     using OpenTelemetry.Context;
     using OpenTelemetry.Tags.Unsafe;
 
@@ -26,12 +27,12 @@ namespace OpenTelemetry.Tags
             get { return AsyncLocalContext.CurrentTagContext; }
         }
 
-        internal static IScope WithTagContext(ITagContext tags)
+        internal static IDisposable WithTagContext(ITagContext tags)
         {
             return new WithTagContextScope(tags);
         }
 
-        private sealed class WithTagContextScope : IScope
+        private sealed class WithTagContextScope : IDisposable
         {
             private readonly ITagContext origContext;
 

--- a/src/OpenTelemetry/Tags/NoopTagContextBuilder.cs
+++ b/src/OpenTelemetry/Tags/NoopTagContextBuilder.cs
@@ -58,9 +58,9 @@ namespace OpenTelemetry.Tags
             return NoopTagContext.Instance;
         }
 
-        public override IScope BuildScoped()
+        public override IDisposable BuildScoped()
         {
-            return NoopScope.Instance;
+            return NoopDisposable.Instance;
         }
     }
 }

--- a/src/OpenTelemetry/Tags/NoopTagger.cs
+++ b/src/OpenTelemetry/Tags/NoopTagger.cs
@@ -66,14 +66,14 @@ namespace OpenTelemetry.Tags
             return NoopTags.NoopTagContextBuilder;
         }
 
-        public override IScope WithTagContext(ITagContext tags)
+        public override IDisposable WithTagContext(ITagContext tags)
         {
             if (tags == null)
             {
                 throw new ArgumentNullException(nameof(tags));
             }
 
-            return NoopScope.Instance;
+            return NoopDisposable.Instance;
         }
     }
 }

--- a/src/OpenTelemetry/Tags/TagContextBuilder.cs
+++ b/src/OpenTelemetry/Tags/TagContextBuilder.cs
@@ -65,7 +65,7 @@ namespace OpenTelemetry.Tags
             return new TagContext(this.Tags);
         }
 
-        public override IScope BuildScoped()
+        public override IDisposable BuildScoped()
         {
             return CurrentTagContextUtils.WithTagContext(this.Build());
         }

--- a/src/OpenTelemetry/Tags/TagContextBuilderBase.cs
+++ b/src/OpenTelemetry/Tags/TagContextBuilderBase.cs
@@ -16,13 +16,13 @@
 
 namespace OpenTelemetry.Tags
 {
-    using OpenTelemetry.Context;
+    using System;
 
     public abstract class TagContextBuilderBase : ITagContextBuilder
     {
         public abstract ITagContext Build();
 
-        public abstract IScope BuildScoped();
+        public abstract IDisposable BuildScoped();
 
         public abstract ITagContextBuilder Put(TagKey key, TagValue value);
 

--- a/src/OpenTelemetry/Tags/Tagger.cs
+++ b/src/OpenTelemetry/Tags/Tagger.cs
@@ -16,7 +16,7 @@
 
 namespace OpenTelemetry.Tags
 {
-    using OpenTelemetry.Context;
+    using System;
     using OpenTelemetry.Trace;
 
     public sealed class Tagger : TaggerBase
@@ -70,10 +70,10 @@ namespace OpenTelemetry.Tags
                 : ToTagContextBuilder(tags);
         }
 
-        public override IScope WithTagContext(ITagContext tags)
+        public override IDisposable WithTagContext(ITagContext tags)
         {
             return this.state.Internal == TaggingState.DISABLED
-                ? NoopScope.Instance
+                ? NoopDisposable.Instance
                 : CurrentTagContextUtils.WithTagContext(ToTagContext(tags));
         }
 

--- a/src/OpenTelemetry/Tags/TaggerBase.cs
+++ b/src/OpenTelemetry/Tags/TaggerBase.cs
@@ -16,7 +16,7 @@
 
 namespace OpenTelemetry.Tags
 {
-    using OpenTelemetry.Context;
+    using System;
 
     public abstract class TaggerBase : ITagger
     {
@@ -30,6 +30,6 @@ namespace OpenTelemetry.Tags
 
         public abstract ITagContextBuilder ToBuilder(ITagContext tags);
 
-        public abstract IScope WithTagContext(ITagContext tags);
+        public abstract IDisposable WithTagContext(ITagContext tags);
     }
 }

--- a/src/OpenTelemetry/Trace/NoopDisposable.cs
+++ b/src/OpenTelemetry/Trace/NoopDisposable.cs
@@ -21,7 +21,7 @@ namespace OpenTelemetry.Trace
     /// <summary>
     /// An implmentation of IDisposable that does nothing.
     /// </summary>
-    public class NoopDisposable : IDisposable
+    internal class NoopDisposable : IDisposable
     {
         /// <summary>
         /// Prevents a default instance of the <see cref="NoopDisposable"/> class from being created.

--- a/src/OpenTelemetry/Trace/Tracer.cs
+++ b/src/OpenTelemetry/Trace/Tracer.cs
@@ -68,7 +68,9 @@ namespace OpenTelemetry.Trace
         }
 
         /// <inheritdoc/>
-        public ISpan CurrentSpan => CurrentSpanUtils.CurrentSpan;
+        public ISpan CurrentSpan => this.CurrentScope.Span;
+
+        public IScope CurrentScope => CurrentSpanUtils.CurrentScope;
 
         /// <inheritdoc/>
         public IBinaryFormat BinaryFormat { get; }
@@ -88,14 +90,18 @@ namespace OpenTelemetry.Trace
             return new SpanBuilder(spanName, this.spanBuilderOptions);
         }
 
-        public IScope WithSpan(ISpan span)
+        /// <inheritdoc/>
+        public IScope WithSpan(ISpan span) => this.WithSpan(span, true);
+
+        /// <inheritdoc/>
+        public IScope WithSpan(ISpan span, bool finishOnDispose)
         {
             if (span == null)
             {
                 throw new ArgumentNullException(nameof(span));
             }
 
-            return CurrentSpanUtils.WithSpan(span, true);
+            return CurrentSpanUtils.WithSpan(span, finishOnDispose);
         }
     }
 }

--- a/test/OpenTelemetry.Tests/Impl/Tags/NoopTagsTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/NoopTagsTest.cs
@@ -41,7 +41,7 @@ namespace OpenTelemetry.Tags.Test
             Assert.Same(NoopTags.NoopTagContextBuilder, noopTagger.EmptyBuilder);
             Assert.Same(NoopTags.NoopTagContextBuilder, noopTagger.ToBuilder(TAG_CONTEXT));
             Assert.Same(NoopTags.NoopTagContextBuilder, noopTagger.CurrentBuilder);
-            Assert.Same(NoopScope.Instance, noopTagger.WithTagContext(TAG_CONTEXT));
+            Assert.Same(NoopDisposable.Instance, noopTagger.WithTagContext(TAG_CONTEXT));
         }
 
         [Fact]
@@ -63,8 +63,8 @@ namespace OpenTelemetry.Tags.Test
         {
             Assert.Same(NoopTags.NoopTagContext, NoopTags.NoopTagContextBuilder.Build());
             Assert.Same(NoopTags.NoopTagContext, NoopTags.NoopTagContextBuilder.Put(KEY, VALUE).Build());
-            Assert.Same(NoopScope.Instance, NoopTags.NoopTagContextBuilder.BuildScoped());
-            Assert.Same(NoopScope.Instance, NoopTags.NoopTagContextBuilder.Put(KEY, VALUE).BuildScoped());
+            Assert.Same(NoopDisposable.Instance, NoopTags.NoopTagContextBuilder.BuildScoped());
+            Assert.Same(NoopDisposable.Instance, NoopTags.NoopTagContextBuilder.Put(KEY, VALUE).BuildScoped());
         }
 
         [Fact]


### PR DESCRIPTION
To support the OpenTracing->OpenTelemetry shim we not only need access to the active Span, we also need to be able to clean it up. In OpenTelemetry, you need to call WithSpan to set the current Span as active. That API method returns an implementation of IScope which, if stored away, **could** be used to clean up the current Span. IScope doesn't expose the Span however, which means that some kind of housekeeping between the current span and this saved IScope instance would have to be done. I don't want to introduce any additional Span/Scope housekeeping in a shim layer. So, I am proposing we extend the public OpenTelemetry API to better align with the current OpenTracing usage patterns.

- Add ISpan property to IScope  
  This will get us the Span->Scope correlation that we are missing

- Add CurrentScope to ITracer  
  This will get us the current scope (and also the current Span)

Supports:
https://github.com/open-telemetry/opentelemetry-dotnet/issues/28