### PR TITLE
Add helper to create service resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Configuration is done by user application: it should configure exporter and may 
     ```csharp
     using (TracerFactory.Create(builder => builder
             .UseZipkin()
-            .SetResource(new Resource(new Dictionary<string, string>() { { "service.name", "http-client-test" } })))
+            .SetResource(Resources.CreateServiceResource("http-client-test")))
     {
         // ...
     }
@@ -272,7 +272,7 @@ Configuration is done by user application: it should configure exporter and may 
             // you may also configure request and dependencies collectors
             .AddRequestCollector()
             .AddDependencyCollector()
-            .SetResource(new Resource(new Dictionary<string, string>() { { "service.name", "my-service" } }))
+            .SetResource(Resources.CreateServiceResource("my-service"))
     });
     ```
 
@@ -292,7 +292,7 @@ Outgoing http calls to Redis made using StackExchange.Redis library can be autom
     using (TracerFactory.Create(b => b
                 .SetSampler(new AlwaysSampleSampler())
                 .UseZipkin()
-                .SetResource(new Resource(new Dictionary<string, string>() { { "service.name", "my-service" } }))
+                .SetResource(Resources.CreateServiceResource("my-service"))
                 .AddCollector(t =>
                 {
                     var collector = new StackExchangeRedisCallsCollector(t);
@@ -314,7 +314,7 @@ You may configure sampler of your choice
  using (TracerFactory.Create(b => b
             .SetSampler(new ProbabilitySampler(0.1))
             .UseZipkin()
-            .SetResource(new Resource(new Dictionary<string, string>() { { "service.name", "my-service" } })))
+            .SetResource(Resources.CreateServiceResource("my-service")))
 {
 
 }
@@ -470,7 +470,7 @@ using (var tracerFactory = TracerFactory.Create(builder => builder
         o => o.InstrumentationKey = "your-instrumentation-key",
         p => p.AddProcessor(nextProcessor => new FilteringSpanProcessor(nextProcessor)))
     .AddProcessorPipeline(pipelineBuilder => pipelineBuilder.AddProcessor(_ => new DebuggingSpanProcessor()))))
-    .SetResource(new Resource(new Dictionary<string, string>() { { "service.name", "test-zipkin" } }))
+    .SetResource(Resources.CreateServiceResource("test-zipkin"))
 
 {
     // ...

--- a/samples/Exporters/TestApplicationInsights.cs
+++ b/samples/Exporters/TestApplicationInsights.cs
@@ -19,6 +19,7 @@ using System.Threading;
 using Microsoft.ApplicationInsights.Extensibility;
 using OpenTelemetry.Context;
 using OpenTelemetry.Exporter.ApplicationInsights;
+using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using OpenTelemetry.Trace.Configuration;
 
@@ -34,6 +35,7 @@ namespace Samples
             DistributedContext dc = DistributedContextBuilder.CreateContext(FrontendKey, "mobile-ios9.3.5");
 
             using (var tracerFactory = TracerFactory.Create(builder => builder
+                .SetResource(Resources.CreateServiceResource("my-service"))
                 .UseApplicationInsights(config => config.InstrumentationKey = "instrumentation-key")))
             {
                 var tracer = tracerFactory.GetTracer("application-insights-test");

--- a/src/OpenTelemetry/Resources/Resources.cs
+++ b/src/OpenTelemetry/Resources/Resources.cs
@@ -1,0 +1,63 @@
+﻿// <copyright file="Resources.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Resources
+{
+    public static class Resources
+    {
+        /// <summary>
+        /// Creates a new <see cref="Resource"/> from service information following standard convention
+        /// https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-resource-semantic-conventions.md#service. 
+        /// </summary>
+        /// <param name="serviceName">Name of the service.</param>
+        /// <param name="serviceInstanceId">Unique identifier of the service instance.</param>
+        /// <param name="serviceNamespace">Optional namespace of the service.</param>
+        /// <param name="serviceVersion">Optional version of the service.</param>
+        public static Resource CreateServiceResource(string serviceName, string serviceInstanceId = null, string serviceNamespace = null, string serviceVersion = null)
+        {
+            if (serviceName == null)
+            {
+                OpenTelemetrySdkEventSource.Log.InvalidArgument("Create service resource", "serviceName", "is null");
+                return Resource.Empty;
+            }
+
+            var attributes = new List<KeyValuePair<string, object>> { new KeyValuePair<string, object>("service.name", serviceName), };
+
+            if (serviceInstanceId == null)
+            {
+                serviceInstanceId = Guid.NewGuid().ToString();
+            }
+
+            attributes.Add(new KeyValuePair<string, object>("service.instance.id", serviceInstanceId));
+
+            if (serviceNamespace != null)
+            {
+                attributes.Add(new KeyValuePair<string, object>("service.namespace", serviceNamespace));
+            }
+
+            if (serviceVersion != null)
+            {
+                attributes.Add(new KeyValuePair<string, object>("service.version", serviceVersion));
+            }
+
+            return new Resource(attributes);
+        }
+    }
+}

--- a/test/OpenTelemetry.Tests/Impl/Resources/ResourcesTests.cs
+++ b/test/OpenTelemetry.Tests/Impl/Resources/ResourcesTests.cs
@@ -1,0 +1,73 @@
+﻿// <copyright file="ResourcesTests.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace OpenTelemetry.Tests.Impl.Resources
+{
+    public class ResourcesTests
+    {
+        [Fact]
+        public void ServiceResource_ServiceName()
+        {
+            var resource = OpenTelemetry.Resources.Resources.CreateServiceResource("my-service");
+            Assert.Equal(2, resource.Attributes.Count());
+            Assert.Contains(new KeyValuePair<string ,object>("service.name", "my-service"), resource.Attributes);
+            Assert.Single(resource.Attributes.Where(kvp => kvp.Key == "service.name"));
+            Assert.True(Guid.TryParse((string)resource.Attributes.Single(kvp => kvp.Key == "service.instance.id").Value, out _));
+        }
+
+        [Fact]
+        public void ServiceResource_ServiceNameAndInstance()
+        {
+            var resource = OpenTelemetry.Resources.Resources.CreateServiceResource("my-service", "123");
+            Assert.Equal(2, resource.Attributes.Count());
+            Assert.Contains(new KeyValuePair<string, object>("service.name", "my-service"), resource.Attributes);
+            Assert.Contains(new KeyValuePair<string, object>("service.instance.id", "123"), resource.Attributes);
+        }
+
+        [Fact]
+        public void ServiceResource_ServiceNameAndInstanceAndNamespace()
+        {
+            var resource = OpenTelemetry.Resources.Resources.CreateServiceResource("my-service", "123", "my-namespace");
+            Assert.Equal(3, resource.Attributes.Count());
+            Assert.Contains(new KeyValuePair<string, object>("service.name", "my-service"), resource.Attributes);
+            Assert.Contains(new KeyValuePair<string, object>("service.instance.id", "123"), resource.Attributes);
+            Assert.Contains(new KeyValuePair<string, object>("service.namespace", "my-namespace"), resource.Attributes);
+        }
+
+        [Fact]
+        public void ServiceResource_ServiceNameAndInstanceAndNamespaceAndVersion()
+        {
+            var resource = OpenTelemetry.Resources.Resources.CreateServiceResource("my-service", "123", "my-namespace", "semVer:1.2.3");
+            Assert.Equal(4, resource.Attributes.Count());
+            Assert.Contains(new KeyValuePair<string, object>("service.name", "my-service"), resource.Attributes);
+            Assert.Contains(new KeyValuePair<string, object>("service.instance.id", "123"), resource.Attributes);
+            Assert.Contains(new KeyValuePair<string, object>("service.namespace", "my-namespace"), resource.Attributes);
+            Assert.Contains(new KeyValuePair<string, object>("service.version", "semVer:1.2.3"), resource.Attributes);
+        }
+
+        [Fact]
+        public void ServiceResource_Empty()
+        {
+            var resource = OpenTelemetry.Resources.Resources.CreateServiceResource(null);
+            Assert.Empty(resource.Attributes);
+        }
+    }
+}


### PR DESCRIPTION
Simplifies resource creation for service resource.

Same approach should be used for other kinds of resources that have conversions (e.g. [container](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-resource-semantic-conventions.md#container) of [k8s](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-resource-semantic-conventions.md#kubernetes or other)

Resources can be merged with another one with something like 

```csharp
var service = Resources.CreateServiceResource("my-service");
var cloud = Resources.CreateCloudResource("azure");

TracerFactory.Create(builder => builder.SetResource(service.Merge(cloud))....
```


