### PR TITLE
Change Application Insights schema for links

### DIFF
--- a/test/OpenTelemetry.Exporter.ApplicationInsights.Tests/OpenTelemetry.Exporter.ApplicationInsights.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.ApplicationInsights.Tests/OpenTelemetry.Exporter.ApplicationInsights.Tests.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="Moq" Version="4.11.0" />


### PR DESCRIPTION
Changing Application Insights exporter to comply with new internal representation for links.