### PR TITLE
Extend TracerBuilder to facilitate ITracer interception

### DIFF
--- a/src/OpenTelemetry/Trace/Configuration/TracerBuilder.cs
+++ b/src/OpenTelemetry/Trace/Configuration/TracerBuilder.cs
@@ -40,10 +40,13 @@ namespace OpenTelemetry.Trace.Configuration
 
         internal List<CollectorFactory> CollectorFactories { get; private set; }
 
+        internal Func<ITracer, ITracer> TracerConstructionInterceptor { get; private set; }
+
         /// <summary>
         /// Configures sampler.
         /// </summary>
         /// <param name="sampler">Sampler instance.</param>
+        /// <returns>The current class instance for chaining.</returns>
         public TracerBuilder SetSampler(ISampler sampler)
         {
             this.Sampler = sampler ?? throw new ArgumentNullException(nameof(sampler));
@@ -54,6 +57,7 @@ namespace OpenTelemetry.Trace.Configuration
         /// Adds processing and exporting pipeline. Pipelines are executed sequentially in the order they are added.
         /// </summary>
         /// <param name="configure">Function that configures pipeline.</param>
+        /// <returns>The current class instance for chaining.</returns>
         public TracerBuilder AddProcessorPipeline(Action<SpanProcessorPipelineBuilder> configure)
         {
             if (configure == null)
@@ -77,6 +81,7 @@ namespace OpenTelemetry.Trace.Configuration
         /// </summary>
         /// <typeparam name="TCollector">Type of collector class.</typeparam>
         /// <param name="collectorFactory">Function that builds collector from <see cref="ITracer"/>.</param>
+        /// <returns>The current class instance for chaining.</returns>
         public TracerBuilder AddCollector<TCollector>(
             Func<ITracer, TCollector> collectorFactory)
             where TCollector : class
@@ -104,6 +109,7 @@ namespace OpenTelemetry.Trace.Configuration
         /// Configures tracing options.
         /// </summary>
         /// <param name="options">Instance of <see cref="TracerConfiguration"/>.</param>
+        /// <returns>The current class instance for chaining.</returns>
         public TracerBuilder SetTracerOptions(TracerConfiguration options)
         {
             this.TracerConfigurationOptions = options ?? throw new ArgumentNullException(nameof(options));
@@ -114,6 +120,7 @@ namespace OpenTelemetry.Trace.Configuration
         /// Configures <see cref="ITextFormat"/> on the tracer.
         /// </summary>
         /// <param name="textFormat"><see cref="ITextFormat"/> implementation class instance.</param>
+        /// <returns>The current class instance for chaining.</returns>
         public TracerBuilder SetTextFormat(ITextFormat textFormat)
         {
             this.TextFormat = textFormat ?? throw new ArgumentNullException(nameof(textFormat));
@@ -124,9 +131,21 @@ namespace OpenTelemetry.Trace.Configuration
         /// Configures <see cref="IBinaryFormat"/> on the tracer.
         /// </summary>
         /// <param name="binaryFormat"><see cref="IBinaryFormat"/> implementation class instance.</param>
+        /// <returns>The current class instance for chaining.</returns>
         public TracerBuilder SetBinaryFormat(IBinaryFormat binaryFormat)
         {
             this.BinaryFormat = binaryFormat ?? throw new ArgumentNullException(nameof(binaryFormat));
+            return this;
+        }
+
+        /// <summary>
+        /// Configures an interceptor Func that executes when an implementation of ITracer is created.
+        /// </summary>
+        /// <param name="interceptor">The interceptor function.</param>
+        /// <returns>The current class instance for chaining.</returns>
+        public TracerBuilder SetTracerConstructionInterceptor(Func<ITracer, ITracer> interceptor)
+        {
+            this.TracerConstructionInterceptor = interceptor ?? throw new ArgumentNullException(nameof(interceptor));
             return this;
         }
 

--- a/test/OpenTelemetry.Tests/Impl/Trace/Config/TracerBuilderTests.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Config/TracerBuilderTests.cs
@@ -38,7 +38,7 @@ namespace OpenTelemetry.Tests.Impl.Trace
             Assert.Throws<ArgumentNullException>(() => new TracerBuilder().SetBinaryFormat(null));
             Assert.Throws<ArgumentNullException>(() => new TracerBuilder().SetTextFormat(null));
             Assert.Throws<ArgumentNullException>(() => new TracerBuilder().AddCollector<object>(null));
-            Assert.Throws<ArgumentNullException>(() => new TracerBuilder().TracerConstructionInterceptor(null));
+            Assert.Throws<ArgumentNullException>(() => new TracerBuilder().SetTracerConstructionInterceptor(null));
         }
 
         [Fact]

--- a/test/OpenTelemetry.Tests/Impl/Trace/Config/TracerBuilderTests.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Config/TracerBuilderTests.cs
@@ -38,6 +38,7 @@ namespace OpenTelemetry.Tests.Impl.Trace
             Assert.Throws<ArgumentNullException>(() => new TracerBuilder().SetBinaryFormat(null));
             Assert.Throws<ArgumentNullException>(() => new TracerBuilder().SetTextFormat(null));
             Assert.Throws<ArgumentNullException>(() => new TracerBuilder().AddCollector<object>(null));
+            Assert.Throws<ArgumentNullException>(() => new TracerBuilder().TracerConstructionInterceptor(null));
         }
 
         [Fact]
@@ -50,6 +51,7 @@ namespace OpenTelemetry.Tests.Impl.Trace
             Assert.Null(builder.TextFormat);
             Assert.Null(builder.TracerConfigurationOptions);
             Assert.Null(builder.CollectorFactories);
+            Assert.Null(builder.TracerConstructionInterceptor);
         }
 
         [Fact]
@@ -65,6 +67,7 @@ namespace OpenTelemetry.Tests.Impl.Trace
             var options = new TracerConfiguration(sampler, 1, 1, 1);
             var binaryFormat = new BinaryFormat();
             var textFormat = new TraceContextFormat();
+            Func<ITracer, ITracer> tracerInterceptionFunc = t => t;
 
             builder
                 .SetSampler(sampler)
@@ -79,6 +82,7 @@ namespace OpenTelemetry.Tests.Impl.Trace
                 .SetTracerOptions(options)
                 .SetBinaryFormat(binaryFormat)
                 .SetTextFormat(textFormat)
+                .SetTracerConstructionInterceptor(tracerInterceptionFunc)
                 .AddCollector(t =>
                 {
                     Assert.NotNull(t);
@@ -97,6 +101,7 @@ namespace OpenTelemetry.Tests.Impl.Trace
             Assert.Same(options, builder.TracerConfigurationOptions);
             Assert.Same(binaryFormat, builder.BinaryFormat);
             Assert.Same(textFormat, builder.TextFormat);
+            Assert.Same(tracerInterceptionFunc, builder.TracerConstructionInterceptor);
             Assert.Single(builder.CollectorFactories);
 
             var collectorFactory = builder.CollectorFactories.Single();

--- a/test/OpenTelemetry.Tests/Impl/Trace/Config/TracerFactoryTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Config/TracerFactoryTest.cs
@@ -308,76 +308,37 @@ namespace OpenTelemetry.Trace.Test
                 this.provider = provider;
             }
 
-            /// <inheritdoc/>
-            public ISpan CurrentSpan => provider.CurrentSpan;
+            public ISpan CurrentSpan => this.provider.CurrentSpan;
 
-            /// <inheritdoc/>
-            public IBinaryFormat BinaryFormat => provider.BinaryFormat;
+            public IBinaryFormat BinaryFormat => this.provider.BinaryFormat;
 
-            /// <inheritdoc/>
-            public ITextFormat TextFormat => provider.TextFormat;
+            public ITextFormat TextFormat => this.provider.TextFormat;
 
-            /// <inheritdoc/>
-            public ISpan StartRootSpan(string operationName, SpanKind kind, DateTimeOffset startTimestamp, Func<IEnumerable<Link>> linksGetter)
+            public ISpan StartRootSpan(string operationName, SpanKind kind, SpanCreationOptions options)
             {
-                return this.provider.StartRootSpan(operationName, kind, startTimestamp, linksGetter);
+                return this.provider.StartRootSpan(operationName, kind, options);
             }
 
-            /// <inheritdoc/>
-            public ISpan StartRootSpan(string operationName, SpanKind kind, DateTimeOffset startTimestamp, IEnumerable<Link> links)
+            public ISpan StartSpan(string operationName, SpanKind kind, SpanCreationOptions options)
             {
-                return this.provider.StartRootSpan(operationName, kind, startTimestamp, links);
+                return this.provider.StartSpan(operationName, kind, options);
             }
 
-            /// <inheritdoc/>
-            public ISpan StartSpan(string operationName, SpanKind kind, DateTimeOffset startTimestamp, Func<IEnumerable<Link>> linksGetter)
+            public ISpan StartSpan(string operationName, ISpan parent, SpanKind kind, SpanCreationOptions options)
             {
-                return this.provider.StartSpan(operationName, kind, startTimestamp, linksGetter);
+                return this.provider.StartSpan(operationName, parent, kind, options);
             }
 
-            /// <inheritdoc/>
-            public ISpan StartSpan(string operationName, SpanKind kind, DateTimeOffset startTimestamp, IEnumerable<Link> links)
+            public ISpan StartSpan(string operationName, in SpanContext parent, SpanKind kind, SpanCreationOptions options)
             {
-                return this.provider.StartSpan(operationName, kind, startTimestamp, links);
+                return this.provider.StartSpan(operationName, parent, kind, options);
             }
 
-            /// <inheritdoc/>
-            public ISpan StartSpan(string operationName, ISpan parent, SpanKind kind, DateTimeOffset startTimestamp, Func<IEnumerable<Link>> linksGetter)
-            {
-                return this.provider.StartSpan(operationName, parent, kind, startTimestamp, linksGetter);
-            }
-
-            /// <inheritdoc/>
-            public ISpan StartSpan(string operationName, ISpan parent, SpanKind kind, DateTimeOffset startTimestamp, IEnumerable<Link> links)
-            {
-                return this.provider.StartSpan(operationName, parent, kind, startTimestamp, links);
-            }
-
-            /// <inheritdoc/>
-            public ISpan StartSpan(string operationName, in SpanContext parent, SpanKind kind, DateTimeOffset startTimestamp, Func<IEnumerable<Link>> linksGetter)
-            {
-                return this.provider.StartSpan(operationName, parent, kind, startTimestamp, linksGetter);
-            }
-
-            /// <inheritdoc/>
-            public ISpan StartSpan(string operationName, in SpanContext parent, SpanKind kind, DateTimeOffset startTimestamp, IEnumerable<Link> links)
-            {
-                return this.provider.StartSpan(operationName, parent, kind, startTimestamp, links);
-            }
-
-            /// <inheritdoc/>
-            public ISpan StartSpanFromActivity(string operationName, Activity activity, SpanKind kind, Func<IEnumerable<Link>> linksGetter)
-            {
-                return this.provider.StartSpanFromActivity(operationName, activity, kind, linksGetter);
-            }
-
-            /// <inheritdoc/>
             public ISpan StartSpanFromActivity(string operationName, Activity activity, SpanKind kind, IEnumerable<Link> links)
             {
                 return this.provider.StartSpanFromActivity(operationName, activity, kind, links);
             }
 
-            /// <inheritdoc/>
             public IDisposable WithSpan(ISpan span)
             {
                 return this.provider.WithSpan(span);


### PR DESCRIPTION
Background:
When the active Span changes, I want to be notified and do something
with the current SpanContext. One way I can see to do that is to intercept
calls to ITracer::WithSpan (or whatever ITracer method(s) are used to activate a Span).

However, the only way to get an instance of ITracer is through the TracerFactory.
I am proposing that we add a new option to TracerBuilder where people can specify
a Func<ITracer, ITracer> that if specified is invoked for all returned ITracers.

This will allow me to create a proxy ITracer implementation and intercept every call.

usage is:
```csharp

services.AddOpenTelemetry(builder =>
{
    builder
        .SetTracerConstructionInterceptor(t => new TracerProxy(t));
});
```

Absolutely open to other suggestions to get what I need here.