### PR TITLE
JaegerTraceExporter gets a maximum flush timer

### DIFF
--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptions.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 using System.Collections.Generic;
 
 namespace OpenTelemetry.Exporter.Jaeger
@@ -28,6 +29,8 @@ namespace OpenTelemetry.Exporter.Jaeger
         public int AgentPort { get; set; } = 6831;
 
         public int? MaxPacketSize { get; set; } = DefaultMaxPacketSize;
+
+        public TimeSpan MaxFlushInterval { get; set; } = TimeSpan.FromSeconds(10);
 
         public Dictionary<string, object> ProcessTags { get; set; }
     }

--- a/src/OpenTelemetry.Exporter.Jaeger/OpenTelemetry.Exporter.Jaeger.csproj
+++ b/src/OpenTelemetry.Exporter.Jaeger/OpenTelemetry.Exporter.Jaeger.csproj
@@ -11,7 +11,9 @@
     <PropertyGroup>
       <NoWarn>$(NoWarn),1591</NoWarn>
     </PropertyGroup>
-
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.5.32" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenTelemetry\OpenTelemetry.csproj" />
     <ProjectReference Include="..\..\lib\Thrift\Thrift.csproj" PrivateAssets="All" />


### PR DESCRIPTION
Currently, spans sent to the underlying JaegerUdpBatcher will sit there under these circumstances:
- The maximum size threshold for the batch has NOT been reached
- The JaegerUdpBatcher instance is not disposed.

If a span is sent to this batcher and there isn't another one for a very
long time, that span can potentially sit forever. This timer ensures that
this case doesn't happen.