### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Approvers ([@open-telemetry/dotnet-approvers](https://github.com/orgs/open-telem
 
 *Find more about the approver role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver).*
 
-Maintainers ([@open-telemetry/dotnet-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-maintainers))::
+Maintainers ([@open-telemetry/dotnet-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-maintainers)):
 
 - [Sergey Kanzhelev](https://github.com/SergeyKanzhelev), Microsoft
 - [Austin Parker](https://github.com/austinlparker), LightStep


### PR DESCRIPTION
Remove a duplicate `:` in the README.