### PR TITLE
Keys with digits are still accepted

### DIFF
--- a/src/OpenTelemetry.Api/Context/Propagation/TracestateUtils.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TracestateUtils.cs
@@ -197,8 +197,7 @@ namespace OpenTelemetry.Context.Propagation
 
             if (key.IsEmpty
                 || key.Length > KeyMaxSize
-                || key[i] < 'a'
-                || key[i] > 'z')
+                || ((!(key[i] >= 'a' && key[i] <= 'z')) && (!(key[i] >= '0' && key[i] <= '9'))))
             {
                 return false;
             }

--- a/test/OpenTelemetry.Tests/Impl/Trace/Propagation/TracestateUtilsTests.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Propagation/TracestateUtilsTests.cs
@@ -83,7 +83,7 @@ namespace OpenTelemetry.Tests.Impl.Trace.Propagation
         [InlineData(", k= v, ", "k", "v")]
         [InlineData("k=\tv", "k", "v")]
         [InlineData("k=v\t", "k", "v")]
-        [InlineData("1k=v\t", "1k", "v")]
+        [InlineData("1k=v", "1k", "v")]
         public void ValidPair(string pair, string expectedKey, string expectedValue)
         {
             var tracestateEntries = new List<KeyValuePair<string, string>>();

--- a/test/OpenTelemetry.Tests/Impl/Trace/Propagation/TracestateUtilsTests.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Propagation/TracestateUtilsTests.cs
@@ -75,21 +75,22 @@ namespace OpenTelemetry.Tests.Impl.Trace.Propagation
         }
 
         [Theory]
-        [InlineData("k=v")]
-        [InlineData(" k=v ")]
-        [InlineData("\tk=v")]
-        [InlineData(" k= v ")]
-        [InlineData(",k=v,")]
-        [InlineData(", k= v, ")]
-        [InlineData("k=\tv")]
-        [InlineData("k=v\t")]
-        public void ValidPair(string pair)
+        [InlineData("k=v", "k", "v")]
+        [InlineData(" k=v ", "k", "v")]
+        [InlineData("\tk=v", "k", "v")]
+        [InlineData(" k= v ", "k", "v")]
+        [InlineData(",k=v,", "k", "v")]
+        [InlineData(", k= v, ", "k", "v")]
+        [InlineData("k=\tv", "k", "v")]
+        [InlineData("k=v\t", "k", "v")]
+        [InlineData("1k=v\t", "1k", "v")]
+        public void ValidPair(string pair, string expectedKey, string expectedValue)
         {
             var tracestateEntries = new List<KeyValuePair<string, string>>();
             Assert.True(TracestateUtils.AppendTracestate(pair, tracestateEntries));
             Assert.Single(tracestateEntries);
-            Assert.Equal(new KeyValuePair<string, string>("k", "v"), tracestateEntries.Single());
-            Assert.Equal("k=v", TracestateUtils.GetString(tracestateEntries));
+            Assert.Equal(new KeyValuePair<string, string>(expectedKey, expectedValue), tracestateEntries.Single());
+            Assert.Equal($"{expectedKey}={expectedValue}", TracestateUtils.GetString(tracestateEntries));
         }
 
         [Theory]


### PR DESCRIPTION
According to W3C specs, keys with digits are still accepted. W3C specs state the followings:
"Note: Identifiers MUST begin with a lowercase letter or a digit, and can only contain lowercase letters (a-z), digits (0-9), underscores (_), dashes (-), asterisks (*), and forward slashes (/)."
