### PR TITLE
Apply design feedback on Metrics and DistributedContext

### DIFF
--- a/src/OpenTelemetry.Api/DistributedContext/DistributedContextEntry.cs
+++ b/src/OpenTelemetry.Api/DistributedContext/DistributedContextEntry.cs
@@ -29,7 +29,7 @@ namespace OpenTelemetry.Context
          /// <param name="key">Key name for the entry.</param>
         /// <param name="value">Value associated with the key name.</param>
         public DistributedContextEntry(string key, string value)
-            : this(key, value, new EntryMetadata(EntryMetadata.NoPropagation))
+            : this(key, value, EntryMetadata.NoPropagationEntry)
         {
         }
 

--- a/src/OpenTelemetry.Api/DistributedContext/EntryMetadata.cs
+++ b/src/OpenTelemetry.Api/DistributedContext/EntryMetadata.cs
@@ -22,27 +22,37 @@ namespace OpenTelemetry.Context
     public readonly struct EntryMetadata
     {
         /// <summary>
-        /// TTL indicating in-process only propagation of an entry.
+        /// TimeToLive (TTL) indicating in-process only propagation of an entry.
         /// </summary>
         public const int NoPropagation = 0;
 
         /// <summary>
-        /// TTL indicating unlimited propagation of an entry.
+        /// TimeToLive (TTL) indicating unlimited propagation of an entry.
         /// </summary>
         public const int UnlimitedPropagation = -1;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EntryMetadata"/> struct.
         /// </summary>
-        /// <param name="entryTTL">TTL for the distributed context entry.</param>
-        public EntryMetadata(int entryTTL)
+        /// <param name="timeToLive">TTL for the distributed context entry.</param>
+        public EntryMetadata(int timeToLive)
         {
-            this.EntryTTL = EntryMetadata.NoPropagation;
+            this.TimeToLive = EntryMetadata.NoPropagation;
         }
 
         /// <summary>
-        /// Gets the EntryTTL is either NO_PROPAGATION (0) or UNLIMITED_PROPAGATION (-1).
+        /// Gets a new instance of the <see cref="EntryMetadata"/> struct with NoPropagation value.
         /// </summary>
-        public int EntryTTL { get; }
+        public static EntryMetadata NoPropagationEntry => new EntryMetadata(NoPropagation);
+
+        /// <summary>
+        /// Gets a new instance of the <see cref="EntryMetadata"/> struct with UnlimitedPropagation value.
+        /// </summary>
+        public static EntryMetadata UnlimitedPropagationEntry => new EntryMetadata(UnlimitedPropagation);
+
+        /// <summary>
+        /// Gets the TimeToLive is either NO_PROPAGATION (0) or UNLIMITED_PROPAGATION (-1).
+        /// </summary>
+        public int TimeToLive { get; }
     }
 }

--- a/src/OpenTelemetry.Api/DistributedContext/EntryMetadata.cs
+++ b/src/OpenTelemetry.Api/DistributedContext/EntryMetadata.cs
@@ -35,10 +35,7 @@ namespace OpenTelemetry.Context
         /// Initializes a new instance of the <see cref="EntryMetadata"/> struct.
         /// </summary>
         /// <param name="timeToLive">TTL for the distributed context entry.</param>
-        public EntryMetadata(int timeToLive)
-        {
-            this.TimeToLive = EntryMetadata.NoPropagation;
-        }
+        private EntryMetadata(int timeToLive) => this.TimeToLive = timeToLive;
 
         /// <summary>
         /// Gets a new instance of the <see cref="EntryMetadata"/> struct with NoPropagation value.
@@ -51,7 +48,7 @@ namespace OpenTelemetry.Context
         public static EntryMetadata UnlimitedPropagationEntry => new EntryMetadata(UnlimitedPropagation);
 
         /// <summary>
-        /// Gets the TimeToLive is either NO_PROPAGATION (0) or UNLIMITED_PROPAGATION (-1).
+        /// Gets the TimeToLive which is either NO_PROPAGATION (0) or UNLIMITED_PROPAGATION (-1).
         /// </summary>
         public int TimeToLive { get; }
     }

--- a/src/OpenTelemetry.Api/Metrics/Meter.cs
+++ b/src/OpenTelemetry.Api/Metrics/Meter.cs
@@ -24,7 +24,7 @@ namespace OpenTelemetry.Metrics
     public abstract class Meter
     {
         /// <summary>
-        /// Creates a counter for Int64 with given name.
+        /// Creates Int64 counter with given name.
         /// </summary>
         /// <param name="name">The name of the counter.</param>
         /// <param name="monotonic">indicates if only positive values are expected.</param>
@@ -32,7 +32,7 @@ namespace OpenTelemetry.Metrics
         public Counter<long> CreateInt64Counter(string name, bool monotonic = true) => this.CreateCounter<long>(name, monotonic);
 
         /// <summary>
-        /// Creates a counter for double with given name.
+        /// Creates double counter with given name.
         /// </summary>
         /// <param name="name">indicates if only positive values are expected.</param>
         /// <param name="monotonic">The name of the counter.</param>
@@ -40,7 +40,7 @@ namespace OpenTelemetry.Metrics
         public Counter<double> CreateDoubleCounter(string name, bool monotonic = true) => this.CreateCounter<double>(name, monotonic);
 
         /// <summary>
-        /// Creates a Gauge for Int64 with given name.
+        /// Creates Int64 Gauge with given name.
         /// </summary>
         /// <param name="name">The name of the counter.</param>
         /// <param name="monotonic">indicates if only positive values are expected.</param>
@@ -48,7 +48,7 @@ namespace OpenTelemetry.Metrics
         public Gauge<long> CreateInt64Gauge(string name, bool monotonic = false) => this.CreateGauge<long>(name, monotonic);
 
         /// <summary>
-        /// Creates a measure for Int64 with given name.
+        /// Creates Int64 Measure with given name.
         /// </summary>
         /// <param name="name">The name of the measure.</param>
         /// <param name="absolute">indicates if only positive values are expected.</param>
@@ -56,7 +56,7 @@ namespace OpenTelemetry.Metrics
         public Measure<long> CreateInt64Measure(string name, bool absolute = true) => this.CreateMeasure<long>(name, absolute);
 
         /// <summary>
-        /// Creates a measure for double type with given name.
+        /// Creates double Measure with given name.
         /// </summary>
         /// <param name="name">The name of the measure.</param>
         /// <param name="absolute">indicates if only positive values are expected.</param>
@@ -64,7 +64,7 @@ namespace OpenTelemetry.Metrics
         public Measure<double> CreateDoubleMeasure(string name, bool absolute = true) => this.CreateMeasure<double>(name, absolute);
 
         /// <summary>
-        /// Creates a Gauge for double with given name.
+        /// Creates double Gauge with given name.
         /// </summary>
         /// <param name="name">The name of the counter.</param>
         /// <param name="monotonic">indicates if only positive values are expected.</param>
@@ -79,7 +79,7 @@ namespace OpenTelemetry.Metrics
         public abstract LabelSet GetLabelSet(IEnumerable<KeyValuePair<string, string>> labels);
 
         /// <summary>
-        /// Creates a counter for double or Int64 type with given name.
+        /// Creates double or Int64 counter with given name.
         /// </summary>
         /// <param name="name">indicates if only positive values are expected.</param>
         /// <param name="monotonic">The name of the counter.</param>
@@ -89,7 +89,7 @@ namespace OpenTelemetry.Metrics
             where T : struct;
 
         /// <summary>
-        /// Creates a Gauge for Int64 or double type with given name.
+        /// Creates double or Int64 Gauge with given name.
         /// </summary>
         /// <param name="name">The name of the counter.</param>
         /// <param name="monotonic">indicates if only positive values are expected.</param>
@@ -99,7 +99,7 @@ namespace OpenTelemetry.Metrics
             where T : struct;
 
         /// <summary>
-        /// Creates a measure for Int64 or double type with given name.
+        /// Creates double or Int64 Measure with given name.
         /// </summary>
         /// <param name="name">The name of the measure.</param>
         /// <param name="absolute">indicates if only positive values are expected.</param>

--- a/src/OpenTelemetry.Api/Metrics/Meter.cs
+++ b/src/OpenTelemetry.Api/Metrics/Meter.cs
@@ -24,12 +24,12 @@ namespace OpenTelemetry.Metrics
     public abstract class Meter
     {
         /// <summary>
-        /// Creates a counter for long with given name.
+        /// Creates a counter for Int64 with given name.
         /// </summary>
         /// <param name="name">The name of the counter.</param>
         /// <param name="monotonic">indicates if only positive values are expected.</param>
         /// <returns>The counter instance.</returns>
-        public abstract Counter<long> CreateLongCounter(string name, bool monotonic = true);
+        public Counter<long> CreateInt64Counter(string name, bool monotonic = true) => this.CreateCounter<long>(name, monotonic);
 
         /// <summary>
         /// Creates a counter for double with given name.
@@ -37,39 +37,39 @@ namespace OpenTelemetry.Metrics
         /// <param name="name">indicates if only positive values are expected.</param>
         /// <param name="monotonic">The name of the counter.</param>
         /// <returns>The counter instance.</returns>
-        public abstract Counter<double> CreateDoubleCounter(string name, bool monotonic = true);
+        public Counter<double> CreateDoubleCounter(string name, bool monotonic = true) => this.CreateCounter<double>(name, monotonic);
 
         /// <summary>
-        /// Creates a Gauge for long with given name.
+        /// Creates a Gauge for Int64 with given name.
         /// </summary>
         /// <param name="name">The name of the counter.</param>
         /// <param name="monotonic">indicates if only positive values are expected.</param>
         /// <returns>The Gauge instance.</returns>
-        public abstract Gauge<long> CreateLongGauge(string name, bool monotonic = false);
+        public Gauge<long> CreateInt64Gauge(string name, bool monotonic = false) => this.CreateGauge<long>(name, monotonic);
 
         /// <summary>
-        /// Creates a Gauge for long with given name.
+        /// Creates a measure for Int64 with given name.
+        /// </summary>
+        /// <param name="name">The name of the measure.</param>
+        /// <param name="absolute">indicates if only positive values are expected.</param>
+        /// <returns>The measure instance.</returns>
+        public Measure<long> CreateInt64Measure(string name, bool absolute = true) => this.CreateMeasure<long>(name, absolute);
+
+        /// <summary>
+        /// Creates a measure for double type with given name.
+        /// </summary>
+        /// <param name="name">The name of the measure.</param>
+        /// <param name="absolute">indicates if only positive values are expected.</param>
+        /// <returns>The measure instance.</returns>
+        public Measure<double> CreateDoubleMeasure(string name, bool absolute = true) => this.CreateMeasure<double>(name, absolute);
+
+        /// <summary>
+        /// Creates a Gauge for double with given name.
         /// </summary>
         /// <param name="name">The name of the counter.</param>
         /// <param name="monotonic">indicates if only positive values are expected.</param>
         /// <returns>The Gauge instance.</returns>
-        public abstract Gauge<double> CreateDoubleGauge(string name, bool monotonic = false);
-
-        /// <summary>
-        /// Creates a measure for long with given name.
-        /// </summary>
-        /// <param name="name">The name of the measure.</param>
-        /// <param name="absolute">indicates if only positive values are expected.</param>
-        /// <returns>The measure instance.</returns>
-        public abstract Measure<long> CreateLongMeasure(string name, bool absolute = true);
-
-        /// <summary>
-        /// Creates a measure for long with given name.
-        /// </summary>
-        /// <param name="name">The name of the measure.</param>
-        /// <param name="absolute">indicates if only positive values are expected.</param>
-        /// <returns>The measure instance.</returns>
-        public abstract Measure<double> CreateDoubleMeasure(string name, bool absolute = true);
+        public Gauge<double> CreateDoubleGauge(string name, bool monotonic = false) => this.CreateGauge<double>(name, monotonic);
 
         /// <summary>
         /// Constructs or retrieves the <see cref="LabelSet"/> from the given label key-value pairs.
@@ -77,5 +77,35 @@ namespace OpenTelemetry.Metrics
         /// <param name="labels">Label key value pairs.</param>
         /// <returns>The <see cref="LabelSet"/> with given label key value pairs.</returns>
         public abstract LabelSet GetLabelSet(IEnumerable<KeyValuePair<string, string>> labels);
+
+        /// <summary>
+        /// Creates a counter for double or Int64 type with given name.
+        /// </summary>
+        /// <param name="name">indicates if only positive values are expected.</param>
+        /// <param name="monotonic">The name of the counter.</param>
+        /// <typeparam name="T">The element type of the counter. Should be either long or double.</typeparam>
+        /// <returns>The counter instance.</returns>
+        protected abstract Counter<T> CreateCounter<T>(string name, bool monotonic = true)
+            where T : struct;
+
+        /// <summary>
+        /// Creates a Gauge for Int64 or double type with given name.
+        /// </summary>
+        /// <param name="name">The name of the counter.</param>
+        /// <param name="monotonic">indicates if only positive values are expected.</param>
+        /// <typeparam name="T">The element type of the Gauge. Should be either long or double.</typeparam>
+        /// <returns>The Gauge instance.</returns>
+        protected abstract Gauge<T> CreateGauge<T>(string name, bool monotonic = false)
+            where T : struct;
+
+        /// <summary>
+        /// Creates a measure for Int64 or double type with given name.
+        /// </summary>
+        /// <param name="name">The name of the measure.</param>
+        /// <param name="absolute">indicates if only positive values are expected.</param>
+        /// <typeparam name="T">The element type of the Measure. Should be either long or double.</typeparam>
+        /// <returns>The measure instance.</returns>
+        protected abstract Measure<T> CreateMeasure<T>(string name, bool absolute = true)
+            where T : struct;
     }
 }

--- a/src/OpenTelemetry.Api/Metrics/NoOpMeter.cs
+++ b/src/OpenTelemetry.Api/Metrics/NoOpMeter.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 using System.Collections.Generic;
 
 namespace OpenTelemetry.Metrics
@@ -23,42 +24,41 @@ namespace OpenTelemetry.Metrics
         {
         }
 
-        public override Counter<double> CreateDoubleCounter(string name, bool monotonic = true)
-        {
-            // return no op
-            throw new System.NotImplementedException();
-        }
-
-        public override Gauge<double> CreateDoubleGauge(string name, bool monotonic = false)
-        {
-            // return no op
-            throw new System.NotImplementedException();
-        }
-
-        public override Measure<double> CreateDoubleMeasure(string name, bool absolute = true)
-        {
-            throw new System.NotImplementedException();
-        }
-
-        public override Counter<long> CreateLongCounter(string name, bool monotonic = true)
-        {
-            // return no op
-            throw new System.NotImplementedException();
-        }
-
-        public override Gauge<long> CreateLongGauge(string name, bool monotonic = false)
-        {
-            // return no op
-            throw new System.NotImplementedException();
-        }
-
-        public override Measure<long> CreateLongMeasure(string name, bool absolute = true)
-        {
-            throw new System.NotImplementedException();
-        }
-
         public override LabelSet GetLabelSet(IEnumerable<KeyValuePair<string, string>> labels)
         {
+            // return no op
+            throw new System.NotImplementedException();
+        }
+
+        protected override Counter<T> CreateCounter<T>(string name, bool monotonic = true)
+        {
+            if (typeof(T) != typeof(long) || typeof(T) != typeof(double))
+            {
+                throw new InvalidOperationException();
+            }
+
+            // return no op
+            throw new System.NotImplementedException();
+        }
+
+        protected override Gauge<T> CreateGauge<T>(string name, bool monotonic = true)
+        {
+            if (typeof(T) != typeof(long) || typeof(T) != typeof(double))
+            {
+                throw new InvalidOperationException();
+            }
+
+            // return no op
+            throw new System.NotImplementedException();
+        }
+
+        protected override Measure<T> CreateMeasure<T>(string name, bool monotonic = true)
+        {
+            if (typeof(T) != typeof(long) || typeof(T) != typeof(double))
+            {
+                throw new InvalidOperationException();
+            }
+
             // return no op
             throw new System.NotImplementedException();
         }


### PR DESCRIPTION
- Reduce the number of abstract methods in Meter and allow overriding protected methods to avoid make it public.
- Rename the word “Long” in the APIs to “Int64”. This is the design guidelines recommendation.
- Add convenient properties NoPropagationEntry and UnlimitedPropagationEntry in EntryMetadata.
- Avoid using the 3 uppercase letters acronym of TTL and just use the full words TimeToLive.