### PR TITLE
Don't calculate start timestamp in noop case 

### DIFF
--- a/src/OpenTelemetry.Abstractions/Trace/TracerExtensions.cs
+++ b/src/OpenTelemetry.Abstractions/Trace/TracerExtensions.cs
@@ -13,10 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using OpenTelemetry.Abstractions.Utils;
 
 namespace OpenTelemetry.Trace
 {
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Trace
         /// <returns>Span instance.</returns>
         public static ISpan StartRootSpan(this ITracer tracer, string operationName)
         {
-            return tracer.StartRootSpan(operationName, SpanKind.Internal, PreciseTimestamp.GetUtcNow(), null as Func<IEnumerable<Link>>);
+            return tracer.StartRootSpan(operationName, SpanKind.Internal, default, null as Func<IEnumerable<Link>>);
         }
 
         /// <summary>
@@ -42,7 +42,7 @@ namespace OpenTelemetry.Trace
         /// <returns>Span instance.</returns>
         public static ISpan StartRootSpan(this ITracer tracer, string operationName, SpanKind kind)
         {
-            return tracer.StartRootSpan(operationName, kind, PreciseTimestamp.GetUtcNow(), null as Func<IEnumerable<Link>>);
+            return tracer.StartRootSpan(operationName, kind, default, null as Func<IEnumerable<Link>>);
         }
 
         /// <summary>
@@ -66,7 +66,7 @@ namespace OpenTelemetry.Trace
         /// <returns>Span instance.</returns>
         public static ISpan StartSpan(this ITracer tracer, string operationName)
         {
-            return tracer.StartSpan(operationName, SpanKind.Internal, PreciseTimestamp.GetUtcNow(), null as Func<IEnumerable<Link>>);
+            return tracer.StartSpan(operationName, SpanKind.Internal, default, null as Func<IEnumerable<Link>>);
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace OpenTelemetry.Trace
         /// <returns>Span instance.</returns>
         public static ISpan StartSpan(this ITracer tracer, string operationName, SpanKind kind)
         {
-            return tracer.StartSpan(operationName, kind, PreciseTimestamp.GetUtcNow(), null as Func<IEnumerable<Link>>);
+            return tracer.StartSpan(operationName, kind, default, null as Func<IEnumerable<Link>>);
         }
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace OpenTelemetry.Trace
         /// <returns>Span instance.</returns>
         public static ISpan StartSpan(this ITracer tracer, string operationName, ISpan parent)
         {
-            return tracer.StartSpan(operationName, parent, SpanKind.Internal, PreciseTimestamp.GetUtcNow(), null as Func<IEnumerable<Link>>);
+            return tracer.StartSpan(operationName, parent, SpanKind.Internal, default, null as Func<IEnumerable<Link>>);
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace OpenTelemetry.Trace
         /// <returns>Span instance.</returns>
         public static ISpan StartSpan(this ITracer tracer, string operationName, ISpan parent, SpanKind kind)
         {
-            return tracer.StartSpan(operationName, parent, kind, PreciseTimestamp.GetUtcNow(), null as Func<IEnumerable<Link>>);
+            return tracer.StartSpan(operationName, parent, kind, default, null as Func<IEnumerable<Link>>);
         }
 
         /// <summary>
@@ -142,7 +142,7 @@ namespace OpenTelemetry.Trace
         /// <returns>Span instance.</returns>
         public static ISpan StartSpan(this ITracer tracer, string operationName, in SpanContext parent)
         {
-            return tracer.StartSpan(operationName, parent, SpanKind.Internal, PreciseTimestamp.GetUtcNow(), null as Func<IEnumerable<Link>>);
+            return tracer.StartSpan(operationName, parent, SpanKind.Internal, default, null as Func<IEnumerable<Link>>);
         }
 
         /// <summary>
@@ -155,7 +155,7 @@ namespace OpenTelemetry.Trace
         /// <returns>Span instance.</returns>
         public static ISpan StartSpan(this ITracer tracer, string operationName, in SpanContext parent, SpanKind kind)
         {
-            return tracer.StartSpan(operationName, parent, kind, PreciseTimestamp.GetUtcNow(), null as Func<IEnumerable<Link>>);
+            return tracer.StartSpan(operationName, parent, kind, default, null as Func<IEnumerable<Link>>);
         }
 
         /// <summary>

--- a/src/OpenTelemetry/Trace/Span.cs
+++ b/src/OpenTelemetry/Trace/Span.cs
@@ -75,7 +75,9 @@ namespace OpenTelemetry.Trace
         {
             this.Name = name;
             this.LibraryResource = libraryResource;
-            this.startTimestamp = startTimestamp;
+
+            this.startTimestamp = startTimestamp == default ? PreciseTimestamp.GetUtcNow() : startTimestamp;
+
             this.tracerConfiguration = tracerConfiguration;
             this.spanProcessor = spanProcessor;
             this.Kind = spanKind;

--- a/src/OpenTelemetry/Trace/Tracer.cs
+++ b/src/OpenTelemetry/Trace/Tracer.cs
@@ -83,11 +83,6 @@ namespace OpenTelemetry.Trace
                 throw new ArgumentNullException(nameof(operationName));
             }
 
-            if (startTimestamp == default)
-            {
-                startTimestamp = PreciseTimestamp.GetUtcNow();
-            }
-
             return Span.CreateRoot(operationName, kind, startTimestamp, linksGetter, this.tracerConfiguration, this.spanProcessor, this.LibraryResource);
         }
 
@@ -97,11 +92,6 @@ namespace OpenTelemetry.Trace
             if (operationName == null)
             {
                 throw new ArgumentNullException(nameof(operationName));
-            }
-
-            if (startTimestamp == default)
-            {
-                startTimestamp = PreciseTimestamp.GetUtcNow();
             }
 
             return Span.CreateRoot(operationName, kind, startTimestamp, links, this.tracerConfiguration, this.spanProcessor, this.LibraryResource);
@@ -132,11 +122,6 @@ namespace OpenTelemetry.Trace
                 parent = this.CurrentSpan;
             }
 
-            if (startTimestamp == default)
-            {
-                startTimestamp = PreciseTimestamp.GetUtcNow();
-            }
-
             return Span.CreateFromParentSpan(operationName, parent, kind, startTimestamp, linksGetter, this.tracerConfiguration,
                 this.spanProcessor, this.LibraryResource);
         }
@@ -154,11 +139,6 @@ namespace OpenTelemetry.Trace
                 parent = this.CurrentSpan;
             }
 
-            if (startTimestamp == default)
-            {
-                startTimestamp = PreciseTimestamp.GetUtcNow();
-            }
-
             return Span.CreateFromParentSpan(operationName, parent, kind, startTimestamp, links, this.tracerConfiguration,
                 this.spanProcessor, this.LibraryResource);
         }
@@ -169,11 +149,6 @@ namespace OpenTelemetry.Trace
             if (operationName == null)
             {
                 throw new ArgumentNullException(nameof(operationName));
-            }
-
-            if (startTimestamp == default)
-            {
-                startTimestamp = PreciseTimestamp.GetUtcNow();
             }
 
             if (parent != null)
@@ -192,11 +167,6 @@ namespace OpenTelemetry.Trace
             if (operationName == null)
             {
                 throw new ArgumentNullException(nameof(operationName));
-            }
-
-            if (startTimestamp == default)
-            {
-                startTimestamp = PreciseTimestamp.GetUtcNow();
             }
 
             if (parent != null)


### PR DESCRIPTION
Micro-optimization for noop case. Defer precise start timestamp calculation to the span construction. 

**Before**

|                           Method |        Mean |      Error |    StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 |  Gen 2 | Allocated |
|--------------------------------- |------------:|-----------:|----------:|------:|--------:|-------:|-------:|-------:|----------:|
|               CreateSpan_Sampled |   909.73 ns | 18.2706 ns | 26.203 ns | 21.17 |    1.31 | 0.1402 |      - |      - |     592 B |
|    CreateSpan_Attributes_Sampled | 1,151.60 ns | 22.9550 ns | 38.979 ns | 26.67 |    1.69 | 0.3033 |      - |      - |    1280 B |
|     CreateSpan_Propagate_Sampled | 2,063.68 ns | 55.7236 ns | 91.556 ns | 47.90 |    3.57 | 0.2232 | 0.0057 | 0.0038 |     972 B |
| CreateSpan_Attributes_NotSampled |   945.80 ns | 18.8336 ns | 50.918 ns | 22.03 |    1.54 | 0.1402 |      - |      - |     592 B |
|                  CreateSpan_Noop |    43.03 ns |  1.0311 ns |  2.390 ns |  1.00 |    0.00 |      - |      - |      - |         - |
|       CreateSpan_Attributes_Noop |    49.75 ns |  1.0744 ns |  1.005 ns |  1.15 |    0.07 |      - |      - |      - |         - |
|        CreateSpan_Propagate_Noop |    44.75 ns |  0.9537 ns |  1.427 ns |  1.04 |    0.07 |      - |      - |      - |         - |


**After**

|                           Method |         Mean |      Error |     StdDev |  Ratio | RatioSD |  Gen 0 |  Gen 1 |  Gen 2 | Allocated |
|--------------------------------- |-------------:|-----------:|-----------:|-------:|--------:|-------:|-------:|-------:|----------:|
|               CreateSpan_Sampled |   866.665 ns | 17.3281 ns | 14.4697 ns | 120.48 |    3.45 | 0.1402 |      - |      - |     592 B |
|    CreateSpan_Attributes_Sampled | 1,124.823 ns | 21.5883 ns | 28.0710 ns | 157.72 |    5.14 | 0.3033 |      - |      - |    1280 B |
|     CreateSpan_Propagate_Sampled | 1,957.069 ns | 37.5300 ns | 48.7996 ns | 271.72 |    6.60 | 0.2232 | 0.0057 | 0.0038 |     972 B |
| CreateSpan_Attributes_NotSampled |   898.687 ns | 17.3024 ns | 23.6837 ns | 126.28 |    3.95 | 0.1402 |      - |      - |     592 B |
|                  CreateSpan_Noop |     7.194 ns |  0.1425 ns |  0.1333 ns |   1.00 |    0.00 |      - |      - |      - |         - |
|       CreateSpan_Attributes_Noop |    17.611 ns |  0.4285 ns |  0.5572 ns |   2.47 |    0.08 |      - |      - |      - |         - |
|        CreateSpan_Propagate_Noop |    10.883 ns |  0.0940 ns |  0.0734 ns |   1.51 |    0.03 |      - |      - |      - |         - |

