### PR TITLE
Expose Attributes, Link, Events, Start/End timestamps on span

### DIFF
--- a/src/OpenTelemetry.Abstractions/Trace/Export/Attributes.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/Export/Attributes.cs
@@ -34,7 +34,7 @@ namespace OpenTelemetry.Trace.Export
 
         public int DroppedAttributesCount { get; }
 
-        public static Attributes Create(IReadOnlyCollection<KeyValuePair<string, object>> attributeMap, int droppedAttributesCount)
+        public static Attributes Create(IEnumerable<KeyValuePair<string, object>> attributeMap, int droppedAttributesCount)
         {
             if (attributeMap == null)
             {

--- a/src/OpenTelemetry.Abstractions/Trace/Export/LinkList.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/Export/LinkList.cs
@@ -34,7 +34,7 @@ namespace OpenTelemetry.Trace.Export
 
         public IEnumerable<ILink> Links { get; }
 
-        public static LinkList Create(IReadOnlyCollection<ILink> links, int droppedLinksCount)
+        public static LinkList Create(IEnumerable<ILink> links, int droppedLinksCount)
         {
             if (links == null)
             {

--- a/src/OpenTelemetry.Abstractions/Trace/Export/TimedEvents.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/Export/TimedEvents.cs
@@ -34,7 +34,7 @@ namespace OpenTelemetry.Trace.Export
 
         public int DroppedEventsCount { get; }
 
-        public static ITimedEvents<T> Create(IReadOnlyCollection<T> events, int droppedEventsCount)
+        public static ITimedEvents<T> Create(IEnumerable<T> events, int droppedEventsCount)
         {
             if (events == null)
             {

--- a/src/OpenTelemetry/Trace/Internal/EvictingQueue.cs
+++ b/src/OpenTelemetry/Trace/Internal/EvictingQueue.cs
@@ -17,9 +17,10 @@
 namespace OpenTelemetry.Trace.Internal
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
 
-    internal class EvictingQueue<T>
+    internal class EvictingQueue<T> : IEnumerable<T>
     {
         private readonly int maxNumEvents;
         private readonly Queue<T> events;
@@ -40,9 +41,14 @@ namespace OpenTelemetry.Trace.Internal
 
         public int DroppedItems => this.totalRecorded - this.events.Count;
 
-        public IReadOnlyCollection<T> ToReadOnlyCollection()
+        public IEnumerator<T> GetEnumerator()
         {
-            return this.events.ToArray();
+            return this.events.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
         }
 
         internal void AddEvent(T evnt)

--- a/src/OpenTelemetry/Trace/Span.cs
+++ b/src/OpenTelemetry/Trace/Span.cs
@@ -19,6 +19,7 @@ namespace OpenTelemetry.Trace
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Linq;
     using OpenTelemetry.Resources;
     using OpenTelemetry.Trace.Config;
     using OpenTelemetry.Trace.Export;
@@ -110,51 +111,36 @@ namespace OpenTelemetry.Trace
         public bool IsRecordingEvents { get; }
 
         /// <summary>
+        /// Gets attributes.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, object>> Attributes => this.attributes ?? Enumerable.Empty<KeyValuePair<string, object>>();
+
+        /// <summary>
+        /// Gets events.
+        /// </summary>
+        public IEnumerable<IEvent> Events => this.events ?? Enumerable.Empty<IEvent>();
+
+        /// <summary>
+        /// Gets links.
+        /// </summary>
+        public IEnumerable<ILink> Links => this.links ?? Enumerable.Empty<ILink>();
+
+        /// <summary>
+        /// Gets span start timestamp.
+        /// </summary>
+        public DateTime StartTimestamp => this.startTimestamp;
+
+        /// <summary>
+        /// Gets span end timestamp.
+        /// </summary>
+        public DateTime EndTimestamp => this.endTimestamp;
+
+        /// <summary>
         /// Gets or sets span kind.
         /// </summary>
         internal SpanKind? Kind { get; set; }
 
         internal bool OwnsActivity { get; }
-
-        private EvictingQueue<KeyValuePair<string, object>> InitializedAttributes
-        {
-            get
-            {
-                if (this.attributes == null)
-                {
-                    this.attributes = new EvictingQueue<KeyValuePair<string, object>>(this.traceConfig.MaxNumberOfAttributes);
-                }
-
-                return this.attributes;
-            }
-        }
-
-        private EvictingQueue<IEvent> InitializedEvents
-        {
-            get
-            {
-                if (this.events == null)
-                {
-                    this.events =
-                        new EvictingQueue<IEvent>(this.traceConfig.MaxNumberOfEvents);
-                }
-
-                return this.events;
-            }
-        }
-
-        private EvictingQueue<ILink> InitializedLinks
-        {
-            get
-            {
-                if (this.links == null)
-                {
-                    this.links = new EvictingQueue<ILink>(this.traceConfig.MaxNumberOfLinks);
-                }
-
-                return this.links;
-            }
-        }
 
         private Status StatusWithDefault => this.status.IsValid ? this.status : Status.Ok;
 
@@ -185,7 +171,12 @@ namespace OpenTelemetry.Trace
                     return;
                 }
 
-                this.InitializedAttributes.AddEvent(new KeyValuePair<string, object>(keyValuePair.Key, keyValuePair.Value));
+                if (this.attributes == null)
+                {
+                    this.attributes = new EvictingQueue<KeyValuePair<string, object>>(this.traceConfig.MaxNumberOfAttributes);
+                }
+
+                this.attributes.AddEvent(new KeyValuePair<string, object>(keyValuePair.Key, keyValuePair.Value));
             }
         }
 
@@ -210,7 +201,13 @@ namespace OpenTelemetry.Trace
                     return;
                 }
 
-                this.InitializedEvents.AddEvent(Event.Create(name, PreciseTimestamp.GetUtcNow()));
+                if (this.events == null)
+                {
+                    this.events =
+                        new EvictingQueue<IEvent>(this.traceConfig.MaxNumberOfEvents);
+                }
+
+                this.events.AddEvent(Event.Create(name, PreciseTimestamp.GetUtcNow()));
             }
         }
 
@@ -240,7 +237,13 @@ namespace OpenTelemetry.Trace
                     return;
                 }
 
-                this.InitializedEvents.AddEvent(Event.Create(name, PreciseTimestamp.GetUtcNow(), eventAttributes));
+                if (this.events == null)
+                {
+                    this.events =
+                        new EvictingQueue<IEvent>(this.traceConfig.MaxNumberOfEvents);
+                }
+
+                this.events.AddEvent(Event.Create(name, PreciseTimestamp.GetUtcNow(), eventAttributes));
             }
         }
 
@@ -265,7 +268,13 @@ namespace OpenTelemetry.Trace
                     return;
                 }
 
-                this.InitializedEvents.AddEvent(addEvent);
+                if (this.events == null)
+                {
+                    this.events =
+                        new EvictingQueue<IEvent>(this.traceConfig.MaxNumberOfEvents);
+                }
+
+                this.events.AddEvent(addEvent);
             }
         }
 
@@ -290,7 +299,12 @@ namespace OpenTelemetry.Trace
                     return;
                 }
 
-                this.InitializedLinks.AddEvent(link);
+                if (this.links == null)
+                {
+                    this.links = new EvictingQueue<ILink>(this.traceConfig.MaxNumberOfLinks);
+                }
+
+                this.links.AddEvent(link);
             }
         }
 
@@ -335,9 +349,9 @@ namespace OpenTelemetry.Trace
                 throw new InvalidOperationException("Getting SpanData for a Span without RECORD_EVENTS option.");
             }
 
-            var attributesSpanData = Attributes.Create(this.attributes?.ToReadOnlyCollection(), this.attributes?.DroppedItems ?? 0);
-            var eventsSpanData = TimedEvents<IEvent>.Create(this.events?.ToReadOnlyCollection(), this.events?.DroppedItems ?? 0);
-            var linksSpanData = LinkList.Create(this.links?.ToReadOnlyCollection(), this.links?.DroppedItems ?? 0);
+            var attributesSpanData = Export.Attributes.Create(this.attributes, this.attributes?.DroppedItems ?? 0);
+            var eventsSpanData = TimedEvents<IEvent>.Create(this.events, this.events?.DroppedItems ?? 0);
+            var linksSpanData = LinkList.Create(this.links, this.links?.DroppedItems ?? 0);
 
             return SpanData.Create(
                 this.Context, // TODO avoid using context, use Activity instead

--- a/test/OpenTelemetry.Collector.AspNetCore.Tests/AttributesExtensions.cs
+++ b/test/OpenTelemetry.Collector.AspNetCore.Tests/AttributesExtensions.cs
@@ -14,16 +14,17 @@
 // limitations under the License.
 // </copyright>
 
+
 namespace OpenTelemetry.Collector.AspNetCore.Tests
 {
+    using System.Collections.Generic;
     using System.Linq;
-    using OpenTelemetry.Trace.Export;
 
     internal static class AttributesExtensions
     {
-        public static object GetValue(this Attributes attributes, string key)
+        public static object GetValue(this IEnumerable<KeyValuePair<string, object>> attributes, string key)
         {
-            return attributes.AttributeMap.FirstOrDefault(kvp => kvp.Key == key).Value;
+            return attributes.FirstOrDefault(kvp => kvp.Key == key).Value;
         }
     }
 }

--- a/test/OpenTelemetry.Collector.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Collector.AspNetCore.Tests/BasicTests.cs
@@ -80,10 +80,10 @@ namespace OpenTelemetry.Collector.AspNetCore.Tests
 
 
             Assert.Equal(2, startEndHandler.Invocations.Count); // begin and end was called
-            var spanData = ((Span)startEndHandler.Invocations[1].Arguments[0]).ToSpanData();
+            var span = ((Span)startEndHandler.Invocations[1].Arguments[0]);
 
-            Assert.Equal(SpanKind.Server, spanData.Kind);
-            Assert.Equal("/api/values", spanData.Attributes.GetValue("http.path"));
+            Assert.Equal(SpanKind.Server, span.Kind);
+            Assert.Equal("/api/values", span.Attributes.GetValue("http.path"));
         }
 
         [Fact]
@@ -137,14 +137,14 @@ namespace OpenTelemetry.Collector.AspNetCore.Tests
             }
 
             Assert.Equal(2, startEndHandler.Invocations.Count); // begin and end was called
-            var spanData = ((Span)startEndHandler.Invocations[0].Arguments[0]).ToSpanData();
+            var span = ((Span)startEndHandler.Invocations[0].Arguments[0]);
 
-            Assert.Equal(SpanKind.Server, spanData.Kind);
-            Assert.Equal("api/Values/{id}", spanData.Name);
-            Assert.Equal("/api/values/2", spanData.Attributes.GetValue("http.path"));
+            Assert.Equal(SpanKind.Server, span.Kind);
+            Assert.Equal("api/Values/{id}", span.Name);
+            Assert.Equal("/api/values/2", span.Attributes.GetValue("http.path"));
 
-            Assert.Equal(expectedTraceId, spanData.Context.TraceId);
-            Assert.Equal(expectedSpanId, spanData.ParentSpanId);
+            Assert.Equal(expectedTraceId, span.Context.TraceId);
+            Assert.Equal(expectedSpanId, span.ParentSpanId);
         }
     }
 }

--- a/test/OpenTelemetry.Collector.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
+++ b/test/OpenTelemetry.Collector.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
@@ -93,11 +93,11 @@ namespace OpenTelemetry.Collector.AspNetCore.Tests
             }
 
             Assert.Equal(2, startEndHandler.Invocations.Count); // begin and end was called
-            var spanData = ((Span)startEndHandler.Invocations[0].Arguments[0]).ToSpanData();
+            var span = ((Span)startEndHandler.Invocations[0].Arguments[0]);
 
-            Assert.Equal(SpanKind.Server, spanData.Kind);
-            Assert.Equal("/api/values", spanData.Attributes.GetValue("http.path"));
-            Assert.Equal(503L, spanData.Attributes.GetValue("http.status_code"));
+            Assert.Equal(SpanKind.Server, span.Kind);
+            Assert.Equal("/api/values", span.Attributes.GetValue("http.path"));
+            Assert.Equal(503L, span.Attributes.GetValue("http.status_code"));
         }
     }
 }

--- a/test/OpenTelemetry.Collector.Dependencies.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Collector.Dependencies.Tests/BasicTests.cs
@@ -70,19 +70,19 @@ namespace OpenTelemetry.Collector.Dependencies.Tests
             }
 
             Assert.Equal(2, startEndHandler.Invocations.Count); // begin and end was called
-            var spanData = ((Span)startEndHandler.Invocations[1].Arguments[0]).ToSpanData();
+            var span = ((Span)startEndHandler.Invocations[1].Arguments[0]);
 
-            Assert.Equal(parent.TraceId, spanData.Context.TraceId);
-            Assert.Equal(parent.SpanId, spanData.ParentSpanId);
-            Assert.NotEqual(parent.SpanId, spanData.Context.SpanId);
-            Assert.NotEqual(default, spanData.Context.SpanId);
+            Assert.Equal(parent.TraceId, span.Context.TraceId);
+            Assert.Equal(parent.SpanId, span.ParentSpanId);
+            Assert.NotEqual(parent.SpanId, span.Context.SpanId);
+            Assert.NotEqual(default, span.Context.SpanId);
 
             Assert.True(request.Headers.TryGetValues("traceparent", out var traceparents));
             Assert.True(request.Headers.TryGetValues("tracestate", out var tracestates));
             Assert.Single(traceparents);
             Assert.Single(tracestates);
 
-            Assert.Equal($"00-{spanData.Context.TraceId}-{spanData.Context.SpanId}-01", traceparents.Single());
+            Assert.Equal($"00-{span.Context.TraceId}-{span.Context.SpanId}-01", traceparents.Single());
             Assert.Equal("k1=v1,k2=v2", tracestates.Single());
         }
 

--- a/test/OpenTelemetry.Collector.Dependencies.Tests/HttpClientTests.cs
+++ b/test/OpenTelemetry.Collector.Dependencies.Tests/HttpClientTests.cs
@@ -20,7 +20,6 @@ namespace OpenTelemetry.Collector.Dependencies.Tests
     using Newtonsoft.Json;
     using OpenTelemetry.Trace;
     using OpenTelemetry.Trace.Config;
-    using OpenTelemetry.Trace.Internal;
     using OpenTelemetry.Trace.Sampler;
     using System;
     using System.Collections.Generic;
@@ -77,13 +76,7 @@ namespace OpenTelemetry.Collector.Dependencies.Tests
             return result;
         }
 
-        public static IEnumerable<object[]> TestData
-        {
-            get
-            {
-                return readTestCases();
-            }
-        }
+        public static IEnumerable<object[]> TestData => readTestCases();
 
         [Theory]
         [MemberData(nameof(TestData))]
@@ -100,7 +93,7 @@ namespace OpenTelemetry.Collector.Dependencies.Tests
 
             var startEndHandler = new Mock<IStartEndHandler>();
             var tracer = new Tracer(startEndHandler.Object, TraceConfig.Default);
-            tc.url = NormaizeValues(tc.url, host, port);
+            tc.url = NormalizeValues(tc.url, host, port);
 
             using (serverLifeTime)
             {
@@ -130,16 +123,16 @@ namespace OpenTelemetry.Collector.Dependencies.Tests
                     }
                     catch (Exception)
                     {
-                        //test case can intentiaonlly send request that will result in exception
+                        //test case can intentionally send request that will result in exception
                     }
                 }
             }
 
             Assert.Equal(2, startEndHandler.Invocations.Count); // begin and end was called
-            var spanData = ((Span)startEndHandler.Invocations[1].Arguments[0]).ToSpanData();
+            var span = ((Span)startEndHandler.Invocations[1].Arguments[0]);
 
-            Assert.Equal(tc.spanName, spanData.Name);
-            Assert.Equal(tc.spanKind, spanData.Kind.ToString());
+            Assert.Equal(tc.spanName, span.Name);
+            Assert.Equal(tc.spanKind, span.Kind.ToString());
 
             var d = new Dictionary<CanonicalCode, string>()
             {
@@ -162,12 +155,12 @@ namespace OpenTelemetry.Collector.Dependencies.Tests
                 { CanonicalCode.Unauthenticated, "UNAUTHENTICATED"},
             };
 
-            Assert.Equal(tc.spanStatus, d[spanData.Status.CanonicalCode]);
+            Assert.Equal(tc.spanStatus, d[span.Status.CanonicalCode]);
 
-            var normilizedAttributes = spanData.Attributes.AttributeMap.ToDictionary(x => x.Key, x => x.Value.ToString());
-            tc.spanAttributes = tc.spanAttributes.ToDictionary(x => x.Key, x => NormaizeValues(x.Value, host, port));
+            var normalizedAttributes = span.Attributes.ToDictionary(x => x.Key, x => x.Value.ToString());
+            tc.spanAttributes = tc.spanAttributes.ToDictionary(x => x.Key, x => NormalizeValues(x.Value, host, port));
 
-            Assert.Equal(tc.spanAttributes.ToHashSet(), normilizedAttributes.ToHashSet());
+            Assert.Equal(tc.spanAttributes.ToHashSet(), normalizedAttributes.ToHashSet());
         }
 
         [Fact]
@@ -198,7 +191,7 @@ namespace OpenTelemetry.Collector.Dependencies.Tests
             await t;
         }
 
-        private string NormaizeValues(string value, string host, int port)
+        private string NormalizeValues(string value, string host, int port)
         {
             return value.Replace("{host}", host).Replace("{port}", port.ToString());
         }

--- a/test/OpenTelemetry.Collector.StackExchangeRedis.Tests/AttributesExtensions.cs
+++ b/test/OpenTelemetry.Collector.StackExchangeRedis.Tests/AttributesExtensions.cs
@@ -14,16 +14,17 @@
 // limitations under the License.
 // </copyright>
 
+
 namespace OpenTelemetry.Collector.StackExchangeRedis.Tests
 {
     using System.Linq;
-    using OpenTelemetry.Trace.Export;
+    using System.Collections.Generic;
 
     internal static class AttributesExtensions
     {
-        public static object GetValue(this Attributes attributes, string key)
+        public static object GetValue(this IEnumerable<KeyValuePair<string, object>> attributes, string key)
         {
-            return attributes.AttributeMap.FirstOrDefault(kvp => kvp.Key == key).Value;
+            return attributes.FirstOrDefault(kvp => kvp.Key == key).Value;
         }
     }
 }

--- a/test/OpenTelemetry.Collector.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToSpanConverterTests.cs
+++ b/test/OpenTelemetry.Collector.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToSpanConverterTests.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System.Linq;
-using OpenTelemetry.Collector.StackExchangeRedis.Tests;
 
 namespace OpenTelemetry.Collector.StackExchangeRedis.Implementation
 {
@@ -24,8 +22,7 @@ namespace OpenTelemetry.Collector.StackExchangeRedis.Implementation
     using StackExchange.Redis.Profiling;
     using Xunit;
     using System;
-    using System.Diagnostics;
-    using System.Collections.Generic;
+    using OpenTelemetry.Collector.StackExchangeRedis.Tests;
 
     public class RedisProfilerEntryToSpanConverterTests
     {
@@ -48,7 +45,7 @@ namespace OpenTelemetry.Collector.StackExchangeRedis.Implementation
             var profiledCommand = new Mock<IProfiledCommand>();
             var now = DateTimeOffset.Now;
             profiledCommand.Setup(m => m.CommandCreated).Returns(now.DateTime);
-            var result = ((Span)RedisProfilerEntryToSpanConverter.ProfilerCommandToSpan(Tracing.Tracer, BlankSpan.Instance, profiledCommand.Object)).ToSpanData();
+            var result = ((Span)RedisProfilerEntryToSpanConverter.ProfilerCommandToSpan(Tracing.Tracer, BlankSpan.Instance, profiledCommand.Object));
             Assert.Equal(now, result.StartTimestamp);
         }
 
@@ -57,8 +54,8 @@ namespace OpenTelemetry.Collector.StackExchangeRedis.Implementation
         {
             var profiledCommand = new Mock<IProfiledCommand>();
             profiledCommand.Setup(m => m.CommandCreated).Returns(DateTime.UtcNow);
-            var result = ((Span)RedisProfilerEntryToSpanConverter.ProfilerCommandToSpan(Tracing.Tracer, BlankSpan.Instance, profiledCommand.Object)).ToSpanData();
-            Assert.Contains(result.Attributes.AttributeMap, kvp => kvp.Key == "db.type");
+            var result = ((Span)RedisProfilerEntryToSpanConverter.ProfilerCommandToSpan(Tracing.Tracer, BlankSpan.Instance, profiledCommand.Object));
+            Assert.Contains(result.Attributes, kvp => kvp.Key == "db.type");
             Assert.Equal("redis", result.Attributes.GetValue("db.type"));
         }
 
@@ -68,8 +65,8 @@ namespace OpenTelemetry.Collector.StackExchangeRedis.Implementation
             var profiledCommand = new Mock<IProfiledCommand>();
             profiledCommand.Setup(m => m.CommandCreated).Returns(DateTime.UtcNow);
             profiledCommand.Setup(m => m.Command).Returns("SET");
-            var result = ((Span)RedisProfilerEntryToSpanConverter.ProfilerCommandToSpan(Tracing.Tracer, BlankSpan.Instance, profiledCommand.Object)).ToSpanData();
-            Assert.Contains(result.Attributes.AttributeMap, kvp => kvp.Key == "db.statement");
+            var result = ((Span)RedisProfilerEntryToSpanConverter.ProfilerCommandToSpan(Tracing.Tracer, BlankSpan.Instance, profiledCommand.Object));
+            Assert.Contains(result.Attributes, kvp => kvp.Key == "db.statement");
             Assert.Equal("SET", result.Attributes.GetValue("db.statement"));
         }
 
@@ -81,8 +78,8 @@ namespace OpenTelemetry.Collector.StackExchangeRedis.Implementation
             var expectedFlags = StackExchange.Redis.CommandFlags.FireAndForget |
                                 StackExchange.Redis.CommandFlags.NoRedirect;
             profiledCommand.Setup(m => m.Flags).Returns(expectedFlags);
-            var result = ((Span)RedisProfilerEntryToSpanConverter.ProfilerCommandToSpan(Tracing.Tracer, BlankSpan.Instance, profiledCommand.Object)).ToSpanData();
-            Assert.Contains(result.Attributes.AttributeMap, kvp => kvp.Key == "redis.flags");
+            var result = ((Span)RedisProfilerEntryToSpanConverter.ProfilerCommandToSpan(Tracing.Tracer, BlankSpan.Instance, profiledCommand.Object));
+            Assert.Contains(result.Attributes, kvp => kvp.Key == "redis.flags");
             Assert.Equal("None, FireAndForget, NoRedirect", result.Attributes.GetValue("redis.flags"));
         }
     }

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
@@ -311,21 +311,5 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
             Assert.Equal("bar", spanMock.Attributes.Last().Key);
             Assert.Equal("baz", (string)spanMock.Attributes.Last().Value);
         }
-
-        /// <summary>
-        /// Gets the SpanData for a given span instance. This assumes the returned value from GetDefaultSpan() is an actual Span.
-        /// </summary>
-        /// <param name="instance">The instance.</param>
-        /// <returns>an instance of SpanData</returns>
-        internal static SpanData GetSpanData(OpenTelemetry.Trace.ISpan instance)
-        {
-            // TODO An explicit interface or interface method on ISpan for retrieving the immutable properties of a given Span is probably a better approach here.
-            if (instance is Span span)
-            {
-                return span.ToSpanData();
-            }
-
-            return null;
-        }
     }
 }

--- a/test/OpenTelemetry.Tests/Impl/Trace/AttributesExtensions.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/AttributesExtensions.cs
@@ -14,30 +14,30 @@
 // limitations under the License.
 // </copyright>
 
-using System.Collections.Generic;
-using Xunit;
 
 namespace OpenTelemetry.Tests
 {
+    using System.Collections.Generic;
     using System.Linq;
-    using OpenTelemetry.Trace.Export;
-
+    using Xunit;
+   
     internal static class AttributesExtensions
     {
-        public static object GetValue(this Attributes attributes, string key)
+        public static object GetValue(this IEnumerable<KeyValuePair<string, object>> attributes, string key)
         {
-            return attributes.AttributeMap.FirstOrDefault(kvp => kvp.Key == key).Value;
+            return attributes.FirstOrDefault(kvp => kvp.Key == key).Value;
         }
 
-        public static void AssertAreSame(this Attributes attributes,
+        public static void AssertAreSame(this IEnumerable<KeyValuePair<string, object>> attributes,
             IEnumerable<KeyValuePair<string, object>> expectedAttributes)
         {
-            var keyValuePairs = expectedAttributes as KeyValuePair<string, object>[] ?? expectedAttributes.ToArray();
-            Assert.Equal(attributes.AttributeMap.Count(), keyValuePairs.Count());
+            var expectedKeyValuePairs = expectedAttributes as KeyValuePair<string, object>[] ?? expectedAttributes.ToArray();
+            var actualKeyValuePairs = attributes as KeyValuePair<string, object>[] ?? attributes.ToArray();
+            Assert.Equal(actualKeyValuePairs.Count(), expectedKeyValuePairs.Count());
 
-            foreach (var attr in attributes.AttributeMap)
+            foreach (var attr in actualKeyValuePairs)
             {
-                Assert.Contains(attr, keyValuePairs);
+                Assert.Contains(attr, expectedKeyValuePairs);
             }
         }
     }

--- a/test/OpenTelemetry.Tests/Impl/Trace/SpanBuilderTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/SpanBuilderTest.cs
@@ -44,14 +44,14 @@ namespace OpenTelemetry.Trace.Test
         [Fact]
         public void StartSpanNullParent()
         {
-            var span = new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
+            var span = (Span) new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
                 .SetSpanKind(SpanKind.Internal)
                 .SetNoParent()
                 .StartSpan();
             Assert.True(span.Context.IsValid);
             Assert.True(span.IsRecordingEvents);
             Assert.True((span.Context.TraceOptions & ActivityTraceFlags.Recorded) != 0);
-            var spanData = ((Span)span).ToSpanData();
+            var spanData = ((Span)span);
             Assert.True(spanData.ParentSpanId == default);
             Assert.InRange(spanData.StartTimestamp, PreciseTimestamp.GetUtcNow().AddSeconds(-1), PreciseTimestamp.GetUtcNow().AddSeconds(1));
             Assert.Equal(SpanName, spanData.Name);
@@ -211,7 +211,7 @@ namespace OpenTelemetry.Trace.Test
         [Fact]
         public void StartSpanNullParentWithRecordEvents()
         {
-            var span = new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
+            var span = (Span) new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
                 .SetSpanKind(SpanKind.Internal)
                 .SetSampler(Samplers.NeverSample)
                 .SetRecordEvents(true)
@@ -220,35 +220,32 @@ namespace OpenTelemetry.Trace.Test
             Assert.True(span.Context.IsValid);
             Assert.True(span.IsRecordingEvents);
             Assert.True((span.Context.TraceOptions & ActivityTraceFlags.Recorded) != 0);
-            var spanData = ((Span)span).ToSpanData();
-            Assert.True(spanData.ParentSpanId == default);
+            Assert.True(span.ParentSpanId == default);
         }
 
         [Fact]
         public void StartSpanWithStartTimestamp()
         {
             var timestamp = DateTime.UtcNow.AddSeconds(-100);
-            var span = new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
+            var span = (Span) new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
                 .SetSpanKind(SpanKind.Internal)
                 .SetSampler(Samplers.AlwaysSample)
                 .SetStartTimestamp(timestamp)
                 .StartSpan();
 
-            var spanData = ((Span)span).ToSpanData();
-            Assert.Equal(timestamp, spanData.StartTimestamp);
+            Assert.Equal(timestamp, span.StartTimestamp);
         }
 
         [Fact]
         public void StartSpanWithImplicitTimestamp()
         {
             var timestamp = PreciseTimestamp.GetUtcNow();
-            var span = new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
+            var span = (Span) new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
                 .SetSpanKind(SpanKind.Internal)
                 .SetSampler(Samplers.AlwaysSample)
                 .StartSpan();
 
-            var spanData = ((Span)span).ToSpanData();
-            Assert.InRange(Math.Abs((timestamp - spanData.StartTimestamp).TotalMilliseconds), 0, 20);
+            Assert.InRange(Math.Abs((timestamp - span.StartTimestamp).TotalMilliseconds), 0, 20);
         }
 
         [Fact]
@@ -276,14 +273,14 @@ namespace OpenTelemetry.Trace.Test
             Assert.True(rootSpan.IsRecordingEvents);
             Assert.True((rootSpan.Context.TraceOptions & ActivityTraceFlags.Recorded) != 0);
 
-            var childSpan = new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
+            var childSpan = (Span) new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
                 .SetSpanKind(SpanKind.Internal)
                 .SetParent(rootSpan)
                 .StartSpan();
 
             Assert.True(childSpan.Context.IsValid);
             Assert.Equal(rootSpan.Context.TraceId, childSpan.Context.TraceId);
-            Assert.Equal(rootSpan.Context.SpanId, ((Span)childSpan).ToSpanData().ParentSpanId);
+            Assert.Equal(rootSpan.Context.SpanId, childSpan.ParentSpanId);
         }
 
         [Fact]
@@ -334,14 +331,14 @@ namespace OpenTelemetry.Trace.Test
             var parentActivity = new Activity(SpanName).Start();
             parentActivity.TraceStateString = "k1=v1,k2=v2";
 
-            var childSpan = new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
+            var childSpan = (Span) new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
                 .SetSpanKind(SpanKind.Internal)
                 .SetNoParent()
                 .StartSpan();
 
             Assert.True(childSpan.Context.IsValid);
             Assert.NotEqual(parentActivity.TraceId, childSpan.Context.TraceId);
-            Assert.True(((Span)childSpan).ToSpanData().ParentSpanId == default);
+            Assert.True(childSpan.ParentSpanId == default);
 
             var activity = ((Span)childSpan).Activity;
             Assert.Equal(parentActivity, Activity.Current);
@@ -406,7 +403,7 @@ namespace OpenTelemetry.Trace.Test
                 .Start();
             activity.TraceStateString = "k1=v1,k2=v2";
 
-            var span = new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
+            var span = (Span) new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
                 .SetSpanKind(SpanKind.Internal)
                 .SetCreateChild(false)
                 .StartSpan();
@@ -420,7 +417,7 @@ namespace OpenTelemetry.Trace.Test
             Assert.Equal(Activity.Current, activity);
             Assert.Equal("k1=v1,k2=v2", span.Context.Tracestate.ToString());
 
-            Assert.Equal(activity.StartTimeUtc, ((Span)span).ToSpanData().StartTimestamp);
+            Assert.Equal(activity.StartTimeUtc, span.StartTimestamp);
         }
 
         [Fact]
@@ -447,7 +444,7 @@ namespace OpenTelemetry.Trace.Test
         [Fact]
         public void StartSpan_ExplicitNoParent()
         {
-            var span = new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
+            var span = (Span) new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
                 .SetSpanKind(SpanKind.Internal)
                 .SetNoParent()
                 .StartSpan();
@@ -455,8 +452,8 @@ namespace OpenTelemetry.Trace.Test
             Assert.True(span.Context.IsValid);
             Assert.True(span.IsRecordingEvents);
             Assert.True((span.Context.TraceOptions & ActivityTraceFlags.Recorded) != 0);
-            var spanData = ((Span)span).ToSpanData();
-            Assert.True(spanData.ParentSpanId == default);
+
+            Assert.True(span.ParentSpanId == default);
 
             var activity = ((Span)span).Activity;
             Assert.Null(Activity.Current);
@@ -468,22 +465,20 @@ namespace OpenTelemetry.Trace.Test
         [Fact]
         public void StartSpan_NoParent()
         {
-            var span = new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
+            var span = (Span) new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
                 .SetSpanKind(SpanKind.Internal)
                 .StartSpan();
 
             Assert.True(span.Context.IsValid);
             Assert.True(span.IsRecordingEvents);
             Assert.True((span.Context.TraceOptions & ActivityTraceFlags.Recorded) != 0);
-            var spanData = ((Span)span).ToSpanData();
-            Assert.True(spanData.ParentSpanId == default);
+            Assert.True(span.ParentSpanId == default);
         }
-
 
         [Fact]
         public void StartSpan_BlankSpanParent()
         {
-            var span = new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
+            var span = (Span) new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
                 .SetSpanKind(SpanKind.Internal)
                 .SetParent(BlankSpan.Instance)
                 .StartSpan();
@@ -491,14 +486,13 @@ namespace OpenTelemetry.Trace.Test
             Assert.True(span.Context.IsValid);
             Assert.True(span.IsRecordingEvents);
             Assert.True((span.Context.TraceOptions & ActivityTraceFlags.Recorded) != 0);
-            var spanData = ((Span)span).ToSpanData();
-            Assert.True(spanData.ParentSpanId == default);
+            Assert.True(span.ParentSpanId == default);
         }
 
         [Fact]
         public void StartSpan_BlankSpanContextParent()
         {
-            var span = new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
+            var span = (Span) new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
                 .SetSpanKind(SpanKind.Internal)
                 .SetParent(SpanContext.Blank)
                 .StartSpan();
@@ -506,8 +500,8 @@ namespace OpenTelemetry.Trace.Test
             Assert.True(span.Context.IsValid);
             Assert.True(span.IsRecordingEvents);
             Assert.True((span.Context.TraceOptions & ActivityTraceFlags.Recorded) != 0);
-            var spanData = ((Span)span).ToSpanData();
-            Assert.True(spanData.ParentSpanId == default);
+
+            Assert.True(span.ParentSpanId == default);
         }
 
 
@@ -554,15 +548,15 @@ namespace OpenTelemetry.Trace.Test
         [Fact]
         public void StartSpanInvalidParent()
         {
-            var span = new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
+            var span = (Span) new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
                 .SetSpanKind(SpanKind.Internal)
                 .SetParent(SpanContext.Blank)
                 .StartSpan();
             Assert.True(span.Context.IsValid);
             Assert.True(span.IsRecordingEvents);
             Assert.True((span.Context.TraceOptions & ActivityTraceFlags.Recorded) != 0);
-            var spanData = ((Span)span).ToSpanData();
-            Assert.True(spanData.ParentSpanId == default);
+
+            Assert.True(span.ParentSpanId == default);
         }
 
         [Fact]
@@ -575,7 +569,7 @@ namespace OpenTelemetry.Trace.Test
                     ActivityTraceFlags.None,
                     Tracestate.Builder.Set("k1", "v1").Build());
 
-            var span = new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
+            var span = (Span) new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
                 .SetSpanKind(SpanKind.Internal)
                 .SetParent(spanContext)
                 .SetRecordEvents(true)
@@ -584,8 +578,8 @@ namespace OpenTelemetry.Trace.Test
             Assert.True(span.Context.IsValid);
             Assert.Equal(spanContext.TraceId, span.Context.TraceId);
             Assert.True((span.Context.TraceOptions & ActivityTraceFlags.Recorded) != 0);
-            var spanData = ((Span)span).ToSpanData();
-            Assert.Equal(spanContext.SpanId, spanData.ParentSpanId);
+            
+            Assert.Equal(spanContext.SpanId, span.ParentSpanId);
             Assert.Equal("k1=v1", span.Context.Tracestate.ToString());
         }
 
@@ -598,13 +592,12 @@ namespace OpenTelemetry.Trace.Test
                     ActivitySpanId.CreateRandom(),
                     ActivityTraceFlags.None, Tracestate.Empty));
 
-            var span = new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
+            var span = (Span) new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
                 .SetSpanKind(SpanKind.Internal)
                 .AddLink(link)
                 .StartSpan();
 
-            var spanData = ((Span)span).ToSpanData();
-            var links = spanData.Links.Links.ToArray();
+            var links = span.Links.ToArray();
 
             Assert.Single(links);
 
@@ -621,13 +614,12 @@ namespace OpenTelemetry.Trace.Test
             var contextLink = SpanContext.Create(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(),
                 ActivityTraceFlags.None, Tracestate.Empty);
 
-            var span = new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
+            var span = (Span) new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
                 .SetSpanKind(SpanKind.Internal)
                 .AddLink(contextLink)
                 .StartSpan();
 
-            var spanData = ((Span)span).ToSpanData();
-            var links = spanData.Links.Links.ToArray();
+            var links = span.Links.ToArray();
 
             Assert.Single(links);
 
@@ -649,13 +641,12 @@ namespace OpenTelemetry.Trace.Test
                     ActivitySpanId.CreateRandom(),
                     ActivityTraceFlags.None, Tracestate.Empty);
 
-            var span = new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
+            var span = (Span) new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
                 .SetSpanKind(SpanKind.Internal)
                 .AddLink(linkContext, new Dictionary<string, object> { ["k"] = "v", })
                 .StartSpan();
 
-            var spanData = ((Span)span).ToSpanData();
-            var links = spanData.Links.Links.ToArray();
+            var links = span.Links.ToArray();
 
             Assert.Single(links);
 
@@ -677,13 +668,12 @@ namespace OpenTelemetry.Trace.Test
                     ActivitySpanId.CreateRandom(),
                     ActivityTraceFlags.None, Tracestate.Empty);
 
-            var span = new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
+            var span = (Span) new SpanBuilder(SpanName, startEndHandler, alwaysSampleTraceConfig)
                 .SetSpanKind(SpanKind.Internal)
                 .AddLink(linkContext)
                 .StartSpan();
 
-            var spanData = ((Span)span).ToSpanData();
-            var links = spanData.Links.Links.ToArray();
+            var links = span.Links.ToArray();
 
             Assert.Single(links);
 

--- a/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
@@ -14,9 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using OpenTelemetry.Tests;
-using OpenTelemetry.Trace.Sampler;
-
 namespace OpenTelemetry.Trace.Test
 {
     using System;
@@ -26,8 +23,10 @@ namespace OpenTelemetry.Trace.Test
     using System.Threading.Tasks;
     using Moq;
     using OpenTelemetry.Abstractions.Utils;
+    using OpenTelemetry.Tests;
     using OpenTelemetry.Trace;
     using OpenTelemetry.Trace.Config;
+    using OpenTelemetry.Trace.Sampler;
     using Xunit;
 
     public class SpanTest : IDisposable
@@ -142,8 +141,7 @@ namespace OpenTelemetry.Trace.Test
             activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
 
             var spanStartTime = PreciseTimestamp.GetUtcNow();
-            var span =
-                Span.StartSpan(
+            var span = (Span) Span.StartSpan(
                     activity,
                     Tracestate.Empty,
                     SpanKind.Internal,
@@ -166,14 +164,13 @@ namespace OpenTelemetry.Trace.Test
             span.AddEvent(Event.Create(EventDescription));
             span.AddEvent(EventDescription, attributes);
             span.AddLink(Link.FromSpanContext(link));
-            var spanData = ((Span)span).ToSpanData();
 
-            Assert.Equal(spanStartTime, spanData.StartTimestamp);
-            Assert.Empty(spanData.Attributes.AttributeMap);
-            Assert.Empty(spanData.Events.Events);
-            Assert.Empty(spanData.Links.Links);
-            Assert.Equal(Status.Ok, spanData.Status);
-            Assert.Equal(spanEndTime, spanData.EndTimestamp);
+            Assert.Equal(spanStartTime, span.StartTimestamp);
+            Assert.Empty(span.Attributes);
+            Assert.Empty(span.Events);
+            Assert.Empty(span.Links);
+            Assert.Equal(Status.Ok, span.Status);
+            Assert.Equal(spanEndTime, span.EndTimestamp);
         }
 
         [Fact]
@@ -183,8 +180,7 @@ namespace OpenTelemetry.Trace.Test
             activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
 
             var spanStartTime = PreciseTimestamp.GetUtcNow();
-            var span =
-                Span.StartSpan(
+            var span = (Span) Span.StartSpan(
                     activity,
                     Tracestate.Empty,
                     SpanKind.Internal,
@@ -194,14 +190,12 @@ namespace OpenTelemetry.Trace.Test
             var spanEndTime = PreciseTimestamp.GetUtcNow();
             span.End();
 
-            var spanData = ((Span)span).ToSpanData();
-
-            AssertApproxSameTimestamp(spanStartTime, spanData.StartTimestamp);
-            Assert.Empty(spanData.Attributes.AttributeMap);
-            Assert.Empty(spanData.Events.Events);
-            Assert.Empty(spanData.Links.Links);
-            Assert.Equal(Status.Ok, spanData.Status);
-            AssertApproxSameTimestamp(spanEndTime, spanData.EndTimestamp);
+            AssertApproxSameTimestamp(spanStartTime, span.StartTimestamp);
+            Assert.Empty(span.Attributes);
+            Assert.Empty(span.Events);
+            Assert.Empty(span.Links);
+            Assert.Equal(Status.Ok, span.Status);
+            AssertApproxSameTimestamp(spanEndTime, span.EndTimestamp);
         }
 
         [Fact]
@@ -216,8 +210,7 @@ namespace OpenTelemetry.Trace.Test
             activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
 
             var spanStartTime = PreciseTimestamp.GetUtcNow();
-            var span =
-                Span.StartSpan(
+            var span = (Span) Span.StartSpan(
                     activity,
                     Tracestate.Empty,
                     SpanKind.Internal,
@@ -242,38 +235,42 @@ namespace OpenTelemetry.Trace.Test
 
             var link = Link.FromSpanContext(contextLink);
             span.AddLink(link);
-            var spanData = ((Span)span).ToSpanData();
-            Assert.Equal(activity.TraceId, spanData.Context.TraceId);
-            Assert.Equal(activity.SpanId, spanData.Context.SpanId);
-            Assert.Equal(activity.ParentSpanId, spanData.ParentSpanId);
-            Assert.Equal(activity.ActivityTraceFlags, spanData.Context.TraceOptions);
-            Assert.Same(Tracestate.Empty, spanData.Context.Tracestate);
 
-            Assert.Equal(SpanName, spanData.Name);
-            Assert.Equal(activity.ParentSpanId, spanData.ParentSpanId);
-            Assert.Equal(0, spanData.Attributes.DroppedAttributesCount);
-            spanData.Attributes.AssertAreSame(expectedAttributes);
-            Assert.Equal(0, spanData.Events.DroppedEventsCount);
-            Assert.Equal(2, spanData.Events.Events.Count());
+            Assert.Equal(activity.TraceId, span.Context.TraceId);
+            Assert.Equal(activity.SpanId, span.Context.SpanId);
+            Assert.Equal(activity.ParentSpanId, span.ParentSpanId);
+            Assert.Equal(activity.ActivityTraceFlags, span.Context.TraceOptions);
+            Assert.Same(Tracestate.Empty, span.Context.Tracestate);
 
-            Assert.Equal(firstEventTime, spanData.Events.Events.ToList()[0].Timestamp);
-            AssertApproxSameTimestamp(spanData.Events.Events.ToList()[1].Timestamp, secondEventTime);
+            Assert.Equal(SpanName, span.Name);
+            Assert.Equal(activity.ParentSpanId, span.ParentSpanId);
 
-            Assert.Equal(Event.Create(EventDescription, firstEventTime), spanData.Events.Events.ToList()[0]);
+            span.Attributes.AssertAreSame(expectedAttributes);
 
-            Assert.Equal(EventDescription, spanData.Events.Events.ToList()[1].Name);
-            Assert.Equal(attributes, spanData.Events.Events.ToList()[1].Attributes);
-            Assert.Equal(0, spanData.Links.DroppedLinksCount);
-            Assert.Single(spanData.Links.Links);
-            Assert.Equal(link, spanData.Links.Links.First());
+            Assert.Equal(2, span.Events.Count());
+            Assert.Equal(firstEventTime, span.Events.ToList()[0].Timestamp);
+            AssertApproxSameTimestamp(span.Events.ToList()[1].Timestamp, secondEventTime);
 
-            Assert.Equal(spanStartTime, spanData.StartTimestamp);
+            Assert.Equal(Event.Create(EventDescription, firstEventTime), span.Events.ToList()[0]);
 
-            Assert.False(spanData.Status.IsValid);
-            Assert.Equal(default, spanData.EndTimestamp);
+            Assert.Equal(EventDescription, span.Events.ToList()[1].Name);
+            Assert.Equal(attributes, span.Events.ToList()[1].Attributes);
+
+            Assert.Single(span.Links);
+            Assert.Equal(link, span.Links.First());
+
+            Assert.Equal(spanStartTime, span.StartTimestamp);
+
+            Assert.True(span.Status.IsValid);
+            Assert.Equal(default, span.EndTimestamp);
 
             var startEndMock = Mock.Get<IStartEndHandler>(startEndHandler);
             startEndMock.Verify(s => s.OnStart(span), Times.Once);
+
+            var spanData = span.ToSpanData();
+            Assert.Equal(0, spanData.Attributes.DroppedAttributesCount);
+            Assert.Equal(0, spanData.Events.DroppedEventsCount);
+            Assert.Equal(0, spanData.Links.DroppedLinksCount);
         }
 
         [Fact]
@@ -288,8 +285,7 @@ namespace OpenTelemetry.Trace.Test
 
             var spanStartTime = PreciseTimestamp.GetUtcNow();
             activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
-            var span =
-                (Span)Span.StartSpan(
+            var span = (Span) Span.StartSpan(
                     activity,
                     Tracestate.Empty,
                     SpanKind.Internal,
@@ -320,34 +316,35 @@ namespace OpenTelemetry.Trace.Test
             var spanEndTime = PreciseTimestamp.GetUtcNow();
             span.End();
 
-            var spanData = ((Span)span).ToSpanData();
-            Assert.Equal(activity.TraceId, spanData.Context.TraceId);
-            Assert.Equal(activity.SpanId, spanData.Context.SpanId);
-            Assert.Equal(activity.ParentSpanId, spanData.ParentSpanId);
-            Assert.Equal(activity.ActivityTraceFlags, spanData.Context.TraceOptions);
+            Assert.Equal(activity.TraceId, span.Context.TraceId);
+            Assert.Equal(activity.SpanId, span.Context.SpanId);
+            Assert.Equal(activity.ParentSpanId, span.ParentSpanId);
+            Assert.Equal(activity.ActivityTraceFlags, span.Context.TraceOptions);
 
-            Assert.Equal(SpanName, spanData.Name);
-            Assert.Equal(activity.ParentSpanId, spanData.ParentSpanId);
-            Assert.Equal(0, spanData.Attributes.DroppedAttributesCount);
+            Assert.Equal(SpanName, span.Name);
+            Assert.Equal(activity.ParentSpanId, span.ParentSpanId);
 
-            spanData.Attributes.AssertAreSame(expectedAttributes);
-            Assert.Equal(0, spanData.Events.DroppedEventsCount);
-            Assert.Equal(2, spanData.Events.Events.Count());
+            span.Attributes.AssertAreSame(expectedAttributes);
+            Assert.Equal(2, span.Events.Count());
 
-            Assert.Equal(firstEventTime, spanData.Events.Events.ToList()[0].Timestamp);
-            AssertApproxSameTimestamp(spanData.Events.Events.ToList()[1].Timestamp, secondEventTime);
+            Assert.Equal(firstEventTime, span.Events.ToList()[0].Timestamp);
+            AssertApproxSameTimestamp(span.Events.ToList()[1].Timestamp, secondEventTime);
 
-            Assert.Equal(Event.Create(EventDescription, firstEventTime), spanData.Events.Events.ToList()[0]);
-            Assert.Equal(0, spanData.Links.DroppedLinksCount);
-            Assert.Single(spanData.Links.Links);
-            Assert.Equal(link, spanData.Links.Links.First());
-            Assert.Equal(spanStartTime, spanData.StartTimestamp);
-            Assert.Equal(Status.Cancelled, spanData.Status);
-            AssertApproxSameTimestamp(spanEndTime, spanData.EndTimestamp);
+            Assert.Equal(Event.Create(EventDescription, firstEventTime), span.Events.ToList()[0]);
+            Assert.Single(span.Links);
+            Assert.Equal(link, span.Links.First());
+            Assert.Equal(spanStartTime, span.StartTimestamp);
+            Assert.Equal(Status.Cancelled, span.Status);
+            AssertApproxSameTimestamp(spanEndTime, span.EndTimestamp);
 
             var startEndMock = Mock.Get<IStartEndHandler>(startEndHandler);
             startEndMock.Verify(s => s.OnStart(span), Times.Once);
             startEndMock.Verify(s => s.OnEnd(span), Times.Once);
+
+            var spanData = span.ToSpanData();
+            Assert.Equal(0, spanData.Attributes.DroppedAttributesCount);
+            Assert.Equal(0, spanData.Events.DroppedEventsCount);
+            Assert.Equal(0, spanData.Links.DroppedLinksCount);
         }
 
         [Fact]
@@ -409,8 +406,7 @@ namespace OpenTelemetry.Trace.Test
 
             var maxNumberOfAttributes = 8;
             var traceConfig = new TraceConfig(Samplers.AlwaysSample, 8 , 128, 32);
-            var span =
-                Span.StartSpan(
+            var span = (Span) Span.StartSpan(
                     activity,
                     Tracestate.Empty,
                     SpanKind.Internal,
@@ -428,27 +424,26 @@ namespace OpenTelemetry.Trace.Test
 
             }
 
-            var spanData = ((Span)span).ToSpanData();
-            Assert.Equal(maxNumberOfAttributes, spanData.Attributes.DroppedAttributesCount);
-            Assert.Equal(maxNumberOfAttributes, spanData.Attributes.AttributeMap.Count());
+            Assert.Equal(maxNumberOfAttributes, span.ToSpanData().Attributes.DroppedAttributesCount);
+            Assert.Equal(maxNumberOfAttributes, span.Attributes.Count());
             for (var i = 0; i < maxNumberOfAttributes; i++)
             {
                 Assert.Equal(
                     i + maxNumberOfAttributes,
-                    spanData
+                    span
                         .Attributes
                         .GetValue("MyStringAttributeKey" + (i + maxNumberOfAttributes)));
             }
 
             span.End();
-            spanData = ((Span)span).ToSpanData();
-            Assert.Equal(maxNumberOfAttributes, spanData.Attributes.DroppedAttributesCount);
-            Assert.Equal(maxNumberOfAttributes, spanData.Attributes.AttributeMap.Count());
+
+            Assert.Equal(maxNumberOfAttributes, span.ToSpanData().Attributes.DroppedAttributesCount);
+            Assert.Equal(maxNumberOfAttributes, span.Attributes.Count());
             for (var i = 0; i < maxNumberOfAttributes; i++)
             {
                 Assert.Equal(
                     i + maxNumberOfAttributes,
-                    spanData
+                    span
                         .Attributes
                         .GetValue("MyStringAttributeKey" + (i + maxNumberOfAttributes)));
             }
@@ -462,8 +457,7 @@ namespace OpenTelemetry.Trace.Test
 
             var maxNumberOfAttributes = 8;
             var traceConfig = new TraceConfig(Samplers.AlwaysSample, maxNumberOfAttributes, 128, 32);
-            var span =
-                Span.StartSpan(
+            var span = (Span) Span.StartSpan(
                     activity,
                     Tracestate.Empty,
                     SpanKind.Internal,
@@ -481,21 +475,20 @@ namespace OpenTelemetry.Trace.Test
 
             }
 
-            var spanData = ((Span)span).ToSpanData();
-            Assert.Equal(maxNumberOfAttributes, spanData.Attributes.DroppedAttributesCount);
-            Assert.Equal(maxNumberOfAttributes, spanData.Attributes.AttributeMap.Count());
+            Assert.Equal(maxNumberOfAttributes, span.ToSpanData().Attributes.DroppedAttributesCount);
+            Assert.Equal(maxNumberOfAttributes, span.Attributes.Count());
             for (var i = 0; i < maxNumberOfAttributes; i++)
             {
                 Assert.Equal(
                     i + maxNumberOfAttributes,
-                    spanData
+                    span
                         .Attributes
                         .GetValue("MyStringAttributeKey" + (i + maxNumberOfAttributes)));
             }
 
             for (var i = 0; i < maxNumberOfAttributes / 2; i++)
             {
-                IDictionary<String, object> attributes = new Dictionary<String, object>();
+                IDictionary<string, object> attributes = new Dictionary<string, object>();
                 attributes.Add("MyStringAttributeKey" + i, i);
                 foreach (var attribute in attributes)
                 {
@@ -504,15 +497,14 @@ namespace OpenTelemetry.Trace.Test
 
             }
 
-            spanData = ((Span)span).ToSpanData();
-            Assert.Equal(maxNumberOfAttributes * 3 / 2, spanData.Attributes.DroppedAttributesCount);
-            Assert.Equal(maxNumberOfAttributes, spanData.Attributes.AttributeMap.Count());
+            Assert.Equal(maxNumberOfAttributes * 3 / 2, span.ToSpanData().Attributes.DroppedAttributesCount);
+            Assert.Equal(maxNumberOfAttributes, span.Attributes.Count());
             // Test that we still have in the attributes map the latest maxNumberOfAttributes / 2 entries.
             for (var i = 0; i < maxNumberOfAttributes / 2; i++)
             {
                 Assert.Equal(
                     i + maxNumberOfAttributes * 3 / 2,
-                    spanData
+                    span
                         .Attributes
                         .GetValue("MyStringAttributeKey" + (i + maxNumberOfAttributes * 3 / 2)));
             }
@@ -521,7 +513,7 @@ namespace OpenTelemetry.Trace.Test
             for (var i = 0; i < maxNumberOfAttributes / 2; i++)
             {
                 Assert.Equal(i,
-                    spanData.Attributes.GetValue("MyStringAttributeKey" + i));
+                    span.Attributes.GetValue("MyStringAttributeKey" + i));
             }
         }
 
@@ -533,8 +525,7 @@ namespace OpenTelemetry.Trace.Test
 
             var maxNumberOfEvents = 8;
             var traceConfig = new TraceConfig(Samplers.AlwaysSample, 32, maxNumberOfEvents, 32);
-            var span =
-                Span.StartSpan(
+            var span = (Span) Span.StartSpan(
                     activity,
                     Tracestate.Empty,
                     SpanKind.Internal,
@@ -551,11 +542,10 @@ namespace OpenTelemetry.Trace.Test
                 await Task.Delay(10);
             }
 
-            var spanData = ((Span)span).ToSpanData();
-            Assert.Equal(maxNumberOfEvents, spanData.Events.DroppedEventsCount);
-            Assert.Equal(maxNumberOfEvents, spanData.Events.Events.Count());
+            Assert.Equal(maxNumberOfEvents, span.ToSpanData().Events.DroppedEventsCount);
+            Assert.Equal(maxNumberOfEvents, span.Events.Count());
 
-            var events = spanData.Events.Events.ToArray();
+            var events = span.Events.ToArray();
 
             for (int i = 0; i < maxNumberOfEvents; i++)
             {
@@ -563,9 +553,9 @@ namespace OpenTelemetry.Trace.Test
             }
 
             span.End();
-            spanData = ((Span)span).ToSpanData();
-            Assert.Equal(maxNumberOfEvents, spanData.Events.DroppedEventsCount);
-            Assert.Equal(maxNumberOfEvents, spanData.Events.Events.Count());
+            
+            Assert.Equal(maxNumberOfEvents, span.ToSpanData().Events.DroppedEventsCount);
+            Assert.Equal(maxNumberOfEvents, span.Events.Count());
         }
 
         [Fact]
@@ -579,8 +569,7 @@ namespace OpenTelemetry.Trace.Test
 
             var maxNumberOfLinks = 8;
             var traceConfig = new TraceConfig(Samplers.AlwaysSample, 32, 128, maxNumberOfLinks);
-            var span =
-                Span.StartSpan(
+            var span = (Span) Span.StartSpan(
                     activity,
                     Tracestate.Empty,
                     SpanKind.Internal,
@@ -593,19 +582,18 @@ namespace OpenTelemetry.Trace.Test
                 span.AddLink(link);
             }
 
-            var spanData = ((Span)span).ToSpanData();
-            Assert.Equal(maxNumberOfLinks, spanData.Links.DroppedLinksCount);
-            Assert.Equal(maxNumberOfLinks, spanData.Links.Links.Count());
-            foreach (var actualLink in spanData.Links.Links)
+            Assert.Equal(maxNumberOfLinks, span.ToSpanData().Links.DroppedLinksCount);
+            Assert.Equal(maxNumberOfLinks, span.Links.Count());
+            foreach (var actualLink in span.Links)
             {
                 Assert.Equal(link, actualLink);
             }
 
             span.End();
-            spanData = ((Span)span).ToSpanData();
-            Assert.Equal(maxNumberOfLinks, spanData.Links.DroppedLinksCount);
-            Assert.Equal(maxNumberOfLinks, spanData.Links.Links.Count());
-            foreach (var actualLink in spanData.Links.Links)
+
+            Assert.Equal(maxNumberOfLinks, span.ToSpanData().Links.DroppedLinksCount);
+            Assert.Equal(maxNumberOfLinks, span.Links.Count());
+            foreach (var actualLink in span.Links)
             {
                 Assert.Equal(link, actualLink);
             }


### PR DESCRIPTION
Yet another step on removing span data. we are going to pass Span impl to exporters and they need to access everything that is exportable.