### PR TITLE
Populate SpanContext in the Span ctor BEFORE calling any SpanProcessor

### DIFF
--- a/src/OpenTelemetry/Trace/Span.cs
+++ b/src/OpenTelemetry/Trace/Span.cs
@@ -92,7 +92,7 @@ namespace OpenTelemetry.Trace
             this.Activity.ActivityTraceFlags =
                 this.IsRecording
                 ? this.Activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded
-                : this.Activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
+                : this.Activity.ActivityTraceFlags &= ~ActivityTraceFlags.Recorded;
 
             // this context is definitely not remote, setting isRemote to false
             this.Context = new SpanContext(this.Activity.TraceId, this.Activity.SpanId, this.Activity.ActivityTraceFlags, false, tracestate);

--- a/src/OpenTelemetry/Trace/Span.cs
+++ b/src/OpenTelemetry/Trace/Span.cs
@@ -89,20 +89,19 @@ namespace OpenTelemetry.Trace
                 this.Activity.SpanId,
                 this.tracerConfiguration);
 
-            if (this.IsRecording)
-            {
-                this.Activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
-
-                this.SetLinks(links);
-                this.spanProcessor.OnStart(this);
-            }
-            else
-            {
-                this.Activity.ActivityTraceFlags &= ~ActivityTraceFlags.Recorded;
-            }
+            this.Activity.ActivityTraceFlags =
+                this.IsRecording
+                ? this.Activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded
+                : this.Activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
 
             // this context is definitely not remote, setting isRemote to false
             this.Context = new SpanContext(this.Activity.TraceId, this.Activity.SpanId, this.Activity.ActivityTraceFlags, false, tracestate);
+
+            if (this.IsRecording)
+            {
+                this.SetLinks(links);
+                this.spanProcessor.OnStart(this);
+            }
         }
 
         public SpanContext Context { get; private set; }

--- a/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
@@ -1014,7 +1014,7 @@ namespace OpenTelemetry.Trace.Test
         private void AssertApproxSameTimestamp(DateTimeOffset one, DateTimeOffset two)
         {
             var timeShift = Math.Abs((one - two).TotalMilliseconds);
-            Assert.InRange(timeShift, 0, 20);
+            Assert.InRange(timeShift, 0, 30);
         }
 
         public void Dispose()

--- a/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
@@ -790,6 +790,15 @@ namespace OpenTelemetry.Trace.Test
 
             var tracer = tracerFactory.GetTracer(null);
             var startTime = DateTimeOffset.UtcNow.AddSeconds(-1);
+            var spanPassedToSpanProcessorHasSpanContext = false;
+
+            spanProcessorMock
+                .Setup(s => s.OnStart(It.IsAny<Span>()))
+                .Callback<Span>(s =>
+                {
+                    spanPassedToSpanProcessorHasSpanContext = s.Context != null;
+                });
+
             var span = (Span)tracer.StartSpan(SpanName, SpanKind.Client, new SpanCreationOptions { StartTimestamp = startTime, LinksFactory = () => new[] { link } });
 
             span.SetAttribute(
@@ -838,6 +847,7 @@ namespace OpenTelemetry.Trace.Test
             var startEndMock = Mock.Get(spanProcessor);
 
             spanProcessorMock.Verify(s => s.OnStart(span), Times.Once);
+            Assert.True(spanPassedToSpanProcessorHasSpanContext);
             startEndMock.Verify(s => s.OnEnd(span), Times.Never);
         }
 


### PR DESCRIPTION
The spans sent to the SpanProcessor::OnStart always had a null SpanContext. There is really no reason not to populate it here.