### PR TITLE
Add converters for ActivitySpanId and ActivityTraceId

### DIFF
--- a/samples/Exporters/Console/TestConsole.cs
+++ b/samples/Exporters/Console/TestConsole.cs
@@ -28,6 +28,9 @@ namespace Samples
 
                 using (tracer.StartActiveSpan("parent", out var parent))
                 {
+                    tracer.CurrentSpan.SetAttribute("key", 123);
+                    tracer.CurrentSpan.AddEvent("test-event");
+
                     using (tracer.StartActiveSpan("child", out var child))
                     {
                         child.SetAttribute("key", "value");

--- a/src/OpenTelemetry.Exporter.Console/ActivitySpanIdConverter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ActivitySpanIdConverter.cs
@@ -21,7 +21,7 @@ using System.Text.Json.Serialization;
 
 namespace OpenTelemetry.Exporter.Console
 {
-    public class ActivitySpanIdConverter : JsonConverter<ActivitySpanId>
+    internal class ActivitySpanIdConverter : JsonConverter<ActivitySpanId>
     {
         public override ActivitySpanId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {

--- a/src/OpenTelemetry.Exporter.Console/ActivitySpanIdConverter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ActivitySpanIdConverter.cs
@@ -1,0 +1,36 @@
+// <copyright file="ActivitySpanIdConverter.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenTelemetry.Exporter.Console
+{
+    public class ActivitySpanIdConverter : JsonConverter<ActivitySpanId>
+    {
+        public override ActivitySpanId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(Utf8JsonWriter writer, ActivitySpanId value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.ToString());
+        }
+    }
+}

--- a/src/OpenTelemetry.Exporter.Console/ActivityTraceIdConverter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ActivityTraceIdConverter.cs
@@ -21,7 +21,7 @@ using System.Text.Json.Serialization;
 
 namespace OpenTelemetry.Exporter.Console
 {
-    public class ActivityTraceIdConverter : JsonConverter<ActivityTraceId>
+    internal class ActivityTraceIdConverter : JsonConverter<ActivityTraceId>
     {
         public override ActivityTraceId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {

--- a/src/OpenTelemetry.Exporter.Console/ActivityTraceIdConverter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ActivityTraceIdConverter.cs
@@ -1,0 +1,36 @@
+// <copyright file="ActivityTraceIdConverter.cs" company="OpenTelemetry Authors">
+// Copyright 2018, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenTelemetry.Exporter.Console
+{
+    public class ActivityTraceIdConverter : JsonConverter<ActivityTraceId>
+    {
+        public override ActivityTraceId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(Utf8JsonWriter writer, ActivityTraceId value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.ToString());
+        }
+    }
+}

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporter.cs
@@ -19,7 +19,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using OpenTelemetry.Trace;
 using OpenTelemetry.Trace.Export;
 
 namespace OpenTelemetry.Exporter.Console
@@ -36,6 +35,8 @@ namespace OpenTelemetry.Exporter.Console
             };
 
             this.serializerOptions.Converters.Add(new JsonStringEnumConverter());
+            this.serializerOptions.Converters.Add(new ActivitySpanIdConverter());
+            this.serializerOptions.Converters.Add(new ActivityTraceIdConverter());
         }
 
         public override Task<ExportResult> ExportAsync(IEnumerable<SpanData> batch, CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes #488.

Both ActivitySpanId and ActivityTraceId do not expose their values with properties, instead you get the value by calling `ToString()`. This means that when using `System.Text.Json` to serialize a span, eg in ConsoleExporter, the values look empty.

This PR adds custom converters for both types that calls `ToString()` in the `Write` method.

The result JSON includes the span and trace IDs as expected.

```
{
  "Context": {
    "TraceId": "6ff6f77998a3e44f9d2c3aa36176dc92",
    "SpanId": "e9512abedcb54e4f",
    "TraceOptions": "Recorded",
    "IsRemote": false,
    "IsValid": true,
    "Tracestate": []
  },
  "Name": "child",
  "Status": {
    "IsValid": true,
    "CanonicalCode": "Ok",
    "Description": null,
    "IsOk": true
  },
  "ParentSpanId": "dd971af42ac73c42",
  "Attributes": [
    {
      "Key": "key",
      "Value": "value"
    }
  ],
  "Events": [],
  "Links": [],
  "StartTimestamp": "2020-02-12T14:03:25.862072+00:00",
  "EndTimestamp": "2020-02-12T14:03:25.862661+00:00",
  "Kind": "Internal",
  "LibraryResource": {
    "Attributes": [
      {
        "Key": "name",
        "Value": "console-test"
      }
    ]
  }
}
```