### PR TITLE
JaegerExporter: Send a batch for each remote service

### DIFF
--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/Batch.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/Batch.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -25,20 +26,15 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
 {
     public class Batch : TAbstractBase
     {
-        public Batch()
+        public Batch(Process process, List<JaegerSpan> spans = null)
         {
+            this.Process = process ?? throw new ArgumentNullException(nameof(process));
+            this.Spans = spans ?? new List<JaegerSpan>();
         }
 
-        public Batch(Process process, IEnumerable<JaegerSpan> spans)
-            : this()
-        {
-            this.Process = process;
-            this.Spans = spans ?? Enumerable.Empty<JaegerSpan>();
-        }
+        public Process Process { get; }
 
-        public Process Process { get; set; }
-
-        public IEnumerable<JaegerSpan> Spans { get; set; }
+        public List<JaegerSpan> Spans { get; }
 
         public async Task WriteAsync(TProtocol oprot, CancellationToken cancellationToken)
         {

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerConversionExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerConversionExtensions.cs
@@ -64,7 +64,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
 
                 if (tag.VStr != null
                     && PeerServiceKeyResolutionDictionary.TryGetValue(label.Key, out int priority)
-                    && (peerService == null || peerService.Item2 > priority))
+                    && (peerService == null || priority < peerService.Item2))
                 {
                     peerService = new Tuple<string, int>(tag.VStr, priority);
                 }

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpBatcher.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpBatcher.cs
@@ -28,13 +28,12 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
         private readonly ITProtocolFactory protocolFactory;
         private readonly JaegerThriftClientTransport clientTransport;
         private readonly JaegerThriftClient thriftClient;
-        private readonly List<JaegerSpan> currentBatch = new List<JaegerSpan>();
 
         private readonly SemaphoreSlim flushLock = new SemaphoreSlim(1);
         private readonly TimeSpan maxFlushInterval;
         private readonly System.Timers.Timer maxFlushIntervalTimer;
 
-        private int? processByteSize;
+        private Dictionary<string, Process> processCache;
         private int batchByteSize;
 
         private bool disposedValue = false; // To detect redundant calls
@@ -67,25 +66,48 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
 
             this.maxFlushIntervalTimer.Elapsed += async (sender, args) =>
             {
-                await this.FlushAsync(CancellationToken.None).ConfigureAwait(false);
+                await this.FlushAsyncInternal(false, CancellationToken.None).ConfigureAwait(false);
             };
         }
 
         public Process Process { get; private set; }
 
+        internal IDictionary<string, Batch> CurrentBatches { get; } = new Dictionary<string, Batch>();
+
         public async Task<int> AppendAsync(JaegerSpan span, CancellationToken cancellationToken)
         {
-            if (!this.processByteSize.HasValue)
+            if (this.processCache == null)
             {
-                this.processByteSize = await this.GetSize(this.Process).ConfigureAwait(false);
-                this.batchByteSize = this.processByteSize.Value;
+                this.Process.ByteSize = await this.GetSize(this.Process).ConfigureAwait(false);
+                this.processCache = new Dictionary<string, Process>
+                {
+                    [this.Process.ServiceName] = this.Process,
+                };
             }
 
-            int spanSize = await this.GetSize(span).ConfigureAwait(false);
+            string spanServiceName = span.JaegerTags?.FirstOrDefault(t => t.Key == "peer.service")?.VStr ?? this.Process.ServiceName;
 
-            if (spanSize + this.processByteSize > this.maxPacketSize)
+            if (!this.processCache.TryGetValue(spanServiceName, out var spanProcess))
             {
-                throw new JaegerExporterException($"ThriftSender received a span that was too large, size = {spanSize + this.processByteSize}, max = {this.maxPacketSize}", null);
+                spanProcess = new Process(spanServiceName, this.Process.Tags);
+                spanProcess.ByteSize = await this.GetSize(spanProcess).ConfigureAwait(false);
+                this.processCache.Add(spanServiceName, spanProcess);
+            }
+
+            int spanByteSize = await this.GetSize(span).ConfigureAwait(false);
+
+            if (spanByteSize + spanProcess.ByteSize > this.maxPacketSize)
+            {
+                throw new JaegerExporterException($"ThriftSender received a span that was too large, size = {spanByteSize + spanProcess.ByteSize}, max = {this.maxPacketSize}", null);
+            }
+
+            int spanTotalBytesNeeded = spanByteSize;
+            if (!this.CurrentBatches.TryGetValue(spanServiceName, out var spanBatch))
+            {
+                spanBatch = new Batch(spanProcess);
+                this.CurrentBatches.Add(spanServiceName, spanBatch);
+
+                spanTotalBytesNeeded += spanProcess.ByteSize;
             }
 
             var flushedSpanCount = 0;
@@ -95,9 +117,14 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
                 await this.flushLock.WaitAsync().ConfigureAwait(false);
 
                 // flush if current batch size plus new span size equals or exceeds max batch size
-                if (this.batchByteSize + spanSize >= this.maxPacketSize)
+                if (this.batchByteSize + spanTotalBytesNeeded >= this.maxPacketSize)
                 {
-                    flushedSpanCount = await this.FlushAsync(cancellationToken).ConfigureAwait(false);
+                    flushedSpanCount = await this.FlushAsyncInternal(true, cancellationToken).ConfigureAwait(false);
+
+                    // Flushing effectively erases the spanBatch we were working on, so we have to rebuild it.
+                    spanBatch.Spans.Clear();
+                    spanTotalBytesNeeded = spanByteSize + spanProcess.ByteSize;
+                    this.CurrentBatches.Add(spanServiceName, spanBatch);
                 }
                 else
                 {
@@ -105,8 +132,8 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
                 }
 
                 // add span to batch and wait for more spans
-                this.currentBatch.Add(span);
-                this.batchByteSize += spanSize;
+                spanBatch.Spans.Add(span);
+                this.batchByteSize += spanTotalBytesNeeded;
             }
             finally
             {
@@ -116,51 +143,9 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
             return flushedSpanCount;
         }
 
-        public async Task<int> FlushAsync(CancellationToken cancellationToken)
-        {
-            try
-            {
-                await this.flushLock.WaitAsync().ConfigureAwait(false);
+        public Task<int> FlushAsync(CancellationToken cancellationToken) => this.FlushAsyncInternal(false, cancellationToken);
 
-                this.maxFlushIntervalTimer.Enabled = false;
-
-                int n = this.currentBatch.Count;
-
-                if (n == 0)
-                {
-                    return 0;
-                }
-
-                try
-                {
-                    await this.SendAsync(this.currentBatch, cancellationToken).ConfigureAwait(false);
-                }
-                finally
-                {
-                    this.currentBatch.Clear();
-                    this.batchByteSize = this.processByteSize.Value;
-                }
-
-                return n;
-            }
-            finally
-            {
-                this.flushLock.Release();
-            }
-        }
-
-        public virtual Task<int> CloseAsync(CancellationToken cancellationToken) => this.FlushAsync(cancellationToken);
-
-        public IEnumerable<Batch> BuildBatchesToTransmit(IEnumerable<JaegerSpan> spans)
-        {
-            return spans
-                .GroupBy(s => s.JaegerTags.FirstOrDefault(t => t.Key == "peer.service")?.VStr)
-                .Select(g => new Batch(
-                    g.Key == null
-                        ? this.Process
-                        : new Process(g.Key, this.Process.Tags),
-                    g));
-        }
+        public Task<int> CloseAsync(CancellationToken cancellationToken) => this.FlushAsyncInternal(false, cancellationToken);
 
         public void Dispose()
         {
@@ -168,18 +153,18 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
             this.Dispose(true);
         }
 
-        protected async Task SendAsync(List<JaegerSpan> spans, CancellationToken cancellationToken)
+        protected async Task SendAsync(IEnumerable<Batch> batches, CancellationToken cancellationToken)
         {
             try
             {
-                foreach (var batch in this.BuildBatchesToTransmit(spans))
+                foreach (var batch in batches)
                 {
                     await this.thriftClient.EmitBatchAsync(batch, cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (Exception ex)
             {
-                throw new JaegerExporterException($"Could not send {spans.Count} spans", ex);
+                throw new JaegerExporterException($"Could not send {batches.Select(b => b.Spans.Count()).Sum()} spans", ex);
             }
         }
 
@@ -195,6 +180,45 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
                 }
 
                 this.disposedValue = true;
+            }
+        }
+
+        private async Task<int> FlushAsyncInternal(bool lockAlreadyHeld, CancellationToken cancellationToken)
+        {
+            if (!lockAlreadyHeld)
+            {
+                await this.flushLock.WaitAsync().ConfigureAwait(false);
+            }
+
+            try
+            {
+                this.maxFlushIntervalTimer.Enabled = false;
+
+                int n = this.CurrentBatches.Values.Sum(b => b.Spans.Count);
+
+                if (n == 0)
+                {
+                    return 0;
+                }
+
+                try
+                {
+                    await this.SendAsync(this.CurrentBatches.Values, cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    this.CurrentBatches.Clear();
+                    this.batchByteSize = 0;
+                }
+
+                return n;
+            }
+            finally
+            {
+                if (!lockAlreadyHeld)
+                {
+                    this.flushLock.Release();
+                }
             }
         }
 

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpBatcher.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpBatcher.cs
@@ -112,10 +112,9 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
 
             var flushedSpanCount = 0;
 
+            await this.flushLock.WaitAsync().ConfigureAwait(false);
             try
             {
-                await this.flushLock.WaitAsync().ConfigureAwait(false);
-
                 // flush if current batch size plus new span size equals or exceeds max batch size
                 if (this.batchByteSize + spanTotalBytesNeeded >= this.maxPacketSize)
                 {

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/Process.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/Process.cs
@@ -49,6 +49,8 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
 
         public IDictionary<string, JaegerTag> Tags { get; set; }
 
+        internal int ByteSize { get; set; }
+
         public async Task WriteAsync(TProtocol oprot, CancellationToken cancellationToken)
         {
             oprot.IncrementRecursionDepth();

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/Process.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/Process.cs
@@ -30,20 +30,24 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
         }
 
         public Process(string serviceName, IDictionary<string, object> processTags)
+            : this(serviceName, processTags?.Select(pt => pt.ToJaegerTag()))
+        {
+        }
+
+        public Process(string serviceName, IEnumerable<JaegerTag> processTags)
             : this()
         {
             this.ServiceName = serviceName;
 
             if (processTags != null)
             {
-                this.Tags = new List<JaegerTag>();
-                this.Tags.AddRange(processTags.Select(pt => pt.ToJaegerTag()));
+                this.Tags = processTags;
             }
         }
 
         public string ServiceName { get; set; }
 
-        public List<JaegerTag> Tags { get; set; }
+        public IEnumerable<JaegerTag> Tags { get; set; }
 
         public async Task WriteAsync(TProtocol oprot, CancellationToken cancellationToken)
         {
@@ -73,7 +77,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
 
                     await oprot.WriteFieldBeginAsync(field, cancellationToken);
                     {
-                        await oprot.WriteListBeginAsync(new TList(TType.Struct, this.Tags.Count), cancellationToken);
+                        await oprot.WriteListBeginAsync(new TList(TType.Struct, this.Tags.Count()), cancellationToken);
 
                         foreach (JaegerTag jt in this.Tags)
                         {

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerSpanConverterTest.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerSpanConverterTest.cs
@@ -320,8 +320,64 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
             Assert.Equal("Event2", eventField.VStr);
         }
 
-        internal SpanData CreateTestSpan(
+        [Fact]
+        public void JaegerSpanConverterTest_GenerateSpan_RemoteEndpointOmittedByDefault()
+        {
+            // Arrange
+            var span = CreateTestSpan();
+
+            // Act
+            var jaegerSpan = span.ToJaegerSpan();
+
+            // Assert
+            Assert.Null(jaegerSpan.JaegerTags.FirstOrDefault(t => t.Key == "peer.service"));
+        }
+
+        [Fact]
+        public void JaegerSpanConverterTest_GenerateSpan_RemoteEndpointResolution()
+        {
+            // Arrange
+            var span = CreateTestSpan(
+                additionalAttributes: new Dictionary<string, object>
+                {
+                    ["net.peer.name"] = "RemoteServiceName",
+                });
+
+            // Act
+            var jaegerSpan = span.ToJaegerSpan();
+
+            // Assert
+            var tag = jaegerSpan.JaegerTags.FirstOrDefault(t => t.Key == "peer.service");
+            Assert.NotNull(tag);
+            Assert.Equal("RemoteServiceName", tag.VStr);
+        }
+
+        [Fact]
+        public void JaegerSpanConverterTest_GenerateSpan_RemoteEndpointResolutionPriority()
+        {
+            // Arrange
+            var span = CreateTestSpan(
+                additionalAttributes: new Dictionary<string, object>
+                {
+                    ["http.host"] = "DiscardedRemoteServiceName",
+                    ["peer.service"] = "RemoteServiceName",
+                    ["peer.hostname"] = "DiscardedRemoteServiceName",
+                });
+
+            // Act
+            var jaegerSpan = span.ToJaegerSpan();
+
+            // Assert
+            var tags = jaegerSpan.JaegerTags.Where(t => t.Key == "peer.service");
+            Assert.Single(tags);
+            var tag = tags.First();
+            Assert.NotNull(tag);
+            Assert.Equal("RemoteServiceName", tag.VStr);
+        }
+
+        internal static SpanData CreateTestSpan(
             bool setAttributes = true,
+            Dictionary<string, object> additionalAttributes = null,
             bool addEvents = true,
             bool addLinks = true)
         {
@@ -332,6 +388,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
 
             var spanId = ActivitySpanId.CreateRandom();
             var parentSpanId = ActivitySpanId.CreateFromBytes(new byte[] { 12, 23, 34, 45, 56, 67, 78, 89 });
+
             var attributes = new Dictionary<string, object>
             {
                 { "stringKey", "value"},
@@ -341,6 +398,14 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
                 { "doubleKey2", 1F},
                 { "boolKey", true},
             };
+            if (additionalAttributes != null)
+            {
+                foreach (var attribute in additionalAttributes)
+                {
+                    attributes.Add(attribute.Key, attribute.Value);
+                }
+            }
+
             var events = new List<Event>
             {
                 new Event(

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerUdpBatcherTests.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerUdpBatcherTests.cs
@@ -1,0 +1,84 @@
+﻿// <copyright file="JaegerUdpBatcherTests.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+using System.Collections.Generic;
+using System.Linq;
+using OpenTelemetry.Exporter.Jaeger.Implementation;
+using Xunit;
+
+namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
+{
+    public class JaegerUdpBatcherTests
+    {
+        [Fact]
+        public void JaegerUdpBatcherTests_BuildBatchesToTransmit_DefaultBatch()
+        {
+            // Arrange
+            var options = new JaegerExporterOptions { ServiceName = "TestService" };
+
+            var jaegerUdpBatcher = new JaegerUdpBatcher(options);
+
+            var spans = new[]
+            {
+                JaegerSpanConverterTest.CreateTestSpan().ToJaegerSpan(),
+                JaegerSpanConverterTest.CreateTestSpan().ToJaegerSpan(),
+                JaegerSpanConverterTest.CreateTestSpan().ToJaegerSpan(),
+            };
+
+            // Act
+            var batches = jaegerUdpBatcher.BuildBatchesToTransmit(spans);
+
+            // Assert
+            Assert.Single(batches);
+            Assert.Equal("TestService", batches.First().Process.ServiceName);
+            Assert.Equal(3, batches.First().Spans.Count());
+        }
+
+        [Fact]
+        public void JaegerUdpBatcherTests_BuildBatchesToTransmit_MultipleBatches()
+        {
+            // Arrange
+            var options = new JaegerExporterOptions { ServiceName = "TestService" };
+
+            var jaegerUdpBatcher = new JaegerUdpBatcher(options);
+
+            var spans = new[]
+            {
+                JaegerSpanConverterTest.CreateTestSpan().ToJaegerSpan(),
+                JaegerSpanConverterTest.CreateTestSpan(
+                    additionalAttributes: new Dictionary<string, object>
+                    {
+                        ["peer.service"] = "MySQL",
+                    })
+                    .ToJaegerSpan(),
+                JaegerSpanConverterTest.CreateTestSpan().ToJaegerSpan(),
+            };
+
+            // Act
+            var batches = jaegerUdpBatcher.BuildBatchesToTransmit(spans);
+
+            // Assert
+            Assert.Equal(2, batches.Count());
+
+            var PrimaryBatch = batches.Where(b => b.Process.ServiceName == "TestService");
+            Assert.Single(PrimaryBatch);
+            Assert.Equal(2, PrimaryBatch.First().Spans.Count());
+
+            var MySQLBatch = batches.Where(b => b.Process.ServiceName == "MySQL");
+            Assert.Single(MySQLBatch);
+            Assert.Single(MySQLBatch.First().Spans);
+        }
+    }
+}

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerUdpBatcherTests.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerUdpBatcherTests.cs
@@ -84,7 +84,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
         public async Task JaegerUdpBatcherTests_BuildBatchesToTransmit_FlushedBatch()
         {
             // Arrange
-            var options = new JaegerExporterOptions { ServiceName = "TestService", MaxFlushInterval = TimeSpan.FromHours(1), MaxPacketSize = 700 };
+            var options = new JaegerExporterOptions { ServiceName = "TestService", MaxFlushInterval = TimeSpan.FromHours(1), MaxPacketSize = 750 };
 
             var jaegerUdpBatcher = new JaegerUdpBatcher(options);
 


### PR DESCRIPTION
This PR is similar to #483. Jaeger will associate all spans in a batch to the ServiceName sent for that batch. This means calls to external services that aren't instrumented (ex: sql, redis, APIs, etc.) won't be detected as dependencies. This really reduces the usefulness of the tool.

What this PR does is update the JaegerExporter to set "peer.service" (same fuzzy logic as #483) on spans and then use that to send batches per service to the Jaeger agent. Should work out of the box for the existing OpenTelemetry collectors (and the SQL one in PR).