### PR TITLE
minor Span impl improvements, no locks on atomic assignments

### DIFF
--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -62,6 +62,12 @@ namespace OpenTelemetry.Internal
             this.WriteEvent(4, ex);
         }
 
+        [Event(5, Message = "Calling '{0}' on ended span.", Level = EventLevel.Warning)]
+        public void UnexpectedCallOnEndedSpan(string methodName)
+        {
+            this.WriteEvent(5, methodName);
+        }
+
         /// <summary>
         /// Returns a culture-independent string representation of the given <paramref name="exception"/> object,
         /// appropriate for diagnostics tracing.

--- a/src/OpenTelemetry/Trace/Internal/EvictingQueue.cs
+++ b/src/OpenTelemetry/Trace/Internal/EvictingQueue.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -50,7 +51,7 @@ namespace OpenTelemetry.Trace.Internal
             return this.GetEnumerator();
         }
 
-        internal void AddEvent(T evnt)
+        internal void Add(T evnt)
         {
             if (evnt == null)
             {

--- a/src/OpenTelemetry/Trace/Span.cs
+++ b/src/OpenTelemetry/Trace/Span.cs
@@ -36,7 +36,8 @@ namespace OpenTelemetry.Trace
         private readonly TracerConfiguration tracerConfiguration;
         private readonly SpanProcessor spanProcessor;
         private readonly DateTimeOffset startTimestamp;
-        
+        private readonly object lck = new object();
+
         private EvictingQueue<KeyValuePair<string, object>> attributes;
         private EvictingQueue<Event> events;
         private EvictingQueue<Link> links;
@@ -193,12 +194,16 @@ namespace OpenTelemetry.Trace
                 return;
             }
 
-            if (this.attributes == null)
+            lock (this.lck)
             {
-                this.attributes = new EvictingQueue<KeyValuePair<string, object>>(this.tracerConfiguration.MaxNumberOfAttributes);
-            }
+                if (this.attributes == null)
+                {
+                    this.attributes =
+                        new EvictingQueue<KeyValuePair<string, object>>(this.tracerConfiguration.MaxNumberOfAttributes);
+                }
 
-            this.attributes.Add(new KeyValuePair<string, object>(keyValuePair.Key, keyValuePair.Value));
+                this.attributes.Add(new KeyValuePair<string, object>(keyValuePair.Key, keyValuePair.Value));
+            }
         }
 
         /// <inheritdoc/>
@@ -254,13 +259,16 @@ namespace OpenTelemetry.Trace
                 return;
             }
 
-            if (this.events == null)
+            lock (this.lck)
             {
-                this.events =
-                    new EvictingQueue<Event>(this.tracerConfiguration.MaxNumberOfEvents);
-            }
+                if (this.events == null)
+                {
+                    this.events =
+                        new EvictingQueue<Event>(this.tracerConfiguration.MaxNumberOfEvents);
+                }
 
-            this.events.Add(addEvent);
+                this.events.Add(addEvent);
+            }
         }
 
         /// <inheritdoc/>
@@ -282,12 +290,15 @@ namespace OpenTelemetry.Trace
                 return;
             }
 
-            if (this.links == null)
+            lock (this.lck)
             {
-                this.links = new EvictingQueue<Link>(this.tracerConfiguration.MaxNumberOfLinks);
-            }
+                if (this.links == null)
+                {
+                    this.links = new EvictingQueue<Link>(this.tracerConfiguration.MaxNumberOfLinks);
+                }
 
-            this.links.Add(link);
+                this.links.Add(link);
+            }
         }
 
         /// <inheritdoc/>

--- a/src/OpenTelemetry/Trace/Span.cs
+++ b/src/OpenTelemetry/Trace/Span.cs
@@ -181,14 +181,14 @@ namespace OpenTelemetry.Trace
                 throw new ArgumentNullException(nameof(keyValuePair.Value));
             }
 
-            if (this.hasEnded)
+            if (!this.IsRecordingEvents)
             {
-                OpenTelemetrySdkEventSource.Log.UnexpectedCallOnEndedSpan("UpdateName");
                 return;
             }
 
-            if (!this.IsRecordingEvents)
+            if (this.hasEnded)
             {
+                OpenTelemetrySdkEventSource.Log.UnexpectedCallOnEndedSpan("SetAttribute");
                 return;
             }
 
@@ -203,14 +203,14 @@ namespace OpenTelemetry.Trace
         /// <inheritdoc/>
         public void AddEvent(string name)
         {
-            if (this.hasEnded)
+            if (!this.IsRecordingEvents)
             {
-                OpenTelemetrySdkEventSource.Log.UnexpectedCallOnEndedSpan("AddEvent");
                 return;
             }
 
-            if (!this.IsRecordingEvents)
+            if (this.hasEnded)
             {
+                OpenTelemetrySdkEventSource.Log.UnexpectedCallOnEndedSpan("AddEvent");
                 return;
             }
 
@@ -220,19 +220,14 @@ namespace OpenTelemetry.Trace
         /// <inheritdoc/>
         public void AddEvent(string name, IDictionary<string, object> eventAttributes)
         {
-            if (eventAttributes == null)
+            if (!this.IsRecordingEvents)
             {
-                throw new ArgumentNullException(nameof(eventAttributes));
+                return;
             }
 
             if (this.hasEnded)
             {
                 OpenTelemetrySdkEventSource.Log.UnexpectedCallOnEndedSpan("AddEvent");
-                return;
-            }
-
-            if (!this.IsRecordingEvents)
-            {
                 return;
             }
 
@@ -247,14 +242,14 @@ namespace OpenTelemetry.Trace
                 throw new ArgumentNullException(nameof(addEvent));
             }
 
-            if (this.hasEnded)
+            if (!this.IsRecordingEvents)
             {
-                OpenTelemetrySdkEventSource.Log.UnexpectedCallOnEndedSpan("AddEvent");
                 return;
             }
 
-            if (!this.IsRecordingEvents)
+            if (this.hasEnded)
             {
+                OpenTelemetrySdkEventSource.Log.UnexpectedCallOnEndedSpan("AddEvent");
                 return;
             }
 
@@ -275,14 +270,14 @@ namespace OpenTelemetry.Trace
                 throw new ArgumentNullException(nameof(link));
             }
 
-            if (this.hasEnded)
+            if (!this.IsRecordingEvents)
             {
-                OpenTelemetrySdkEventSource.Log.UnexpectedCallOnEndedSpan("AddLink");
                 return;
             }
 
-            if (!this.IsRecordingEvents)
+            if (this.hasEnded)
             {
+                OpenTelemetrySdkEventSource.Log.UnexpectedCallOnEndedSpan("AddLink");
                 return;
             }
 
@@ -327,14 +322,9 @@ namespace OpenTelemetry.Trace
         /// <inheritdoc/>
         public void SetAttribute(string key, string value)
         {
-            if (key == null)
+            if (!this.IsRecordingEvents)
             {
-                throw new ArgumentNullException(nameof(key));
-            }
-
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
+                return;
             }
 
             this.SetAttribute(new KeyValuePair<string, object>(key, value));
@@ -343,9 +333,9 @@ namespace OpenTelemetry.Trace
         /// <inheritdoc/>
         public void SetAttribute(string key, long value)
         {
-            if (key == null)
+            if (!this.IsRecordingEvents)
             {
-                throw new ArgumentNullException(nameof(key));
+                return;
             }
 
             this.SetAttribute(new KeyValuePair<string, object>(key, value));
@@ -354,9 +344,9 @@ namespace OpenTelemetry.Trace
         /// <inheritdoc/>
         public void SetAttribute(string key, double value)
         {
-            if (key == null)
+            if (!this.IsRecordingEvents)
             {
-                throw new ArgumentNullException(nameof(key));
+                return;
             }
 
             this.SetAttribute(new KeyValuePair<string, object>(key, value));
@@ -365,9 +355,9 @@ namespace OpenTelemetry.Trace
         /// <inheritdoc/>
         public void SetAttribute(string key, bool value)
         {
-            if (key == null)
+            if (!this.IsRecordingEvents)
             {
-                throw new ArgumentNullException(nameof(key));
+                return;
             }
 
             this.SetAttribute(new KeyValuePair<string, object>(key, value));

--- a/src/OpenTelemetry/Trace/Span.cs
+++ b/src/OpenTelemetry/Trace/Span.cs
@@ -183,7 +183,7 @@ namespace OpenTelemetry.Trace
                 throw new ArgumentNullException(nameof(keyValuePair.Value));
             }
 
-            if (!this.IsRecordingEvents)
+            if (!this.IsRecording)
             {
                 return;
             }
@@ -209,7 +209,7 @@ namespace OpenTelemetry.Trace
         /// <inheritdoc/>
         public void AddEvent(string name)
         {
-            if (!this.IsRecordingEvents)
+            if (!this.IsRecording)
             {
                 return;
             }
@@ -226,7 +226,7 @@ namespace OpenTelemetry.Trace
         /// <inheritdoc/>
         public void AddEvent(string name, IDictionary<string, object> eventAttributes)
         {
-            if (!this.IsRecordingEvents)
+            if (!this.IsRecording)
             {
                 return;
             }
@@ -334,7 +334,7 @@ namespace OpenTelemetry.Trace
         /// <inheritdoc/>
         public void SetAttribute(string key, string value)
         {
-            if (!this.IsRecordingEvents)
+            if (!this.IsRecording)
             {
                 return;
             }
@@ -345,7 +345,7 @@ namespace OpenTelemetry.Trace
         /// <inheritdoc/>
         public void SetAttribute(string key, long value)
         {
-            if (!this.IsRecordingEvents)
+            if (!this.IsRecording)
             {
                 return;
             }
@@ -356,7 +356,7 @@ namespace OpenTelemetry.Trace
         /// <inheritdoc/>
         public void SetAttribute(string key, double value)
         {
-            if (!this.IsRecordingEvents)
+            if (!this.IsRecording)
             {
                 return;
             }
@@ -367,7 +367,7 @@ namespace OpenTelemetry.Trace
         /// <inheritdoc/>
         public void SetAttribute(string key, bool value)
         {
-            if (!this.IsRecordingEvents)
+            if (!this.IsRecording)
             {
                 return;
             }


### PR DESCRIPTION
Fixes #271 

**[update] No perf improvements are coming because Span has to be thread-safe, ignore numbers below.**

In the majority of cases, Span is not used concurrently. Even when attributes or events are added, it does not normally happen concurrently.

Let's declare span as not thread-safe and let rare instrumentations that need concurrency do the locking.
If we'll find it's common with e.g. Events, we can create lazy lock when first event is added.

this change removes locking which this simplifies code and reduces allocations 


**After**

|                           Method |        Mean |      Error |     StdDev | Allocated |
|--------------------------------- |------------:|-----------:|-----------:|----------:|
|               CreateSpan_Sampled |   772.27 ns |  7.1575 ns |  6.6951 ns |     560 B |
|    CreateSpan_Attributes_Sampled |   929.65 ns |  8.1989 ns |  7.6692 ns |    1248 B |
|     CreateSpan_Propagate_Sampled | 1,859.91 ns | 19.3340 ns | 17.1391 ns |     933 B |
| CreateSpan_Attributes_NotSampled |   795.95 ns |  7.8778 ns |  7.3689 ns |     560 B |
|                  CreateSpan_Noop |    38.63 ns |  0.3342 ns |  0.2962 ns |         - |
|       CreateSpan_Attributes_Noop |    44.45 ns |  0.3592 ns |  0.3360 ns |         - |
|        CreateSpan_Propagate_Noop |    41.12 ns |  0.4033 ns |  0.3773 ns |         - |

**Before**

|                           Method |        Mean |      Error |     StdDev | Allocated |
|--------------------------------- |------------:|-----------:|-----------:|----------:|
|               CreateSpan_Sampled |   775.89 ns | 10.9065 ns |  9.6683 ns |     592 B |
|    CreateSpan_Attributes_Sampled | 1,016.07 ns |  6.3040 ns |  5.5883 ns |    1280 B |
|     CreateSpan_Propagate_Sampled | 1,894.26 ns | 22.0567 ns | 20.6319 ns |     966 B |
| CreateSpan_Attributes_NotSampled |   802.46 ns |  5.3171 ns |  4.9736 ns |     592 B |
|                  CreateSpan_Noop |    38.56 ns |  0.2433 ns |  0.2275 ns |         - |
|       CreateSpan_Attributes_Noop |    44.65 ns |  0.3581 ns |  0.3350 ns |         - |
|        CreateSpan_Propagate_Noop |    41.41 ns |  0.3090 ns |  0.2891 ns |         - |


