### PR TITLE
Don't reference Thrift as NuGet package from the Jaeger exporter.

### DIFF
--- a/src/OpenTelemetry.Exporter.Jaeger/OpenTelemetry.Exporter.Jaeger.csproj
+++ b/src/OpenTelemetry.Exporter.Jaeger/OpenTelemetry.Exporter.Jaeger.csproj
@@ -10,6 +10,16 @@
 
   <ItemGroup>
     <ProjectReference Include="..\OpenTelemetry.Abstractions\OpenTelemetry.Abstractions.csproj" />
-    <ProjectReference Include="..\..\lib\Thrift\Thrift.csproj" />
+    <ProjectReference Include="..\..\lib\Thrift\Thrift.csproj" PrivateAssets="All" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);GetMyPackageFiles</TargetsForTfmSpecificBuildOutput>
+  </PropertyGroup>
+
+  <Target Name="GetMyPackageFiles">
+    <ItemGroup>
+      <BuildOutputInPackage Include="$(OutputPath)Thrift.dll" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
Include Thrift.dll in the lib directory of the export package.

Fixes:
https://github.com/open-telemetry/opentelemetry-dotnet/issues/175

See https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#project-to-project-references for a description of these MSBuild items.

Here is the generated .nuspec file for the Jaeger exporter now.

```xml

<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <id>OpenTelemetry.Exporter.Jaeger</id>
    <version>0.2.0-alpha.16</version>
    <authors>OpenTelemetry authors</authors>
    <owners>OpenTelemetry authors</owners>
    <requireLicenseAcceptance>true</requireLicenseAcceptance>
    <license type="expression">Apache-2.0</license>
    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
    <projectUrl>https://opentelemetry.io/</projectUrl>
    <iconUrl>https://opentelemetry.io/img/logos/opentelemetry-icon-color.png</iconUrl>
    <description>Package Description</description>
    <tags>Tracing OpenTelemetry Management Monitoring Jaeger distributed-tracing</tags>
    <repository type="git" url="https://github.com/pcwiese/opentelemetry-dotnet.git" commit="5c5f2fc191c8a5b1a5b419bbe2b530fee1a567f4" />
    <dependencies>
      <group targetFramework=".NETFramework4.6">
        <dependency id="OpenTelemetry.Abstractions" version="0.2.0-alpha.16" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard2.0">
        <dependency id="OpenTelemetry.Abstractions" version="0.2.0-alpha.16" exclude="Build,Analyzers" />
      </group>
    </dependencies>
  </metadata>
  <files>
    <file src="bin\Debug\net46\Thrift.dll" target="lib\net46\Thrift.dll" />
    <file src="Z:\src\opentelemetry-dotnet\src\OpenTelemetry.Exporter.Jaeger\bin\Debug\net46\OpenTelemetry.Exporter.Jaeger.dll" target="lib\net46\OpenTelemetry.Exporter.Jaeger.dll" />
    <file src="Z:\src\opentelemetry-dotnet\src\OpenTelemetry.Exporter.Jaeger\bin\Debug\net46\OpenTelemetry.Exporter.Jaeger.xml" target="lib\net46\OpenTelemetry.Exporter.Jaeger.xml" />
    <file src="bin\Debug\netstandard2.0\Thrift.dll" target="lib\netstandard2.0\Thrift.dll" />
    <file src="Z:\src\opentelemetry-dotnet\src\OpenTelemetry.Exporter.Jaeger\bin\Debug\netstandard2.0\OpenTelemetry.Exporter.Jaeger.dll" target="lib\netstandard2.0\OpenTelemetry.Exporter.Jaeger.dll" />
    <file src="Z:\src\opentelemetry-dotnet\src\OpenTelemetry.Exporter.Jaeger\bin\Debug\netstandard2.0\OpenTelemetry.Exporter.Jaeger.xml" target="lib\netstandard2.0\OpenTelemetry.Exporter.Jaeger.xml" />
  </files>
</package>

```

I tried the package locally and it functions.