### PR TITLE
Remove Link.FromActivity due to not clearly defined behavior

### DIFF
--- a/src/OpenTelemetry.Abstractions/Trace/ISpanBuilder.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/ISpanBuilder.cs
@@ -90,13 +90,6 @@ namespace OpenTelemetry.Trace
         /// <summary>
         /// Set the <see cref="Link"/> on the span.
         /// </summary>
-        /// <param name="activity"><see cref="Activity"/> context to set on span.</param>
-        /// <returns>This span builder for chaining.</returns>
-        ISpanBuilder AddLink(Activity activity);
-
-        /// <summary>
-        /// Set the <see cref="Link"/> on the span.
-        /// </summary>
         /// <param name="link"><see cref="Link"/> to set on span.</param>
         /// <returns>This span builder for chaining.</returns>
         ISpanBuilder AddLink(ILink link);

--- a/src/OpenTelemetry.Abstractions/Trace/Link.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/Link.cs
@@ -41,35 +41,6 @@ namespace OpenTelemetry.Trace
         /// <inheritdoc/>
         public IDictionary<string, object> Attributes { get; }
 
-        /// <summary>
-        /// Creates a <see cref="ILink"/> from Activity.
-        /// </summary>
-        /// <param name="activity">Activity to create link from.</param>
-        /// <returns>New <see cref="ILink"/> instance.</returns>
-        public static ILink FromActivity(Activity activity)
-        {
-            if (activity == null)
-            {
-                throw new ArgumentNullException(nameof(activity));
-            }
-
-            if (activity.IdFormat != ActivityIdFormat.W3C)
-            {
-                throw new ArgumentException("Current Activity is not in W3C format");
-            }
-
-            var tracestate = Tracestate.Empty;
-            var tracestateBuilder = Tracestate.Builder;
-            if (TracestateUtils.TryExtractTracestate(activity.TraceStateString, tracestateBuilder))
-            {
-                tracestate = tracestateBuilder.Build();
-            }
-
-            return new Link(
-                SpanContext.Create(activity.TraceId, activity.SpanId, activity.ActivityTraceFlags, tracestate),
-                EmptyAttributes);
-        }
-
         public static ILink FromSpanContext(SpanContext context)
         {
             return new Link(context, EmptyAttributes);

--- a/src/OpenTelemetry.Abstractions/Trace/NoopSpanBuilder.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/NoopSpanBuilder.cs
@@ -140,17 +140,6 @@ namespace OpenTelemetry.Trace
         }
 
         /// <inheritdoc/>
-        public ISpanBuilder AddLink(Activity activity)
-        {
-            if (activity == null)
-            {
-                throw new ArgumentNullException(nameof(activity));
-            }
-
-            return this;
-        }
-
-        /// <inheritdoc/>
         public ISpanBuilder AddLink(ILink link)
         {
             if (link == null)

--- a/src/OpenTelemetry/Trace/SpanBuilder.cs
+++ b/src/OpenTelemetry/Trace/SpanBuilder.cs
@@ -191,17 +191,6 @@ namespace OpenTelemetry.Trace
         }
 
         /// <inheritdoc/>
-        public ISpanBuilder AddLink(Activity activity)
-        {
-            if (activity == null)
-            {
-                throw new ArgumentNullException(nameof(activity));
-            }
-
-            return this.AddLink(Link.FromActivity(activity));
-        }
-
-        /// <inheritdoc/>
         public ISpanBuilder SetRecordEvents(bool recordEvents)
         {
             this.recordEvents = recordEvents;

--- a/test/OpenTelemetry.Tests/Impl/Trace/LinkTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/LinkTest.cs
@@ -39,7 +39,7 @@ namespace OpenTelemetry.Trace.Test
         }
 
         [Fact]
-        public void FromSpanContext_ChildLink()
+        public void FromSpanContext()
         {
             var link = Link.FromSpanContext(spanContext);
             Assert.Equal(spanContext.TraceId, link.Context.TraceId);
@@ -47,24 +47,7 @@ namespace OpenTelemetry.Trace.Test
         }
 
         [Fact]
-        public void FromSpanContext_ChildLink_WithAttributes()
-        {
-            var link = Link.FromSpanContext(spanContext, attributesMap);
-            Assert.Equal(spanContext.TraceId, link.Context.TraceId);
-            Assert.Equal(spanContext.SpanId, link.Context.SpanId);
-            Assert.Equal(attributesMap, link.Attributes);
-        }
-
-        [Fact]
-        public void FromSpanContext_ParentLink()
-        {
-            var link = Link.FromSpanContext(spanContext);
-            Assert.Equal(spanContext.TraceId, link.Context.TraceId);
-            Assert.Equal(spanContext.SpanId, link.Context.SpanId);
-        }
-
-        [Fact]
-        public void FromSpanContext_ParentLink_WithAttributes()
+        public void FromSpanContext_WithAttributes()
         {
             var link = Link.FromSpanContext(spanContext, attributesMap);
             Assert.Equal(spanContext.TraceId, link.Context.TraceId);
@@ -83,41 +66,6 @@ namespace OpenTelemetry.Trace.Test
             Assert.Contains(spanContext.TraceId.ToString(), link.ToString());
             Assert.Contains(spanContext.SpanId.ToString(), spanContext.SpanId.ToString());
             Assert.Contains(string.Join(", ", attributesMap.Select(kvp => $"{kvp.Key}={kvp.Value}")), link.ToString());
-        }
-
-        [Fact]
-        public void FromSpanContext_FromActivity()
-        {
-            var activity = new Activity("foo")
-                .SetIdFormat(ActivityIdFormat.W3C)
-                .Start();
-            activity.TraceStateString = "k1=v1, k2=v2";
-
-            var link = Link.FromActivity(activity);
-            Assert.Equal(activity.TraceId, link.Context.TraceId);
-            Assert.Equal(activity.SpanId, link.Context.SpanId);
-
-            var entries = link.Context.Tracestate.Entries.ToArray();
-            Assert.Equal(2, entries.Length);
-            Assert.Equal("k1", entries[0].Key);
-            Assert.Equal("v1", entries[0].Value);
-            Assert.Equal("k2", entries[1].Key);
-            Assert.Equal("v2", entries[1].Value);
-        }
-
-        [Fact]
-        public void FromSpanContext_FromNullActivity()
-        {
-            Assert.Throws<ArgumentNullException>( () => Link.FromActivity(null));
-        }
-
-        [Fact]
-        public void FromSpanContext_FromHierarchicalActivity()
-        {
-            var activity = new Activity("foo")
-                .SetIdFormat(ActivityIdFormat.Hierarchical)
-                .Start();
-            Assert.Throws<ArgumentException>(() => Link.FromActivity(activity));
         }
 
         public void Dispose()

--- a/test/OpenTelemetry.Tests/Impl/Trace/NoopSpanBuilderTests.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/NoopSpanBuilderTests.cs
@@ -44,7 +44,6 @@ namespace OpenTelemetry.Tests.Impl.Trace
             a.Stop();
 
             Assert.Throws<ArgumentNullException>(() => spanBuilder.SetSampler(null));
-            Assert.Throws<ArgumentNullException>(() => spanBuilder.AddLink((Activity)null));
             Assert.Throws<ArgumentNullException>(() => spanBuilder.AddLink((ILink)null));
             Assert.Throws<ArgumentNullException>(() => spanBuilder.AddLink((SpanContext)null));
             Assert.Throws<ArgumentNullException>(() => spanBuilder.AddLink(null, null));

--- a/test/OpenTelemetry.Tests/Impl/Trace/SpanBuilderTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/SpanBuilderTest.cs
@@ -599,14 +599,12 @@ namespace OpenTelemetry.Trace.Test
         [Fact]
         public void StartSpan_WithLinkFromActivity()
         {
-            var activityLink = new Activity("foo")
-                .SetIdFormat(ActivityIdFormat.W3C)
-                .Start();
-            activityLink.Stop();
+            var contextLink = SpanContext.Create(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(),
+                ActivityTraceFlags.None, Tracestate.Empty);
 
             var span = new SpanBuilder(SpanName, spanBuilderOptions)
                 .SetSpanKind(SpanKind.Internal)
-                .AddLink(activityLink)
+                .AddLink(contextLink)
                 .StartSpan();
 
             var spanData = ((Span)span).ToSpanData();
@@ -614,11 +612,11 @@ namespace OpenTelemetry.Trace.Test
 
             Assert.Single(links);
 
-            Assert.NotEqual(default, activityLink.TraceId);
-            Assert.NotEqual(default, activityLink.SpanId);
-            Assert.Equal(activityLink.TraceId, links[0].Context.TraceId);
-            Assert.Equal(activityLink.SpanId, links[0].Context.SpanId);
-            Assert.Equal(activityLink.ActivityTraceFlags, links[0].Context.TraceOptions);
+            Assert.NotEqual(default, contextLink.TraceId);
+            Assert.NotEqual(default, contextLink.SpanId);
+            Assert.Equal(contextLink.TraceId, links[0].Context.TraceId);
+            Assert.Equal(contextLink.SpanId, links[0].Context.SpanId);
+            Assert.Equal(contextLink.TraceOptions, links[0].Context.TraceOptions);
             Assert.Empty(links[0].Context.Tracestate.Entries);
             Assert.Equal(0, links[0].Attributes.Count);
         }
@@ -893,7 +891,6 @@ namespace OpenTelemetry.Trace.Test
             a.Stop();
 
             Assert.Throws<ArgumentNullException>(() => spanBuilder.SetSampler(null));
-            Assert.Throws<ArgumentNullException>(() => spanBuilder.AddLink((Activity)null));
             Assert.Throws<ArgumentNullException>(() => spanBuilder.AddLink((ILink)null));
             Assert.Throws<ArgumentNullException>(() => spanBuilder.AddLink((SpanContext)null));
             Assert.Throws<ArgumentNullException>(() => spanBuilder.AddLink(null, null));

--- a/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
@@ -52,10 +52,8 @@ namespace OpenTelemetry.Trace.Test
         [Fact]
         public void ToSpanData_NoRecordEvents()
         {
-            var activityLink = new Activity(SpanName)
-                .SetIdFormat(ActivityIdFormat.W3C)
-                .Start();
-            activityLink.Stop();
+            var link = SpanContext.Create(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(),
+                ActivityTraceFlags.None, Tracestate.Empty);
 
             var activity = new Activity(SpanName)
                 .SetIdFormat(ActivityIdFormat.W3C)
@@ -78,7 +76,7 @@ namespace OpenTelemetry.Trace.Test
 
             span.AddEvent(Event.Create(EventDescription));
             span.AddEvent(EventDescription, attributes);
-            span.AddLink(Link.FromActivity(activityLink));
+            span.AddLink(Link.FromSpanContext(link));
             span.End();
             // exception.expect(IllegalStateException);
             Assert.Throws<InvalidOperationException>(() => ((Span)span).ToSpanData());
@@ -133,11 +131,8 @@ namespace OpenTelemetry.Trace.Test
         [Fact]
         public void NoEventsRecordedAfterEnd()
         {
-            var activityLink = new Activity(SpanName)
-                .SetIdFormat(ActivityIdFormat.W3C)
-                .Start();
-
-            activityLink.Stop();
+            var link = SpanContext.Create(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(),
+                ActivityTraceFlags.None, Tracestate.Empty);
 
             var activity = new Activity(SpanName).Start();
             activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
@@ -165,7 +160,7 @@ namespace OpenTelemetry.Trace.Test
 
             span.AddEvent(Event.Create(EventDescription));
             span.AddEvent(EventDescription, attributes);
-            span.AddLink(Link.FromActivity(activityLink));
+            span.AddLink(Link.FromSpanContext(link));
             var spanData = ((Span)span).ToSpanData();
 
             AssertApproxSameTimestamp(spanData.StartTimestamp, spanStartTime);
@@ -179,10 +174,8 @@ namespace OpenTelemetry.Trace.Test
         [Fact]
         public async Task ToSpanData_ActiveSpan()
         {
-            var activityLink = new Activity(SpanName)
-                .SetIdFormat(ActivityIdFormat.W3C)
-                .Start();
-            activityLink.Stop();
+            var contextLink = SpanContext.Create(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(),
+                ActivityTraceFlags.None, Tracestate.Empty);
 
             var activity = new Activity(SpanName)
                 .SetParentId(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom())
@@ -213,7 +206,7 @@ namespace OpenTelemetry.Trace.Test
             var secondEventTime = PreciseTimestamp.GetUtcNow();
             span.AddEvent(EventDescription, attributes);
 
-            var link = Link.FromActivity(activityLink);
+            var link = Link.FromSpanContext(contextLink);
             span.AddLink(link);
             var spanData = ((Span)span).ToSpanData();
             Assert.Equal(activity.TraceId, spanData.Context.TraceId);
@@ -251,10 +244,8 @@ namespace OpenTelemetry.Trace.Test
         [Fact]
         public async Task GoSpanData_EndedSpan()
         {
-            var activityLink = new Activity(SpanName)
-                .SetIdFormat(ActivityIdFormat.W3C)
-                .Start();
-            activityLink.Stop();
+            var contextLink = SpanContext.Create(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(),
+                ActivityTraceFlags.None, Tracestate.Empty);
 
             var activity = new Activity(SpanName)
                 .SetParentId(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom())
@@ -286,7 +277,7 @@ namespace OpenTelemetry.Trace.Test
             var secondEventTime = PreciseTimestamp.GetUtcNow();
             span.AddEvent(EventDescription, attributes);
 
-            var link = Link.FromActivity(activityLink);
+            var link = Link.FromSpanContext(contextLink);
             span.AddLink(link);
             span.Status = Status.Cancelled;
 
@@ -543,10 +534,8 @@ namespace OpenTelemetry.Trace.Test
         [Fact]
         public void DroppingLinks()
         {
-            var activityLink = new Activity(SpanName)
-                .SetIdFormat(ActivityIdFormat.W3C)
-                .Start();
-            activityLink.Stop();
+            var contextLink = SpanContext.Create(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(),
+                ActivityTraceFlags.None, Tracestate.Empty);
 
             var activity = new Activity(SpanName).Start();
             activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
@@ -561,7 +550,7 @@ namespace OpenTelemetry.Trace.Test
                     SpanKind.Internal,
                     traceParams,
                     startEndHandler);
-            var link = Link.FromActivity(activityLink);
+            var link = Link.FromSpanContext(contextLink);
             for (var i = 0; i < 2 * maxNumberOfLinks; i++)
             {
                 span.AddLink(link);


### PR DESCRIPTION
Creating a link from Activity is ambiguous as Activity has SpanId and ParentSpanId and it's not clear when links should be created from parent and when from the child.
 
Considering this, I propose to remove this API and use `Link.FromSpanContext` whenever possible to avoid this ambiguity. 

If we'll find that we have to have `FromActivity` API, we should get back to it and discuss how to deal with ambiguity.

Beginning of the discussion in https://github.com/open-telemetry/opentelemetry-dotnet/pull/200#discussion_r322900939

## Motivation and explanation

Links are the way to represent relationships between different traces and typical use case is batching in messaging scenarios. 

Activity is .NET primitive for distributed tracing which is a combination of `Span`, `SpanContext` and `Scope`.

Microsoft  SDKs, libraries and platform will continue to use Activities for now as they are part of the platform and no additional dependencies are required.

------

Producer (via queue SDK) creates an Activity for each message and also when sending the messages. Auto-collector in OpenTelemetry will create Span for each Activity. 

*Send* span will be linked to all the messages in the batch.

In this case, producer may use the message  activity (`messageActivity.TraceId` and `messageActivity.SpanId`) to represent link on *send* span.

On the consumer side, a consumer may construct Activity to represent the context in the message. But in this case, it will be **parent** context  (`messageActivity.TraceId` and `messageActivity.ParentSpanId`). 

This way there is no single clear way how to construct a link.





