### PR TITLE
fix: null check on possibly nullified field

### DIFF
--- a/src/OpenTelemetry/Collector/DiagnosticSourceSubscriber.cs
+++ b/src/OpenTelemetry/Collector/DiagnosticSourceSubscriber.cs
@@ -54,7 +54,7 @@ namespace OpenTelemetry.Collector
             {
                 if (this.handlers.ContainsKey(value.Name))
                 {
-                    this.subscriptions.GetOrAdd(value.Name, name =>
+                    this.subscriptions?.GetOrAdd(value.Name, name =>
                     {
                         var dl = new DiagnosticSourceListener<TInput>(this.handlers[value.Name](this.tracerFactory, this.sampler));
                         dl.Subscription = value.Subscribe(dl);


### PR DESCRIPTION
While doing review/reading code I spotted what I believe to be a race condition:

Thread 1 calls `OnNext`, `if ((Interlocked.Read(ref this.disposed) == 0) && this.subscriptions != null)` passes since instance isn't disposed yet. Before Thread 1 reaches `this.subscriptions.GetOrAdd(value.Name, name =>`, a Thread 2 calls `Dispose` which sets `disposed=1` and more importantly `this.subscriptions = null`. 