### PR TITLE
Support service resource conventions in Application Insights exporter

### DIFF
--- a/src/OpenTelemetry.Exporter.ApplicationInsights/ApplicationInsightsTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.ApplicationInsights/ApplicationInsightsTraceExporter.cs
@@ -85,7 +85,9 @@ namespace OpenTelemetry.Exporter.ApplicationInsights
                     out var parentId,
                     out var success,
                     out var duration,
-                    out var roleName);
+                    out var roleName,
+                    out var roleInstance,
+                    out var version);
 
                 // BUILDING resulting telemetry
                 OperationTelemetry result;
@@ -103,8 +105,6 @@ namespace OpenTelemetry.Exporter.ApplicationInsights
                 {
                     result = new RequestTelemetry();
                 }
-
-                result.Context.Cloud.RoleName = roleName;
 
                 Uri url = null;
                 string data = null;
@@ -261,6 +261,8 @@ namespace OpenTelemetry.Exporter.ApplicationInsights
                     log.Context.Operation.Id = traceId;
                     log.Context.Operation.ParentId = spanId;
                     log.Context.Cloud.RoleName = roleName;
+                    log.Context.Cloud.RoleInstance = roleInstance;
+                    log.Context.Component.Version = version;
 
                     this.telemetryClient.Track(log);
                 }
@@ -277,6 +279,9 @@ namespace OpenTelemetry.Exporter.ApplicationInsights
                 result.Name = name;
                 result.Context.Operation.Id = traceId;
                 result.Context.User.UserAgent = userAgent;
+                result.Context.Cloud.RoleName = roleName;
+                result.Context.Cloud.RoleInstance = roleInstance;
+                result.Context.Component.Version = version;
 
                 if (parentId != null)
                 {
@@ -353,7 +358,9 @@ namespace OpenTelemetry.Exporter.ApplicationInsights
             out string parentId,
             out bool? success,
             out TimeSpan duration,
-            out string roleName)
+            out string roleName,
+            out string roleInstance,
+            out string serviceVersion)
         {
             name = span.Name;
 
@@ -382,13 +389,38 @@ namespace OpenTelemetry.Exporter.ApplicationInsights
 
             duration = span.EndTimestamp - span.StartTimestamp;
 
+            string serviceName = null;
+            string serviceNamespace = null;
+            serviceVersion = null;
+            roleInstance = null;
+
             foreach (var attribute in span.LibraryResource.Attributes)
             {
-                if (attribute.Key == "service.name" && attribute.Value is string serviceName)
+                if (attribute.Key == "service.name" && attribute.Value is string)
                 {
-                    roleName = serviceName;
-                    break;
+                    serviceName = (string)attribute.Value;
                 }
+                else if (attribute.Key == "service.namespace" && attribute.Value is string)
+                {
+                    serviceNamespace = (string)attribute.Value;
+                }
+                else if (attribute.Key == "service.version" && attribute.Value is string)
+                {
+                    serviceVersion = (string)attribute.Value;
+                }
+                else if (attribute.Key == "service.instance.id" && attribute.Value is string)
+                {
+                    roleInstance = (string)attribute.Value;
+                }
+            }
+
+            if (serviceName != null && serviceNamespace != null)
+            {
+                roleName = string.Concat(serviceNamespace, ".", serviceName);
+            }
+            else
+            {
+                roleName = serviceName;
             }
         }
 


### PR DESCRIPTION
Resource has [conventions for service](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-resource-semantic-conventions.md#service)

This change maps 
- `<service.namespace>.<service.name>` to roleName
- `service.instance.id` to roleInstance
- `service.version` to component version


