### PR TITLE
ApplicationInsights exporter: minor improvements for EventHubs and readme

### DIFF
--- a/src/OpenTelemetry.Exporter.ApplicationInsights/ApplicationInsightsTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.ApplicationInsights/ApplicationInsightsTraceExporter.cs
@@ -36,6 +36,10 @@ namespace OpenTelemetry.Exporter.ApplicationInsights
     /// </summary>
     public class ApplicationInsightsTraceExporter : SpanExporter, IDisposable
     {
+        private const string InProcDependencyType = "InProc";
+        private const string QueueMessageDependencyType = "Queue Message";
+        private const string EventHubsDependencyType = "Azure Event Hubs";
+        private const string HttpDependencyType = "Http";
         private readonly TelemetryClient telemetryClient;
         private readonly string serviceEndpoint;
 
@@ -98,8 +102,8 @@ namespace OpenTelemetry.Exporter.ApplicationInsights
                     {
                         Name = name,
                         ResultCode = resultCode,
-                        Type = span.Kind == SpanKind.Internal ? "InProc" :
-                               span.Kind == SpanKind.Producer ? "Queue Message" : null,
+                        Type = span.Kind == SpanKind.Internal ? InProcDependencyType :
+                               span.Kind == SpanKind.Producer ? QueueMessageDependencyType : null,
                     };
                 }
                 else
@@ -129,9 +133,16 @@ namespace OpenTelemetry.Exporter.ApplicationInsights
                         break;
                     default:
 
-                        if (result is DependencyTelemetry dependency && dependency.Type == null)
+                        if (result is DependencyTelemetry dependency && component != null)
                         {
-                            dependency.Type = component;
+                            if (dependency.Type == null)
+                            {
+                                dependency.Type = component;
+                            }
+                            else if (dependency.Type == InProcDependencyType)
+                            {
+                                dependency.Type = string.Concat(dependency.Type, " | ", component);
+                            }
                         }
 
                         foreach (var attribute in span.Attributes)
@@ -539,7 +550,7 @@ namespace OpenTelemetry.Exporter.ApplicationInsights
 
                 if (string.IsNullOrEmpty(dependency.Type))
                 {
-                    dependency.Type = "Http";
+                    dependency.Type = HttpDependencyType;
                 }
             }
             else if (telemetry is RequestTelemetry request)
@@ -581,14 +592,67 @@ namespace OpenTelemetry.Exporter.ApplicationInsights
                 {
                     // Target uniquely identifies the resource, we use both: queueName and endpoint
                     // with schema used for SQL-dependencies
-                    dependency.Target = string.Concat(endpoint, " | ", queueName);
-                    dependency.Type = "Azure Event Hubs";
+                    dependency.Target = string.Concat(endpoint, "/", queueName);
+                    dependency.Type = EventHubsDependencyType;
                 }
                 else if (telemetry is RequestTelemetry request)
                 {
-                    request.Source = string.Concat(endpoint, " | ", queueName);
+                    request.Source = string.Concat(endpoint, "/", queueName);
+                    if (this.TryGetAverageTimeInQueueForBatch(span, out long enqueuedTime))
+                    {
+                        request.Metrics["timeSinceEnqueued"] = enqueuedTime;
+                    }
                 }
             }
+        }
+
+        private bool TryGetAverageTimeInQueueForBatch(SpanData span, out long avgTimeInQueue)
+        {
+            avgTimeInQueue = 0;
+            int linksCount = 0;
+            foreach (var link in span.Links)
+            {
+                if (!this.TryGetEnqueuedTime(link, out var msgEnqueuedTime))
+                {
+                    // instrumentation does not consistently report enqueued time, ignoring whole span
+                    return false;
+                }
+
+                avgTimeInQueue += Math.Max(span.StartTimestamp.ToUnixTimeMilliseconds() - msgEnqueuedTime, 0);
+                linksCount++;
+            }
+
+            if (linksCount == 0)
+            {
+                return false;
+            }
+
+            avgTimeInQueue /= linksCount;
+            return true;
+        }
+
+        private bool TryGetEnqueuedTime(Link link, out long enqueuedTime)
+        {
+            enqueuedTime = 0;
+            foreach (var attribute in link.Attributes)
+            {
+                if (attribute.Key == "enqueuedTime")
+                {
+                    if (attribute.Value is string strValue)
+                    {
+                        return long.TryParse(strValue, out enqueuedTime);
+                    }
+
+                    // future case
+                    if (attribute.Value is long longValue)
+                    {
+                        enqueuedTime = longValue;
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         private string GetComponent(SpanData span)

--- a/src/OpenTelemetry.Exporter.ApplicationInsights/OpenTelemetry.Exporter.ApplicationInsights.csproj
+++ b/src/OpenTelemetry.Exporter.ApplicationInsights/OpenTelemetry.Exporter.ApplicationInsights.csproj
@@ -4,14 +4,15 @@
     <Description>Application Insights exporter for Open Telemetry.</Description>
     <PackageTags>$(PackageTags);application-insights;azure;distributed-tracing</PackageTags>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="Implementation\**" />
+    <EmbeddedResource Remove="Implementation\**" />
+    <None Remove="Implementation\**" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\OpenTelemetry\OpenTelemetry.csproj" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.11.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Implementation\" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Exporter.ApplicationInsights/README.md
+++ b/src/OpenTelemetry.Exporter.ApplicationInsights/README.md
@@ -1,0 +1,115 @@
+﻿# Using OpenTelemetry with Application Insights
+
+## Create Application Insights resource
+If you don't have resource yet [create one](https://docs.microsoft.com/en-us/azure/azure-monitor/app/create-new-resource). 
+
+## Setup for applications with dependency injection 
+
+If you have ASP.NET Core web application or worker service, or if you simply use use `Microsoft.Extensions.DependencyInjection`,
+just call `AddOpenTelemetry` during host builder configuration in `ConfigureServices` (in `Startup` or `Program`).
+
+1. Install packages (latest version)
+``` xml
+    <PackageReference Include="OpenTelemetry" Version="0.2.0-alpha.182" />
+    <PackageReference Include="OpenTelemetry.Collector.AspNetCore" Version="0.2.0-alpha.182" />
+    <PackageReference Include="OpenTelemetry.Collector.Dependencies" Version="0.2.0-alpha.182" />
+    <PackageReference Include="OpenTelemetry.Exporter.ApplicationInsights" Version="0.2.0-alpha.182" />
+    <PackageReference Include="OpenTelemetry.Hosting" Version="0.2.0-alpha.182" />
+```
+
+2. Set up OpenTelemetry
+```csharp
+services.AddOpenTelemetry((sp, builder) =>
+{
+    builder
+        .SetResource(Resources.CreateServiceResource("my-service"))   // set any service name as you would like to appear on the Application Map
+        .UseApplicationInsights(telemetryConfiguration =>
+        {
+            telemetryConfiguration.InstrumentationKey = Configuration.GetValue<string>("ApplicationInsights:InstrumentationKey");
+        })
+        .AddRequestCollector() // regirsters ASP.NET Core incoming requests tracking 
+        .AddDependencyCollector(); // regirsters outgoing requests tracking
+});
+```
+
+## Applications without dependency injection
+
+1. Install OpenTelemetry packages (latest version)
+
+``` xml
+<PackageReference Include="OpenTelemetry" Version="0.2.0-alpha.182" />
+<PackageReference Include="OpenTelemetry.Collector.Dependencies" Version="0.2.0-alpha.182" />
+<PackageReference Include="OpenTelemetry.Exporter.ApplicationInsights" Version="0.2.0-alpha.182" />
+```
+
+2. Create `TraceFactory` and make sure to keep it alive during application lifetime.
+Avoid creating multiple `TracerFactories` and dispose factory before application exits.
+
+```csharp
+var tracerFactory = TracerFactory.Create(builder => 
+    builder
+        .SetResource(Resources.CreateServiceResource("my-service"))   // set any service name as you would like to appear on the Application Map
+        .UseApplicationInsights(telemetryConfiguration =>
+        {
+            telemetryConfiguration.InstrumentationKey = "your instrumentation key";
+        })
+        .AddDependencyCollector(); // regirsters outgoing requests tracking
+
+                var tracer = tracerFactory.GetTracer("http-client-test");
+
+// start root span
+using (tracer.StartActiveSpan("root span", out _))
+{
+    // do stuff, start other spans, etc 
+}
+
+// dispose before exit to flush all spans
+tracerFactory.Dispose();
+```
+
+### Export exception and logs from ILogger
+
+OpenTelemetry does not support logging yet, but you can export your logs to Application Insights.
+Here is [more info](https://docs.microsoft.com/en-us/azure/azure-monitor/app/ilogger) on ILogger support with Application Insights.
+
+Logs will be correlated to the OpenTelemetry spans.
+
+1. In addition to OpenTelemetry packages, install  `Microsoft.Extensions.Logging.ApplicationInsights` (latest).
+```xml
+<PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.12.1" />
+```
+
+2. Configure logging per [documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/app/ilogger).
+
+Here is the full example:
+
+```csharp
+public static IHostBuilder CreateHostBuilder(string[] args) =>
+    Host.CreateDefaultBuilder(args)
+        //....
+        .ConfigureServices((context, services) =>
+        {
+            var instrumentationKey = context.Configuration.GetValue<string>("ApplicationInsights:InstrumentationKey");
+
+            // set up OpenTelemetry
+            services.AddOpenTelemetry(b => b
+                .SetResource(Resources.CreateServiceResource("line-counter")) // use unique name 
+                .UseApplicationInsights(o => o.InstrumentationKey = instrumentationKey)
+                .AddDependencyCollector()
+                .AddRequestCollector());
+
+            // set up correlation between spans and logs
+            services.Configure<TelemetryConfiguration>(telemetryConfiguration =>
+            {
+                telemetryConfiguration.TelemetryInitializers.Add(new OperationCorrelationTelemetryInitializer());
+            });
+        })
+        .ConfigureLogging((context, builder) =>
+        {
+            var instrumentationKey = context.Configuration.GetValue<string>("ApplicationInsights:InstrumentationKey");
+
+            // configure Application Insights provider for ILogger
+            builder.AddApplicationInsights(instrumentationKey);
+        });
+```
+

--- a/test/OpenTelemetry.Exporter.ApplicationInsights.Tests/Implementation/ApplicationInsightsTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.ApplicationInsights.Tests/Implementation/ApplicationInsightsTraceExporterTests.cs
@@ -317,6 +317,43 @@ namespace OpenTelemetry.Exporter.ApplicationInsights.Tests
         }
 
         [Fact]
+        public void OpenTelemetryTelemetryConverterTests_TracksInternalSpanWithAzNamespaceAsDependency()
+        {
+            // ARRANGE
+            GetDefaults(out var traceId, out var parentSpanId, out var traceOptions, out var tracestate, out var name, out var attributes, out var events, out var links, out var status, out var kind);
+            kind = SpanKind.Internal;
+
+            var endTimestamp = DateTimeOffset.UtcNow;
+            var startTimestamp = endTimestamp.AddSeconds(-1);
+
+            var span = CreateSpanData(name, traceId, parentSpanId, traceOptions, tracestate, kind, status,
+                new SpanCreationOptions { StartTimestamp = startTimestamp, Attributes = new Dictionary<string, object> { ["az.namespace"] = "Microsoft.Storage", } }, endTimestamp);
+
+            // ACT
+            var sentItems = ConvertSpan(span);
+
+            // ASSERT
+            Assert.Single(sentItems);
+            Assert.True(sentItems.Single() is DependencyTelemetry);
+
+            var dependency = sentItems.OfType<DependencyTelemetry>().Single();
+            Assert.Equal("spanName", dependency.Name);
+            Assert.Equal("InProc | Microsoft.Storage", dependency.Type);
+            Assert.Equal(startTimestamp, dependency.Timestamp);
+            Assert.Equal(1, dependency.Duration.TotalSeconds);
+
+            Assert.Equal(TestTraceId, dependency.Context.Operation.Id);
+
+            Assert.Equal(span.Context.SpanId.ToHexString(), dependency.Id);
+            Assert.Equal(parentSpanId.ToHexString(), dependency.Context.Operation.ParentId);
+
+            Assert.Equal("Ok", dependency.ResultCode);
+            Assert.True(dependency.Success.HasValue);
+            Assert.True(dependency.Success);
+
+            // Assert.Equal("lf_unspecified-oc:0.0.0", dependency.Context.GetInternalContext().SdkVersion);
+        }
+        [Fact]
         public void OpenTelemetryTelemetryConverterTests_DoesNotTrackCallToAppInsights()
         {
             // ARRANGE
@@ -1759,11 +1796,12 @@ namespace OpenTelemetry.Exporter.ApplicationInsights.Tests
 
             Assert.True(request.Success);
             Assert.Equal("Ok", request.ResponseCode);
-            Assert.Equal("sb://endpoint.com/123 | queueName", request.Source);
+            Assert.Equal("sb://endpoint.com/123/queueName", request.Source);
 
             Assert.StartsWith("ot:", request.Context.GetInternalContext().SdkVersion);
 
             Assert.Empty(request.Properties);
+            Assert.Empty(request.Metrics);
         }
 
         [Fact]
@@ -1807,10 +1845,185 @@ namespace OpenTelemetry.Exporter.ApplicationInsights.Tests
 
             Assert.True(request.Success);
             Assert.Equal("Ok", request.ResponseCode);
-            Assert.Equal("sb://endpoint.com/123 | queueName", request.Source);
+            Assert.Equal("sb://endpoint.com/123/queueName", request.Source);
 
             Assert.StartsWith("ot:", request.Context.GetInternalContext().SdkVersion);
             Assert.Empty(request.Properties);
+            Assert.Empty(request.Metrics);
+        }
+
+        [Fact]
+        public void OpenTelemetryTelemetryConverterTests_TracksEventHubsRequestWithTimeInQueue()
+        {
+            // ARRANGE
+            GetDefaults(out var traceId, out var parentSpanId, out var traceOptions, out var tracestate, out var name, out var attributes, out var events, out var links, out var status, out var kind);
+
+            var endTimestamp = DateTimeOffset.UtcNow;
+            var startTimestamp = endTimestamp.AddSeconds(-1);
+            parentSpanId = default;
+
+            var link0Enqueued = startTimestamp.AddMilliseconds(-100).ToUnixTimeMilliseconds();
+            var link1Enqueued = startTimestamp.AddMilliseconds(-200).ToUnixTimeMilliseconds();
+            var link2Enqueued = startTimestamp.AddMilliseconds(-300).ToUnixTimeMilliseconds();
+
+            var link0 = new Link(RandomContext(), new Dictionary<string, object> {["enqueuedTime"] = link0Enqueued });
+            var link1 = new Link(RandomContext(), new Dictionary<string, object> { ["enqueuedTime"] = link1Enqueued });
+            var link2 = new Link(RandomContext(), new Dictionary<string, object> {["enqueuedTime"] = link2Enqueued });
+
+            var options = new SpanCreationOptions
+            {
+                StartTimestamp = startTimestamp,
+                Links = new List<Link> {link0, link1, link2},
+                Attributes = new Dictionary<string, object>
+                {
+                    ["az.namespace"] = "Microsoft.EventHub",
+                    ["message_bus.destination"] = "queueName",
+                    ["peer.address"] = "sb://endpoint.com/123",
+                },
+            };
+
+            var span = CreateSpanData(name, traceId, parentSpanId, traceOptions, tracestate, kind, status, options, endTimestamp);
+
+            // ACT
+            var sentItems = ConvertSpan(span);
+
+            // ASSERT
+            Assert.Single(sentItems);
+            Assert.True(sentItems.Single() is RequestTelemetry);
+
+            var request = sentItems.OfType<RequestTelemetry>().Single();
+            Assert.Single(request.Metrics);
+            Assert.True(request.Metrics.TryGetValue("timeSinceEnqueued", out var timeInQueue));
+
+            var expectedTimeInQueue = 200; // avg diff with request start time across links
+            Assert.Equal(expectedTimeInQueue, timeInQueue);
+        }
+
+        [Fact]
+        public void OpenTelemetryTelemetryConverterTests_TracksEventHubsRequestWithTimeInQueueString()
+        {
+            // ARRANGE
+            GetDefaults(out var traceId, out var parentSpanId, out var traceOptions, out var tracestate, out var name, out var attributes, out var events, out var links, out var status, out var kind);
+
+            var endTimestamp = DateTimeOffset.UtcNow;
+            var startTimestamp = endTimestamp.AddSeconds(-1);
+            parentSpanId = default;
+
+            var link0Enqueued = startTimestamp.AddMilliseconds(-1).ToUnixTimeMilliseconds();
+            var link1Enqueued = startTimestamp.AddMilliseconds(-2).ToUnixTimeMilliseconds();
+            var link2Enqueued = startTimestamp.AddMilliseconds(-3).ToUnixTimeMilliseconds();
+
+            var link0 = new Link(RandomContext(), new Dictionary<string, object> { ["enqueuedTime"] = link0Enqueued.ToString() });
+            var link1 = new Link(RandomContext(), new Dictionary<string, object> { ["enqueuedTime"] = link1Enqueued.ToString() });
+            var link2 = new Link(RandomContext(), new Dictionary<string, object> { ["enqueuedTime"] = link2Enqueued.ToString() });
+
+            var options = new SpanCreationOptions
+            {
+                StartTimestamp = startTimestamp,
+                Links = new List<Link> { link0, link1, link2 },
+                Attributes = new Dictionary<string, object>
+                {
+                    ["az.namespace"] = "Microsoft.EventHub",
+                    ["message_bus.destination"] = "queueName",
+                    ["peer.address"] = "sb://endpoint.com/123",
+                },
+            };
+
+            var span = CreateSpanData(name, traceId, parentSpanId, traceOptions, tracestate, kind, status, options, endTimestamp);
+
+            // ACT
+            var sentItems = ConvertSpan(span);
+
+            // ASSERT
+            Assert.Single(sentItems);
+            Assert.True(sentItems.Single() is RequestTelemetry);
+
+            var request = sentItems.OfType<RequestTelemetry>().Single();
+            Assert.Single(request.Metrics);
+            Assert.True(request.Metrics.TryGetValue("timeSinceEnqueued", out var timeInQueue));
+
+            var expectedTimeInQueue = 2; // avg diff with request start time across links
+            Assert.Equal(expectedTimeInQueue, timeInQueue);
+        }
+
+        [Fact]
+        public void OpenTelemetryTelemetryConverterTests_TracksEventHubsRequestWithTimeInQueueNegative()
+        {
+            // ARRANGE
+            GetDefaults(out var traceId, out var parentSpanId, out var traceOptions, out var tracestate, out var name, out var attributes, out var events, out var links, out var status, out var kind);
+
+            var endTimestamp = DateTimeOffset.UtcNow;
+            var startTimestamp = endTimestamp.AddSeconds(-1);
+            parentSpanId = default;
+
+            var link0Enqueued = startTimestamp.AddMilliseconds(100).ToUnixTimeMilliseconds();
+
+            var link0 = new Link(RandomContext(), new Dictionary<string, object> { ["enqueuedTime"] = link0Enqueued.ToString() });
+
+            var options = new SpanCreationOptions
+            {
+                StartTimestamp = startTimestamp,
+                Links = new List<Link> { link0 },
+                Attributes = new Dictionary<string, object>
+                {
+                    ["az.namespace"] = "Microsoft.EventHub",
+                    ["message_bus.destination"] = "queueName",
+                    ["peer.address"] = "sb://endpoint.com/123",
+                },
+            };
+
+            var span = CreateSpanData(name, traceId, parentSpanId, traceOptions, tracestate, kind, status, options, endTimestamp);
+
+            // ACT
+            var sentItems = ConvertSpan(span);
+
+            // ASSERT
+            Assert.Single(sentItems);
+            Assert.True(sentItems.Single() is RequestTelemetry);
+
+            var request = sentItems.OfType<RequestTelemetry>().Single();
+            Assert.Single(request.Metrics);
+            Assert.True(request.Metrics.TryGetValue("timeSinceEnqueued", out var timeInQueue));
+
+            var expectedTimeInQueue = 0; // messages were enqueued before request started because of clock difference, ignoring the value
+            Assert.Equal(expectedTimeInQueue, timeInQueue);
+        }
+
+        [Fact]
+        public void OpenTelemetryTelemetryConverterTests_TracksEventHubsRequestWithTimeInQueueInvalid()
+        {
+            // ARRANGE
+            GetDefaults(out var traceId, out var parentSpanId, out var traceOptions, out var tracestate, out var name, out var attributes, out var events, out var links, out var status, out var kind);
+
+            var endTimestamp = DateTimeOffset.UtcNow;
+            var startTimestamp = endTimestamp.AddSeconds(-1);
+            parentSpanId = default;
+
+            var link0 = new Link(RandomContext(), new Dictionary<string, object> { ["enqueuedTime"] = "abc" });
+
+            var options = new SpanCreationOptions
+            {
+                StartTimestamp = startTimestamp,
+                Links = new List<Link> { link0 },
+                Attributes = new Dictionary<string, object>
+                {
+                    ["az.namespace"] = "Microsoft.EventHub",
+                    ["message_bus.destination"] = "queueName",
+                    ["peer.address"] = "sb://endpoint.com/123",
+                },
+            };
+
+            var span = CreateSpanData(name, traceId, parentSpanId, traceOptions, tracestate, kind, status, options, endTimestamp);
+
+            // ACT
+            var sentItems = ConvertSpan(span);
+
+            // ASSERT
+            Assert.Single(sentItems);
+            Assert.True(sentItems.Single() is RequestTelemetry);
+
+            var request = sentItems.OfType<RequestTelemetry>().Single();
+            Assert.Empty(request.Metrics);
         }
 
         [Fact]
@@ -1855,7 +2068,7 @@ namespace OpenTelemetry.Exporter.ApplicationInsights.Tests
 
             Assert.True(dependency.Success);
             Assert.Equal("Ok", dependency.ResultCode);
-            Assert.Equal("sb://endpoint.com/123 | queueName", dependency.Target);
+            Assert.Equal("sb://endpoint.com/123/queueName", dependency.Target);
             Assert.Equal("Azure Event Hubs", dependency.Type);
 
             Assert.StartsWith("ot:", dependency.Context.GetInternalContext().SdkVersion);
@@ -1904,7 +2117,7 @@ namespace OpenTelemetry.Exporter.ApplicationInsights.Tests
 
             Assert.True(dependency.Success);
             Assert.Equal("Ok", dependency.ResultCode);
-            Assert.Equal("sb://endpoint.com/123 | queueName", dependency.Target);
+            Assert.Equal("sb://endpoint.com/123/queueName", dependency.Target);
             Assert.Equal("Azure Event Hubs", dependency.Type);
 
             Assert.StartsWith("ot:", dependency.Context.GetInternalContext().SdkVersion);
@@ -2043,6 +2256,11 @@ namespace OpenTelemetry.Exporter.ApplicationInsights.Tests
             }
 
             return (SpanData)processor.Invocations[0].Arguments[0];
+        }
+
+        private SpanContext RandomContext()
+        {
+            return new SpanContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded, true);
         }
     }
 };


### PR DESCRIPTION
1. Add readme on how to use OTel with AppInsights and configure logging
2. Enable reporting time in queue for EventHubs