### PR TITLE
Fixed Jaeger options

### DIFF
--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpBatcher.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpBatcher.cs
@@ -23,7 +23,6 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
 {
     public class JaegerUdpBatcher : IJaegerUdpBatcher
     {
-        private const int DefaultMaxPacketSize = 65000;
         private readonly int? maxPacketSize;
         private readonly ITProtocolFactory protocolFactory;
         private readonly JaegerThriftClientTransport clientTransport;
@@ -38,9 +37,9 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
 
         public JaegerUdpBatcher(JaegerExporterOptions options)
         {
-            this.maxPacketSize = (!options.MaxPacketSize.HasValue || options.MaxPacketSize == 0) ? DefaultMaxPacketSize : options.MaxPacketSize;
+            this.maxPacketSize = (!options.MaxPacketSize.HasValue || options.MaxPacketSize == 0) ? JaegerExporterOptions.DefaultMaxPacketSize : options.MaxPacketSize;
             this.protocolFactory = new TCompactProtocol.Factory();
-            this.clientTransport = new JaegerThriftClientTransport(options.AgentHost, options.AgentPort.Value);
+            this.clientTransport = new JaegerThriftClientTransport(options.AgentHost, options.AgentPort);
             this.thriftClient = new JaegerThriftClient(this.protocolFactory.GetProtocol(this.clientTransport));
             this.process = new Process(options.ServiceName, options.ProcessTags);
             this.processByteSize = this.GetSize(this.process);

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptions.cs
@@ -19,13 +19,15 @@ namespace OpenTelemetry.Exporter.Jaeger
 {
     public class JaegerExporterOptions
     {
+        internal const int DefaultMaxPacketSize = 65000;
+
         public string ServiceName { get; set; }
 
-        public string AgentHost { get; set; }
+        public string AgentHost { get; set; } = "localhost";
 
-        public int? AgentPort { get; set; }
+        public int AgentPort { get; set; } = 6831;
 
-        public int? MaxPacketSize { get; set; }
+        public int? MaxPacketSize { get; set; } = DefaultMaxPacketSize;
 
         public Dictionary<string, object> ProcessTags { get; set; }
     }

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerTraceExporterTests.cs
@@ -1,0 +1,47 @@
+// <copyright file="JaegerTraceExporterTests.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+using System;
+using Xunit;
+
+namespace OpenTelemetry.Exporter.Jaeger.Tests
+{
+    public class JaegerTraceExporterTests
+    {
+        [Fact]
+        public void Constructor_EmptyServiceName_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var options = new JaegerExporterOptions();
+            
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentException>(() => new JaegerTraceExporter(options));
+            Assert.Equal("ServiceName", exception.ParamName);
+        }
+        
+        [Fact]
+        public void Constructor_ValidOptions_ReturnsInstance()
+        {
+            // Arrange
+            var options = new JaegerExporterOptions {ServiceName = "test_service"};
+
+            // Act
+            var exporter = new JaegerTraceExporter(options);
+            
+            // Assert
+            Assert.NotNull(exporter);
+        }
+    }
+}


### PR DESCRIPTION
* Fixed Jaeger default options not being used in `JaegerUdpBatcher`
* Fixed Jaeger options validations to run before initiating `JaegerUdpBatcher`
* Added Unit Tests for Jaeger Options