### PR TITLE
Fix build warnings

### DIFF
--- a/test/OpenTelemetry.Tests/Impl/Trace/Config/TracerFactoryTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Config/TracerFactoryTest.cs
@@ -95,7 +95,7 @@ namespace OpenTelemetry.Trace.Test
             Assert.True(span.IsRecording);
             Assert.Equal(1, exporterCalledCount);
             Assert.Single(((SpanSdk)span).LibraryResource.Attributes);
-            Assert.Single(((SpanSdk)span).LibraryResource.Attributes.Where(kvp => kvp.Key == "name" && kvp.Value == "my-app"));
+            Assert.Single(((SpanSdk)span).LibraryResource.Attributes.Where(kvp => kvp.Key == "name" && kvp.Value.ToString() == "my-app"));
 
             Assert.NotNull(collector1);
             Assert.NotNull(collector2);

--- a/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
@@ -994,7 +994,7 @@ namespace OpenTelemetry.Trace.Test
             span.SetAttribute("string", "foo");
             span.SetAttribute("bool", false);
             span.SetAttribute("long", -1L);
-            span.SetAttribute("ulong", (ulong)1);
+            span.SetAttribute("ulong", 1UL);
             span.SetAttribute("uint", 2U);
             span.SetAttribute("int", -2);
             span.SetAttribute("sbyte", (sbyte)-3);


### PR DESCRIPTION
Fixes two build warnings

```
Impl/Trace/Config/TracerFactoryTest.cs(98,104): warning CS0252: Possible unintended reference comparison; to get a value comparison, cast the left hand side to type 'string' [/Users/mgoldsmith/code/opentelemetry-dotnet/test/OpenTelemetry.Tests/OpenTelemetry.Tests.csproj]
Impl/Trace/SpanTest.cs(997,40): warning SA1139: Use literal suffix notation instead of casting [/Users/mgoldsmith/code/opentelemetry-dotnet/test/OpenTelemetry.Tests/OpenTelemetry.Tests.csproj]
```