### PR TITLE
Support explicit timestamps for OpenTracing ISpanBuilder and ISpan operations.

### DIFF
--- a/samples/LoggingTracer/LoggingTracer/LoggingSpanBuilder.cs
+++ b/samples/LoggingTracer/LoggingTracer/LoggingSpanBuilder.cs
@@ -124,6 +124,7 @@ namespace LoggingTracer
             Logger.Log($"SpanBuilder.SetSpanKind({spanKind})");
             return this;
         }
+
         public ISpan StartSpan()
         {
             Logger.Log("SpanBuilder.StartSpan()");

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
@@ -65,6 +65,11 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// </summary>
         private Trace.SpanContext parentSpanContext;
 
+        /// <summary>
+        /// The explicit start time, if any.
+        /// </summary>
+        private DateTimeOffset? explicitStartTime;
+
         private bool ignoreActiveSpan;
 
         private Trace.SpanKind spanKind;
@@ -182,6 +187,11 @@ namespace OpenTelemetry.Shims.OpenTracing
                 builder.SetNoParent();
             }
 
+            if (this.explicitStartTime.HasValue)
+            {
+                builder.SetStartTimestamp(this.explicitStartTime.Value);
+            }
+
             foreach (var link in this.links)
             {
                 builder.AddLink(link);
@@ -220,8 +230,8 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public ISpanBuilder WithStartTimestamp(DateTimeOffset timestamp)
         {
-            // TODO No explicit timestamp support.
-            throw new NotImplementedException();
+            this.explicitStartTime = timestamp;
+            return this;
         }
 
         /// <inheritdoc/>

--- a/src/OpenTelemetry.Shims.OpenTracing/TracerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/TracerShim.cs
@@ -19,7 +19,6 @@ namespace OpenTelemetry.Shims.OpenTracing
     using System;
     using System.Collections.Generic;
     using global::OpenTracing.Propagation;
-    using OpenTelemetry.Trace;
 
     public class TracerShim : global::OpenTracing.ITracer
     {
@@ -52,7 +51,7 @@ namespace OpenTelemetry.Shims.OpenTracing
                 throw new ArgumentNullException(nameof(format));
             }
 
-            if (carrier == default)
+            if (carrier == null)
             {
                 throw new ArgumentNullException(nameof(carrier));
             }
@@ -106,7 +105,7 @@ namespace OpenTelemetry.Shims.OpenTracing
                 throw new ArgumentNullException(nameof(format));
             }
 
-            if (carrier == default)
+            if (carrier == null)
             {
                 throw new ArgumentNullException(nameof(carrier));
             }

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanBuilderShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanBuilderShimTests.cs
@@ -54,6 +54,20 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
         }
 
         [Fact]
+        public void StartWithExplicitTimestamp()
+        {
+            var spanBuilderMock = GetDefaultSpanBuilderMock();
+            var shim = new SpanBuilderShim(GetDefaultTracer(spanBuilderMock), "foo");
+
+            var startTimestamp = DateTimeOffset.UtcNow;
+            shim.WithStartTimestamp(startTimestamp);
+
+            shim.Start();
+            spanBuilderMock.Verify(x => x.SetStartTimestamp(startTimestamp), Times.Once);
+            spanBuilderMock.Verify(x => x.StartSpan(), Times.Once);
+        }
+
+        [Fact]
         public void AsChildOf_WithNullSpan()
         {
             var spanBuilderMock = GetDefaultSpanBuilderMock();


### PR DESCRIPTION
The OpenTelemetry API now supports setting explicit timestamps for Spans and Events. This change simply uses those facilities in the shim.