### PR TITLE
Experiment: ResourceValue as struct

### DIFF
--- a/samples/LoggingTracer/LoggingTracer/LoggingExporter.cs
+++ b/samples/LoggingTracer/LoggingTracer/LoggingExporter.cs
@@ -58,7 +58,7 @@ namespace LoggingTracer
 
         private static string StringifyResource(Resource resource)
         {
-            return string.Join(", ", resource.Labels.Select(l => l.Value));
+            return string.Join(", ", resource.Attributes.Select(l => l.Value));
         }
 
         private static void AppendIndentedLine(StringBuilder sb, int indentationLevel, string line)

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/resource/v1/resource.proto
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/resource/v1/resource.proto
@@ -22,6 +22,6 @@ option java_outer_classname = "ResourceProto";
 
 // Resource information.
 message Resource {
-  // Set of labels that describe the resource.
-  map<string,string> labels = 1;
+  // Set of attributes that describe the resource.
+  map<string,string> attributes = 1;
 }

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinSpan.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinSpan.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using OpenTelemetry.Resources;
 
 namespace OpenTelemetry.Exporter.Zipkin.Implementation
 {
@@ -137,7 +138,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
                 return this;
             }
 
-            internal Builder PutTag(string key, string value)
+            internal Builder PutTag(ResourceKey key, string value)
             {
                 if (this.result.Tags == null)
                 {
@@ -149,7 +150,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
                     throw new ArgumentNullException(nameof(key));
                 }
 
-                this.result.Tags[key] = value ?? throw new ArgumentNullException(nameof(value));
+                this.result.Tags[key.ToString()] = value ?? throw new ArgumentNullException(nameof(value));
 
                 return this;
             }

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinTraceExporter.cs
@@ -140,7 +140,7 @@ namespace OpenTelemetry.Exporter.Zipkin
             string serviceName = string.Empty;
             string serviceNamespace = string.Empty;
 
-            foreach (var label in otelSpan.LibraryResource.Labels)
+            foreach (var label in otelSpan.LibraryResource.Attributes)
             {
                 string key = label.Key;
                 string val = label.Value;

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinTraceExporter.cs
@@ -140,10 +140,10 @@ namespace OpenTelemetry.Exporter.Zipkin
             string serviceName = string.Empty;
             string serviceNamespace = string.Empty;
 
-            foreach (var label in otelSpan.LibraryResource.Attributes)
+            foreach (var attribute in otelSpan.LibraryResource.Attributes)
             {
-                string key = label.Key;
-                string val = label.Value;
+                var key = attribute.Key;
+                string val = attribute.Value;
 
                 if (key == "service.name")
                 {

--- a/src/OpenTelemetry/Resources/Resource.cs
+++ b/src/OpenTelemetry/Resources/Resource.cs
@@ -36,11 +36,11 @@ namespace OpenTelemetry.Resources
         /// <summary>
         /// Creates a new <see cref="Resource"/>.
         /// </summary>
-        /// <param name="labels">An <see cref="IDictionary{String, String}"/> of labels that describe the resource.</param>
-        public Resource(IEnumerable<KeyValuePair<string, string>> labels)
+        /// <param name="attributes">An <see cref="IDictionary{String, String}"/> of attributes that describe the resource.</param>
+        public Resource(IEnumerable<KeyValuePair<string, string>> attributes)
         {
-            ValidateLabels(labels);
-            this.Labels = labels;
+            ValidateAttributes(attributes);
+            this.Attributes = attributes;
         }
 
         /// <summary>
@@ -51,7 +51,7 @@ namespace OpenTelemetry.Resources
         /// <summary>
         /// Gets the collection of key-value pairs describing the resource.
         /// </summary>
-        public IEnumerable<KeyValuePair<string, string>> Labels { get; }
+        public IEnumerable<KeyValuePair<string, string>> Attributes { get; }
 
         /// <summary>
         /// Returns a new, merged <see cref="Resource"/> by merging the current <see cref="Resource"/> with the.
@@ -61,47 +61,47 @@ namespace OpenTelemetry.Resources
         /// <returns><see cref="Resource"/>.</returns>
         public Resource Merge(Resource other)
         {
-            var newLabels = new Dictionary<string, string>();
+            var newAttributes = new Dictionary<string, string>();
 
-            foreach (var label in this.Labels)
+            foreach (var attribute in this.Attributes)
             {
-                if (!newLabels.TryGetValue(label.Key, out var value) || string.IsNullOrEmpty(value))
+                if (!newAttributes.TryGetValue(attribute.Key, out var value) || string.IsNullOrEmpty(value))
                 {
-                    newLabels[label.Key] = label.Value;
+                    newAttributes[attribute.Key] = attribute.Value;
                 }
             }
 
             if (other != null)
             {
-                foreach (var label in other.Labels)
+                foreach (var attribute in other.Attributes)
                 {
-                    if (!newLabels.TryGetValue(label.Key, out var value) || string.IsNullOrEmpty(value))
+                    if (!newAttributes.TryGetValue(attribute.Key, out var value) || string.IsNullOrEmpty(value))
                     {
-                        newLabels[label.Key] = label.Value;
+                        newAttributes[attribute.Key] = attribute.Value;
                     }
                 }
             }
 
-            return new Resource(newLabels);
+            return new Resource(newAttributes);
         }
 
-        private static void ValidateLabels(IEnumerable<KeyValuePair<string, string>> labels)
+        private static void ValidateAttributes(IEnumerable<KeyValuePair<string, string>> attributes)
         {
-            if (labels == null)
+            if (attributes == null)
             {
-                throw new ArgumentNullException(nameof(labels));
+                throw new ArgumentNullException(nameof(attributes));
             }
 
-            foreach (var label in labels)
+            foreach (var attribute in attributes)
             {
-                if (!IsValidAndNotEmpty(label.Key))
+                if (!IsValidAndNotEmpty(attribute.Key))
                 {
-                    throw new ArgumentException($"Label key should be a string with a length greater than 0 and not exceeding {MaxResourceTypeNameLength} characters.");
+                    throw new ArgumentException($"Attribute key should be a string with a length greater than 0 and not exceeding {MaxResourceTypeNameLength} characters.");
                 }
 
-                if (!IsValid(label.Value))
+                if (!IsValid(attribute.Value))
                 {
-                    throw new ArgumentException($"Label value should be a string with a length not exceeding {MaxResourceTypeNameLength} characters.");
+                    throw new ArgumentException($"Attribute value should be a string with a length not exceeding {MaxResourceTypeNameLength} characters.");
                 }
             }
         }

--- a/src/OpenTelemetry/Resources/Resource.cs
+++ b/src/OpenTelemetry/Resources/Resource.cs
@@ -31,13 +31,13 @@ namespace OpenTelemetry.Resources
         /// <summary>
         /// Maximum length of the resource type name.
         /// </summary>
-        private const int MaxResourceTypeNameLength = 255;
+        internal const int MaxResourceTypeNameLength = 255;
 
         /// <summary>
         /// Creates a new <see cref="Resource"/>.
         /// </summary>
-        /// <param name="attributes">An <see cref="IDictionary{String, String}"/> of attributes that describe the resource.</param>
-        public Resource(IEnumerable<KeyValuePair<string, string>> attributes)
+        /// <param name="attributes">An <see cref="IDictionary{ResourceKey, String}"/> of attributes that describe the resource.</param>
+        public Resource(IEnumerable<KeyValuePair<ResourceKey, string>> attributes)
         {
             ValidateAttributes(attributes);
             this.Attributes = attributes;
@@ -46,12 +46,12 @@ namespace OpenTelemetry.Resources
         /// <summary>
         /// Gets an empty Resource.
         /// </summary>
-        public static Resource Empty { get; } = new Resource(Enumerable.Empty<KeyValuePair<string, string>>());
+        public static Resource Empty { get; } = new Resource(Enumerable.Empty<KeyValuePair<ResourceKey, string>>());
 
         /// <summary>
         /// Gets the collection of key-value pairs describing the resource.
         /// </summary>
-        public IEnumerable<KeyValuePair<string, string>> Attributes { get; }
+        public IEnumerable<KeyValuePair<ResourceKey, string>> Attributes { get; }
 
         /// <summary>
         /// Returns a new, merged <see cref="Resource"/> by merging the current <see cref="Resource"/> with the.
@@ -61,7 +61,7 @@ namespace OpenTelemetry.Resources
         /// <returns><see cref="Resource"/>.</returns>
         public Resource Merge(Resource other)
         {
-            var newAttributes = new Dictionary<string, string>();
+            var newAttributes = new Dictionary<ResourceKey, string>();
 
             foreach (var attribute in this.Attributes)
             {
@@ -85,7 +85,7 @@ namespace OpenTelemetry.Resources
             return new Resource(newAttributes);
         }
 
-        private static void ValidateAttributes(IEnumerable<KeyValuePair<string, string>> attributes)
+        private static void ValidateAttributes(IEnumerable<KeyValuePair<ResourceKey, string>> attributes)
         {
             if (attributes == null)
             {
@@ -94,7 +94,7 @@ namespace OpenTelemetry.Resources
 
             foreach (var attribute in attributes)
             {
-                if (!IsValidAndNotEmpty(attribute.Key))
+                if (!attribute.Key.IsValid())
                 {
                     throw new ArgumentException($"Attribute key should be a string with a length greater than 0 and not exceeding {MaxResourceTypeNameLength} characters.");
                 }
@@ -104,11 +104,6 @@ namespace OpenTelemetry.Resources
                     throw new ArgumentException($"Attribute value should be a string with a length not exceeding {MaxResourceTypeNameLength} characters.");
                 }
             }
-        }
-
-        private static bool IsValidAndNotEmpty(string name)
-        {
-            return !string.IsNullOrEmpty(name) && IsValid(name);
         }
 
         private static bool IsValid(string name)

--- a/src/OpenTelemetry/Resources/ResourceKey.cs
+++ b/src/OpenTelemetry/Resources/ResourceKey.cs
@@ -1,0 +1,102 @@
+// <copyright file="ResourceKey.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using OpenTelemetry.Utils;
+
+namespace OpenTelemetry.Resources
+{
+    public readonly struct ResourceKey : IEquatable<ResourceKey>
+    {
+        private readonly int intValue;
+        private readonly double doubleValue;
+        private readonly string stringValue;
+        private readonly Type type;
+
+        private ResourceKey(Type type, int intValue = 0, double doubleValue = 0, string stringValue = null)
+        {
+            this.type = type;
+            this.intValue = intValue;
+            this.doubleValue = doubleValue;
+            this.stringValue = stringValue;
+        }
+
+        public static implicit operator ResourceKey(int value) => new ResourceKey(typeof(int), value);
+
+        public static implicit operator ResourceKey(double value) =>
+            new ResourceKey(typeof(double), doubleValue: value);
+
+        public static implicit operator ResourceKey(string value) =>
+            new ResourceKey(typeof(string), stringValue: value);
+
+        public static bool operator ==(ResourceKey left, ResourceKey right) => left.Equals(right);
+
+        public static bool operator !=(ResourceKey left, ResourceKey right) => !left.Equals(right);
+
+        public bool Equals(ResourceKey other)
+            => this.intValue == other.intValue
+               && this.doubleValue == other.doubleValue
+               && this.stringValue == other.stringValue
+               && Equals(this.type, other.type);
+
+        public override bool Equals(object obj) => obj is ResourceKey other && this.Equals(other);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = this.intValue;
+                hashCode = (hashCode * 397) ^ this.doubleValue.GetHashCode();
+                hashCode = (hashCode * 397) ^ (this.stringValue != null ? this.stringValue.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (this.type != null ? this.type.GetHashCode() : 0);
+                return hashCode;
+            }
+        }
+
+        public override string ToString()
+        {
+            if (this.type == typeof(int))
+            {
+                return this.intValue.ToString(CultureInfo.InvariantCulture);
+            }
+
+            if (this.type == typeof(double))
+            {
+                return this.doubleValue.ToString(CultureInfo.InvariantCulture);
+            }
+
+            if (this.type == typeof(string))
+            {
+                return this.stringValue;
+            }
+
+            Debug.Fail("private ctor, only supported types are defined as implicit operators.");
+            return null;
+        }
+
+        internal bool IsValid()
+            => this != default
+               // TODO: Any validation for int, double, bool?
+               // && this.type != typeof(int) || this.intValue == 0
+               // && this.type != typeof(double) || this.intValue == 0
+               && (this.type != typeof(string)
+                   || !string.IsNullOrWhiteSpace(this.stringValue)
+                   || this.stringValue.Length > Resource.MaxResourceTypeNameLength
+                   || !StringUtil.IsPrintableString(this.stringValue));
+    }
+}

--- a/src/OpenTelemetry/Trace/Configuration/TracerFactory.cs
+++ b/src/OpenTelemetry/Trace/Configuration/TracerFactory.cs
@@ -55,7 +55,7 @@ namespace OpenTelemetry.Trace.Configuration
             }
             else if (builder.ProcessingPipelines.Count == 1)
             {
-                // if there is only one pipeline - use it's outer processor as a 
+                // if there is only one pipeline - use it's outer processor as a
                 // single processor on the tracer.
                 var processorFactory = builder.ProcessingPipelines[0];
                 this.spanProcessor = processorFactory.Build();
@@ -156,15 +156,15 @@ namespace OpenTelemetry.Trace.Configuration
             }
         }
 
-        private static IEnumerable<KeyValuePair<string, string>> CreateLibraryResourceLabels(string name, string version)
+        private static IEnumerable<KeyValuePair<ResourceKey, string>> CreateLibraryResourceLabels(string name, string version)
         {
-            var labels = new Dictionary<string, string> { { "name", name } };
+            var attributes = new Dictionary<ResourceKey, string> { { "name", name } };
             if (!string.IsNullOrEmpty(version))
             {
-                labels.Add("version", version);
+                attributes.Add("version", version);
             }
 
-            return labels;
+            return attributes;
         }
 
         private readonly struct TracerRegistryKey

--- a/test/OpenTelemetry.Tests/Impl/Resources/ResourceTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Resources/ResourceTest.cs
@@ -28,159 +28,137 @@ namespace OpenTelemetry.Impl.Resources
         private static readonly Random Random = new Random();
 
         [Fact]
-        public static void CreateResource_NullLabelCollection()
+        public static void CreateResource_NullAttributeCollection()
         {
             // Act and Assert
             Assert.Throws<ArgumentNullException>(() => new Resource(null));
         }
 
         [Fact]
-        public void CreateResource_NullLabelValue()
+        public void CreateResource_NullAttributeValue()
         {
             // Arrange
-            var labelCount = 3;
-            var labels = CreateLabels(labelCount);
-            labels.Add("NullValue", null);
+            var attributeCount = 3;
+            var attributes = this.CreateAttributes(attributeCount);
+            attributes.Add("NullValue", null);
 
             // Act
-            var ex = Assert.Throws<ArgumentException>(() => new Resource(labels));
+            var ex = Assert.Throws<ArgumentException>(() => new Resource(attributes));
 
             // Assert
-            Assert.Equal("Label value should be a string with a length not exceeding 255 characters.", ex.Message);
+            Assert.Equal("Attribute value should be a string with a length not exceeding 255 characters.", ex.Message);
         }
 
         [Fact]
-        public void CreateResource_EmptyLabelKey()
+        public void CreateResource_EmptyAttributeKey()
         {
             // Arrange
-            var labels = new Dictionary<string, string> { { string.Empty, "value" } };
+            var attributes = new Dictionary<string, string> { { string.Empty, "value" } };
 
             // Act
-            var ex = Assert.Throws<ArgumentException>(() => new Resource(labels));
+            var ex = Assert.Throws<ArgumentException>(() => new Resource(attributes));
 
             // Assert
-            Assert.Equal("Label key should be a string with a length greater than 0 and not exceeding 255 characters.", ex.Message);
+            Assert.Equal("Attribute key should be a string with a length greater than 0 and not exceeding 255 characters.", ex.Message);
         }
 
         [Fact]
-        public void CreateResource_EmptyLabelValue()
+        public void CreateResource_EmptyAttributeValue()
         {
             // Arrange
-            var labels = new Dictionary<string, string> {{"EmptyValue", string.Empty}};
+            var attributes = new Dictionary<string, string> {{"EmptyValue", string.Empty}};
 
             // does not throw
-            var resource = new Resource(labels);
+            var resource = new Resource(attributes);
 
             // Assert
-            Assert.Single(resource.Labels);
-            Assert.Contains(new KeyValuePair<string, string>("EmptyValue", string.Empty), resource.Labels);
+            Assert.Single(resource.Attributes);
+            Assert.Contains(new KeyValuePair<string, string>("EmptyValue", string.Empty), resource.Attributes);
         }
 
         [Fact]
-        public void CreateResource_ExceedsLengthLabelValue()
+        public void CreateResource_ExceedsLengthAttributeValue()
         {
             // Arrange
-            var labels = new Dictionary<string, string> { { "ExceedsLengthValue", RandomString(256) }};
+            var attributes = new Dictionary<string, string> { { "ExceedsLengthValue", RandomString(256) }};
 
             // Act
-            var ex = Assert.Throws<ArgumentException>(() => new Resource(labels));
+            var ex = Assert.Throws<ArgumentException>(() => new Resource(attributes));
 
             // Assert
-            Assert.Equal("Label value should be a string with a length not exceeding 255 characters.", ex.Message);
+            Assert.Equal("Attribute value should be a string with a length not exceeding 255 characters.", ex.Message);
         }
 
 
         [Fact]
-        public void CreateResource_MaxLengthLabelValue()
+        public void CreateResource_MaxLengthAttributeValue()
         {
             // Arrange
-            var labels = new Dictionary<string, string> { { "ExceedsLengthValue", RandomString(255) } };
+            var attributes = new Dictionary<string, string> { { "ExceedsLengthValue", RandomString(255) } };
 
             // Act
-            var resource = new Resource(labels);
+            var resource = new Resource(attributes);
 
             // Assert
             Assert.NotNull(resource);
-            Assert.NotNull(resource.Labels);
-            Assert.Single( resource.Labels);
-            Assert.Contains(labels.Single(), resource.Labels);
+            Assert.NotNull(resource.Attributes);
+            Assert.Single( resource.Attributes);
+            Assert.Contains(attributes.Single(), resource.Attributes);
         }
 
         [Fact]
-        public void CreateResource_EmptyLabel()
+        public void CreateResource_EmptyAttribute()
         {
             // Arrange
-            var labelCount = 0;
-            var labels = CreateLabels(labelCount);
+            var attributeCount = 0;
+            var attributes = this.CreateAttributes(attributeCount);
 
             // Act
-            var resource = new Resource(labels);
+            var resource = new Resource(attributes);
 
             // Assert
-            ValidateResource(resource, labelCount);
+            ValidateResource(resource, attributeCount);
         }
 
         [Fact]
-        public void CreateResource_SingleLabel()
+        public void CreateResource_SingleAttribute()
         {
             // Arrange
-            var labelCount = 1;
-            var labels = CreateLabels(labelCount);
+            var attributeCount = 1;
+            var attributes = this.CreateAttributes(attributeCount);
 
             // Act
-            var resource = new Resource(labels);
+            var resource = new Resource(attributes);
 
             // Assert
-            ValidateResource(resource, labelCount);
+            ValidateResource(resource, attributeCount);
         }
 
         [Fact]
-        public void CreateResource_MultipleLabel()
+        public void CreateResource_MultipleAttribute()
         {
             // Arrange
-            var labelCount = 5;
-            var labels = CreateLabels(labelCount);
+            var attributeCount = 5;
+            var attributes = this.CreateAttributes(attributeCount);
 
             // Act
-            var resource = new Resource(labels);
+            var resource = new Resource(attributes);
 
             // Assert
-            ValidateResource(resource, labelCount);
+            ValidateResource(resource, attributeCount);
         }
 
         [Fact]
-        public void MergeResource_EmptyLabelSource_MultiLabelTarget()
+        public void MergeResource_EmptyAttributeSource_MultiAttributeTarget()
         {
             // Arrange
-            var sourceLabelCount = 0;
-            var sourceLabels = CreateLabels(sourceLabelCount);
-            var sourceResource = new Resource(sourceLabels);
+            var sourceAttributeCount = 0;
+            var sourceAttributes = this.CreateAttributes(sourceAttributeCount);
+            var sourceResource = new Resource(sourceAttributes);
 
-            var otherLabelCount = 3;
-            var otherLabels = CreateLabels(otherLabelCount);
-            var otherResource = new Resource(otherLabels);
-
-            // Act
-            var newResource = sourceResource.Merge(otherResource);
-
-            // Assert
-            Assert.NotSame(otherResource, newResource);
-            Assert.NotSame(sourceResource, newResource);
-
-            ValidateResource(newResource, sourceLabelCount + otherLabelCount);
-        }
-
-        [Fact]
-        public void MergeResource_MultiLabelSource_EmptyLabelTarget()
-        {
-            // Arrange
-            var sourceLabelCount = 3;
-            var sourceLabels = CreateLabels(sourceLabelCount);
-            var sourceResource = new Resource(sourceLabels);
-
-            var otherLabelCount = 0;
-            var otherLabels = CreateLabels(otherLabelCount);
-            var otherResource = new Resource(otherLabels);
+            var otherAttributeCount = 3;
+            var otherAttributes = this.CreateAttributes(otherAttributeCount);
+            var otherResource = new Resource(otherAttributes);
 
             // Act
             var newResource = sourceResource.Merge(otherResource);
@@ -188,20 +166,21 @@ namespace OpenTelemetry.Impl.Resources
             // Assert
             Assert.NotSame(otherResource, newResource);
             Assert.NotSame(sourceResource, newResource);
-            ValidateResource(newResource, sourceLabelCount + otherLabelCount);
+
+            ValidateResource(newResource, sourceAttributeCount + otherAttributeCount);
         }
 
         [Fact]
-        public void MergeResource_MultiLabelSource_MultiLabelTarget_NoOverlap()
+        public void MergeResource_MultiAttributeSource_EmptyAttributeTarget()
         {
             // Arrange
-            var sourceLabelCount = 3;
-            var sourceLabels = CreateLabels(sourceLabelCount);
-            var sourceResource = new Resource(sourceLabels);
+            var sourceAttributeCount = 3;
+            var sourceAttributes = this.CreateAttributes(sourceAttributeCount);
+            var sourceResource = new Resource(sourceAttributes);
 
-            var otherLabelCount = 3;
-            var otherLabels = CreateLabels(otherLabelCount, sourceLabelCount);
-            var otherResource = new Resource(otherLabels);
+            var otherAttributeCount = 0;
+            var otherAttributes = this.CreateAttributes(otherAttributeCount);
+            var otherResource = new Resource(otherAttributes);
 
             // Act
             var newResource = sourceResource.Merge(otherResource);
@@ -209,20 +188,20 @@ namespace OpenTelemetry.Impl.Resources
             // Assert
             Assert.NotSame(otherResource, newResource);
             Assert.NotSame(sourceResource, newResource);
-            ValidateResource(newResource, sourceLabelCount + otherLabelCount);
+            ValidateResource(newResource, sourceAttributeCount + otherAttributeCount);
         }
 
         [Fact]
-        public void MergeResource_MultiLabelSource_MultiLabelTarget_SingleOverlap()
+        public void MergeResource_MultiAttributeSource_MultiAttributeTarget_NoOverlap()
         {
             // Arrange
-            var sourceLabelCount = 3;
-            var sourceLabels = CreateLabels(sourceLabelCount);
-            var sourceResource = new Resource(sourceLabels);
+            var sourceAttributeCount = 3;
+            var sourceAttributes = this.CreateAttributes(sourceAttributeCount);
+            var sourceResource = new Resource(sourceAttributes);
 
-            var otherLabelCount = 3;
-            var otherLabels = CreateLabels(otherLabelCount, sourceLabelCount - 1);
-            var otherResource = new Resource(otherLabels);
+            var otherAttributeCount = 3;
+            var otherAttributes = this.CreateAttributes(otherAttributeCount, sourceAttributeCount);
+            var otherResource = new Resource(otherAttributes);
 
             // Act
             var newResource = sourceResource.Merge(otherResource);
@@ -230,26 +209,47 @@ namespace OpenTelemetry.Impl.Resources
             // Assert
             Assert.NotSame(otherResource, newResource);
             Assert.NotSame(sourceResource, newResource);
-            ValidateResource(newResource, sourceLabelCount + otherLabelCount - 1);
+            ValidateResource(newResource, sourceAttributeCount + otherAttributeCount);
+        }
 
-            // Also verify target labels were not overwritten
-            foreach (var otherLabel in otherLabels)
+        [Fact]
+        public void MergeResource_MultiAttributeSource_MultiAttributeTarget_SingleOverlap()
+        {
+            // Arrange
+            var sourceAttributeCount = 3;
+            var sourceAttributes = this.CreateAttributes(sourceAttributeCount);
+            var sourceResource = new Resource(sourceAttributes);
+
+            var otherAttributeCount = 3;
+            var otherAttributes = this.CreateAttributes(otherAttributeCount, sourceAttributeCount - 1);
+            var otherResource = new Resource(otherAttributes);
+
+            // Act
+            var newResource = sourceResource.Merge(otherResource);
+
+            // Assert
+            Assert.NotSame(otherResource, newResource);
+            Assert.NotSame(sourceResource, newResource);
+            ValidateResource(newResource, sourceAttributeCount + otherAttributeCount - 1);
+
+            // Also verify target attributes were not overwritten
+            foreach (var otherAttribute in otherAttributes)
             {
-                Assert.Contains(otherLabel, otherResource.Labels);
+                Assert.Contains(otherAttribute, otherResource.Attributes);
             }
         }
 
         [Fact]
-        public void MergeResource_MultiLabelSource_MultiLabelTarget_FullOverlap()
+        public void MergeResource_MultiAttributeSource_MultiAttributeTarget_FullOverlap()
         {
             // Arrange
-            var sourceLabelCount = 3;
-            var sourceLabels = CreateLabels(sourceLabelCount);
-            var sourceResource = new Resource(sourceLabels);
+            var sourceAttributeCount = 3;
+            var sourceAttributes = this.CreateAttributes(sourceAttributeCount);
+            var sourceResource = new Resource(sourceAttributes);
 
-            var otherLabelCount = 3;
-            var otherLabels = CreateLabels(otherLabelCount);
-            var otherResource = new Resource(otherLabels);
+            var otherAttributeCount = 3;
+            var otherAttributes = this.CreateAttributes(otherAttributeCount);
+            var otherResource = new Resource(otherAttributes);
 
             // Act
             var newResource = sourceResource.Merge(otherResource);
@@ -257,32 +257,32 @@ namespace OpenTelemetry.Impl.Resources
             // Assert
             Assert.NotSame(otherResource, newResource);
             Assert.NotSame(sourceResource, newResource);
-            ValidateResource(newResource, otherLabelCount);
+            ValidateResource(newResource, otherAttributeCount);
 
-            // Also verify target labels were not overwritten
-            foreach (var otherLabel in otherLabels)
+            // Also verify target attributes were not overwritten
+            foreach (var otherAttribute in otherAttributes)
             {
-                Assert.Contains(otherLabel, otherResource.Labels);
+                Assert.Contains(otherAttribute, otherResource.Attributes);
             }
         }
 
         [Fact]
-        public void MergeResource_MultiLabelSource_DuplicatedKeysInPrimary()
+        public void MergeResource_MultiAttributeSource_DuplicatedKeysInPrimary()
         {
             // Arrange
-            var sourceLabels = new List<KeyValuePair<string, string>>
+            var sourceAttributes = new List<KeyValuePair<string, string>>
             {
                 new KeyValuePair<string, string>("key1", "value1"),
                 new KeyValuePair<string, string>("key1", "value1.1"),
             };
-            var sourceResource = new Resource(sourceLabels);
+            var sourceResource = new Resource(sourceAttributes);
 
-            var otherLabels = new List<KeyValuePair<string, string>>
+            var otherAttributes = new List<KeyValuePair<string, string>>
             {
                 new KeyValuePair<string, string>("key2", "value2"),
             };
 
-            var otherResource = new Resource(otherLabels);
+            var otherResource = new Resource(otherAttributes);
 
             // Act
             var newResource = sourceResource.Merge(otherResource);
@@ -291,45 +291,45 @@ namespace OpenTelemetry.Impl.Resources
             Assert.NotSame(otherResource, newResource);
             Assert.NotSame(sourceResource, newResource);
 
-            Assert.Equal(2, newResource.Labels.Count());
-            Assert.Contains(new KeyValuePair<string, string>("key1", "value1"), newResource.Labels);
-            Assert.Contains(new KeyValuePair<string, string>("key2", "value2"), newResource.Labels);
+            Assert.Equal(2, newResource.Attributes.Count());
+            Assert.Contains(new KeyValuePair<string, string>("key1", "value1"), newResource.Attributes);
+            Assert.Contains(new KeyValuePair<string, string>("key2", "value2"), newResource.Attributes);
         }
 
         [Fact]
-        public void MergeResource_SecondaryCanOverridePrimaryEmptyLabelValue()
+        public void MergeResource_SecondaryCanOverridePrimaryEmptyAttributeValue()
         {
             // Arrange
-            var primaryLabels = new Dictionary<string, string> { { "value", string.Empty } };
-            var secondaryLabels = new Dictionary<string, string> { { "value", "not empty" } };
-            var primaryResource = new Resource(primaryLabels);
-            var secondaryResource = new Resource(secondaryLabels);
+            var primaryAttributes = new Dictionary<string, string> { { "value", string.Empty } };
+            var secondaryAttributes = new Dictionary<string, string> { { "value", "not empty" } };
+            var primaryResource = new Resource(primaryAttributes);
+            var secondaryResource = new Resource(secondaryAttributes);
 
             var newResource = primaryResource.Merge(secondaryResource);
 
             // Assert
-            Assert.Single(newResource.Labels);
-            Assert.Contains(new KeyValuePair<string, string>("value", "not empty"), newResource.Labels);
+            Assert.Single(newResource.Attributes);
+            Assert.Contains(new KeyValuePair<string, string>("value", "not empty"), newResource.Attributes);
         }
 
-        private static void AddLabels(Dictionary<string, string> labels, int labelCount, int startIndex = 0)
+        private static void AddAttributes(Dictionary<string, string> attributes, int attributeCount, int startIndex = 0)
         {
-            for (var i = startIndex; i < labelCount + startIndex; ++i)
+            for (var i = startIndex; i < attributeCount + startIndex; ++i)
             {
-                labels.Add($"{KeyName}{i}", $"{ValueName}{i}");
+                attributes.Add($"{KeyName}{i}", $"{ValueName}{i}");
             }
         }
 
-        private Dictionary<string, string> CreateLabels(int labelCount, int startIndex = 0)
+        private Dictionary<string, string> CreateAttributes(int attributeCount, int startIndex = 0)
         {
-            var labels = new Dictionary<string, string>();
-            AddLabels(labels, labelCount, startIndex);
-            return labels;
+            var attributes = new Dictionary<string, string>();
+            AddAttributes(attributes, attributeCount, startIndex);
+            return attributes;
         }
 
-        private static void ValidateLabels(IEnumerable<KeyValuePair<string, string>> labels, int startIndex = 0)
+        private static void ValidateAttributes(IEnumerable<KeyValuePair<string, string>> attributes, int startIndex = 0)
         {
-            var keyValuePairs = labels as KeyValuePair<string, string>[] ?? labels.ToArray();
+            var keyValuePairs = attributes as KeyValuePair<string, string>[] ?? attributes.ToArray();
             for (var i = startIndex; i < keyValuePairs.Length; ++i)
             {
                 Assert.Contains(new KeyValuePair<string, string>(
@@ -337,12 +337,12 @@ namespace OpenTelemetry.Impl.Resources
             }
         }
 
-        private static void ValidateResource(Resource resource, int labelCount)
+        private static void ValidateResource(Resource resource, int attributeCount)
         {
             Assert.NotNull(resource);
-            Assert.NotNull(resource.Labels);
-            Assert.Equal(labelCount, resource.Labels.Count());
-            ValidateLabels(resource.Labels);
+            Assert.NotNull(resource.Attributes);
+            Assert.Equal(attributeCount, resource.Attributes.Count());
+            ValidateAttributes(resource.Attributes);
         }
 
         private static string RandomString(int length)

--- a/test/OpenTelemetry.Tests/Impl/Resources/ResourceTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Resources/ResourceTest.cs
@@ -53,7 +53,7 @@ namespace OpenTelemetry.Impl.Resources
         public void CreateResource_EmptyAttributeKey()
         {
             // Arrange
-            var attributes = new Dictionary<string, string> { { string.Empty, "value" } };
+            var attributes = new Dictionary<ResourceKey, string> { { string.Empty, "value" } };
 
             // Act
             var ex = Assert.Throws<ArgumentException>(() => new Resource(attributes));
@@ -66,21 +66,21 @@ namespace OpenTelemetry.Impl.Resources
         public void CreateResource_EmptyAttributeValue()
         {
             // Arrange
-            var attributes = new Dictionary<string, string> {{"EmptyValue", string.Empty}};
+            var attributes = new Dictionary<ResourceKey, string> {{"EmptyValue", string.Empty}};
 
             // does not throw
             var resource = new Resource(attributes);
 
             // Assert
             Assert.Single(resource.Attributes);
-            Assert.Contains(new KeyValuePair<string, string>("EmptyValue", string.Empty), resource.Attributes);
+            Assert.Contains(new KeyValuePair<ResourceKey, string>("EmptyValue", string.Empty), resource.Attributes);
         }
 
         [Fact]
         public void CreateResource_ExceedsLengthAttributeValue()
         {
             // Arrange
-            var attributes = new Dictionary<string, string> { { "ExceedsLengthValue", RandomString(256) }};
+            var attributes = new Dictionary<ResourceKey, string> { { "ExceedsLengthValue", RandomString(256) }};
 
             // Act
             var ex = Assert.Throws<ArgumentException>(() => new Resource(attributes));
@@ -94,7 +94,7 @@ namespace OpenTelemetry.Impl.Resources
         public void CreateResource_MaxLengthAttributeValue()
         {
             // Arrange
-            var attributes = new Dictionary<string, string> { { "ExceedsLengthValue", RandomString(255) } };
+            var attributes = new Dictionary<ResourceKey, string> { { "ExceedsLengthValue", RandomString(255) } };
 
             // Act
             var resource = new Resource(attributes);
@@ -270,16 +270,16 @@ namespace OpenTelemetry.Impl.Resources
         public void MergeResource_MultiAttributeSource_DuplicatedKeysInPrimary()
         {
             // Arrange
-            var sourceAttributes = new List<KeyValuePair<string, string>>
+            var sourceAttributes = new List<KeyValuePair<ResourceKey, string>>
             {
-                new KeyValuePair<string, string>("key1", "value1"),
-                new KeyValuePair<string, string>("key1", "value1.1"),
+                new KeyValuePair<ResourceKey, string>("key1", "value1"),
+                new KeyValuePair<ResourceKey, string>("key1", "value1.1"),
             };
             var sourceResource = new Resource(sourceAttributes);
 
-            var otherAttributes = new List<KeyValuePair<string, string>>
+            var otherAttributes = new List<KeyValuePair<ResourceKey, string>>
             {
-                new KeyValuePair<string, string>("key2", "value2"),
+                new KeyValuePair<ResourceKey, string>("key2", "value2"),
             };
 
             var otherResource = new Resource(otherAttributes);
@@ -292,16 +292,16 @@ namespace OpenTelemetry.Impl.Resources
             Assert.NotSame(sourceResource, newResource);
 
             Assert.Equal(2, newResource.Attributes.Count());
-            Assert.Contains(new KeyValuePair<string, string>("key1", "value1"), newResource.Attributes);
-            Assert.Contains(new KeyValuePair<string, string>("key2", "value2"), newResource.Attributes);
+            Assert.Contains(new KeyValuePair<ResourceKey, string>("key1", "value1"), newResource.Attributes);
+            Assert.Contains(new KeyValuePair<ResourceKey, string>("key2", "value2"), newResource.Attributes);
         }
 
         [Fact]
         public void MergeResource_SecondaryCanOverridePrimaryEmptyAttributeValue()
         {
             // Arrange
-            var primaryAttributes = new Dictionary<string, string> { { "value", string.Empty } };
-            var secondaryAttributes = new Dictionary<string, string> { { "value", "not empty" } };
+            var primaryAttributes = new Dictionary<ResourceKey, string> { { "value", string.Empty } };
+            var secondaryAttributes = new Dictionary<ResourceKey, string> { { "value", "not empty" } };
             var primaryResource = new Resource(primaryAttributes);
             var secondaryResource = new Resource(secondaryAttributes);
 
@@ -309,10 +309,10 @@ namespace OpenTelemetry.Impl.Resources
 
             // Assert
             Assert.Single(newResource.Attributes);
-            Assert.Contains(new KeyValuePair<string, string>("value", "not empty"), newResource.Attributes);
+            Assert.Contains(new KeyValuePair<ResourceKey, string>("value", "not empty"), newResource.Attributes);
         }
 
-        private static void AddAttributes(Dictionary<string, string> attributes, int attributeCount, int startIndex = 0)
+        private static void AddAttributes(Dictionary<ResourceKey, string> attributes, int attributeCount, int startIndex = 0)
         {
             for (var i = startIndex; i < attributeCount + startIndex; ++i)
             {
@@ -320,19 +320,19 @@ namespace OpenTelemetry.Impl.Resources
             }
         }
 
-        private Dictionary<string, string> CreateAttributes(int attributeCount, int startIndex = 0)
+        private Dictionary<ResourceKey, string> CreateAttributes(int attributeCount, int startIndex = 0)
         {
-            var attributes = new Dictionary<string, string>();
+            var attributes = new Dictionary<ResourceKey, string>();
             AddAttributes(attributes, attributeCount, startIndex);
             return attributes;
         }
 
-        private static void ValidateAttributes(IEnumerable<KeyValuePair<string, string>> attributes, int startIndex = 0)
+        private static void ValidateAttributes(IEnumerable<KeyValuePair<ResourceKey, string>> attributes, int startIndex = 0)
         {
-            var keyValuePairs = attributes as KeyValuePair<string, string>[] ?? attributes.ToArray();
+            var keyValuePairs = attributes as KeyValuePair<ResourceKey, string>[] ?? attributes.ToArray();
             for (var i = startIndex; i < keyValuePairs.Length; ++i)
             {
-                Assert.Contains(new KeyValuePair<string, string>(
+                Assert.Contains(new KeyValuePair<ResourceKey, string>(
                     $"{KeyName}{i}", $"{ValueName}{i}"), keyValuePairs);
             }
         }

--- a/test/OpenTelemetry.Tests/Impl/Trace/Config/TracerFactoryTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Config/TracerFactoryTest.cs
@@ -97,8 +97,8 @@ namespace OpenTelemetry.Trace.Test
             // default sampler is always sample
             Assert.True(span.IsRecording);
             Assert.Equal(1, exporterCalledCount);
-            Assert.Single(((Span)span).LibraryResource.Labels);
-            Assert.Single(((Span)span).LibraryResource.Labels.Where(kvp => kvp.Key == "name" && kvp.Value == "my-app"));
+            Assert.Single(((Span)span).LibraryResource.Attributes);
+            Assert.Single(((Span)span).LibraryResource.Attributes.Where(kvp => kvp.Key == "name" && kvp.Value == "my-app"));
 
             Assert.NotNull(collector1);
             Assert.NotNull(collector2);
@@ -109,13 +109,13 @@ namespace OpenTelemetry.Trace.Test
 
             Assert.Equal(3, exporterCalledCount);
 
-            Assert.Equal(2, span1.LibraryResource.Labels.Count());
-            Assert.Equal(2, span2.LibraryResource.Labels.Count());
-            Assert.Single(span1.LibraryResource.Labels.Where(kvp => kvp.Key == "name" && kvp.Value == "TestCollector"));
-            Assert.Single(span2.LibraryResource.Labels.Where(kvp => kvp.Key == "name" && kvp.Value == "TestCollector"));
+            Assert.Equal(2, span1.LibraryResource.Attributes.Count());
+            Assert.Equal(2, span2.LibraryResource.Attributes.Count());
+            Assert.Single(span1.LibraryResource.Attributes.Where(kvp => kvp.Key == "name" && kvp.Value == "TestCollector"));
+            Assert.Single(span2.LibraryResource.Attributes.Where(kvp => kvp.Key == "name" && kvp.Value == "TestCollector"));
 
-            Assert.Single(span1.LibraryResource.Labels.Where(kvp => kvp.Key == "version" && kvp.Value == "semver:1.0.0.0"));
-            Assert.Single(span2.LibraryResource.Labels.Where(kvp => kvp.Key == "version" && kvp.Value == "semver:1.0.0.0"));
+            Assert.Single(span1.LibraryResource.Attributes.Where(kvp => kvp.Key == "version" && kvp.Value == "semver:1.0.0.0"));
+            Assert.Single(span2.LibraryResource.Attributes.Where(kvp => kvp.Key == "version" && kvp.Value == "semver:1.0.0.0"));
 
             tracerFactory.Dispose();
             Assert.True(collector1.IsDisposed);
@@ -169,8 +169,8 @@ namespace OpenTelemetry.Trace.Test
         {
             var tracerFactory = TracerFactory.Create(b => { });
             var tracer = (Tracer)tracerFactory.GetTracer("");
-            Assert.DoesNotContain(tracer.LibraryResource.Labels, kvp => kvp.Key == "name");
-            Assert.DoesNotContain(tracer.LibraryResource.Labels, kvp => kvp.Key == "version");
+            Assert.DoesNotContain(tracer.LibraryResource.Attributes, kvp => kvp.Key == "name");
+            Assert.DoesNotContain(tracer.LibraryResource.Attributes, kvp => kvp.Key == "version");
         }
 
         [Fact]
@@ -178,8 +178,8 @@ namespace OpenTelemetry.Trace.Test
         {
             var tracerFactory = TracerFactory.Create(b => { });
             var tracer = (Tracer)tracerFactory.GetTracer(null, "semver:1.0.0");
-            Assert.DoesNotContain(tracer.LibraryResource.Labels, kvp => kvp.Key == "name");
-            Assert.DoesNotContain(tracer.LibraryResource.Labels, kvp => kvp.Key == "version");
+            Assert.DoesNotContain(tracer.LibraryResource.Attributes, kvp => kvp.Key == "name");
+            Assert.DoesNotContain(tracer.LibraryResource.Attributes, kvp => kvp.Key == "version");
         }
 
         [Fact]
@@ -187,8 +187,8 @@ namespace OpenTelemetry.Trace.Test
         {
             var tracerFactory = TracerFactory.Create(b => { });
             var tracer = (Tracer)tracerFactory.GetTracer("foo");
-            Assert.Equal("foo", tracer.LibraryResource.Labels.Single(kvp => kvp.Key == "name").Value);
-            Assert.DoesNotContain(tracer.LibraryResource.Labels, kvp => kvp.Key == "version");
+            Assert.Equal("foo", tracer.LibraryResource.Attributes.Single(kvp => kvp.Key == "name").Value);
+            Assert.DoesNotContain(tracer.LibraryResource.Attributes, kvp => kvp.Key == "version");
         }
 
         [Fact]
@@ -196,8 +196,8 @@ namespace OpenTelemetry.Trace.Test
         {
             var tracerFactory = TracerFactory.Create(b => { });
             var tracer = (Tracer)tracerFactory.GetTracer("foo", "semver:1.2.3");
-            Assert.Equal("foo", tracer.LibraryResource.Labels.Single(kvp => kvp.Key == "name").Value);
-            Assert.Equal("semver:1.2.3", tracer.LibraryResource.Labels.Single(kvp => kvp.Key == "version").Value);
+            Assert.Equal("foo", tracer.LibraryResource.Attributes.Single(kvp => kvp.Key == "name").Value);
+            Assert.Equal("semver:1.2.3", tracer.LibraryResource.Attributes.Single(kvp => kvp.Key == "version").Value);
         }
 
         [Fact]
@@ -205,9 +205,9 @@ namespace OpenTelemetry.Trace.Test
         {
             var tracerFactory = TracerFactory.Create(b => { b.SetResource(new Resource(new Dictionary<string, string>() { { "a", "b" } })); });
             var tracer = (Tracer)tracerFactory.GetTracer("foo", "semver:1.2.3");
-            Assert.Equal("b", tracer.LibraryResource.Labels.Single(kvp => kvp.Key == "a").Value);
-            Assert.Equal("foo", tracer.LibraryResource.Labels.Single(kvp => kvp.Key == "name").Value);
-            Assert.Equal("semver:1.2.3", tracer.LibraryResource.Labels.Single(kvp => kvp.Key == "version").Value);
+            Assert.Equal("b", tracer.LibraryResource.Attributes.Single(kvp => kvp.Key == "a").Value);
+            Assert.Equal("foo", tracer.LibraryResource.Attributes.Single(kvp => kvp.Key == "name").Value);
+            Assert.Equal("semver:1.2.3", tracer.LibraryResource.Attributes.Single(kvp => kvp.Key == "version").Value);
         }
 
         [Fact]
@@ -217,7 +217,7 @@ namespace OpenTelemetry.Trace.Test
                 b.SetResource(new Resource(new Dictionary<string, string>() { { "a", "b" } }))
                 .SetResource(new Resource(new Dictionary<string, string>() { { "a", "c" } })); });
             var tracer = (Tracer)tracerFactory.GetTracer("foo", "semver:1.2.3");
-            Assert.Equal("c", tracer.LibraryResource.Labels.Single(kvp => kvp.Key == "a").Value);
+            Assert.Equal("c", tracer.LibraryResource.Attributes.Single(kvp => kvp.Key == "a").Value);
         }
 
         [Fact]

--- a/test/OpenTelemetry.Tests/Impl/Trace/Config/TracerFactoryTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Config/TracerFactoryTest.cs
@@ -140,7 +140,7 @@ namespace OpenTelemetry.Trace.Test
 
             TestProcessor testProcessor1 = null;
             var testProcessor2 = new TestProcessor(_ => processCalledCount ++);
-            
+
             var tracerFactory = TracerFactory.Create(b => b
                 .AddProcessorPipeline(p => p
                     .SetExporter(testExporter)
@@ -163,7 +163,7 @@ namespace OpenTelemetry.Trace.Test
             Assert.True(testProcessor1.IsDisposed);
             Assert.True(testProcessor2.IsDisposed);
         }
-        
+
         [Fact]
         public void GetTracer_NoName_NoVersion()
         {
@@ -203,7 +203,7 @@ namespace OpenTelemetry.Trace.Test
         [Fact]
         public void GetTracerReturnsTracerWithResourceAfterSetResource()
         {
-            var tracerFactory = TracerFactory.Create(b => { b.SetResource(new Resource(new Dictionary<string, string>() { { "a", "b" } })); });
+            var tracerFactory = TracerFactory.Create(b => { b.SetResource(new Resource(new Dictionary<ResourceKey, string>() { { "a", "b" } })); });
             var tracer = (Tracer)tracerFactory.GetTracer("foo", "semver:1.2.3");
             Assert.Equal("b", tracer.LibraryResource.Attributes.Single(kvp => kvp.Key == "a").Value);
             Assert.Equal("foo", tracer.LibraryResource.Attributes.Single(kvp => kvp.Key == "name").Value);
@@ -213,9 +213,9 @@ namespace OpenTelemetry.Trace.Test
         [Fact]
         public void GetTracerReturnsTracerWithResourceOverriddenBySetResource()
         {
-            var tracerFactory = TracerFactory.Create(b => { 
-                b.SetResource(new Resource(new Dictionary<string, string>() { { "a", "b" } }))
-                .SetResource(new Resource(new Dictionary<string, string>() { { "a", "c" } })); });
+            var tracerFactory = TracerFactory.Create(b => {
+                b.SetResource(new Resource(new Dictionary<ResourceKey, string>() { { "a", "b" } }))
+                .SetResource(new Resource(new Dictionary<ResourceKey, string>() { { "a", "c" } })); });
             var tracer = (Tracer)tracerFactory.GetTracer("foo", "semver:1.2.3");
             Assert.Equal("c", tracer.LibraryResource.Attributes.Single(kvp => kvp.Key == "a").Value);
         }


### PR DESCRIPTION
An attempt to come up with a "union type" for the Resource Value.
Since this might be total crap, I'm opening a draft to discuss before investing time.

If we decided to move on with this, we'd need to discuss/consider:

1. When mapping attributes from OTel which have a value of type `ResourceValue` to a `string` like in the case of Zipkin, what would be correct behavior be? Is there any consideration to the `ToString` formatting of this or simply calling `ToString` on all the inner types is good enough?
2. Needs tests for validation and also using the API not only with `string` value but also the other types
3. Implement the correct types. Spec says: `string, int64, double, bool.`
4. Add `in` when taking `ResourceValue` as a parameter in the SDK/API.
5. Write some benchmarks (probably before anything) to make sure this isn't prohibitively slow.

