### PR TITLE
Make ITracer an abstract class and rename to Tracer

### DIFF
--- a/benchmarks/OpenTelemetrySdkBenchmarks.cs
+++ b/benchmarks/OpenTelemetrySdkBenchmarks.cs
@@ -26,9 +26,9 @@ namespace Benchmarks
     [MemoryDiagnoser]
     public class OpenTelemetrySdkBenchmarks
     {
-        private readonly ITracer alwaysSampleTracer;
-        private readonly ITracer neverSampleTracer;
-        private readonly ITracer noopTracer;
+        private readonly Tracer alwaysSampleTracer;
+        private readonly Tracer neverSampleTracer;
+        private readonly Tracer noopTracer;
 
         public OpenTelemetrySdkBenchmarks()
         {

--- a/benchmarks/Tracing/SpanCreationScenarios.cs
+++ b/benchmarks/Tracing/SpanCreationScenarios.cs
@@ -20,14 +20,14 @@ namespace Benchmarks.Tracing
 {
     internal class SpanCreationScenarios
     {
-        public static ISpan CreateSpan(ITracer tracer)
+        public static ISpan CreateSpan(Tracer tracer)
         {
             var span = tracer.StartSpan("span");
             span.End();
             return span;
         }
 
-        public static ISpan CreateSpan_Attributes(ITracer tracer)
+        public static ISpan CreateSpan_Attributes(Tracer tracer)
         {
             var span = tracer.StartSpan("span");
             span.SetAttribute("attribute1", "1");
@@ -38,7 +38,7 @@ namespace Benchmarks.Tracing
             return span;
         }
 
-        public static ISpan CreateSpan_Propagate(ITracer tracer)
+        public static ISpan CreateSpan_Propagate(Tracer tracer)
         {
             var span = tracer.StartSpan("span");
             using (tracer.WithSpan(span))
@@ -49,7 +49,7 @@ namespace Benchmarks.Tracing
             return span;
         }
 
-        public static ISpan CreateSpan_Active(ITracer tracer)
+        public static ISpan CreateSpan_Active(Tracer tracer)
         {
             using (tracer.StartActiveSpan("span", out var span))
             {
@@ -57,7 +57,7 @@ namespace Benchmarks.Tracing
             }
         }
 
-        public static ISpan CreateSpan_Active_GetCurrent(ITracer tracer)
+        public static ISpan CreateSpan_Active_GetCurrent(Tracer tracer)
         {
             ISpan span;
             

--- a/samples/Exporters/TestJaeger.cs
+++ b/samples/Exporters/TestJaeger.cs
@@ -52,7 +52,7 @@ namespace Samples
             }
         }
 
-        private static void DoWork(int i, ITracer tracer)
+        private static void DoWork(int i, Tracer tracer)
         {
             // Start another span. If another span was already started, it'll use that span as the parent span.
             // In this example, the main method already started a span, so that'll be the parent span, and this will be

--- a/samples/Exporters/TestLightstep.cs
+++ b/samples/Exporters/TestLightstep.cs
@@ -39,7 +39,7 @@ namespace Samples
             }
         }
 
-        private static void DoWork(int i, ITracer tracer)
+        private static void DoWork(int i, Tracer tracer)
         {
             using (tracer.WithSpan(tracer.StartSpan("DoWork")))
             {

--- a/samples/Exporters/TestRedis.cs
+++ b/samples/Exporters/TestRedis.cs
@@ -63,7 +63,7 @@ namespace Samples
             }
         }
 
-        private static void DoWork(IDatabase db, ITracer tracer)
+        private static void DoWork(IDatabase db, Tracer tracer)
         {
             // Start another span. If another span was already started, it'll use that span as the parent span.
             // In this example, the main method already started a span, so that'll be the parent span, and this will be

--- a/samples/Exporters/TestZipkin.cs
+++ b/samples/Exporters/TestZipkin.cs
@@ -50,7 +50,7 @@ namespace Samples
             return null;
         }
 
-        private static void DoWork(int i, ITracer tracer)
+        private static void DoWork(int i, Tracer tracer)
         {
             // Start another span. If another span was already started, it'll use that span as the parent span.
             // In this example, the main method already started a span, so that'll be the parent span, and this will be

--- a/samples/LoggingTracer/LoggingTracer/LoggingTracer.cs
+++ b/samples/LoggingTracer/LoggingTracer/LoggingTracer.cs
@@ -24,7 +24,7 @@ namespace LoggingTracer
     /// <summary>
     /// Logger tracer.
     /// </summary>
-    public class LoggingTracer : ITracer
+    public class LoggingTracer : Tracer
     {
         private readonly string prefix;
 
@@ -38,44 +38,44 @@ namespace LoggingTracer
         }
 
         /// <inheritdoc/>
-        public ISpan CurrentSpan => CurrentSpanUtils.CurrentSpan;
+        public override ISpan CurrentSpan => CurrentSpanUtils.CurrentSpan;
 
         /// <inheritdoc/>
-        public IBinaryFormat BinaryFormat => new LoggingBinaryFormat();
+        public override IBinaryFormat BinaryFormat => new LoggingBinaryFormat();
 
         /// <inheritdoc/>
-        public ITextFormat TextFormat => new LoggingTextFormat();
+        public override ITextFormat TextFormat => new LoggingTextFormat();
 
         /// <inheritdoc/>
-        public IDisposable WithSpan(ISpan span, bool endOnDispose)
+        public override IDisposable WithSpan(ISpan span, bool endOnDispose)
         {
             Logger.Log($"{this.prefix}.WithSpan {endOnDispose}");
             return new CurrentSpanUtils.LoggingScope(span);
         }
 
         /// <inheritdoc/>
-        public ISpan StartRootSpan(string operationName, SpanKind kind, SpanCreationOptions options)
+        public override ISpan StartRootSpan(string operationName, SpanKind kind, SpanCreationOptions options)
         {
             Logger.Log($"{this.prefix}.StartRootSpan({operationName}, {kind}, {options.StartTimestamp:o}, {options.LinksFactory}, {options.Links})");
             return new LoggingSpan(operationName, kind);
         }
 
         /// <inheritdoc/>
-        public ISpan StartSpan(string operationName, ISpan parent, SpanKind kind, SpanCreationOptions options)
+        public override ISpan StartSpan(string operationName, ISpan parent, SpanKind kind, SpanCreationOptions options)
         {
             Logger.Log($"{this.prefix}.StartSpan({operationName}, {parent.GetType().Name}, {kind}, {options.StartTimestamp:o}, {options.LinksFactory}, {options.Links})");
             return new LoggingSpan(operationName, kind);
         }
 
         /// <inheritdoc/>
-        public ISpan StartSpan(string operationName, in SpanContext parent, SpanKind kind, SpanCreationOptions options)
+        public override ISpan StartSpan(string operationName, in SpanContext parent, SpanKind kind, SpanCreationOptions options)
         {
             Logger.Log($"{this.prefix}.StartSpan({operationName}, {parent.GetType().Name}, {kind}, {options.StartTimestamp:o}, {options.LinksFactory}, {options.Links})");
             return new LoggingSpan(operationName, kind);
         }
 
         /// <inheritdoc/>
-        public ISpan StartSpanFromActivity(string operationName, Activity activity, SpanKind kind, IEnumerable<Link> links)
+        public override ISpan StartSpanFromActivity(string operationName, Activity activity, SpanKind kind, IEnumerable<Link> links)
         {
             Logger.Log($"{this.prefix}.StartSpanFromActivity({operationName}, {activity.OperationName}, {kind}, {links})");
             return new LoggingSpan(operationName, kind);

--- a/samples/LoggingTracer/LoggingTracer/LoggingTracerFactory.cs
+++ b/samples/LoggingTracer/LoggingTracer/LoggingTracerFactory.cs
@@ -21,7 +21,7 @@ namespace LoggingTracer
     public class LoggingTracerFactory : TracerFactoryBase
     {
         /// <inheritdoc/>
-        public override ITracer GetTracer(string name, string version = null)
+        public override Tracer GetTracer(string name, string version = null)
         {
             Logger.Log($"ITracerFactory.GetTracer('{name}', '{version}')");
 

--- a/src/OpenTelemetry.Api/Trace/ProxyTracer.cs
+++ b/src/OpenTelemetry.Api/Trace/ProxyTracer.cs
@@ -25,50 +25,50 @@ namespace OpenTelemetry.Trace
     /// <summary>
     /// No-op tracer.
     /// </summary>
-    internal sealed class ProxyTracer : ITracer
+    internal sealed class ProxyTracer : Tracer
     {
         private static readonly IDisposable NoopScope = new NoopDisposable();
         private readonly IBinaryFormat binaryFormat = new BinaryFormat();
         private readonly ITextFormat textFormat = new TraceContextFormat();
 
-        private ITracer realTracer;
+        private Tracer realTracer;
 
         /// <inheritdoc/>
-        public ISpan CurrentSpan => this.realTracer?.CurrentSpan ?? BlankSpan.Instance;
+        public override ISpan CurrentSpan => this.realTracer?.CurrentSpan ?? BlankSpan.Instance;
 
         /// <inheritdoc/>
-        public IBinaryFormat BinaryFormat => this.realTracer?.BinaryFormat ?? this.binaryFormat;
+        public override IBinaryFormat BinaryFormat => this.realTracer?.BinaryFormat ?? this.binaryFormat;
 
         /// <inheritdoc/>
-        public ITextFormat TextFormat => this.realTracer?.TextFormat ?? this.textFormat;
+        public override ITextFormat TextFormat => this.realTracer?.TextFormat ?? this.textFormat;
 
         /// <inheritdoc/>
-        public IDisposable WithSpan(ISpan span, bool endOnDispose)
+        public override IDisposable WithSpan(ISpan span, bool endOnDispose)
         {
             return this.realTracer != null ? this.realTracer.WithSpan(span, endOnDispose) : NoopScope;
         }
 
-        public ISpan StartRootSpan(string operationName, SpanKind kind, SpanCreationOptions options)
+        public override ISpan StartRootSpan(string operationName, SpanKind kind, SpanCreationOptions options)
         {
             return this.realTracer != null ? this.realTracer.StartRootSpan(operationName, kind, options) : BlankSpan.Instance;
         }
 
-        public ISpan StartSpan(string operationName, ISpan parent, SpanKind kind, SpanCreationOptions options)
+        public override ISpan StartSpan(string operationName, ISpan parent, SpanKind kind, SpanCreationOptions options)
         {
             return this.realTracer != null ? this.realTracer.StartSpan(operationName, parent, kind, options) : BlankSpan.Instance;
         }
 
-        public ISpan StartSpan(string operationName, in SpanContext parent, SpanKind kind, SpanCreationOptions options)
+        public override ISpan StartSpan(string operationName, in SpanContext parent, SpanKind kind, SpanCreationOptions options)
         {
             return this.realTracer != null ? this.realTracer.StartSpan(operationName, parent, kind, options) : BlankSpan.Instance;
         }
 
-        public ISpan StartSpanFromActivity(string operationName, Activity activity, SpanKind kind, IEnumerable<Link> links)
+        public override ISpan StartSpanFromActivity(string operationName, Activity activity, SpanKind kind, IEnumerable<Link> links)
         {
             return this.realTracer != null ? this.realTracer.StartSpanFromActivity(operationName, activity, kind, links) : BlankSpan.Instance;
         }
 
-        public void UpdateTracer(ITracer realTracer)
+        public void UpdateTracer(Tracer realTracer)
         {
             if (this.realTracer != null)
             {

--- a/src/OpenTelemetry.Api/Trace/Tracer.cs
+++ b/src/OpenTelemetry.Api/Trace/Tracer.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ITracer.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="Tracer.cs" company="OpenTelemetry Authors">
 // Copyright 2018, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,22 +24,22 @@ namespace OpenTelemetry.Trace
     /// <summary>
     /// Tracer to record distributed tracing information.
     /// </summary>
-    public interface ITracer
+    public abstract class Tracer
     {
         /// <summary>
         /// Gets the current span from the context.
         /// </summary>
-        ISpan CurrentSpan { get; }
+        public abstract ISpan CurrentSpan { get; }
 
         /// <summary>
         /// Gets the <see cref="IBinaryFormat"/> for this implementation.
         /// </summary>
-        IBinaryFormat BinaryFormat { get; }
+        public abstract IBinaryFormat BinaryFormat { get; }
 
         /// <summary>
         /// Gets the <see cref="ITextFormat"/> for this implementation.
         /// </summary>
-        ITextFormat TextFormat { get; }
+        public abstract ITextFormat TextFormat { get; }
 
         /// <summary>
         /// Activates the span on the current context.
@@ -47,7 +47,7 @@ namespace OpenTelemetry.Trace
         /// <param name="span">Span to associate with the current context.</param>
         /// <param name="endSpanOnDispose">Flag indicating if span should end when scope is disposed.</param>
         /// <returns>Disposable object to control span to current context association.</returns>
-        IDisposable WithSpan(ISpan span, bool endSpanOnDispose);
+        public abstract IDisposable WithSpan(ISpan span, bool endSpanOnDispose);
 
         // TODO: add sampling hints
 
@@ -58,7 +58,7 @@ namespace OpenTelemetry.Trace
         /// <param name="kind">Kind.</param>
         /// <param name="options">Advanced span creation options.</param>
         /// <returns>Span instance.</returns>
-        ISpan StartRootSpan(string operationName, SpanKind kind, SpanCreationOptions options);
+        public abstract ISpan StartRootSpan(string operationName, SpanKind kind, SpanCreationOptions options);
 
         /// <summary>
         /// Starts span.
@@ -68,9 +68,9 @@ namespace OpenTelemetry.Trace
         /// <param name="kind">Kind.</param>
         /// <param name="options">Advanced span creation options.</param>
         /// <returns>Span instance.</returns>
-        ISpan StartSpan(string operationName, ISpan parent, SpanKind kind, SpanCreationOptions options);
+        public abstract ISpan StartSpan(string operationName, ISpan parent, SpanKind kind, SpanCreationOptions options);
 
-       /// <summary>
+        /// <summary>
         /// Starts span.
         /// </summary>
         /// <param name="operationName">Span name.</param>
@@ -78,7 +78,7 @@ namespace OpenTelemetry.Trace
         /// <param name="kind">Kind.</param>
         /// <param name="options">Advanced span creation options.</param>
         /// <returns>Span instance.</returns>
-        ISpan StartSpan(string operationName, in SpanContext parent, SpanKind kind, SpanCreationOptions options);
+        public abstract ISpan StartSpan(string operationName, in SpanContext parent, SpanKind kind, SpanCreationOptions options);
 
         /// <summary>
         /// Starts span from auto-collected <see cref="Activity"/>.
@@ -88,6 +88,6 @@ namespace OpenTelemetry.Trace
         /// <param name="kind">Kind.</param>
         /// <param name="links">Links collection.</param>
         /// <returns>Span scope instance.</returns>
-        ISpan StartSpanFromActivity(string operationName, Activity activity, SpanKind kind, IEnumerable<Link> links);
+        public abstract ISpan StartSpanFromActivity(string operationName, Activity activity, SpanKind kind, IEnumerable<Link> links);
     }
 }

--- a/src/OpenTelemetry.Api/Trace/TracerActiveSpanExtensions.cs
+++ b/src/OpenTelemetry.Api/Trace/TracerActiveSpanExtensions.cs
@@ -31,7 +31,7 @@ namespace OpenTelemetry.Trace
         /// <param name="tracer">Tracer instance.</param>
         /// <param name="span">Span to activate.</param>
         /// <returns>Disposable object to control span to current context association.</returns>
-        public static IDisposable WithSpan(this ITracer tracer, ISpan span)
+        public static IDisposable WithSpan(this Tracer tracer, ISpan span)
         {
             return tracer.WithSpan(span, false);
         }
@@ -43,7 +43,7 @@ namespace OpenTelemetry.Trace
         /// <param name="operationName">Span name.</param>
         /// <param name="span">Created span.</param>
         /// <returns>Scope.</returns>
-        public static IDisposable StartActiveSpan(this ITracer tracer, string operationName, out ISpan span)
+        public static IDisposable StartActiveSpan(this Tracer tracer, string operationName, out ISpan span)
         {
             span = tracer.StartSpan(operationName, SpanKind.Internal, null);
             return tracer.WithSpan(span, true);
@@ -57,7 +57,7 @@ namespace OpenTelemetry.Trace
         /// <param name="kind">Kind.</param>
         /// <param name="span">Created span.</param>
         /// <returns>Scope.</returns>
-        public static IDisposable StartActiveSpan(this ITracer tracer, string operationName, SpanKind kind, out ISpan span)
+        public static IDisposable StartActiveSpan(this Tracer tracer, string operationName, SpanKind kind, out ISpan span)
         {
             span = tracer.StartSpan(operationName, kind, null);
             return tracer.WithSpan(span, true);
@@ -72,7 +72,7 @@ namespace OpenTelemetry.Trace
         /// <param name="options">Advanced span creation options.</param>
         /// <param name="span">Created span.</param>
         /// <returns>Scope.</returns>
-        public static IDisposable StartActiveSpan(this ITracer tracer, string operationName, SpanKind kind, SpanCreationOptions options, out ISpan span)
+        public static IDisposable StartActiveSpan(this Tracer tracer, string operationName, SpanKind kind, SpanCreationOptions options, out ISpan span)
         {
             span = tracer.StartSpan(operationName, kind, options);
             return tracer.WithSpan(span, true);
@@ -86,7 +86,7 @@ namespace OpenTelemetry.Trace
         /// <param name="parent">Parent for new span.</param>
         /// <param name="span">Created span.</param>
         /// <returns>Scope.</returns>
-        public static IDisposable StartActiveSpan(this ITracer tracer, string operationName, SpanContext parent, out ISpan span)
+        public static IDisposable StartActiveSpan(this Tracer tracer, string operationName, SpanContext parent, out ISpan span)
         {
             span = tracer.StartSpan(operationName, parent, SpanKind.Internal, null);
             return tracer.WithSpan(span, true);
@@ -101,7 +101,7 @@ namespace OpenTelemetry.Trace
         /// <param name="kind">Kind.</param>
         /// <param name="span">Created span.</param>
         /// <returns>Scope.</returns>
-        public static IDisposable StartActiveSpan(this ITracer tracer, string operationName, SpanContext parent, SpanKind kind, out ISpan span)
+        public static IDisposable StartActiveSpan(this Tracer tracer, string operationName, SpanContext parent, SpanKind kind, out ISpan span)
         {
             span = tracer.StartSpan(operationName, parent, kind, null);
             return tracer.WithSpan(span, true);
@@ -117,7 +117,7 @@ namespace OpenTelemetry.Trace
         /// <param name="options">Advanced span creation options.</param>
         /// <param name="span">Created span.</param>
         /// <returns>Scope.</returns>
-        public static IDisposable StartActiveSpan(this ITracer tracer, string operationName, SpanContext parent, SpanKind kind, SpanCreationOptions options, out ISpan span)
+        public static IDisposable StartActiveSpan(this Tracer tracer, string operationName, SpanContext parent, SpanKind kind, SpanCreationOptions options, out ISpan span)
         {
             span = tracer.StartSpan(operationName, parent, kind, options);
             return tracer.WithSpan(span, true);
@@ -131,7 +131,7 @@ namespace OpenTelemetry.Trace
         /// <param name="parent">Parent for new span.</param>
         /// <param name="span">Created span.</param>
         /// <returns>Scope.</returns>
-        public static IDisposable StartActiveSpan(this ITracer tracer, string operationName, ISpan parent, out ISpan span)
+        public static IDisposable StartActiveSpan(this Tracer tracer, string operationName, ISpan parent, out ISpan span)
         {
             span = tracer.StartSpan(operationName, parent, SpanKind.Internal, null);
             return tracer.WithSpan(span, true);
@@ -146,7 +146,7 @@ namespace OpenTelemetry.Trace
         /// <param name="kind">Kind.</param>
         /// <param name="span">Created span.</param>
         /// <returns>Scope.</returns>
-        public static IDisposable StartActiveSpan(this ITracer tracer, string operationName, ISpan parent, SpanKind kind, out ISpan span)
+        public static IDisposable StartActiveSpan(this Tracer tracer, string operationName, ISpan parent, SpanKind kind, out ISpan span)
         {
             span = tracer.StartSpan(operationName, parent, kind, null);
             return tracer.WithSpan(span, true);
@@ -162,7 +162,7 @@ namespace OpenTelemetry.Trace
         /// <param name="options">Advanced span creation options.</param>
         /// <param name="span">Created span.</param>
         /// <returns>Scope.</returns>
-        public static IDisposable StartActiveSpan(this ITracer tracer, string operationName, ISpan parent, SpanKind kind, SpanCreationOptions options, out ISpan span)
+        public static IDisposable StartActiveSpan(this Tracer tracer, string operationName, ISpan parent, SpanKind kind, SpanCreationOptions options, out ISpan span)
         {
             span = tracer.StartSpan(operationName, parent, kind, options);
             return tracer.WithSpan(span, true);
@@ -176,7 +176,7 @@ namespace OpenTelemetry.Trace
         /// <param name="activity">Parent for new span.</param>
         /// <param name="span">Created span.</param>
         /// <returns>Scope.</returns>
-        public static IDisposable StartActiveSpanFromActivity(this ITracer tracer, string operationName, Activity activity, out ISpan span)
+        public static IDisposable StartActiveSpanFromActivity(this Tracer tracer, string operationName, Activity activity, out ISpan span)
         {
             span = tracer.StartSpanFromActivity(operationName, activity, SpanKind.Internal, null);
             return tracer.WithSpan(span, true);
@@ -191,7 +191,7 @@ namespace OpenTelemetry.Trace
         /// <param name="kind">Kind.</param>
         /// <param name="span">Created span.</param>
         /// <returns>Scope.</returns>
-        public static IDisposable StartActiveSpanFromActivity(this ITracer tracer, string operationName, Activity activity, SpanKind kind, out ISpan span)
+        public static IDisposable StartActiveSpanFromActivity(this Tracer tracer, string operationName, Activity activity, SpanKind kind, out ISpan span)
         {
             span = tracer.StartSpanFromActivity(operationName, activity, kind, null);
             return tracer.WithSpan(span, true);
@@ -207,7 +207,7 @@ namespace OpenTelemetry.Trace
         /// <param name="links">Links collection.</param>
         /// <param name="span">Created span.</param>
         /// <returns>Scope.</returns>
-        public static IDisposable StartActiveSpanFromActivity(this ITracer tracer, string operationName, Activity activity, SpanKind kind, IEnumerable<Link> links, out ISpan span)
+        public static IDisposable StartActiveSpanFromActivity(this Tracer tracer, string operationName, Activity activity, SpanKind kind, IEnumerable<Link> links, out ISpan span)
         {
             span = tracer.StartSpanFromActivity(operationName, activity, kind, links);
             return tracer.WithSpan(span, true);

--- a/src/OpenTelemetry.Api/Trace/TracerExtensions.cs
+++ b/src/OpenTelemetry.Api/Trace/TracerExtensions.cs
@@ -19,7 +19,7 @@ using System.Diagnostics;
 namespace OpenTelemetry.Trace
 {
     /// <summary>
-    /// Extension methods for the <see cref="ITracer"/>.
+    /// Extension methods for the <see cref="Tracer"/>.
     /// </summary>
     public static class TracerExtensions
     {
@@ -29,7 +29,7 @@ namespace OpenTelemetry.Trace
         /// <param name="tracer">Tracer instance.</param>
         /// <param name="operationName">Span name.</param>
         /// <returns>Span instance.</returns>
-        public static ISpan StartRootSpan(this ITracer tracer, string operationName)
+        public static ISpan StartRootSpan(this Tracer tracer, string operationName)
         {
             return tracer.StartRootSpan(operationName, SpanKind.Internal, null);
         }
@@ -41,7 +41,7 @@ namespace OpenTelemetry.Trace
         /// <param name="operationName">Span name.</param>
         /// <param name="kind">Kind.</param>
         /// <returns>Span instance.</returns>
-        public static ISpan StartRootSpan(this ITracer tracer, string operationName, SpanKind kind)
+        public static ISpan StartRootSpan(this Tracer tracer, string operationName, SpanKind kind)
         {
             return tracer.StartRootSpan(operationName, kind, null);
         }
@@ -52,7 +52,7 @@ namespace OpenTelemetry.Trace
         /// <param name="tracer">Tracer instance.</param>
         /// <param name="operationName">Span name.</param>
         /// <returns>Span instance.</returns>
-        public static ISpan StartSpan(this ITracer tracer, string operationName)
+        public static ISpan StartSpan(this Tracer tracer, string operationName)
         {
             return tracer.StartSpan(operationName, null, SpanKind.Internal, null);
         }
@@ -64,7 +64,7 @@ namespace OpenTelemetry.Trace
         /// <param name="operationName">Span name.</param>
         /// <param name="kind">Kind.</param>
         /// <returns>Span instance.</returns>
-        public static ISpan StartSpan(this ITracer tracer, string operationName, SpanKind kind)
+        public static ISpan StartSpan(this Tracer tracer, string operationName, SpanKind kind)
         {
             return tracer.StartSpan(operationName, null, kind, null);
         }
@@ -77,7 +77,7 @@ namespace OpenTelemetry.Trace
         /// <param name="kind">Kind.</param>
         /// <param name="options">Advanced span creation options.</param>
         /// <returns>Span instance.</returns>
-        public static ISpan StartSpan(this ITracer tracer, string operationName, SpanKind kind, SpanCreationOptions options)
+        public static ISpan StartSpan(this Tracer tracer, string operationName, SpanKind kind, SpanCreationOptions options)
         {
             return tracer.StartSpan(operationName, null, kind, options);
         }
@@ -89,7 +89,7 @@ namespace OpenTelemetry.Trace
         /// <param name="operationName">Span name.</param>
         /// <param name="parent">Parent for new span.</param>
         /// <returns>Span instance.</returns>
-        public static ISpan StartSpan(this ITracer tracer, string operationName, ISpan parent)
+        public static ISpan StartSpan(this Tracer tracer, string operationName, ISpan parent)
         {
             return tracer.StartSpan(operationName, parent, SpanKind.Internal, null);
         }
@@ -102,7 +102,7 @@ namespace OpenTelemetry.Trace
         /// <param name="parent">Parent for new span.</param>
         /// <param name="kind">Kind.</param>
         /// <returns>Span instance.</returns>
-        public static ISpan StartSpan(this ITracer tracer, string operationName, ISpan parent, SpanKind kind)
+        public static ISpan StartSpan(this Tracer tracer, string operationName, ISpan parent, SpanKind kind)
         {
             return tracer.StartSpan(operationName, parent, kind, null);
         }
@@ -114,7 +114,7 @@ namespace OpenTelemetry.Trace
         /// <param name="operationName">Span name.</param>
         /// <param name="parent">Parent for new span.</param>
         /// <returns>Span instance.</returns>
-        public static ISpan StartSpan(this ITracer tracer, string operationName, in SpanContext parent)
+        public static ISpan StartSpan(this Tracer tracer, string operationName, in SpanContext parent)
         {
             return tracer.StartSpan(operationName, parent, SpanKind.Internal, null);
         }
@@ -127,7 +127,7 @@ namespace OpenTelemetry.Trace
         /// <param name="parent">Parent for new span.</param>
         /// <param name="kind">Kind.</param>
         /// <returns>Span instance.</returns>
-        public static ISpan StartSpan(this ITracer tracer, string operationName, in SpanContext parent, SpanKind kind)
+        public static ISpan StartSpan(this Tracer tracer, string operationName, in SpanContext parent, SpanKind kind)
         {
             return tracer.StartSpan(operationName, parent, kind, null);
         }
@@ -139,7 +139,7 @@ namespace OpenTelemetry.Trace
         /// <param name="operationName">Span name.</param>
         /// <param name="activity">Activity instance to create span from.</param>
         /// <returns>Span scope instance.</returns>
-        public static ISpan StartSpanFromActivity(this ITracer tracer, string operationName, Activity activity)
+        public static ISpan StartSpanFromActivity(this Tracer tracer, string operationName, Activity activity)
         {
             return tracer.StartSpanFromActivity(operationName, activity, SpanKind.Internal, null);
         }
@@ -152,7 +152,7 @@ namespace OpenTelemetry.Trace
         /// <param name="activity">Activity instance to create span from.</param>
         /// <param name="kind">Kind.</param>
         /// <returns>Span scope instance.</returns>
-        public static ISpan StartSpanFromActivity(this ITracer tracer, string operationName, Activity activity, SpanKind kind)
+        public static ISpan StartSpanFromActivity(this Tracer tracer, string operationName, Activity activity, SpanKind kind)
         {
             return tracer.StartSpanFromActivity(operationName, activity, kind, null);
         }

--- a/src/OpenTelemetry.Api/Trace/TracerFactoryBase.cs
+++ b/src/OpenTelemetry.Api/Trace/TracerFactoryBase.cs
@@ -63,12 +63,12 @@ namespace OpenTelemetry.Trace
         }
 
         /// <summary>
-        /// Returns an ITracer for a given name and version.
+        /// Returns an Tracer for a given name and version.
         /// </summary>
         /// <param name="name">Name of the instrumentation library.</param>
         /// <param name="version">Version of the instrumentation library (optional).</param>
         /// <returns>Tracer for the given name and version information.</returns>
-        public virtual ITracer GetTracer(string name, string version = null)
+        public virtual Tracer GetTracer(string name, string version = null)
         {
             return isInitialized ? defaultFactory.GetTracer(name, version) : proxy;
         }

--- a/src/OpenTelemetry.Collector.AspNetCore/AspNetCoreCollector.cs
+++ b/src/OpenTelemetry.Collector.AspNetCore/AspNetCoreCollector.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Collector.AspNetCore
         /// Initializes a new instance of the <see cref="AspNetCoreCollector"/> class.
         /// </summary>
         /// <param name="tracer">Tracer to record traced with.</param>
-        public AspNetCoreCollector(ITracer tracer)
+        public AspNetCoreCollector(Tracer tracer)
             : this(tracer, new AspNetCoreCollectorOptions())
         {
         }
@@ -40,7 +40,7 @@ namespace OpenTelemetry.Collector.AspNetCore
         /// </summary>
         /// <param name="tracer">Tracer to record traced with.</param>
         /// <param name="options">Configuration options for dependencies collector.</param>
-        public AspNetCoreCollector(ITracer tracer, AspNetCoreCollectorOptions options)
+        public AspNetCoreCollector(Tracer tracer, AspNetCoreCollectorOptions options)
         {
             this.diagnosticSourceSubscriber = new DiagnosticSourceSubscriber(new HttpInListener("Microsoft.AspNetCore", tracer), options.EventFilter);
             this.diagnosticSourceSubscriber.Subscribe();

--- a/src/OpenTelemetry.Collector.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Collector.AspNetCore/Implementation/HttpInListener.cs
@@ -33,7 +33,7 @@ namespace OpenTelemetry.Collector.AspNetCore.Implementation
         private readonly PropertyFetcher beforeActionTemplateFetcher = new PropertyFetcher("Template");
         private readonly bool hostingSupportsW3C = false;
 
-        public HttpInListener(string name, ITracer tracer)
+        public HttpInListener(string name, Tracer tracer)
             : base(name, tracer)
         {
             this.hostingSupportsW3C = typeof(HttpRequest).Assembly.GetName().Version.Major >= 3;

--- a/src/OpenTelemetry.Collector.Dependencies/AzureClientsCollector.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/AzureClientsCollector.cs
@@ -29,7 +29,7 @@ namespace OpenTelemetry.Collector.Dependencies
         /// Initializes a new instance of the <see cref="AzureClientsCollector"/> class.
         /// </summary>
         /// <param name="tracer">Tracer to record traced with.</param>
-        public AzureClientsCollector(ITracer tracer)
+        public AzureClientsCollector(Tracer tracer)
         {
             this.diagnosticSourceSubscriber = new DiagnosticSourceSubscriber(
                 name => new AzureSdkDiagnosticListener(name, tracer),

--- a/src/OpenTelemetry.Collector.Dependencies/AzurePipelineCollector.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/AzurePipelineCollector.cs
@@ -29,7 +29,7 @@ namespace OpenTelemetry.Collector.Dependencies
         /// Initializes a new instance of the <see cref="AzurePipelineCollector"/> class.
         /// </summary>
         /// <param name="tracer">Tracer to record traced with.</param>
-        public AzurePipelineCollector(ITracer tracer)
+        public AzurePipelineCollector(Tracer tracer)
         {
             this.diagnosticSourceSubscriber = new DiagnosticSourceSubscriber(new AzureSdkDiagnosticListener("Azure.Pipeline", tracer), null);
             this.diagnosticSourceSubscriber.Subscribe();

--- a/src/OpenTelemetry.Collector.Dependencies/HttpClientCollector.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/HttpClientCollector.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Collector.Dependencies
         /// Initializes a new instance of the <see cref="HttpClientCollector"/> class.
         /// </summary>
         /// <param name="tracer">Tracer to record traced with.</param>
-        public HttpClientCollector(ITracer tracer)
+        public HttpClientCollector(Tracer tracer)
             : this(tracer, new HttpClientCollectorOptions())
         {
         }
@@ -40,7 +40,7 @@ namespace OpenTelemetry.Collector.Dependencies
         /// </summary>
         /// <param name="tracer">Tracer to record traced with.</param>
         /// <param name="options">Configuration options for dependencies collector.</param>
-        public HttpClientCollector(ITracer tracer, HttpClientCollectorOptions options)
+        public HttpClientCollector(Tracer tracer, HttpClientCollectorOptions options)
         {
             this.diagnosticSourceSubscriber = new DiagnosticSourceSubscriber(new HttpHandlerDiagnosticListener(tracer, options), options.EventFilter);
             this.diagnosticSourceSubscriber.Subscribe();

--- a/src/OpenTelemetry.Collector.Dependencies/Implementation/AzureSdkDiagnosticListener.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/Implementation/AzureSdkDiagnosticListener.cs
@@ -27,7 +27,7 @@ namespace OpenTelemetry.Collector.Dependencies
         // all fetchers must not be reused between DiagnosticSources.
         private readonly PropertyFetcher linksPropertyFetcher = new PropertyFetcher("Links");
 
-        public AzureSdkDiagnosticListener(string sourceName, ITracer tracer)
+        public AzureSdkDiagnosticListener(string sourceName, Tracer tracer)
             : base(sourceName, tracer)
         {
         }

--- a/src/OpenTelemetry.Collector.Dependencies/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Collector.Dependencies/Implementation/HttpHandlerDiagnosticListener.cs
@@ -34,7 +34,7 @@ namespace OpenTelemetry.Collector.Dependencies.Implementation
         private readonly bool httpClientSupportsW3C = false;
         private readonly HttpClientCollectorOptions options;
 
-        public HttpHandlerDiagnosticListener(ITracer tracer, HttpClientCollectorOptions options)
+        public HttpHandlerDiagnosticListener(Tracer tracer, HttpClientCollectorOptions options)
             : base("HttpHandlerDiagnosticListener", tracer)
         {
             var framework = Assembly

--- a/src/OpenTelemetry.Collector.StackExchangeRedis/Implementation/RedisProfilerEntryToSpanConverter.cs
+++ b/src/OpenTelemetry.Collector.StackExchangeRedis/Implementation/RedisProfilerEntryToSpanConverter.cs
@@ -21,7 +21,7 @@ namespace OpenTelemetry.Collector.StackExchangeRedis.Implementation
 {
     internal static class RedisProfilerEntryToSpanConverter
     {
-        public static ISpan ProfilerCommandToSpan(ITracer tracer, ISpan parentSpan, IProfiledCommand command)
+        public static ISpan ProfilerCommandToSpan(Tracer tracer, ISpan parentSpan, IProfiledCommand command)
         {
             var name = command.Command; // Example: SET;
             if (string.IsNullOrEmpty(name))
@@ -79,7 +79,7 @@ namespace OpenTelemetry.Collector.StackExchangeRedis.Implementation
             return span;
         }
 
-        public static void DrainSession(ITracer tracer, ISpan parentSpan, IEnumerable<IProfiledCommand> sessionCommands)
+        public static void DrainSession(Tracer tracer, ISpan parentSpan, IEnumerable<IProfiledCommand> sessionCommands)
         {
             foreach (var command in sessionCommands)
             {

--- a/src/OpenTelemetry.Collector.StackExchangeRedis/StackExchangeRedisCallsCollector.cs
+++ b/src/OpenTelemetry.Collector.StackExchangeRedis/StackExchangeRedisCallsCollector.cs
@@ -28,7 +28,7 @@ namespace OpenTelemetry.Collector.StackExchangeRedis
     /// </summary>
     public class StackExchangeRedisCallsCollector : IDisposable
     {
-        private readonly ITracer tracer;
+        private readonly Tracer tracer;
 
         private readonly CancellationTokenSource cancellationTokenSource;
         private readonly CancellationToken cancellationToken;
@@ -40,7 +40,7 @@ namespace OpenTelemetry.Collector.StackExchangeRedis
         /// Initializes a new instance of the <see cref="StackExchangeRedisCallsCollector"/> class.
         /// </summary>
         /// <param name="tracer">Tracer to record traced with.</param>
-        public StackExchangeRedisCallsCollector(ITracer tracer)
+        public StackExchangeRedisCallsCollector(Tracer tracer)
         {
             this.tracer = tracer;
 

--- a/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
@@ -25,13 +25,13 @@ namespace OpenTelemetry.Shims.OpenTracing
     {
         private static readonly ConditionalWeakTable<Trace.ISpan, global::OpenTracing.IScope> SpanScopeTable = new ConditionalWeakTable<Trace.ISpan, global::OpenTracing.IScope>();
 
-        private readonly Trace.ITracer tracer;
+        private readonly Trace.Tracer tracer;
 
 #if DEBUG
         private int spanScopeTableCount;
 #endif
 
-        public ScopeManagerShim(Trace.ITracer tracer)
+        public ScopeManagerShim(Trace.Tracer tracer)
         {
             this.tracer = tracer ?? throw new ArgumentNullException(nameof(tracer));
         }

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
@@ -31,7 +31,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <summary>
         /// The tracer.
         /// </summary>
-        private readonly Trace.ITracer tracer;
+        private readonly Trace.Tracer tracer;
 
         /// <summary>
         /// The span name.
@@ -77,7 +77,7 @@ namespace OpenTelemetry.Shims.OpenTracing
 
         private bool error;
 
-        public SpanBuilderShim(Trace.ITracer tracer, string spanName, IList<string> rootOperationNamesForActivityBasedAutoCollectors = null)
+        public SpanBuilderShim(Trace.Tracer tracer, string spanName, IList<string> rootOperationNamesForActivityBasedAutoCollectors = null)
         {
             this.tracer = tracer ?? throw new ArgumentNullException(nameof(tracer));
             this.spanName = spanName ?? throw new ArgumentNullException(nameof(spanName));

--- a/src/OpenTelemetry.Shims.OpenTracing/TracerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/TracerShim.cs
@@ -22,9 +22,9 @@ namespace OpenTelemetry.Shims.OpenTracing
 {
     public class TracerShim : global::OpenTracing.ITracer
     {
-        private readonly Trace.ITracer tracer;
+        private readonly Trace.Tracer tracer;
 
-        private TracerShim(Trace.ITracer tracer)
+        private TracerShim(Trace.Tracer tracer)
         {
             this.tracer = tracer ?? throw new ArgumentNullException(nameof(tracer));
             this.ScopeManager = new ScopeManagerShim(this.tracer);
@@ -36,7 +36,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public global::OpenTracing.ISpan ActiveSpan => this.ScopeManager.Active?.Span;
 
-        public static global::OpenTracing.ITracer Create(Trace.ITracer tracer)
+        public static global::OpenTracing.ITracer Create(Trace.Tracer tracer)
         {
             return new TracerShim(tracer);
         }

--- a/src/OpenTelemetry/Collector/ListenerHandler.cs
+++ b/src/OpenTelemetry/Collector/ListenerHandler.cs
@@ -20,9 +20,9 @@ namespace OpenTelemetry.Collector
 {
     public abstract class ListenerHandler
     {
-        protected readonly ITracer Tracer;
+        protected readonly Tracer Tracer;
 
-        public ListenerHandler(string sourceName, ITracer tracer)
+        public ListenerHandler(string sourceName, Tracer tracer)
         {
             this.SourceName = sourceName;
             this.Tracer = tracer;

--- a/src/OpenTelemetry/Trace/Configuration/TracerBuilder.cs
+++ b/src/OpenTelemetry/Trace/Configuration/TracerBuilder.cs
@@ -90,9 +90,9 @@ namespace OpenTelemetry.Trace.Configuration
         /// Adds auto-collectors for spans.
         /// </summary>
         /// <typeparam name="TCollector">Type of collector class.</typeparam>
-        /// <param name="collectorFactory">Function that builds collector from <see cref="ITracer"/>.</param>
+        /// <param name="collectorFactory">Function that builds collector from <see cref="Tracer"/>.</param>
         public TracerBuilder AddCollector<TCollector>(
-            Func<ITracer, TCollector> collectorFactory)
+            Func<Tracer, TCollector> collectorFactory)
             where TCollector : class
         {
             if (collectorFactory == null)
@@ -125,7 +125,7 @@ namespace OpenTelemetry.Trace.Configuration
         }
 
         /// <summary>
-        /// Configures <see cref="ITextFormat"/> on the tracer.
+        /// Configures <see cref="ITextFormat"/> on the tracerSdk.
         /// </summary>
         /// <param name="textFormat"><see cref="ITextFormat"/> implementation class instance.</param>
         public TracerBuilder SetTextFormat(ITextFormat textFormat)
@@ -135,7 +135,7 @@ namespace OpenTelemetry.Trace.Configuration
         }
 
         /// <summary>
-        /// Configures <see cref="IBinaryFormat"/> on the tracer.
+        /// Configures <see cref="IBinaryFormat"/> on the tracerSdk.
         /// </summary>
         /// <param name="binaryFormat"><see cref="IBinaryFormat"/> implementation class instance.</param>
         public TracerBuilder SetBinaryFormat(IBinaryFormat binaryFormat)
@@ -148,9 +148,9 @@ namespace OpenTelemetry.Trace.Configuration
         {
             public readonly string Name;
             public readonly string Version;
-            public readonly Func<ITracer, object> Factory;
+            public readonly Func<Tracer, object> Factory;
 
-            internal CollectorFactory(string name, string version, Func<ITracer, object> factory)
+            internal CollectorFactory(string name, string version, Func<Tracer, object> factory)
             {
                 this.Name = name;
                 this.Version = version;

--- a/src/OpenTelemetry/Trace/Span.cs
+++ b/src/OpenTelemetry/Trace/Span.cs
@@ -186,7 +186,7 @@ namespace OpenTelemetry.Trace
         public SpanKind? Kind { get; }
 
         /// <summary>
-        /// Gets the "Library Resource" (name + version) associated with the Tracer that produced this span.
+        /// Gets the "Library Resource" (name + version) associated with the TracerSdk that produced this span.
         /// </summary>
         public Resource LibraryResource { get; }
 

--- a/src/OpenTelemetry/Trace/TracerSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerSdk.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Tracer.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="TracerSdk.cs" company="OpenTelemetry Authors">
 // Copyright 2018, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,20 +25,20 @@ using OpenTelemetry.Trace.Export;
 
 namespace OpenTelemetry.Trace
 {
-    internal sealed class Tracer : ITracer
+    internal sealed class TracerSdk : Tracer
     {
         private readonly SpanProcessor spanProcessor;
         private readonly TracerConfiguration tracerConfiguration;
         private readonly Sampler sampler;
 
-        static Tracer()
+        static TracerSdk()
         {
             Activity.DefaultIdFormat = ActivityIdFormat.W3C;
             Activity.ForceDefaultIdFormat = true;
         }
 
         /// <summary>
-        /// Creates an instance of <see cref="Tracer"/>.
+        /// Creates an instance of <see cref="TracerSdk"/>.
         /// </summary>
         /// <param name="spanProcessor">Span processor.</param>
         /// <param name="sampler">Sampler to use.</param>
@@ -46,7 +46,7 @@ namespace OpenTelemetry.Trace
         /// <param name="binaryFormat">Binary format context propagator.</param>
         /// <param name="textFormat">Text format context propagator.</param>
         /// <param name="libraryResource">Resource describing the instrumentation library.</param>
-        internal Tracer(SpanProcessor spanProcessor, Sampler sampler, TracerConfiguration tracerConfiguration, IBinaryFormat binaryFormat, ITextFormat textFormat, Resource libraryResource)
+        internal TracerSdk(SpanProcessor spanProcessor, Sampler sampler, TracerConfiguration tracerConfiguration, IBinaryFormat binaryFormat, ITextFormat textFormat, Resource libraryResource)
         {
             this.spanProcessor = spanProcessor ?? throw new ArgumentNullException(nameof(spanProcessor));
             this.tracerConfiguration = tracerConfiguration ?? throw new ArgumentNullException(nameof(tracerConfiguration));
@@ -59,15 +59,15 @@ namespace OpenTelemetry.Trace
         public Resource LibraryResource { get; }
 
         /// <inheritdoc/>
-        public ISpan CurrentSpan => (ISpan)Span.Current ?? BlankSpan.Instance;
+        public override ISpan CurrentSpan => (ISpan)Span.Current ?? BlankSpan.Instance;
 
         /// <inheritdoc/>
-        public IBinaryFormat BinaryFormat { get; }
+        public override IBinaryFormat BinaryFormat { get; }
 
         /// <inheritdoc/>
-        public ITextFormat TextFormat { get; }
+        public override ITextFormat TextFormat { get; }
 
-        public IDisposable WithSpan(ISpan span, bool endSpanOnDispose)
+        public override IDisposable WithSpan(ISpan span, bool endSpanOnDispose)
         {
             if (span == null)
             {
@@ -83,13 +83,13 @@ namespace OpenTelemetry.Trace
         }
 
         /// <inheritdoc/>
-        public ISpan StartRootSpan(string operationName, SpanKind kind, SpanCreationOptions options)
+        public override ISpan StartRootSpan(string operationName, SpanKind kind, SpanCreationOptions options)
         {
             return Span.CreateRoot(operationName, kind, options, this.sampler, this.tracerConfiguration, this.spanProcessor, this.LibraryResource);
         }
 
         /// <inheritdoc/>
-        public ISpan StartSpan(string operationName, ISpan parent, SpanKind kind, SpanCreationOptions options)
+        public override ISpan StartSpan(string operationName, ISpan parent, SpanKind kind, SpanCreationOptions options)
         {
             if (parent == null)
             {
@@ -101,7 +101,7 @@ namespace OpenTelemetry.Trace
         }
 
         /// <inheritdoc/>
-        public ISpan StartSpan(string operationName, in SpanContext parent, SpanKind kind, SpanCreationOptions options)
+        public override ISpan StartSpan(string operationName, in SpanContext parent, SpanKind kind, SpanCreationOptions options)
         {
             if (parent != null)
             {
@@ -114,7 +114,7 @@ namespace OpenTelemetry.Trace
         }
 
         /// <inheritdoc/>
-        public ISpan StartSpanFromActivity(string operationName, Activity activity, SpanKind kind, IEnumerable<Link> links)
+        public override ISpan StartSpanFromActivity(string operationName, Activity activity, SpanKind kind, IEnumerable<Link> links)
         {
             bool isValidActivity = true;
             if (activity == null)

--- a/test/OpenTelemetry.Collector.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToSpanConverterTests.cs
+++ b/test/OpenTelemetry.Collector.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToSpanConverterTests.cs
@@ -27,7 +27,7 @@ namespace OpenTelemetry.Collector.StackExchangeRedis.Implementation
 {
     public class RedisProfilerEntryToSpanConverterTests
     {
-        private readonly ITracer tracer;
+        private readonly Tracer tracer;
 
         public RedisProfilerEntryToSpanConverterTests()
         {

--- a/test/OpenTelemetry.Exporter.ApplicationInsights.Tests/Implementation/ApplicationInsightsTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.ApplicationInsights.Tests/Implementation/ApplicationInsightsTraceExporterTests.cs
@@ -41,7 +41,7 @@ namespace OpenTelemetry.Exporter.ApplicationInsights.Tests
         private readonly byte[] testTraceIdBytes = { 0xd7, 0x9b, 0xdd, 0xa7, 0xeb, 0x9c, 0x4a, 0x9f, 0xa9, 0xbd, 0xa5, 0x2f, 0xe7, 0xb4, 0x8b, 0x95 };
         private readonly byte[] testSpanIdBytes = { 0xd7, 0xdd, 0xeb, 0x4a, 0xa9, 0xa5, 0xe7, 0x8b };
         private readonly byte[] testParentSpanIdBytes = { 0x9b, 0xa7, 0x9c, 0x9f, 0xbd, 0x2f, 0xb4, 0x95 };
-        private readonly ITracer tracer;
+        private readonly Tracer tracer;
         private readonly JsonSerializerSettings jsonSettingThrowOnError = new JsonSerializerSettings
         {
             MissingMemberHandling = MissingMemberHandling.Error,

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerSpanConverterTest.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerSpanConverterTest.cs
@@ -31,7 +31,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
         private const long MillisPerSecond = 1000L;
         private const long NanosPerMillisecond = 1000 * 1000;
         private const long NanosPerSecond = NanosPerMillisecond * MillisPerSecond;
-        private readonly ITracer tracer;
+        private readonly Tracer tracer;
 
         public JaegerSpanConverterTest()
         {

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerThriftIntegrationTest.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerThriftIntegrationTest.cs
@@ -31,7 +31,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
 {
     public class JaegerThriftIntegrationTest
     {
-        private readonly ITracer tracer;
+        private readonly Tracer tracer;
 
         public JaegerThriftIntegrationTest()
         {

--- a/test/OpenTelemetry.Exporter.LightStep.Tests/LightStepSpanConverterTest.cs
+++ b/test/OpenTelemetry.Exporter.LightStep.Tests/LightStepSpanConverterTest.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Exporter.LightStep.Tests
 {
     public class LightStepSpanConverterTest
     {
-        private readonly ITracer tracer;
+        private readonly Tracer tracer;
 
         public LightStepSpanConverterTest()
         {

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/ScopeManagerShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/ScopeManagerShimTests.cs
@@ -31,7 +31,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
         [Fact]
         public void Active_IsNull()
         {
-            var tracerMock = new Mock<ITracer>();
+            var tracerMock = new Mock<Tracer>();
             tracerMock.Setup(x => x.CurrentSpan).Returns(Trace.BlankSpan.Instance);
 
             var shim = new ScopeManagerShim(tracerMock.Object);
@@ -42,7 +42,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
         [Fact]
         public void Active_IsNotNull()
         {
-            var tracerMock = new Mock<ITracer>();
+            var tracerMock = new Mock<Tracer>();
             var shim = new ScopeManagerShim(tracerMock.Object);
             var openTracingSpan = new SpanShim(Defaults.GetOpenTelemetrySpanMock());
             var scopeMock = new Mock<IDisposable>();
@@ -60,7 +60,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
         [Fact]
         public void Activate_SpanMustBeShim()
         {
-            var tracerMock = new Mock<ITracer>();
+            var tracerMock = new Mock<Tracer>();
             var shim = new ScopeManagerShim(tracerMock.Object);
 
             Assert.Throws<ArgumentException>(() => shim.Activate(new Mock<global::OpenTracing.ISpan>().Object, true));
@@ -69,7 +69,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
         [Fact]
         public void Activate()
         {
-            var tracerMock = new Mock<ITracer>();
+            var tracerMock = new Mock<Tracer>();
             var shim = new ScopeManagerShim(tracerMock.Object);
             var scopeMock = new Mock<IDisposable>();
             var spanShim = new SpanShim(Defaults.GetOpenTelemetryMockSpan().Object);

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanBuilderShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanBuilderShimTests.cs
@@ -31,7 +31,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
         public void CtorArgumentValidation()
         {
             Assert.Throws<ArgumentNullException>(() => new SpanBuilderShim(null, "foo"));
-            Assert.Throws<ArgumentNullException>(() => new SpanBuilderShim(new Mock<ITracer>().Object, null));
+            Assert.Throws<ArgumentNullException>(() => new SpanBuilderShim(new Mock<Tracer>().Object, null));
         }
 
         [Fact]
@@ -324,9 +324,9 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
             Assert.Equal(spanMock, span.Span);
         }
 
-        private static Mock<ITracer> GetDefaultTracerMock(SpanMock spanMock = null)
+        private static Mock<Tracer> GetDefaultTracerMock(SpanMock spanMock = null)
         {
-            var mock = new Mock<ITracer>();
+            var mock = new Mock<Tracer>();
             spanMock = spanMock ?? Defaults.GetOpenTelemetrySpanMock();
 
             mock.Setup(x => x.StartRootSpan(It.IsAny<string>(), It.IsAny<SpanKind>(), It.IsAny<SpanCreationOptions>())).Returns(spanMock);

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/TracerShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/TracerShimTests.cs
@@ -37,7 +37,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
         [Fact]
         public void ScopeManager_NotNull()
         {
-            var tracerMock = new Mock<Trace.ITracer>();
+            var tracerMock = new Mock<Trace.Tracer>();
             var shim = TracerShim.Create(tracerMock.Object);
 
             // Internals of the ScopeManagerShim tested elsewhere
@@ -47,7 +47,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
         [Fact]
         public void BuildSpan_NotNull()
         {
-            var tracerMock = new Mock<Trace.ITracer>();
+            var tracerMock = new Mock<Trace.Tracer>();
             var shim = TracerShim.Create(tracerMock.Object);
 
             // Internals of the SpanBuilderShim tested elsewhere
@@ -57,7 +57,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
         [Fact]
         public void Inject_ArgumentValidation()
         {
-            var tracerMock = new Mock<Trace.ITracer>();
+            var tracerMock = new Mock<Trace.Tracer>();
             var shim = TracerShim.Create(tracerMock.Object);
 
             var spanContextShim = new SpanContextShim(Defaults.GetOpenTelemetrySpanContext());
@@ -73,7 +73,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
         [Fact]
         public void Inject_UnknownFormatIgnored()
         {
-            var tracerMock = new Mock<Trace.ITracer>();
+            var tracerMock = new Mock<Trace.Tracer>();
             var shim = TracerShim.Create(tracerMock.Object);
 
             var spanContextShim = new SpanContextShim(Defaults.GetOpenTelemetrySpanContext());
@@ -89,7 +89,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
         [Fact]
         public void Extract_ArgumentValidation()
         {
-            var tracerMock = new Mock<Trace.ITracer>();
+            var tracerMock = new Mock<Trace.Tracer>();
             var shim = TracerShim.Create(tracerMock.Object);
 
             Assert.Throws<ArgumentNullException>(() => shim.Extract(null, new Mock<ITextMap>().Object));
@@ -99,7 +99,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
         [Fact]
         public void Extract_UnknownFormatIgnored()
         {
-            var tracerMock = new Mock<Trace.ITracer>();
+            var tracerMock = new Mock<Trace.Tracer>();
             var shim = TracerShim.Create(tracerMock.Object);
 
             var spanContextShim = new SpanContextShim(Defaults.GetOpenTelemetrySpanContext());
@@ -115,7 +115,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
         [Fact]
         public void Extract_InvalidTraceParent()
         {
-            var tracerMock = new Mock<Trace.ITracer>();
+            var tracerMock = new Mock<Trace.Tracer>();
             var shim = TracerShim.Create(tracerMock.Object);
 
             var mockCarrier = new Mock<ITextMap>();
@@ -139,7 +139,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
         [Fact]
         public void InjectExtract_TextMap_Ok()
         {
-            var tracerMock = new Mock<Trace.ITracer>();
+            var tracerMock = new Mock<Trace.Tracer>();
 
             var carrier = new TextMapCarrier();
 
@@ -162,7 +162,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
         [Fact]
         public void InjectExtract_Binary_Ok()
         {
-            var tracerMock = new Mock<Trace.ITracer>();
+            var tracerMock = new Mock<Trace.Tracer>();
 
             var carrier = new BinaryCarrier();
 

--- a/test/OpenTelemetry.Tests/Impl/Trace/Config/TracerBuilderTests.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Config/TracerBuilderTests.cs
@@ -104,7 +104,7 @@ namespace OpenTelemetry.Tests.Impl.Trace
             Assert.Equal("semver:" + typeof(TestCollector).Assembly.GetName().Version, collectorFactory.Version);
 
             Assert.NotNull(collectorFactory.Factory);
-            collectorFactory.Factory(new Tracer(new SimpleSpanProcessor(exporter), new AlwaysSampleSampler(), options, binaryFormat, textFormat,
+            collectorFactory.Factory(new TracerSdk(new SimpleSpanProcessor(exporter), new AlwaysSampleSampler(), options, binaryFormat, textFormat,
                 Resource.Empty));
 
             Assert.True(collectorFactoryCalled);
@@ -112,8 +112,8 @@ namespace OpenTelemetry.Tests.Impl.Trace
 
         private class TestCollector 
         {
-            private readonly ITracer tracer;
-            public TestCollector(ITracer tracer)
+            private readonly Tracer tracer;
+            public TestCollector(Tracer tracer)
             {
                 this.tracer = tracer;
             }

--- a/test/OpenTelemetry.Tests/Impl/Trace/Config/TracerFactoryBaseTests.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Config/TracerFactoryBaseTests.cs
@@ -34,7 +34,7 @@ namespace OpenTelemetry.Tests.Impl.Trace.Config
             Assert.NotNull(TracerFactoryBase.Default);
             var defaultTracer = TracerFactoryBase.Default.GetTracer("");
             Assert.NotNull(defaultTracer);
-            Assert.Same(defaultTracer, TracerFactoryBase.Default.GetTracer("named tracer"));
+            Assert.Same(defaultTracer, TracerFactoryBase.Default.GetTracer("named tracerSdk"));
 
             var span = defaultTracer.StartSpan("foo");
             Assert.IsType<BlankSpan>(span);
@@ -48,9 +48,9 @@ namespace OpenTelemetry.Tests.Impl.Trace.Config
 
             var defaultTracer = TracerFactoryBase.Default.GetTracer("");
             Assert.NotNull(defaultTracer);
-            Assert.IsType<Tracer>(defaultTracer);
+            Assert.IsType<TracerSdk>(defaultTracer);
 
-            Assert.NotSame(defaultTracer, TracerFactoryBase.Default.GetTracer("named tracer"));
+            Assert.NotSame(defaultTracer, TracerFactoryBase.Default.GetTracer("named tracerSdk"));
 
             var span = defaultTracer.StartSpan("foo");
             Assert.IsType<Span>(span);
@@ -82,7 +82,7 @@ namespace OpenTelemetry.Tests.Impl.Trace.Config
 
             var newDefaultTracer = TracerFactoryBase.Default.GetTracer("");
             Assert.NotSame(defaultTracer, newDefaultTracer);
-            Assert.IsType<Tracer>(newDefaultTracer);
+            Assert.IsType<TracerSdk>(newDefaultTracer);
         }
 
         public void Dispose()

--- a/test/OpenTelemetry.Tests/Impl/Trace/Config/TracerFactoryTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Config/TracerFactoryTest.cs
@@ -42,7 +42,7 @@ namespace OpenTelemetry.Trace.Test
             var tracerFactory = TracerFactory.Create(b => { });
             var tracer = tracerFactory.GetTracer("");
             Assert.NotNull(tracer);
-            Assert.IsType<Tracer>(tracer);
+            Assert.IsType<TracerSdk>(tracer);
 
             Assert.IsType<BinaryFormat>(tracer.BinaryFormat);
             Assert.IsType<TraceContextFormat>(tracer.TextFormat);
@@ -168,7 +168,7 @@ namespace OpenTelemetry.Trace.Test
         public void GetTracer_NoName_NoVersion()
         {
             var tracerFactory = TracerFactory.Create(b => { });
-            var tracer = (Tracer)tracerFactory.GetTracer("");
+            var tracer = (TracerSdk)tracerFactory.GetTracer("");
             Assert.DoesNotContain(tracer.LibraryResource.Attributes, kvp => kvp.Key == "name");
             Assert.DoesNotContain(tracer.LibraryResource.Attributes, kvp => kvp.Key == "version");
         }
@@ -177,7 +177,7 @@ namespace OpenTelemetry.Trace.Test
         public void GetTracer_NoName_Version()
         {
             var tracerFactory = TracerFactory.Create(b => { });
-            var tracer = (Tracer)tracerFactory.GetTracer(null, "semver:1.0.0");
+            var tracer = (TracerSdk)tracerFactory.GetTracer(null, "semver:1.0.0");
             Assert.DoesNotContain(tracer.LibraryResource.Attributes, kvp => kvp.Key == "name");
             Assert.DoesNotContain(tracer.LibraryResource.Attributes, kvp => kvp.Key == "version");
         }
@@ -186,7 +186,7 @@ namespace OpenTelemetry.Trace.Test
         public void GetTracer_Name_NoVersion()
         {
             var tracerFactory = TracerFactory.Create(b => { });
-            var tracer = (Tracer)tracerFactory.GetTracer("foo");
+            var tracer = (TracerSdk)tracerFactory.GetTracer("foo");
             Assert.Equal("foo", tracer.LibraryResource.Attributes.Single(kvp => kvp.Key == "name").Value);
             Assert.DoesNotContain(tracer.LibraryResource.Attributes, kvp => kvp.Key == "version");
         }
@@ -195,7 +195,7 @@ namespace OpenTelemetry.Trace.Test
         public void GetTracer_Name_Version()
         {
             var tracerFactory = TracerFactory.Create(b => { });
-            var tracer = (Tracer)tracerFactory.GetTracer("foo", "semver:1.2.3");
+            var tracer = (TracerSdk)tracerFactory.GetTracer("foo", "semver:1.2.3");
             Assert.Equal("foo", tracer.LibraryResource.Attributes.Single(kvp => kvp.Key == "name").Value);
             Assert.Equal("semver:1.2.3", tracer.LibraryResource.Attributes.Single(kvp => kvp.Key == "version").Value);
         }
@@ -204,7 +204,7 @@ namespace OpenTelemetry.Trace.Test
         public void GetTracerReturnsTracerWithResourceAfterSetResource()
         {
             var tracerFactory = TracerFactory.Create(b => { b.SetResource(new Resource(new Dictionary<string, string>() { { "a", "b" } })); });
-            var tracer = (Tracer)tracerFactory.GetTracer("foo", "semver:1.2.3");
+            var tracer = (TracerSdk)tracerFactory.GetTracer("foo", "semver:1.2.3");
             Assert.Equal("b", tracer.LibraryResource.Attributes.Single(kvp => kvp.Key == "a").Value);
             Assert.Equal("foo", tracer.LibraryResource.Attributes.Single(kvp => kvp.Key == "name").Value);
             Assert.Equal("semver:1.2.3", tracer.LibraryResource.Attributes.Single(kvp => kvp.Key == "version").Value);
@@ -216,7 +216,7 @@ namespace OpenTelemetry.Trace.Test
             var tracerFactory = TracerFactory.Create(b => { 
                 b.SetResource(new Resource(new Dictionary<string, string>() { { "a", "b" } }))
                 .SetResource(new Resource(new Dictionary<string, string>() { { "a", "c" } })); });
-            var tracer = (Tracer)tracerFactory.GetTracer("foo", "semver:1.2.3");
+            var tracer = (TracerSdk)tracerFactory.GetTracer("foo", "semver:1.2.3");
             Assert.Equal("c", tracer.LibraryResource.Attributes.Single(kvp => kvp.Key == "a").Value);
         }
 
@@ -284,10 +284,10 @@ namespace OpenTelemetry.Trace.Test
 
         private class TestCollector : IDisposable
         {
-            private readonly ITracer tracer;
+            private readonly Tracer tracer;
             public bool IsDisposed { get; private set; }
 
-            public TestCollector(ITracer tracer)
+            public TestCollector(Tracer tracer)
             {
                 this.tracer = tracer;
             }

--- a/test/OpenTelemetry.Tests/Impl/Trace/CurrentSpanTests.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/CurrentSpanTests.cs
@@ -24,7 +24,7 @@ namespace OpenTelemetry.Trace.Test
 {
     public class CurrentSpanTests: IDisposable
     {
-        private readonly ITracer tracer;
+        private readonly Tracer tracer;
 
         public CurrentSpanTests()
         {

--- a/test/OpenTelemetry.Tests/Impl/Trace/Export/SimpleSpanProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Export/SimpleSpanProcessorTests.cs
@@ -31,7 +31,7 @@ namespace OpenTelemetry.Trace.Export.Test
         private const string SpanName2 = "MySpanName/2";
 
         private TestExporter spanExporter;
-        private ITracer tracer;
+        private Tracer tracer;
 
         public SimpleSpanProcessorTest()
         {

--- a/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
@@ -58,7 +58,7 @@ namespace OpenTelemetry.Trace.Test
         [Fact]
         public void StartSpanFrom_Recorded_ParentSpan()
         {
-            var tracer = (Tracer)tracerFactory.GetTracer("foo", "semver:1.0.0");
+            var tracer = (TracerSdk)tracerFactory.GetTracer("foo", "semver:1.0.0");
 
             var traceState = new List<KeyValuePair<string, string>> {new KeyValuePair<string, string>("k1", "v1")};
             var grandParentContext = new SpanContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded, false, traceState);

--- a/test/OpenTelemetry.Tests/Impl/Trace/TracerTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/TracerTest.cs
@@ -36,7 +36,7 @@ namespace OpenTelemetry.Trace.Test
         private const string SpanName = "MySpanName";
         private readonly SpanProcessor spanProcessor;
         private readonly TracerConfiguration tracerConfiguration;
-        private readonly Tracer tracer;
+        private readonly TracerSdk tracerSdk;
         private readonly TracerFactory tracerFactory;
 
         public TracerTest()
@@ -45,86 +45,86 @@ namespace OpenTelemetry.Trace.Test
             tracerConfiguration = new TracerConfiguration();
             tracerFactory = TracerFactory.Create(b => b
                     .AddProcessorPipeline(p => p.AddProcessor(_ => spanProcessor)));
-            tracer = (Tracer)tracerFactory.GetTracer(null);
+            this.tracerSdk = (TracerSdk)tracerFactory.GetTracer(null);
         }
 
         [Fact]
         public void BadConstructorArgumentsThrow()
         {
             var noopProc = new SimpleSpanProcessor(new TestExporter(null));
-            Assert.Throws<ArgumentNullException>(() => new Tracer(null, new AlwaysSampleSampler(), new TracerConfiguration(), new BinaryFormat(), new TraceContextFormat(), Resource.Empty));
+            Assert.Throws<ArgumentNullException>(() => new TracerSdk(null, new AlwaysSampleSampler(), new TracerConfiguration(), new BinaryFormat(), new TraceContextFormat(), Resource.Empty));
 
-            Assert.Throws<ArgumentNullException>(() => new Tracer(noopProc, new AlwaysSampleSampler(), null, new BinaryFormat(), new TraceContextFormat(), Resource.Empty));
+            Assert.Throws<ArgumentNullException>(() => new TracerSdk(noopProc, new AlwaysSampleSampler(), null, new BinaryFormat(), new TraceContextFormat(), Resource.Empty));
 
-            Assert.Throws<ArgumentNullException>(() => new Tracer(noopProc, new AlwaysSampleSampler(), new TracerConfiguration(), null, new TraceContextFormat(), Resource.Empty));
-            Assert.Throws<ArgumentNullException>(() => new Tracer(noopProc, new AlwaysSampleSampler(), new TracerConfiguration(), new BinaryFormat(), null, Resource.Empty));
+            Assert.Throws<ArgumentNullException>(() => new TracerSdk(noopProc, new AlwaysSampleSampler(), new TracerConfiguration(), null, new TraceContextFormat(), Resource.Empty));
+            Assert.Throws<ArgumentNullException>(() => new TracerSdk(noopProc, new AlwaysSampleSampler(), new TracerConfiguration(), new BinaryFormat(), null, Resource.Empty));
 
-            Assert.Throws<ArgumentNullException>(() => new Tracer(noopProc, new AlwaysSampleSampler(), new TracerConfiguration(), new BinaryFormat(), new TraceContextFormat(), null));
+            Assert.Throws<ArgumentNullException>(() => new TracerSdk(noopProc, new AlwaysSampleSampler(), new TracerConfiguration(), new BinaryFormat(), new TraceContextFormat(), null));
         }
 
         [Fact]
         public void Tracer_StartRootSpan_BadArgs_NullSpanName()
         {
-            var span1 = (Span)tracer.StartRootSpan(null);
+            var span1 = (Span)this.tracerSdk.StartRootSpan(null);
             Assert.Equal(string.Empty, span1.Name);
 
-            var span2 = (Span)tracer.StartRootSpan(null, SpanKind.Client);
+            var span2 = (Span)this.tracerSdk.StartRootSpan(null, SpanKind.Client);
             Assert.Equal(string.Empty, span2.Name);
 
-            var span3 = (Span)tracer.StartRootSpan(null, SpanKind.Client, null);
+            var span3 = (Span)this.tracerSdk.StartRootSpan(null, SpanKind.Client, null);
             Assert.Equal(string.Empty, span3.Name);
         }
 
         [Fact]
         public void Tracer_StartSpan_BadArgs_NullSpanName()
         {
-            var span1 = (Span)tracer.StartSpan(null);
+            var span1 = (Span)this.tracerSdk.StartSpan(null);
             Assert.Equal(string.Empty, span1.Name);
 
-            var span2 = (Span)tracer.StartSpan(null, SpanKind.Client);
+            var span2 = (Span)this.tracerSdk.StartSpan(null, SpanKind.Client);
             Assert.Equal(string.Empty, span2.Name);
 
-            var span3 = (Span)tracer.StartSpan(null, SpanKind.Client, null);
+            var span3 = (Span)this.tracerSdk.StartSpan(null, SpanKind.Client, null);
             Assert.Equal(string.Empty, span3.Name);
         }
 
         [Fact]
         public void Tracer_StartSpan_FromParent_BadArgs_NullSpanName()
         {
-            var span1 = (Span)tracer.StartSpan(null, BlankSpan.Instance);
+            var span1 = (Span)this.tracerSdk.StartSpan(null, BlankSpan.Instance);
             Assert.Equal(string.Empty, span1.Name);
 
-            var span2 = (Span)tracer.StartSpan(null, BlankSpan.Instance, SpanKind.Client);
+            var span2 = (Span)this.tracerSdk.StartSpan(null, BlankSpan.Instance, SpanKind.Client);
             Assert.Equal(string.Empty, span2.Name);
 
-            var span3 = (Span)tracer.StartSpan(null, BlankSpan.Instance, SpanKind.Client, null);
+            var span3 = (Span)this.tracerSdk.StartSpan(null, BlankSpan.Instance, SpanKind.Client, null);
             Assert.Equal(string.Empty, span3.Name);
         }
 
         [Fact]
         public void Tracer_StartSpan_FromParentContext_BadArgs_NullSpanName()
         {
-            var span1 = (Span)tracer.StartSpan(null, SpanContext.BlankLocal);
+            var span1 = (Span)this.tracerSdk.StartSpan(null, SpanContext.BlankLocal);
             Assert.Equal(string.Empty, span1.Name);
 
-            var span2 = (Span)tracer.StartSpan(null, SpanContext.BlankLocal, SpanKind.Client);
+            var span2 = (Span)this.tracerSdk.StartSpan(null, SpanContext.BlankLocal, SpanKind.Client);
             Assert.Equal(string.Empty, span2.Name);
 
-            var span3 = (Span)tracer.StartSpan(null, SpanContext.BlankLocal, SpanKind.Client, null);
+            var span3 = (Span)this.tracerSdk.StartSpan(null, SpanContext.BlankLocal, SpanKind.Client, null);
             Assert.Equal(string.Empty, span3.Name);
         }
 
         [Fact]
         public void Tracer_StartSpan_FromActivity_BadArgs_NullSpanName()
         {
-            var span = (Span)tracer.StartSpanFromActivity(null, new Activity("foo").Start());
+            var span = (Span)this.tracerSdk.StartSpanFromActivity(null, new Activity("foo").Start());
             Assert.Equal(string.Empty, span.Name);
         }
 
         [Fact]
         public void Tracer_StartSpan_FromActivity_BadArgs_NullActivity()
         {
-            var span = (Span)tracer.StartSpanFromActivity("foo", null);
+            var span = (Span)this.tracerSdk.StartSpanFromActivity("foo", null);
             Assert.NotNull(span);
             Assert.Equal("foo", span.Name);
             Assert.Equal(default, span.ParentSpanId);
@@ -133,24 +133,24 @@ namespace OpenTelemetry.Trace.Test
         [Fact]
         public void GetCurrentSpanBlank()
         {
-            Assert.Same(BlankSpan.Instance, tracer.CurrentSpan);
+            Assert.Same(BlankSpan.Instance, this.tracerSdk.CurrentSpan);
         }
 
         [Fact]
         public void GetCurrentSpan()
         {
-            var span = tracer.StartSpan("foo");
-            using (tracer.WithSpan(span))
+            var span = this.tracerSdk.StartSpan("foo");
+            using (this.tracerSdk.WithSpan(span))
             {
-                Assert.Same(span, tracer.CurrentSpan);
+                Assert.Same(span, this.tracerSdk.CurrentSpan);
             }
-            Assert.Same(BlankSpan.Instance, tracer.CurrentSpan);
+            Assert.Same(BlankSpan.Instance, this.tracerSdk.CurrentSpan);
         }
 
         [Fact]
         public void CreateSpan_Sampled()
         {
-            var span = tracer.StartSpan("foo");
+            var span = this.tracerSdk.StartSpan("foo");
             Assert.True(span.IsRecording);
         }
 
@@ -169,7 +169,7 @@ namespace OpenTelemetry.Trace.Test
         [Fact]
         public void CreateSpan_ByTracerWithResource()
         {
-            var tracer = (Tracer)tracerFactory.GetTracer("foo", "semver:1.0.0");
+            var tracer = (TracerSdk)tracerFactory.GetTracer("foo", "semver:1.0.0");
             var span = (Span)tracer.StartSpan("some span");
             Assert.Equal(tracer.LibraryResource, span.LibraryResource);
         }
@@ -177,26 +177,26 @@ namespace OpenTelemetry.Trace.Test
         [Fact]
         public void WithSpanNull()
         {
-            Assert.NotNull(this.tracer.WithSpan(null));
-            Assert.Equal(BlankSpan.Instance, this.tracer.CurrentSpan);
+            Assert.NotNull(this.tracerSdk.WithSpan(null));
+            Assert.Equal(BlankSpan.Instance, this.tracerSdk.CurrentSpan);
 
-            using (this.tracer.StartActiveSpan("some span", out var span))
+            using (this.tracerSdk.StartActiveSpan("some span", out var span))
             {
-                this.tracer.WithSpan(null);
-                Assert.Equal(span, this.tracer.CurrentSpan);
+                this.tracerSdk.WithSpan(null);
+                Assert.Equal(span, this.tracerSdk.CurrentSpan);
             }
         }
 
         [Fact]
         public void GetTextFormat()
         {
-            Assert.NotNull(tracer.TextFormat);
+            Assert.NotNull(this.tracerSdk.TextFormat);
         }
 
         [Fact]
         public void GetBinaryFormat()
         {
-            Assert.NotNull(tracer.BinaryFormat);
+            Assert.NotNull(this.tracerSdk.BinaryFormat);
         }
 
         [Fact]


### PR DESCRIPTION
Tracer in SDK becomes `TracerSdk` (which is internal class).

This allows Tracer abstraction to be extendable.