### PR TITLE
Use DateTimeOffset instead of DateTime

### DIFF
--- a/samples/LoggingTracer/LoggingTracer/LoggingSpan.cs
+++ b/samples/LoggingTracer/LoggingTracer/LoggingSpan.cs
@@ -37,7 +37,7 @@ namespace LoggingTracer
 
         public void End() => Logger.Log($"Span.End, Name: {this.Name}");
 
-        public void End(DateTime endTimestamp) => Logger.Log($"Span.End, Name: {this.Name}, Timestamp: {endTimestamp}");
+        public void End(DateTimeOffset endTimestamp) => Logger.Log($"Span.End, Name: {this.Name}, Timestamp: {endTimestamp:o}");
 
         public void SetAttribute(string key, object value) => this.LogSetAttribute(key, value);
 

--- a/samples/LoggingTracer/LoggingTracer/LoggingSpanBuilder.cs
+++ b/samples/LoggingTracer/LoggingTracer/LoggingSpanBuilder.cs
@@ -104,7 +104,7 @@ namespace LoggingTracer
             return this;
         }
 
-        public ISpanBuilder SetStartTimestamp(DateTime startTimestamp)
+        public ISpanBuilder SetStartTimestamp(DateTimeOffset startTimestamp)
         {
             Logger.Log($"SpanBuilder.SetStartTimestamp({startTimestamp})");
             return this;

--- a/src/OpenTelemetry.Abstractions/Internal/BlankSpan.cs
+++ b/src/OpenTelemetry.Abstractions/Internal/BlankSpan.cs
@@ -161,7 +161,8 @@ namespace OpenTelemetry.Trace
         {
         }
 
-        public void End(DateTime endTimestamp)
+        /// <inheritdoc />
+        public void End(DateTimeOffset endTimestamp)
         {
         }
     }

--- a/src/OpenTelemetry.Abstractions/Trace/Event.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/Event.cs
@@ -28,7 +28,7 @@ namespace OpenTelemetry.Trace
         private static readonly ReadOnlyDictionary<string, object> EmptyAttributes =
                 new ReadOnlyDictionary<string, object>(new Dictionary<string, object>());
 
-        internal Event(string name, DateTime timestamp, IDictionary<string, object> attributes)
+        internal Event(string name, DateTimeOffset timestamp, IDictionary<string, object> attributes)
         {
             this.Name = name ?? throw new ArgumentNullException(nameof(name));
             this.Attributes = attributes ?? throw new ArgumentNullException(nameof(attributes));
@@ -39,7 +39,7 @@ namespace OpenTelemetry.Trace
         public string Name { get; }
 
         /// <inheritdoc/>
-        public DateTime Timestamp { get; }
+        public DateTimeOffset Timestamp { get; }
 
         /// <inheritdoc/>
         public IDictionary<string, object> Attributes { get; }
@@ -62,7 +62,7 @@ namespace OpenTelemetry.Trace
         /// <param name="timestamp">The timestamp of the <see cref="Event"/>.</param>
         /// <returns>A new <see cref="Event"/> with the provided name.</returns>
         /// <exception cref="ArgumentNullException">If <c>name</c> is <c>null</c>.</exception>
-        public static IEvent Create(string name, DateTime timestamp)
+        public static IEvent Create(string name, DateTimeOffset timestamp)
         {
             return new Event(name, timestamp, EmptyAttributes);
         }
@@ -75,7 +75,7 @@ namespace OpenTelemetry.Trace
         /// <param name="attributes">The <see cref="IDictionary{String, Object}"/> of attributes for the <see cref="Event"/>.</param>
         /// <returns>A new <see cref="Event"/> with the provided name and set of attributes.</returns>
         /// <exception cref="ArgumentNullException">If <c>name</c> or <c>attributes</c> is <c>null</c>.</exception>
-        public static IEvent Create(string name, DateTime timestamp, IDictionary<string, object> attributes)
+        public static IEvent Create(string name, DateTimeOffset timestamp, IDictionary<string, object> attributes)
         {
             if (attributes == null)
             {

--- a/src/OpenTelemetry.Abstractions/Trace/IEvent.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/IEvent.cs
@@ -32,7 +32,7 @@ namespace OpenTelemetry.Trace
         /// <summary>
         /// Gets the <see cref="IEvent"/> timestamp.
         /// </summary>
-        DateTime Timestamp { get; }
+        DateTimeOffset Timestamp { get; }
 
         /// <summary>
         /// Gets the <see cref="IDictionary{String, IAttributeValue}"/> collection of attributes associated with the event.

--- a/src/OpenTelemetry.Abstractions/Trace/ISpan.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/ISpan.cs
@@ -122,7 +122,7 @@ namespace OpenTelemetry.Trace
         /// <summary>
         /// End the span.
         /// </summary>
-        /// <param name="endTimestamp">End UTC timestamp.</param>
-        void End(DateTime endTimestamp);
+        /// <param name="endTimestamp">End timestamp.</param>
+        void End(DateTimeOffset endTimestamp);
     }
 }

--- a/src/OpenTelemetry.Abstractions/Trace/ISpanBuilder.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/ISpanBuilder.cs
@@ -113,10 +113,10 @@ namespace OpenTelemetry.Trace
         /// <summary>
         /// Set start UTC timestamp value.
         /// </summary>
-        /// <param name="startTimestamp">Start timestamp in UTC.
+        /// <param name="startTimestamp">Start timestamp.
         /// If this method was not called, during <see cref="StartSpan"/> current precise time will be used.</param>
         /// <returns>This span builder for chaining.</returns>
-        ISpanBuilder SetStartTimestamp(DateTime startTimestamp);
+        ISpanBuilder SetStartTimestamp(DateTimeOffset startTimestamp);
 
         /// <summary>
         /// Starts the span.

--- a/src/OpenTelemetry.Abstractions/Trace/NoopSpanBuilder.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/NoopSpanBuilder.cs
@@ -39,7 +39,8 @@ namespace OpenTelemetry.Trace
             return this;
         }
 
-        public ISpanBuilder SetStartTimestamp(DateTime startTimestamp)
+        /// <inheritdoc/>
+        public ISpanBuilder SetStartTimestamp(DateTimeOffset startTimestamp)
         {
             return this;
         }

--- a/src/OpenTelemetry.Abstractions/Trace/SpanData.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/SpanData.cs
@@ -33,14 +33,14 @@ namespace OpenTelemetry.Trace
             ActivitySpanId parentSpanId,
             Resource resource,
             string name,
-            DateTime startTimestamp,
+            DateTimeOffset startTimestamp,
             Attributes attributes,
             ITimedEvents<IEvent> events,
             ILinks links,
             int? childSpanCount,
             Status status,
             SpanKind kind,
-            DateTime endTimestamp)
+            DateTimeOffset endTimestamp)
         {
             this.Context = context ?? throw new ArgumentNullException(nameof(context));
             this.ParentSpanId = parentSpanId;
@@ -107,14 +107,14 @@ namespace OpenTelemetry.Trace
         public SpanKind Kind { get; }
 
         /// <summary>
-        /// Gets the start UTC <see cref="DateTime"/>.
+        /// Gets the start <see cref="DateTimeOffset"/>.
         /// </summary>
-        public DateTime StartTimestamp { get; }
+        public DateTimeOffset StartTimestamp { get; }
 
         /// <summary>
-        /// Gets the end UTC <see cref="DateTime"/>.
+        /// Gets the end <see cref="DateTimeOffset"/>.
         /// </summary>
-        public DateTime EndTimestamp { get; }
+        public DateTimeOffset EndTimestamp { get; }
 
         /// <summary>
         /// Returns a new immutable <see cref="SpanData"/>.
@@ -137,14 +137,14 @@ namespace OpenTelemetry.Trace
                         ActivitySpanId parentSpanId,
                         Resource resource,
                         string name,
-                        DateTime startTimestamp,
+                        DateTimeOffset startTimestamp,
                         Attributes attributes,
                         ITimedEvents<IEvent> events,
                         ILinks links,
                         int? childSpanCount,
                         Status status,
                         SpanKind kind,
-                        DateTime endTimestamp)
+                        DateTimeOffset endTimestamp)
         {
             if (events == null)
             {
@@ -196,7 +196,7 @@ namespace OpenTelemetry.Trace
             if (o is SpanData that)
             {
                 return this.Context.Equals(that.Context)
-                     && ((this.ParentSpanId == null) ? (that.ParentSpanId == null) : this.ParentSpanId.Equals(that.ParentSpanId))
+                     && ((this.ParentSpanId == default) ? (that.ParentSpanId == default) : this.ParentSpanId.Equals(that.ParentSpanId))
                      && this.Resource.Equals(that.Resource)
                      && this.Name.Equals(that.Name)
                      && this.StartTimestamp.Equals(that.StartTimestamp)
@@ -205,7 +205,7 @@ namespace OpenTelemetry.Trace
                      && this.Links.Equals(that.Links)
                      && ((this.ChildSpanCount == null) ? (that.ChildSpanCount == null) : this.ChildSpanCount.Equals(that.ChildSpanCount))
                      && this.Status.Equals(that.Status)
-                     && ((this.EndTimestamp == null) ? (that.EndTimestamp == null) : this.EndTimestamp.Equals(that.EndTimestamp));
+                     && ((this.EndTimestamp == default) ? (that.EndTimestamp == default) : this.EndTimestamp.Equals(that.EndTimestamp));
             }
 
             return false;
@@ -218,7 +218,7 @@ namespace OpenTelemetry.Trace
             h *= 1000003;
             h ^= this.Context.GetHashCode();
             h *= 1000003;
-            h ^= (this.ParentSpanId == null) ? 0 : this.ParentSpanId.GetHashCode();
+            h ^= (this.ParentSpanId == default) ? 0 : this.ParentSpanId.GetHashCode();
             h *= 1000003;
             h ^= this.Resource.GetHashCode();
             h *= 1000003;
@@ -237,7 +237,7 @@ namespace OpenTelemetry.Trace
             h *= 1000003;
             h ^= this.Status.GetHashCode();
             h *= 1000003;
-            h ^= (this.EndTimestamp == null) ? 0 : this.EndTimestamp.GetHashCode();
+            h ^= (this.EndTimestamp == default) ? 0 : this.EndTimestamp.GetHashCode();
             return h;
         }
     }

--- a/src/OpenTelemetry.Abstractions/Utils/PreciseTimestamp.cs
+++ b/src/OpenTelemetry.Abstractions/Utils/PreciseTimestamp.cs
@@ -49,7 +49,7 @@ namespace OpenTelemetry.Utils
         /// Returns high resolution (1 DateTime tick) current UTC DateTime.
         /// </summary>
         /// <returns>DateTime UTC now with high resolution.</returns>
-        public static DateTime GetUtcNow()
+        public static DateTimeOffset GetUtcNow()
         {
 #if NET45 || NET46
             // DateTime.UtcNow accuracy on .NET Framework is ~16ms, this method
@@ -63,14 +63,14 @@ namespace OpenTelemetry.Utils
             // DateTime.AddSeconds (or Milliseconds) rounds value to 1 ms, use AddTicks to prevent it
             return tmp.SyncUtcNow.AddTicks(dateTimeTicksDiff);
 #else
-            return DateTime.UtcNow;
+            return DateTimeOffset.UtcNow;
 #endif
         }
 
 #if NET45 || NET46
         private static void Sync()
         {
-            // wait for DateTime.UtcNow update to the next granular value
+            // wait for DateTimeOffset.UtcNow update to the next granular value
             Thread.Sleep(1);
             timeSync = new TimeSync();
         }
@@ -108,7 +108,7 @@ namespace OpenTelemetry.Utils
 
         private class TimeSync
         {
-            public readonly DateTime SyncUtcNow = DateTime.UtcNow;
+            public readonly DateTimeOffset SyncUtcNow = DateTimeOffset.UtcNow;
             public readonly long SyncStopwatchTicks = Stopwatch.GetTimestamp();
         }
 #endif

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerConversionExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerConversionExtensions.cs
@@ -134,11 +134,11 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
             };
         }
 
-        public static long ToEpochMicroseconds(this DateTime timestamp)
+        public static long ToEpochMicroseconds(this DateTimeOffset timestamp)
         {
             // Truncate sub-microsecond precision before offsetting by the Unix Epoch to avoid
             // the last digit being off by one for dates that result in negative Unix times
-            long microseconds = timestamp.Ticks / TicksPerMicrosecond;
+            long microseconds = timestamp.UtcDateTime.Ticks / TicksPerMicrosecond;
             return microseconds - UnixEpochMicroseconds;
         }
     }

--- a/src/OpenTelemetry.Exporter.LightStep/Implementation/LightStepSpanExtensions.cs
+++ b/src/OpenTelemetry.Exporter.LightStep/Implementation/LightStepSpanExtensions.cs
@@ -44,7 +44,7 @@ namespace OpenTelemetry.Exporter.LightStep.Implementation
             {
                 SpanId = spanId, TraceId = traceId,
             };
-            span.StartTimestamp = data.StartTimestamp;
+            span.StartTimestamp = data.StartTimestamp.UtcDateTime;
             span.DurationMicros = Convert.ToUInt64(Math.Abs(duration.Ticks) / 10);
 
             foreach (var attr in data.Attributes.AttributeMap)
@@ -58,7 +58,7 @@ namespace OpenTelemetry.Exporter.LightStep.Implementation
 
                 // TODO: Make this actually pass attributes in correctly
                 fields.Add(new Tag { Key = evt.Name, StringValue = evt.Attributes.ToString() });
-                span.Logs.Add(new Log { Timestamp = evt.Timestamp, Fields = fields });
+                span.Logs.Add(new Log { Timestamp = evt.Timestamp.UtcDateTime, Fields = fields });
             }
 
             return span;

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/TraceExporterHandler.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/TraceExporterHandler.cs
@@ -139,9 +139,9 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
             return spanBuilder.Build();
         }
 
-        private long ToEpochMicroseconds(DateTime timestamp)
+        private long ToEpochMicroseconds(DateTimeOffset timestamp)
         {
-            return new DateTimeOffset(timestamp).ToUnixTimeMilliseconds() * 1000;
+            return timestamp.ToUnixTimeMilliseconds() * 1000;
         }
 
         private string EncodeTraceId(ActivityTraceId traceId)

--- a/src/OpenTelemetry/Trace/Span.cs
+++ b/src/OpenTelemetry/Trace/Span.cs
@@ -33,13 +33,13 @@ namespace OpenTelemetry.Trace
         private readonly ITraceParams traceParams;
         private readonly IStartEndHandler startEndHandler;
         private readonly Lazy<SpanContext> spanContext;
-        private readonly DateTime startTimestamp;
+        private readonly DateTimeOffset startTimestamp;
         private readonly object @lock = new object();
         private EvictingQueue<KeyValuePair<string, object>> attributes;
         private EvictingQueue<IEvent> events;
         private EvictingQueue<ILink> links;
         private Status status;
-        private DateTime endTimestamp;
+        private DateTimeOffset endTimestamp;
 
         private Span(
                 Activity activity,
@@ -47,7 +47,7 @@ namespace OpenTelemetry.Trace
                 SpanKind spanKind,
                 ITraceParams traceParams,
                 IStartEndHandler startEndHandler,
-                DateTime startTimestamp,
+                DateTimeOffset startTimestamp,
                 bool ownsActivity)
         {
             this.Activity = activity;
@@ -300,7 +300,7 @@ namespace OpenTelemetry.Trace
             this.End(PreciseTimestamp.GetUtcNow());
         }
 
-        public void End(DateTime endTimestamp)
+        public void End(DateTimeOffset endTimestamp)
         {
             this.endTimestamp = endTimestamp;
             if (this.OwnsActivity && this.Activity == Activity.Current)
@@ -429,7 +429,7 @@ namespace OpenTelemetry.Trace
                         SpanKind spanKind,
                         ITraceParams traceParams,
                         IStartEndHandler startEndHandler,
-                        DateTime startTimestamp,
+                        DateTimeOffset startTimestamp,
                         bool ownsActivity = true)
         {
             var span = new Span(

--- a/src/OpenTelemetry/Trace/SpanBuilder.cs
+++ b/src/OpenTelemetry/Trace/SpanBuilder.cs
@@ -37,7 +37,7 @@ namespace OpenTelemetry.Trace
         private ISampler sampler;
         private List<ILink> links;
         private bool recordEvents;
-        private DateTime startTimestamp;
+        private DateTimeOffset startTimestamp;
 
         internal SpanBuilder(string name, SpanBuilderOptions options)
         {
@@ -198,7 +198,7 @@ namespace OpenTelemetry.Trace
             return this;
         }
 
-        public ISpanBuilder SetStartTimestamp(DateTime startTimestamp)
+        public ISpanBuilder SetStartTimestamp(DateTimeOffset startTimestamp)
         {
             this.startTimestamp = startTimestamp;
             return this;
@@ -212,7 +212,7 @@ namespace OpenTelemetry.Trace
 
             if (this.startTimestamp == default)
             {
-                this.startTimestamp = activityForSpan.StartTimeUtc;
+                this.startTimestamp = new DateTimeOffset(activityForSpan.StartTimeUtc);
             }
 
             var activeTraceParams = this.options.TraceConfig.ActiveTraceParams;

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerSpanConverterTest.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerSpanConverterTest.cs
@@ -39,9 +39,9 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
         [Fact]
         public void JaegerSpanConverterTest_ConvertSpanToJaegerSpan_AllPropertiesSet()
         {
-            var startTimestamp = DateTime.Now;
+            var startTimestamp = DateTimeOffset.Now;
             var endTimestamp = startTimestamp.AddSeconds(60);
-            var eventTimestamp = DateTime.Now;
+            var eventTimestamp = DateTimeOffset.Now;
 
             var traceId = ActivityTraceId.CreateRandom();
             var traceIdAsInt = new Int128(traceId);
@@ -160,7 +160,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
             var logs = jaegerSpan.Logs.ToArray();
             var jaegerLog = logs[0];
             Assert.Equal(events.Events.First().Timestamp.ToEpochMicroseconds(), jaegerLog.Timestamp);
-            Assert.Equal(jaegerLog.Fields.Count(), 2);
+            Assert.Equal(2, jaegerLog.Fields.Count());
             var eventFields = jaegerLog.Fields.ToArray();
             var eventField = eventFields[0];
             Assert.Equal("key", eventField.Key);
@@ -171,7 +171,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
 
             jaegerLog = logs[1];
             Assert.Equal(events.Events.First().Timestamp.ToEpochMicroseconds(), jaegerLog.Timestamp);
-            Assert.Equal(jaegerLog.Fields.Count(), 2);
+            Assert.Equal(2, jaegerLog.Fields.Count());
             eventFields = jaegerLog.Fields.ToArray();
             eventField = eventFields[0];
             Assert.Equal("key", eventField.Key);
@@ -184,9 +184,9 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
         [Fact]
         public void JaegerSpanConverterTest_ConvertSpanToJaegerSpan_NoAttributes()
         {
-            var startTimestamp = DateTime.Now;
+            var startTimestamp = DateTimeOffset.Now;
             var endTimestamp = startTimestamp.AddSeconds(60);
-            var eventTimestamp = DateTime.Now;
+            var eventTimestamp = DateTimeOffset.Now;
 
             var traceId = ActivityTraceId.CreateRandom();
             var traceIdAsInt = new Int128(traceId);
@@ -273,7 +273,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
             var logs = jaegerSpan.Logs.ToArray();
             var jaegerLog = logs[0];
             Assert.Equal(events.Events.First().Timestamp.ToEpochMicroseconds(), jaegerLog.Timestamp);
-            Assert.Equal(jaegerLog.Fields.Count(), 2);
+            Assert.Equal(2, jaegerLog.Fields.Count());
             var eventFields = jaegerLog.Fields.ToArray();
             var eventField = eventFields[0];
             Assert.Equal("key", eventField.Key);
@@ -284,7 +284,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
 
             jaegerLog = logs[1];
             Assert.Equal(events.Events.First().Timestamp.ToEpochMicroseconds(), jaegerLog.Timestamp);
-            Assert.Equal(jaegerLog.Fields.Count(), 2);
+            Assert.Equal(2, jaegerLog.Fields.Count());
             eventFields = jaegerLog.Fields.ToArray();
             eventField = eventFields[0];
             Assert.Equal("key", eventField.Key);
@@ -297,9 +297,9 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
         [Fact]
         public void JaegerSpanConverterTest_ConvertSpanToJaegerSpan_NoEvents()
         {
-            var startTimestamp = DateTime.Now;
+            var startTimestamp = DateTimeOffset.Now;
             var endTimestamp = startTimestamp.AddSeconds(60);
-            var eventTimestamp = DateTime.Now;
+            var eventTimestamp = DateTimeOffset.Now;
 
             var traceId = ActivityTraceId.CreateRandom();
             var traceIdAsInt = new Int128(traceId);
@@ -400,9 +400,9 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
         [Fact]
         public void JaegerSpanConverterTest_ConvertSpanToJaegerSpan_NoLinks()
         {
-            var startTimestamp = DateTime.Now;
+            var startTimestamp = DateTimeOffset.Now;
             var endTimestamp = startTimestamp.AddSeconds(60);
-            var eventTimestamp = DateTime.Now;
+            var eventTimestamp = DateTimeOffset.Now;
 
             var traceId = ActivityTraceId.CreateRandom();
             var traceIdAsInt = new Int128(traceId);
@@ -514,7 +514,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
 
             jaegerLog = logs[1];
             Assert.Equal(events.Events.First().Timestamp.ToEpochMicroseconds(), jaegerLog.Timestamp);
-            Assert.Equal(jaegerLog.Fields.Count(), 2);
+            Assert.Equal(2, jaegerLog.Fields.Count());
             eventFields = jaegerLog.Fields.ToArray();
             eventField = eventFields[0];
             Assert.Equal("key", eventField.Key);

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerThriftIntegrationTest.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerThriftIntegrationTest.cs
@@ -54,9 +54,9 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
 
         private SpanData CreateTestSpan()
         {
-            var startTimestamp = new DateTime(2019, 1, 1);
+            var startTimestamp = new DateTimeOffset(2019, 1, 1, 0, 0, 0, TimeSpan.Zero);
             var endTimestamp = startTimestamp.AddSeconds(60);
-            var eventTimestamp = new DateTime(2019, 1, 1);
+            var eventTimestamp = new DateTimeOffset(2019, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
             var traceId = ActivityTraceId.CreateFromString("e8ea7e9ac72de94e91fabc613f9686b2".AsSpan());
             var traceIdAsInt = new Int128(traceId);

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanMock.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanMock.cs
@@ -78,7 +78,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
             this.HasEnded = true;
         }
 
-        public void End(DateTime endTimestamp)
+        public void End(DateTimeOffset endTimestamp)
         {
             this.End();
         }
@@ -129,7 +129,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
 
             public string Name { get; }
 
-            public DateTime Timestamp { get; }
+            public DateTimeOffset Timestamp { get; }
 
             public IDictionary<string, object> Attributes { get; }
         }

--- a/test/OpenTelemetry.Tests/Impl/Trace/Export/SpanDataTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Export/SpanDataTest.cs
@@ -31,11 +31,11 @@ namespace OpenTelemetry.Trace.Export.Test
         private const string EVENT_TEXT = "MyEventText";
         private const SpanKind SPAN_KIND = SpanKind.Client;
         private const int CHILD_SPAN_COUNT = 13;
-        private static readonly DateTime startTimestamp = PreciseTimestamp.GetUtcNow().AddSeconds(-1);
-        private static readonly DateTime eventTimestamp1 = startTimestamp.AddMilliseconds(1);
-        private static readonly DateTime eventTimestamp2 = startTimestamp.AddMilliseconds(2);
-        private static readonly DateTime eventTimestamp3 = startTimestamp.AddMilliseconds(3);
-        private static readonly DateTime endTimestamp = startTimestamp.AddMilliseconds(4);
+        private static readonly DateTimeOffset startTimestamp = PreciseTimestamp.GetUtcNow().AddSeconds(-1);
+        private static readonly DateTimeOffset eventTimestamp1 = startTimestamp.AddMilliseconds(1);
+        private static readonly DateTimeOffset eventTimestamp2 = startTimestamp.AddMilliseconds(2);
+        private static readonly DateTimeOffset eventTimestamp3 = startTimestamp.AddMilliseconds(3);
+        private static readonly DateTimeOffset endTimestamp = startTimestamp.AddMilliseconds(4);
         private static readonly Status status = Status.DeadlineExceeded.WithDescription("TooSlow");
         private readonly SpanContext spanContext;
         private readonly ActivitySpanId parentSpanId;

--- a/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
@@ -544,7 +544,7 @@ namespace OpenTelemetry.Trace.Test
                     startEndHandler,
                     PreciseTimestamp.GetUtcNow());
 
-            var eventTimestamps = new DateTime[2 * maxNumberOfEvents];
+            var eventTimestamps = new DateTimeOffset[2 * maxNumberOfEvents];
             
             for (int i = 0; i < 2 * maxNumberOfEvents; i++)
             {
@@ -729,7 +729,7 @@ namespace OpenTelemetry.Trace.Test
             Activity.Current = null;
         }
 
-        private void AssertApproxSameTimestamp(DateTime one, DateTime two)
+        private void AssertApproxSameTimestamp(DateTimeOffset one, DateTimeOffset two)
         {
             var timeShift = Math.Abs((one - two).TotalMilliseconds);
             Assert.InRange(timeShift, double.Epsilon, 20);

--- a/test/OpenTelemetry.Tests/Impl/Trace/TestSpan.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/TestSpan.cs
@@ -74,7 +74,7 @@ namespace OpenTelemetry.Trace.Test
         {
         }
 
-        public void End(DateTime endTimestamp)
+        public void End(DateTimeOffset endTimestamp)
         {
         }
     }


### PR DESCRIPTION
As per discussion in this thread https://github.com/open-telemetry/opentelemetry-dotnet/pull/211#discussion_r326808570

and this article https://docs.microsoft.com/en-us/dotnet/standard/datetime/choosing-between-datetime

`DateTimeOffset` is preferable over `DateTime` and should be used by default