### PR TITLE
Cleanup: Remove SetAttribute(string) and AddEvent(name, attributes) overloads on Span

### DIFF
--- a/samples/Exporters/TestJaeger.cs
+++ b/samples/Exporters/TestJaeger.cs
@@ -75,7 +75,7 @@ namespace Samples
                 var attributes = new Dictionary<string, object>();
                 attributes.Add("use", "demo");
                 attributes.Add("iteration", i);
-                span.AddEvent("Invoking DoWork", attributes);
+                span.AddEvent(new Event("Invoking DoWork", attributes));
             }
         }
     }

--- a/samples/Exporters/TestLightstep.cs
+++ b/samples/Exporters/TestLightstep.cs
@@ -60,7 +60,7 @@ namespace Samples
                 // Annotate our span to capture metadata about our operation
                 var attributes = new Dictionary<string, object>();
                 attributes.Add("use", "demo");
-                span.AddEvent("Invoking DoWork", attributes);
+                span.AddEvent(new Event("Invoking DoWork", attributes));
             }
         }
     }

--- a/samples/Exporters/TestRedis.cs
+++ b/samples/Exporters/TestRedis.cs
@@ -96,7 +96,7 @@ namespace Samples
                 {
                     { "use", "demo" },
                 };
-                span.AddEvent("Invoking DoWork", attributes);
+                span.AddEvent(new Event("Invoking DoWork", attributes));
             }
         }
     }

--- a/samples/Exporters/TestZipkin.cs
+++ b/samples/Exporters/TestZipkin.cs
@@ -70,9 +70,8 @@ namespace Samples
                 }
 
                 // Annotate our span to capture metadata about our operation
-                var attributes = new Dictionary<string, object>();
-                attributes.Add("use", "demo");
-                span.AddEvent("Invoking DoWork", attributes);
+                var attributes = new Dictionary<string, object> { { "use", "demo" } };
+                span.AddEvent(new Event("Invoking DoWork", attributes));
             }
         }
     }

--- a/src/OpenTelemetry.Api/Internal/BlankSpan.cs
+++ b/src/OpenTelemetry.Api/Internal/BlankSpan.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 using System;
-using System.Collections.Generic;
 
 namespace OpenTelemetry.Trace
 {
@@ -47,37 +46,12 @@ namespace OpenTelemetry.Trace
         }
 
         /// <inheritdoc />
-        public void SetAttribute(KeyValuePair<string, object> keyValuePair)
-        {
-        }
-
-        /// <inheritdoc />
-        public void SetAttribute(string key, string value)
-        {
-        }
-
-        /// <inheritdoc />
-        public void SetAttribute(string key, long value)
-        {
-        }
-
-        /// <inheritdoc />
-        public void SetAttribute(string key, double value)
-        {
-        }
-
-        /// <inheritdoc />
-        public void SetAttribute(string key, bool value)
+        public void SetAttribute(string key, object value)
         {
         }
 
         /// <inheritdoc />
         public void AddEvent(string name)
-        {
-        }
-
-        /// <inheritdoc />
-        public void AddEvent(string name, IDictionary<string, object> attributes)
         {
         }
 

--- a/src/OpenTelemetry.Api/Internal/BlankSpan.cs
+++ b/src/OpenTelemetry.Api/Internal/BlankSpan.cs
@@ -51,6 +51,21 @@ namespace OpenTelemetry.Trace
         }
 
         /// <inheritdoc />
+        public void SetAttribute(string key, bool value)
+        {
+        }
+
+        /// <inheritdoc />
+        public void SetAttribute(string key, long value)
+        {
+        }
+
+        /// <inheritdoc />
+        public void SetAttribute(string key, double value)
+        {
+        }
+
+        /// <inheritdoc />
         public void AddEvent(string name)
         {
         }

--- a/src/OpenTelemetry.Api/Trace/Event.cs
+++ b/src/OpenTelemetry.Api/Trace/Event.cs
@@ -61,6 +61,18 @@ namespace OpenTelemetry.Trace
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="Event"/> class.
+        /// </summary>
+        /// <param name="name">Event name.</param>
+        /// <param name="attributes">Event attributes.</param>
+        public Event(string name, IDictionary<string, object> attributes)
+        {
+            this.Name = name ?? string.Empty;
+            this.Attributes = attributes ?? EmptyAttributes;
+            this.Timestamp = PreciseTimestamp.GetUtcNow();
+        }
+
+        /// <summary>
         /// Gets the <see cref="Event"/> name.
         /// </summary>
         public string Name { get; }

--- a/src/OpenTelemetry.Api/Trace/ISpan.cs
+++ b/src/OpenTelemetry.Api/Trace/ISpan.cs
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using System;
-using System.Collections.Generic;
 
 namespace OpenTelemetry.Trace
 {
@@ -55,36 +55,9 @@ namespace OpenTelemetry.Trace
         /// <summary>
         /// Puts a new attribute to the span.
         /// </summary>
-        /// <param name="key">Key of the attribute.</param>
+        /// <param name="key">Attribute key.</param>
         /// <param name="value">Attribute value.</param>
-        void SetAttribute(string key, string value);
-
-        /// <summary>
-        /// Puts a new attribute to the span.
-        /// </summary>
-        /// <param name="key">Key of the attribute.</param>
-        /// <param name="value">Attribute value.</param>
-        void SetAttribute(string key, long value);
-
-        /// <summary>
-        /// Puts a new attribute to the span.
-        /// </summary>
-        /// <param name="key">Key of the attribute.</param>
-        /// <param name="value">Attribute value.</param>
-        void SetAttribute(string key, double value);
-
-        /// <summary>
-        /// Puts a new attribute to the span.
-        /// </summary>
-        /// <param name="key">Key of the attribute.</param>
-        /// <param name="value">Attribute value.</param>
-        void SetAttribute(string key, bool value);
-
-        /// <summary>
-        /// Puts a new attribute to the span.
-        /// </summary>
-        /// <param name="attribute">Attribute as a <see cref="KeyValuePair{TKey, TValue}"/>.</param>
-        void SetAttribute(KeyValuePair<string, object> attribute);
+        void SetAttribute(string key, object value);
 
         /// <summary>
         /// Adds a single <see cref="Event"/> to the <see cref="ISpan"/>.
@@ -93,14 +66,7 @@ namespace OpenTelemetry.Trace
         void AddEvent(string name);
 
         /// <summary>
-        /// Adds a single <see cref="Event"/> with the <see cref="IDictionary{String, IAttributeValue}"/> attributes to the <see cref="ISpan"/>.
-        /// </summary>
-        /// <param name="name">Event name.</param>
-        /// <param name="attributes"><see cref="IDictionary{String, IAttributeValue}"/> of attributes name/value pairs associated with the <see cref="Event"/>.</param>
-        void AddEvent(string name, IDictionary<string, object> attributes);
-
-        /// <summary>
-        /// Adds an <see cref="Event"/> object to the <see cref="ISpan"/>.
+        /// Adds an <see cref="Event"/> instance to the <see cref="ISpan"/>.
         /// </summary>
         /// <param name="newEvent"><see cref="Event"/> to add to the span.</param>
         void AddEvent(Event newEvent);

--- a/src/OpenTelemetry.Api/Trace/ISpan.cs
+++ b/src/OpenTelemetry.Api/Trace/ISpan.cs
@@ -53,11 +53,32 @@ namespace OpenTelemetry.Trace
         void UpdateName(string name);
 
         /// <summary>
-        /// Puts a new attribute to the span.
+        /// Sets a new attribute on the span.
         /// </summary>
         /// <param name="key">Attribute key.</param>
         /// <param name="value">Attribute value.</param>
         void SetAttribute(string key, object value);
+
+        /// <summary>
+        /// Sets a new attribute on the span.
+        /// </summary>
+        /// <param name="key">Attribute key.</param>
+        /// <param name="value">Attribute value.</param>
+        void SetAttribute(string key, long value);
+
+        /// <summary>
+        /// Sets a new attribute on the span.
+        /// </summary>
+        /// <param name="key">Attribute key.</param>
+        /// <param name="value">Attribute value.</param>
+        void SetAttribute(string key, bool value);
+
+        /// <summary>
+        /// Sets a new attribute on the span.
+        /// </summary>
+        /// <param name="key">Attribute key.</param>
+        /// <param name="value">Attribute value.</param>
+        void SetAttribute(string key, double value);
 
         /// <summary>
         /// Adds a single <see cref="Event"/> to the <see cref="ISpan"/>.

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
@@ -201,7 +201,7 @@ namespace OpenTelemetry.Shims.OpenTracing
 
             foreach (var kvp in this.attributes)
             {
-                span.SetAttribute(kvp);
+                span.SetAttribute(kvp.Key, kvp.Value);
             }
 
             if (this.error)

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanShim.cs
@@ -18,10 +18,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using global::OpenTracing;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Shims.OpenTracing
 {
-    public sealed class SpanShim : ISpan
+    public sealed class SpanShim : global::OpenTracing.ISpan
     {
         /// <summary>
         /// The default event name if not specified.
@@ -82,7 +83,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         }
 
         /// <inheritdoc/>
-        public ISpan Log(DateTimeOffset timestamp, IEnumerable<KeyValuePair<string, object>> fields)
+        public global::OpenTracing.ISpan Log(DateTimeOffset timestamp, IEnumerable<KeyValuePair<string, object>> fields)
         {
             if (fields is null)
             {
@@ -93,26 +94,21 @@ namespace OpenTelemetry.Shims.OpenTracing
             var eventName = payload.Item1;
             var eventAttributes = payload.Item2;
 
-            if (timestamp == DateTimeOffset.MinValue)
-            {
-                this.Span.AddEvent(eventName, eventAttributes);
-            }
-            else
-            {
-                this.Span.AddEvent(new Trace.Event(eventName, timestamp, eventAttributes));
-            }
+            this.Span.AddEvent(timestamp == DateTimeOffset.MinValue
+                ? new Event(eventName, eventAttributes)
+                : new Event(eventName, timestamp, eventAttributes));
 
             return this;
         }
 
         /// <inheritdoc/>
-        public ISpan Log(IEnumerable<KeyValuePair<string, object>> fields)
+        public global::OpenTracing.ISpan Log(IEnumerable<KeyValuePair<string, object>> fields)
         {
             return this.Log(DateTimeOffset.MinValue, fields);
         }
 
         /// <inheritdoc/>
-        public ISpan Log(string @event)
+        public global::OpenTracing.ISpan Log(string @event)
         {
             if (@event is null)
             {
@@ -124,7 +120,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         }
 
         /// <inheritdoc/>
-        public ISpan Log(DateTimeOffset timestamp, string @event)
+        public global::OpenTracing.ISpan Log(DateTimeOffset timestamp, string @event)
         {
             if (@event is null)
             {
@@ -136,7 +132,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         }
 
         /// <inheritdoc/>
-        public ISpan SetBaggageItem(string key, string value)
+        public global::OpenTracing.ISpan SetBaggageItem(string key, string value)
         {
             if (key is null)
             {
@@ -148,7 +144,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         }
 
         /// <inheritdoc/>
-        public ISpan SetOperationName(string operationName)
+        public global::OpenTracing.ISpan SetOperationName(string operationName)
         {
             if (operationName is null)
             {
@@ -160,7 +156,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         }
 
         /// <inheritdoc/>
-        public ISpan SetTag(string key, string value)
+        public global::OpenTracing.ISpan SetTag(string key, string value)
         {
             if (key is null)
             {
@@ -172,7 +168,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         }
 
         /// <inheritdoc/>
-        public ISpan SetTag(string key, bool value)
+        public global::OpenTracing.ISpan SetTag(string key, bool value)
         {
             if (key is null)
             {
@@ -194,7 +190,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         }
 
         /// <inheritdoc/>
-        public ISpan SetTag(string key, int value)
+        public global::OpenTracing.ISpan SetTag(string key, int value)
         {
             if (key is null)
             {
@@ -206,7 +202,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         }
 
         /// <inheritdoc/>
-        public ISpan SetTag(string key, double value)
+        public global::OpenTracing.ISpan SetTag(string key, double value)
         {
             if (key is null)
             {
@@ -218,13 +214,13 @@ namespace OpenTelemetry.Shims.OpenTracing
         }
 
         /// <inheritdoc/>
-        public ISpan SetTag(global::OpenTracing.Tag.BooleanTag tag, bool value)
+        public global::OpenTracing.ISpan SetTag(global::OpenTracing.Tag.BooleanTag tag, bool value)
         {
             return this.SetTag(tag?.Key, value);
         }
 
         /// <inheritdoc/>
-        public ISpan SetTag(global::OpenTracing.Tag.IntOrStringTag tag, string value)
+        public global::OpenTracing.ISpan SetTag(global::OpenTracing.Tag.IntOrStringTag tag, string value)
         {
             if (int.TryParse(value, out var result))
             {
@@ -235,13 +231,13 @@ namespace OpenTelemetry.Shims.OpenTracing
         }
 
         /// <inheritdoc/>
-        public ISpan SetTag(global::OpenTracing.Tag.IntTag tag, int value)
+        public global::OpenTracing.ISpan SetTag(global::OpenTracing.Tag.IntTag tag, int value)
         {
             return this.SetTag(tag?.Key, value);
         }
 
         /// <inheritdoc/>
-        public ISpan SetTag(global::OpenTracing.Tag.StringTag tag, string value)
+        public global::OpenTracing.ISpan SetTag(global::OpenTracing.Tag.StringTag tag, string value)
         {
             return this.SetTag(tag?.Key, value);
         }

--- a/src/OpenTelemetry/Trace/Span.cs
+++ b/src/OpenTelemetry/Trace/Span.cs
@@ -121,7 +121,7 @@ namespace OpenTelemetry.Trace
                 {
                     foreach (var attribute in spanCreationOptions.Attributes)
                     {
-                        this.SetAttribute(attribute);
+                        this.SetAttribute(attribute.Key, attribute.Value);
                     }
                 }
 
@@ -234,7 +234,7 @@ namespace OpenTelemetry.Trace
         }
 
         /// <inheritdoc/>
-        public void SetAttribute(KeyValuePair<string, object> keyValuePair)
+        public void SetAttribute(string key, object value)
         {
             if (!this.IsRecording)
             {
@@ -247,6 +247,13 @@ namespace OpenTelemetry.Trace
                 return;
             }
 
+            object sanitizedValue = value;
+            if (value == null || !this.IsAttributeValueTypeSupported(value))
+            {
+                OpenTelemetrySdkEventSource.Log.InvalidArgument("SetAttribute", nameof(value), $"Type '{value?.GetType()}' of attribute '{key}' is not supported");
+                sanitizedValue = string.Empty;
+            }
+
             lock (this.lck)
             {
                 if (this.attributes == null)
@@ -255,7 +262,7 @@ namespace OpenTelemetry.Trace
                         new EvictingQueue<KeyValuePair<string, object>>(this.tracerConfiguration.MaxNumberOfAttributes);
                 }
 
-                this.attributes.Add(new KeyValuePair<string, object>(keyValuePair.Key ?? string.Empty, keyValuePair.Value ?? string.Empty));
+                this.attributes.Add(new KeyValuePair<string, object>(key ?? string.Empty, sanitizedValue));
             }
         }
 
@@ -274,23 +281,6 @@ namespace OpenTelemetry.Trace
             }
 
             this.AddEvent(new Event(name, PreciseTimestamp.GetUtcNow()));
-        }
-
-        /// <inheritdoc/>
-        public void AddEvent(string name, IDictionary<string, object> eventAttributes)
-        {
-            if (!this.IsRecording)
-            {
-                return;
-            }
-
-            if (this.hasEnded)
-            {
-                OpenTelemetrySdkEventSource.Log.UnexpectedCallOnEndedSpan("AddEvent");
-                return;
-            }
-
-            this.AddEvent(new Event(name, PreciseTimestamp.GetUtcNow(), eventAttributes));
         }
 
         /// <inheritdoc/>
@@ -356,50 +346,6 @@ namespace OpenTelemetry.Trace
             {
                 this.spanProcessor.OnEnd(this);
             }
-        }
-
-        /// <inheritdoc/>
-        public void SetAttribute(string key, string value)
-        {
-            if (!this.IsRecording)
-            {
-                return;
-            }
-
-            this.SetAttribute(new KeyValuePair<string, object>(key, value));
-        }
-
-        /// <inheritdoc/>
-        public void SetAttribute(string key, long value)
-        {
-            if (!this.IsRecording)
-            {
-                return;
-            }
-
-            this.SetAttribute(new KeyValuePair<string, object>(key, value));
-        }
-
-        /// <inheritdoc/>
-        public void SetAttribute(string key, double value)
-        {
-            if (!this.IsRecording)
-            {
-                return;
-            }
-
-            this.SetAttribute(new KeyValuePair<string, object>(key, value));
-        }
-
-        /// <inheritdoc/>
-        public void SetAttribute(string key, bool value)
-        {
-            if (!this.IsRecording)
-            {
-                return;
-            }
-
-            this.SetAttribute(new KeyValuePair<string, object>(key, value));
         }
 
         public void Dispose()
@@ -715,6 +661,35 @@ namespace OpenTelemetry.Trace
             {
                 OpenTelemetrySdkEventSource.Log.AttemptToEndScopeWhichIsNotCurrent(this.Name);
             }
+        }
+
+        private bool IsAttributeValueTypeSupported(object attributeValue)
+        {
+            if (this.IsNumericBoolOrString(attributeValue))
+            {
+                return true;
+            }
+
+            // TODO add array support
+
+            return false;
+        }
+
+        private bool IsNumericBoolOrString(object attributeValue)
+        {
+            return attributeValue is string
+                   || attributeValue is bool
+                   || attributeValue is int
+                   || attributeValue is uint
+                   || attributeValue is long
+                   || attributeValue is ulong
+                   || attributeValue is double
+                   || attributeValue is sbyte
+                   || attributeValue is byte
+                   || attributeValue is short
+                   || attributeValue is ushort
+                   || attributeValue is float
+                   || attributeValue is decimal;
         }
 
         private readonly struct ActivityAndTracestate

--- a/src/OpenTelemetry/Trace/Span.cs
+++ b/src/OpenTelemetry/Trace/Span.cs
@@ -267,6 +267,84 @@ namespace OpenTelemetry.Trace
         }
 
         /// <inheritdoc/>
+        public void SetAttribute(string key, bool value)
+        {
+            if (!this.IsRecording)
+            {
+                return;
+            }
+
+            if (this.hasEnded)
+            {
+                OpenTelemetrySdkEventSource.Log.UnexpectedCallOnEndedSpan("SetAttribute");
+                return;
+            }
+
+            lock (this.lck)
+            {
+                if (this.attributes == null)
+                {
+                    this.attributes =
+                        new EvictingQueue<KeyValuePair<string, object>>(this.tracerConfiguration.MaxNumberOfAttributes);
+                }
+
+                this.attributes.Add(new KeyValuePair<string, object>(key ?? string.Empty, value));
+            }
+        }
+
+        /// <inheritdoc/>
+        public void SetAttribute(string key, long value)
+        {
+            if (!this.IsRecording)
+            {
+                return;
+            }
+
+            if (this.hasEnded)
+            {
+                OpenTelemetrySdkEventSource.Log.UnexpectedCallOnEndedSpan("SetAttribute");
+                return;
+            }
+
+            lock (this.lck)
+            {
+                if (this.attributes == null)
+                {
+                    this.attributes =
+                        new EvictingQueue<KeyValuePair<string, object>>(this.tracerConfiguration.MaxNumberOfAttributes);
+                }
+
+                this.attributes.Add(new KeyValuePair<string, object>(key ?? string.Empty, value));
+            }
+        }
+
+        /// <inheritdoc/>
+        public void SetAttribute(string key, double value)
+        {
+            if (!this.IsRecording)
+            {
+                return;
+            }
+
+            if (this.hasEnded)
+            {
+                OpenTelemetrySdkEventSource.Log.UnexpectedCallOnEndedSpan("SetAttribute");
+                return;
+            }
+
+            lock (this.lck)
+            {
+                if (this.attributes == null)
+                {
+                    this.attributes =
+                        new EvictingQueue<KeyValuePair<string, object>>(this.tracerConfiguration.MaxNumberOfAttributes);
+                }
+
+                this.attributes.Add(new KeyValuePair<string, object>(key ?? string.Empty, value));
+            }
+        }
+
+        /// <inheritdoc/>
         public void AddEvent(string name)
         {
             if (!this.IsRecording)

--- a/test/OpenTelemetry.Collector.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
+++ b/test/OpenTelemetry.Collector.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
@@ -99,7 +99,7 @@ namespace OpenTelemetry.Collector.AspNetCore.Tests
 
             Assert.Equal(SpanKind.Server, span.Kind);
             Assert.Equal("/api/values", span.Attributes.GetValue("http.path"));
-            Assert.Equal(503, span.Attributes.GetValue("http.status_code"));
+            Assert.Equal(503L, span.Attributes.GetValue("http.status_code"));
         }
     }
 }

--- a/test/OpenTelemetry.Collector.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
+++ b/test/OpenTelemetry.Collector.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
@@ -99,7 +99,7 @@ namespace OpenTelemetry.Collector.AspNetCore.Tests
 
             Assert.Equal(SpanKind.Server, span.Kind);
             Assert.Equal("/api/values", span.Attributes.GetValue("http.path"));
-            Assert.Equal(503L, span.Attributes.GetValue("http.status_code"));
+            Assert.Equal(503, span.Attributes.GetValue("http.status_code"));
         }
     }
 }

--- a/test/OpenTelemetry.Exporter.ApplicationInsights.Tests/Implementation/ApplicationInsightsTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.ApplicationInsights.Tests/Implementation/ApplicationInsightsTraceExporterTests.cs
@@ -1471,12 +1471,12 @@ namespace OpenTelemetry.Exporter.ApplicationInsights.Tests
             var now = DateTimeOffset.UtcNow.AddSeconds(-1);
 
             span.AddEvent(new Event("test message1", now));
-            span.AddEvent("test message2", new Dictionary<string, object>()
+            span.AddEvent(new Event("test message2", new Dictionary<string, object>()
             {
                 { "custom.stringAttribute", "string" },
                 { "custom.longAttribute", long.MaxValue },
                 { "custom.boolAttribute", true },
-            });
+            }));
 
             var sentItems = ConvertSpan(span);
 

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerSpanConverterTest.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerSpanConverterTest.cs
@@ -382,7 +382,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
             {
                 foreach (var attribute in attributes)
                 {
-                    span.SetAttribute(attribute);
+                    span.SetAttribute(attribute.Key, attribute.Value);
                 }
             }
 

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerThriftIntegrationTest.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerThriftIntegrationTest.cs
@@ -121,7 +121,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
 
             foreach (var attribute in attributes)
             {
-                span.SetAttribute(attribute);
+                span.SetAttribute(attribute.Key, attribute.Value);
             }
 
             foreach (var evnt in events)

--- a/test/OpenTelemetry.Exporter.LightStep.Tests/LightStepSpanConverterTest.cs
+++ b/test/OpenTelemetry.Exporter.LightStep.Tests/LightStepSpanConverterTest.cs
@@ -84,7 +84,7 @@ namespace OpenTelemetry.Exporter.LightStep.Tests
 
             foreach (var attribute in attrs)
             {
-                span.SetAttribute(attribute);
+                span.SetAttribute(attribute.Key, attribute.Value);
             }
 
             foreach (var evnt in evts)

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanMock.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanMock.cs
@@ -76,6 +76,21 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
             this.Attributes.Add(new KeyValuePair<string, object>(key, value));
         }
 
+        public void SetAttribute(string key, long value)
+        {
+            this.SetAttribute(key, (object)value);
+        }
+
+        public void SetAttribute(string key, bool value)
+        {
+            this.SetAttribute(key, (object)value);
+        }
+
+        public void SetAttribute(string key, double value)
+        {
+            this.SetAttribute(key, (object)value);
+        }
+
         public void UpdateName(string name)
         {
             this.Name = name;

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanMock.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanMock.cs
@@ -23,11 +23,11 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
     /// <summary>
     /// A mock ISpan implementation for unit tests. Sometimes an actual Mock is just easier to deal with than objects created with Moq.
     /// </summary>
-    internal class SpanMock : Trace.ISpan, IDisposable
+    internal class SpanMock : ISpan, IDisposable
     {
         private static readonly ReadOnlyDictionary<string, object> EmptyAttributes = new ReadOnlyDictionary<string, object>(new Dictionary<string, object>());
 
-        public SpanMock(Trace.SpanContext spanContext)
+        public SpanMock(SpanContext spanContext)
         {
             this.Context = spanContext;
             this.Events = new List<Event>();
@@ -56,19 +56,9 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
             this.Events.Add(new Event(name));
         }
 
-        public void AddEvent(string name, IDictionary<string, object> attributes)
-        {
-            this.Events.Add(new Event(name, default, attributes));
-        }
-
         public void AddEvent(Event newEvent)
         {
             this.Events.Add(newEvent);
-        }
-
-        public void AddLink(Link link)
-        {
-            this.Links.Add(link);
         }
 
         public void End()
@@ -81,39 +71,14 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
             this.End();
         }
 
-        public void SetAttribute(string key, string value)
+        public void SetAttribute(string key, object value)
         {
-            this.SetAttribute<string>(key, value);
-        }
-
-        public void SetAttribute(string key, long value)
-        {
-            this.SetAttribute<long>(key, value);
-        }
-
-        public void SetAttribute(string key, double value)
-        {
-            this.SetAttribute<double>(key, value);
-        }
-
-        public void SetAttribute(string key, bool value)
-        {
-            this.SetAttribute<bool>(key, value);
-        }
-
-        public void SetAttribute(KeyValuePair<string, object> keyValuePair)
-        {
-            this.Attributes.Add(keyValuePair);
+            this.Attributes.Add(new KeyValuePair<string, object>(key, value));
         }
 
         public void UpdateName(string name)
         {
             this.Name = name;
-        }
-
-        private void SetAttribute<TValue>(string key, TValue value)
-        {
-            this.SetAttribute(new KeyValuePair<string, object>(key, value));
         }
 
         public void Dispose()

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
@@ -231,7 +231,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
 
             Assert.Single(spanMock.Attributes);
             Assert.Equal("foo", spanMock.Attributes.First().Key);
-            Assert.Equal(1, (long)spanMock.Attributes.First().Value);
+            Assert.Equal(1, spanMock.Attributes.First().Value);
         }
 
         [Fact]
@@ -297,7 +297,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
 
             Assert.Single(spanMock.Attributes);
             Assert.Equal("foo", spanMock.Attributes.First().Key);
-            Assert.Equal(1, (long)spanMock.Attributes.First().Value);
+            Assert.Equal(1, spanMock.Attributes.First().Value);
         }
 
         [Fact]
@@ -314,7 +314,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
             Assert.Equal(2, spanMock.Attributes.Count);
 
             Assert.Equal("foo", spanMock.Attributes.First().Key);
-            Assert.Equal(1, (long)spanMock.Attributes.First().Value);
+            Assert.Equal(1, spanMock.Attributes.First().Value);
 
             Assert.Equal("bar", spanMock.Attributes.Last().Key);
             Assert.Equal("baz", (string)spanMock.Attributes.Last().Value);

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
@@ -231,7 +231,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
 
             Assert.Single(spanMock.Attributes);
             Assert.Equal("foo", spanMock.Attributes.First().Key);
-            Assert.Equal(1, spanMock.Attributes.First().Value);
+            Assert.Equal(1L, spanMock.Attributes.First().Value);
         }
 
         [Fact]
@@ -297,7 +297,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
 
             Assert.Single(spanMock.Attributes);
             Assert.Equal("foo", spanMock.Attributes.First().Key);
-            Assert.Equal(1, spanMock.Attributes.First().Value);
+            Assert.Equal(1L, spanMock.Attributes.First().Value);
         }
 
         [Fact]
@@ -314,7 +314,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
             Assert.Equal(2, spanMock.Attributes.Count);
 
             Assert.Equal("foo", spanMock.Attributes.First().Key);
-            Assert.Equal(1, spanMock.Attributes.First().Value);
+            Assert.Equal(1L, spanMock.Attributes.First().Value);
 
             Assert.Equal("bar", spanMock.Attributes.Last().Key);
             Assert.Equal("baz", (string)spanMock.Attributes.Last().Value);

--- a/test/OpenTelemetry.Tests/Impl/Trace/BlankSpanTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/BlankSpanTest.cs
@@ -39,17 +39,17 @@ namespace OpenTelemetry.Trace.Test
                 "MyStringAttributeKey2", "MyStringAttributeValue2");
             foreach (var a in attributes)
             {
-                BlankSpan.Instance.SetAttribute(a);
+                BlankSpan.Instance.SetAttribute(a.Key, a.Value);
             }
 
             foreach (var a in multipleAttributes)
             {
-                BlankSpan.Instance.SetAttribute(a);
+                BlankSpan.Instance.SetAttribute(a.Key, a.Value);
             }
 
             BlankSpan.Instance.AddEvent("MyEvent");
-            BlankSpan.Instance.AddEvent("MyEvent", attributes);
-            BlankSpan.Instance.AddEvent("MyEvent", multipleAttributes);
+            BlankSpan.Instance.AddEvent(new Event("MyEvent", attributes));
+            BlankSpan.Instance.AddEvent(new Event("MyEvent", multipleAttributes));
             BlankSpan.Instance.AddEvent(new Event("MyEvent"));
 
             Assert.False(BlankSpan.Instance.Context.IsValid);

--- a/test/OpenTelemetry.Tests/Impl/Trace/EventTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/EventTest.cs
@@ -43,7 +43,7 @@ namespace OpenTelemetry.Trace.Test
         public void FromDescriptionAndDefaultTimestamp()
         {
             var approxTimestamp = PreciseTimestamp.GetUtcNow();
-            var @event = new Event("MyEventText", default);
+            var @event = new Event("MyEventText", (DateTimeOffset)default);
             Assert.Equal("MyEventText", @event.Name);
             Assert.Equal(0, @event.Attributes.Count);
             Assert.InRange(Math.Abs((approxTimestamp - @event.Timestamp).TotalMilliseconds), double.Epsilon, 20);

--- a/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
@@ -24,6 +24,7 @@ using Moq;
 using OpenTelemetry.Api.Utils;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace.Export;
+using OpenTelemetry.Trace.Samplers;
 using Xunit;
 
 namespace OpenTelemetry.Trace.Test
@@ -49,6 +50,7 @@ namespace OpenTelemetry.Trace.Test
             attributes.Add("MyStringAttributeKey", "MyStringAttributeValue");
             attributes.Add("MyLongAttributeKey", 123L);
             attributes.Add("MyBooleanAttributeKey", false);
+            attributes.Add("MyDoubleAttributeKey", 0.1d);
             expectedAttributes = new List<KeyValuePair<string, object>>(attributes)
             {
                 new KeyValuePair<string, object>("MySingleStringAttributeKey", "MySingleStringAttributeValue"),
@@ -737,7 +739,28 @@ namespace OpenTelemetry.Trace.Test
         }
 
         [Fact]
-        public void EndSpan_EventsNotRecorded()
+        public void NotRecordedSpan_NoAttributesOrEventsAdded()
+        {
+            var tracer = TracerFactory.Create(b => b
+                    .SetSampler(new NeverSampleSampler()))
+                .GetTracer(null);
+
+            var span = (Span)tracer.StartRootSpan(SpanName, SpanKind.Client);
+
+            // Check that adding attributes or events is not possible on not recorded span
+            span.SetAttribute("string", "value");
+            span.SetAttribute("long", 1L);
+            span.SetAttribute("bool", false);
+            span.SetAttribute("double", 0.1d);
+            span.SetAttribute("decimal", 0.2M);
+
+            span.AddEvent(new Event(EventDescription));
+            Assert.Empty(span.Attributes);
+            Assert.Empty(span.Events);
+        }
+
+        [Fact]
+        public void EndSpan_NotAddingAttributesOrEvents()
         {
             var tracer = tracerFactory.GetTracer(null);
 
@@ -982,15 +1005,15 @@ namespace OpenTelemetry.Trace.Test
             Assert.Single(span.Attributes.Where(kvp => kvp.Key == "string" && kvp.Value is string sv && sv == "foo"));
             Assert.Single(span.Attributes.Where(kvp => kvp.Key == "bool" && kvp.Value is bool bv && bv == false));
             Assert.Single(span.Attributes.Where(kvp => kvp.Key == "long" && kvp.Value is long lv && lv == -1));
-            Assert.Single(span.Attributes.Where(kvp => kvp.Key == "ulong" && kvp.Value is ulong uv && uv == 1));
-            Assert.Single(span.Attributes.Where(kvp => kvp.Key == "uint" && kvp.Value is uint uv && uv == 2));
-            Assert.Single(span.Attributes.Where(kvp => kvp.Key == "int" && kvp.Value is int iv && iv == -2));
-            Assert.Single(span.Attributes.Where(kvp => kvp.Key == "sbyte" && kvp.Value is sbyte sv && sv == -3));
-            Assert.Single(span.Attributes.Where(kvp => kvp.Key == "byte" && kvp.Value is byte bv && bv == 3));
-            Assert.Single(span.Attributes.Where(kvp => kvp.Key == "short" && kvp.Value is short sv && sv == -4));
-            Assert.Single(span.Attributes.Where(kvp => kvp.Key == "ushort" && kvp.Value is ushort uv && uv == 4));
+            Assert.Single(span.Attributes.Where(kvp => kvp.Key == "ulong" && kvp.Value is double lv && lv == 1));
+            Assert.Single(span.Attributes.Where(kvp => kvp.Key == "uint" && kvp.Value is long uv && uv == 2));
+            Assert.Single(span.Attributes.Where(kvp => kvp.Key == "int" && kvp.Value is long iv && iv == -2));
+            Assert.Single(span.Attributes.Where(kvp => kvp.Key == "sbyte" && kvp.Value is long sv && sv == -3));
+            Assert.Single(span.Attributes.Where(kvp => kvp.Key == "byte" && kvp.Value is long bv && bv == 3));
+            Assert.Single(span.Attributes.Where(kvp => kvp.Key == "short" && kvp.Value is long sv && sv == -4));
+            Assert.Single(span.Attributes.Where(kvp => kvp.Key == "ushort" && kvp.Value is long uv && uv == 4));
             Assert.Single(span.Attributes.Where(kvp => kvp.Key == "double" && kvp.Value is double dv && dv == 0.1));
-            Assert.Single(span.Attributes.Where(kvp => kvp.Key == "float" && kvp.Value is float fv && fv == 0.2f));
+            Assert.Single(span.Attributes.Where(kvp => kvp.Key == "float" && kvp.Value is double fv && Math.Round(fv, 3) == 0.2));
             Assert.Single(span.Attributes.Where(kvp => kvp.Key == "decimal" && kvp.Value is decimal dv && dv == 0.3M));
         }
 

--- a/test/OpenTelemetry.Tests/Impl/Trace/TestSpan.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/TestSpan.cs
@@ -33,31 +33,11 @@ namespace OpenTelemetry.Trace.Test
             throw new NotImplementedException();
         }
 
-        public void SetAttribute(KeyValuePair<string, object> keyValuePair)
-        {
-        }
-
-        public void SetAttribute(string key, string value)
-        {
-        }
-
-        public void SetAttribute(string key, long value)
-        {
-        }
-
-        public void SetAttribute(string key, double value)
-        {
-        }
-
-        public void SetAttribute(string key, bool value)
+        public void SetAttribute(string key, object value)
         {
         }
 
         public void AddEvent(string name)
-        {
-        }
-
-        public void AddEvent(string name, IDictionary<string, object> attributes)
         {
         }
 

--- a/test/OpenTelemetry.Tests/Impl/Trace/TestSpan.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/TestSpan.cs
@@ -14,16 +14,11 @@
 // limitations under the License.
 // </copyright>
 using System;
-using System.Collections.Generic;
 
 namespace OpenTelemetry.Trace.Test
 {
     public class TestSpan : ISpan
     {
-        public TestSpan()
-        {
-        }
-
         public SpanContext Context { get; }
         public bool IsRecording { get; }
         public Status Status { get; set; }
@@ -37,15 +32,23 @@ namespace OpenTelemetry.Trace.Test
         {
         }
 
+        public void SetAttribute(string key, long value)
+        {
+        }
+
+        public void SetAttribute(string key, bool value)
+        {
+        }
+
+        public void SetAttribute(string key, double value)
+        {
+        }
+
         public void AddEvent(string name)
         {
         }
 
         public void AddEvent(Event newEvent)
-        {
-        }
-
-        public void AddLink(Link link)
         {
         }
 

--- a/test/OpenTelemetry.Tests/Impl/Trace/TracerTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/TracerTest.cs
@@ -389,7 +389,7 @@ namespace OpenTelemetry.Trace.Test
             }
 
             Assert.Equal(maxNumberOfAttributes, span.Attributes.Count());
-            for (long i = 0; i < maxNumberOfAttributes; i++)
+            for (int i = 0; i < maxNumberOfAttributes; i++)
             {
                 Assert.Equal(
                     i + maxNumberOfAttributes,
@@ -401,7 +401,7 @@ namespace OpenTelemetry.Trace.Test
             span.End();
 
             Assert.Equal(maxNumberOfAttributes, span.Attributes.Count());
-            for (long i = 0; i < maxNumberOfAttributes; i++)
+            for (int i = 0; i < maxNumberOfAttributes; i++)
             {
                 Assert.Equal(
                     i + maxNumberOfAttributes,

--- a/test/OpenTelemetry.Tests/Impl/Trace/TracerTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/TracerTest.cs
@@ -383,13 +383,13 @@ namespace OpenTelemetry.Trace.Test
                 .GetTracer(null);
 
             var span = (Span)tracer.StartRootSpan(SpanName);
-            for (var i = 0; i < 2 * maxNumberOfAttributes; i++)
+            for (long i = 0; i < 2 * maxNumberOfAttributes; i++)
             {
                 span.SetAttribute("MyStringAttributeKey" + i, i);
             }
 
             Assert.Equal(maxNumberOfAttributes, span.Attributes.Count());
-            for (int i = 0; i < maxNumberOfAttributes; i++)
+            for (long i = 0; i < maxNumberOfAttributes; i++)
             {
                 Assert.Equal(
                     i + maxNumberOfAttributes,
@@ -401,7 +401,7 @@ namespace OpenTelemetry.Trace.Test
             span.End();
 
             Assert.Equal(maxNumberOfAttributes, span.Attributes.Count());
-            for (int i = 0; i < maxNumberOfAttributes; i++)
+            for (long i = 0; i < maxNumberOfAttributes; i++)
             {
                 Assert.Equal(
                     i + maxNumberOfAttributes,


### PR DESCRIPTION
**SetAttribute** overloads allow to set bool, long, double, int, string and object attributes. 
According to the spec any numeric, boolean or string types are allowed AND arrays of them.

> The attribute value, which is either:
 A primitive type: string, boolean or numeric.
An array of primitive type values. The array MUST be homogeneous, i.e. it MUST NOT contain values of different types.

This makes it impossible to keep up with all possible attribute types through the API. 
So this change **limits SetAttribute to (string, object/long/double/bool) overloads only** and does not allow non-supported attribute types. Boxing is inevitable in any case, since we are storing attributes in IEnumerable<KeyValuePair<string, object>>


Also, we have **3 overloads to add event on span** (from name,name and attributes and from event instance).
This change adds Event ctor with (name, attributes), but limits AddEvent on Span to `AddEvent(name)` and `AddEvent(event)`