### PR TITLE
Fix InvalidCastException in AzureSdkListener

### DIFF
--- a/benchmarks/Benchmarks.csproj
+++ b/benchmarks/Benchmarks.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp2.2;net462</TargetFrameworks>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenTelemetry.Collector.Dependencies/Implementation/PropertyFetcher.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/Implementation/PropertyFetcher.cs
@@ -86,7 +86,12 @@ namespace OpenTelemetry.Collector.Dependencies.Implementation
 
                 public override object Fetch(object obj)
                 {
-                    return this.propertyFetch((TObject)obj);
+                    if (obj is TObject o)
+                    {
+                        return this.propertyFetch(o);
+                    }
+
+                    return null;
                 }
             }
         }


### PR DESCRIPTION
PropertyFetcher threw InvalidCastException if it has already cached delegate for fetching, but was used on object of another type.

Also, micro-fix to make benchmarks not packable