### PR TITLE
added startup filter to simplify onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,17 +270,6 @@ Configuration is done by user application: it should configure exporter and may 
     });
     ```
 
-3. Start auto-collectors
-
-   To start collection or just to create tracers to creates spans manually, `TracerFactory` needs to be resolved.
-
-    ```csharp
-    public void Configure(IApplicationBuilder app, TracerFactory factory)
-    {
-        // ...
-    }
-    ```
-
 ### Using StackExchange.Redis collector
 
 Outgoing http calls to Redis made using StackExchange.Redis library can be automatically tracked.
@@ -308,7 +297,7 @@ Outgoing http calls to Redis made using StackExchange.Redis library can be autom
     }
     ```
 
-You can combine it with dependency injection as shown in previous example, in this case, do not forget to resolve `TracerFactory`.
+You can combine it with dependency injection as shown in previous example.
 
 ### Custom samplers
 

--- a/src/OpenTelemetry.Hosting/Implementation/OpenTelemetryStartupFilter.cs
+++ b/src/OpenTelemetry.Hosting/Implementation/OpenTelemetryStartupFilter.cs
@@ -1,0 +1,59 @@
+﻿// <copyright file="OpenTelemetryStartupFilter.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry.Trace.Configuration;
+
+namespace OpenTelemetry.Implementation
+{
+    internal class OpenTelemetryStartupFilter : IStartupFilter
+    {
+        private readonly ILogger<OpenTelemetryStartupFilter> logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenTelemetryStartupFilter"/> class.
+        /// </summary>
+        /// <param name="logger">Instance of ILogger.</param>
+        public OpenTelemetryStartupFilter(ILogger<OpenTelemetryStartupFilter> logger)
+        {
+            this.logger = logger;
+        }
+
+        /// <inheritdoc/>
+        public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+        {
+            return app =>
+            {
+                try
+                {
+                    // Attempting to resolve TracerFactory triggers configuration of all monitoring
+                    var tc = app.ApplicationServices.GetService<TracerFactory>();
+                }
+                catch (Exception ex)
+                {
+                    this.logger.LogWarning(0, ex, "Failed to resolve TracerFactory.");
+                }
+
+                // Invoking next builder is not wrapped in try catch to ensure any exceptions gets propogated up.
+                next(app);
+            };
+        }
+    }
+}

--- a/src/OpenTelemetry.Hosting/OpenTelemetry.Hosting.csproj
+++ b/src/OpenTelemetry.Hosting/OpenTelemetry.Hosting.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.0" />
     <ProjectReference Include="..\OpenTelemetry\OpenTelemetry.csproj" />
   </ItemGroup>
 </Project>

--- a/src/OpenTelemetry.Hosting/OpenTelemetryServicesExtensions.cs
+++ b/src/OpenTelemetry.Hosting/OpenTelemetryServicesExtensions.cs
@@ -17,9 +17,11 @@
 namespace Microsoft.Extensions.DependencyInjection
 {
     using System;
+    using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.DependencyInjection.Extensions;
     using Microsoft.Extensions.Hosting;
     using OpenTelemetry.Hosting.Implementation;
+    using OpenTelemetry.Implementation;
     using OpenTelemetry.Trace;
     using OpenTelemetry.Trace.Configuration;
 
@@ -110,6 +112,9 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             services.AddSingleton<TracerFactoryBase>(s => createFactory(s));
+
+            // Using startup filter to instantiate TracerFactory
+            services.AddSingleton<IStartupFilter, OpenTelemetryStartupFilter>();
             AddOpenTelemetryCore(services);
 
             return services;


### PR DESCRIPTION
This adds reference to `Microsoft.AspNetCore.Hosting.Abstractions` but makes enablement much easier - no need to resolve the TraceFactory.

CC: @pakrym @JamesNK for suggestions 