### PR TITLE
Use IsEnabled DS callback to filter out requests

### DIFF
--- a/samples/Exporters/TestHttpClient.cs
+++ b/samples/Exporters/TestHttpClient.cs
@@ -40,7 +40,7 @@ namespace Samples
 
             var tracerFactory = new TracerFactory(new BatchingSpanProcessor(exporter));
             var tracer = tracerFactory.GetTracer(string.Empty);
-            using (new DependenciesCollector(new DependenciesCollectorOptions(), tracerFactory, Samplers.AlwaysSample))
+            using (new DependenciesCollector(new DependenciesCollectorOptions(), tracerFactory))
             {
                 using (tracer.WithSpan(tracer.SpanBuilder("incoming request").SetSampler(Samplers.AlwaysSample).StartSpan()))
                 {

--- a/src/OpenTelemetry.Collector.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Collector.AspNetCore/Implementation/HttpInListener.cs
@@ -24,7 +24,7 @@ namespace OpenTelemetry.Collector.AspNetCore.Implementation
     using Microsoft.AspNetCore.Http.Features;
     using OpenTelemetry.Trace;
 
-    internal class HttpInListener : ListenerHandler<HttpRequest>
+    internal class HttpInListener : ListenerHandler
     {
         private static readonly string UnknownHostName = "UNKNOWN-HOST";
         private readonly PropertyFetcher startContextFetcher = new PropertyFetcher("HttpContext");
@@ -34,8 +34,8 @@ namespace OpenTelemetry.Collector.AspNetCore.Implementation
         private readonly PropertyFetcher beforeActionTemplateFetcher = new PropertyFetcher("Template");
         private readonly bool hostingSupportsW3C = false;
 
-        public HttpInListener(string name, ITracer tracer, Func<HttpRequest, ISampler> samplerFactory)
-            : base(name, tracer, samplerFactory)
+        public HttpInListener(string name, ITracer tracer)
+            : base(name, tracer)
         {
             this.hostingSupportsW3C = typeof(HttpRequest).Assembly.GetName().Version.Major >= 3;
         }
@@ -65,8 +65,7 @@ namespace OpenTelemetry.Collector.AspNetCore.Implementation
             var path = (request.PathBase.HasValue || request.Path.HasValue) ? (request.PathBase + request.Path).ToString() : "/";
 
             var spanBuilder = this.Tracer.SpanBuilder(path)
-                .SetSpanKind(SpanKind.Server)
-                .SetSampler(this.SamplerFactory(request));
+                .SetSpanKind(SpanKind.Server);
 
             if (this.hostingSupportsW3C)
             {

--- a/src/OpenTelemetry.Collector.AspNetCore/RequestsCollectorOptions.cs
+++ b/src/OpenTelemetry.Collector.AspNetCore/RequestsCollectorOptions.cs
@@ -17,29 +17,39 @@
 namespace OpenTelemetry.Collector.AspNetCore
 {
     using System;
-    using Microsoft.AspNetCore.Http;
-    using OpenTelemetry.Trace;
 
     /// <summary>
     /// Options for requests collector.
     /// </summary>
     public class RequestsCollectorOptions
     {
-        private static readonly Func<HttpRequest, ISampler> DefaultSampler = (req) => { return null; };
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RequestsCollectorOptions"/> class.
+        /// </summary>
+        public RequestsCollectorOptions()
+        {
+            this.EventFilter = DefaultFilter;
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RequestsCollectorOptions"/> class.
         /// </summary>
-        /// <param name="sampler">Custom sampling function, if any.</param>
-        public RequestsCollectorOptions(Func<HttpRequest, ISampler> sampler = null)
+        /// <param name="eventFilter">Custom filtering predicate for DiagnosticSource events, if any.</param>
+        internal RequestsCollectorOptions(Func<string, object, object, bool> eventFilter = null)
         {
-            this.CustomSampler = sampler ?? DefaultSampler;
+            // TODO This API is unusable and likely to change, let's not expose it for now.
+
+            this.EventFilter = eventFilter;
         }
 
         /// <summary>
-        /// Gets a hook to exclude calls based on domain
-        /// or other per-request criterion.
+        /// Gets a hook to exclude calls based on domain or other per-request criterion.
         /// </summary>
-        public Func<HttpRequest, ISampler> CustomSampler { get; private set; }
+        public Func<string, object, object, bool> EventFilter { get; }
+
+        private static bool DefaultFilter(string activityName, object arg1, object unused)
+        {
+            return true;
+        }
     }
 }

--- a/src/OpenTelemetry.Collector.AspNetCore/RequestsCollectorOptions.cs
+++ b/src/OpenTelemetry.Collector.AspNetCore/RequestsCollectorOptions.cs
@@ -45,7 +45,7 @@ namespace OpenTelemetry.Collector.AspNetCore
         /// <summary>
         /// Gets a hook to exclude calls based on domain or other per-request criterion.
         /// </summary>
-        public Func<string, object, object, bool> EventFilter { get; }
+        internal Func<string, object, object, bool> EventFilter { get; }
 
         private static bool DefaultFilter(string activityName, object arg1, object unused)
         {

--- a/src/OpenTelemetry.Collector.Dependencies/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/AssemblyInfo.cs
@@ -13,3 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
+using System.Runtime.CompilerServices;
+
+#if SIGNED
+[assembly: InternalsVisibleTo("OpenTelemetry.Collector.Dependencies.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010051c1562a090fb0c9f391012a32198b5e5d9a60e9b80fa2d7b434c9e5ccb7259bd606e66f9660676afc6692b8cdc6793d190904551d2103b7b22fa636dcbb8208839785ba402ea08fc00c8f1500ccef28bbf599aa64ffb1e1d5dc1bf3420a3777badfe697856e9d52070a50c3ea5821c80bef17ca3acffa28f89dd413f096f898")]
+#else
+[assembly: InternalsVisibleTo("OpenTelemetry.Collector.Dependencies.Tests")]
+#endif

--- a/src/OpenTelemetry.Collector.Dependencies/AzureSdkDiagnosticListener.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/AzureSdkDiagnosticListener.cs
@@ -23,15 +23,13 @@ namespace OpenTelemetry.Collector.Dependencies
     using OpenTelemetry.Collector.Dependencies.Implementation;
     using OpenTelemetry.Trace;
 
-    internal class AzureSdkDiagnosticListener : ListenerHandler<HttpRequestMessage>
+    internal class AzureSdkDiagnosticListener : ListenerHandler
     {
         private static readonly PropertyFetcher LinksPropertyFetcher = new PropertyFetcher("Links");
-        private readonly ISampler sampler;
 
-        public AzureSdkDiagnosticListener(string sourceName, ITracer tracer, ISampler sampler)
-            : base(sourceName, tracer, null)
+        public AzureSdkDiagnosticListener(string sourceName, ITracer tracer)
+            : base(sourceName, tracer)
         {
-            this.sampler = sampler;
         }
 
         public void OnCompleted()
@@ -65,8 +63,7 @@ namespace OpenTelemetry.Collector.Dependencies
             }
 
             var spanBuilder = this.Tracer.SpanBuilder(operationName)
-                .SetCreateChild(false)
-                .SetSampler(this.sampler);
+                .SetCreateChild(false);
 
             var links = LinksPropertyFetcher.Fetch(valueValue) as IEnumerable<Activity> ?? Array.Empty<Activity>();
 

--- a/src/OpenTelemetry.Collector.Dependencies/DependenciesCollectorOptions.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/DependenciesCollectorOptions.cs
@@ -46,7 +46,7 @@ namespace OpenTelemetry.Collector.Dependencies
         /// <summary>
         /// Gets a hook to exclude calls based on domain or other per-request criterion.
         /// </summary>
-        public Func<string, object, object, bool> EventFilter { get; }
+        internal Func<string, object, object, bool> EventFilter { get; }
 
         private static bool DefaultFilter(string activityName, object arg1, object unused)
         {

--- a/src/OpenTelemetry.Collector.Dependencies/DependenciesCollectorOptions.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/DependenciesCollectorOptions.cs
@@ -18,29 +18,66 @@ namespace OpenTelemetry.Collector.Dependencies
 {
     using System;
     using System.Net.Http;
-    using OpenTelemetry.Trace;
-    using OpenTelemetry.Trace.Sampler;
 
     /// <summary>
     /// Options for dependencies collector.
     /// </summary>
     public class DependenciesCollectorOptions
     {
-        private static readonly Func<HttpRequestMessage, ISampler> DefaultSampler = (req) => { return ((req.RequestUri != null) && req.RequestUri.ToString().Contains("zipkin.azurewebsites.net")) ? Samplers.NeverSample : null; };
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DependenciesCollectorOptions"/> class.
+        /// </summary>
+        public DependenciesCollectorOptions()
+        {
+            this.EventFilter = DefaultFilter;
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DependenciesCollectorOptions"/> class.
         /// </summary>
-        /// <param name="sampler">Custom sampling function, if any.</param>
-        public DependenciesCollectorOptions(Func<HttpRequestMessage, ISampler> sampler = null)
+        /// <param name="eventFilter">Custom filtering predicate for DiagnosticSource events, if any.</param>
+        internal DependenciesCollectorOptions(Func<string, object, object, bool> eventFilter)
         {
-            this.CustomSampler = sampler ?? DefaultSampler;
+            // TODO This API is unusable and likely to change, let's not expose it for now.
+
+            this.EventFilter = eventFilter;
         }
 
         /// <summary>
-        /// Gets a hook to exclude calls based on domain
-        /// or other per-request criterion.
+        /// Gets a hook to exclude calls based on domain or other per-request criterion.
         /// </summary>
-        public Func<HttpRequestMessage, ISampler> CustomSampler { get; private set; }
+        public Func<string, object, object, bool> EventFilter { get; }
+
+        private static bool DefaultFilter(string activityName, object arg1, object unused)
+        {
+            // TODO: there is some preliminary consensus that we should introduce 'terminal' spans or context.
+            // exporters should ensure they set it
+
+            if (activityName == "System.Net.Http.HttpRequestOut" &&
+                arg1 is HttpRequestMessage request &&
+                request.RequestUri != null &&
+                request.Method == HttpMethod.Post)
+            {
+                var originalString = request.RequestUri.OriginalString;
+
+                // zipkin
+                if (originalString.Contains(":9411/api/v2/spans"))
+                {
+                    return false;
+                }
+
+                // applicationinsights
+                if (originalString.StartsWith("https://dc.services.visualstudio") ||
+                    originalString.StartsWith("https://rt.services.visualstudio") ||
+                    originalString.StartsWith("https://dc.applicationinsights") ||
+                    originalString.StartsWith("https://live.applicationinsights") ||
+                    originalString.StartsWith("https://quickpulse.applicationinsights"))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
     }
 }

--- a/src/OpenTelemetry.Collector.Dependencies/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/Implementation/HttpHandlerDiagnosticListener.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Collector.Dependencies.Implementation
     using System.Threading.Tasks;
     using OpenTelemetry.Trace;
 
-    internal class HttpHandlerDiagnosticListener : ListenerHandler<HttpRequestMessage>
+    internal class HttpHandlerDiagnosticListener : ListenerHandler
     {
         private readonly PropertyFetcher startRequestFetcher = new PropertyFetcher("Request");
         private readonly PropertyFetcher stopResponseFetcher = new PropertyFetcher("Response");
@@ -34,8 +34,8 @@ namespace OpenTelemetry.Collector.Dependencies.Implementation
         private readonly PropertyFetcher stopRequestStatusFetcher = new PropertyFetcher("RequestTaskStatus");
         private readonly bool httpClientSupportsW3C = false;
 
-        public HttpHandlerDiagnosticListener(ITracer tracer, Func<HttpRequestMessage, ISampler> samplerFactory)
-            : base("HttpHandlerDiagnosticListener", tracer, samplerFactory)
+        public HttpHandlerDiagnosticListener(ITracer tracer)
+            : base("HttpHandlerDiagnosticListener", tracer)
         {
             var framework = Assembly
                 .GetEntryAssembly()?
@@ -68,7 +68,6 @@ namespace OpenTelemetry.Collector.Dependencies.Implementation
 
             var span = this.Tracer.SpanBuilder(request.RequestUri.AbsolutePath)
                 .SetSpanKind(SpanKind.Client)
-                .SetSampler(this.SamplerFactory(request))
                 .SetCreateChild(false)
                 .StartSpan();
 

--- a/src/OpenTelemetry/Collector/DiagnosticSourceListener.cs
+++ b/src/OpenTelemetry/Collector/DiagnosticSourceListener.cs
@@ -20,11 +20,11 @@ namespace OpenTelemetry.Collector
     using System.Collections.Generic;
     using System.Diagnostics;
 
-    internal class DiagnosticSourceListener<TInput> : IObserver<KeyValuePair<string, object>>, IDisposable
+    internal class DiagnosticSourceListener : IObserver<KeyValuePair<string, object>>, IDisposable
     {
-        private readonly ListenerHandler<TInput> handler;
+        private readonly ListenerHandler handler;
 
-        public DiagnosticSourceListener(ListenerHandler<TInput> handler)
+        public DiagnosticSourceListener(ListenerHandler handler)
         {
             this.handler = handler ?? throw new ArgumentNullException(nameof(handler));
         }

--- a/src/OpenTelemetry/Collector/DiagnosticSourceSubscriber.cs
+++ b/src/OpenTelemetry/Collector/DiagnosticSourceSubscriber.cs
@@ -23,21 +23,21 @@ namespace OpenTelemetry.Collector
     using System.Threading;
     using OpenTelemetry.Trace;
 
-    public class DiagnosticSourceSubscriber<TInput> : IDisposable, IObserver<DiagnosticListener>
+    public class DiagnosticSourceSubscriber : IDisposable, IObserver<DiagnosticListener>
     {
-        private readonly Dictionary<string, Func<ITracerFactory, Func<TInput, ISampler>, ListenerHandler<TInput>>> handlers;
+        private readonly Dictionary<string, Func<ITracerFactory, ListenerHandler>> handlers;
         private readonly ITracerFactory tracerFactory;
-        private readonly Func<TInput, ISampler> sampler;
-        private ConcurrentDictionary<string, DiagnosticSourceListener<TInput>> subscriptions;
+        private readonly Func<string, object, object, bool> filter;
+        private ConcurrentDictionary<string, DiagnosticSourceListener> subscriptions;
         private long disposed;
         private IDisposable subscription;
 
-        public DiagnosticSourceSubscriber(Dictionary<string, Func<ITracerFactory, Func<TInput, ISampler>, ListenerHandler<TInput>>> handlers, ITracerFactory tracerFactory, Func<TInput, ISampler> sampler)
+        public DiagnosticSourceSubscriber(Dictionary<string, Func<ITracerFactory, ListenerHandler>> handlers, ITracerFactory tracerFactory, Func<string, object, object, bool> filter)
         {
-            this.subscriptions = new ConcurrentDictionary<string, DiagnosticSourceListener<TInput>>();
+            this.subscriptions = new ConcurrentDictionary<string, DiagnosticSourceListener>();
             this.handlers = handlers ?? throw new ArgumentNullException(nameof(handlers));
             this.tracerFactory = tracerFactory ?? throw new ArgumentNullException(nameof(tracerFactory));
-            this.sampler = sampler ?? throw new ArgumentNullException(nameof(sampler));
+            this.filter = filter;
         }
 
         public void Subscribe()
@@ -56,8 +56,8 @@ namespace OpenTelemetry.Collector
                 {
                     this.subscriptions.GetOrAdd(value.Name, name =>
                     {
-                        var dl = new DiagnosticSourceListener<TInput>(this.handlers[value.Name](this.tracerFactory, this.sampler));
-                        dl.Subscription = value.Subscribe(dl);
+                        var dl = new DiagnosticSourceListener(this.handlers[value.Name](this.tracerFactory));
+                        dl.Subscription = this.filter == null ? value.Subscribe(dl) : value.Subscribe(dl, this.filter);
                         return dl;
                     });
                 }

--- a/src/OpenTelemetry/Collector/ListenerHandler.cs
+++ b/src/OpenTelemetry/Collector/ListenerHandler.cs
@@ -16,21 +16,17 @@
 
 namespace OpenTelemetry.Collector
 {
-    using System;
     using System.Diagnostics;
     using OpenTelemetry.Trace;
 
-    public abstract class ListenerHandler<TInput>
+    public abstract class ListenerHandler
     {
         protected readonly ITracer Tracer;
 
-        protected readonly Func<TInput, ISampler> SamplerFactory;
-
-        public ListenerHandler(string sourceName, ITracer tracer, Func<TInput, ISampler> samplerFactory)
+        public ListenerHandler(string sourceName, ITracer tracer)
         {
             this.SourceName = sourceName;
             this.Tracer = tracer;
-            this.SamplerFactory = samplerFactory;
         }
 
         public string SourceName { get; }

--- a/test/OpenTelemetry.Collector.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Collector.AspNetCore.Tests/BasicTests.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System.Threading;
 using OpenTelemetry.Resources;
 
 namespace OpenTelemetry.Collector.AspNetCore.Tests
@@ -24,7 +25,6 @@ namespace OpenTelemetry.Collector.AspNetCore.Tests
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
     using OpenTelemetry.Trace;
-    using OpenTelemetry.Trace.Config;
     using OpenTelemetry.Trace.Export;
     using Moq;
     using Microsoft.AspNetCore.TestHost;
@@ -48,8 +48,8 @@ namespace OpenTelemetry.Collector.AspNetCore.Tests
         [Fact]
         public async Task SuccessfulTemplateControllerCallGeneratesASpan()
         {
-            var panProcessor = new Mock<SpanProcessor>(new NoopSpanExporter());
-            var tracerFactory = new TracerFactory(panProcessor.Object);
+            var spanProcessor = new Mock<SpanProcessor>(new NoopSpanExporter());
+            var tracerFactory = new TracerFactory(spanProcessor.Object);
 
             void ConfigureTestServices(IServiceCollection services) =>
                 services.AddSingleton<ITracerFactory>(tracerFactory);
@@ -67,23 +67,12 @@ namespace OpenTelemetry.Collector.AspNetCore.Tests
                 // Assert
                 response.EnsureSuccessStatusCode(); // Status Code 200-299
 
-                for (var i = 0; i < 10; i++)
-                {
-                    if (panProcessor.Invocations.Count == 2)
-                    {
-                        break;
-                    }
-
-                    // We need to let End callback execute as it is executed AFTER response was returned.
-                    // In unit tests environment there may be a lot of parallel unit tests executed, so 
-                    // giving some breezing room for the End callback to complete
-                    await Task.Delay(TimeSpan.FromSeconds(1));
-                }
+                WaitForProcessorInvocations(spanProcessor, 2);
             }
 
 
-            Assert.Equal(2, panProcessor.Invocations.Count); // begin and end was called
-            var span = ((Span)panProcessor.Invocations[1].Arguments[0]);
+            Assert.Equal(2, spanProcessor.Invocations.Count); // begin and end was called
+            var span = ((Span)spanProcessor.Invocations[1].Arguments[0]);
 
             Assert.Equal(SpanKind.Server, span.Kind);
             Assert.Equal("/api/values", span.Attributes.GetValue("http.path"));
@@ -101,7 +90,7 @@ namespace OpenTelemetry.Collector.AspNetCore.Tests
             tf.Setup(m => m.Extract<HttpRequest>(It.IsAny<HttpRequest>(), It.IsAny<Func<HttpRequest, string, IEnumerable<string>>>())).Returns(new SpanContext(
                 expectedTraceId,
                 expectedSpanId,
-                ActivityTraceFlags.None));
+                ActivityTraceFlags.Recorded));
 
             var tracerFactory = new TracerFactory(spanProcessor.Object, null, tf.Object);
         
@@ -121,18 +110,7 @@ namespace OpenTelemetry.Collector.AspNetCore.Tests
                 // Assert
                 response.EnsureSuccessStatusCode(); // Status Code 200-299
 
-                for (var i = 0; i < 10; i++)
-                {
-                    if (spanProcessor.Invocations.Count == 2)
-                    {
-                        break;
-                    }
-
-                    // We need to let End callback execute as it is executed AFTER response was returned.
-                    // In unit tests environment there may be a lot of parallel unit tests executed, so 
-                    // giving some breezing room for the End callback to complete
-                    await Task.Delay(TimeSpan.FromSeconds(1));
-                }
+                WaitForProcessorInvocations(spanProcessor, 2);
             }
 
             Assert.Equal(2, spanProcessor.Invocations.Count); // begin and end was called
@@ -144,6 +122,69 @@ namespace OpenTelemetry.Collector.AspNetCore.Tests
 
             Assert.Equal(expectedTraceId, span.Context.TraceId);
             Assert.Equal(expectedSpanId, span.ParentSpanId);
+        }
+
+        [Fact]
+        public async Task FilterOutRequest()
+        {
+            var spanProcessor = new Mock<SpanProcessor>(new NoopSpanExporter());
+            var tracerFactory = new TracerFactory(spanProcessor.Object);
+
+            void ConfigureTestServices(IServiceCollection services)
+            {
+                bool Filter(string eventName, object arg1, object _)
+                {
+                    if (eventName == "Microsoft.AspNetCore.Hosting.HttpRequestIn" &&
+                        arg1 is HttpContext context &&
+                        context.Request.Path == "/api/values/2")
+                    {
+                        return false;
+                    }
+
+                    return true;
+                }
+
+                services.AddSingleton<RequestsCollectorOptions>(_ => new RequestsCollectorOptions(Filter));
+                services.AddSingleton<ITracerFactory>(tracerFactory);
+            }
+
+            // Arrange
+            using (var client = this.factory
+                .WithWebHostBuilder(builder =>
+                    builder.ConfigureTestServices(ConfigureTestServices))
+                .CreateClient())
+            {
+
+                // Act
+                var response1 = await client.GetAsync("/api/values");
+                var response2 = await client.GetAsync("/api/values/2");
+
+                // Assert
+                response1.EnsureSuccessStatusCode(); // Status Code 200-299
+                response2.EnsureSuccessStatusCode(); // Status Code 200-299
+
+                WaitForProcessorInvocations(spanProcessor, 2);
+            }
+
+            // we should only create one span and never call processor with another
+            Assert.Equal(2, spanProcessor.Invocations.Count); // begin and end was called
+            var span = ((Span)spanProcessor.Invocations[1].Arguments[0]);
+
+            Assert.Equal(SpanKind.Server, span.Kind);
+            Assert.Equal("/api/values", span.Attributes.GetValue("http.path"));
+        }
+
+        private static void WaitForProcessorInvocations(Mock<SpanProcessor> spanProcessor, int invocationCount)
+        {
+            // We need to let End callback execute as it is executed AFTER response was returned.
+            // In unit tests environment there may be a lot of parallel unit tests executed, so 
+            // giving some breezing room for the End callback to complete
+            Assert.True(SpinWait.SpinUntil(() =>
+                {
+                    Thread.Sleep(10);
+                    return spanProcessor.Invocations.Count >= 2;
+                },
+                TimeSpan.FromSeconds(1)));
         }
     }
 }

--- a/test/OpenTelemetry.Collector.Dependencies.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Collector.Dependencies.Tests/BasicTests.cs
@@ -14,19 +14,16 @@
 // limitations under the License.
 // </copyright>
 
-using System.Linq;
-using OpenTelemetry.Resources;
-
 namespace OpenTelemetry.Collector.Dependencies.Tests
 {
     using Moq;
     using OpenTelemetry.Trace;
-    using OpenTelemetry.Trace.Config;
     using OpenTelemetry.Trace.Export;
-    using OpenTelemetry.Trace.Sampler;
     using System;
     using System.Diagnostics;
+    using System.Linq;
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using Xunit;
 
@@ -65,7 +62,7 @@ namespace OpenTelemetry.Collector.Dependencies.Tests
                 .Start();
             parent.TraceStateString = "k1=v1,k2=v2";
 
-            using (new DependenciesCollector(new DependenciesCollectorOptions(), tracerFactory, Samplers.AlwaysSample))
+            using (new DependenciesCollector(new DependenciesCollectorOptions(), tracerFactory))
             using (var c = new HttpClient())
             {
                 await c.SendAsync(request);
@@ -102,13 +99,59 @@ namespace OpenTelemetry.Collector.Dependencies.Tests
 
             request.Headers.Add("traceparent", "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01");
 
-            using (new DependenciesCollector(new DependenciesCollectorOptions(), tracerFactory, Samplers.AlwaysSample))
+            using (new DependenciesCollector(new DependenciesCollectorOptions(), tracerFactory))
             using (var c = new HttpClient())
             {
                 await c.SendAsync(request);
             }
 
             Assert.Equal(0, spanProcessor.Invocations.Count); 
+        }
+
+        [Fact]
+        public async Task HttpDependenciesCollectorFiltersOutRequests()
+        {
+            var spanProcessor = new Mock<SpanProcessor>(new NoopSpanExporter());
+            var tracerFactory = new TracerFactory(spanProcessor.Object);
+
+            var options = new DependenciesCollectorOptions((activityName, arg1, _) => !(activityName == "System.Net.Http.HttpRequestOut" &&
+                                                                                        arg1 is HttpRequestMessage request &&
+                                                                                        request.RequestUri.OriginalString.Contains(url)));
+
+            using (new DependenciesCollector(options, tracerFactory))
+            using (var c = new HttpClient())
+            {
+                await c.GetAsync(url);
+            }
+
+            Assert.Equal(0, spanProcessor.Invocations.Count);
+        }
+
+
+        [Fact]
+        public async Task HttpDependenciesCollectorFiltersOutRequestsToExporterEndpoints()
+        {
+            var spanProcessor = new Mock<SpanProcessor>(new NoopSpanExporter());
+            var tracerFactory = new TracerFactory(spanProcessor.Object);
+
+            var options = new DependenciesCollectorOptions();
+
+            using (new DependenciesCollector(options, tracerFactory))
+            using (var c = new HttpClient())
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100)))
+            {
+                try
+                {
+                    await c.PostAsync("https://dc.services.visualstudio.com/", new StringContent(""), cts.Token);
+                    await c.PostAsync("https://localhost:9411/api/v2/spans", new StringContent(""), cts.Token);
+                }
+                catch
+                {
+                    // ignore all, whatever response is,  we don't want anything tracked
+                }
+            }
+
+            Assert.Equal(0, spanProcessor.Invocations.Count);
         }
 
         public void Dispose()

--- a/test/OpenTelemetry.Collector.Dependencies.Tests/HttpClientTests.cs
+++ b/test/OpenTelemetry.Collector.Dependencies.Tests/HttpClientTests.cs
@@ -100,7 +100,7 @@ namespace OpenTelemetry.Collector.Dependencies.Tests
 
             using (serverLifeTime)
             {
-                using (var dc = new DependenciesCollector(new DependenciesCollectorOptions(), tracerFactory, Samplers.AlwaysSample))
+                using (var dc = new DependenciesCollector(new DependenciesCollectorOptions(), tracerFactory))
                 {
 
                     try

--- a/test/TestApp.AspNetCore.2.0/Startup.cs
+++ b/test/TestApp.AspNetCore.2.0/Startup.cs
@@ -26,6 +26,7 @@ using OpenTelemetry.Trace.Sampler;
 using System.Net.Http;
 using OpenTelemetry.Exporter.Zipkin;
 using OpenTelemetry.Trace.Config;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace TestApp.AspNetCore._2._0
 {
@@ -45,9 +46,9 @@ namespace TestApp.AspNetCore._2._0
             services.AddSingleton<HttpClient>();
 
             services.AddSingleton<ISampler>(Samplers.AlwaysSample);
-            services.AddSingleton<RequestsCollectorOptions>(new RequestsCollectorOptions());
+            services.TryAddSingleton<RequestsCollectorOptions>(new RequestsCollectorOptions());
             services.AddSingleton<RequestsCollector>();
-            services.AddSingleton<DependenciesCollectorOptions>(new DependenciesCollectorOptions());
+            services.TryAddSingleton<DependenciesCollectorOptions>(new DependenciesCollectorOptions());
             services.AddSingleton<DependenciesCollector>();
             services.AddSingleton<CallbackMiddleware.CallbackMiddlewareImpl>(new CallbackMiddleware.CallbackMiddlewareImpl());
             services.AddSingleton<ZipkinTraceExporterOptions>(new ZipkinTraceExporterOptions { ServiceName = "tracing-to-zipkin-service" });


### PR DESCRIPTION
Fixes #166

DiagnosticSource provides an efficient callback to prevent instrumentation for certain events.
We should use it instead of sampler/named tracer when possible to minimize perf impact on the application. 

Now we need to filter out  HTTP calls to exporters (AppInsights, Zipkin, not sure about LightStep). 
Users *may* configure callback that will sample out certain requests - they write which ones.
Sampling happens too late and not the right mechanism to filter.

This change
- Removes filtering based on custom sampler
- Adds default filter for known endpoints (app insights and zipkin)
- hides the ability to configure it - this will need to come as a separate feature likely after 1.0. Now I just want to minimize public API  surface 