### PR TITLE
Fix the master build by repairing the OpenTelemetry.Exporter.Ocagent.csproj build

### DIFF
--- a/OpenTelemetry.sln
+++ b/OpenTelemetry.sln
@@ -103,6 +103,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.Hosting", "sr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.Hosting.Tests", "test\OpenTelemetry.Hosting.Tests\OpenTelemetry.Hosting.Tests.csproj", "{4CB1187F-27F2-48F9-83F4-3A7567F73B5F}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.Exporter.Ocagent", "src\OpenTelemetry.Exporter.Ocagent\OpenTelemetry.Exporter.Ocagent.csproj", "{4C456038-78DD-4EDD-B9B1-562D4AA8F153}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -229,6 +231,10 @@ Global
 		{4CB1187F-27F2-48F9-83F4-3A7567F73B5F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4CB1187F-27F2-48F9-83F4-3A7567F73B5F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4CB1187F-27F2-48F9-83F4-3A7567F73B5F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4C456038-78DD-4EDD-B9B1-562D4AA8F153}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4C456038-78DD-4EDD-B9B1-562D4AA8F153}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4C456038-78DD-4EDD-B9B1-562D4AA8F153}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4C456038-78DD-4EDD-B9B1-562D4AA8F153}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/OpenTelemetry.Exporter.Ocagent/Implementation/SpanExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Ocagent/Implementation/SpanExtensions.cs
@@ -122,9 +122,9 @@ namespace OpenTelemetry.Exporter.Ocagent.Implementation
             }
         }
 
-        private static Proto.Trace.V1.Span.Types.TimeEvents FromITimeEvents(IEnumerable<IEvent> events)
+        private static Proto.Trace.V1.Span.Types.TimeEvents FromITimeEvents(IEnumerable<Event> events)
         {
-            var eventArray = events as IEvent[] ?? events.ToArray();
+            var eventArray = events as Event[] ?? events.ToArray();
             var timedEvents = new Proto.Trace.V1.Span.Types.TimeEvents
             {
                 TimeEvent = { eventArray.Select(FromITimeEvent), },
@@ -135,7 +135,7 @@ namespace OpenTelemetry.Exporter.Ocagent.Implementation
             return timedEvents;
         }
 
-        private static Proto.Trace.V1.Span.Types.Link FromILink(ILink source)
+        private static Proto.Trace.V1.Span.Types.Link FromILink(Link source)
         {
             // protobuf doesn't understand Span<T> yet: https://github.com/protocolbuffers/protobuf/issues/3431
             Span<byte> traceIdBytes = stackalloc byte[16];
@@ -154,7 +154,7 @@ namespace OpenTelemetry.Exporter.Ocagent.Implementation
             return result;
         }
 
-        private static Proto.Trace.V1.Span.Types.TimeEvent FromITimeEvent(IEvent source)
+        private static Proto.Trace.V1.Span.Types.TimeEvent FromITimeEvent(Event source)
         {
             return new Proto.Trace.V1.Span.Types.TimeEvent
             {

--- a/src/OpenTelemetry.Exporter.Ocagent/OcagentTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Ocagent/OcagentTraceExporter.cs
@@ -34,6 +34,9 @@ namespace OpenTelemetry.Exporter.Ocagent
     using OpenTelemetry.Trace;
     using OpenTelemetry.Trace.Export;
 
+    /// <summary>
+    /// The trace exporter to otelcol.
+    /// </summary>
     // TODO support async exporting and results
     public class OcagentTraceExporter : SpanExporter, IDisposable
     {
@@ -46,6 +49,14 @@ namespace OpenTelemetry.Exporter.Ocagent
         private CancellationTokenSource cts;
         private Task runTask;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OcagentTraceExporter"/> class.
+        /// </summary>
+        /// <param name="agentEndpoint">The agent endpoint.</param>
+        /// <param name="hostName">Name of the host.</param>
+        /// <param name="serviceName">Name of the service.</param>
+        /// <param name="credentials">The credentials.</param>
+        /// <param name="spanBatchSize">Size of the span batch.</param>
         public OcagentTraceExporter(string agentEndpoint, string hostName, string serviceName, ChannelCredentials credentials = null, uint spanBatchSize = MaxSpanBatchSize)
         {
             this.channel = new Channel(agentEndpoint, credentials ?? ChannelCredentials.Insecure);
@@ -75,6 +86,7 @@ namespace OpenTelemetry.Exporter.Ocagent
             this.Start();
         }
 
+        /// <inheritdoc/>
         public override async Task<ExportResult> ExportAsync(IEnumerable<Span> spanDataList, CancellationToken cancellationToken)
         {
             await Task.Run(
@@ -94,6 +106,7 @@ namespace OpenTelemetry.Exporter.Ocagent
             return ExportResult.Success;
         }
 
+        /// <inheritdoc/>
         public override async Task ShutdownAsync(CancellationToken cancellationToken)
         {
             // TODO support cancellation based on cancellationToken
@@ -110,6 +123,7 @@ namespace OpenTelemetry.Exporter.Ocagent
             }
         }
 
+        /// <inheritdoc/>
         public void Dispose()
         {
             this.ShutdownAsync(CancellationToken.None).Wait();


### PR DESCRIPTION
Apparently the build pipeline for the master branch ci is not looking
exclusively at the .sln, so this project must build.

This is simply a build fix and nothing else.

The master build from my previous check-in failed:
https://dev.azure.com/opentelemetry/pipelines/_build/results?buildId=811