### PR TITLE
provide extension method on exception to do string conversion.

### DIFF
--- a/src/OpenTelemetry.Abstractions/Utils/Extensions.cs
+++ b/src/OpenTelemetry.Abstractions/Utils/Extensions.cs
@@ -1,0 +1,46 @@
+﻿// <copyright file="Extensions.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Utils
+{
+    using System;
+    using System.Globalization;
+    using System.Threading;
+
+    public static class Extensions
+    {
+        /// <summary>
+        /// Returns a culture-independent string representation of the given <paramref name="exception"/> object,
+        /// appropriate for diagnostics tracing.
+        /// </summary>
+        /// <param name="exception">the exception onject to be converted.</param>
+        /// <returns>the string representing the exception.</returns>
+        public static string ToInvariantString(this Exception exception)
+        {
+            var originalUICulture = Thread.CurrentThread.CurrentUICulture;
+
+            try
+            {
+                Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+                return exception.ToString();
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentUICulture = originalUICulture;
+            }
+        }
+    }
+}

--- a/src/OpenTelemetry/Collector/CollectorEventSource.cs
+++ b/src/OpenTelemetry/Collector/CollectorEventSource.cs
@@ -20,6 +20,7 @@ namespace OpenTelemetry.Collector
     using System.Diagnostics.Tracing;
     using System.Globalization;
     using System.Threading;
+    using OpenTelemetry.Utils;
 
     /// <summary>
     /// EventSource events emitted from the project.
@@ -34,7 +35,7 @@ namespace OpenTelemetry.Collector
         {
             if (this.IsEnabled(EventLevel.Warning, EventKeywords.All))
             {
-                this.ExceptionInCustomSampler(ToInvariantString(ex));
+                this.ExceptionInCustomSampler(ex.ToInvariantString());
             }
         }
 
@@ -64,7 +65,7 @@ namespace OpenTelemetry.Collector
                 return;
             }
 
-            this.UnknownErrorProcessingEvent(handlerName, eventName, ToInvariantString(ex));
+            this.UnknownErrorProcessingEvent(handlerName, eventName, ex.ToInvariantString());
         }
 
         [Event(4, Message = "Unknown error processing event '{0}' from handler '{1}', Exception: {2}", Level = EventLevel.Error)]
@@ -77,25 +78,6 @@ namespace OpenTelemetry.Collector
         public void NullPayload(string eventName)
         {
             this.WriteEvent(5, eventName);
-        }
-
-        /// <summary>
-        /// Returns a culture-independent string representation of the given <paramref name="exception"/> object,
-        /// appropriate for diagnostics tracing.
-        /// </summary>
-        private static string ToInvariantString(Exception exception)
-        {
-            var originalUICulture = Thread.CurrentThread.CurrentUICulture;
-
-            try
-            {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
-                return exception.ToString();
-            }
-            finally
-            {
-                Thread.CurrentThread.CurrentUICulture = originalUICulture;
-            }
         }
     }
 }

--- a/src/OpenTelemetry/Implementation/OpenTelemetryEventSource.cs
+++ b/src/OpenTelemetry/Implementation/OpenTelemetryEventSource.cs
@@ -20,6 +20,7 @@ namespace OpenTelemetry.Implementation
     using System.Diagnostics.Tracing;
     using System.Globalization;
     using System.Threading;
+    using OpenTelemetry.Utils;
 
     [EventSource(Name = "OpenTelemetry-Base")]
     internal class OpenTelemetryEventSource : EventSource
@@ -31,7 +32,7 @@ namespace OpenTelemetry.Implementation
         {
             if (Log.IsEnabled(EventLevel.Warning, EventKeywords.All))
             {
-                this.ExporterThrownExceptionWarning(ToInvariantString(ex));
+                this.ExporterThrownExceptionWarning(ex.ToInvariantString());
             }
         }
 
@@ -46,7 +47,7 @@ namespace OpenTelemetry.Implementation
         {
             if (Log.IsEnabled(EventLevel.Warning, EventKeywords.All))
             {
-                this.FailedReadingEnvironmentVariableWarning(environmentVariableName, ToInvariantString(ex));
+                this.FailedReadingEnvironmentVariableWarning(environmentVariableName, ex.ToInvariantString());
             }
         }
 
@@ -54,25 +55,6 @@ namespace OpenTelemetry.Implementation
         public void FailedReadingEnvironmentVariableWarning(string environmentVariableName, string ex)
         {
             this.WriteEvent(3, environmentVariableName, ex);
-        }
-
-        /// <summary>
-        /// Returns a culture-independent string representation of the given <paramref name="exception"/> object,
-        /// appropriate for diagnostics tracing.
-        /// </summary>
-        private static string ToInvariantString(Exception exception)
-        {
-            var originalUICulture = Thread.CurrentThread.CurrentUICulture;
-
-            try
-            {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
-                return exception.ToString();
-            }
-            finally
-            {
-                Thread.CurrentThread.CurrentUICulture = originalUICulture;
-            }
         }
     }
 }

--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -21,6 +21,7 @@ namespace OpenTelemetry.Internal
     using System.Globalization;
     using System.Threading;
     using OpenTelemetry.Trace.Export;
+    using OpenTelemetry.Utils;
 
     /// <summary>
     /// EventSource implementation for OpenTelemetry SDK implementation.
@@ -35,7 +36,7 @@ namespace OpenTelemetry.Internal
         {
             if (this.IsEnabled(EventLevel.Warning, EventKeywords.All))
             {
-                this.SpanProcessorException(ToInvariantString(ex));
+                this.SpanProcessorException(ex.ToInvariantString());
             }
         }
 
@@ -61,25 +62,6 @@ namespace OpenTelemetry.Internal
         public void SpanProcessorException(string ex)
         {
             this.WriteEvent(4, ex);
-        }
-
-        /// <summary>
-        /// Returns a culture-independent string representation of the given <paramref name="exception"/> object,
-        /// appropriate for diagnostics tracing.
-        /// </summary>
-        private static string ToInvariantString(Exception exception)
-        {
-            var originalUICulture = Thread.CurrentThread.CurrentUICulture;
-
-            try
-            {
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
-                return exception.ToString();
-            }
-            finally
-            {
-                Thread.CurrentThread.CurrentUICulture = originalUICulture;
-            }
         }
     }
 }


### PR DESCRIPTION
Depending on this, we may merge all the individual EventSources into a single one:
https://github.com/open-telemetry/opentelemetry-dotnet/issues/85#issuecomment-537306129