### PR TITLE
Support binary SpanContext propagation in the OpenTracing shim

### DIFF
--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/OpenTelemetry.Shims.OpenTracing.Tests.csproj
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/OpenTelemetry.Shims.OpenTracing.Tests.csproj
@@ -17,6 +17,5 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\OpenTelemetry.Shims.OpenTracing\OpenTelemetry.Shims.OpenTracing.csproj" />
-    <ProjectReference Include="..\..\src\OpenTelemetry\OpenTelemetry.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
OpenTracing v0.12.1 added support for binary SpanContext propagation. This PR implements that missing functionality in the OpenTracing shim.