### PR TITLE
ref: cleanup sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -292,6 +292,9 @@ paket-files/
 .idea/
 *.sln.iml
 
+# macOS
+.DS_Store
+
 # CodeRush
 .cr/
 

--- a/samples/LoggingTracer/LoggingTracer.Demo.AspNetCore/LoggingTracer.Demo.AspNetCore.csproj
+++ b/samples/LoggingTracer/LoggingTracer.Demo.AspNetCore/LoggingTracer.Demo.AspNetCore.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
 
     <ProjectReference Include="..\..\..\src\OpenTelemetry.Abstractions\OpenTelemetry.Abstractions.csproj" />
 

--- a/samples/LoggingTracer/LoggingTracer.Demo.AspNetCore/LoggingTracerExtensions.cs
+++ b/samples/LoggingTracer/LoggingTracer.Demo.AspNetCore/LoggingTracerExtensions.cs
@@ -7,16 +7,17 @@
     using OpenTelemetry.Trace;
     using OpenTelemetry.Trace.Sampler;
 
-    static class LoggingTracerExtensions {
+    internal static class LoggingTracerExtensions
+    {
         internal static void AddLoggingTracer(this IServiceCollection services)
         {
-            services.AddSingleton<ITracer>(new global::LoggingTracer.LoggingTracer());
+            services.AddSingleton<ITracer, LoggingTracer>();
 
-            services.AddSingleton<ISampler>(Samplers.AlwaysSample);
-            services.AddSingleton<RequestsCollectorOptions>(new RequestsCollectorOptions());
+            services.AddSingleton(Samplers.AlwaysSample);
+            services.AddSingleton<RequestsCollectorOptions>();
             services.AddSingleton<RequestsCollector>();
 
-            services.AddSingleton<DependenciesCollectorOptions>(new DependenciesCollectorOptions());
+            services.AddSingleton<DependenciesCollectorOptions>();
             services.AddSingleton<DependenciesCollector>();
         }
 

--- a/samples/LoggingTracer/LoggingTracer.Demo.ConsoleApp/Program.cs
+++ b/samples/LoggingTracer/LoggingTracer.Demo.ConsoleApp/Program.cs
@@ -1,6 +1,5 @@
-﻿namespace LoggingTracer.ConsoleApp
+﻿namespace LoggingTracer.Demo.ConsoleApp
 {
-    using System.Threading;
     using System.Threading.Tasks;
     using OpenTelemetry.Trace;
 

--- a/samples/LoggingTracer/LoggingTracer/CurrentSpanUtils.cs
+++ b/samples/LoggingTracer/LoggingTracer/CurrentSpanUtils.cs
@@ -26,13 +26,13 @@
 
             public void Dispose()
             {
-                Logger.Log($"Scope.Dispose");
+                Logger.Log("Scope.Dispose");
                 var current = asyncLocalContext.Value;
                 asyncLocalContext.Value = this.origContext;
 
                 if (current != this.origContext)
                 {
-                    Logger.Log($"Scope.Dispose: current != this.origContext");
+                    Logger.Log("Scope.Dispose: current != this.origContext");
                 }
 
                 if (this.endSpan)

--- a/samples/LoggingTracer/LoggingTracer/Logger.cs
+++ b/samples/LoggingTracer/LoggingTracer/Logger.cs
@@ -7,24 +7,14 @@
     {
         private static DateTime startTime = DateTime.UtcNow;
 
-        static Logger()
-        {
-            PrintHeader();
-        }
+        static Logger() => PrintHeader();
 
-        public static void PrintHeader()
-        {
-            Console.WriteLine("MsSinceStart | ThreadId | API");
-        }
+        public static void PrintHeader() => Console.WriteLine("MsSinceStart | ThreadId | API");
 
         public static void Log(string s)
-        {
-            Console.WriteLine($"{MillisSinceStart(),12} | {Thread.CurrentThread.ManagedThreadId,8} | {s}");
-        }
+            => Console.WriteLine($"{MillisSinceStart(),12} | {Thread.CurrentThread.ManagedThreadId,8} | {s}");
 
         private static int MillisSinceStart()
-        {
-            return (int)DateTime.UtcNow.Subtract(startTime).TotalMilliseconds;
-        }
+            => (int)DateTime.UtcNow.Subtract(startTime).TotalMilliseconds;
     }
 }

--- a/samples/LoggingTracer/LoggingTracer/LoggingBinaryFormat.cs
+++ b/samples/LoggingTracer/LoggingTracer/LoggingBinaryFormat.cs
@@ -11,25 +11,23 @@
 
         public SpanContext Extract<T>(T carrier, Func<T, string, IEnumerable<string>> getter)
         {
-            Logger.Log($"LoggingBinaryFormat.Extract(...)");
+            Logger.Log("LoggingBinaryFormat.Extract(...)");
             return SpanContext.Blank;
         }
 
         public SpanContext FromByteArray(byte[] bytes)
         {
-            Logger.Log($"LoggingBinaryFormat.FromByteArray(...)");
+            Logger.Log("LoggingBinaryFormat.FromByteArray(...)");
             return SpanContext.Blank;
         }
 
         public void Inject<T>(SpanContext spanContext, T carrier, Action<T, string, string> setter)
-        {
-            Logger.Log($"LoggingBinaryFormat.Inject({spanContext}, ...)");
-        }
+            => Logger.Log($"LoggingBinaryFormat.Inject({spanContext}, ...)");
 
         public byte[] ToByteArray(SpanContext spanContext)
         {
             Logger.Log($"LoggingBinaryFormat.ToByteArray({spanContext})");
-            return new byte[0];
+            return Array.Empty<byte>();
         }
     }
 }

--- a/samples/LoggingTracer/LoggingTracer/LoggingSpan.cs
+++ b/samples/LoggingTracer/LoggingTracer/LoggingSpan.cs
@@ -5,6 +5,13 @@
 
     public class LoggingSpan : ISpan
     {
+        public LoggingSpan(string name, SpanKind kind)
+        {
+            Logger.Log($"Span.ctor({name}, {kind})");
+            this.Name = name;
+            this.Kind = kind;
+        }
+
         public string Name { get; set; }
 
         public SpanContext Context { get; set; }
@@ -17,67 +24,31 @@
 
         public bool IsRecordingEvents => true;
 
-        public LoggingSpan(string name, SpanKind kind)
-        {
-            Logger.Log($"Span.ctor({name}, {kind})");
-            this.Name = name;
-            this.Kind = kind;
-        }
-
-        public void AddEvent(string name)
-        {
-            Logger.Log($"Span.AddEvent({name})");
-        }
+        public void AddEvent(string name) => Logger.Log($"Span.AddEvent({name})");
 
         public void AddEvent(string name, IDictionary<string, object> attributes)
-        {
-            Logger.Log($"Span.AddEvent({name}, attributes: {attributes.Count})");
-        }
+            => Logger.Log($"Span.AddEvent({name}, attributes: {attributes.Count})");
 
-        public void AddEvent(IEvent newEvent)
-        {
-            Logger.Log($"Span.AddEvent({newEvent})");
-        }
+        public void AddEvent(IEvent newEvent) => Logger.Log($"Span.AddEvent({newEvent})");
 
-        public void AddLink(ILink link)
-        {
-            Logger.Log($"Span.AddLink({link})");
-        }
+        public void AddLink(ILink link) => Logger.Log($"Span.AddLink({link})");
 
-        public void End()
-        {
-            Logger.Log($"Span.End, Name: {this.Name}");
-        }
+        public void End() => Logger.Log($"Span.End, Name: {this.Name}");
 
-        public void SetAttribute(string key, object value)
-        {
-            Logger.Log($"Span.SetAttribute({key}, {value})");
-        }
+        public void SetAttribute(string key, object value) => this.LogSetAttribute(key, value);
 
-        public void SetAttribute(string key, string value)
-        {
-            Logger.Log($"Span.SetAttribute({key}, {value})");
-        }
+        public void SetAttribute(string key, string value) => this.LogSetAttribute(key, value);
 
-        public void SetAttribute(string key, long value)
-        {
-            Logger.Log($"Span.SetAttribute({key}, {value})");
-        }
+        public void SetAttribute(string key, long value) => this.LogSetAttribute(key, value);
 
-        public void SetAttribute(string key, double value)
-        {
-            Logger.Log($"Span.SetAttribute({key}, {value})");
-        }
+        public void SetAttribute(string key, double value) => this.LogSetAttribute(key, value);
 
-        public void SetAttribute(string key, bool value)
-        {
-            Logger.Log($"Span.SetAttribute({key}, {value})");
-        }
+        public void SetAttribute(string key, bool value) => this.LogSetAttribute(key, value);
 
         public void SetAttribute(KeyValuePair<string, object> keyValuePair)
         {
             Logger.Log($"Span.SetAttributes(attributes: {keyValuePair})");
-             this.SetAttribute(keyValuePair.Key, keyValuePair.Value);
+            this.SetAttribute(keyValuePair.Key, keyValuePair.Value);
         }
 
         public void UpdateName(string name)
@@ -85,5 +56,7 @@
             Logger.Log($"Span.UpdateName({name})");
             this.Name = name;
         }
+
+        private void LogSetAttribute(string key, object value) => Logger.Log($"Span.SetAttribute({key}, {value})");
     }
 }

--- a/samples/LoggingTracer/LoggingTracer/LoggingSpanBuilder.cs
+++ b/samples/LoggingTracer/LoggingTracer/LoggingSpanBuilder.cs
@@ -22,13 +22,15 @@
             this.span = new LoggingSpan(spanName, spanKind);
         }
 
-        public LoggingSpanBuilder(string spanName, SpanKind spanKind, ISpan parent) : this(spanName, spanKind)
+        public LoggingSpanBuilder(string spanName, SpanKind spanKind, ISpan parent)
+            : this(spanName, spanKind)
         {
             Logger.Log($"SpanBuilder.ctor({spanName}, {spanKind}, {parent})");
             this.parent = parent;
         }
 
-        public LoggingSpanBuilder(string spanName, SpanKind spanKind, SpanContext remoteParentSpanContext) : this(spanName, spanKind)
+        public LoggingSpanBuilder(string spanName, SpanKind spanKind, SpanContext remoteParentSpanContext)
+            : this(spanName, spanKind)
         {
             Logger.Log($"SpanBuilder.ctor({spanName}, {spanKind}, {remoteParentSpanContext})");
             this.remoteParentSpanContext = remoteParentSpanContext;
@@ -66,7 +68,7 @@
 
         public ISpanBuilder SetNoParent()
         {
-            Logger.Log($"SpanBuilder.SetNoParent()");
+            Logger.Log("SpanBuilder.SetNoParent()");
             return this;
         }
 
@@ -114,19 +116,19 @@
 
         public IScope StartScopedSpan()
         {
-            Logger.Log($"SpanBuilder.StartScopedSpan()");
+            Logger.Log("SpanBuilder.StartScopedSpan()");
             return new CurrentSpanUtils.LoggingScope(this.span);
         }
 
         public IScope StartScopedSpan(out ISpan currentSpan)
         {
-            Logger.Log($"SpanBuilder.StartScopedSpan()");
+            Logger.Log("SpanBuilder.StartScopedSpan()");
             return new CurrentSpanUtils.LoggingScope(currentSpan = this.span);
         }
 
         public ISpan StartSpan()
         {
-            Logger.Log($"SpanBuilder.StartSpan()");
+            Logger.Log("SpanBuilder.StartSpan()");
             return this.span;
         }
     }

--- a/samples/LoggingTracer/LoggingTracer/LoggingTextFormat.cs
+++ b/samples/LoggingTracer/LoggingTracer/LoggingTextFormat.cs
@@ -11,7 +11,7 @@
 
         public SpanContext Extract<T>(T carrier, Func<T, string, IEnumerable<string>> getter)
         {
-            Logger.Log($"LoggingTextFormat.Extract(...)");
+            Logger.Log("LoggingTextFormat.Extract(...)");
             return SpanContext.Blank;
         }
 

--- a/samples/LoggingTracer/LoggingTracer/LoggingTracer.cs
+++ b/samples/LoggingTracer/LoggingTracer/LoggingTracer.cs
@@ -12,10 +12,7 @@
 
         public ITextFormat TextFormat => new LoggingTextFormat();
 
-        public void RecordSpanData(SpanData span)
-        {
-            Logger.Log($"Tracer.RecordSpanData({span})");
-        }
+        public void RecordSpanData(SpanData span) => Logger.Log($"Tracer.RecordSpanData({span})");
 
         public ISpanBuilder SpanBuilder(string spanName)
         {
@@ -31,13 +28,13 @@
 
         public ISpanBuilder SpanBuilderWithParentContext(string spanName, SpanKind spanKind = SpanKind.Internal, SpanContext remoteParentSpanContext = null)
         {
-            Logger.Log($"Tracer.SpanBuilderWithRemoteParent");
+            Logger.Log("Tracer.SpanBuilderWithRemoteParent");
             return new LoggingSpanBuilder(spanName, spanKind, remoteParentSpanContext);
         }
 
         public IScope WithSpan(ISpan span)
         {
-            Logger.Log($"Tracer.WithSpan");
+            Logger.Log("Tracer.WithSpan");
             return new CurrentSpanUtils.LoggingScope(span);
         }
     }


### PR DESCRIPTION
The goal was:

* Get rid of warnings
* Remove unused dependencies
* Simplify DI setup
* Shorten code whenever possible (assuming it's OK to prefer `=>` over `{ }` when possible).