### PR TITLE
Add SpanKind to Sampler per specs

### DIFF
--- a/src/OpenTelemetry/Trace/Sampler.cs
+++ b/src/OpenTelemetry/Trace/Sampler.cs
@@ -39,9 +39,10 @@ namespace OpenTelemetry.Trace
         /// Typical example of a name change is when <see cref="ISpan"/> representing incoming http request
         /// has a name of url path and then being updated with route name when routing complete.
         /// </param>
+        /// <param name="spanKind">The type of the Span.</param>
         /// <param name="attributes">Initial set of Attributes for the Span being constructed.</param>
         /// <param name="links">Links associated with the span.</param>
         /// <returns>Sampling decision on whether Span needs to be sampled or not.</returns>
-        public abstract Decision ShouldSample(in SpanContext parentContext, in ActivityTraceId traceId, in ActivitySpanId spanId, string name, IDictionary<string, object> attributes, IEnumerable<Link> links);
+        public abstract Decision ShouldSample(in SpanContext parentContext, in ActivityTraceId traceId, in ActivitySpanId spanId, string name, SpanKind spanKind, IDictionary<string, object> attributes, IEnumerable<Link> links);
     }
 }

--- a/src/OpenTelemetry/Trace/Samplers/AlwaysParentSampler.cs
+++ b/src/OpenTelemetry/Trace/Samplers/AlwaysParentSampler.cs
@@ -23,7 +23,7 @@ namespace OpenTelemetry.Trace.Samplers
         public override string Description { get; } = nameof(AlwaysParentSampler);
 
         /// <inheritdoc />
-        public override Decision ShouldSample(in SpanContext parentContext, in ActivityTraceId traceId, in ActivitySpanId spanId, string name, IDictionary<string, object> attributes, IEnumerable<Link> parentLinks)
+        public override Decision ShouldSample(in SpanContext parentContext, in ActivityTraceId traceId, in ActivitySpanId spanId, string name, SpanKind spanKind, IDictionary<string, object> attributes, IEnumerable<Link> parentLinks)
         {
             if (parentContext.IsValid && parentContext.TraceOptions.HasFlag(ActivityTraceFlags.Recorded))
             {

--- a/src/OpenTelemetry/Trace/Samplers/AlwaysSampleSampler.cs
+++ b/src/OpenTelemetry/Trace/Samplers/AlwaysSampleSampler.cs
@@ -23,7 +23,7 @@ namespace OpenTelemetry.Trace.Samplers
         public override string Description { get; } = nameof(AlwaysSampleSampler);
 
         /// <inheritdoc />
-        public override Decision ShouldSample(in SpanContext parentContext, in ActivityTraceId traceId, in ActivitySpanId spanId, string name, IDictionary<string, object> attributes, IEnumerable<Link> parentLinks)
+        public override Decision ShouldSample(in SpanContext parentContext, in ActivityTraceId traceId, in ActivitySpanId spanId, string name, SpanKind spanKind, IDictionary<string, object> attributes, IEnumerable<Link> parentLinks)
         {
             return new Decision(true);
         }

--- a/src/OpenTelemetry/Trace/Samplers/NeverSampleSampler.cs
+++ b/src/OpenTelemetry/Trace/Samplers/NeverSampleSampler.cs
@@ -23,7 +23,7 @@ namespace OpenTelemetry.Trace.Samplers
         public override string Description { get; } = nameof(NeverSampleSampler);
 
         /// <inheritdoc />
-        public override Decision ShouldSample(in SpanContext parentContext, in ActivityTraceId traceId, in ActivitySpanId spanId, string name, IDictionary<string, object> attributes, IEnumerable<Link> links)
+        public override Decision ShouldSample(in SpanContext parentContext, in ActivityTraceId traceId, in ActivitySpanId spanId, string name, SpanKind spanKind, IDictionary<string, object> attributes, IEnumerable<Link> links)
         {
             return new Decision(false);
         }

--- a/src/OpenTelemetry/Trace/Samplers/ProbabilitySampler.cs
+++ b/src/OpenTelemetry/Trace/Samplers/ProbabilitySampler.cs
@@ -57,7 +57,7 @@ namespace OpenTelemetry.Trace.Samplers
         public override string Description { get; }
 
         /// <inheritdoc />
-        public override Decision ShouldSample(in SpanContext parentContext, in ActivityTraceId traceId, in ActivitySpanId spanId, string name, IDictionary<string, object> attributes, IEnumerable<Link> links)
+        public override Decision ShouldSample(in SpanContext parentContext, in ActivityTraceId traceId, in ActivitySpanId spanId, string name, SpanKind spanKind, IDictionary<string, object> attributes, IEnumerable<Link> links)
         {
             // If the parent is sampled keep the sampling decision.
             if (parentContext.IsValid &&

--- a/src/OpenTelemetry/Trace/SpanSdk.cs
+++ b/src/OpenTelemetry/Trace/SpanSdk.cs
@@ -108,6 +108,7 @@ namespace OpenTelemetry.Trace
             this.IsRecording = MakeSamplingDecision(
                 parentSpanContext,
                 name,
+                spanKind,
                 spanCreationOptions?.Attributes,
                 links, // we'll enumerate again, but double enumeration over small collection is cheaper than allocation
                 this.Activity.TraceId,
@@ -597,13 +598,14 @@ namespace OpenTelemetry.Trace
         private static bool MakeSamplingDecision(
             SpanContext parent,
             string name,
+            SpanKind spanKind,
             IDictionary<string, object> attributes,
             IEnumerable<Link> parentLinks,
             ActivityTraceId traceId,
             ActivitySpanId spanId,
             Sampler sampler)
         {
-            return sampler.ShouldSample(parent, traceId, spanId, name, attributes, parentLinks).IsSampled;
+            return sampler.ShouldSample(parent, traceId, spanId, name, spanKind, attributes, parentLinks).IsSampled;
         }
 
         private static ActivityAndTracestate FromCurrentParentActivity(string spanName, Activity current)

--- a/test/OpenTelemetry.Tests/Impl/Trace/Samplers/SamplersTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Samplers/SamplersTest.cs
@@ -24,6 +24,7 @@ namespace OpenTelemetry.Trace.Samplers.Test
     {
         private static readonly string SpanName = "MySpanName";
         private static readonly int NUM_SAMPLE_TRIES = 1000;
+        private static readonly SpanKind SpanKindServer = SpanKind.Server;
         private readonly ActivityTraceId traceId;
         private readonly ActivitySpanId parentSpanId;
         private readonly ActivitySpanId spanId;
@@ -52,6 +53,7 @@ namespace OpenTelemetry.Trace.Samplers.Test
                             traceId,
                             spanId,
                             "Another name",
+                            SpanKindServer,
                             null,
                             null).IsSampled);
 
@@ -63,6 +65,7 @@ namespace OpenTelemetry.Trace.Samplers.Test
                             traceId,
                             spanId,
                             "Yet another name",
+                            SpanKindServer,
                             null,
                             null).IsSampled);
 
@@ -85,6 +88,7 @@ namespace OpenTelemetry.Trace.Samplers.Test
                             traceId,
                             spanId,
                             "bar",
+                            SpanKindServer,
                             null,
                             null).IsSampled);
             // Not sampled parent.
@@ -95,6 +99,7 @@ namespace OpenTelemetry.Trace.Samplers.Test
                             traceId,
                             spanId,
                             "quux",
+                            SpanKindServer,
                             null,
                             null).IsSampled);
         }
@@ -211,6 +216,7 @@ namespace OpenTelemetry.Trace.Samplers.Test
                         notSampledtraceId,
                         ActivitySpanId.CreateRandom(),
                         SpanName,
+                        SpanKindServer,
                         null,
                         null).IsSampled);
             // This traceId will be sampled by the ProbabilitySampler because the first 8 bytes as long
@@ -242,6 +248,7 @@ namespace OpenTelemetry.Trace.Samplers.Test
                         sampledtraceId,
                         ActivitySpanId.CreateRandom(),
                         SpanName,
+                        SpanKindServer,
                         null,
                         null).IsSampled);
         }
@@ -264,6 +271,7 @@ namespace OpenTelemetry.Trace.Samplers.Test
                     ActivityTraceId.CreateRandom(),
                     ActivitySpanId.CreateRandom(),
                     SpanName,
+                    SpanKindServer,
                     null,
                     links).IsSampled)
                 {

--- a/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
@@ -1509,6 +1509,7 @@ namespace OpenTelemetry.Trace.Test
                 in It.Ref<ActivityTraceId>.IsAny,
                 in It.Ref<ActivitySpanId>.IsAny,
                 It.IsAny<string>(),
+                It.IsAny<SpanKind>(),
                 It.IsAny<IDictionary<string, object>>(),
                 It.IsAny<IEnumerable<Link>>())).Returns(new Decision(true));
 
@@ -1520,6 +1521,7 @@ namespace OpenTelemetry.Trace.Test
                 in It.Ref<ActivityTraceId>.IsAny,
                 in It.Ref<ActivitySpanId>.IsAny,
                 It.IsAny<string>(),
+                It.IsAny<SpanKind>(),
                 It.Is<IDictionary<string, object>>(a => a == this.attributes),
                 It.IsAny<IEnumerable<Link>>()), Times.Once);
         }
@@ -1538,6 +1540,7 @@ namespace OpenTelemetry.Trace.Test
                 in It.Ref<ActivityTraceId>.IsAny,
                 in It.Ref<ActivitySpanId>.IsAny,
                 It.IsAny<string>(),
+                It.IsAny<SpanKind>(),
                 It.IsAny<IDictionary<string, object>>(),
                 It.IsAny<IEnumerable<Link>>())).Returns(new Decision(false));
 
@@ -1549,6 +1552,7 @@ namespace OpenTelemetry.Trace.Test
                 in It.Ref<ActivityTraceId>.IsAny,
                 in It.Ref<ActivitySpanId>.IsAny,
                 It.IsAny<string>(),
+                It.IsAny<SpanKind>(),
                 It.Is<IDictionary<string, object>>(a => a == this.attributes),
                 It.IsAny<IEnumerable<Link>>()), Times.Once);
         }


### PR DESCRIPTION
According to the current specification, SpanKind is a required parameter to the samplers.
https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/sdk-tracing.md#sampler