### PR TITLE
Make TracerFactoryBase.Default non settable

### DIFF
--- a/src/OpenTelemetry.Api/Trace/TracerFactoryBase.cs
+++ b/src/OpenTelemetry.Api/Trace/TracerFactoryBase.cs
@@ -27,30 +27,39 @@ namespace OpenTelemetry.Trace
         private static TracerFactoryBase defaultFactory = new TracerFactoryBase();
 
         /// <summary>
-        /// Gets or sets the default instance of <see cref="TracerFactoryBase"/>.
+        /// Gets the default instance of <see cref="TracerFactoryBase"/>.
         /// </summary>
         public static TracerFactoryBase Default
         {
             get => defaultFactory;
-            set
+        }
+
+        /// <summary>
+        /// Sets the default instance of <see cref="TracerFactoryBase"/>.
+        /// </summary>
+        /// <param name="tracerFactory">Instance of <see cref="TracerFactoryBase"/>.</param>
+        /// <remarks>
+        /// This method can only be called once. Calling it multiple times will throw an <see cref="System.InvalidOperationException"/>.
+        /// </remarks>
+        /// <exception cref="System.InvalidOperationException">Thrown when called multiple times.</exception>
+        public static void SetDefault(TracerFactoryBase tracerFactory)
+        {
+            if (isInitialized)
             {
-                if (isInitialized)
-                {
-                    throw new InvalidOperationException("Default factory is already set");
-                }
-
-                defaultFactory = value ?? throw new ArgumentNullException(nameof(value));
-
-                // some libraries might have already used and cached ProxyTracer.
-                // let's update it to real one and forward all calls.
-
-                // resource assignment is not possible for libraries that cache tracer before SDK is initialized.
-                // SDK (Tracer) must be at least partially initialized before any collection starts to capture resources.
-                // we might be able to work this around with events.
-                proxy.UpdateTracer(defaultFactory.GetTracer(null));
-
-                isInitialized = true;
+                throw new InvalidOperationException("Default factory is already set");
             }
+
+            defaultFactory = tracerFactory ?? throw new ArgumentNullException(nameof(tracerFactory));
+
+            // some libraries might have already used and cached ProxyTracer.
+            // let's update it to real one and forward all calls.
+
+            // resource assignment is not possible for libraries that cache tracer before SDK is initialized.
+            // SDK (Tracer) must be at least partially initialized before any collection starts to capture resources.
+            // we might be able to work this around with events.
+            proxy.UpdateTracer(defaultFactory.GetTracer(null));
+
+            isInitialized = true;
         }
 
         /// <summary>

--- a/test/OpenTelemetry.Tests/Impl/Trace/Config/TracerFactoryBaseTests.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Config/TracerFactoryBaseTests.cs
@@ -44,7 +44,7 @@ namespace OpenTelemetry.Tests.Impl.Trace.Config
         public void TraceFactory_SetDefault()
         {
             var factory = TracerFactory.Create(b => { });
-            TracerFactoryBase.Default = factory;
+            TracerFactoryBase.SetDefault(factory);
 
             var defaultTracer = TracerFactoryBase.Default.GetTracer("");
             Assert.NotNull(defaultTracer);
@@ -59,14 +59,14 @@ namespace OpenTelemetry.Tests.Impl.Trace.Config
         [Fact]
         public void TraceFactory_SetDefaultNull()
         {
-            Assert.Throws<ArgumentNullException>(() => TracerFactoryBase.Default = null);
+            Assert.Throws<ArgumentNullException>(() => TracerFactoryBase.SetDefault(null));
         }
 
         [Fact]
         public void TraceFactory_SetDefaultTwice_Throws()
         {
-            TracerFactoryBase.Default = TracerFactory.Create(b => { });
-            Assert.Throws<InvalidOperationException>(() => TracerFactoryBase.Default = TracerFactory.Create(b => { }));
+            TracerFactoryBase.SetDefault(TracerFactory.Create(b => { }));
+            Assert.Throws<InvalidOperationException>(() => TracerFactoryBase.SetDefault(TracerFactory.Create(b => { })));
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace OpenTelemetry.Tests.Impl.Trace.Config
             var noopSpan = defaultTracer.StartSpan("foo");
             Assert.IsType<BlankSpan>(noopSpan);
 
-            TracerFactoryBase.Default = TracerFactory.Create(b => { });
+            TracerFactoryBase.SetDefault(TracerFactory.Create(b => { }));
             var span = defaultTracer.StartSpan("foo");
             Assert.IsType<Span>(span);
 

--- a/test/OpenTelemetry.Tests/Impl/Trace/TracingTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/TracingTest.cs
@@ -28,7 +28,7 @@ namespace OpenTelemetry.Trace.Test
             Assert.Equal(typeof(ProxyTracer), TracerFactoryBase.Default.GetTracer(null).GetType());
 
             var newFactory = TracerFactory.Create(_ => { });
-            TracerFactoryBase.Default = newFactory;
+            TracerFactoryBase.SetDefault(newFactory);
             Assert.IsAssignableFrom<TracerFactory>(TracerFactoryBase.Default);
         }
 


### PR DESCRIPTION
Instead a method called SetDefault has been added to make it more explicit that it is not okay to set it multiple times.

closes #301