### PR TITLE
Initial implementation of the OpenTracing bridge.

### DIFF
--- a/src/OpenTelemetry.Abstractions/Context/Propagation/TraceContextFormat.cs
+++ b/src/OpenTelemetry.Abstractions/Context/Propagation/TraceContextFormat.cs
@@ -54,7 +54,7 @@ namespace OpenTelemetry.Context.Propagation
                     return SpanContext.Blank;
                 }
 
-                var traceparent = traceparentCollection.First();
+                var traceparent = traceparentCollection?.First();
                 var traceparentParsed = this.TryExtractTraceparent(traceparent, out var traceId, out var spanId, out var traceoptions);
 
                 if (!traceparentParsed)

--- a/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
@@ -1,0 +1,115 @@
+﻿// <copyright file="ScopeManagerShim.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Shims.OpenTracing
+{
+    using System;
+    using System.Runtime.CompilerServices;
+    using System.Threading;
+    using global::OpenTracing;
+
+    public sealed class ScopeManagerShim : IScopeManager
+    {
+        private static readonly ConditionalWeakTable<Trace.ISpan, global::OpenTracing.IScope> SpanScopeTable = new ConditionalWeakTable<Trace.ISpan, global::OpenTracing.IScope>();
+
+        private readonly Trace.ITracer tracer;
+
+#if DEBUG
+        private int spanScopeTableCount;
+#endif
+
+        public ScopeManagerShim(Trace.ITracer tracer)
+        {
+            this.tracer = tracer ?? throw new ArgumentNullException(nameof(tracer));
+        }
+
+#if DEBUG
+        public int SpanScopeTableCount => this.spanScopeTableCount;
+#endif
+
+        /// <inheritdoc/>
+        public global::OpenTracing.IScope Active
+        {
+            get
+            {
+                var currentSpan = this.tracer.CurrentSpan;
+                if (currentSpan == Trace.BlankSpan.Instance)
+                {
+                    return null;
+                }
+
+                if (SpanScopeTable.TryGetValue(currentSpan, out var openTracingScope))
+                {
+                    return openTracingScope;
+                }
+
+                return new ScopeAdapter(currentSpan);
+            }
+        }
+
+        /// <inheritdoc/>
+        public global::OpenTracing.IScope Activate(ISpan span, bool finishSpanOnDispose)
+        {
+            if (!(span is SpanShim shim))
+            {
+                throw new ArgumentException("span is not a valid SpanShim object");
+            }
+
+            var scope = this.tracer.WithSpan(shim.Span);
+
+            var adapter = new ScopeAdapter(
+                shim.Span,
+                () =>
+                {
+                    var removed = SpanScopeTable.Remove(shim.Span);
+#if DEBUG
+                    if (removed)
+                    {
+                        Interlocked.Decrement(ref this.spanScopeTableCount);
+                    }
+#endif
+                    scope.Dispose();
+                });
+
+            SpanScopeTable.Add(shim.Span, adapter);
+#if DEBUG
+            Interlocked.Increment(ref this.spanScopeTableCount);
+#endif
+
+            return adapter;
+        }
+
+        private class ScopeAdapter : global::OpenTracing.IScope
+        {
+            private readonly Action disposeAction;
+
+            public ScopeAdapter(Trace.ISpan span, Action disposeAction = null)
+            {
+                this.Span = new SpanShim(span);
+                this.disposeAction = disposeAction;
+            }
+
+            /// <inheritdoc/>
+            public ISpan Span { get; }
+
+            /// <inheritdoc/>
+            public void Dispose()
+            {
+                this.disposeAction?.Invoke();
+            }
+        }
+    }
+}

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
@@ -1,0 +1,359 @@
+﻿// <copyright file="SpanBuilderShim.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Shims.OpenTracing
+{
+    using System;
+    using System.Collections.Generic;
+    using global::OpenTracing;
+
+    /// <summary>
+    /// Adapts OpenTracing ISpanBuilder to an underlying OpenTelemetry ISpanBuilder.
+    /// </summary>
+    /// <remarks>Instances of this class are not thread-safe.</remarks>
+    /// <seealso cref="global::OpenTracing.ISpanBuilder" />
+    public sealed class SpanBuilderShim : ISpanBuilder
+    {
+        /// <summary>
+        /// The tracer.
+        /// </summary>
+        private readonly Trace.ITracer tracer;
+
+        /// <summary>
+        /// The span name.
+        /// </summary>
+        private readonly string spanName;
+
+        /// <summary>
+        /// The OpenTelemetry links. These correspond loosely to OpenTracing references.
+        /// </summary>
+        private readonly List<Trace.ILink> links = new List<Trace.ILink>();
+
+        /// <summary>
+        /// The OpenTelemetry attributes. These correspond to OpenTracing Tags.
+        /// </summary>
+        private readonly List<KeyValuePair<string, object>> attributes = new List<KeyValuePair<string, object>>();
+
+        /// <summary>
+        /// The set of operation names for System.Diagnostics.Activity based automatic collectors that indicate a root span.
+        /// </summary>
+        private readonly IList<string> rootOperationNamesForActivityBasedAutoCollectors = new List<string>
+        {
+            "Microsoft.AspNetCore.Hosting.HttpRequestIn",
+        };
+
+        /// <summary>
+        /// The parent as an ISpan, if any.
+        /// </summary>
+        private Trace.ISpan parentSpan;
+
+        /// <summary>
+        /// The parent as an SpanContext, if any.
+        /// </summary>
+        private Trace.SpanContext parentSpanContext;
+
+        private bool ignoreActiveSpan;
+
+        private Trace.SpanKind spanKind;
+
+        private bool error;
+
+        public SpanBuilderShim(Trace.ITracer tracer, string spanName, IList<string> rootOperationNamesForActivityBasedAutoCollectors = null)
+        {
+            this.tracer = tracer ?? throw new ArgumentNullException(nameof(tracer));
+            this.spanName = spanName ?? throw new ArgumentNullException(nameof(spanName));
+            this.ScopeManager = new ScopeManagerShim(this.tracer);
+            this.rootOperationNamesForActivityBasedAutoCollectors = rootOperationNamesForActivityBasedAutoCollectors ?? this.rootOperationNamesForActivityBasedAutoCollectors;
+        }
+
+        private global::OpenTracing.IScopeManager ScopeManager { get; }
+
+        private bool ParentSet => this.parentSpan != null || this.parentSpanContext != null;
+
+        /// <inheritdoc/>
+        public ISpanBuilder AsChildOf(ISpanContext parent)
+        {
+            if (parent == null)
+            {
+                return this;
+            }
+
+            return this.AddReference(global::OpenTracing.References.ChildOf, parent);
+        }
+
+        /// <inheritdoc/>
+        public ISpanBuilder AsChildOf(ISpan parent)
+        {
+            if (parent == null)
+            {
+                return this;
+            }
+
+            if (!this.ParentSet)
+            {
+                this.parentSpan = GetOpenTelemetrySpan(parent);
+                return this;
+            }
+
+            return this.AsChildOf(parent.Context);
+        }
+
+        /// <inheritdoc/>
+        public ISpanBuilder AddReference(string referenceType, ISpanContext referencedContext)
+        {
+            if (referencedContext == null)
+            {
+                return this;
+            }
+
+            if (referenceType is null)
+            {
+                throw new ArgumentNullException(nameof(referenceType));
+            }
+
+            // TODO There is no relation between OpenTracing.References (referenceType) and OpenTelemetry Link
+            var actualContext = GetOpenTelemetrySpanContext(referencedContext);
+            if (!this.ParentSet)
+            {
+                this.parentSpanContext = actualContext;
+                return this;
+            }
+            else
+            {
+                this.links.Add(Trace.Link.FromSpanContext(actualContext));
+            }
+
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ISpanBuilder IgnoreActiveSpan()
+        {
+            this.ignoreActiveSpan = true;
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ISpan Start()
+        {
+            var builder = this.tracer.SpanBuilder(this.spanName);
+
+            if (this.parentSpan == null && this.parentSpanContext == null && (this.tracer.CurrentSpan == null || this.tracer.CurrentSpan == Trace.BlankSpan.Instance))
+            {
+                // We need to know if we should inherit an existing Activity-based context or start a new one.
+                if (System.Diagnostics.Activity.Current != null && System.Diagnostics.Activity.Current.IdFormat == System.Diagnostics.ActivityIdFormat.W3C)
+                {
+                    var operationName = System.Diagnostics.Activity.Current.OperationName;
+                    if (this.rootOperationNamesForActivityBasedAutoCollectors.Contains(operationName))
+                    {
+                        builder.SetCreateChild(false);
+                    }
+                    else
+                    {
+                        builder.SetCreateChild(true);
+                    }
+                }
+            }
+            else if (this.parentSpan != null)
+            {
+                builder.SetParent(this.parentSpan);
+            }
+            else if (this.parentSpanContext != null)
+            {
+                builder.SetParent(this.parentSpanContext);
+            }
+
+            // If specified, this takes precedence and will clear a previously set parent.
+            if (this.ignoreActiveSpan)
+            {
+                builder.SetNoParent();
+            }
+
+            foreach (var link in this.links)
+            {
+                builder.AddLink(link);
+            }
+
+            if (this.spanKind != default)
+            {
+                builder.SetSpanKind(this.spanKind);
+            }
+
+            var span = builder.StartSpan();
+
+            foreach (var kvp in this.attributes)
+            {
+                span.SetAttribute(kvp);
+            }
+
+            if (this.error)
+            {
+                span.Status = Trace.Status.Unknown;
+            }
+
+            return new SpanShim(span);
+        }
+
+        /// <inheritdoc/>
+        public IScope StartActive() => this.StartActive(true);
+
+        /// <inheritdoc/>
+        public IScope StartActive(bool finishSpanOnDispose)
+        {
+            var span = this.Start();
+            return this.ScopeManager.Activate(span, finishSpanOnDispose);
+        }
+
+        /// <inheritdoc/>
+        public ISpanBuilder WithStartTimestamp(DateTimeOffset timestamp)
+        {
+            // TODO No explicit timestamp support.
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public ISpanBuilder WithTag(string key, string value)
+        {
+            // see https://opentracing.io/specification/conventions/ for special key handling.
+            if (global::OpenTracing.Tag.Tags.SpanKind.Key.Equals(key))
+            {
+                switch (value)
+                {
+                    case global::OpenTracing.Tag.Tags.SpanKindClient:
+                        this.spanKind = Trace.SpanKind.Client;
+                        break;
+                    case global::OpenTracing.Tag.Tags.SpanKindServer:
+                        this.spanKind = Trace.SpanKind.Server;
+                        break;
+                    case global::OpenTracing.Tag.Tags.SpanKindProducer:
+                        this.spanKind = Trace.SpanKind.Producer;
+                        break;
+                    case global::OpenTracing.Tag.Tags.SpanKindConsumer:
+                        this.spanKind = Trace.SpanKind.Consumer;
+                        break;
+                    default:
+                        this.spanKind = Trace.SpanKind.Internal;
+                        break;
+                }
+            }
+            else if (global::OpenTracing.Tag.Tags.Error.Key.Equals(key) && bool.TryParse(value, out var booleanValue))
+            {
+                this.error = booleanValue;
+            }
+            else
+            {
+                // Keys must be non-null.
+                // Null values => string.Empty.
+                if (key != null)
+                {
+                    this.attributes.Add(new KeyValuePair<string, object>(key, value ?? string.Empty));
+                }
+            }
+
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ISpanBuilder WithTag(string key, bool value)
+        {
+            if (global::OpenTracing.Tag.Tags.Error.Key.Equals(key))
+            {
+                this.error = value;
+            }
+            else
+            {
+                this.attributes.Add(new KeyValuePair<string, object>(key, value));
+            }
+
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ISpanBuilder WithTag(string key, int value)
+        {
+            this.attributes.Add(new KeyValuePair<string, object>(key, value));
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ISpanBuilder WithTag(string key, double value)
+        {
+            this.attributes.Add(new KeyValuePair<string, object>(key, value));
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ISpanBuilder WithTag(global::OpenTracing.Tag.BooleanTag tag, bool value)
+        {
+            return this.WithTag(tag.Key, value);
+        }
+
+        /// <inheritdoc/>
+        public ISpanBuilder WithTag(global::OpenTracing.Tag.IntOrStringTag tag, string value)
+        {
+            if (int.TryParse(value, out var result))
+            {
+                return this.WithTag(tag.Key, result);
+            }
+
+            return this.WithTag(tag.Key, value);
+        }
+
+        /// <inheritdoc/>
+        public ISpanBuilder WithTag(global::OpenTracing.Tag.IntTag tag, int value)
+        {
+            return this.WithTag(tag.Key, value);
+        }
+
+        /// <inheritdoc/>
+        public ISpanBuilder WithTag(global::OpenTracing.Tag.StringTag tag, string value)
+        {
+            return this.WithTag(tag.Key, value);
+        }
+
+        /// <summary>
+        /// Gets an implementation of OpenTelemetry ISpan from the OpenTracing ISpan.
+        /// </summary>
+        /// <param name="span">The span.</param>
+        /// <returns>an implementation of OpenTelemetry ISpan.</returns>
+        /// <exception cref="ArgumentException">span is not a valid SpanShim object.</exception>
+        private static Trace.ISpan GetOpenTelemetrySpan(ISpan span)
+        {
+            if (!(span is SpanShim shim))
+            {
+                throw new ArgumentException("span is not a valid SpanShim object");
+            }
+
+            return shim.Span;
+        }
+
+        /// <summary>
+        /// Gets the OpenTelemetry SpanContext.
+        /// </summary>
+        /// <param name="spanContext">The span context.</param>
+        /// <returns>the OpenTelemetry SpanContext.</returns>
+        /// <exception cref="ArgumentException">context is not a valid SpanContextShim object.</exception>
+        private static Trace.SpanContext GetOpenTelemetrySpanContext(ISpanContext spanContext)
+        {
+            if (!(spanContext is SpanContextShim shim))
+            {
+                throw new ArgumentException("context is not a valid SpanContextShim object");
+            }
+
+            return shim.SpanContext;
+        }
+    }
+}

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanContextShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanContextShim.cs
@@ -1,0 +1,45 @@
+﻿// <copyright file="SpanContextShim.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Shims.OpenTracing
+{
+    using System;
+    using System.Collections.Generic;
+    using global::OpenTracing;
+
+    public sealed class SpanContextShim : ISpanContext
+    {
+        public SpanContextShim(Trace.SpanContext spanContext)
+        {
+            this.SpanContext = spanContext ?? throw new ArgumentNullException(nameof(spanContext));
+        }
+
+        public Trace.SpanContext SpanContext { get; private set; }
+
+        /// <inheritdoc/>
+        public string TraceId => this.SpanContext.TraceId.ToString();
+
+        /// <inheritdoc/>
+        public string SpanId => this.SpanContext.SpanId.ToString();
+
+        /// <inheritdoc/>
+        public IEnumerable<KeyValuePair<string, string>> GetBaggageItems()
+        {
+            // TODO
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanShim.cs
@@ -1,0 +1,292 @@
+﻿// <copyright file="SpanShim.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Shims.OpenTracing
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using global::OpenTracing;
+
+    public sealed class SpanShim : ISpan
+    {
+        /// <summary>
+        /// The default event name if not specified.
+        /// </summary>
+        public const string DefaultEventName = "log";
+
+        private static readonly IReadOnlyCollection<Type> OpenTelemetrySupportedAttributeValueTypes = new List<Type>
+        {
+            typeof(string),
+            typeof(bool),
+            typeof(byte),
+            typeof(short),
+            typeof(int),
+            typeof(long),
+            typeof(float),
+            typeof(double),
+        };
+
+        private readonly SpanContextShim spanContextShim;
+
+        public SpanShim(Trace.ISpan span)
+        {
+            this.Span = span ?? throw new ArgumentNullException(nameof(span));
+
+            if (this.Span.Context == null)
+            {
+                throw new ArgumentNullException(nameof(this.Span.Context));
+            }
+
+            this.spanContextShim = new SpanContextShim(this.Span.Context);
+        }
+
+        public ISpanContext Context => this.spanContextShim;
+
+        public Trace.ISpan Span { get; private set; }
+
+        /// <inheritdoc/>
+        public void Finish()
+        {
+            this.Span.End();
+        }
+
+        /// <inheritdoc/>
+        public void Finish(DateTimeOffset finishTimestamp)
+        {
+            // TODO No way to add explicit timestamp.
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public string GetBaggageItem(string key)
+        {
+            if (key is null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            return this.Context.GetBaggageItems().FirstOrDefault(kvp => kvp.Key.Equals(key)).Value;
+        }
+
+        /// <inheritdoc/>
+        public ISpan Log(IEnumerable<KeyValuePair<string, object>> fields)
+        {
+            if (fields is null)
+            {
+                throw new ArgumentNullException(nameof(fields));
+            }
+
+            var payload = ConvertToEventPayload(fields);
+            if (payload.Item2.Any())
+            {
+                this.Span.AddEvent(payload.Item1, payload.Item2);
+                return this;
+            }
+            else
+            {
+                this.Span.AddEvent(payload.Item1);
+            }
+
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ISpan Log(DateTimeOffset timestamp, IEnumerable<KeyValuePair<string, object>> fields)
+        {
+            // TODO No way to add explicit timestamps to Span events.
+            return this.Log(fields);
+        }
+
+        /// <inheritdoc/>
+        public ISpan Log(string @event)
+        {
+            if (@event is null)
+            {
+                throw new ArgumentNullException(nameof(@event));
+            }
+
+            this.Span.AddEvent(@event);
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ISpan Log(DateTimeOffset timestamp, string @event)
+        {
+            // TODO No way to add explicit timestamps to Span events.
+            return this.Log(@event);
+        }
+
+        /// <inheritdoc/>
+        public ISpan SetBaggageItem(string key, string value)
+        {
+            if (key is null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            // TODO Revisit once DistributedContext is finalized
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public ISpan SetOperationName(string operationName)
+        {
+            if (operationName is null)
+            {
+                throw new ArgumentNullException(nameof(operationName));
+            }
+
+            this.Span.UpdateName(operationName);
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ISpan SetTag(string key, string value)
+        {
+            if (key is null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            this.Span.SetAttribute(key, value);
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ISpan SetTag(string key, bool value)
+        {
+            if (key is null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            // Special case the OpenTracing Error Tag
+            // see https://opentracing.io/specification/conventions/
+            if (global::OpenTracing.Tag.Tags.Error.Key.Equals(key))
+            {
+                this.Span.Status = value ? Trace.Status.Unknown : Trace.Status.Ok;
+            }
+            else
+            {
+                this.Span.SetAttribute(key, value);
+            }
+
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ISpan SetTag(string key, int value)
+        {
+            if (key is null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            this.Span.SetAttribute(key, value);
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ISpan SetTag(string key, double value)
+        {
+            if (key is null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            this.Span.SetAttribute(key, value);
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public ISpan SetTag(global::OpenTracing.Tag.BooleanTag tag, bool value)
+        {
+            return this.SetTag(tag?.Key, value);
+        }
+
+        /// <inheritdoc/>
+        public ISpan SetTag(global::OpenTracing.Tag.IntOrStringTag tag, string value)
+        {
+            if (int.TryParse(value, out var result))
+            {
+                return this.SetTag(tag?.Key, result);
+            }
+
+            return this.SetTag(tag?.Key, value);
+        }
+
+        /// <inheritdoc/>
+        public ISpan SetTag(global::OpenTracing.Tag.IntTag tag, int value)
+        {
+            return this.SetTag(tag?.Key, value);
+        }
+
+        /// <inheritdoc/>
+        public ISpan SetTag(global::OpenTracing.Tag.StringTag tag, string value)
+        {
+            return this.SetTag(tag?.Key, value);
+        }
+
+        /// <summary>
+        /// Constructs an OpenTelemetry event payload from an OpenTracing Log key/value map.
+        /// </summary>
+        /// <param name="fields">The fields.</param>
+        /// <returns>A 2-Tuple containing the event name and payload information.</returns>
+        private static Tuple<string, IDictionary<string, object>> ConvertToEventPayload(IEnumerable<KeyValuePair<string, object>> fields)
+        {
+            string eventName = null;
+            var attributes = new Dictionary<string, object>();
+
+            foreach (var field in fields)
+            {
+                // TODO verify null values are NOT allowed.
+                if (field.Value == null)
+                {
+                    continue;
+                }
+
+                // Duplicate keys must be ignored even though they appear to be allowed in OpenTracing.
+                if (attributes.ContainsKey(field.Key))
+                {
+                    continue;
+                }
+
+                if (eventName == null && field.Key.Equals(LogFields.Event) && field.Value is string value)
+                {
+                    // This is meant to be the event name
+                    eventName = value;
+
+                    // We don't want to add the event name as a separate attribute
+                    continue;
+                }
+
+                // Supported types are added directly, all other types are converted to strings.
+                if (OpenTelemetrySupportedAttributeValueTypes.Contains(field.Value.GetType()))
+                {
+                    attributes.Add(field.Key, field.Value);
+                }
+                else
+                {
+                    // TODO should we completely ignore unsupported types?
+                    attributes.Add(field.Key, field.Value.ToString());
+                }
+            }
+
+            return new Tuple<string, IDictionary<string, object>>(eventName ?? DefaultEventName, attributes);
+        }
+    }
+}

--- a/src/OpenTelemetry.Shims.OpenTracing/TracerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/TracerShim.cs
@@ -1,0 +1,122 @@
+﻿// <copyright file="TracerShim.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Shims.OpenTracing
+{
+    using System;
+    using System.Collections.Generic;
+    using global::OpenTracing.Propagation;
+    using OpenTelemetry.Trace;
+
+    public class TracerShim : global::OpenTracing.ITracer
+    {
+        private readonly Trace.ITracer tracer;
+
+        private TracerShim(Trace.ITracer tracer)
+        {
+            this.tracer = tracer ?? throw new ArgumentNullException(nameof(tracer));
+            this.ScopeManager = new ScopeManagerShim(this.tracer);
+        }
+
+        public global::OpenTracing.IScopeManager ScopeManager { get; private set; }
+
+        public global::OpenTracing.ISpan ActiveSpan => this.ScopeManager.Active?.Span;
+
+        public static global::OpenTracing.ITracer Create(Trace.ITracer tracer)
+        {
+            return new TracerShim(tracer);
+        }
+
+        public global::OpenTracing.ISpanBuilder BuildSpan(string operationName)
+        {
+            return new SpanBuilderShim(this.tracer, operationName);
+        }
+
+        public global::OpenTracing.ISpanContext Extract<TCarrier>(global::OpenTracing.Propagation.IFormat<TCarrier> format, TCarrier carrier)
+        {
+            if (format is null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+
+            if (carrier == default)
+            {
+                throw new ArgumentNullException(nameof(carrier));
+            }
+
+            Trace.SpanContext spanContext = null;
+
+            // TODO Add binary support post OpenTracing vNext.
+            if (format == BuiltinFormats.TextMap || format == BuiltinFormats.HttpHeaders)
+            {
+                // We know carrier is of Type ITextMap because we made it in here.
+                var carrierMap = new Dictionary<string, IEnumerable<string>>();
+
+                foreach (var entry in (ITextMap)carrier)
+                {
+                    carrierMap.Add(entry.Key, new[] { entry.Value });
+                }
+
+                IEnumerable<string> GetCarrierKeyValue(Dictionary<string, IEnumerable<string>> source, string key)
+                {
+                    if (key == null || !source.TryGetValue(key, out var value))
+                    {
+                        return null;
+                    }
+
+                    return value;
+                }
+
+                spanContext = this.tracer.TextFormat?.Extract(carrierMap, GetCarrierKeyValue);
+            }
+
+            return (spanContext == null || spanContext == SpanContext.Blank) ? null : new SpanContextShim(spanContext);
+        }
+
+        public void Inject<TCarrier>(
+            global::OpenTracing.ISpanContext spanContext,
+            global::OpenTracing.Propagation.IFormat<TCarrier> format,
+            TCarrier carrier)
+        {
+            if (spanContext is null)
+            {
+                throw new ArgumentNullException(nameof(spanContext));
+            }
+
+            if (!(spanContext is SpanContextShim shim))
+            {
+                throw new ArgumentException("context is not a valid SpanContextShim object");
+            }
+
+            if (format is null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+
+            if (carrier == default)
+            {
+                throw new ArgumentNullException(nameof(carrier));
+            }
+
+            // TODO Add binary support post OpenTracing vNext.
+            if (format == BuiltinFormats.TextMap || format == BuiltinFormats.HttpHeaders)
+            {
+                // We know carrier is of Type ITextMap because we made it in here.
+                this.tracer.TextFormat?.Inject(shim.SpanContext, (ITextMap)carrier, (adapter, key, value) => adapter.Set(key, value));
+            }
+        }
+    }
+}

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/Defaults.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/Defaults.cs
@@ -1,0 +1,58 @@
+﻿// <copyright file="SpanContextShimTests.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Shims.OpenTracing.Tests
+{
+    using System.Diagnostics;
+    using Moq;
+    using OpenTelemetry.Trace;
+
+    /// <summary>
+    /// A set of static helper methods for creating some default test setup objects.
+    /// </summary>
+    internal static class Defaults
+    {
+        public static SpanContext GetOpenTelemetrySpanContext()
+        {
+            return SpanContext.Create(
+                ActivityTraceId.CreateRandom(),
+                ActivitySpanId.CreateRandom(),
+                ActivityTraceFlags.None,
+                Tracestate.Empty);
+        }
+
+        /// <summary>
+        /// Creates an instance of SpanMock from this test project. This is a basic implementation used to verify calls to add events, links, and attributes.
+        /// </summary>
+        /// <returns>an instance of Span</returns>
+        public static SpanMock GetOpenTelemetrySpanMock()
+        {
+            return new SpanMock(GetOpenTelemetrySpanContext());
+        }
+
+        /// <summary>
+        /// Gets a mock implementation of OpenTelemtry ISpan suitable for certain kinds of unit tests.
+        /// </summary>
+        /// <returns>a mock of the OpenTelemetry ISpan.</returns>
+        public static Mock<ISpan> GetOpenTelemetryMockSpan()
+        {
+            var spanContext = GetOpenTelemetrySpanContext();
+            var mock = new Mock<ISpan>();
+            mock.Setup(o => o.Context).Returns(spanContext);
+            return mock;
+        }
+    }
+}

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/OpenTelemetry.Shims.OpenTracing.Tests.csproj
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/OpenTelemetry.Shims.OpenTracing.Tests.csproj
@@ -17,5 +17,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\OpenTelemetry.Shims.OpenTracing\OpenTelemetry.Shims.OpenTracing.csproj" />
+    <ProjectReference Include="..\..\src\OpenTelemetry\OpenTelemetry.csproj" />
   </ItemGroup>
 </Project>

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/ScopeManagerShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/ScopeManagerShimTests.cs
@@ -1,0 +1,94 @@
+﻿// <copyright file="ScopeManagerShimTests.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Shims.OpenTracing.Tests
+{
+    using System;
+    using Moq;
+    using OpenTelemetry.Trace;
+    using Xunit;
+
+    public class ScopeManagerShimTests
+    {
+        [Fact]
+        public void CtorArgumentValidation()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ScopeManagerShim(null));
+        }
+
+        [Fact]
+        public void Active_IsNull()
+        {
+            var tracerMock = new Mock<ITracer>();
+            tracerMock.Setup(x => x.CurrentSpan).Returns(Trace.BlankSpan.Instance);
+
+            var shim = new ScopeManagerShim(tracerMock.Object);
+
+            Assert.Null(shim.Active);
+        }
+
+        [Fact]
+        public void Active_IsNotNull()
+        {
+            var tracerMock = new Mock<ITracer>();
+            var shim = new ScopeManagerShim(tracerMock.Object);
+            var openTracingSpan = new SpanShim(Defaults.GetOpenTelemetrySpanMock());
+            var scopeMock = new Mock<Context.IScope>();
+
+            tracerMock.Setup(x => x.WithSpan(openTracingSpan.Span)).Returns(scopeMock.Object);
+            tracerMock.Setup(x => x.CurrentSpan).Returns(openTracingSpan.Span);
+
+            var scope = shim.Activate(openTracingSpan, true);
+            Assert.NotNull(scope);
+
+            var activeScope = shim.Active;
+            Assert.Equal(scope, activeScope);
+        }
+
+        [Fact]
+        public void Activate_SpanMustBeShim()
+        {
+            var tracerMock = new Mock<ITracer>();
+            var shim = new ScopeManagerShim(tracerMock.Object);
+
+            Assert.Throws<ArgumentException>(() => shim.Activate(new Mock<global::OpenTracing.ISpan>().Object, true));
+        }
+
+        [Fact]
+        public void Activate()
+        {
+            var tracerMock = new Mock<ITracer>();
+            var shim = new ScopeManagerShim(tracerMock.Object);
+            var scopeMock = new Mock<Context.IScope>();
+            var spanShim = new SpanShim(Defaults.GetOpenTelemetryMockSpan().Object);
+
+            tracerMock.Setup(x => x.WithSpan(spanShim.Span)).Returns(scopeMock.Object);
+
+            using (shim.Activate(spanShim, true))
+            {
+#if DEBUG
+                Assert.Equal(1, shim.SpanScopeTableCount);
+#endif
+            }
+
+#if DEBUG
+            Assert.Equal(0, shim.SpanScopeTableCount);
+#endif
+            tracerMock.Verify(x => x.WithSpan(spanShim.Span), Times.Once);
+            scopeMock.Verify(x => x.Dispose(), Times.Once);
+        }
+    }
+}

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanBuilderShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanBuilderShimTests.cs
@@ -1,0 +1,339 @@
+﻿// <copyright file="SpanBuilderShimTests.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+namespace OpenTelemetry.Shims.OpenTracing.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Moq;
+    using Xunit;
+
+    public class SpanBuilderShimTests
+    {
+        [Fact]
+        public void CtorArgumentValidation()
+        {
+            Assert.Throws<ArgumentNullException>(() => new SpanBuilderShim(null, "foo"));
+            Assert.Throws<ArgumentNullException>(() => new SpanBuilderShim(new Mock<Trace.ITracer>().Object, null));
+        }
+
+        [Fact]
+        public void IgnoreActiveSpan()
+        {
+            var spanBuilderMock = GetDefaultSpanBuilderMock();
+            var shim = new SpanBuilderShim(GetDefaultTracer(spanBuilderMock), "foo");
+
+            // Add a parent. The shim requires that the ISpan implementation be a SpanShim
+            shim.AsChildOf(new SpanShim(Defaults.GetOpenTelemetryMockSpan().Object));
+
+            // Set to Ignore
+            shim.IgnoreActiveSpan();
+
+            spanBuilderMock.Verify(o => o.SetParent(It.IsAny<Trace.SpanContext>()), Times.Never);
+
+            // There should be two methods calls to the underlying the builder. SetNoParent is last.
+            int callOrder = 0;
+            spanBuilderMock.Setup(x => x.SetParent(It.IsAny<Trace.ISpan>())).Callback(() => Assert.Equal(0, callOrder++));
+            spanBuilderMock.Setup(x => x.SetNoParent()).Callback(() => Assert.Equal(1, callOrder++));
+
+            // build
+            shim.Start();
+        }
+
+        [Fact]
+        public void AsChildOf_WithNullSpan()
+        {
+            var spanBuilderMock = GetDefaultSpanBuilderMock();
+            var shim = new SpanBuilderShim(GetDefaultTracer(spanBuilderMock), "foo");
+
+            // Add a null parent
+            shim.AsChildOf((global::OpenTracing.ISpan)null);
+
+            // build
+            shim.Start();
+
+            spanBuilderMock.Verify(o => o.SetParent(It.IsAny<Trace.ISpan>()), Times.Never);
+            spanBuilderMock.Verify(o => o.SetParent(It.IsAny<Trace.SpanContext>()), Times.Never);
+        }
+
+        [Fact]
+        public void AsChildOf_WithSpan()
+        {
+            var spanBuilderMock = GetDefaultSpanBuilderMock();
+            var shim = new SpanBuilderShim(GetDefaultTracer(spanBuilderMock), "foo");
+
+            // Add a parent.
+            var span = new SpanShim(Defaults.GetOpenTelemetryMockSpan().Object);
+            shim.AsChildOf(span);
+
+            // build
+            shim.Start();
+
+            spanBuilderMock.Verify(o => o.SetParent(span.Span), Times.Once);
+            spanBuilderMock.Verify(o => o.SetParent(It.IsAny<Trace.SpanContext>()), Times.Never);
+        }
+
+        [Fact]
+        public void Start_ActivityOperationRootSpanChecks()
+        {
+            // Create an activity
+            var activity = new System.Diagnostics.Activity("foo")
+                .SetIdFormat(System.Diagnostics.ActivityIdFormat.W3C)
+                .Start();
+
+            try
+            {
+                // matching root operation name
+                var spanBuilderMock = GetDefaultSpanBuilderMock();
+                var shim = new SpanBuilderShim(GetDefaultTracer(spanBuilderMock), "foo", new List<string> { "foo" });
+                shim.Start();
+                spanBuilderMock.Verify(o => o.SetCreateChild(false), Times.Once);
+
+                // mis-matched root operation name
+                spanBuilderMock = GetDefaultSpanBuilderMock();
+                shim = new SpanBuilderShim(GetDefaultTracer(spanBuilderMock), "foo", new List<string> { "bar" });
+                shim.Start();
+                spanBuilderMock.Verify(o => o.SetCreateChild(true), Times.Once);
+            }
+            finally
+            {
+                activity.Stop();
+            }
+        }
+
+        [Fact]
+        public void AsChildOf_MultipleCallsWithSpan()
+        {
+            var spanBuilderMock = GetDefaultSpanBuilderMock();
+            var shim = new SpanBuilderShim(GetDefaultTracer(spanBuilderMock), "foo");
+
+            // Multiple calls
+            var span1 = new SpanShim(Defaults.GetOpenTelemetryMockSpan().Object);
+            var span2 = new SpanShim(Defaults.GetOpenTelemetryMockSpan().Object);
+            shim.AsChildOf(span1);
+            shim.AsChildOf(span2);
+
+            // build
+            shim.Start();
+
+            spanBuilderMock.Verify(o => o.SetParent(span1.Span), Times.Once);
+            spanBuilderMock.Verify(o => o.SetParent(It.IsAny<Trace.SpanContext>()), Times.Never);
+
+            // The rest become links
+            spanBuilderMock.Verify(o => o.AddLink(It.Is<Trace.ILink>(link => link.Context == span2.Span.Context)), Times.Once);
+        }
+
+        [Fact]
+        public void AsChildOf_WithNullSpanContext()
+        {
+            var spanBuilderMock = GetDefaultSpanBuilderMock();
+            var shim = new SpanBuilderShim(GetDefaultTracer(spanBuilderMock), "foo");
+
+            // Add a null parent
+            shim.AsChildOf((global::OpenTracing.ISpanContext)null);
+
+            // build
+            shim.Start();
+
+            // should be no parent.
+            spanBuilderMock.Verify(o => o.SetParent(It.IsAny<Trace.SpanContext>()), Times.Never);
+            spanBuilderMock.Verify(o => o.SetParent(It.IsAny<Trace.ISpan>()), Times.Never);
+        }
+
+        [Fact]
+        public void AsChildOfWithSpanContext()
+        {
+            var spanBuilderMock = GetDefaultSpanBuilderMock();
+            var shim = new SpanBuilderShim(GetDefaultTracer(spanBuilderMock), "foo");
+
+            // Add a parent
+            var spanContext = SpanContextShimTests.GetSpanContextShim();
+            shim.AsChildOf(spanContext);
+
+            // build
+            shim.Start();
+
+            spanBuilderMock.Verify(o => o.SetParent(spanContext.SpanContext), Times.Once);
+            spanBuilderMock.Verify(o => o.SetParent(It.IsAny<Trace.ISpan>()), Times.Never);
+        }
+
+        [Fact]
+        public void AsChildOf_MultipleCallsWithSpanContext()
+        {
+            var spanBuilderMock = GetDefaultSpanBuilderMock();
+            var shim = new SpanBuilderShim(GetDefaultTracer(spanBuilderMock), "foo");
+
+            // Multiple calls
+            var spanContext1 = SpanContextShimTests.GetSpanContextShim();
+            var spanContext2 = SpanContextShimTests.GetSpanContextShim();
+            shim.AsChildOf(spanContext1);
+            shim.AsChildOf(spanContext2);
+
+            // build
+            shim.Start();
+
+            // Only a single call to SetParent
+            spanBuilderMock.Verify(o => o.SetParent(spanContext1.SpanContext), Times.Once);
+            spanBuilderMock.Verify(o => o.SetParent(It.IsAny<Trace.ISpan>()), Times.Never);
+
+            // The rest become links
+            spanBuilderMock.Verify(o => o.AddLink(It.Is<Trace.ILink>(link => link.Context == spanContext2.SpanContext)), Times.Once);
+        }
+
+        [Fact]
+        public void WithTag_KeyisSpanKindStringValue()
+        {
+            var spanMock = Defaults.GetOpenTelemetrySpanMock();
+            var spanBuilderMock = GetDefaultSpanBuilderMock(spanMock);
+            var shim = new SpanBuilderShim(GetDefaultTracer(spanBuilderMock), "foo");
+
+            shim.WithTag(global::OpenTracing.Tag.Tags.SpanKind.Key, global::OpenTracing.Tag.Tags.SpanKindClient);
+
+            // build
+            shim.Start();
+
+            // Not an attribute
+            Assert.Empty(spanMock.Attributes);
+
+            spanBuilderMock.Verify(o => o.SetSpanKind(Trace.SpanKind.Client), Times.Once);
+        }
+
+        [Fact]
+        public void WithTag_KeyisErrorStringValue()
+        {
+            var spanMock = Defaults.GetOpenTelemetrySpanMock();
+            var spanBuilderMock = GetDefaultSpanBuilderMock(spanMock);
+            var shim = new SpanBuilderShim(GetDefaultTracer(spanBuilderMock), "foo");
+
+            shim.WithTag(global::OpenTracing.Tag.Tags.Error.Key, "true");
+
+            // build
+            shim.Start();
+
+            // Not an attribute
+            Assert.Empty(spanMock.Attributes);
+
+            // Span status should be set
+            Assert.Equal(Trace.Status.Unknown, spanMock.Status);
+        }
+
+        [Fact]
+        public void WithTag_KeyisNullStringValue()
+        {
+            var spanMock = Defaults.GetOpenTelemetrySpanMock();
+            var spanBuilderMock = GetDefaultSpanBuilderMock(spanMock);
+            var shim = new SpanBuilderShim(GetDefaultTracer(spanBuilderMock), "foo");
+
+            shim.WithTag((string)null, "unused");
+
+            // build
+            shim.Start();
+
+            // Null key was ignored
+            Assert.Empty(spanMock.Attributes);
+        }
+
+        [Fact]
+        public void WithTag_ValueisNullStringValue()
+        {
+            var spanMock = Defaults.GetOpenTelemetrySpanMock();
+            var spanBuilderMock = GetDefaultSpanBuilderMock(spanMock);
+            var shim = new SpanBuilderShim(GetDefaultTracer(spanBuilderMock), "foo");
+
+            shim.WithTag("foo", null);
+
+            // build
+            shim.Start();
+
+            // Null value was turned into string.empty
+            Assert.Equal("foo", spanMock.Attributes.First().Key);
+            Assert.Equal(string.Empty, spanMock.Attributes.First().Value);
+        }
+
+        [Fact]
+        public void WithTag_KeyisErrorBoolValue()
+        {
+            var spanMock = Defaults.GetOpenTelemetrySpanMock();
+            var spanBuilderMock = GetDefaultSpanBuilderMock(spanMock);
+            var shim = new SpanBuilderShim(GetDefaultTracer(spanBuilderMock), "foo");
+
+            shim.WithTag(global::OpenTracing.Tag.Tags.Error.Key, true);
+
+            // build
+            shim.Start();
+
+            // Not an attribute
+            Assert.Empty(spanMock.Attributes);
+
+            // Span status should be set
+            Assert.Equal(Trace.Status.Unknown, spanMock.Status);
+        }
+
+        [Fact]
+        public void WithTag_VariousValueTypes()
+        {
+            var spanMock = Defaults.GetOpenTelemetrySpanMock();
+            var spanBuilderMock = GetDefaultSpanBuilderMock(spanMock);
+            var shim = new SpanBuilderShim(GetDefaultTracer(spanBuilderMock), "foo");
+
+            shim.WithTag("foo", "unused");
+            shim.WithTag("bar", false);
+            shim.WithTag("baz", 1);
+            shim.WithTag("bizzle", 1D);
+            shim.WithTag(new global::OpenTracing.Tag.BooleanTag("shnizzle"), true);
+            shim.WithTag(new global::OpenTracing.Tag.IntOrStringTag("febrizzle"), "unused");
+            shim.WithTag(new global::OpenTracing.Tag.StringTag("mobizzle"), "unused");
+
+            // build
+            shim.Start();
+
+            // Just verify the count
+            Assert.Equal(7, spanMock.Attributes.Count);
+        }
+
+        [Fact]
+        public void Start()
+        {
+            var spanMock = Defaults.GetOpenTelemetrySpanMock();
+            var spanBuilderMock = GetDefaultSpanBuilderMock(spanMock);
+            var shim = new SpanBuilderShim(GetDefaultTracer(spanBuilderMock), "foo");
+
+            // build
+            var span = shim.Start() as SpanShim;
+
+            // Just check the return value is a SpanShim and that the underlying OpenTelemetry Span.
+            // There is nothing left to verify because the rest of the tests were already calling .Start() prior to verification.
+            Assert.NotNull(span);
+            Assert.Equal(spanMock, span.Span);
+        }
+
+        private static Mock<Trace.ISpanBuilder> GetDefaultSpanBuilderMock(SpanMock spanMock = null)
+        {
+            var mock = new Mock<Trace.ISpanBuilder>();
+            spanMock = spanMock ?? Defaults.GetOpenTelemetrySpanMock();
+            mock.Setup(x => x.StartSpan()).Returns(spanMock);
+
+            return mock;
+        }
+
+        private static Trace.ITracer GetDefaultTracer(Mock<Trace.ISpanBuilder> spanBuilderMock)
+        {
+            var tracerMock = new Mock<Trace.ITracer>();
+            tracerMock.Setup(x => x.SpanBuilder(It.IsAny<string>())).Returns(spanBuilderMock.Object);
+            return tracerMock.Object;
+        }
+    }
+}

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanContextShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanContextShimTests.cs
@@ -1,0 +1,57 @@
+﻿// <copyright file="SpanContextShimTests.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Shims.OpenTracing.Tests
+{
+    using System;
+    using Xunit;
+
+    public class SpanContextShimTests
+    {
+        [Fact]
+        public void CtorArgumentValidation()
+        {
+            Assert.Throws<ArgumentNullException>(() => new SpanContextShim(null));
+        }
+
+        [Fact]
+        public void GetTraceId()
+        {
+            var shim = GetSpanContextShim();
+
+            Assert.Equal(shim.SpanContext.TraceId.ToString(), shim.TraceId);
+        }
+
+        [Fact]
+        public void GetSpanId()
+        {
+            var shim = GetSpanContextShim();
+
+            Assert.Equal(shim.SpanContext.SpanId.ToString(), shim.SpanId);
+        }
+
+        [Fact]
+        public void GetBaggage()
+        {
+            // TODO
+        }
+
+        internal static SpanContextShim GetSpanContextShim()
+        {
+            return new SpanContextShim(Defaults.GetOpenTelemetrySpanContext());
+        }
+    }
+}

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanMock.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanMock.cs
@@ -1,0 +1,139 @@
+﻿// <copyright file="SpanMock.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+namespace OpenTelemetry.Shims.OpenTracing.Tests
+{
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using OpenTelemetry.Trace;
+
+    /// <summary>
+    /// A mock ISpan implementation for unit tests. Sometimes an actual Mock is just easier to deal with than objects created with Moq.
+    /// </summary>
+    internal class SpanMock : Trace.ISpan
+    {
+        private static readonly ReadOnlyDictionary<string, object> EmptyAttributes = new ReadOnlyDictionary<string, object>(new Dictionary<string, object>());
+
+        public SpanMock(Trace.SpanContext spanContext)
+        {
+            this.Context = spanContext;
+            this.Events = new List<IEvent>();
+            this.Links = new List<ILink>();
+            this.Attributes = new List<KeyValuePair<string, object>>();
+        }
+
+        public string Name { get; private set; }
+
+        public List<IEvent> Events { get; }
+
+        public List<ILink> Links { get; }
+
+        public List<KeyValuePair<string, object>> Attributes { get; }
+
+        public SpanContext Context { get; private set; }
+
+        public bool IsRecordingEvents { get; private set; }
+
+        public Status Status { get; set; }
+
+        public bool HasEnded { get; private set; }
+
+        public void AddEvent(string name)
+        {
+            this.Events.Add(new Event(name, EmptyAttributes));
+        }
+
+        public void AddEvent(string name, IDictionary<string, object> attributes)
+        {
+            this.Events.Add(new Event(name, attributes));
+        }
+
+        public void AddEvent(IEvent newEvent)
+        {
+            this.Events.Add(newEvent);
+        }
+
+        public void AddLink(ILink link)
+        {
+            this.Links.Add(link);
+        }
+
+        public void End()
+        {
+            this.HasEnded = true;
+        }
+
+        public void SetAttribute(string key, string value)
+        {
+            this.SetAttribute<string>(key, value);
+        }
+
+        public void SetAttribute(string key, long value)
+        {
+            this.SetAttribute<long>(key, value);
+        }
+
+        public void SetAttribute(string key, double value)
+        {
+            this.SetAttribute<double>(key, value);
+        }
+
+        public void SetAttribute(string key, bool value)
+        {
+            this.SetAttribute<bool>(key, value);
+        }
+
+        public void SetAttribute(KeyValuePair<string, object> keyValuePair)
+        {
+            this.Attributes.Add(keyValuePair);
+        }
+
+        public void UpdateName(string name)
+        {
+            this.Name = name;
+        }
+
+        private void SetAttribute<TValue>(string key, TValue value)
+        {
+            this.SetAttribute(new KeyValuePair<string, object>(key, value));
+        }
+
+        public class Event : Trace.IEvent
+        {
+            public Event(string name, IDictionary<string, object> attributes)
+            {
+                this.Name = name;
+                this.Attributes = attributes;
+            }
+
+            public string Name { get; }
+
+            public IDictionary<string, object> Attributes { get; }
+        }
+
+        public class Link : Trace.ILink
+        {
+            public Link(SpanContext spanContext, IDictionary<string, object> attributes)
+            {
+                this.Context = spanContext;
+                this.Attributes = attributes;
+            }
+
+            public SpanContext Context { get; }
+
+            public IDictionary<string, object> Attributes { get; }
+        }
+    }
+}

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/TracerShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/TracerShimTests.cs
@@ -1,0 +1,175 @@
+﻿// <copyright file="TracerShimTests.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Shims.OpenTracing.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using global::OpenTracing;
+    using global::OpenTracing.Propagation;
+    using Moq;
+    using OpenTelemetry.Context.Propagation;
+    using OpenTelemetry.Trace;
+    using Xunit;
+
+    public class TracerShimTests
+    {
+        [Fact]
+        public void CtorArgumentValidation()
+        {
+            Assert.Throws<ArgumentNullException>(() => TracerShim.Create(null));
+        }
+
+        [Fact]
+        public void ScopeManager_NotNull()
+        {
+            var shim = TracerShim.Create(NoopTracer.Instance);
+
+            // Internals of the ScopeManagerShim tested elsewhere
+            Assert.NotNull(shim.ScopeManager as ScopeManagerShim);
+        }
+
+        [Fact]
+        public void BuildSpan_NotNull()
+        {
+            var shim = TracerShim.Create(NoopTracer.Instance);
+
+            // Internals of the SpanBuilderShim tested elsewhere
+            Assert.NotNull(shim.BuildSpan("foo") as SpanBuilderShim);
+        }
+
+        [Fact]
+        public void Inject_ArgumentValidation()
+        {
+            var shim = TracerShim.Create(NoopTracer.Instance);
+
+            var spanContextShim = new SpanContextShim(Defaults.GetOpenTelemetrySpanContext());
+            var mockFormat = new Mock<IFormat<ITextMap>>();
+            var mockCarrier = new Mock<ITextMap>();
+
+            Assert.Throws<ArgumentNullException>(() => shim.Inject(null, mockFormat.Object, mockCarrier.Object));
+            Assert.Throws<ArgumentException>(() => shim.Inject(new Mock<ISpanContext>().Object, mockFormat.Object, mockCarrier.Object));
+            Assert.Throws<ArgumentNullException>(() => shim.Inject(spanContextShim, null, mockCarrier.Object));
+            Assert.Throws<ArgumentNullException>(() => shim.Inject(spanContextShim, mockFormat.Object, null));
+        }
+
+        [Fact]
+        public void Inject_UnknownFormatIgnored()
+        {
+            var shim = TracerShim.Create(NoopTracer.Instance);
+
+            var spanContextShim = new SpanContextShim(Defaults.GetOpenTelemetrySpanContext());
+
+            // Only two specific types of ITextMap are supported, and neither is a Mock.
+            var mockCarrier = new Mock<ITextMap>();
+            shim.Inject(spanContextShim, new Mock<IFormat<ITextMap>>().Object, mockCarrier.Object);
+
+            // Verify that the carrier mock was never called.
+            mockCarrier.Verify(x => x.Set(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public void Inject_Ok()
+        {
+            var shim = TracerShim.Create(NoopTracer.Instance);
+
+            var spanContextShim = new SpanContextShim(Defaults.GetOpenTelemetrySpanContext());
+
+            var mockCarrier = new Mock<ITextMap>();
+            shim.Inject(spanContextShim, BuiltinFormats.TextMap, mockCarrier.Object);
+
+            // Verify that the carrier mock was invoked at least one time.
+            mockCarrier.Verify(x => x.Set(It.IsAny<string>(), It.IsAny<string>()), Times.AtLeastOnce);
+        }
+
+        [Fact]
+        public void Extract_ArgumentValidation()
+        {
+            var shim = TracerShim.Create(NoopTracer.Instance);
+
+            Assert.Throws<ArgumentNullException>(() => shim.Extract(null, new Mock<ITextMap>().Object));
+            Assert.Throws<ArgumentNullException>(() => shim.Extract(new Mock<IFormat<ITextMap>>().Object, null));
+        }
+
+        [Fact]
+        public void Extract_UnknownFormatIgnored()
+        {
+            var shim = TracerShim.Create(NoopTracer.Instance);
+
+            var spanContextShim = new SpanContextShim(Defaults.GetOpenTelemetrySpanContext());
+
+            // Only two specific types of ITextMap are supported, and neither is a Mock.
+            var mockCarrier = new Mock<ITextMap>();
+            var context = shim.Extract(new Mock<IFormat<ITextMap>>().Object, mockCarrier.Object);
+
+            // Verify that the carrier mock was never called.
+            mockCarrier.Verify(x => x.GetEnumerator(), Times.Never);
+        }
+
+        [Fact]
+        public void Extract_InvalidTraceParent()
+        {
+            var shim = TracerShim.Create(NoopTracer.Instance);
+
+            var mockCarrier = new Mock<ITextMap>();
+
+            // The NoopTracer uses OpenTelemetry.Context.Propagation.TraceContextFormat, so we need to satisfy the traceparent key at the least
+            var carrierMap = new Dictionary<string, string>
+            {
+                // This is an invalid traceparent value
+                { "traceparent", "unused" },
+            };
+
+            mockCarrier.Setup(x => x.GetEnumerator()).Returns(carrierMap.GetEnumerator());
+            var spanContextShim = shim.Extract(BuiltinFormats.TextMap, mockCarrier.Object) as SpanContextShim;
+
+            // Verify that the carrier was called
+            mockCarrier.Verify(x => x.GetEnumerator(), Times.Once);
+
+            Assert.Null(spanContextShim);
+        }
+
+        [Fact]
+        public void Extract_Ok()
+        {
+            var shim = TracerShim.Create(NoopTracer.Instance);
+
+            var mockCarrier = new Mock<ITextMap>();
+
+            // The NoopTracer uses OpenTelemetry.Context.Propagation.TraceContextFormat, so we need to satisfy that.
+            var traceContextFormat = new TraceContextFormat();
+            var spanContext = Defaults.GetOpenTelemetrySpanContext();
+
+            var carrierMap = new Dictionary<string, string>();
+
+            // inject the SpanContext into the carrier map
+            traceContextFormat.Inject<Dictionary<string, string>>(spanContext, carrierMap, (map, key, value) => map.Add(key, value));
+
+            // send the populated carrier map to the extract method.
+            mockCarrier.Setup(x => x.GetEnumerator()).Returns(carrierMap.GetEnumerator());
+            var spanContextShim = shim.Extract(BuiltinFormats.TextMap, mockCarrier.Object) as SpanContextShim;
+
+            // Verify that the carrier was called
+            mockCarrier.Verify(x => x.GetEnumerator(), Times.Once);
+
+            Assert.Equal(spanContext, spanContextShim.SpanContext);
+        }
+
+
+        public interface UnsupportedCarrierType
+        { }
+    }
+}


### PR DESCRIPTION
This is, where possible, a direct port of the current Java shim. There are some holes/TODOS. Notably:

- Missing the Binary injection/extraction of the span context.  This doesn't exist with the current implementation of OpenTracing yet.
- Missing explicit timestamps for calls to OpenTracing ISpan::Log.
- Missing explicit timestamps for calls to OpenTracing ISpan::Finish. Requires implementation of https://github.com/open-telemetry/oteps/blob/master/text/0002-remove-spandata.md
- Various calls to set/get baggage are not implemented. Requires OpenTelemetry DistributedContext to be finalized.

Other oddities worth nothing:
- The SpanBuilderShim has some conditional code for calling OpenTel SetCreateChild(true|false)
- The ScopeManagerShim is actively tracking scopes returned by calls to OpenTel WithSpan and associating those with the OpenTel ISpan used when calling WithSpan.

I tested this shim against an ASP.NET Core 3 Preview 8 service wired up with OpenTracing netcore and grpc collectors and exporting to Jaeger backend.

The included tests are unit tests only; no E2E tests.