### PR TITLE
ref: Move using outside namespace

### DIFF
--- a/build/OpenTelemetry.prod.loose.ruleset
+++ b/build/OpenTelemetry.prod.loose.ruleset
@@ -67,7 +67,7 @@
     <Rule Id="SA1132" Action="None" />
     <Rule Id="SA1133" Action="Warning" />
     <Rule Id="SA1134" Action="None" />
-    <Rule Id="SA1200" Action="Warning" />
+    <Rule Id="SA1200" Action="None" />
     <Rule Id="SA1201" Action="Warning" />
     <Rule Id="SA1202" Action="Warning" />
     <Rule Id="SA1203" Action="Warning" />

--- a/build/OpenTelemetry.prod.ruleset
+++ b/build/OpenTelemetry.prod.ruleset
@@ -67,7 +67,7 @@
     <Rule Id="SA1132" Action="Error" />
     <Rule Id="SA1133" Action="Error" />
     <Rule Id="SA1134" Action="Error" />
-    <Rule Id="SA1200" Action="Error" />
+    <Rule Id="SA1200" Action="None" />
     <Rule Id="SA1201" Action="Error" />
     <Rule Id="SA1202" Action="Error" />
     <Rule Id="SA1203" Action="Error" />

--- a/samples/Exporters/Program.cs
+++ b/samples/Exporters/Program.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using CommandLine;
 
 namespace Samples
 {
-    using System;
-    using CommandLine;
-
     /// <summary>
     /// Main samples entry point.
     /// </summary>

--- a/samples/Exporters/TestApplicationInsights.cs
+++ b/samples/Exporters/TestApplicationInsights.cs
@@ -13,21 +13,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.ApplicationInsights.Extensibility;
+using OpenTelemetry.Exporter.ApplicationInsights;
+using OpenTelemetry.Stats;
+using OpenTelemetry.Stats.Aggregations;
+using OpenTelemetry.Stats.Measures;
+using OpenTelemetry.Tags;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Trace.Configuration;
 
 namespace Samples
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading;
-    using Microsoft.ApplicationInsights.Extensibility;
-    using OpenTelemetry.Exporter.ApplicationInsights;
-    using OpenTelemetry.Stats;
-    using OpenTelemetry.Stats.Aggregations;
-    using OpenTelemetry.Stats.Measures;
-    using OpenTelemetry.Tags;
-    using OpenTelemetry.Trace;
-    using OpenTelemetry.Trace.Configuration;
-
     internal class TestApplicationInsights
     {
         private static readonly ITagger Tagger = Tags.Tagger;

--- a/samples/Exporters/TestHttpClient.cs
+++ b/samples/Exporters/TestHttpClient.cs
@@ -13,16 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Net.Http;
+using OpenTelemetry.Collector.Dependencies;
+using OpenTelemetry.Exporter.Zipkin;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Trace.Configuration;
 
 namespace Samples
 {
-    using System;
-    using System.Net.Http;
-    using OpenTelemetry.Collector.Dependencies;
-    using OpenTelemetry.Exporter.Zipkin;
-    using OpenTelemetry.Trace;
-    using OpenTelemetry.Trace.Configuration;
-
     internal class TestHttpClient
     {
         internal static object Run()

--- a/samples/Exporters/TestJaeger.cs
+++ b/samples/Exporters/TestJaeger.cs
@@ -13,16 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using OpenTelemetry.Exporter.Jaeger;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Trace.Configuration;
 
 namespace Samples
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading;
-    using OpenTelemetry.Exporter.Jaeger;
-    using OpenTelemetry.Trace;
-    using OpenTelemetry.Trace.Configuration;
-
     internal class TestJaeger
     {
         internal static object Run(string host, int port)

--- a/samples/Exporters/TestPrometheus.cs
+++ b/samples/Exporters/TestPrometheus.cs
@@ -13,19 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenTelemetry.Exporter.Prometheus;
+using OpenTelemetry.Stats;
+using OpenTelemetry.Stats.Aggregations;
+using OpenTelemetry.Stats.Measures;
+using OpenTelemetry.Tags;
 
 namespace Samples
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using OpenTelemetry.Exporter.Prometheus;
-    using OpenTelemetry.Stats;
-    using OpenTelemetry.Stats.Aggregations;
-    using OpenTelemetry.Stats.Measures;
-    using OpenTelemetry.Tags;
-
     internal class TestPrometheus
     {
         private static readonly ITagger Tagger = Tags.Tagger;

--- a/samples/Exporters/TestRedis.cs
+++ b/samples/Exporters/TestRedis.cs
@@ -13,18 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using OpenTelemetry.Collector.StackExchangeRedis;
+using OpenTelemetry.Exporter.Zipkin;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Trace.Configuration;
+using StackExchange.Redis;
 
 namespace Samples
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading;
-    using OpenTelemetry.Collector.StackExchangeRedis;
-    using OpenTelemetry.Exporter.Zipkin;
-    using OpenTelemetry.Trace;
-    using OpenTelemetry.Trace.Configuration;
-    using StackExchange.Redis;
-
     internal class TestRedis
     {
         internal static object Run(string zipkinUri)

--- a/samples/Exporters/TestStackdriver.cs
+++ b/samples/Exporters/TestStackdriver.cs
@@ -13,20 +13,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using OpenTelemetry.Exporter.Stackdriver;
+using OpenTelemetry.Stats;
+using OpenTelemetry.Stats.Aggregations;
+using OpenTelemetry.Stats.Measures;
+using OpenTelemetry.Tags;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Trace.Configuration;
 
 namespace Samples
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading;
-    using OpenTelemetry.Exporter.Stackdriver;
-    using OpenTelemetry.Stats;
-    using OpenTelemetry.Stats.Aggregations;
-    using OpenTelemetry.Stats.Measures;
-    using OpenTelemetry.Tags;
-    using OpenTelemetry.Trace;
-    using OpenTelemetry.Trace.Configuration;
-
     internal class TestStackdriver
     {
         private static readonly ITagger Tagger = Tags.Tagger;

--- a/samples/Exporters/TestZipkin.cs
+++ b/samples/Exporters/TestZipkin.cs
@@ -13,16 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using OpenTelemetry.Exporter.Zipkin;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Trace.Configuration;
 
 namespace Samples
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading;
-    using OpenTelemetry.Exporter.Zipkin;
-    using OpenTelemetry.Trace;
-    using OpenTelemetry.Trace.Configuration;
-
     internal class TestZipkin
     {
         internal static object Run(string zipkinUri)

--- a/samples/LoggingTracer/LoggingTracer.Demo.AspNetCore/LoggingTracerExtensions.cs
+++ b/samples/LoggingTracer/LoggingTracer.Demo.AspNetCore/LoggingTracerExtensions.cs
@@ -1,16 +1,15 @@
 ﻿// <copyright file="LoggingTracerExtensions.cs" company="PlaceholderCompany">
 // Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Collector.AspNetCore;
+using OpenTelemetry.Collector.Dependencies;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Trace.Sampler;
 
 namespace LoggingTracer.Demo.AspNetCore
 {
-    using Microsoft.AspNetCore.Builder;
-    using Microsoft.Extensions.DependencyInjection;
-    using OpenTelemetry.Collector.AspNetCore;
-    using OpenTelemetry.Collector.Dependencies;
-    using OpenTelemetry.Trace;
-    using OpenTelemetry.Trace.Sampler;
-
     internal static class LoggingTracerExtensions
     {
         internal static void AddLoggingTracer(this IServiceCollection services)

--- a/samples/LoggingTracer/LoggingTracer.Demo.AspNetCore/Program.cs
+++ b/samples/LoggingTracer/LoggingTracer.Demo.AspNetCore/Program.cs
@@ -1,12 +1,11 @@
 ﻿// <copyright file="Program.cs" company="PlaceholderCompany">
 // Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
 
 namespace LoggingTracer.Demo.AspNetCore
 {
-    using Microsoft.AspNetCore;
-    using Microsoft.AspNetCore.Hosting;
-
     public class Program
     {
         public static void Main(string[] args)

--- a/samples/LoggingTracer/LoggingTracer.Demo.AspNetCore/Startup.cs
+++ b/samples/LoggingTracer/LoggingTracer.Demo.AspNetCore/Startup.cs
@@ -1,14 +1,13 @@
 ﻿// <copyright file="Startup.cs" company="PlaceholderCompany">
 // Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace LoggingTracer.Demo.AspNetCore
 {
-    using Microsoft.AspNetCore.Builder;
-    using Microsoft.AspNetCore.Hosting;
-    using Microsoft.AspNetCore.Http;
-    using Microsoft.Extensions.DependencyInjection;
-
     public class Startup
     {
         public void ConfigureServices(IServiceCollection services)

--- a/samples/LoggingTracer/LoggingTracer.Demo.ConsoleApp/Program.cs
+++ b/samples/LoggingTracer/LoggingTracer.Demo.ConsoleApp/Program.cs
@@ -1,12 +1,11 @@
 ﻿// <copyright file="Program.cs" company="PlaceholderCompany">
 // Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
+using System.Threading.Tasks;
+using OpenTelemetry.Trace;
 
 namespace LoggingTracer.Demo.ConsoleApp
 {
-    using System.Threading.Tasks;
-    using OpenTelemetry.Trace;
-
     public class Program
     {
         public static async Task Main(string[] args)

--- a/samples/LoggingTracer/LoggingTracer/CurrentSpanUtils.cs
+++ b/samples/LoggingTracer/LoggingTracer/CurrentSpanUtils.cs
@@ -1,13 +1,12 @@
 ﻿// <copyright file="CurrentSpanUtils.cs" company="PlaceholderCompany">
 // Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
+using System;
+using System.Threading;
+using OpenTelemetry.Trace;
 
 namespace LoggingTracer
 {
-    using System;
-    using System.Threading;
-    using OpenTelemetry.Trace;
-
     /// <summary>
     /// Span utils for Logging-only SDK implementation.
     /// </summary>

--- a/samples/LoggingTracer/LoggingTracer/Logger.cs
+++ b/samples/LoggingTracer/LoggingTracer/Logger.cs
@@ -1,12 +1,11 @@
 ﻿// <copyright file="Logger.cs" company="PlaceholderCompany">
 // Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
+using System;
+using System.Threading;
 
 namespace LoggingTracer
 {
-    using System;
-    using System.Threading;
-
     public static class Logger
     {
         private static DateTime startTime = DateTime.UtcNow;

--- a/samples/LoggingTracer/LoggingTracer/LoggingBinaryFormat.cs
+++ b/samples/LoggingTracer/LoggingTracer/LoggingBinaryFormat.cs
@@ -1,14 +1,13 @@
 ﻿// <copyright file="LoggingBinaryFormat.cs" company="PlaceholderCompany">
 // Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using OpenTelemetry.Context.Propagation;
+using OpenTelemetry.Trace;
 
 namespace LoggingTracer
 {
-    using System;
-    using System.Collections.Generic;
-    using OpenTelemetry.Context.Propagation;
-    using OpenTelemetry.Trace;
-
     public sealed class LoggingBinaryFormat : IBinaryFormat
     {
         public ISet<string> Fields => null;

--- a/samples/LoggingTracer/LoggingTracer/LoggingSpan.cs
+++ b/samples/LoggingTracer/LoggingTracer/LoggingSpan.cs
@@ -1,13 +1,12 @@
 ﻿// <copyright file="LoggingSpan.cs" company="PlaceholderCompany">
 // Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using OpenTelemetry.Trace;
 
 namespace LoggingTracer
 {
-    using System;
-    using System.Collections.Generic;
-    using OpenTelemetry.Trace;
-
     public class LoggingSpan : ISpan
     {
         public LoggingSpan(string name, SpanKind kind)

--- a/samples/LoggingTracer/LoggingTracer/LoggingTextFormat.cs
+++ b/samples/LoggingTracer/LoggingTracer/LoggingTextFormat.cs
@@ -1,14 +1,13 @@
 ﻿// <copyright file="LoggingTextFormat.cs" company="PlaceholderCompany">
 // Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using OpenTelemetry.Context.Propagation;
+using OpenTelemetry.Trace;
 
 namespace LoggingTracer
 {
-    using System;
-    using System.Collections.Generic;
-    using OpenTelemetry.Context.Propagation;
-    using OpenTelemetry.Trace;
-
     public sealed class LoggingTextFormat : ITextFormat
     {
         public ISet<string> Fields => null;

--- a/samples/LoggingTracer/LoggingTracer/LoggingTracer.cs
+++ b/samples/LoggingTracer/LoggingTracer/LoggingTracer.cs
@@ -1,15 +1,14 @@
 ﻿// <copyright file="LoggingTracer.cs" company="PlaceholderCompany">
 // Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using OpenTelemetry.Context.Propagation;
+using OpenTelemetry.Trace;
 
 namespace LoggingTracer
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using OpenTelemetry.Context.Propagation;
-    using OpenTelemetry.Trace;
-
     public class LoggingTracer : ITracer
     {
         private string prefix;

--- a/samples/LoggingTracer/LoggingTracer/LoggingTracerFactory.cs
+++ b/samples/LoggingTracer/LoggingTracer/LoggingTracerFactory.cs
@@ -1,12 +1,11 @@
 ﻿// <copyright file="LoggingTracerFactory.cs" company="PlaceholderCompany">
 // Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
+using System.Collections.Generic;
+using OpenTelemetry.Trace;
 
 namespace LoggingTracer
 {
-    using System.Collections.Generic;
-    using OpenTelemetry.Trace;
-
     public class LoggingTracerFactory : TracerFactoryBase
     {
         public override ITracer GetTracer(string name, string version = null)

--- a/src/OpenTelemetry.Abstractions/Context/Propagation/BinaryFormat.cs
+++ b/src/OpenTelemetry.Abstractions/Context/Propagation/BinaryFormat.cs
@@ -13,15 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Context.Propagation
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Linq;
-    using OpenTelemetry.Trace;
-
     public class BinaryFormat : IBinaryFormat
     {
         private const byte VersionId = 0;

--- a/src/OpenTelemetry.Abstractions/Context/Propagation/IBinaryFormat.cs
+++ b/src/OpenTelemetry.Abstractions/Context/Propagation/IBinaryFormat.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Context.Propagation
 {
-    using OpenTelemetry.Trace;
-
     /// <summary>
     /// Binary format propagator.
     /// </summary>

--- a/src/OpenTelemetry.Abstractions/Context/Propagation/ITextFormat.cs
+++ b/src/OpenTelemetry.Abstractions/Context/Propagation/ITextFormat.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Context.Propagation
 {
-    using System;
-    using System.Collections.Generic;
-    using OpenTelemetry.Trace;
-
     /// <summary>
     /// Text format wire context propagator. Helps to extract and inject context from textual
     /// representation (typically http headers or metadata colleciton).

--- a/src/OpenTelemetry.Abstractions/Context/Propagation/SpanContextParseException.cs
+++ b/src/OpenTelemetry.Abstractions/Context/Propagation/SpanContextParseException.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Context.Propagation
 {
-    using System;
-
     public class SpanContextParseException : Exception
     {
         public SpanContextParseException(string message)

--- a/src/OpenTelemetry.Abstractions/Context/Propagation/TraceContextFormat.cs
+++ b/src/OpenTelemetry.Abstractions/Context/Propagation/TraceContextFormat.cs
@@ -13,16 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using OpenTelemetry.Abstractions.Context.Propagation;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Context.Propagation
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Linq;
-    using OpenTelemetry.Abstractions.Context.Propagation;
-    using OpenTelemetry.Trace;
-
     /// <summary>
     /// W3C trace context text wire protocol formatter. See https://github.com/w3c/distributed-tracing/.
     /// </summary>

--- a/src/OpenTelemetry.Abstractions/Context/Propagation/TracestateUtils.cs
+++ b/src/OpenTelemetry.Abstractions/Context/Propagation/TracestateUtils.cs
@@ -14,18 +14,18 @@
 // limitations under the License.
 // </copyright>
 
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+
 #if ABSTRACTIONS
 namespace OpenTelemetry.Abstractions.Context.Propagation
 #else
 namespace OpenTelemetry.Context.Propagation
 #endif
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Linq;
-    using System.Text;
-
     /// <summary>
     /// Extension methods to extract Tracestate from string.
     /// </summary>

--- a/src/OpenTelemetry.Abstractions/Internal/BlankSpan.cs
+++ b/src/OpenTelemetry.Abstractions/Internal/BlankSpan.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
 
 namespace OpenTelemetry.Trace
 {
-    using System;
-    using System.Collections.Generic;
-
     /// <summary>
     /// Blank span.
     /// </summary>

--- a/src/OpenTelemetry.Abstractions/Metrics/DefaultMeter.cs
+++ b/src/OpenTelemetry.Abstractions/Metrics/DefaultMeter.cs
@@ -13,15 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using OpenTelemetry.Metrics.Implementation;
+using OpenTelemetry.Tags;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Metrics
 {
-    using System;
-    using System.Collections.Generic;
-    using OpenTelemetry.Metrics.Implementation;
-    using OpenTelemetry.Tags;
-    using OpenTelemetry.Trace;
-
     /// <summary>
     /// No-op implementation of a meter interface.
     /// </summary>

--- a/src/OpenTelemetry.Abstractions/Metrics/ICounterDouble.cs
+++ b/src/OpenTelemetry.Abstractions/Metrics/ICounterDouble.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using OpenTelemetry.Metrics.Implementation;
 
 namespace OpenTelemetry.Metrics
 {
-    using OpenTelemetry.Metrics.Implementation;
-
     /// <summary>
     /// Counter metric, to report instantaneous measurement of a double value. Cumulative values can go
     /// up or stay the same, but can never go down.Cumulative values cannot be negative.

--- a/src/OpenTelemetry.Abstractions/Metrics/ICounterLong.cs
+++ b/src/OpenTelemetry.Abstractions/Metrics/ICounterLong.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using OpenTelemetry.Metrics.Implementation;
 
 namespace OpenTelemetry.Metrics
 {
-    using OpenTelemetry.Metrics.Implementation;
-
     /// <summary>
     /// Counter metric, to report instantaneous measurement of a double value. Cumulative values can go
     /// up or stay the same, but can never go down.Cumulative values cannot be negative.

--- a/src/OpenTelemetry.Abstractions/Metrics/IGaugeDouble.cs
+++ b/src/OpenTelemetry.Abstractions/Metrics/IGaugeDouble.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using OpenTelemetry.Metrics.Implementation;
 
 namespace OpenTelemetry.Metrics
 {
-    using OpenTelemetry.Metrics.Implementation;
-
     /// <summary>
     /// Gauge metric, to report instantaneous measurement of a double value. Cumulative values can go
     /// up or down.

--- a/src/OpenTelemetry.Abstractions/Metrics/IGaugeLong.cs
+++ b/src/OpenTelemetry.Abstractions/Metrics/IGaugeLong.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using OpenTelemetry.Metrics.Implementation;
 
 namespace OpenTelemetry.Metrics
 {
-    using OpenTelemetry.Metrics.Implementation;
-
     /// <summary>
     /// Gauge metric, to report instantaneous measurement of a double value. Cumulative values can go
     /// up or stay the same, but can never go down.Cumulative values cannot be negative.

--- a/src/OpenTelemetry.Abstractions/Metrics/IMeter.cs
+++ b/src/OpenTelemetry.Abstractions/Metrics/IMeter.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
+using OpenTelemetry.Metrics.Implementation;
+using OpenTelemetry.Tags;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Metrics
 {
-    using System.Collections.Generic;
-    using OpenTelemetry.Metrics.Implementation;
-    using OpenTelemetry.Tags;
-    using OpenTelemetry.Trace;
-
     /// <summary>
     /// Returns a builder for <see cref="ICounterDouble"/>.
     /// </summary>

--- a/src/OpenTelemetry.Abstractions/Metrics/IMetric{T}.cs
+++ b/src/OpenTelemetry.Abstractions/Metrics/IMetric{T}.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
 
 namespace OpenTelemetry.Metrics
 {
-    using System;
-    using System.Collections.Generic;
-
     /// <summary>
     /// Base interface for all metrics defined in this package.
     /// </summary>

--- a/src/OpenTelemetry.Abstractions/Metrics/Implementation/IMetricBuilder{T}.cs
+++ b/src/OpenTelemetry.Abstractions/Metrics/Implementation/IMetricBuilder{T}.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
 
 namespace OpenTelemetry.Metrics.Implementation
 {
-    using System.Collections.Generic;
-
     /// <summary>
     /// Metric builder interface.
     /// </summary>

--- a/src/OpenTelemetry.Abstractions/Tags/ITagContext.cs
+++ b/src/OpenTelemetry.Abstractions/Tags/ITagContext.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
 
 namespace OpenTelemetry.Tags
 {
-    using System.Collections.Generic;
-
     /// <summary>
     /// Collection of tags representing the tags context.
     /// </summary>

--- a/src/OpenTelemetry.Abstractions/Tags/ITagContextBuilder.cs
+++ b/src/OpenTelemetry.Abstractions/Tags/ITagContextBuilder.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Tags
 {
-    using System;
-
     /// <summary>
     /// Tags context builder.
     /// </summary>

--- a/src/OpenTelemetry.Abstractions/Tags/ITagger.cs
+++ b/src/OpenTelemetry.Abstractions/Tags/ITagger.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Tags
 {
-    using System;
-
     /// <summary>
     /// Tags API configuraiton.
     /// </summary>

--- a/src/OpenTelemetry.Abstractions/Tags/Tag.cs
+++ b/src/OpenTelemetry.Abstractions/Tags/Tag.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Tags
 {
-    using System;
-
     /// <summary>
     /// Tag with the key and value.
     /// </summary>

--- a/src/OpenTelemetry.Abstractions/Tags/TagKey.cs
+++ b/src/OpenTelemetry.Abstractions/Tags/TagKey.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using OpenTelemetry.Utils;
 
 namespace OpenTelemetry.Tags
 {
-    using System;
-    using OpenTelemetry.Utils;
-
     /// <summary>
     /// Tag key.
     /// </summary>

--- a/src/OpenTelemetry.Abstractions/Tags/TagValue.cs
+++ b/src/OpenTelemetry.Abstractions/Tags/TagValue.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using OpenTelemetry.Utils;
 
 namespace OpenTelemetry.Tags
 {
-    using System;
-    using OpenTelemetry.Utils;
-
     /// <summary>
     /// Tag key.
     /// </summary>

--- a/src/OpenTelemetry.Abstractions/Tags/TagValues.cs
+++ b/src/OpenTelemetry.Abstractions/Tags/TagValues.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
 
 namespace OpenTelemetry.Tags
 {
-    using System.Collections.Generic;
-
     /// <summary>
     /// Collection of tags.
     /// </summary>

--- a/src/OpenTelemetry.Abstractions/Trace/Decision.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/Decision.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
+using System.Linq;
 
 namespace OpenTelemetry.Trace
 {
-    using System.Collections.Generic;
-    using System.Linq;
-
     /// <summary>
     /// Sampling decision.
     /// </summary>

--- a/src/OpenTelemetry.Abstractions/Trace/Event.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/Event.cs
@@ -13,15 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using OpenTelemetry.Abstractions.Utils;
 
 namespace OpenTelemetry.Trace
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Collections.ObjectModel;
-    using System.Linq;
-    using OpenTelemetry.Abstractions.Utils;
-
     /// <summary>
     /// A text annotation associated with a collection of attributes.
     /// </summary>

--- a/src/OpenTelemetry.Abstractions/Trace/ISampler.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/ISampler.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace OpenTelemetry.Trace
 {
-    using System.Collections.Generic;
-    using System.Diagnostics;
-
     /// <summary>
     /// Sampler to reduce data volume. This sampler executes before Span object was created.
     /// </summary>

--- a/src/OpenTelemetry.Abstractions/Trace/ISpan.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/ISpan.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
 
 namespace OpenTelemetry.Trace
 {
-    using System;
-    using System.Collections.Generic;
-
     /// <summary>
     /// <para>Span represents the execution of the certain span of code or span of time between two events which is part of
     /// a distributed trace and has result of execution, context of execution and other properties.</para>

--- a/src/OpenTelemetry.Abstractions/Trace/ITracer.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/ITracer.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using OpenTelemetry.Context.Propagation;
 
 namespace OpenTelemetry.Trace
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using OpenTelemetry.Context.Propagation;
-
     /// <summary>
     /// Tracer to record distributed tracing information.
     /// </summary>

--- a/src/OpenTelemetry.Abstractions/Trace/Link.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/Link.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace OpenTelemetry.Trace
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
     /// <summary>
     /// Link associated with the span.
     /// </summary>

--- a/src/OpenTelemetry.Abstractions/Trace/ProxyTracer.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/ProxyTracer.cs
@@ -13,15 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using OpenTelemetry.Context.Propagation;
 
 namespace OpenTelemetry.Trace
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Threading;
-    using OpenTelemetry.Context.Propagation;
-
     /// <summary>
     /// No-op tracer.
     /// </summary>

--- a/src/OpenTelemetry.Abstractions/Trace/Sampler/Internal/AlwaysSampleSampler.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/Sampler/Internal/AlwaysSampleSampler.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace OpenTelemetry.Trace.Sampler.Internal
 {
-    using System.Collections.Generic;
-    using System.Diagnostics;
-
     internal sealed class AlwaysSampleSampler : ISampler
     {
         internal AlwaysSampleSampler()

--- a/src/OpenTelemetry.Abstractions/Trace/Sampler/Internal/NeverSampleSampler.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/Sampler/Internal/NeverSampleSampler.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace OpenTelemetry.Trace.Sampler.Internal
 {
-    using System.Collections.Generic;
-    using System.Diagnostics;
-
     /// <inheritdoc />
     internal sealed class NeverSampleSampler : ISampler
     {

--- a/src/OpenTelemetry.Abstractions/Trace/SpanContext.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/SpanContext.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 
 namespace OpenTelemetry.Trace
 {
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Linq;
-
     /// <summary>
     /// A class that represents a span context. A span context contains the state that must propagate to
     /// child <see cref="ISpan"/> and across process boundaries. It contains the identifiers <see cref="ActivityTraceId"/>

--- a/src/OpenTelemetry.Abstractions/Trace/TracerExtensions.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/TracerExtensions.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics;
+using OpenTelemetry.Abstractions.Utils;
 
 namespace OpenTelemetry.Trace
 {
-    using System;
-    using System.Diagnostics;
-    using OpenTelemetry.Abstractions.Utils;
-
     public static class TracerExtensions
     {
         /// <summary>

--- a/src/OpenTelemetry.Abstractions/Trace/TracerFactoryBase.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/TracerFactoryBase.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Trace
 {
-    using System;
-
     /// <summary>
     /// Creates Tracers for an instrumentation library.
     /// </summary>

--- a/src/OpenTelemetry.Abstractions/Utils/PreciseTimestamp.cs
+++ b/src/OpenTelemetry.Abstractions/Utils/PreciseTimestamp.cs
@@ -14,19 +14,19 @@
 // limitations under the License.
 // </copyright>
 
+using System;
+using System.Diagnostics;
+#if NET45 || NET46
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+#endif
+
 #if ABSTRACTIONS
 namespace OpenTelemetry.Abstractions.Utils
 #else
 namespace OpenTelemetry.Utils
 #endif
 {
-    using System;
-    using System.Diagnostics;
-#if NET45 || NET46
-    using System.Diagnostics.CodeAnalysis;
-    using System.Threading;
-#endif
-
     internal class PreciseTimestamp
     {
         /// <summary>

--- a/src/OpenTelemetry.Collector.AspNetCore/AspNetCoreCollector.cs
+++ b/src/OpenTelemetry.Collector.AspNetCore/AspNetCoreCollector.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using OpenTelemetry.Collector.AspNetCore.Implementation;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Collector.AspNetCore
 {
-    using System;
-    using OpenTelemetry.Collector.AspNetCore.Implementation;
-    using OpenTelemetry.Trace;
-
     /// <summary>
     /// Requests collector.
     /// </summary>

--- a/src/OpenTelemetry.Collector.AspNetCore/AspNetCoreCollectorOptions.cs
+++ b/src/OpenTelemetry.Collector.AspNetCore/AspNetCoreCollectorOptions.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Collector.AspNetCore
 {
-    using System;
-
     /// <summary>
     /// Options for requests collector.
     /// </summary>

--- a/src/OpenTelemetry.Collector.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Collector.AspNetCore/Implementation/HttpInListener.cs
@@ -13,17 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Collector.AspNetCore.Implementation
 {
-    using System;
-    using System.Diagnostics;
-    using System.Linq;
-    using System.Text;
-    using Microsoft.AspNetCore.Http;
-    using Microsoft.AspNetCore.Http.Features;
-    using OpenTelemetry.Trace;
-
     internal class HttpInListener : ListenerHandler
     {
         private static readonly string UnknownHostName = "UNKNOWN-HOST";

--- a/src/OpenTelemetry.Collector.AspNetCore/Implementation/PropertyFetcher.cs
+++ b/src/OpenTelemetry.Collector.AspNetCore/Implementation/PropertyFetcher.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Linq;
+using System.Reflection;
 
 namespace OpenTelemetry.Collector.AspNetCore.Implementation
 {
-    using System;
-    using System.Linq;
-    using System.Reflection;
-
     internal class PropertyFetcher
     {
         private readonly string propertyName;

--- a/src/OpenTelemetry.Collector.AspNetCore/TracerBuilderExtensions.cs
+++ b/src/OpenTelemetry.Collector.AspNetCore/TracerBuilderExtensions.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using OpenTelemetry.Trace.Configuration;
 
 namespace OpenTelemetry.Collector.AspNetCore
 {
-    using System;
-    using OpenTelemetry.Trace.Configuration;
-
     public static class TracerBuilderExtensions
     {
         public static TracerBuilder AddRequestCollector(this TracerBuilder builder)

--- a/src/OpenTelemetry.Collector.Dependencies/AzureClientsCollector.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/AzureClientsCollector.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Collector.Dependencies
 {
-    using System;
-    using OpenTelemetry.Trace;
-
     /// <summary>
     /// Dependencies collector.
     /// </summary>

--- a/src/OpenTelemetry.Collector.Dependencies/AzurePipelineCollector.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/AzurePipelineCollector.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Collector.Dependencies
 {
-    using System;
-    using OpenTelemetry.Trace;
-
     /// <summary>
     /// Dependencies collector.
     /// </summary>

--- a/src/OpenTelemetry.Collector.Dependencies/DependenciesCollector.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/DependenciesCollector.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Collector.Dependencies
 {
-    using System;
-    using System.Collections.Generic;
-    using OpenTelemetry.Trace;
-
     public class DependenciesCollector : IDisposable
     {
         private readonly List<IDisposable> collectors = new List<IDisposable>();

--- a/src/OpenTelemetry.Collector.Dependencies/HttpClientCollector.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/HttpClientCollector.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using OpenTelemetry.Collector.Dependencies.Implementation;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Collector.Dependencies
 {
-    using System;
-    using OpenTelemetry.Collector.Dependencies.Implementation;
-    using OpenTelemetry.Trace;
-
     /// <summary>
     /// Dependencies collector.
     /// </summary>

--- a/src/OpenTelemetry.Collector.Dependencies/HttpClientCollectorOptions.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/HttpClientCollectorOptions.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Net.Http;
 
 namespace OpenTelemetry.Collector.Dependencies
 {
-    using System;
-    using System.Net.Http;
-
     /// <summary>
     /// Options for dependencies collector.
     /// </summary>

--- a/src/OpenTelemetry.Collector.Dependencies/Implementation/AzureSdkDiagnosticListener.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/Implementation/AzureSdkDiagnosticListener.cs
@@ -13,16 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.Http;
+using OpenTelemetry.Collector.Dependencies.Implementation;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Collector.Dependencies
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Net.Http;
-    using OpenTelemetry.Collector.Dependencies.Implementation;
-    using OpenTelemetry.Trace;
-
     internal class AzureSdkDiagnosticListener : ListenerHandler
     {
         private static readonly PropertyFetcher LinksPropertyFetcher = new PropertyFetcher("Links");

--- a/src/OpenTelemetry.Collector.Dependencies/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/Implementation/HttpHandlerDiagnosticListener.cs
@@ -13,19 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Runtime.Versioning;
+using System.Threading.Tasks;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Collector.Dependencies.Implementation
 {
-    using System;
-    using System.Diagnostics;
-    using System.Linq;
-    using System.Net;
-    using System.Net.Http;
-    using System.Reflection;
-    using System.Runtime.Versioning;
-    using System.Threading.Tasks;
-    using OpenTelemetry.Trace;
-
     internal class HttpHandlerDiagnosticListener : ListenerHandler
     {
         private readonly PropertyFetcher startRequestFetcher = new PropertyFetcher("Request");

--- a/src/OpenTelemetry.Collector.Dependencies/Implementation/PropertyFetcher.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/Implementation/PropertyFetcher.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Linq;
+using System.Reflection;
 
 namespace OpenTelemetry.Collector.Dependencies.Implementation
 {
-    using System;
-    using System.Linq;
-    using System.Reflection;
-
     internal class PropertyFetcher
     {
         private readonly string propertyName;

--- a/src/OpenTelemetry.Collector.Dependencies/TracerBuilderExtensions.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/TracerBuilderExtensions.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using OpenTelemetry.Trace.Configuration;
 
 namespace OpenTelemetry.Collector.Dependencies
 {
-    using System;
-    using OpenTelemetry.Trace.Configuration;
-
     public static class TracerBuilderExtensions
     {
         public static TracerBuilder AddDependencyCollector(this TracerBuilder builder)

--- a/src/OpenTelemetry.Collector.StackExchangeRedis/Implementation/RedisProfilerEntryToSpanConverter.cs
+++ b/src/OpenTelemetry.Collector.StackExchangeRedis/Implementation/RedisProfilerEntryToSpanConverter.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
+using OpenTelemetry.Trace;
+using StackExchange.Redis.Profiling;
 
 namespace OpenTelemetry.Collector.StackExchangeRedis.Implementation
 {
-    using System.Collections.Generic;
-    using OpenTelemetry.Trace;
-    using StackExchange.Redis.Profiling;
-
     internal static class RedisProfilerEntryToSpanConverter
     {
         public static ISpan ProfilerCommandToSpan(ITracer tracer, ISpan parentSpan, IProfiledCommand command)

--- a/src/OpenTelemetry.Collector.StackExchangeRedis/StackExchangeRedisCallsCollector.cs
+++ b/src/OpenTelemetry.Collector.StackExchangeRedis/StackExchangeRedisCallsCollector.cs
@@ -13,17 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenTelemetry.Collector.StackExchangeRedis.Implementation;
+using OpenTelemetry.Trace;
+using StackExchange.Redis.Profiling;
 
 namespace OpenTelemetry.Collector.StackExchangeRedis
 {
-    using System;
-    using System.Collections.Concurrent;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using OpenTelemetry.Collector.StackExchangeRedis.Implementation;
-    using OpenTelemetry.Trace;
-    using StackExchange.Redis.Profiling;
-
     /// <summary>
     /// Redis calls collector.
     /// </summary>

--- a/src/OpenTelemetry.Exporter.ApplicationInsights/ApplicationInsightsMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.ApplicationInsights/ApplicationInsightsMetricExporter.cs
@@ -13,16 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.ApplicationInsights.Extensibility;
+using OpenTelemetry.Exporter.ApplicationInsights.Implementation;
+using OpenTelemetry.Stats;
 
 namespace OpenTelemetry.Exporter.ApplicationInsights
 {
-    using System;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Microsoft.ApplicationInsights.Extensibility;
-    using OpenTelemetry.Exporter.ApplicationInsights.Implementation;
-    using OpenTelemetry.Stats;
-
     /// <summary>
     /// Exporter of OpenTelemetry spans and metrics to Azure Application Insights.
     /// </summary>

--- a/src/OpenTelemetry.Exporter.ApplicationInsights/ApplicationInsightsTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.ApplicationInsights/ApplicationInsightsTraceExporter.cs
@@ -13,24 +13,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.Extensibility.Implementation;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Trace.Export;
 
 namespace OpenTelemetry.Exporter.ApplicationInsights
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Globalization;
-    using System.Linq;
-    using System.Reflection;
-    using System.Text;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Microsoft.ApplicationInsights;
-    using Microsoft.ApplicationInsights.DataContracts;
-    using Microsoft.ApplicationInsights.Extensibility;
-    using Microsoft.ApplicationInsights.Extensibility.Implementation;
-    using OpenTelemetry.Trace;
-    using OpenTelemetry.Trace.Export;
-
     public class ApplicationInsightsTraceExporter : SpanExporter, IDisposable
     {
         private readonly TelemetryClient telemetryClient;

--- a/src/OpenTelemetry.Exporter.ApplicationInsights/Implementation/MetricsExporterThread.cs
+++ b/src/OpenTelemetry.Exporter.ApplicationInsights/Implementation/MetricsExporterThread.cs
@@ -13,18 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics;
+using System.Threading;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using OpenTelemetry.Stats;
+using OpenTelemetry.Stats.Aggregations;
 
 namespace OpenTelemetry.Exporter.ApplicationInsights.Implementation
 {
-    using System;
-    using System.Diagnostics;
-    using System.Threading;
-    using Microsoft.ApplicationInsights;
-    using Microsoft.ApplicationInsights.DataContracts;
-    using Microsoft.ApplicationInsights.Extensibility;
-    using OpenTelemetry.Stats;
-    using OpenTelemetry.Stats.Aggregations;
-
     internal class MetricsExporterThread
     {
         private readonly IViewManager viewManager;

--- a/src/OpenTelemetry.Exporter.ApplicationInsights/TracerBuilderExtensions.cs
+++ b/src/OpenTelemetry.Exporter.ApplicationInsights/TracerBuilderExtensions.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using Microsoft.ApplicationInsights.Extensibility;
+using OpenTelemetry.Trace.Configuration;
 
 namespace OpenTelemetry.Exporter.ApplicationInsights
 {
-    using System;
-    using Microsoft.ApplicationInsights.Extensibility;
-    using OpenTelemetry.Trace.Configuration;
-
     public static class TracerBuilderExtensions
     {
         public static TracerBuilder UseApplicationInsights(this TracerBuilder builder, Action<TelemetryConfiguration> configure)

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/Batch.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/Batch.cs
@@ -1,4 +1,4 @@
-// <copyright file="Batch.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="Batch.cs" company="OpenTelemetry Authors">
 // Copyright 2018, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,20 +13,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Thrift.Protocols;
+using Thrift.Protocols.Entities;
+using Thrift.Protocols.Utilities;
 
 namespace OpenTelemetry.Exporter.Jaeger.Implementation
 {
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Thrift.Protocols;
-    using Thrift.Protocols.Entities;
-    using Thrift.Protocols.Utilities;
-
     public class Batch : TAbstractBase
     {
         public Batch()

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/EmitBatchArgs.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/EmitBatchArgs.cs
@@ -1,4 +1,4 @@
-// <copyright file="EmitBatchArgs.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="EmitBatchArgs.cs" company="OpenTelemetry Authors">
 // Copyright 2018, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,16 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Thrift.Protocols;
+using Thrift.Protocols.Entities;
 
 namespace OpenTelemetry.Exporter.Jaeger.Implementation
 {
-    using System;
-    using System.Text;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Thrift.Protocols;
-    using Thrift.Protocols.Entities;
-
     public class EmitBatchArgs : TAbstractBase
     {
         public EmitBatchArgs()

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/IJaegerUdpBatcher.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/IJaegerUdpBatcher.cs
@@ -1,4 +1,4 @@
-// <copyright file="IJaegerUdpBatcher.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="IJaegerUdpBatcher.cs" company="OpenTelemetry Authors">
 // Copyright 2018, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace OpenTelemetry.Exporter.Jaeger.Implementation
 {
-    using System;
-    using System.Threading;
-    using System.Threading.Tasks;
-
     public interface IJaegerUdpBatcher : IDisposable
     {
         Task<int> AppendAsync(JaegerSpan span, CancellationToken cancellationToken);

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/IJaegerUdpClient.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/IJaegerUdpClient.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Net;
+using System.Threading.Tasks;
 
 namespace OpenTelemetry.Exporter.Jaeger.Implementation
 {
-    using System;
-    using System.Net;
-    using System.Threading.Tasks;
-
     public interface IJaegerUdpClient : IDisposable
     {
         bool Connected { get; }

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/InMemoryTransport.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/InMemoryTransport.cs
@@ -1,4 +1,4 @@
-// <copyright file="InMemoryTransport.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="InMemoryTransport.cs" company="OpenTelemetry Authors">
 // Copyright 2018, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,15 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Thrift.Transports;
 
 namespace OpenTelemetry.Exporter.Jaeger.Implementation
 {
-    using System;
-    using System.IO;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Thrift.Transports;
-
     public class InMemoryTransport : TClientTransport
     {
         private readonly MemoryStream byteStream;

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/Int128.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/Int128.cs
@@ -1,4 +1,4 @@
-// <copyright file="Int128.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="Int128.cs" company="OpenTelemetry Authors">
 // Copyright 2018, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics;
 
 namespace OpenTelemetry.Exporter.Jaeger.Implementation
 {
-    using System;
-    using System.Diagnostics;
-
     public struct Int128
     {
         public static Int128 Empty = default;

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerConversionExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerConversionExtensions.cs
@@ -13,15 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Exporter.Jaeger.Implementation
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Linq;
-    using OpenTelemetry.Trace;
-
     public static class JaegerConversionExtensions
     {
         private const int DaysPerYear = 365;

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerExporterException.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerExporterException.cs
@@ -1,4 +1,4 @@
-// <copyright file="JaegerExporterException.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="JaegerExporterException.cs" company="OpenTelemetry Authors">
 // Copyright 2018, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Exporter.Jaeger.Implementation
 {
-    using System;
-
     public class JaegerExporterException : Exception
     {
         public JaegerExporterException(string message, Exception originalException)

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerLog.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerLog.cs
@@ -1,4 +1,4 @@
-// <copyright file="JaegerLog.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="JaegerLog.cs" company="OpenTelemetry Authors">
 // Copyright 2018, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,18 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Thrift.Protocols;
+using Thrift.Protocols.Entities;
 
 namespace OpenTelemetry.Exporter.Jaeger.Implementation
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Thrift.Protocols;
-    using Thrift.Protocols.Entities;
-
     public class JaegerLog : TAbstractBase
     {
         public JaegerLog()

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerSpan.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerSpan.cs
@@ -1,4 +1,4 @@
-// <copyright file="JaegerSpan.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="JaegerSpan.cs" company="OpenTelemetry Authors">
 // Copyright 2018, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,18 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Thrift.Protocols;
+using Thrift.Protocols.Entities;
 
 namespace OpenTelemetry.Exporter.Jaeger.Implementation
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Thrift.Protocols;
-    using Thrift.Protocols.Entities;
-
     public class JaegerSpan : TAbstractBase
     {
         public JaegerSpan()

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerSpanRef.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerSpanRef.cs
@@ -13,16 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Thrift.Protocols;
+using Thrift.Protocols.Entities;
 
 namespace OpenTelemetry.Exporter.Jaeger.Implementation
 {
-    using System;
-    using System.Text;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Thrift.Protocols;
-    using Thrift.Protocols.Entities;
-
     public class JaegerSpanRef : TAbstractBase
     {
         public JaegerSpanRef()

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerSpanRefType.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerSpanRefType.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Exporter.Jaeger.Implementation
 {
-    using System;
-
     /// <summary>
     /// Represents the different types of Jaeger Spans.
     /// </summary>

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerTag.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerTag.cs
@@ -1,4 +1,4 @@
-// <copyright file="JaegerTag.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="JaegerTag.cs" company="OpenTelemetry Authors">
 // Copyright 2018, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,16 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Thrift.Protocols;
+using Thrift.Protocols.Entities;
 
 namespace OpenTelemetry.Exporter.Jaeger.Implementation
 {
-    using System;
-    using System.Text;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Thrift.Protocols;
-    using Thrift.Protocols.Entities;
-
     public class JaegerTag : TAbstractBase
     {
         public JaegerTag()

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerTagType.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerTagType.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Exporter.Jaeger.Implementation
 {
-    using System;
-
     /// <summary>
     /// Indicates the data type of a Jaeger tag.
     /// </summary>

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerThriftClient.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerThriftClient.cs
@@ -1,4 +1,4 @@
-// <copyright file="JaegerThriftClient.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="JaegerThriftClient.cs" company="OpenTelemetry Authors">
 // Copyright 2018, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,16 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Thrift;
+using Thrift.Protocols;
+using Thrift.Protocols.Entities;
 
 namespace OpenTelemetry.Exporter.Jaeger.Implementation
 {
-    using System;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Thrift;
-    using Thrift.Protocols;
-    using Thrift.Protocols.Entities;
-
     public class JaegerThriftClient : TBaseClient, IDisposable
     {
         public JaegerThriftClient(TProtocol protocol)

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerThriftClientTransport.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerThriftClientTransport.cs
@@ -1,4 +1,4 @@
-// <copyright file="JaegerThriftClientTransport.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="JaegerThriftClientTransport.cs" company="OpenTelemetry Authors">
 // Copyright 2018, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,16 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.IO;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Thrift.Transports;
 
 namespace OpenTelemetry.Exporter.Jaeger.Implementation
 {
-    using System;
-    using System.IO;
-    using System.Net.Sockets;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Thrift.Transports;
-
     public class JaegerThriftClientTransport : TClientTransport
     {
         private readonly IJaegerUdpClient udpClient;

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpBatcher.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpBatcher.cs
@@ -13,15 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Thrift.Protocols;
 
 namespace OpenTelemetry.Exporter.Jaeger.Implementation
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Thrift.Protocols;
-
     public class JaegerUdpBatcher : IJaegerUdpBatcher
     {
         private const int DefaultMaxPacketSize = 65000;

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpClient.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpClient.cs
@@ -1,4 +1,4 @@
-// <copyright file="JaegerUdpClient.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="JaegerUdpClient.cs" company="OpenTelemetry Authors">
 // Copyright 2018, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
 
 namespace OpenTelemetry.Exporter.Jaeger.Implementation
 {
-    using System;
-    using System.Net;
-    using System.Net.Sockets;
-    using System.Threading.Tasks;
-
     public class JaegerUdpClient : IJaegerUdpClient
     {
         private readonly UdpClient client;

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/Process.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/Process.cs
@@ -1,4 +1,4 @@
-// <copyright file="Process.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="Process.cs" company="OpenTelemetry Authors">
 // Copyright 2018, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,18 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Thrift.Protocols;
+using Thrift.Protocols.Entities;
 
 namespace OpenTelemetry.Exporter.Jaeger.Implementation
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Thrift.Protocols;
-    using Thrift.Protocols.Entities;
-
     public class Process : TAbstractBase
     {
         public Process()

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptions.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
 
 namespace OpenTelemetry.Exporter.Jaeger
 {
-    using System.Collections.Generic;
-
     public class JaegerExporterOptions
     {
         public string ServiceName { get; set; }

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerTraceExporter.cs
@@ -13,18 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenTelemetry.Exporter.Jaeger.Implementation;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Trace.Export;
 
 namespace OpenTelemetry.Exporter.Jaeger
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using OpenTelemetry.Exporter.Jaeger.Implementation;
-    using OpenTelemetry.Trace;
-    using OpenTelemetry.Trace.Export;
-
     public class JaegerTraceExporter : SpanExporter, IDisposable
     {
         public const string DefaultAgentUdpHost = "localhost";

--- a/src/OpenTelemetry.Exporter.LightStep/Implementation/LightStepReport.cs
+++ b/src/OpenTelemetry.Exporter.LightStep/Implementation/LightStepReport.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace OpenTelemetry.Exporter.LightStep.Implementation
 {
 #pragma warning disable SA1402 // File may only contain a single type
-    using System.Collections.Generic;
-    using Newtonsoft.Json;
-
     internal class LightStepReport
     {
         [JsonProperty("auth")]

--- a/src/OpenTelemetry.Exporter.LightStep/Implementation/LightStepSpan.cs
+++ b/src/OpenTelemetry.Exporter.LightStep/Implementation/LightStepSpan.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace OpenTelemetry.Exporter.LightStep.Implementation
 {
 #pragma warning disable SA1402 // File may only contain a single type
-    using System;
-    using System.Collections.Generic;
-    using Newtonsoft.Json;
-
     public class LightStepSpan
     {
         [JsonProperty("operationName")]

--- a/src/OpenTelemetry.Exporter.LightStep/Implementation/LightStepSpanExtensions.cs
+++ b/src/OpenTelemetry.Exporter.LightStep/Implementation/LightStepSpanExtensions.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Exporter.LightStep.Implementation
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using OpenTelemetry.Trace;
-
     public static class LightStepSpanExtensions
     {
         public static LightStepSpan ToLightStepSpan(this Span data)

--- a/src/OpenTelemetry.Exporter.LightStep/LightStepTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.LightStep/LightStepTraceExporter.cs
@@ -13,21 +13,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using OpenTelemetry.Exporter.LightStep.Implementation;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Trace.Export;
 
 namespace OpenTelemetry.Exporter.LightStep
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Net;
-    using System.Net.Http;
-    using System.Text;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Newtonsoft.Json;
-    using OpenTelemetry.Exporter.LightStep.Implementation;
-    using OpenTelemetry.Trace;
-    using OpenTelemetry.Trace.Export;
-
     public class LightStepTraceExporter : SpanExporter
     {
         private readonly LightStepTraceExporterOptions options;

--- a/src/OpenTelemetry.Exporter.LightStep/LightStepTraceExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.LightStep/LightStepTraceExporterOptions.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Exporter.LightStep
 {
-    using System;
-
     public sealed class LightStepTraceExporterOptions
     {
         public Uri Satellite { get; set; } = new Uri("https://collector.lightstep.com:443/api/v2/reports");

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/MetricsHttpServer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/MetricsHttpServer.cs
@@ -13,15 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.IO;
+using System.Net;
+using System.Threading;
+using OpenTelemetry.Stats;
 
 namespace OpenTelemetry.Exporter.Prometheus.Implementation
 {
-    using System;
-    using System.IO;
-    using System.Net;
-    using System.Threading;
-    using OpenTelemetry.Stats;
-
     internal class MetricsHttpServer
     {
         private readonly IViewManager viewManager;

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusMetricBuilder.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusMetricBuilder.cs
@@ -13,17 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using OpenTelemetry.Stats;
+using OpenTelemetry.Stats.Aggregations;
 
 namespace OpenTelemetry.Exporter.Prometheus.Implementation
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Linq;
-    using System.Text;
-    using OpenTelemetry.Stats;
-    using OpenTelemetry.Stats.Aggregations;
-
     internal class PrometheusMetricBuilder
     {
         public static readonly string ContentType = "text/plain; version = 0.0.4";

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporter.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporter.cs
@@ -13,15 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenTelemetry.Exporter.Prometheus.Implementation;
+using OpenTelemetry.Stats;
 
 namespace OpenTelemetry.Exporter.Prometheus
 {
-    using System;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using OpenTelemetry.Exporter.Prometheus.Implementation;
-    using OpenTelemetry.Stats;
-
     /// <summary>
     /// Exporter of Open Telemetry traces and metrics to Azure Application Insights.
     /// </summary>

--- a/src/OpenTelemetry.Exporter.Stackdriver/Implementation/Constants.cs
+++ b/src/OpenTelemetry.Exporter.Stackdriver/Implementation/Constants.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Exporter.Stackdriver.Implementation
 {
-    using System;
-
     internal class Constants
     {
         public static readonly string PackagVersionUndefined = "undefined";

--- a/src/OpenTelemetry.Exporter.Stackdriver/Implementation/ExporterStackdriverEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Stackdriver/Implementation/ExporterStackdriverEventSource.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics.Tracing;
+using System.Globalization;
+using System.Threading;
 
 namespace OpenTelemetry.Exporter.Stackdriver.Implementation
 {
-    using System;
-    using System.Diagnostics.Tracing;
-    using System.Globalization;
-    using System.Threading;
-
     [EventSource(Name = "OpenTelemetry-Exporter-Stackdriver")]
     internal class ExporterStackdriverEventSource : EventSource
     {

--- a/src/OpenTelemetry.Exporter.Stackdriver/Implementation/GoogleCloudResourceUtils.cs
+++ b/src/OpenTelemetry.Exporter.Stackdriver/Implementation/GoogleCloudResourceUtils.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.IO;
+using Google.Api;
 
 namespace OpenTelemetry.Exporter.Stackdriver.Implementation
 {
-    using System;
-    using System.IO;
-    using Google.Api;
-
     /// <summary>
     /// Utility methods for working with Google Cloud Resources.
     /// </summary>

--- a/src/OpenTelemetry.Exporter.Stackdriver/Implementation/MetricsConversions.cs
+++ b/src/OpenTelemetry.Exporter.Stackdriver/Implementation/MetricsConversions.cs
@@ -13,18 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
+using Google.Api;
+using Google.Cloud.Monitoring.V3;
+using Google.Protobuf.WellKnownTypes;
+using OpenTelemetry.Exporter.Stackdriver.Utils;
+using OpenTelemetry.Stats;
+using OpenTelemetry.Stats.Aggregations;
+using OpenTelemetry.Stats.Measures;
+using OpenTelemetry.Tags;
 
 namespace OpenTelemetry.Exporter.Stackdriver.Implementation
 {
-    using System.Collections.Generic;
-    using Google.Api;
-    using Google.Cloud.Monitoring.V3;
-    using Google.Protobuf.WellKnownTypes;
-    using OpenTelemetry.Exporter.Stackdriver.Utils;
-    using OpenTelemetry.Stats;
-    using OpenTelemetry.Stats.Aggregations;
-    using OpenTelemetry.Stats.Measures;
-    using OpenTelemetry.Tags;
     using static Google.Api.Distribution.Types;
     using static Google.Api.MetricDescriptor.Types;
 

--- a/src/OpenTelemetry.Exporter.Stackdriver/Implementation/SpanExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Stackdriver/Implementation/SpanExtensions.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Linq;
+using Google.Cloud.Trace.V2;
+using Google.Protobuf.WellKnownTypes;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Exporter.Stackdriver.Implementation
 {
-    using System.Linq;
-    using Google.Cloud.Trace.V2;
-    using Google.Protobuf.WellKnownTypes;
-    using OpenTelemetry.Trace;
-
     internal static class SpanExtensions
     {
         /// <summary>

--- a/src/OpenTelemetry.Exporter.Stackdriver/Implementation/StackdriverStatsConfiguration.cs
+++ b/src/OpenTelemetry.Exporter.Stackdriver/Implementation/StackdriverStatsConfiguration.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using Google.Api;
+using Google.Apis.Auth.OAuth2;
 
 namespace OpenTelemetry.Exporter.Stackdriver.Implementation
 {
-    using System;
-    using Google.Api;
-    using Google.Apis.Auth.OAuth2;
-
     /// <summary>
     /// Configuration for exporting stats into Stackdriver.
     /// </summary>

--- a/src/OpenTelemetry.Exporter.Stackdriver/Implementation/StackdriverStatsExporter.cs
+++ b/src/OpenTelemetry.Exporter.Stackdriver/Implementation/StackdriverStatsExporter.cs
@@ -13,26 +13,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Google.Api;
+using Google.Api.Gax;
+using Google.Api.Gax.Grpc;
+using Google.Apis.Auth.OAuth2;
+using Google.Cloud.Monitoring.V3;
+using Grpc.Auth;
+using Grpc.Core;
+using OpenTelemetry.Exporter.Stackdriver.Utils;
+using OpenTelemetry.Stats;
 
 namespace OpenTelemetry.Exporter.Stackdriver.Implementation
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Linq;
-    using System.Reflection;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Google.Api;
-    using Google.Api.Gax;
-    using Google.Api.Gax.Grpc;
-    using Google.Apis.Auth.OAuth2;
-    using Google.Cloud.Monitoring.V3;
-    using Grpc.Auth;
-    using Grpc.Core;
-    using OpenTelemetry.Exporter.Stackdriver.Utils;
-    using OpenTelemetry.Stats;
-
     internal class StackdriverStatsExporter
     {
         private readonly MonitoredResource monitoredResource;

--- a/src/OpenTelemetry.Exporter.Stackdriver/StackdriverMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Stackdriver/StackdriverMetricExporter.cs
@@ -13,16 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using Google.Api.Gax;
+using Google.Apis.Auth.OAuth2;
+using Google.Cloud.Monitoring.V3;
+using OpenTelemetry.Exporter.Stackdriver.Implementation;
+using OpenTelemetry.Stats;
+using OpenTelemetry.Trace.Export;
 
 namespace OpenTelemetry.Exporter.Stackdriver
 {
-    using Google.Api.Gax;
-    using Google.Apis.Auth.OAuth2;
-    using Google.Cloud.Monitoring.V3;
-    using OpenTelemetry.Exporter.Stackdriver.Implementation;
-    using OpenTelemetry.Stats;
-    using OpenTelemetry.Trace.Export;
-
     /// <summary>
     /// Implementation of the exporter to Stackdriver.
     /// </summary>

--- a/src/OpenTelemetry.Exporter.Stackdriver/StackdriverTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Stackdriver/StackdriverTraceExporter.cs
@@ -13,21 +13,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Google.Api.Gax.Grpc;
+using Google.Cloud.Trace.V2;
+using Grpc.Core;
+using OpenTelemetry.Exporter.Stackdriver.Implementation;
+using OpenTelemetry.Trace.Export;
 
 namespace OpenTelemetry.Exporter.Stackdriver
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Reflection;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Google.Api.Gax.Grpc;
-    using Google.Cloud.Trace.V2;
-    using Grpc.Core;
-    using OpenTelemetry.Exporter.Stackdriver.Implementation;
-    using OpenTelemetry.Trace.Export;
-
     /// <summary>
     /// Exports a group of spans to Stackdriver.
     /// </summary>

--- a/src/OpenTelemetry.Exporter.Stackdriver/Utils/CommonUtils.cs
+++ b/src/OpenTelemetry.Exporter.Stackdriver/Utils/CommonUtils.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
 
 namespace OpenTelemetry.Exporter.Stackdriver.Utils
 {
-    using System.Collections.Generic;
-
     /// <summary>
     /// Common Utility Methods that are not metrics/trace specific.
     /// </summary>

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinAnnotation.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinAnnotation.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using Newtonsoft.Json;
 
 namespace OpenTelemetry.Exporter.Zipkin.Implementation
 {
-    using Newtonsoft.Json;
-
     internal class ZipkinAnnotation
     {
         [JsonProperty("timestamp")]

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinEndpoint.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinEndpoint.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using Newtonsoft.Json;
 
 namespace OpenTelemetry.Exporter.Zipkin.Implementation
 {
-    using Newtonsoft.Json;
-
     internal class ZipkinEndpoint
     {
         [JsonProperty("serviceName")]

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinSpan.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinSpan.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace OpenTelemetry.Exporter.Zipkin.Implementation
 {
-    using System;
-    using System.Collections.Generic;
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Converters;
-
     internal class ZipkinSpan
     {
         [JsonProperty("traceId")]

--- a/src/OpenTelemetry.Exporter.Zipkin/TracerBuilderExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/TracerBuilderExtensions.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using OpenTelemetry.Trace.Configuration;
 
 namespace OpenTelemetry.Exporter.Zipkin
 {
-    using System;
-    using OpenTelemetry.Trace.Configuration;
-
     public static class TracerBuilderExtensions
     {
         public static TracerBuilder UseZipkin(this TracerBuilder builder, Action<ZipkinTraceExporterOptions> configure)

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinTraceExporter.cs
@@ -13,23 +13,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using OpenTelemetry.Exporter.Zipkin.Implementation;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Trace.Export;
 
 namespace OpenTelemetry.Exporter.Zipkin
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Net;
-    using System.Net.Http;
-    using System.Net.Sockets;
-    using System.Text;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Newtonsoft.Json;
-    using OpenTelemetry.Exporter.Zipkin.Implementation;
-    using OpenTelemetry.Trace;
-    using OpenTelemetry.Trace.Export;
-
     public class ZipkinTraceExporter : SpanExporter
     {
         private const long MillisPerSecond = 1000L;

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinTraceExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinTraceExporterOptions.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Exporter.Zipkin
 {
-    using System;
-
     /// <summary>
     /// Zipkin trace exporter options.
     /// </summary>

--- a/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using global::OpenTracing;
 
 namespace OpenTelemetry.Shims.OpenTracing
 {
-    using System;
-    using System.Runtime.CompilerServices;
-    using System.Threading;
-    using global::OpenTracing;
-
     public sealed class ScopeManagerShim : IScopeManager
     {
         private static readonly ConditionalWeakTable<Trace.ISpan, global::OpenTracing.IScope> SpanScopeTable = new ConditionalWeakTable<Trace.ISpan, global::OpenTracing.IScope>();

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using global::OpenTracing;
 
 namespace OpenTelemetry.Shims.OpenTracing
 {
-    using System;
-    using System.Collections.Generic;
-    using global::OpenTracing;
-
     /// <summary>
     /// Adapts OpenTracing ISpanBuilder to an underlying OpenTelemetry ISpanBuilder.
     /// </summary>

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanContextShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanContextShim.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using global::OpenTracing;
 
 namespace OpenTelemetry.Shims.OpenTracing
 {
-    using System;
-    using System.Collections.Generic;
-    using global::OpenTracing;
-
     public sealed class SpanContextShim : ISpanContext
     {
         public SpanContextShim(Trace.SpanContext spanContext)

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanShim.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using global::OpenTracing;
 
 namespace OpenTelemetry.Shims.OpenTracing
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using global::OpenTracing;
-
     public sealed class SpanShim : ISpan
     {
         /// <summary>

--- a/src/OpenTelemetry.Shims.OpenTracing/TracerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/TracerShim.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using global::OpenTracing.Propagation;
 
 namespace OpenTelemetry.Shims.OpenTracing
 {
-    using System;
-    using System.Collections.Generic;
-    using global::OpenTracing.Propagation;
-
     public class TracerShim : global::OpenTracing.ITracer
     {
         private readonly Trace.ITracer tracer;

--- a/src/OpenTelemetry/Collector/CollectorEventSource.cs
+++ b/src/OpenTelemetry/Collector/CollectorEventSource.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics.Tracing;
+using System.Globalization;
+using System.Threading;
 
 namespace OpenTelemetry.Collector
 {
-    using System;
-    using System.Diagnostics.Tracing;
-    using System.Globalization;
-    using System.Threading;
-
     /// <summary>
     /// EventSource events emitted from the project.
     /// </summary>

--- a/src/OpenTelemetry/Collector/DiagnosticSourceListener.cs
+++ b/src/OpenTelemetry/Collector/DiagnosticSourceListener.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace OpenTelemetry.Collector
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-
     internal class DiagnosticSourceListener : IObserver<KeyValuePair<string, object>>
     {
         private readonly ListenerHandler handler;

--- a/src/OpenTelemetry/Collector/DiagnosticSourceSubscriber.cs
+++ b/src/OpenTelemetry/Collector/DiagnosticSourceSubscriber.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics;
+using System.Threading;
 
 namespace OpenTelemetry.Collector
 {
-    using System;
-    using System.Diagnostics;
-    using System.Threading;
-
     public class DiagnosticSourceSubscriber : IDisposable, IObserver<DiagnosticListener>
     {
         private readonly ListenerHandler handler;

--- a/src/OpenTelemetry/Collector/ListenerHandler.cs
+++ b/src/OpenTelemetry/Collector/ListenerHandler.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Diagnostics;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Collector
 {
-    using System.Diagnostics;
-    using OpenTelemetry.Trace;
-
     public abstract class ListenerHandler
     {
         protected readonly ITracer Tracer;

--- a/src/OpenTelemetry/Context/Propagation/B3Format.cs
+++ b/src/OpenTelemetry/Context/Propagation/B3Format.cs
@@ -13,15 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Context.Propagation
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Linq;
-    using OpenTelemetry.Trace;
-
     /// <summary>
     /// B3 text propagator. See https://github.com/openzipkin/b3-propagation for the specification.
     /// </summary>

--- a/src/OpenTelemetry/Implementation/OpenTelemetryEventSource.cs
+++ b/src/OpenTelemetry/Implementation/OpenTelemetryEventSource.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics.Tracing;
+using System.Globalization;
+using System.Threading;
 
 namespace OpenTelemetry.Implementation
 {
-    using System;
-    using System.Diagnostics.Tracing;
-    using System.Globalization;
-    using System.Threading;
-
     [EventSource(Name = "OpenTelemetry-Base")]
     internal class OpenTelemetryEventSource : EventSource
     {

--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -13,15 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics.Tracing;
+using System.Globalization;
+using System.Threading;
+using OpenTelemetry.Trace.Export;
 
 namespace OpenTelemetry.Internal
 {
-    using System;
-    using System.Diagnostics.Tracing;
-    using System.Globalization;
-    using System.Threading;
-    using OpenTelemetry.Trace.Export;
-
     /// <summary>
     /// EventSource implementation for OpenTelemetry SDK implementation.
     /// </summary>

--- a/src/OpenTelemetry/Internal/VarInt.cs
+++ b/src/OpenTelemetry/Internal/VarInt.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.IO;
 
 namespace OpenTelemetry.Internal
 {
-    using System;
-    using System.IO;
-
     public static class VarInt
     {
         /// <summary>

--- a/src/OpenTelemetry/Resources/Resource.cs
+++ b/src/OpenTelemetry/Resources/Resource.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenTelemetry.Utils;
 
 namespace OpenTelemetry.Resources
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using OpenTelemetry.Utils;
-
     /// <summary>
     /// <see cref="Resource"/> represents a resource, which captures identifying information about the entities
     /// for which signals (stats or traces) are reported.

--- a/src/OpenTelemetry/Stats/Aggregation.cs
+++ b/src/OpenTelemetry/Stats/Aggregation.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using OpenTelemetry.Stats.Aggregations;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-    using OpenTelemetry.Stats.Aggregations;
-
     public abstract class Aggregation : IAggregation
     {
         public abstract T Match<T>(Func<ISum, T> p0, Func<ICount, T> p1, Func<IMean, T> p2, Func<IDistribution, T> p3, Func<ILastValue, T> p4, Func<IAggregation, T> p5);

--- a/src/OpenTelemetry/Stats/AggregationData.cs
+++ b/src/OpenTelemetry/Stats/AggregationData.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using OpenTelemetry.Stats.Aggregations;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-    using OpenTelemetry.Stats.Aggregations;
-
     public abstract class AggregationData : IAggregationData
     {
         public abstract T Match<T>(

--- a/src/OpenTelemetry/Stats/Aggregations/Count.cs
+++ b/src/OpenTelemetry/Stats/Aggregations/Count.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics;
 
 namespace OpenTelemetry.Stats.Aggregations
 {
-    using System;
-    using System.Diagnostics;
-
     [DebuggerDisplay("{ToString(),nq}")]
     public sealed class Count : Aggregation, ICount
     {

--- a/src/OpenTelemetry/Stats/Aggregations/CountData.cs
+++ b/src/OpenTelemetry/Stats/Aggregations/CountData.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics;
 
 namespace OpenTelemetry.Stats.Aggregations
 {
-    using System;
-    using System.Diagnostics;
-
     [DebuggerDisplay("{ToString(),nq}")]
     public class CountData : AggregationData, ICountData
     {

--- a/src/OpenTelemetry/Stats/Aggregations/Distribution.cs
+++ b/src/OpenTelemetry/Stats/Aggregations/Distribution.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics;
 
 namespace OpenTelemetry.Stats.Aggregations
 {
-    using System;
-    using System.Diagnostics;
-
     [DebuggerDisplay("{ToString(),nq}")]
     public sealed class Distribution : Aggregation, IDistribution
     {

--- a/src/OpenTelemetry/Stats/Aggregations/DistributionData.cs
+++ b/src/OpenTelemetry/Stats/Aggregations/DistributionData.cs
@@ -13,15 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using OpenTelemetry.Utils;
 
 namespace OpenTelemetry.Stats.Aggregations
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Linq;
-    using OpenTelemetry.Utils;
-
     [DebuggerDisplay("{ToString(),nq}")]
     public class DistributionData : AggregationData, IDistributionData
     {

--- a/src/OpenTelemetry/Stats/Aggregations/IDistributionData.cs
+++ b/src/OpenTelemetry/Stats/Aggregations/IDistributionData.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
 
 namespace OpenTelemetry.Stats.Aggregations
 {
-    using System.Collections.Generic;
-
     /// <summary>
     /// Data accumulated by distributed aggregation.
     /// </summary>

--- a/src/OpenTelemetry/Stats/Aggregations/LastValue.cs
+++ b/src/OpenTelemetry/Stats/Aggregations/LastValue.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics;
 
 namespace OpenTelemetry.Stats.Aggregations
 {
-    using System;
-    using System.Diagnostics;
-
     [DebuggerDisplay("{ToString(),nq}")]
     public sealed class LastValue : Aggregation, ILastValue
     {

--- a/src/OpenTelemetry/Stats/Aggregations/LastValueDataDouble.cs
+++ b/src/OpenTelemetry/Stats/Aggregations/LastValueDataDouble.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics;
+using OpenTelemetry.Utils;
 
 namespace OpenTelemetry.Stats.Aggregations
 {
-    using System;
-    using System.Diagnostics;
-    using OpenTelemetry.Utils;
-
     [DebuggerDisplay("{ToString(),nq}")]
     public sealed class LastValueDataDouble : AggregationData, ILastValueDataDouble
     {

--- a/src/OpenTelemetry/Stats/Aggregations/LastValueDataLong.cs
+++ b/src/OpenTelemetry/Stats/Aggregations/LastValueDataLong.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics;
 
 namespace OpenTelemetry.Stats.Aggregations
 {
-    using System;
-    using System.Diagnostics;
-
     [DebuggerDisplay("{ToString(),nq}")]
     public sealed class LastValueDataLong : AggregationData, ILastValueDataLong
     {

--- a/src/OpenTelemetry/Stats/Aggregations/Mean.cs
+++ b/src/OpenTelemetry/Stats/Aggregations/Mean.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics;
 
 namespace OpenTelemetry.Stats.Aggregations
 {
-    using System;
-    using System.Diagnostics;
-
     [DebuggerDisplay("{ToString(),nq}")]
     public sealed class Mean : Aggregation, IMean
     {

--- a/src/OpenTelemetry/Stats/Aggregations/MeanData.cs
+++ b/src/OpenTelemetry/Stats/Aggregations/MeanData.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics;
+using OpenTelemetry.Utils;
 
 namespace OpenTelemetry.Stats.Aggregations
 {
-    using System;
-    using System.Diagnostics;
-    using OpenTelemetry.Utils;
-
     [DebuggerDisplay("{ToString(),nq}")]
     public class MeanData : AggregationData, IMeanData
     {

--- a/src/OpenTelemetry/Stats/Aggregations/Sum.cs
+++ b/src/OpenTelemetry/Stats/Aggregations/Sum.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics;
 
 namespace OpenTelemetry.Stats.Aggregations
 {
-    using System;
-    using System.Diagnostics;
-
     [DebuggerDisplay("{ToString(),nq}")]
     public sealed class Sum : Aggregation, ISum
     {

--- a/src/OpenTelemetry/Stats/Aggregations/SumDataDouble.cs
+++ b/src/OpenTelemetry/Stats/Aggregations/SumDataDouble.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics;
+using OpenTelemetry.Utils;
 
 namespace OpenTelemetry.Stats.Aggregations
 {
-    using System;
-    using System.Diagnostics;
-    using OpenTelemetry.Utils;
-
     [DebuggerDisplay("{ToString(),nq}")]
     public sealed class SumDataDouble : AggregationData, ISumDataDouble
     {

--- a/src/OpenTelemetry/Stats/Aggregations/SumDataLong.cs
+++ b/src/OpenTelemetry/Stats/Aggregations/SumDataLong.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics;
 
 namespace OpenTelemetry.Stats.Aggregations
 {
-    using System;
-    using System.Diagnostics;
-
     [DebuggerDisplay("{ToString(),nq}")]
     public sealed class SumDataLong : AggregationData, ISumDataLong
     {

--- a/src/OpenTelemetry/Stats/BucketBoundaries.cs
+++ b/src/OpenTelemetry/Stats/BucketBoundaries.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenTelemetry.Utils;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using OpenTelemetry.Utils;
-
     public sealed class BucketBoundaries : IBucketBoundaries
     {
         private BucketBoundaries(IReadOnlyList<double> boundaries)

--- a/src/OpenTelemetry/Stats/CumulativeMutableViewData.cs
+++ b/src/OpenTelemetry/Stats/CumulativeMutableViewData.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using OpenTelemetry.Tags;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-    using System.Collections.Concurrent;
-    using System.Collections.Generic;
-    using OpenTelemetry.Tags;
-
     internal class CumulativeMutableViewData : MutableViewData
     {
         private readonly IDictionary<TagValues, MutableAggregation> tagValueAggregationMap = new ConcurrentDictionary<TagValues, MutableAggregation>();

--- a/src/OpenTelemetry/Stats/CurrentStatsState.cs
+++ b/src/OpenTelemetry/Stats/CurrentStatsState.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-
     public sealed class CurrentStatsState
     {
         private readonly object lck = new object();

--- a/src/OpenTelemetry/Stats/IAggregation.cs
+++ b/src/OpenTelemetry/Stats/IAggregation.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using OpenTelemetry.Stats.Aggregations;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-    using OpenTelemetry.Stats.Aggregations;
-
     /// <summary>
     /// Represents the type of aggregation.
     /// </summary>

--- a/src/OpenTelemetry/Stats/IAggregationData.cs
+++ b/src/OpenTelemetry/Stats/IAggregationData.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using OpenTelemetry.Stats.Aggregations;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-    using OpenTelemetry.Stats.Aggregations;
-
     /// <summary>
     /// Gets the aggregation data.
     /// </summary>

--- a/src/OpenTelemetry/Stats/IBucketBoundaries.cs
+++ b/src/OpenTelemetry/Stats/IBucketBoundaries.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
 
 namespace OpenTelemetry.Stats
 {
-    using System.Collections.Generic;
-
     /// <summary>
     /// Bucket boundaries for the distribution aggregator.
     /// </summary>

--- a/src/OpenTelemetry/Stats/IMeasure.cs
+++ b/src/OpenTelemetry/Stats/IMeasure.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using OpenTelemetry.Stats.Measures;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-    using OpenTelemetry.Stats.Measures;
-
     /// <summary>
     /// A single measure to track.
     /// </summary>

--- a/src/OpenTelemetry/Stats/IMeasureMap.cs
+++ b/src/OpenTelemetry/Stats/IMeasureMap.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using OpenTelemetry.Stats.Measures;
+using OpenTelemetry.Tags;
 
 namespace OpenTelemetry.Stats
 {
-    using OpenTelemetry.Stats.Measures;
-    using OpenTelemetry.Tags;
-
     /// <summary>
     /// Measure map. Holds the mapping of measures and values.
     /// </summary>

--- a/src/OpenTelemetry/Stats/IMeasurement.cs
+++ b/src/OpenTelemetry/Stats/IMeasurement.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using OpenTelemetry.Stats.Measurements;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-    using OpenTelemetry.Stats.Measurements;
-
     /// <summary>
     /// Represents a single measurement for a measure.
     /// </summary>

--- a/src/OpenTelemetry/Stats/IView.cs
+++ b/src/OpenTelemetry/Stats/IView.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
+using OpenTelemetry.Tags;
 
 namespace OpenTelemetry.Stats
 {
-    using System.Collections.Generic;
-    using OpenTelemetry.Tags;
-
     /// <summary>
     /// Stats recording view.
     /// </summary>

--- a/src/OpenTelemetry/Stats/IViewData.cs
+++ b/src/OpenTelemetry/Stats/IViewData.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using OpenTelemetry.Tags;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-    using System.Collections.Generic;
-    using OpenTelemetry.Tags;
-
     /// <summary>
     /// Result data of the view aggregation.
     /// </summary>

--- a/src/OpenTelemetry/Stats/IViewManager.cs
+++ b/src/OpenTelemetry/Stats/IViewManager.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
 
 namespace OpenTelemetry.Stats
 {
-    using System.Collections.Generic;
-
     /// <summary>
     /// View manager that holds all configured views.
     /// </summary>

--- a/src/OpenTelemetry/Stats/Measure.cs
+++ b/src/OpenTelemetry/Stats/Measure.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using OpenTelemetry.Stats.Measures;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-    using OpenTelemetry.Stats.Measures;
-
     public abstract class Measure : IMeasure
     {
         internal const int NameMaxLength = 255;

--- a/src/OpenTelemetry/Stats/MeasureMap.cs
+++ b/src/OpenTelemetry/Stats/MeasureMap.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using OpenTelemetry.Stats.Measures;
+using OpenTelemetry.Tags;
+using OpenTelemetry.Tags.Unsafe;
 
 namespace OpenTelemetry.Stats
 {
-    using OpenTelemetry.Stats.Measures;
-    using OpenTelemetry.Tags;
-    using OpenTelemetry.Tags.Unsafe;
-
     internal sealed class MeasureMap : MeasureMapBase
     {
         private readonly StatsManager statsManager;

--- a/src/OpenTelemetry/Stats/MeasureMapBase.cs
+++ b/src/OpenTelemetry/Stats/MeasureMapBase.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using OpenTelemetry.Stats.Measures;
+using OpenTelemetry.Tags;
 
 namespace OpenTelemetry.Stats
 {
-    using OpenTelemetry.Stats.Measures;
-    using OpenTelemetry.Tags;
-
     public abstract class MeasureMapBase : IMeasureMap
     {
         public abstract IMeasureMap Put(IMeasureDouble measure, double value);

--- a/src/OpenTelemetry/Stats/MeasureMapBuilder.cs
+++ b/src/OpenTelemetry/Stats/MeasureMapBuilder.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
+using OpenTelemetry.Stats.Measurements;
+using OpenTelemetry.Stats.Measures;
 
 namespace OpenTelemetry.Stats
 {
-    using System.Collections.Generic;
-    using OpenTelemetry.Stats.Measurements;
-    using OpenTelemetry.Stats.Measures;
-
     internal class MeasureMapBuilder
     {
         private readonly List<IMeasurement> measurements = new List<IMeasurement>();

--- a/src/OpenTelemetry/Stats/MeasureToViewMap.cs
+++ b/src/OpenTelemetry/Stats/MeasureToViewMap.cs
@@ -13,15 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using OpenTelemetry.Tags;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-    using System.Collections.Concurrent;
-    using System.Collections.Generic;
-    using System.Collections.Immutable;
-    using OpenTelemetry.Tags;
-
     internal sealed class MeasureToViewMap
     {
         private readonly IDictionary<string, ICollection<MutableViewData>> mutableMap = new ConcurrentDictionary<string, ICollection<MutableViewData>>();

--- a/src/OpenTelemetry/Stats/Measurement.cs
+++ b/src/OpenTelemetry/Stats/Measurement.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using OpenTelemetry.Stats.Measurements;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-    using OpenTelemetry.Stats.Measurements;
-
     public abstract class Measurement : IMeasurement
     {
         public abstract IMeasure Measure { get; }

--- a/src/OpenTelemetry/Stats/Measurements/MeasurementDouble.cs
+++ b/src/OpenTelemetry/Stats/Measurements/MeasurementDouble.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics;
+using OpenTelemetry.Stats.Measures;
+using OpenTelemetry.Utils;
 
 namespace OpenTelemetry.Stats.Measurements
 {
-    using System;
-    using System.Diagnostics;
-    using OpenTelemetry.Stats.Measures;
-    using OpenTelemetry.Utils;
-
     [DebuggerDisplay("{ToString(),nq}")]
     public sealed class MeasurementDouble : Measurement, IMeasurementDouble
     {

--- a/src/OpenTelemetry/Stats/Measurements/MeasurementLong.cs
+++ b/src/OpenTelemetry/Stats/Measurements/MeasurementLong.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics;
+using OpenTelemetry.Stats.Measures;
 
 namespace OpenTelemetry.Stats.Measurements
 {
-    using System;
-    using System.Diagnostics;
-    using OpenTelemetry.Stats.Measures;
-
     [DebuggerDisplay("{ToString(),nq}")]
     public sealed class MeasurementLong : Measurement, IMeasurementLong
     {

--- a/src/OpenTelemetry/Stats/Measures/MeasureDouble.cs
+++ b/src/OpenTelemetry/Stats/Measures/MeasureDouble.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics;
+using OpenTelemetry.Utils;
 
 namespace OpenTelemetry.Stats.Measures
 {
-    using System;
-    using System.Diagnostics;
-    using OpenTelemetry.Utils;
-
     [DebuggerDisplay("{ToString(),nq}")]
     public class MeasureDouble : Measure, IMeasureDouble
     {

--- a/src/OpenTelemetry/Stats/Measures/MeasureLong.cs
+++ b/src/OpenTelemetry/Stats/Measures/MeasureLong.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics;
+using OpenTelemetry.Utils;
 
 namespace OpenTelemetry.Stats.Measures
 {
-    using System;
-    using System.Diagnostics;
-    using OpenTelemetry.Utils;
-
     [DebuggerDisplay("{ToString(),nq}")]
     public sealed class MeasureLong : Measure, IMeasureLong
     {

--- a/src/OpenTelemetry/Stats/MutableAggregation.cs
+++ b/src/OpenTelemetry/Stats/MutableAggregation.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-
     internal abstract class MutableAggregation
     {
         private const double Tolerance = 1e-6;

--- a/src/OpenTelemetry/Stats/MutableCount.cs
+++ b/src/OpenTelemetry/Stats/MutableCount.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-
     internal sealed class MutableCount : MutableAggregation
     {
         internal MutableCount()

--- a/src/OpenTelemetry/Stats/MutableDistribution.cs
+++ b/src/OpenTelemetry/Stats/MutableDistribution.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-
     internal sealed class MutableDistribution : MutableAggregation
     {
         private const double TOLERANCE = 1e-6;

--- a/src/OpenTelemetry/Stats/MutableLastValue.cs
+++ b/src/OpenTelemetry/Stats/MutableLastValue.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-
     internal sealed class MutableLastValue : MutableAggregation
     {
         internal double LastValue = double.NaN;

--- a/src/OpenTelemetry/Stats/MutableMean.cs
+++ b/src/OpenTelemetry/Stats/MutableMean.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-
     internal sealed class MutableMean : MutableAggregation
     {
         internal MutableMean()

--- a/src/OpenTelemetry/Stats/MutableSum.cs
+++ b/src/OpenTelemetry/Stats/MutableSum.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-
     internal sealed class MutableSum : MutableAggregation
     {
         internal MutableSum()

--- a/src/OpenTelemetry/Stats/MutableViewData.cs
+++ b/src/OpenTelemetry/Stats/MutableViewData.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using OpenTelemetry.Stats.Aggregations;
+using OpenTelemetry.Tags;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-    using System.Collections.Generic;
-    using OpenTelemetry.Stats.Aggregations;
-    using OpenTelemetry.Tags;
-
     internal abstract class MutableViewData
     {
         internal static readonly TagValue UnknownTagValue = null;

--- a/src/OpenTelemetry/Stats/NoopMeasureMap.cs
+++ b/src/OpenTelemetry/Stats/NoopMeasureMap.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using OpenTelemetry.Stats.Measures;
+using OpenTelemetry.Tags;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-    using OpenTelemetry.Stats.Measures;
-    using OpenTelemetry.Tags;
-
     internal sealed class NoopMeasureMap : MeasureMapBase
     {
         internal static readonly NoopMeasureMap Instance = new NoopMeasureMap();

--- a/src/OpenTelemetry/Stats/NoopViewManager.cs
+++ b/src/OpenTelemetry/Stats/NoopViewManager.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using OpenTelemetry.Tags;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Collections.Immutable;
-    using OpenTelemetry.Tags;
-
     internal sealed class NoopViewManager : ViewManagerBase
     {
         private readonly IDictionary<IViewName, IView> registeredViews = new Dictionary<IViewName, IView>();

--- a/src/OpenTelemetry/Stats/Stats.cs
+++ b/src/OpenTelemetry/Stats/Stats.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Stats
 {
-    using OpenTelemetry.Internal;
-
     public class Stats
     {
         private static readonly Stats StatsValue = new Stats();

--- a/src/OpenTelemetry/Stats/StatsExtensions.cs
+++ b/src/OpenTelemetry/Stats/StatsExtensions.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenTelemetry.Tags;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using OpenTelemetry.Tags;
-
     public static class StatsExtensions
     {
         public static bool ContainsKeys(this IView view, IEnumerable<TagKey> keys)

--- a/src/OpenTelemetry/Stats/StatsManager.cs
+++ b/src/OpenTelemetry/Stats/StatsManager.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using OpenTelemetry.Internal;
+using OpenTelemetry.Tags;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-    using System.Collections.Generic;
-    using OpenTelemetry.Internal;
-    using OpenTelemetry.Tags;
-
     internal sealed class StatsManager
     {
         private readonly IEventQueue queue;

--- a/src/OpenTelemetry/Stats/StatsRecorder.cs
+++ b/src/OpenTelemetry/Stats/StatsRecorder.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-
     public sealed class StatsRecorder : StatsRecorderBase
     {
         private readonly StatsManager statsManager;

--- a/src/OpenTelemetry/Stats/View.cs
+++ b/src/OpenTelemetry/Stats/View.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenTelemetry.Tags;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using OpenTelemetry.Tags;
-
     public sealed class View : IView
     {
         internal View(IViewName name, string description, IMeasure measure, IAggregation aggregation, IReadOnlyList<TagKey> columns)

--- a/src/OpenTelemetry/Stats/ViewData.cs
+++ b/src/OpenTelemetry/Stats/ViewData.cs
@@ -13,17 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using OpenTelemetry.Stats.Aggregations;
+using OpenTelemetry.Tags;
+using OpenTelemetry.Utils;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Collections.ObjectModel;
-    using System.Linq;
-    using OpenTelemetry.Stats.Aggregations;
-    using OpenTelemetry.Tags;
-    using OpenTelemetry.Utils;
-
     public sealed class ViewData : IViewData
     {
         internal ViewData(IView view, IDictionary<TagValues, IAggregationData> aggregationMap, DateTimeOffset start, DateTimeOffset end)

--- a/src/OpenTelemetry/Stats/ViewManager.cs
+++ b/src/OpenTelemetry/Stats/ViewManager.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
 
 namespace OpenTelemetry.Stats
 {
-    using System.Collections.Generic;
-
     public sealed class ViewManager : ViewManagerBase
     {
         private readonly StatsManager statsManager;

--- a/src/OpenTelemetry/Stats/ViewManagerBase.cs
+++ b/src/OpenTelemetry/Stats/ViewManagerBase.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
 
 namespace OpenTelemetry.Stats
 {
-    using System.Collections.Generic;
-
     public abstract class ViewManagerBase : IViewManager
     {
         public abstract ISet<IView> AllExportedViews { get; }

--- a/src/OpenTelemetry/Stats/ViewName.cs
+++ b/src/OpenTelemetry/Stats/ViewName.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using OpenTelemetry.Utils;
 
 namespace OpenTelemetry.Stats
 {
-    using System;
-    using OpenTelemetry.Utils;
-
     public sealed class ViewName : IViewName
     {
         internal const int NameMaxLength = 255;

--- a/src/OpenTelemetry/Tags/CurrentTagContextUtils.cs
+++ b/src/OpenTelemetry/Tags/CurrentTagContextUtils.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using OpenTelemetry.Tags.Unsafe;
 
 namespace OpenTelemetry.Tags
 {
-    using System;
-    using OpenTelemetry.Tags.Unsafe;
-
     internal static class CurrentTagContextUtils
     {
         internal static ITagContext CurrentTagContext => AsyncLocalContext.CurrentTagContext;

--- a/src/OpenTelemetry/Tags/CurrentTaggingState.cs
+++ b/src/OpenTelemetry/Tags/CurrentTaggingState.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Tags
 {
-    using System;
-
     public sealed class CurrentTaggingState
     {
         private readonly object lck = new object();

--- a/src/OpenTelemetry/Tags/NoopDisposable.cs
+++ b/src/OpenTelemetry/Tags/NoopDisposable.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Tags
 {
-    using System;
-
     internal class NoopDisposable : IDisposable
     {
         internal static readonly IDisposable Instance = new NoopDisposable();

--- a/src/OpenTelemetry/Tags/NoopTagContext.cs
+++ b/src/OpenTelemetry/Tags/NoopTagContext.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
 
 namespace OpenTelemetry.Tags
 {
-    using System.Collections.Generic;
-
     public sealed class NoopTagContext : TagContextBase
     {
         internal static readonly ITagContext Instance = new NoopTagContext();

--- a/src/OpenTelemetry/Tags/NoopTagContextBinarySerializer.cs
+++ b/src/OpenTelemetry/Tags/NoopTagContextBinarySerializer.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using OpenTelemetry.Tags.Propagation;
 
 namespace OpenTelemetry.Tags
 {
-    using System;
-    using OpenTelemetry.Tags.Propagation;
-
     public class NoopTagContextBinarySerializer : TagContextBinarySerializerBase
     {
         internal static readonly ITagContextBinarySerializer Instance = new NoopTagContextBinarySerializer();

--- a/src/OpenTelemetry/Tags/NoopTagContextBuilder.cs
+++ b/src/OpenTelemetry/Tags/NoopTagContextBuilder.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Tags
 {
-    using System;
-
     internal sealed class NoopTagContextBuilder : TagContextBuilderBase
     {
         internal static readonly ITagContextBuilder Instance = new NoopTagContextBuilder();

--- a/src/OpenTelemetry/Tags/NoopTagger.cs
+++ b/src/OpenTelemetry/Tags/NoopTagger.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Tags
 {
-    using System;
-
     internal sealed class NoopTagger : TaggerBase
     {
         internal static readonly ITagger Instance = new NoopTagger();

--- a/src/OpenTelemetry/Tags/NoopTags.cs
+++ b/src/OpenTelemetry/Tags/NoopTags.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using OpenTelemetry.Tags.Propagation;
 
 namespace OpenTelemetry.Tags
 {
-    using OpenTelemetry.Tags.Propagation;
-
     internal sealed class NoopTags
     {
         internal static ITagger NoopTagger

--- a/src/OpenTelemetry/Tags/Propagation/SerializationUtils.cs
+++ b/src/OpenTelemetry/Tags/Propagation/SerializationUtils.cs
@@ -13,15 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Tags.Propagation
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Text;
-    using OpenTelemetry.Internal;
-
     internal static class SerializationUtils
     {
         internal const int VersionId = 0;

--- a/src/OpenTelemetry/Tags/Propagation/TagContextDeserializationException.cs
+++ b/src/OpenTelemetry/Tags/Propagation/TagContextDeserializationException.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Tags.Propagation
 {
-    using System;
-
     public sealed class TagContextDeserializationException : Exception
     {
         public TagContextDeserializationException(string message)

--- a/src/OpenTelemetry/Tags/Propagation/TagContextSerializationException.cs
+++ b/src/OpenTelemetry/Tags/Propagation/TagContextSerializationException.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Tags.Propagation
 {
-    using System;
-
     public sealed class TagContextSerializationException : Exception
     {
         public TagContextSerializationException(string message)

--- a/src/OpenTelemetry/Tags/TagContext.cs
+++ b/src/OpenTelemetry/Tags/TagContext.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace OpenTelemetry.Tags
 {
-    using System.Collections.Generic;
-    using System.Collections.ObjectModel;
-    using System.Linq;
-
     public sealed class TagContext : TagContextBase
     {
         public static readonly ITagContext Empty = new TagContext(new Dictionary<TagKey, TagValue>());

--- a/src/OpenTelemetry/Tags/TagContextBase.cs
+++ b/src/OpenTelemetry/Tags/TagContextBase.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using OpenTelemetry.Utils;
 
 namespace OpenTelemetry.Tags
 {
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Linq;
-    using OpenTelemetry.Utils;
-
     public abstract class TagContextBase : ITagContext
     {
         /// <inheritdoc/>

--- a/src/OpenTelemetry/Tags/TagContextBuilder.cs
+++ b/src/OpenTelemetry/Tags/TagContextBuilder.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using OpenTelemetry.Context;
 
 namespace OpenTelemetry.Tags
 {
-    using System;
-    using System.Collections.Generic;
-    using OpenTelemetry.Context;
-
     internal sealed class TagContextBuilder : TagContextBuilderBase
     {
         internal TagContextBuilder(IDictionary<TagKey, TagValue> tags)

--- a/src/OpenTelemetry/Tags/TagContextBuilderBase.cs
+++ b/src/OpenTelemetry/Tags/TagContextBuilderBase.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Tags
 {
-    using System;
-
     public abstract class TagContextBuilderBase : ITagContextBuilder
     {
         public abstract ITagContext Build();

--- a/src/OpenTelemetry/Tags/Tagger.cs
+++ b/src/OpenTelemetry/Tags/Tagger.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Tags
 {
-    using System;
-
     public sealed class Tagger : TaggerBase
     {
         private readonly CurrentTaggingState state;

--- a/src/OpenTelemetry/Tags/TaggerBase.cs
+++ b/src/OpenTelemetry/Tags/TaggerBase.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Tags
 {
-    using System;
-
     public abstract class TaggerBase : ITagger
     {
         public abstract ITagContext Empty { get; }

--- a/src/OpenTelemetry/Tags/Tags.cs
+++ b/src/OpenTelemetry/Tags/Tags.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using OpenTelemetry.Tags.Propagation;
 
 namespace OpenTelemetry.Tags
 {
-    using OpenTelemetry.Tags.Propagation;
-
     public sealed class Tags
     {
         private static readonly object Lock = new object();

--- a/src/OpenTelemetry/Tags/Unsafe/AsyncLocalContext.cs
+++ b/src/OpenTelemetry/Tags/Unsafe/AsyncLocalContext.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
+using System.Threading;
 
 namespace OpenTelemetry.Tags.Unsafe
 {
-    using System.Collections.Generic;
-    using System.Threading;
-
     internal static class AsyncLocalContext
     {
         private static readonly ITagContext EmptyTagContextInstance = new EmptyTagContext();

--- a/src/OpenTelemetry/Trace/Configuration/TracerBuilder.cs
+++ b/src/OpenTelemetry/Trace/Configuration/TracerBuilder.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using OpenTelemetry.Context.Propagation;
+using OpenTelemetry.Trace.Export;
 
 namespace OpenTelemetry.Trace.Configuration
 {
-    using System;
-    using System.Collections.Generic;
-    using OpenTelemetry.Context.Propagation;
-    using OpenTelemetry.Trace.Export;
-
     public class TracerBuilder
     {
         internal TracerBuilder()

--- a/src/OpenTelemetry/Trace/Configuration/TracerConfiguration.cs
+++ b/src/OpenTelemetry/Trace/Configuration/TracerConfiguration.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using OpenTelemetry.Trace.Sampler;
 
 namespace OpenTelemetry.Trace.Configuration
 {
-    using System;
-    using OpenTelemetry.Trace.Sampler;
-
     /// <summary>
     /// Trace configuration that can be updates in runtime.
     /// </summary>

--- a/src/OpenTelemetry/Trace/Configuration/TracerFactory.cs
+++ b/src/OpenTelemetry/Trace/Configuration/TracerFactory.cs
@@ -13,16 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using OpenTelemetry.Context.Propagation;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace.Export;
+using OpenTelemetry.Trace.Sampler;
 
 namespace OpenTelemetry.Trace.Configuration
 {
-    using System;
-    using System.Collections.Generic;
-    using OpenTelemetry.Context.Propagation;
-    using OpenTelemetry.Resources;
-    using OpenTelemetry.Trace.Export;
-    using OpenTelemetry.Trace.Sampler;
-
     public class TracerFactory : TracerFactoryBase, IDisposable
     {
         private readonly object lck = new object();

--- a/src/OpenTelemetry/Trace/Export/BatchingSpanProcessor.cs
+++ b/src/OpenTelemetry/Trace/Export/BatchingSpanProcessor.cs
@@ -13,17 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Trace.Export
 {
-    using System;
-    using System.Collections.Concurrent;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using OpenTelemetry.Internal;
-
     /// <summary>
     /// Implements span processor that batches spans before calling exporter.
     /// </summary>

--- a/src/OpenTelemetry/Trace/Export/NoopSpanExporter.cs
+++ b/src/OpenTelemetry/Trace/Export/NoopSpanExporter.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace OpenTelemetry.Trace.Export
 {
-    using System.Collections.Generic;
-    using System.Threading;
-    using System.Threading.Tasks;
-
     /// <inheritdoc />
     internal sealed class NoopSpanExporter : SpanExporter
     {

--- a/src/OpenTelemetry/Trace/Export/SimpleSpanProcessor.cs
+++ b/src/OpenTelemetry/Trace/Export/SimpleSpanProcessor.cs
@@ -13,15 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenTelemetry.Internal;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Trace.Export
 {
-    using System;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using OpenTelemetry.Internal;
-    using OpenTelemetry.Trace;
-
     /// <summary>
     /// Implements simple span processor that exports spans in OnEnd call without batching.
     /// </summary>

--- a/src/OpenTelemetry/Trace/Export/SpanExporter.cs
+++ b/src/OpenTelemetry/Trace/Export/SpanExporter.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Trace.Export
 {
-    using System.Collections.Generic;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using OpenTelemetry.Trace;
-
     /// <summary>
     /// SpanExporter base class.
     /// </summary>

--- a/src/OpenTelemetry/Trace/Export/SpanProcessor.cs
+++ b/src/OpenTelemetry/Trace/Export/SpanProcessor.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Trace.Export
 {
-    using System;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using OpenTelemetry.Trace;
-
     /// <summary>
     /// Span processor base class. 
     /// </summary>

--- a/src/OpenTelemetry/Trace/Internal/CurrentSpanUtils.cs
+++ b/src/OpenTelemetry/Trace/Internal/CurrentSpanUtils.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using OpenTelemetry.Context;
 
 namespace OpenTelemetry.Trace.Internal
 {
-    using System;
-    using System.Diagnostics;
-    using System.Runtime.CompilerServices;
-    using OpenTelemetry.Context;
-
     internal static class CurrentSpanUtils
     {
         private static readonly ConditionalWeakTable<Activity, ISpan> ActivitySpanTable = new ConditionalWeakTable<Activity, ISpan>();

--- a/src/OpenTelemetry/Trace/Internal/EvictingQueue.cs
+++ b/src/OpenTelemetry/Trace/Internal/EvictingQueue.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections;
+using System.Collections.Generic;
 
 namespace OpenTelemetry.Trace.Internal
 {
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-
     internal class EvictingQueue<T> : IEnumerable<T>
     {
         private readonly int maxNumEvents;

--- a/src/OpenTelemetry/Trace/Sampler/ProbabilitySampler.cs
+++ b/src/OpenTelemetry/Trace/Sampler/ProbabilitySampler.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using OpenTelemetry.Utils;
 
 namespace OpenTelemetry.Trace.Sampler
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using OpenTelemetry.Utils;
-
     /// <inheritdoc />
     public sealed class ProbabilitySampler : ISampler
     {

--- a/src/OpenTelemetry/Trace/Span.cs
+++ b/src/OpenTelemetry/Trace/Span.cs
@@ -13,20 +13,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using OpenTelemetry.Context.Propagation;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace.Configuration;
+using OpenTelemetry.Trace.Export;
+using OpenTelemetry.Trace.Internal;
+using OpenTelemetry.Utils;
 
 namespace OpenTelemetry.Trace
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Linq;
-    using OpenTelemetry.Context.Propagation;
-    using OpenTelemetry.Resources;
-    using OpenTelemetry.Trace.Configuration;
-    using OpenTelemetry.Trace.Export;
-    using OpenTelemetry.Trace.Internal;
-    using OpenTelemetry.Utils;
-
     /// <summary>
     /// Span implementation.
     /// </summary>

--- a/src/OpenTelemetry/Trace/Tracer.cs
+++ b/src/OpenTelemetry/Trace/Tracer.cs
@@ -13,20 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using OpenTelemetry.Context.Propagation;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace.Configuration;
+using OpenTelemetry.Trace.Export;
+using OpenTelemetry.Trace.Internal;
+using OpenTelemetry.Utils;
 
 namespace OpenTelemetry.Trace
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-
-    using OpenTelemetry.Context.Propagation;
-    using OpenTelemetry.Resources;
-    using OpenTelemetry.Trace.Configuration;
-    using OpenTelemetry.Trace.Export;
-    using OpenTelemetry.Trace.Internal;
-    using OpenTelemetry.Utils;
-
     internal sealed class Tracer : ITracer
     {
         private readonly SpanProcessor spanProcessor;

--- a/src/OpenTelemetry/Utils/DoubleUtil.cs
+++ b/src/OpenTelemetry/Utils/DoubleUtil.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 
 namespace OpenTelemetry.Utils
 {
-    using System;
-
     internal static class DoubleUtil
     {
         public static long ToInt64(double arg)

--- a/test/OpenTelemetry.Collector.AspNetCore.Tests/AttributesExtensions.cs
+++ b/test/OpenTelemetry.Collector.AspNetCore.Tests/AttributesExtensions.cs
@@ -14,12 +14,11 @@
 // limitations under the License.
 // </copyright>
 
+using System.Collections.Generic;
+using System.Linq;
 
 namespace OpenTelemetry.Collector.AspNetCore.Tests
 {
-    using System.Collections.Generic;
-    using System.Linq;
-
     internal static class AttributesExtensions
     {
         public static object GetValue(this IEnumerable<KeyValuePair<string, object>> attributes, string key)

--- a/test/OpenTelemetry.Collector.Dependencies.Tests/HttpClientTests.cs
+++ b/test/OpenTelemetry.Collector.Dependencies.Tests/HttpClientTests.cs
@@ -13,23 +13,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using Moq;
+using Newtonsoft.Json;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Trace.Configuration;
+using OpenTelemetry.Trace.Export;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
 
 namespace OpenTelemetry.Collector.Dependencies.Tests
 {
-    using Moq;
-    using Newtonsoft.Json;
-    using OpenTelemetry.Trace;
-    using OpenTelemetry.Trace.Configuration;
-    using OpenTelemetry.Trace.Export;
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Linq;
-    using System.Net.Http;
-    using System.Reflection;
-    using System.Threading.Tasks;
-    using Xunit;
-
     public partial class HttpClientTests
     {
         public class HttpOutTestCase

--- a/test/OpenTelemetry.Collector.Dependencies.Tests/TestServer.cs
+++ b/test/OpenTelemetry.Collector.Dependencies.Tests/TestServer.cs
@@ -13,15 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
 
 namespace OpenTelemetry.Collector.Dependencies.Tests
 {
-    using System;
-    using System.Net;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Xunit;
-
     public class TestServer
     {
         private static readonly Random GlobalRandom = new Random();

--- a/test/OpenTelemetry.Collector.StackExchangeRedis.Tests/AttributesExtensions.cs
+++ b/test/OpenTelemetry.Collector.StackExchangeRedis.Tests/AttributesExtensions.cs
@@ -14,12 +14,11 @@
 // limitations under the License.
 // </copyright>
 
+using System.Linq;
+using System.Collections.Generic;
 
 namespace OpenTelemetry.Collector.StackExchangeRedis.Tests
 {
-    using System.Linq;
-    using System.Collections.Generic;
-
     internal static class AttributesExtensions
     {
         public static object GetValue(this IEnumerable<KeyValuePair<string, object>> attributes, string key)

--- a/test/OpenTelemetry.Exporter.ApplicationInsights.Tests/Implementation/StubTelemetryChannel.cs
+++ b/test/OpenTelemetry.Exporter.ApplicationInsights.Tests/Implementation/StubTelemetryChannel.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using Microsoft.ApplicationInsights.Channel;
+using System;
 
 namespace OpenTelemetry.Exporter.ApplicationInsights.Tests
 {
-    using Microsoft.ApplicationInsights.Channel;
-    using System;
-
     /// <summary>
     /// A stub of <see cref="ITelemetryChannel"/>.
     /// </summary>

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/ThriftUdpClientTransportTests.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/ThriftUdpClientTransportTests.cs
@@ -1,4 +1,4 @@
-// <copyright file="ThriftUdpClientTransportTests.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="ThriftUdpClientTransportTests.cs" company="OpenTelemetry Authors">
 // Copyright 2018, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,18 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using OpenTelemetry.Exporter.Jaeger.Implementation;
+using Thrift.Transports;
+using Xunit;
 
 namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
 {
-    using System;
-    using System.IO;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Moq;
-    using OpenTelemetry.Exporter.Jaeger.Implementation;
-    using Thrift.Transports;
-    using Xunit;
-
     public class ThriftUdpClientTransportTests: IDisposable
     {
         private MemoryStream testingMemoryStream = new MemoryStream();

--- a/test/OpenTelemetry.Exporter.Stackdriver.Tests/Impl/StackdriverStatsConfigurationTests.cs
+++ b/test/OpenTelemetry.Exporter.Stackdriver.Tests/Impl/StackdriverStatsConfigurationTests.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using OpenTelemetry.Exporter.Stackdriver.Implementation;
+using System;
+using Xunit;
 
 namespace OpenTelemetry.Exporter.Stackriver.Tests
 {
-    using OpenTelemetry.Exporter.Stackdriver.Implementation;
-    using System;
-    using Xunit;
-
     public class StackdriverStatsConfigurationTests
     {
         public StackdriverStatsConfigurationTests()

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/Defaults.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/Defaults.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Diagnostics;
+using Moq;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Shims.OpenTracing.Tests
 {
-    using System.Diagnostics;
-    using Moq;
-    using OpenTelemetry.Trace;
-
     /// <summary>
     /// A set of static helper methods for creating some default test setup objects.
     /// </summary>

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/ScopeManagerShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/ScopeManagerShimTests.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using Moq;
+using OpenTelemetry.Trace;
+using Xunit;
 
 namespace OpenTelemetry.Shims.OpenTracing.Tests
 {
-    using System;
-    using Moq;
-    using OpenTelemetry.Trace;
-    using Xunit;
-
     public class ScopeManagerShimTests
     {
         [Fact]

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanBuilderShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanBuilderShimTests.cs
@@ -14,17 +14,16 @@
 // limitations under the License.
 // </copyright>
 
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using OpenTelemetry.Trace;
+using Moq;
+using Xunit;
 
 namespace OpenTelemetry.Shims.OpenTracing.Tests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Linq;
-    using OpenTelemetry.Trace;
-    using Moq;
-    using Xunit;
-
     public class SpanBuilderShimTests
     {
         [Fact]

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanContextShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanContextShimTests.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics;
+using OpenTelemetry.Trace;
+using Xunit;
 
 namespace OpenTelemetry.Shims.OpenTracing.Tests
 {
-    using System;
-    using System.Diagnostics;
-    using OpenTelemetry.Trace;
-    using Xunit;
-
     public class SpanContextShimTests
     {
         [Fact]

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanMock.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanMock.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Shims.OpenTracing.Tests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Collections.ObjectModel;
-    using OpenTelemetry.Trace;
-
     /// <summary>
     /// A mock ISpan implementation for unit tests. Sometimes an actual Mock is just easier to deal with than objects created with Moq.
     /// </summary>

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
@@ -13,17 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using global::OpenTracing.Tag;
+using Moq;
+using OpenTelemetry.Trace;
+using Xunit;
 
 namespace OpenTelemetry.Shims.OpenTracing.Tests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using global::OpenTracing.Tag;
-    using Moq;
-    using OpenTelemetry.Trace;
-    using Xunit;
-
     public class SpanShimTests
     {
         [Fact]

--- a/test/OpenTelemetry.Tests/Impl/Internal/TimestampConverterTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Internal/TimestampConverterTest.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using Xunit;
 
 namespace OpenTelemetry.Internal.Test
 {
-    using Xunit;
-
     public class TimestampConverterTest
     {
         [Fact]

--- a/test/OpenTelemetry.Tests/Impl/Resources/ResourceTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Resources/ResourceTest.cs
@@ -13,15 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using Xunit;
+using OpenTelemetry.Resources;
+using System.Collections.Generic;
+using System;
+using System.Linq;
 
 namespace OpenTelemetry.Impl.Resources
 {
-    using Xunit;
-    using OpenTelemetry.Resources;
-    using System.Collections.Generic;
-    using System;
-    using System.Linq;
-
     public class ResourceTest
     {
         private const string KeyName = "key";

--- a/test/OpenTelemetry.Tests/Impl/Stats/AggregationDataTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Stats/AggregationDataTest.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using OpenTelemetry.Stats.Aggregations;
+using Xunit;
 
 namespace OpenTelemetry.Stats.Test
 {
-    using System;
-    using System.Collections.Generic;
-    using OpenTelemetry.Stats.Aggregations;
-    using Xunit;
-
     public class AggregationDataTest
     {
         private static readonly double TOLERANCE = 1e-6;

--- a/test/OpenTelemetry.Tests/Impl/Stats/AggregationTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Stats/AggregationTest.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using OpenTelemetry.Stats.Aggregations;
+using Xunit;
 
 namespace OpenTelemetry.Stats.Test
 {
-    using System;
-    using System.Collections.Generic;
-    using OpenTelemetry.Stats.Aggregations;
-    using Xunit;
-
     public class AggregationTest
     {
         [Fact]

--- a/test/OpenTelemetry.Tests/Impl/Stats/BucketBoundariesTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Stats/BucketBoundariesTest.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using Xunit;
 
 namespace OpenTelemetry.Stats.Test
 {
-    using System;
-    using System.Collections.Generic;
-    using Xunit;
-
     public class BucketBoundariesTest
     {
 

--- a/test/OpenTelemetry.Tests/Impl/Stats/CurrentStatsStateTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Stats/CurrentStatsStateTest.cs
@@ -13,15 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
 
 namespace OpenTelemetry.Stats.Test
 {
-    using System;
-    using System.Linq;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Xunit;
-
     public class CurrentStatsStateTest
     {
         [Fact]

--- a/test/OpenTelemetry.Tests/Impl/Stats/MeasureMapBuilderTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Stats/MeasureMapBuilderTest.cs
@@ -13,17 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenTelemetry.Stats.Measurements;
+using OpenTelemetry.Stats.Measures;
+using OpenTelemetry.Utils;
+using Xunit;
 
 namespace OpenTelemetry.Stats.Test
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using OpenTelemetry.Stats.Measurements;
-    using OpenTelemetry.Stats.Measures;
-    using OpenTelemetry.Utils;
-    using Xunit;
-
     public class MeasureMapBuilderTest
     {
 

--- a/test/OpenTelemetry.Tests/Impl/Stats/MeasureTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Stats/MeasureTest.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using OpenTelemetry.Stats.Measures;
+using Xunit;
 
 namespace OpenTelemetry.Stats.Test
 {
-    using System;
-    using System.Collections.Generic;
-    using OpenTelemetry.Stats.Measures;
-    using Xunit;
-
     public class MeasureTest
     {
         [Fact]

--- a/test/OpenTelemetry.Tests/Impl/Stats/MeasureToViewMapTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Stats/MeasureToViewMapTest.cs
@@ -13,15 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
+using OpenTelemetry.Stats.Aggregations;
+using OpenTelemetry.Stats.Measures;
+using OpenTelemetry.Tags;
+using Xunit;
 
 namespace OpenTelemetry.Stats.Test
 {
-    using System.Collections.Generic;
-    using OpenTelemetry.Stats.Aggregations;
-    using OpenTelemetry.Stats.Measures;
-    using OpenTelemetry.Tags;
-    using Xunit;
-
     public class MeasureToViewMapTest
     {
         private static readonly IMeasure MEASURE = MeasureDouble.Create("my measurement", "measurement description", "By");

--- a/test/OpenTelemetry.Tests/Impl/Stats/MutableAggregationTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Stats/MutableAggregationTest.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using Xunit;
 
 namespace OpenTelemetry.Stats.Test
 {
-    using System;
-    using System.Collections.Generic;
-    using Xunit;
-
     public class MutableAggregationTest
     {
         private const double TOLERANCE = 1e-6;

--- a/test/OpenTelemetry.Tests/Impl/Stats/MutableViewDataTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Stats/MutableViewDataTest.cs
@@ -13,16 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using OpenTelemetry.Stats.Aggregations;
+using OpenTelemetry.Stats.Measures;
+using OpenTelemetry.Tags;
+using Xunit;
 
 namespace OpenTelemetry.Stats.Test
 {
-    using System;
-    using System.Collections.Generic;
-    using OpenTelemetry.Stats.Aggregations;
-    using OpenTelemetry.Stats.Measures;
-    using OpenTelemetry.Tags;
-    using Xunit;
-
     public class MutableViewDataTest
     {
 

--- a/test/OpenTelemetry.Tests/Impl/Stats/NoopStatsTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Stats/NoopStatsTest.cs
@@ -13,16 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using OpenTelemetry.Stats.Measures;
+using OpenTelemetry.Tags;
+using Xunit;
 
 namespace OpenTelemetry.Stats.Test
 {
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-    using OpenTelemetry.Stats.Measures;
-    using OpenTelemetry.Tags;
-    using Xunit;
-
     public class NoopStatsTest
     {
         private static readonly Tag TAG = Tag.Create(TagKey.Create("key"), TagValue.Create("value"));

--- a/test/OpenTelemetry.Tests/Impl/Stats/NoopViewManagerTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Stats/NoopViewManagerTest.cs
@@ -13,16 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using OpenTelemetry.Stats.Aggregations;
+using OpenTelemetry.Stats.Measures;
+using OpenTelemetry.Tags;
+using Xunit;
 
 namespace OpenTelemetry.Stats.Test
 {
-    using System;
-    using System.Collections.Generic;
-    using OpenTelemetry.Stats.Aggregations;
-    using OpenTelemetry.Stats.Measures;
-    using OpenTelemetry.Tags;
-    using Xunit;
-
     public class NoopViewManagerTest
     {
         private static readonly IMeasureDouble Measure = MeasureDouble.Create("my measure", "description", "s");

--- a/test/OpenTelemetry.Tests/Impl/Stats/QuickStartExampleTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Stats/QuickStartExampleTest.cs
@@ -13,17 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
+using System.Linq;
+using OpenTelemetry.Stats.Aggregations;
+using OpenTelemetry.Stats.Measures;
+using OpenTelemetry.Tags;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenTelemetry.Stats.Test
 {
-    using System.Collections.Generic;
-    using System.Linq;
-    using OpenTelemetry.Stats.Aggregations;
-    using OpenTelemetry.Stats.Measures;
-    using OpenTelemetry.Tags;
-    using Xunit;
-    using Xunit.Abstractions;
-
     public class QuickStartExampleTest
     {
         readonly ITestOutputHelper output;

--- a/test/OpenTelemetry.Tests/Impl/Stats/StatsDefaultTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Stats/StatsDefaultTest.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using Xunit;
 
 namespace OpenTelemetry.Stats.Test
 {
-    using Xunit;
-
     public class StatsDefaultTest
     {
         // [Fact]

--- a/test/OpenTelemetry.Tests/Impl/Stats/StatsRecorderTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Stats/StatsRecorderTest.cs
@@ -13,19 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using OpenTelemetry.Stats.Aggregations;
+using OpenTelemetry.Stats.Measures;
+using OpenTelemetry.Tags;
+using OpenTelemetry.Tags.Unsafe;
+using Xunit;
+using System.Collections;
 
 namespace OpenTelemetry.Stats.Test
 {
-    using System;
-    using System.Linq;
-    using System.Collections.Generic;
-    using OpenTelemetry.Stats.Aggregations;
-    using OpenTelemetry.Stats.Measures;
-    using OpenTelemetry.Tags;
-    using OpenTelemetry.Tags.Unsafe;
-    using Xunit;
-    using System.Collections;
-
     public class StatsRecorderTest
     {
         private static readonly TagKey KEY = TagKey.Create("KEY");

--- a/test/OpenTelemetry.Tests/Impl/Stats/StatsTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Stats/StatsTest.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using Xunit;
 
 namespace OpenTelemetry.Stats.Test
 {
-    using Xunit;
-
     public class StatsTest
     {
         [Fact(Skip = "Fix statics usage")]

--- a/test/OpenTelemetry.Tests/Impl/Stats/StatsTestUtil.cs
+++ b/test/OpenTelemetry.Tests/Impl/Stats/StatsTestUtil.cs
@@ -13,16 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenTelemetry.Stats.Aggregations;
+using OpenTelemetry.Tags;
+using Xunit;
 
 namespace OpenTelemetry.Stats.Test
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using OpenTelemetry.Stats.Aggregations;
-    using OpenTelemetry.Tags;
-    using Xunit;
-
     internal static class StatsTestUtil
     {
         internal static IAggregationData CreateAggregationData(IAggregation aggregation, IMeasure measure, params double[] values)

--- a/test/OpenTelemetry.Tests/Impl/Stats/ViewDataTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Stats/ViewDataTest.cs
@@ -13,16 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using OpenTelemetry.Stats.Aggregations;
+using OpenTelemetry.Stats.Measures;
+using OpenTelemetry.Tags;
+using Xunit;
 
 namespace OpenTelemetry.Stats.Test
 {
-    using System;
-    using System.Collections.Generic;
-    using OpenTelemetry.Stats.Aggregations;
-    using OpenTelemetry.Stats.Measures;
-    using OpenTelemetry.Tags;
-    using Xunit;
-
     public class ViewDataTest
     {
         // tag keys

--- a/test/OpenTelemetry.Tests/Impl/Stats/ViewManagerTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Stats/ViewManagerTest.cs
@@ -13,18 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenTelemetry.Abstractions.Utils;
+using OpenTelemetry.Stats.Aggregations;
+using OpenTelemetry.Stats.Measures;
+using OpenTelemetry.Tags;
+using Xunit;
 
 namespace OpenTelemetry.Stats.Test
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using OpenTelemetry.Abstractions.Utils;
-    using OpenTelemetry.Stats.Aggregations;
-    using OpenTelemetry.Stats.Measures;
-    using OpenTelemetry.Tags;
-    using Xunit;
-
     public class ViewManagerTest
     {
         private static readonly TagKey Key = TagKey.Create("Key");

--- a/test/OpenTelemetry.Tests/Impl/Stats/ViewTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Stats/ViewTest.cs
@@ -13,16 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using OpenTelemetry.Stats.Aggregations;
+using OpenTelemetry.Stats.Measures;
+using OpenTelemetry.Tags;
+using Xunit;
 
 namespace OpenTelemetry.Stats.Test
 {
-    using System;
-    using System.Collections.Generic;
-    using OpenTelemetry.Stats.Aggregations;
-    using OpenTelemetry.Stats.Measures;
-    using OpenTelemetry.Tags;
-    using Xunit;
-
     public class ViewTest
     {
         private static readonly IViewName Name = ViewName.Create("test-view-name");

--- a/test/OpenTelemetry.Tests/Impl/Tags/CurrentTagContextUtilsTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/CurrentTagContextUtilsTest.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
+using OpenTelemetry.Tags.Unsafe;
+using Xunit;
 
 namespace OpenTelemetry.Tags.Test
 {
-    using System.Collections.Generic;
-    using OpenTelemetry.Tags.Unsafe;
-    using Xunit;
-
     public class CurrentTagContextUtilsTest
     {
         private static readonly Tag TAG = Tag.Create(TagKey.Create("key"), TagValue.Create("value"));

--- a/test/OpenTelemetry.Tests/Impl/Tags/CurrentTaggingStateTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/CurrentTaggingStateTest.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using Xunit;
 
 namespace OpenTelemetry.Tags.Test
 {
-    using System;
-    using Xunit;
-
     public class CurrentTaggingStateTest
     {
         [Fact]

--- a/test/OpenTelemetry.Tests/Impl/Tags/Propagation/TagContextBinarySerializerTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/Propagation/TagContextBinarySerializerTest.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
 
 namespace OpenTelemetry.Tags.Propagation.Test
 {
-    using System.Collections.Generic;
-
     public class TagContextBinarySerializerTest
     {
         private readonly CurrentTaggingState state;

--- a/test/OpenTelemetry.Tests/Impl/Tags/Propagation/TagContextDeserializationExceptionTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/Propagation/TagContextDeserializationExceptionTest.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using Xunit;
 
 namespace OpenTelemetry.Tags.Propagation.Test
 {
-    using System;
-    using Xunit;
-
     public class TagContextDeserializationExceptionTest
     {
         [Fact]

--- a/test/OpenTelemetry.Tests/Impl/Tags/Propagation/TagContextDeserializationTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/Propagation/TagContextDeserializationTest.cs
@@ -13,15 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.IO;
+using System.Text;
+using OpenTelemetry.Internal;
+using Xunit;
 
 namespace OpenTelemetry.Tags.Propagation.Test
 {
-    using System;
-    using System.IO;
-    using System.Text;
-    using OpenTelemetry.Internal;
-    using Xunit;
-
     public class TagContextDeserializationTest
     {
         private readonly CurrentTaggingState state;

--- a/test/OpenTelemetry.Tests/Impl/Tags/Propagation/TagContextRoundtripTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/Propagation/TagContextRoundtripTest.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using Xunit;
 
 namespace OpenTelemetry.Tags.Propagation.Test
 {
-    using System;
-    using Xunit;
-
     public class TagContextRoundtripTest
     {
 

--- a/test/OpenTelemetry.Tests/Impl/Tags/Propagation/TagContextSerializationExceptionTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/Propagation/TagContextSerializationExceptionTest.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using Xunit;
 
 namespace OpenTelemetry.Tags.Propagation.Test
 {
-    using System;
-    using Xunit;
-
     public class TagContextSerializationExceptionTest
     {
         [Fact]

--- a/test/OpenTelemetry.Tests/Impl/Tags/Propagation/TagContextSerializationTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/Propagation/TagContextSerializationTest.cs
@@ -13,18 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using OpenTelemetry.Internal;
+using Xunit;
 
 namespace OpenTelemetry.Tags.Propagation.Test
 {
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Linq;
-    using System.Text;
-    using OpenTelemetry.Internal;
-    using Xunit;
-
     public class TagContextSerializationTest
     {
         private static readonly TagKey K1 = TagKey.Create("k1");

--- a/test/OpenTelemetry.Tests/Impl/Tags/ScopedTagContextsTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/ScopedTagContextsTest.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
+using Xunit;
 
 namespace OpenTelemetry.Tags.Test
 {
-    using System.Collections.Generic;
-    using Xunit;
-
     public class ScopedTagContextsTest
     {
         private static readonly TagKey KEY_1 = TagKey.Create("key 1");

--- a/test/OpenTelemetry.Tests/Impl/Tags/TagContextBaseTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/TagContextBaseTest.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
+using Xunit;
 
 namespace OpenTelemetry.Tags.Test
 {
-    using System.Collections.Generic;
-    using Xunit;
-
     public class TagContextBaseTest
     {
         private static readonly Tag TAG1 = Tag.Create(TagKey.Create("key"), TagValue.Create("val"));

--- a/test/OpenTelemetry.Tests/Impl/Tags/TagContextTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/TagContextTest.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using Xunit;
 
 namespace OpenTelemetry.Tags.Test
 {
-    using System;
-    using System.Collections.Generic;
-    using Xunit;
-
     public class TagContextTest
     {
         private readonly ITagger tagger = new Tagger(new CurrentTaggingState());

--- a/test/OpenTelemetry.Tests/Impl/Tags/TagKeyTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/TagKeyTest.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using Xunit;
 
 namespace OpenTelemetry.Tags.Test
 {
-    using System;
-    using Xunit;
-
     public class TagKeyTest
     {
         [Fact]

--- a/test/OpenTelemetry.Tests/Impl/Tags/TagTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/TagTest.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using Xunit;
 
 namespace OpenTelemetry.Tags.Test
 {
-    using Xunit;
-
     public class TagTest
     {
         [Fact]

--- a/test/OpenTelemetry.Tests/Impl/Tags/TagValueTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/TagValueTest.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using Xunit;
 
 namespace OpenTelemetry.Tags.Test
 {
-    using System;
-    using Xunit;
-
     public class TagValueTest
     {
         [Fact]

--- a/test/OpenTelemetry.Tests/Impl/Tags/TaggerTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/TaggerTest.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
+using OpenTelemetry.Tags.Unsafe;
+using Xunit;
 
 namespace OpenTelemetry.Tags.Test
 {
-    using System.Collections.Generic;
-    using OpenTelemetry.Tags.Unsafe;
-    using Xunit;
-
     public class TaggerTest
     {
         private readonly CurrentTaggingState state;

--- a/test/OpenTelemetry.Tests/Impl/Tags/TagsDefaultTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/TagsDefaultTest.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using Xunit;
 
 namespace OpenTelemetry.Tags.Test
 {
-    using Xunit;
-
     public class TagsDefaultTest
     {
         [Fact(Skip = "Fix statics usage")]

--- a/test/OpenTelemetry.Tests/Impl/Tags/TagsTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/TagsTest.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using OpenTelemetry.Tags.Propagation;
+using Xunit;
 
 namespace OpenTelemetry.Tags.Test
 {
-    using OpenTelemetry.Tags.Propagation;
-    using Xunit;
-
     public class TagsTest
     {
         public TagsTest()

--- a/test/OpenTelemetry.Tests/Impl/Tags/TagsTestUtil.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/TagsTestUtil.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
+using System.Linq;
 
 namespace OpenTelemetry.Tags.Test
 {
-    using System.Collections.Generic;
-    using System.Linq;
-
     internal static class TagsTestUtil
     {
         public static ICollection<Tag> TagContextToList(ITagContext tags)

--- a/test/OpenTelemetry.Tests/Impl/Testing/Export/TestExporter.cs
+++ b/test/OpenTelemetry.Tests/Impl/Testing/Export/TestExporter.cs
@@ -13,17 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Trace.Export;
 
 namespace OpenTelemetry.Testing.Export
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Collections.Concurrent;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using OpenTelemetry.Trace;
-    using OpenTelemetry.Trace.Export;
-
     public class TestExporter : SpanExporter
     {
         private readonly ConcurrentQueue<Span> spanDataList = new ConcurrentQueue<Span>();

--- a/test/OpenTelemetry.Tests/Impl/Trace/AttributesExtensions.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/AttributesExtensions.cs
@@ -14,14 +14,13 @@
 // limitations under the License.
 // </copyright>
 
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
 
 namespace OpenTelemetry.Tests
 {
-    using System.Collections.Generic;
-    using System.Linq;
-    using Xunit;
-   
-    internal static class AttributesExtensions
+       internal static class AttributesExtensions
     {
         public static object GetValue(this IEnumerable<KeyValuePair<string, object>> attributes, string key)
         {

--- a/test/OpenTelemetry.Tests/Impl/Trace/Config/TraceParamsTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Config/TraceParamsTest.cs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using OpenTelemetry.Trace.Configuration;
+using OpenTelemetry.Trace.Sampler;
+using Xunit;
 
 namespace OpenTelemetry.Trace.Config.Test
 {
-    using System;
-    using OpenTelemetry.Trace.Configuration;
-    using OpenTelemetry.Trace.Sampler;
-    using Xunit;
-
     public class TraceConfigTest
     {
         [Fact]

--- a/test/OpenTelemetry.Tests/Impl/Trace/EventTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/EventTest.cs
@@ -13,15 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using OpenTelemetry.Utils;
+using Xunit;
 
 namespace OpenTelemetry.Trace.Test
 {
-    using System;
-    using System.Linq;
-    using System.Collections.Generic;
-    using OpenTelemetry.Utils;
-    using Xunit;
-
     public class EventTest
     {
         [Fact]

--- a/test/OpenTelemetry.Tests/Impl/Trace/LinkTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/LinkTest.cs
@@ -13,15 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Xunit;
 
 namespace OpenTelemetry.Trace.Test
 {
-    using System;
-    using System.Linq;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using Xunit;
-
     public class LinkTest : IDisposable
     {
         private readonly IDictionary<string, object> attributesMap = new Dictionary<string, object>();

--- a/test/OpenTelemetry.Tests/Impl/Trace/Propagation/B3FormatTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Propagation/B3FormatTest.cs
@@ -13,16 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using OpenTelemetry.Trace;
+using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenTelemetry.Context.Propagation.Test
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using OpenTelemetry.Trace;
-    using Xunit;
-    using Xunit.Abstractions;
-
     public class B3FormatTest
     {
         private static readonly string TraceIdBase16 = "ff000000000000000000000000000041";

--- a/test/OpenTelemetry.Tests/Impl/Trace/Propagation/BinaryFormatTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Propagation/BinaryFormatTest.cs
@@ -13,15 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Diagnostics;
+using OpenTelemetry.Context.Propagation;
+using OpenTelemetry.Trace;
+using System;
+using Xunit;
 
 namespace OpenTelemetry.Context.Propagation.Test
 {
-    using System.Diagnostics;
-    using OpenTelemetry.Context.Propagation;
-    using OpenTelemetry.Trace;
-    using System;
-    using Xunit;
-
     public class BinaryFormatTest
     {
         private static readonly byte[] TraceIdBytes = new byte[] { 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79 };

--- a/test/OpenTelemetry.Tests/Impl/Trace/Propagation/SpanContextParseExceptionTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Propagation/SpanContextParseExceptionTest.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using Xunit;
 
 namespace OpenTelemetry.Context.Propagation.Test
 {
-    using System;
-    using Xunit;
-
     public class SpanContextParseExceptionTest
     {
         [Fact]

--- a/test/OpenTelemetry.Tests/Impl/Trace/Propagation/TraceContextTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Propagation/TraceContextTest.cs
@@ -13,17 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Context.Propagation;
+using Xunit;
 
 namespace OpenTelemetry.Impl.Trace.Propagation
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Linq;
-    using OpenTelemetry.Trace;
-    using OpenTelemetry.Context.Propagation;
-    using Xunit;
-
     public class TraceContextTest
     {
         private static readonly string[] empty = new string[0];

--- a/test/OpenTelemetry.Tests/Impl/Trace/Sampler/SamplersTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Sampler/SamplersTest.cs
@@ -13,17 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Globalization;
+using OpenTelemetry.Trace.Internal;
+using OpenTelemetry.Trace.Test;
+using Xunit;
 
 namespace OpenTelemetry.Trace.Sampler.Test
 {
-    using System;
-    using System.Diagnostics;
-    using System.Collections.Generic;
-    using System.Globalization;
-    using OpenTelemetry.Trace.Internal;
-    using OpenTelemetry.Trace.Test;
-    using Xunit;
-
     public class SamplersTest
     {
         private static readonly String SPAN_NAME = "MySpanName";

--- a/test/OpenTelemetry.Tests/Impl/Trace/SpanContextTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/SpanContextTest.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Diagnostics;
+using Xunit;
 
 namespace OpenTelemetry.Trace.Test
 {
-    using System.Diagnostics;
-    using Xunit;
-
     public class SpanContextTest
     {
         private static readonly byte[] firstTraceIdBytes =

--- a/test/OpenTelemetry.Tests/Impl/Trace/StatusTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/StatusTest.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using Xunit;
 
 namespace OpenTelemetry.Trace.Test
 {
-    using Xunit;
-
     public class StatusTest
     {
         [Fact]

--- a/test/OpenTelemetry.Tests/Impl/Trace/TestSpan.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/TestSpan.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Generic;
 
 namespace OpenTelemetry.Trace.Test
 {
-    using System;
-    using System.Collections.Generic;
-
     public class TestSpan : ISpan
     {
         public TestSpan()

--- a/test/OpenTelemetry.Tests/Impl/Trace/TracingTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/TracingTest.cs
@@ -13,13 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using OpenTelemetry.Trace.Configuration;
+using OpenTelemetry.Trace.Sampler.Internal;
+using Xunit;
 
 namespace OpenTelemetry.Trace.Test
 {
-    using OpenTelemetry.Trace.Configuration;
-    using OpenTelemetry.Trace.Sampler.Internal;
-    using Xunit;
-
     public class TracingTest
     {
         [Fact]

--- a/test/OpenTelemetry.Tests/Impl/Utils/CanonicalCodeExtensions.cs
+++ b/test/OpenTelemetry.Tests/Impl/Utils/CanonicalCodeExtensions.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Utils
 {
-    using OpenTelemetry.Trace;
-
     internal static class CanonicalCodeExtensions
     {
         public static Status ToStatus(this CanonicalCode code)

--- a/test/TestApp.AspNetCore.2.0/CallbackMiddleware.cs
+++ b/test/TestApp.AspNetCore.2.0/CallbackMiddleware.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
 
 namespace TestApp.AspNetCore._2._0
 {
-    using Microsoft.AspNetCore.Http;
-    using System.Threading.Tasks;
-
     public class CallbackMiddleware
     {
         public class CallbackMiddlewareImpl

--- a/test/TestApp.AspNetCore.2.0/Controllers/ForwardController.cs
+++ b/test/TestApp.AspNetCore.2.0/Controllers/ForwardController.cs
@@ -13,15 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
 
 namespace TestApp.AspNetCore._2._0.Controllers
 {
-    using System.Net.Http;
-    using System.Text;
-    using System.Threading.Tasks;
-    using Microsoft.AspNetCore.Mvc;
-    using Newtonsoft.Json;
-
     [Route("api/[controller]")]
     public class ForwardController : Controller
     {

--- a/test/TestApp.AspNetCore.2.0/Controllers/ValuesController.cs
+++ b/test/TestApp.AspNetCore.2.0/Controllers/ValuesController.cs
@@ -13,12 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
 
 namespace TestApp.AspNetCore._2._0.Controllers
 {
-    using System.Collections.Generic;
-    using Microsoft.AspNetCore.Mvc;
-
     [Route("api/[controller]")]
     public class ValuesController : Controller
     {


### PR DESCRIPTION
Moving `using` directives before the `namespace` declaration.

See this for details: https://github.com/open-telemetry/opentelemetry-dotnet/issues/156#issuecomment-539675382

/cc @lmolkova 