### PR TITLE
NoOp meters

### DIFF
--- a/src/OpenTelemetry.Api/Metrics/LabelSet.cs
+++ b/src/OpenTelemetry.Api/Metrics/LabelSet.cs
@@ -26,6 +26,11 @@ namespace OpenTelemetry.Metrics
     public class LabelSet
     {
         /// <summary>
+        /// Empty LabelSet.
+        /// </summary>
+        public static readonly LabelSet BlankLabelSet = new LabelSet();
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="LabelSet"/> class.
         /// </summary>
         /// <param name="labels">labels from which labelset should be constructed.</param>
@@ -33,6 +38,10 @@ namespace OpenTelemetry.Metrics
         {
             this.Labels = labels;
             this.LabelSetEncoded = this.GetLabelSetEncoded(labels);
+        }
+
+        private LabelSet()
+        {
         }
 
         /// <summary>

--- a/src/OpenTelemetry.Api/Metrics/NoOpCounter.cs
+++ b/src/OpenTelemetry.Api/Metrics/NoOpCounter.cs
@@ -1,0 +1,47 @@
+﻿// <copyright file="NoOpCounter.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Collections.Generic;
+using OpenTelemetry.Context;
+using OpenTelemetry.Trace;
+
+namespace OpenTelemetry.Metrics
+{
+    /// <summary>
+    /// A no-op counter instrument.
+    /// </summary>
+    /// <typeparam name="T">The type of counter. Only long and double are supported now.</typeparam>
+    public sealed class NoOpCounter<T> : Counter<T>
+        where T : struct
+    {
+        /// <summary>
+        /// No op counter instance.
+        /// </summary>
+        public static readonly NoOpCounter<T> Instance = new NoOpCounter<T>();
+
+        /// <inheritdoc/>
+        public override CounterHandle<T> GetHandle(LabelSet labelset)
+        {
+            return NoOpCounterHandle<T>.Instance;
+        }
+
+        /// <inheritdoc/>
+        public override CounterHandle<T> GetHandle(IEnumerable<KeyValuePair<string, string>> labels)
+        {
+            return NoOpCounterHandle<T>.Instance;
+        }
+    }
+}

--- a/src/OpenTelemetry.Api/Metrics/NoOpCounterHandle.cs
+++ b/src/OpenTelemetry.Api/Metrics/NoOpCounterHandle.cs
@@ -1,0 +1,44 @@
+﻿// <copyright file="NoOpCounterHandle.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using OpenTelemetry.Context;
+using OpenTelemetry.Trace;
+
+namespace OpenTelemetry.Metrics
+{
+    /// <summary>
+    /// No-Op handle.
+    /// </summary>
+    /// <typeparam name="T">The type of counter. Only long and double are supported now.</typeparam>
+    public sealed class NoOpCounterHandle<T> : CounterHandle<T>
+        where T : struct
+    {
+        /// <summary>
+        /// No op counter handle instance.
+        /// </summary>
+        public static readonly NoOpCounterHandle<T> Instance = new NoOpCounterHandle<T>();
+
+        /// <inheritdoc/>
+        public override void Add(in SpanContext context, T value)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override void Add(in DistributedContext context, T value)
+        {
+        }
+    }
+}

--- a/src/OpenTelemetry.Api/Metrics/NoOpGauge.cs
+++ b/src/OpenTelemetry.Api/Metrics/NoOpGauge.cs
@@ -1,0 +1,47 @@
+﻿// <copyright file="NoOpGauge.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Collections.Generic;
+using OpenTelemetry.Context;
+using OpenTelemetry.Trace;
+
+namespace OpenTelemetry.Metrics
+{
+    /// <summary>
+    /// A no-op gauge instrument.
+    /// </summary>
+    /// <typeparam name="T">The type of gauge. Only long and double are supported now.</typeparam>
+    public sealed class NoOpGauge<T> : Gauge<T>
+        where T : struct
+    {
+        /// <summary>
+        /// No op gauge instance.
+        /// </summary>
+        public static readonly NoOpGauge<T> Instance = new NoOpGauge<T>();
+
+        /// <inheritdoc/>
+        public override GaugeHandle<T> GetHandle(LabelSet labelset)
+        {
+            return NoOpGaugeHandle<T>.Instance;
+        }
+
+        /// <inheritdoc/>
+        public override GaugeHandle<T> GetHandle(IEnumerable<KeyValuePair<string, string>> labels)
+        {
+            return NoOpGaugeHandle<T>.Instance;
+        }
+    }
+}

--- a/src/OpenTelemetry.Api/Metrics/NoOpGaugeHandle.cs
+++ b/src/OpenTelemetry.Api/Metrics/NoOpGaugeHandle.cs
@@ -20,7 +20,7 @@ using OpenTelemetry.Trace;
 namespace OpenTelemetry.Metrics
 {
     /// <summary>
-    /// Handle to the metrics gauge with the defined <see cref="LabelSet"/>.
+    /// No-Op handle.
     /// </summary>
     /// <typeparam name="T">The type of gauge. Only long and double are supported now.</typeparam>
     public sealed class NoOpGaugeHandle<T> : GaugeHandle<T>

--- a/src/OpenTelemetry.Api/Metrics/NoOpGaugeHandle.cs
+++ b/src/OpenTelemetry.Api/Metrics/NoOpGaugeHandle.cs
@@ -1,0 +1,44 @@
+﻿// <copyright file="NoOpGaugeHandle.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using OpenTelemetry.Context;
+using OpenTelemetry.Trace;
+
+namespace OpenTelemetry.Metrics
+{
+    /// <summary>
+    /// Handle to the metrics gauge with the defined <see cref="LabelSet"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of gauge. Only long and double are supported now.</typeparam>
+    public sealed class NoOpGaugeHandle<T> : GaugeHandle<T>
+        where T : struct
+    {
+        /// <summary>
+        /// No op gauge handle instance.
+        /// </summary>
+        public static readonly NoOpGaugeHandle<T> Instance = new NoOpGaugeHandle<T>();
+
+        /// <inheritdoc/>
+        public override void Set(in SpanContext context, T value)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override void Set(in DistributedContext context, T value)
+        {
+        }
+    }
+}

--- a/src/OpenTelemetry.Api/Metrics/NoOpMeasure.cs
+++ b/src/OpenTelemetry.Api/Metrics/NoOpMeasure.cs
@@ -1,0 +1,47 @@
+﻿// <copyright file="NoOpMeasure.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Collections.Generic;
+using OpenTelemetry.Context;
+using OpenTelemetry.Trace;
+
+namespace OpenTelemetry.Metrics
+{
+    /// <summary>
+    /// No op measure instrument.
+    /// </summary>
+    /// <typeparam name="T">The type of counter. Only long and double are supported now.</typeparam>
+    public sealed class NoOpMeasure<T> : Measure<T>
+        where T : struct
+    {
+        /// <summary>
+        /// No op measure instance.
+        /// </summary>
+        public static readonly NoOpMeasure<T> Instance = new NoOpMeasure<T>();
+
+        /// <inheritdoc/>
+        public override MeasureHandle<T> GetHandle(LabelSet labelset)
+        {
+            return NoOpMeasureHandle<T>.Instance;
+        }
+
+        /// <inheritdoc/>
+        public override MeasureHandle<T> GetHandle(IEnumerable<KeyValuePair<string, string>> labels)
+        {
+            return NoOpMeasureHandle<T>.Instance;
+        }
+    }
+}

--- a/src/OpenTelemetry.Api/Metrics/NoOpMeasureHandle.cs
+++ b/src/OpenTelemetry.Api/Metrics/NoOpMeasureHandle.cs
@@ -1,0 +1,44 @@
+﻿// <copyright file="NoOpMeasureHandle.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using OpenTelemetry.Context;
+using OpenTelemetry.Trace;
+
+namespace OpenTelemetry.Metrics
+{
+    /// <summary>
+    /// No op measure handle.
+    /// </summary>
+    /// <typeparam name="T">The type of Measure. Only long and double are supported now.</typeparam>
+    public sealed class NoOpMeasureHandle<T> : MeasureHandle<T>
+        where T : struct
+    {
+        /// <summary>
+        /// No op measure handle instance.
+        /// </summary>
+        public static readonly NoOpMeasureHandle<T> Instance = new NoOpMeasureHandle<T>();
+
+        /// <inheritdoc/>
+        public override void Record(in SpanContext context, T value)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override void Record(in DistributedContext context, T value)
+        {
+        }
+    }
+}

--- a/src/OpenTelemetry.Api/Metrics/NoOpMeter.cs
+++ b/src/OpenTelemetry.Api/Metrics/NoOpMeter.cs
@@ -26,38 +26,38 @@ namespace OpenTelemetry.Metrics
 
         public override Counter<double> CreateDoubleCounter(string name, bool monotonic = true)
         {
-            throw new NotImplementedException();
+            return NoOpCounter<double>.Instance;
         }
 
         public override Gauge<double> CreateDoubleGauge(string name, bool monotonic = false)
         {
-            throw new NotImplementedException();
+            return NoOpGauge<double>.Instance;
         }
 
         public override Measure<double> CreateDoubleMeasure(string name, bool absolute = true)
         {
-            throw new NotImplementedException();
+            return NoOpMeasure<double>.Instance;
         }
 
         public override Counter<long> CreateInt64Counter(string name, bool monotonic = true)
         {
-            throw new NotImplementedException();
+            return NoOpCounter<long>.Instance;
         }
 
         public override Gauge<long> CreateInt64Gauge(string name, bool monotonic = false)
         {
-            throw new NotImplementedException();
+            return NoOpGauge<long>.Instance;
         }
 
         public override Measure<long> CreateInt64Measure(string name, bool absolute = true)
         {
-            throw new NotImplementedException();
+            return NoOpMeasure<long>.Instance;
         }
 
         public override LabelSet GetLabelSet(IEnumerable<KeyValuePair<string, string>> labels)
         {
             // return no op
-            throw new System.NotImplementedException();
+            return LabelSet.BlankLabelSet;
         }
     }
 }

--- a/test/OpenTelemetry.Tests/Impl/Trace/Config/MeterFactoryBaseTests.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Config/MeterFactoryBaseTests.cs
@@ -1,0 +1,47 @@
+﻿// <copyright file="MeterFactoryBaseTests.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using OpenTelemetry.Metrics;
+using Xunit;
+
+namespace OpenTelemetry.Tests.Impl.Trace.Config
+{
+    public class MeterFactoryBaseTests
+    {
+        [Fact]
+        public void MeterFactoryBase_Default()
+        {
+            Assert.NotNull(MeterFactoryBase.Default);
+            var defaultMeter = MeterFactoryBase.Default.GetMeter("");
+            Assert.NotNull(defaultMeter);
+            Assert.IsType<NoOpMeter>(defaultMeter);
+
+            var namedMeter = MeterFactoryBase.Default.GetMeter("named meter");
+            //  The same NoOpMeter must be returned always.
+            Assert.Same(defaultMeter, namedMeter);
+
+            var counter = defaultMeter.CreateDoubleCounter("somename");
+            Assert.IsType<NoOpCounter<double>>(counter);
+
+            var labels1 = new List<KeyValuePair<string, string>>();
+            labels1.Add(new KeyValuePair<string, string>("dim1", "value1"));
+            var counterHandle = counter.GetHandle(labels1);
+            Assert.IsType<NoOpCounterHandle<double>>(counterHandle);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds/fixes NoOp meters - when no SDK is available, libraries will be getting NoOp meters which does "no-op" and return instantly when any metric instrument updates are called.

Once the configuration story is fully ironed out for metrics (which will decide how to replace NoOp with actual Meter), this can take similar approach to NoOpTracers, where a ProxyTracer is created which proxies to real Tracer if available, else does 'no-op'.

(attempting to do really small PRs with baby steps....).