### PR TITLE
Maintain crlf line endings in md files in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,9 @@ indent_style = space
 indent_size = 4 
 insert_final_newline = true 
 charset = utf-8-bom 
+# maintain DOS/Windows style line endings in markdown files
+[*.md]
+end_of_line = crlf
 ############################### 
 # .NET Coding Conventions     # 
 ############################### 

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ indent_style = space
 indent_size = 4 
 insert_final_newline = true 
 charset = utf-8-bom 
-# maintain DOS/Windows style line endings in markdown files
+# maintain DOS/Windows style line endings in md files
 [*.md]
 end_of_line = crlf
 ############################### 


### PR DESCRIPTION
The default line endings on DOS/Windows systems is `crlf`, where linux based systems just use `lf`. This change prevents editors that adhere to .editorconfig (eg VS Code) from trying to update the whole file's line endings to the current system's preferred style.