### PR TITLE
Do not share property fetchers and listeners between DiagnosticSources

### DIFF
--- a/src/OpenTelemetry.Collector.Dependencies/AzureClientsCollector.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/AzureClientsCollector.cs
@@ -32,7 +32,7 @@ namespace OpenTelemetry.Collector.Dependencies
         public AzureClientsCollector(ITracer tracer)
         {
             this.diagnosticSourceSubscriber = new DiagnosticSourceSubscriber(
-                new AzureSdkDiagnosticListener("Azure", tracer),
+                name => new AzureSdkDiagnosticListener(name, tracer),
                 listener => listener.Name.StartsWith("Azure."),
                 null);
             this.diagnosticSourceSubscriber.Subscribe();

--- a/src/OpenTelemetry.Collector.Dependencies/Implementation/AzureSdkDiagnosticListener.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/Implementation/AzureSdkDiagnosticListener.cs
@@ -24,7 +24,8 @@ namespace OpenTelemetry.Collector.Dependencies
 {
     internal class AzureSdkDiagnosticListener : ListenerHandler
     {
-        private static readonly PropertyFetcher LinksPropertyFetcher = new PropertyFetcher("Links");
+        // all fetchers must not be reused between DiagnosticSources.
+        private readonly PropertyFetcher linksPropertyFetcher = new PropertyFetcher("Links");
 
         public AzureSdkDiagnosticListener(string sourceName, ITracer tracer)
             : base(sourceName, tracer)
@@ -63,7 +64,7 @@ namespace OpenTelemetry.Collector.Dependencies
             }
 
             List<Link> parentLinks = null;
-            if (LinksPropertyFetcher.Fetch(valueValue) is IEnumerable<Activity> activityLinks)
+            if (this.linksPropertyFetcher.Fetch(valueValue) is IEnumerable<Activity> activityLinks)
             {
                 if (activityLinks.Any())
                 {


### PR DESCRIPTION
Property fetchers cache delegate that gets properties from objects via reflection. Caching makes it efficient.
 
When they are shared between DiagnosticSources and events, they may stop working since types of payloads and properties are different.

This change instantiates AzureSdkListener per DiagnosticSource (previously there was just one listener for all sources) and instantiates Links property fetcher per listener.

Fetcher is still shared for all events within Source, but we believe this is good enough (i.e. works for Azure SDKs and there are no plans to break it).

/cc @pakrym 