### PR TITLE
Experiment: C# 8 and nullable reference types

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/open-telemetry/opentelemetry-dotnet</PackageProjectUrl>
-	<LangVersion>7.3</LangVersion>
+	<LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceContextFormat.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceContextFormat.cs
@@ -61,7 +61,7 @@ namespace OpenTelemetry.Context.Propagation
                     return SpanContext.BlankRemote;
                 }
 
-                List<KeyValuePair<string, string>> tracestate = null;
+                List<KeyValuePair<string, string>>? tracestate = null;
                 var tracestateCollection = getter(carrier, "tracestate");
                 if (tracestateCollection != null)
                 {
@@ -234,7 +234,7 @@ namespace OpenTelemetry.Context.Propagation
             throw new ArgumentOutOfRangeException(nameof(c), $"Invalid character: {c}.");
         }
 
-        private bool TryExtractTracestate(string[] tracestateCollection, out List<KeyValuePair<string, string>> tracestateResult)
+        private bool TryExtractTracestate(string[] tracestateCollection, out List<KeyValuePair<string, string>>? tracestateResult)
         {
             tracestateResult = null;
 

--- a/src/OpenTelemetry.Api/Context/Propagation/TracestateUtils.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TracestateUtils.cs
@@ -43,7 +43,6 @@ namespace OpenTelemetry.Context.Propagation
         /// <returns>True if string was parsed successfully and tracestate was recognized, false otherwise.</returns>
         internal static bool AppendTracestate(string tracestateString, List<KeyValuePair<string, string>> tracestate)
         {
-            Debug.Assert(tracestate != null, "tracestate list cannot be null");
             if (string.IsNullOrEmpty(tracestateString))
             {
                 return false;

--- a/src/OpenTelemetry.Api/Metrics/MeterFactoryBase.cs
+++ b/src/OpenTelemetry.Api/Metrics/MeterFactoryBase.cs
@@ -37,7 +37,7 @@ namespace OpenTelemetry.Metrics
         /// <param name="name">Name of the instrumentation library.</param>
         /// <param name="version">Version of the instrumentation library (optional).</param>
         /// <returns>Meter with the given component name and version.</returns>
-        public virtual Meter GetMeter(string name, string version = null)
+        public virtual Meter GetMeter(string name, string? version = null)
         {
             return noOpMeter;
         }

--- a/src/OpenTelemetry.Api/OpenTelemetry.Api.csproj
+++ b/src/OpenTelemetry.Api/OpenTelemetry.Api.csproj
@@ -4,6 +4,7 @@
     <Description>OpenTelemetry .NET instrumentation API</Description>
     <RootNamespace>OpenTelemetry</RootNamespace>
     <DefineConstants>$(DefineConstants);API</DefineConstants>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Trace\Internal\**" />

--- a/src/OpenTelemetry.Api/Trace/ITracer.cs
+++ b/src/OpenTelemetry.Api/Trace/ITracer.cs
@@ -58,7 +58,7 @@ namespace OpenTelemetry.Trace
         /// <param name="kind">Kind.</param>
         /// <param name="options">Advanced span creation options.</param>
         /// <returns>Span instance.</returns>
-        ISpan StartRootSpan(string operationName, SpanKind kind, SpanCreationOptions options);
+        ISpan StartRootSpan(string operationName, SpanKind kind, SpanCreationOptions? options);
 
         /// <summary>
         /// Starts span.
@@ -68,7 +68,7 @@ namespace OpenTelemetry.Trace
         /// <param name="kind">Kind.</param>
         /// <param name="options">Advanced span creation options.</param>
         /// <returns>Span instance.</returns>
-        ISpan StartSpan(string operationName, ISpan parent, SpanKind kind, SpanCreationOptions options);
+        ISpan StartSpan(string operationName, ISpan? parent, SpanKind kind, SpanCreationOptions? options);
 
        /// <summary>
         /// Starts span.
@@ -78,7 +78,7 @@ namespace OpenTelemetry.Trace
         /// <param name="kind">Kind.</param>
         /// <param name="options">Advanced span creation options.</param>
         /// <returns>Span instance.</returns>
-        ISpan StartSpan(string operationName, in SpanContext parent, SpanKind kind, SpanCreationOptions options);
+        ISpan StartSpan(string operationName, in SpanContext parent, SpanKind kind, SpanCreationOptions? options);
 
         /// <summary>
         /// Starts span from auto-collected <see cref="Activity"/>.
@@ -88,6 +88,6 @@ namespace OpenTelemetry.Trace
         /// <param name="kind">Kind.</param>
         /// <param name="links">Links collection.</param>
         /// <returns>Span scope instance.</returns>
-        ISpan StartSpanFromActivity(string operationName, Activity activity, SpanKind kind, IEnumerable<Link> links);
+        ISpan StartSpanFromActivity(string operationName, Activity activity, SpanKind kind, IEnumerable<Link>? links);
     }
 }

--- a/src/OpenTelemetry.Api/Trace/ProxyTracer.cs
+++ b/src/OpenTelemetry.Api/Trace/ProxyTracer.cs
@@ -31,7 +31,7 @@ namespace OpenTelemetry.Trace
         private readonly IBinaryFormat binaryFormat = new BinaryFormat();
         private readonly ITextFormat textFormat = new TraceContextFormat();
 
-        private ITracer realTracer;
+        private ITracer? realTracer;
 
         /// <inheritdoc/>
         public ISpan CurrentSpan => this.realTracer?.CurrentSpan ?? BlankSpan.Instance;
@@ -48,22 +48,22 @@ namespace OpenTelemetry.Trace
             return this.realTracer != null ? this.realTracer.WithSpan(span, endOnDispose) : NoopScope;
         }
 
-        public ISpan StartRootSpan(string operationName, SpanKind kind, SpanCreationOptions options)
+        public ISpan StartRootSpan(string operationName, SpanKind kind, SpanCreationOptions? options)
         {
             return this.realTracer != null ? this.realTracer.StartRootSpan(operationName, kind, options) : BlankSpan.Instance;
         }
 
-        public ISpan StartSpan(string operationName, ISpan parent, SpanKind kind, SpanCreationOptions options)
+        public ISpan StartSpan(string operationName, ISpan? parent, SpanKind kind, SpanCreationOptions? options)
         {
             return this.realTracer != null ? this.realTracer.StartSpan(operationName, parent, kind, options) : BlankSpan.Instance;
         }
 
-        public ISpan StartSpan(string operationName, in SpanContext parent, SpanKind kind, SpanCreationOptions options)
+        public ISpan StartSpan(string operationName, in SpanContext parent, SpanKind kind, SpanCreationOptions? options)
         {
             return this.realTracer != null ? this.realTracer.StartSpan(operationName, parent, kind, options) : BlankSpan.Instance;
         }
 
-        public ISpan StartSpanFromActivity(string operationName, Activity activity, SpanKind kind, IEnumerable<Link> links)
+        public ISpan StartSpanFromActivity(string operationName, Activity activity, SpanKind kind, IEnumerable<Link>? links)
         {
             return this.realTracer != null ? this.realTracer.StartSpanFromActivity(operationName, activity, kind, links) : BlankSpan.Instance;
         }

--- a/src/OpenTelemetry.Api/Trace/SpanContext.cs
+++ b/src/OpenTelemetry.Api/Trace/SpanContext.cs
@@ -45,7 +45,7 @@ namespace OpenTelemetry.Trace
         /// associate with the <see cref="SpanContext"/>.</param>
         /// <param name="isRemote">The value indicating whether this <see cref="SpanContext"/> was propagated from the remote parent.</param>
         /// <param name="tracestate">The tracestate to associate with the <see cref="SpanContext"/>.</param>
-        public SpanContext(ActivityTraceId traceId, ActivitySpanId spanId, ActivityTraceFlags traceOptions, bool isRemote = false, IEnumerable<KeyValuePair<string, string>> tracestate = null)
+        public SpanContext(ActivityTraceId traceId, ActivitySpanId spanId, ActivityTraceFlags traceOptions, bool isRemote = false, IEnumerable<KeyValuePair<string, string>>? tracestate = null)
         {
             this.TraceId = traceId;
             this.SpanId = spanId;

--- a/src/OpenTelemetry.Api/Trace/SpanCreationOptions.cs
+++ b/src/OpenTelemetry.Api/Trace/SpanCreationOptions.cs
@@ -33,17 +33,17 @@ namespace OpenTelemetry.Trace
         /// <summary>
         /// Gets or sets list of <see cref="Link"/>.
         /// </summary>
-        public IEnumerable<Link> Links { get; set; }
+        public IEnumerable<Link>? Links { get; set; }
 
         /// <summary>
         /// Gets or sets attributes known prior to span creation.
         /// </summary>
-        public IDictionary<string, object> Attributes { get; set; }
+        public IDictionary<string, object>? Attributes { get; set; }
 
         /// <summary>
         /// Gets or sets Links factory. Use it to deserialize list of <see cref="Link"/> lazily
         /// when application configures OpenTelemetry implementation that supports links.
         /// </summary>
-        public Func<IEnumerable<Link>> LinksFactory { get; set; }
+        public Func<IEnumerable<Link>>? LinksFactory { get; set; }
     }
 }

--- a/src/OpenTelemetry.Api/Trace/Status.cs
+++ b/src/OpenTelemetry.Api/Trace/Status.cs
@@ -142,7 +142,7 @@ namespace OpenTelemetry.Trace
         /// </summary>
         public static readonly Status DataLoss = new Status(CanonicalCode.DataLoss);
 
-        internal Status(CanonicalCode canonicalCode, string description = null)
+        internal Status(CanonicalCode canonicalCode, string? description = null)
         {
             this.CanonicalCode = canonicalCode;
             this.Description = description;
@@ -163,10 +163,10 @@ namespace OpenTelemetry.Trace
         /// <summary>
         /// Gets the status description.
         /// </summary>
-        public string Description { get; }
+        public string? Description { get; }
 
         /// <summary>
-        /// Gets a value indicating whether span completed sucessfully.
+        /// Gets a value indicating whether span completed successfully.
         /// </summary>
         public bool IsOk
         {
@@ -208,7 +208,7 @@ namespace OpenTelemetry.Trace
         {
             var result = 1;
             result = (31 * result) + this.CanonicalCode.GetHashCode();
-            result = (31 * result) + this.Description.GetHashCode();
+            result = (31 * result) + this.Description?.GetHashCode() ?? 0;
             return result;
         }
 

--- a/src/OpenTelemetry.Api/Trace/TracerExtensions.cs
+++ b/src/OpenTelemetry.Api/Trace/TracerExtensions.cs
@@ -77,7 +77,7 @@ namespace OpenTelemetry.Trace
         /// <param name="kind">Kind.</param>
         /// <param name="options">Advanced span creation options.</param>
         /// <returns>Span instance.</returns>
-        public static ISpan StartSpan(this ITracer tracer, string operationName, SpanKind kind, SpanCreationOptions options)
+        public static ISpan StartSpan(this ITracer tracer, string operationName, SpanKind kind, SpanCreationOptions? options)
         {
             return tracer.StartSpan(operationName, null, kind, options);
         }

--- a/src/OpenTelemetry.Api/Trace/TracerFactoryBase.cs
+++ b/src/OpenTelemetry.Api/Trace/TracerFactoryBase.cs
@@ -68,7 +68,7 @@ namespace OpenTelemetry.Trace
         /// <param name="name">Name of the instrumentation library.</param>
         /// <param name="version">Version of the instrumentation library (optional).</param>
         /// <returns>Tracer for the given name and version information.</returns>
-        public virtual ITracer GetTracer(string name, string version = null)
+        public virtual ITracer GetTracer(string? name, string? version = null)
         {
             return isInitialized ? defaultFactory.GetTracer(name, version) : proxy;
         }


### PR DESCRIPTION
This is again a proposal to start a discussion.
While doing this I found a bug on `GetHashCode` in `Trace/Status.cs`. Since `Description` can be null, it would throw.

Would you be interested in adding C# 8 and moving the code towards nullability checks?

If so, I'd be happy to keep going with this change.

Also worth noting that in the process I believe a few questions will arise, for example should we use more `Array.Empty<>` instead of `null` for parameters taking `IEnumerable` or not.