### PR TITLE
added DistributedContext metadata

### DIFF
--- a/src/OpenTelemetry.Api/Tags/DistributedContextEntry.cs
+++ b/src/OpenTelemetry.Api/Tags/DistributedContextEntry.cs
@@ -25,7 +25,7 @@ namespace OpenTelemetry.Tags
         /// <summary>
         /// Initializes a new instance of the <see cref="DistributedContextEntry"/> class with the key and value.
         /// </summary>
-        /// <param name="key">Key name for the tag.</param>
+         /// <param name="key">Key name for the entry.</param>
         /// <param name="value">Value associated with the key name.</param>
         public DistributedContextEntry(string key, string value)
             : this(key, value, new EntryMetadata(EntryMetadata.NoPropagation))

--- a/src/OpenTelemetry.Api/Tags/DistributedContextEntry.cs
+++ b/src/OpenTelemetry.Api/Tags/DistributedContextEntry.cs
@@ -35,7 +35,7 @@ namespace OpenTelemetry.Tags
         /// <summary>
         /// Initializes a new instance of the <see cref="DistributedContextEntry"/> class with the key and value.
         /// </summary>
-        /// <param name="key">Key name for the tag.</param>
+        /// <param name="key">Key name for the entry.</param>
         /// <param name="value">Value associated with the key name.</param>
         /// <param name="metadata">Entry metadata.</param>
         public DistributedContextEntry(string key, string value, in EntryMetadata metadata)

--- a/src/OpenTelemetry.Api/Tags/DistributedContextEntry.cs
+++ b/src/OpenTelemetry.Api/Tags/DistributedContextEntry.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Tag.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="DistributedContextEntry.cs" company="OpenTelemetry Authors">
 // Copyright 2018, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,19 +18,31 @@ using System;
 namespace OpenTelemetry.Tags
 {
     /// <summary>
-    /// Tag with the key and value.
+    /// Distributed Context entry with the key, value and metadata.
     /// </summary>
-    public sealed class Tag
+    public sealed class DistributedContextEntry
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Tag"/> class with the key and value.
+        /// Initializes a new instance of the <see cref="DistributedContextEntry"/> class with the key and value.
         /// </summary>
         /// <param name="key">Key name for the tag.</param>
         /// <param name="value">Value associated with the key name.</param>
-        internal Tag(string key, string value)
+        public DistributedContextEntry(string key, string value)
+            : this(key, value, new EntryMetadata(EntryMetadata.NoPropagation))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DistributedContextEntry"/> class with the key and value.
+        /// </summary>
+        /// <param name="key">Key name for the tag.</param>
+        /// <param name="value">Value associated with the key name.</param>
+        /// <param name="metadata">Entry metadata.</param>
+        public DistributedContextEntry(string key, string value, in EntryMetadata metadata)
         {
             this.Key = key ?? throw new ArgumentNullException(nameof(key));
             this.Value = value ?? throw new ArgumentNullException(nameof(value));
+            this.Metadata = metadata;
         }
 
         /// <summary>
@@ -44,20 +56,14 @@ namespace OpenTelemetry.Tags
         public string Value { get; }
 
         /// <summary>
-        /// Creates a new <see cref="Tag"/> from the given key and value.
+        /// Gets the metadata associated with this entry.
         /// </summary>
-        /// <param name="key">The tag's key.</param>
-        /// <param name="value">The tag's value.</param>
-        /// <returns><see cref="Tag"/>.</returns>
-        public static Tag Create(string key, string value)
-        {
-            return new Tag(key, value);
-        }
+        public EntryMetadata Metadata { get; }
 
         /// <inheritdoc/>
         public override string ToString()
         {
-            return nameof(Tag)
+            return nameof(DistributedContextEntry)
                 + "{"
                 + nameof(this.Key) + "=" + this.Key + ", "
                 + nameof(this.Value) + "=" + this.Value
@@ -72,7 +78,7 @@ namespace OpenTelemetry.Tags
                 return true;
             }
 
-            if (o is Tag that)
+            if (o is DistributedContextEntry that)
             {
                 return this.Key.Equals(that.Key)
                      && this.Value.Equals(that.Value);

--- a/src/OpenTelemetry.Api/Tags/EntryMetadata.cs
+++ b/src/OpenTelemetry.Api/Tags/EntryMetadata.cs
@@ -1,0 +1,48 @@
+﻿// <copyright file="EntryMetadata.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Tags
+{
+    /// <summary>
+    /// Metadata associated with the Distributed Context entry.
+    /// </summary>
+    public readonly struct EntryMetadata
+    {
+        /// <summary>
+        /// TTL indicating in-process only propagation of an entry.
+        /// </summary>
+        public const int NoPropagation = 0;
+
+        /// <summary>
+        /// TTL indicating unlimited propagation of an entry.
+        /// </summary>
+        public const int UnlimitedPropagation = -1;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EntryMetadata"/> struct.
+        /// </summary>
+        /// <param name="entryTTL">TTL for the distributed context entry.</param>
+        public EntryMetadata(int entryTTL)
+        {
+            this.EntryTTL = EntryMetadata.NoPropagation;
+        }
+
+        /// <summary>
+        /// Gets the EntryTTL is either NO_PROPAGATION (0) or UNLIMITED_PROPAGATION (-1).
+        /// </summary>
+        public int EntryTTL { get; }
+    }
+}

--- a/src/OpenTelemetry.Api/Tags/ITagContext.cs
+++ b/src/OpenTelemetry.Api/Tags/ITagContext.cs
@@ -20,7 +20,7 @@ namespace OpenTelemetry.Tags
     /// <summary>
     /// Collection of tags representing the tags context.
     /// </summary>
-    public interface ITagContext : IEnumerable<Tag>
+    public interface ITagContext : IEnumerable<DistributedContextEntry>
     {
     }
 }

--- a/src/OpenTelemetry/Tags/NoopTagContext.cs
+++ b/src/OpenTelemetry/Tags/NoopTagContext.cs
@@ -21,9 +21,9 @@ namespace OpenTelemetry.Tags
     {
         internal static readonly ITagContext Instance = new NoopTagContext();
 
-        public override IEnumerator<Tag> GetEnumerator()
+        public override IEnumerator<DistributedContextEntry> GetEnumerator()
         {
-            return new List<Tag>().GetEnumerator();
+            return new List<DistributedContextEntry>().GetEnumerator();
         }
     }
 }

--- a/src/OpenTelemetry/Tags/Propagation/SerializationUtils.cs
+++ b/src/OpenTelemetry/Tags/Propagation/SerializationUtils.cs
@@ -153,7 +153,7 @@ else
             }
         }
 
-        private static void EncodeTag(Tag tag, MemoryStream byteArrayDataOutput)
+        private static void EncodeTag(DistributedContextEntry tag, MemoryStream byteArrayDataOutput)
         {
             byteArrayDataOutput.WriteByte(TagFieldId);
             EncodeString(tag.Key, byteArrayDataOutput);

--- a/src/OpenTelemetry/Tags/TagContext.cs
+++ b/src/OpenTelemetry/Tags/TagContext.cs
@@ -30,9 +30,9 @@ namespace OpenTelemetry.Tags
 
         public IDictionary<string, string> Tags { get; }
 
-        public override IEnumerator<Tag> GetEnumerator()
+        public override IEnumerator<DistributedContextEntry> GetEnumerator()
         {
-            var result = this.Tags.Select((kvp) => Tag.Create(kvp.Key, kvp.Value));
+            var result = this.Tags.Select((kvp) => new DistributedContextEntry(kvp.Key, kvp.Value));
             return result.ToList().GetEnumerator();
         }
     }

--- a/src/OpenTelemetry/Tags/TagContextBase.cs
+++ b/src/OpenTelemetry/Tags/TagContextBase.cs
@@ -40,12 +40,12 @@ namespace OpenTelemetry.Tags
             var t1Enumerator = this.GetEnumerator();
             var t2Enumerator = otherTags.GetEnumerator();
 
-            List<Tag> tags1 = null;
-            List<Tag> tags2 = null;
+            List<DistributedContextEntry> tags1 = null;
+            List<DistributedContextEntry> tags2 = null;
 
             if (t1Enumerator == null)
             {
-                tags1 = new List<Tag>();
+                tags1 = new List<DistributedContextEntry>();
             }
             else
             {
@@ -54,7 +54,7 @@ namespace OpenTelemetry.Tags
 
             if (t2Enumerator == null)
             {
-                tags2 = new List<Tag>();
+                tags2 = new List<DistributedContextEntry>();
             }
             else
             {
@@ -84,7 +84,7 @@ namespace OpenTelemetry.Tags
             return hashCode;
         }
 
-        public abstract IEnumerator<Tag> GetEnumerator();
+        public abstract IEnumerator<DistributedContextEntry> GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator()
         {

--- a/src/OpenTelemetry/Tags/Unsafe/AsyncLocalContext.cs
+++ b/src/OpenTelemetry/Tags/Unsafe/AsyncLocalContext.cs
@@ -51,9 +51,9 @@ namespace OpenTelemetry.Tags.Unsafe
 
         internal sealed class EmptyTagContext : TagContextBase
         {
-            public override IEnumerator<Tag> GetEnumerator()
+            public override IEnumerator<DistributedContextEntry> GetEnumerator()
             {
-                return new List<Tag>().GetEnumerator();
+                return new List<DistributedContextEntry>().GetEnumerator();
             }
         }
     }

--- a/test/OpenTelemetry.Tests/Impl/Stats/NoopStatsTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Stats/NoopStatsTest.cs
@@ -24,7 +24,7 @@ namespace OpenTelemetry.Stats.Test
 {
     public class NoopStatsTest
     {
-        private static readonly Tag TAG = Tag.Create("key", "value");
+        private static readonly DistributedContextEntry TAG = new DistributedContextEntry("key", "value");
         private static readonly IMeasureDouble MEASURE =  MeasureDouble.Create("my measure", "description", "s");
 
         private readonly ITagContext tagContext = new TestTagContext();
@@ -54,9 +54,9 @@ namespace OpenTelemetry.Stats.Test
 
         class TestTagContext : ITagContext
         {
-            public IEnumerator<Tag> GetEnumerator()
+            public IEnumerator<DistributedContextEntry> GetEnumerator()
             {
-                var l =  new List<Tag>() { TAG };
+                var l =  new List<DistributedContextEntry>() { TAG };
                 return l.GetEnumerator();
             }
 

--- a/test/OpenTelemetry.Tests/Impl/Stats/StatsRecorderTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Stats/StatsRecorderTest.cs
@@ -83,7 +83,7 @@ namespace OpenTelemetry.Stats.Test
                     new List<string>() { KEY });
             viewManager.RegisterView(view);
             var orig = AsyncLocalContext.CurrentTagContext;
-            AsyncLocalContext.CurrentTagContext = new SimpleTagContext(Tag.Create(KEY, VALUE));
+            AsyncLocalContext.CurrentTagContext = new SimpleTagContext(new DistributedContextEntry(KEY, VALUE));
  
             try
             {
@@ -122,7 +122,7 @@ namespace OpenTelemetry.Stats.Test
                 .Put(MEASURE_DOUBLE_NO_VIEW_1, 1.0)
                 .Put(MEASURE_DOUBLE, 2.0)
                 .Put(MEASURE_DOUBLE_NO_VIEW_2, 3.0)
-                .Record(new SimpleTagContext(Tag.Create(KEY, VALUE)));
+                .Record(new SimpleTagContext(new DistributedContextEntry(KEY, VALUE)));
 
             IViewData viewData = viewManager.GetView(viewName);
 
@@ -151,8 +151,8 @@ namespace OpenTelemetry.Stats.Test
 
             viewManager.RegisterView(view);
             IMeasureMap statsRecord = statsRecorder.NewMeasureMap().Put(MEASURE_DOUBLE, 1.0);
-            statsRecord.Record(new SimpleTagContext(Tag.Create(KEY, VALUE)));
-            statsRecord.Record(new SimpleTagContext(Tag.Create(KEY, VALUE_2)));
+            statsRecord.Record(new SimpleTagContext(new DistributedContextEntry(KEY, VALUE)));
+            statsRecord.Record(new SimpleTagContext(new DistributedContextEntry(KEY, VALUE_2)));
             IViewData viewData = viewManager.GetView(viewName);
 
             // There should be two entries.
@@ -185,7 +185,7 @@ namespace OpenTelemetry.Stats.Test
             statsRecorder
                 .NewMeasureMap()
                 .Put(MEASURE_DOUBLE, 1.0)
-                .Record(new SimpleTagContext(Tag.Create(KEY, VALUE)));
+                .Record(new SimpleTagContext(new DistributedContextEntry(KEY, VALUE)));
             Assert.Equal(CreateEmptyViewData(view), viewManager.GetView(VIEW_NAME));
         }
 
@@ -206,7 +206,7 @@ namespace OpenTelemetry.Stats.Test
             statsRecorder
                 .NewMeasureMap()
                 .Put(MEASURE_DOUBLE, 1.0)
-                .Record(new SimpleTagContext(Tag.Create(KEY, VALUE)));
+                .Record(new SimpleTagContext(new DistributedContextEntry(KEY, VALUE)));
             Assert.Equal(CreateEmptyViewData(view), viewManager.GetView(VIEW_NAME));
 
             Stats.State = StatsCollectionState.ENABLED;
@@ -216,7 +216,7 @@ namespace OpenTelemetry.Stats.Test
             statsRecorder
                 .NewMeasureMap()
                 .Put(MEASURE_DOUBLE, 4.0)
-                .Record(new SimpleTagContext(Tag.Create(KEY, VALUE)));
+                .Record(new SimpleTagContext(new DistributedContextEntry(KEY, VALUE)));
             TagValues tv = TagValues.Create(new List<string>() { VALUE });
             StatsTestUtil.AssertAggregationMapEquals(
                 viewManager.GetView(VIEW_NAME).AggregationMap,
@@ -251,14 +251,14 @@ namespace OpenTelemetry.Stats.Test
 
         class SimpleTagContext : TagContextBase
         {
-            private readonly IEnumerable<Tag> tags;
+            private readonly IEnumerable<DistributedContextEntry> tags;
 
-            public SimpleTagContext(params Tag[] tags)
+            public SimpleTagContext(params DistributedContextEntry[] tags)
             {
-                this.tags = new List<Tag>(tags);
+                this.tags = new List<DistributedContextEntry>(tags);
             }
 
-            public override IEnumerator<Tag> GetEnumerator()
+            public override IEnumerator<DistributedContextEntry> GetEnumerator()
             {
                 return tags.GetEnumerator();
             }

--- a/test/OpenTelemetry.Tests/Impl/Tags/CurrentTagContextUtilsTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/CurrentTagContextUtilsTest.cs
@@ -21,7 +21,7 @@ namespace OpenTelemetry.Tags.Test
 {
     public class CurrentTagContextUtilsTest
     {
-        private static readonly Tag TAG = Tag.Create("key", "value");
+        private static readonly DistributedContextEntry TAG = new DistributedContextEntry("key", "value");
 
         private readonly ITagContext tagContext = new TestTagContext();
 
@@ -101,9 +101,9 @@ namespace OpenTelemetry.Tags.Test
 
             }
 
-            public override IEnumerator<Tag> GetEnumerator()
+            public override IEnumerator<DistributedContextEntry> GetEnumerator()
             {
-                return new List<Tag>() { TAG }.GetEnumerator();
+                return new List<DistributedContextEntry>() { TAG }.GetEnumerator();
             }
         }
     }

--- a/test/OpenTelemetry.Tests/Impl/Tags/NoopTagsTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/NoopTagsTest.cs
@@ -127,9 +127,9 @@ namespace OpenTelemetry.Tags.Test
 
         class TestTagContext : ITagContext
         {
-            public IEnumerator<Tag> GetEnumerator()
+            public IEnumerator<DistributedContextEntry> GetEnumerator()
             {
-                var list = new List<Tag>() { Tag.Create(KEY, VALUE) };
+                var list = new List<DistributedContextEntry>() { new DistributedContextEntry(KEY, VALUE) };
                 return list.GetEnumerator();
             }
 

--- a/test/OpenTelemetry.Tests/Impl/Tags/Propagation/TagContextBinarySerializerTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/Propagation/TagContextBinarySerializerTest.cs
@@ -79,9 +79,9 @@ namespace OpenTelemetry.Tags.Propagation.Test
 
             }
 
-            public override IEnumerator<Tag> GetEnumerator()
+            public override IEnumerator<DistributedContextEntry> GetEnumerator()
             {
-                return new List<Tag>() { Tag.Create("key", "value") }.GetEnumerator();
+                return new List<DistributedContextEntry>() { new DistributedContextEntry("key", "value") }.GetEnumerator();
             }
         }
     }

--- a/test/OpenTelemetry.Tests/Impl/Tags/Propagation/TagContextSerializationTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/Propagation/TagContextSerializationTest.cs
@@ -36,10 +36,10 @@ namespace OpenTelemetry.Tags.Propagation.Test
         private static readonly string V3 = "v3";
         private static readonly string V4 = "v4";
 
-        private static readonly Tag T1 = Tag.Create(K1, V1);
-        private static readonly Tag T2 = Tag.Create(K2, V2);
-        private static readonly Tag T3 = Tag.Create(K3, V3);
-        private static readonly Tag T4 = Tag.Create(K4, V4);
+        private static readonly DistributedContextEntry T1 = new DistributedContextEntry(K1, V1);
+        private static readonly DistributedContextEntry T2 = new DistributedContextEntry(K2, V2);
+        private static readonly DistributedContextEntry T3 = new DistributedContextEntry(K3, V3);
+        private static readonly DistributedContextEntry T4 = new DistributedContextEntry(K4, V4);
 
         private readonly CurrentTaggingState state;
         private readonly ITagger tagger;
@@ -104,7 +104,7 @@ namespace OpenTelemetry.Tags.Propagation.Test
             Assert.Throws<TagContextSerializationException>(() => serializer.ToByteArray(tagContext));
         }
 
-        private void TestSerialize(params Tag[] tags)
+        private void TestSerialize(params DistributedContextEntry[] tags)
         {
             var builder = tagger.EmptyBuilder;
             foreach (var tag in tags)
@@ -116,7 +116,7 @@ namespace OpenTelemetry.Tags.Propagation.Test
             var tagsList = tags.ToList();
             var tagPermutation = Permutate(tagsList, tagsList.Count);
             ISet<String> possibleOutPuts = new HashSet<String>();
-            foreach (List<Tag> list in tagPermutation) {
+            foreach (List<DistributedContextEntry> list in tagPermutation) {
                 var expected = new MemoryStream();
                 expected.WriteByte(SerializationUtils.VersionId);
                 foreach (var tag in list) {

--- a/test/OpenTelemetry.Tests/Impl/Tags/ScopedTagContextsTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/ScopedTagContextsTest.cs
@@ -61,7 +61,7 @@ namespace OpenTelemetry.Tags.Test
             try
             {
                 var newTags = tagger.CurrentBuilder.Put(KEY_2, VALUE_2).Build();
-                Assert.Equal(new List<Tag>() { Tag.Create(KEY_1, VALUE_1), Tag.Create(KEY_2, VALUE_2) },
+                Assert.Equal(new List<DistributedContextEntry>() { new DistributedContextEntry(KEY_1, VALUE_1), new DistributedContextEntry(KEY_2, VALUE_2) },
                     TagsTestUtil.TagContextToList(newTags));
                 Assert.Same(scopedTags, tagger.CurrentTagContext);
             }
@@ -78,7 +78,7 @@ namespace OpenTelemetry.Tags.Test
             var scope = tagger.EmptyBuilder.Put(KEY_1, VALUE_1).BuildScoped();
             try
             {
-                Assert.Equal(new List<Tag>() { Tag.Create(KEY_1, VALUE_1) }, TagsTestUtil.TagContextToList(tagger.CurrentTagContext));
+                Assert.Equal(new List<DistributedContextEntry>() { new DistributedContextEntry(KEY_1, VALUE_1) }, TagsTestUtil.TagContextToList(tagger.CurrentTagContext));
             }
             finally
             {
@@ -97,7 +97,7 @@ namespace OpenTelemetry.Tags.Test
                 var scope2 = tagger.CurrentBuilder.Put(KEY_2, VALUE_2).BuildScoped();
                 try
                 {
-                    Assert.Equal(new List<Tag>() { Tag.Create(KEY_1, VALUE_1), Tag.Create(KEY_2, VALUE_2) },
+                    Assert.Equal(new List<DistributedContextEntry>() { new DistributedContextEntry(KEY_1, VALUE_1), new DistributedContextEntry(KEY_2, VALUE_2) },
                         TagsTestUtil.TagContextToList(tagger.CurrentTagContext));
                 }
                 finally

--- a/test/OpenTelemetry.Tests/Impl/Tags/TagContextBaseTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/TagContextBaseTest.cs
@@ -20,8 +20,8 @@ namespace OpenTelemetry.Tags.Test
 {
     public class TagContextBaseTest
     {
-        private static readonly Tag TAG1 = Tag.Create("key", "val");
-        private static readonly Tag TAG2 = Tag.Create("key2", "val");
+        private static readonly DistributedContextEntry TAG1 = new DistributedContextEntry("key", "val");
+        private static readonly DistributedContextEntry TAG2 = new DistributedContextEntry("key2", "val");
 
         [Fact]
         public void Equals_IgnoresTagOrderAndTagContextClass()
@@ -42,8 +42,8 @@ namespace OpenTelemetry.Tags.Test
         [Fact]
         public void Equals_HandlesNullIterator()
         {
-            var ctx1 = new SimpleTagContext((IEnumerable<Tag>)null);
-            var ctx2 = new SimpleTagContext((IEnumerable<Tag>)null);
+            var ctx1 = new SimpleTagContext((IEnumerable<DistributedContextEntry>)null);
+            var ctx2 = new SimpleTagContext((IEnumerable<DistributedContextEntry>)null);
             var ctx3 = new SimpleTagContext();
             Assert.True(ctx1.Equals(ctx2));
             Assert.True(ctx1.Equals(ctx3));
@@ -85,30 +85,30 @@ namespace OpenTelemetry.Tags.Test
 
         class TestTagContext : TagContextBase
         {
-            public override IEnumerator<Tag> GetEnumerator()
+            public override IEnumerator<DistributedContextEntry> GetEnumerator()
             {
-                var l = new List<Tag>() { TAG1, TAG2 };
+                var l = new List<DistributedContextEntry>() { TAG1, TAG2 };
                 return l.GetEnumerator();
             }
         }
 
         class SimpleTagContext : TagContextBase
         {
-            private readonly IEnumerable<Tag> tags;
+            private readonly IEnumerable<DistributedContextEntry> tags;
 
             // This Error Prone warning doesn't seem correct, because the constructor is just calling
             // another constructor.
-            public SimpleTagContext(params Tag[] tags)
-                : this(new List<Tag>(tags))
+            public SimpleTagContext(params DistributedContextEntry[] tags)
+                : this(new List<DistributedContextEntry>(tags))
             {
             }
 
-            public SimpleTagContext(IEnumerable<Tag> tags)
+            public SimpleTagContext(IEnumerable<DistributedContextEntry> tags)
             {
-                this.tags = tags == null ? null : new List<Tag>(tags);
+                this.tags = tags == null ? null : new List<DistributedContextEntry>(tags);
             }
 
-            public override IEnumerator<Tag> GetEnumerator()
+            public override IEnumerator<DistributedContextEntry> GetEnumerator()
             {
                 return tags == null ? null : tags.GetEnumerator();
             }

--- a/test/OpenTelemetry.Tests/Impl/Tags/TagContextTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/TagContextTest.cs
@@ -108,7 +108,7 @@ namespace OpenTelemetry.Tags.Test
             Assert.True(i.MoveNext());
             var tag2 = i.Current;
             Assert.False(i.MoveNext());
-            Assert.Equal(new List<Tag>() { Tag.Create(K1, V1), Tag.Create(K2, V2)}, new List<Tag>() { tag1, tag2 });
+            Assert.Equal(new List<DistributedContextEntry>() { new DistributedContextEntry(K1, V1), new DistributedContextEntry(K2, V2)}, new List<DistributedContextEntry>() { tag1, tag2 });
 
         }
 
@@ -144,9 +144,9 @@ namespace OpenTelemetry.Tags.Test
 
         class TestTagContext : TagContextBase
         {
-            public override IEnumerator<Tag> GetEnumerator()
+            public override IEnumerator<DistributedContextEntry> GetEnumerator()
             {
-                return new List<Tag>() { Tag.Create(K1, V1), Tag.Create(K2, V2) }.GetEnumerator();
+                return new List<DistributedContextEntry>() { new DistributedContextEntry(K1, V1), new DistributedContextEntry(K2, V2) }.GetEnumerator();
             }
         }
     }

--- a/test/OpenTelemetry.Tests/Impl/Tags/TagTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/TagTest.cs
@@ -22,16 +22,16 @@ namespace OpenTelemetry.Tags.Test
         [Fact]
         public void TestGetKey()
         {
-            Assert.Equal("k", Tag.Create("k", "v").Key);
+            Assert.Equal("k", new DistributedContextEntry("k", "v").Key);
         }
 
         [Fact]
         public void TestTagEquals()
         {
-            var tag1 = Tag.Create("Key", "foo");
-            var tag2 = Tag.Create("Key", "foo");
-            var tag3 = Tag.Create("Key", "bar");
-            var tag4 = Tag.Create("Key2", "foo");
+            var tag1 = new DistributedContextEntry("Key", "foo");
+            var tag2 = new DistributedContextEntry("Key", "foo");
+            var tag3 = new DistributedContextEntry("Key", "bar");
+            var tag4 = new DistributedContextEntry("Key2", "foo");
             Assert.Equal(tag1, tag2);
             Assert.NotEqual(tag1, tag3);
             Assert.NotEqual(tag1, tag4);

--- a/test/OpenTelemetry.Tests/Impl/Tags/TaggerTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/TaggerTest.cs
@@ -32,9 +32,9 @@ namespace OpenTelemetry.Tags.Test
         private static readonly string V2 = "v2";
         private static readonly string V3 = "v3";
 
-        private static readonly Tag TAG1 = Tag.Create(K1, V1);
-        private static readonly Tag TAG2 = Tag.Create(K2, V2);
-        private static readonly Tag TAG3 = Tag.Create(K3, V3);
+        private static readonly DistributedContextEntry TAG1 = new DistributedContextEntry(K1, V1);
+        private static readonly DistributedContextEntry TAG2 = new DistributedContextEntry(K2, V2);
+        private static readonly DistributedContextEntry TAG3 = new DistributedContextEntry(K3, V3);
 
         public TaggerTest()
         {
@@ -89,7 +89,7 @@ namespace OpenTelemetry.Tags.Test
             ITagContext tags = new SimpleTagContext(TAG1, TAG2, TAG3);
             var result = GetResultOfCurrentBuilder(tags);
             Assert.IsType<TagContextBuilder>(result);
-            Assert.Equal(new List<Tag>() { TAG1, TAG2, TAG3 }, TagsTestUtil.TagContextToList(result.Build()));
+            Assert.Equal(new List<DistributedContextEntry>() { TAG1, TAG2, TAG3 }, TagsTestUtil.TagContextToList(result.Build()));
         }
 
         [Fact]
@@ -103,11 +103,11 @@ namespace OpenTelemetry.Tags.Test
         [Fact]
         public void CurrentBuilder_RemoveDuplicateTags()
         {
-            var tag1 = Tag.Create(K1, V1);
-            var tag2 = Tag.Create(K1, V2);
+            var tag1 = new DistributedContextEntry(K1, V1);
+            var tag2 = new DistributedContextEntry(K1, V2);
             ITagContext tagContextWithDuplicateTags = new SimpleTagContext(tag1, tag2);
             var result = GetResultOfCurrentBuilder(tagContextWithDuplicateTags);
-            Assert.Equal(new List<Tag>() { tag2 }, TagsTestUtil.TagContextToList(result.Build()));
+            Assert.Equal(new List<DistributedContextEntry>() { tag2 }, TagsTestUtil.TagContextToList(result.Build()));
         }
 
         [Fact]
@@ -115,7 +115,7 @@ namespace OpenTelemetry.Tags.Test
         {
             ITagContext tagContextWithNullTag = new SimpleTagContext(TAG1, null, TAG2);
             var result = GetResultOfCurrentBuilder(tagContextWithNullTag);
-            Assert.Equal(new List<Tag>() { TAG1, TAG2 }, TagsTestUtil.TagContextToList(result.Build()));
+            Assert.Equal(new List<DistributedContextEntry>() { TAG1, TAG2 }, TagsTestUtil.TagContextToList(result.Build()));
         }
 
         // [Fact]
@@ -157,18 +157,18 @@ namespace OpenTelemetry.Tags.Test
         {
             ITagContext unknownTagContext = new SimpleTagContext(TAG1, TAG2, TAG3);
             var newTagContext = tagger.ToBuilder(unknownTagContext).Build();
-            Assert.Equal(new List<Tag>() { TAG1, TAG2, TAG3 }, TagsTestUtil.TagContextToList(newTagContext));
+            Assert.Equal(new List<DistributedContextEntry>() { TAG1, TAG2, TAG3 }, TagsTestUtil.TagContextToList(newTagContext));
             Assert.IsType<TagContext>(newTagContext);
         }
 
         [Fact]
         public void ToBuilder_RemoveDuplicatesFromUnknownTagContext()
         {
-            var tag1 = Tag.Create(K1, V1);
-            var tag2 = Tag.Create(K1, V2);
+            var tag1 = new DistributedContextEntry(K1, V1);
+            var tag2 = new DistributedContextEntry(K1, V2);
             ITagContext tagContextWithDuplicateTags = new SimpleTagContext(tag1, tag2);
             var newTagContext = tagger.ToBuilder(tagContextWithDuplicateTags).Build();
-            Assert.Equal(new List<Tag>() { tag2 }, TagsTestUtil.TagContextToList(newTagContext));
+            Assert.Equal(new List<DistributedContextEntry>() { tag2 }, TagsTestUtil.TagContextToList(newTagContext));
         }
 
         [Fact]
@@ -176,7 +176,7 @@ namespace OpenTelemetry.Tags.Test
         {
             ITagContext tagContextWithNullTag = new SimpleTagContext(TAG1, null, TAG2);
             var newTagContext = tagger.ToBuilder(tagContextWithNullTag).Build();
-            Assert.Equal(new List<Tag>() { TAG1, TAG2 }, TagsTestUtil.TagContextToList(newTagContext));
+            Assert.Equal(new List<DistributedContextEntry>() { TAG1, TAG2 }, TagsTestUtil.TagContextToList(newTagContext));
         }
 
         // [Fact]
@@ -213,17 +213,17 @@ namespace OpenTelemetry.Tags.Test
             ITagContext unknownTagContext = new SimpleTagContext(TAG1, TAG2, TAG3);
             var result = GetResultOfGetCurrentTagContext(unknownTagContext);
             Assert.IsType<TagContext>(result);
-            Assert.Equal(new List<Tag>() { TAG1, TAG2, TAG3 }, TagsTestUtil.TagContextToList(result));
+            Assert.Equal(new List<DistributedContextEntry>() { TAG1, TAG2, TAG3 }, TagsTestUtil.TagContextToList(result));
         }
 
         [Fact]
         public void GetCurrentTagContext_RemoveDuplicatesFromUnknownTagContext()
         {
-            var tag1 = Tag.Create(K1, V1);
-            var tag2 = Tag.Create(K1, V2);
+            var tag1 = new DistributedContextEntry(K1, V1);
+            var tag2 = new DistributedContextEntry(K1, V2);
             ITagContext tagContextWithDuplicateTags = new SimpleTagContext(tag1, tag2);
             var result = GetResultOfGetCurrentTagContext(tagContextWithDuplicateTags);
-            Assert.Equal(new List<Tag>() { tag2 }, TagsTestUtil.TagContextToList(result));
+            Assert.Equal(new List<DistributedContextEntry>() { tag2 }, TagsTestUtil.TagContextToList(result));
         }
 
         [Fact]
@@ -231,7 +231,7 @@ namespace OpenTelemetry.Tags.Test
         {
             ITagContext tagContextWithNullTag = new SimpleTagContext(TAG1, null, TAG2);
             var result = GetResultOfGetCurrentTagContext(tagContextWithNullTag);
-            Assert.Equal(new List<Tag>() { TAG1, TAG2 }, TagsTestUtil.TagContextToList(result));
+            Assert.Equal(new List<DistributedContextEntry>() { TAG1, TAG2 }, TagsTestUtil.TagContextToList(result));
         }
 
         // [Fact]
@@ -273,17 +273,17 @@ namespace OpenTelemetry.Tags.Test
             ITagContext unknownTagContext = new SimpleTagContext(TAG1, TAG2, TAG3);
             var result = GetResultOfWithTagContext(unknownTagContext);
             Assert.IsType<TagContext>(result);
-            Assert.Equal(new List<Tag>() { TAG1, TAG2, TAG3 }, TagsTestUtil.TagContextToList(result));
+            Assert.Equal(new List<DistributedContextEntry>() { TAG1, TAG2, TAG3 }, TagsTestUtil.TagContextToList(result));
         }
 
         [Fact]
         public void WithTagContext_RemoveDuplicatesFromUnknownTagContext()
         {
-            var tag1 = Tag.Create(K1, V1);
-            var tag2 = Tag.Create(K1, V2);
+            var tag1 = new DistributedContextEntry(K1, V1);
+            var tag2 = new DistributedContextEntry(K1, V2);
             ITagContext tagContextWithDuplicateTags = new SimpleTagContext(tag1, tag2);
             var result = GetResultOfWithTagContext(tagContextWithDuplicateTags);
-            Assert.Equal(new List<Tag>() { tag2 }, TagsTestUtil.TagContextToList(result));
+            Assert.Equal(new List<DistributedContextEntry>() { tag2 }, TagsTestUtil.TagContextToList(result));
         }
 
         [Fact]
@@ -291,7 +291,7 @@ namespace OpenTelemetry.Tags.Test
         {
             ITagContext tagContextWithNullTag = new SimpleTagContext(TAG1, null, TAG2);
             var result = GetResultOfWithTagContext(tagContextWithNullTag);
-            Assert.Equal(new List<Tag>() { TAG1, TAG2 }, TagsTestUtil.TagContextToList(result));
+            Assert.Equal(new List<DistributedContextEntry>() { TAG1, TAG2 }, TagsTestUtil.TagContextToList(result));
         }
 
         // [Fact]
@@ -333,14 +333,14 @@ namespace OpenTelemetry.Tags.Test
 
         class SimpleTagContext : TagContextBase
         {
-            private readonly List<Tag> tags;
+            private readonly List<DistributedContextEntry> tags;
 
-            public SimpleTagContext(params Tag[] tags)
+            public SimpleTagContext(params DistributedContextEntry[] tags)
             {
-                this.tags = new List<Tag>(tags);
+                this.tags = new List<DistributedContextEntry>(tags);
             }
 
-            public override IEnumerator<Tag> GetEnumerator()
+            public override IEnumerator<DistributedContextEntry> GetEnumerator()
             {
                 return tags.GetEnumerator();
             }

--- a/test/OpenTelemetry.Tests/Impl/Tags/TagsTestUtil.cs
+++ b/test/OpenTelemetry.Tests/Impl/Tags/TagsTestUtil.cs
@@ -20,7 +20,7 @@ namespace OpenTelemetry.Tags.Test
 {
     internal static class TagsTestUtil
     {
-        public static ICollection<Tag> TagContextToList(ITagContext tags)
+        public static ICollection<DistributedContextEntry> TagContextToList(ITagContext tags)
         {
             return tags.ToList();
         }


### PR DESCRIPTION
Fixes #33 

One step towards #117 

- `Tag` renamed to `DistributedContextEntry`
- `DistributedContextEntry` is constructed via constructor instead of `Create` method
- Added `EntryMetadata` class
