### PR TITLE
[JaegerExporter] Periodically flush undelivered Spans

### DIFF
--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpBatcher.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpBatcher.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
 using Thrift.Protocols;
 
 namespace OpenTelemetry.Exporter.Jaeger.Implementation
@@ -31,12 +32,31 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
         private readonly int processByteSize;
         private readonly List<JaegerSpan> currentBatch = new List<JaegerSpan>();
 
+        private readonly AsyncSemaphore flushLock = new AsyncSemaphore(1);
+        private readonly TimeSpan maxFlushInterval;
+        private readonly System.Timers.Timer maxFlushIntervalTimer;
+
         private int batchByteSize;
 
         private bool disposedValue = false; // To detect redundant calls
 
         public JaegerUdpBatcher(JaegerExporterOptions options)
         {
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            if (string.IsNullOrWhiteSpace(options.ServiceName))
+            {
+                throw new ArgumentException("Service Name is required", nameof(options.ServiceName));
+            }
+
+            if (options.MaxFlushInterval <= TimeSpan.Zero)
+            {
+                options.MaxFlushInterval = TimeSpan.FromSeconds(10);
+            }
+
             this.maxPacketSize = (!options.MaxPacketSize.HasValue || options.MaxPacketSize == 0) ? JaegerExporterOptions.DefaultMaxPacketSize : options.MaxPacketSize;
             this.protocolFactory = new TCompactProtocol.Factory();
             this.clientTransport = new JaegerThriftClientTransport(options.AgentHost, options.AgentPort);
@@ -44,6 +64,19 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
             this.process = new Process(options.ServiceName, options.ProcessTags);
             this.processByteSize = this.GetSize(this.process);
             this.batchByteSize = this.processByteSize;
+
+            this.maxFlushInterval = options.MaxFlushInterval;
+            this.maxFlushIntervalTimer = new System.Timers.Timer
+            {
+                AutoReset = false,
+                Enabled = false,
+                Interval = this.maxFlushInterval.TotalMilliseconds,
+            };
+
+            this.maxFlushIntervalTimer.Elapsed += async (sender, args) =>
+            {
+                await this.FlushAsync(CancellationToken.None).ConfigureAwait(false);
+            };
         }
 
         public async Task<int> AppendAsync(JaegerSpan span, CancellationToken cancellationToken)
@@ -57,38 +90,51 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
 
             var flushedSpanCount = 0;
 
-            // flush if current batch size plus new span size equals or exceeds max batch size
-            if (this.batchByteSize + spanSize >= this.maxPacketSize)
+            using (await this.flushLock.EnterAsync().ConfigureAwait(false))
             {
-                flushedSpanCount = await this.FlushAsync(cancellationToken).ConfigureAwait(false);
+                // flush if current batch size plus new span size equals or exceeds max batch size
+                if (this.batchByteSize + spanSize >= this.maxPacketSize)
+                {
+                    flushedSpanCount = await this.FlushAsync(cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    this.maxFlushIntervalTimer.Enabled = true;
+                }
+
+                // add span to batch and wait for more spans
+                this.currentBatch.Add(span);
+                this.batchByteSize += spanSize;
             }
 
-            // add span to batch and wait for more spans
-            this.currentBatch.Add(span);
-            this.batchByteSize += spanSize;
             return flushedSpanCount;
         }
 
         public async Task<int> FlushAsync(CancellationToken cancellationToken)
         {
-            int n = this.currentBatch.Count;
-
-            if (n == 0)
+            using (await this.flushLock.EnterAsync().ConfigureAwait(false))
             {
-                return 0;
-            }
+                this.maxFlushIntervalTimer.Enabled = false;
 
-            try
-            {
-                await this.SendAsync(this.process, this.currentBatch, cancellationToken).ConfigureAwait(false);
-            }
-            finally
-            {
-                this.currentBatch.Clear();
-                this.batchByteSize = this.processByteSize;
-            }
+                int n = this.currentBatch.Count;
 
-            return n;
+                if (n == 0)
+                {
+                    return 0;
+                }
+
+                try
+                {
+                    await this.SendAsync(this.process, this.currentBatch, cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    this.currentBatch.Clear();
+                    this.batchByteSize = this.processByteSize;
+                }
+
+                return n;
+            }
         }
 
         public virtual Task<int> CloseAsync(CancellationToken cancellationToken) => this.FlushAsync(cancellationToken);

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpBatcher.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpBatcher.cs
@@ -164,6 +164,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
             {
                 if (disposing)
                 {
+                    this.maxFlushIntervalTimer.Dispose();
                     this.thriftClient.Dispose();
                     this.clientTransport.Dispose();
                 }

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptions.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 using System.Collections.Generic;
 
 namespace OpenTelemetry.Exporter.Jaeger
@@ -28,6 +29,8 @@ namespace OpenTelemetry.Exporter.Jaeger
         public int AgentPort { get; set; } = 6831;
 
         public int? MaxPacketSize { get; set; } = DefaultMaxPacketSize;
+
+        public TimeSpan MaxFlushInterval { get; set; } = TimeSpan.FromSeconds(10);
 
         public Dictionary<string, object> ProcessTags { get; set; }
     }

--- a/src/OpenTelemetry.Exporter.Jaeger/OpenTelemetry.Exporter.Jaeger.csproj
+++ b/src/OpenTelemetry.Exporter.Jaeger/OpenTelemetry.Exporter.Jaeger.csproj
@@ -13,7 +13,6 @@
     </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.5.32" />
     <ProjectReference Include="..\OpenTelemetry\OpenTelemetry.csproj" />
     <ProjectReference Include="..\..\lib\Thrift\Thrift.csproj" PrivateAssets="All" />
   </ItemGroup>

--- a/src/OpenTelemetry.Exporter.Jaeger/OpenTelemetry.Exporter.Jaeger.csproj
+++ b/src/OpenTelemetry.Exporter.Jaeger/OpenTelemetry.Exporter.Jaeger.csproj
@@ -13,6 +13,7 @@
     </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.5.32" />
     <ProjectReference Include="..\OpenTelemetry\OpenTelemetry.csproj" />
     <ProjectReference Include="..\..\lib\Thrift\Thrift.csproj" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
A Span will never be delivered if the maximum batch size isn't hit or the component is not torn down. We need to flush these undelivered Spans.

The timer is enabled if a Span is batched up and not sent and then disabled the next time the batch is flushed. We have to protect the calls to FlushAsync because they now come from multiple threads.