### PR TITLE
Add support for array attributes

### DIFF
--- a/src/OpenTelemetry.Api/Trace/TelemetrySpan.cs
+++ b/src/OpenTelemetry.Api/Trace/TelemetrySpan.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 using System;
+using System.Collections;
 
 namespace OpenTelemetry.Trace
 {

--- a/src/OpenTelemetry.Api/Trace/TelemetrySpan.cs
+++ b/src/OpenTelemetry.Api/Trace/TelemetrySpan.cs
@@ -54,6 +54,7 @@ namespace OpenTelemetry.Trace
 
         /// <summary>
         /// Sets a new attribute on the span.
+        /// <para>The value may be an <see cref="IEnumerable"/> of primetive types. Note the enumeration may be iterated multiple times.</para>
         /// </summary>
         /// <param name="key">Attribute key.</param>
         /// <param name="value">Attribute value.</param>

--- a/src/OpenTelemetry.Api/Trace/TelemetrySpan.cs
+++ b/src/OpenTelemetry.Api/Trace/TelemetrySpan.cs
@@ -56,7 +56,7 @@ namespace OpenTelemetry.Trace
         /// Sets a new attribute on the span.
         /// </summary>
         /// <param name="key">Attribute key.</param>
-        /// <param name="value">Attribute value. The value may be an <see cref="IEnumerable"/> of primetive types. An enumeration may be iterated multiple times.</param>
+        /// <param name="value">Attribute value. The value may be an <see cref="IEnumerable"/> of primitive types. An enumeration may be iterated multiple times.</param>
         public abstract void SetAttribute(string key, object value);
 
         /// <summary>

--- a/src/OpenTelemetry.Api/Trace/TelemetrySpan.cs
+++ b/src/OpenTelemetry.Api/Trace/TelemetrySpan.cs
@@ -54,10 +54,9 @@ namespace OpenTelemetry.Trace
 
         /// <summary>
         /// Sets a new attribute on the span.
-        /// <para>The value may be an <see cref="IEnumerable"/> of primetive types. Note the enumeration may be iterated multiple times.</para>
         /// </summary>
         /// <param name="key">Attribute key.</param>
-        /// <param name="value">Attribute value.</param>
+        /// <param name="value">Attribute value. The value may be an <see cref="IEnumerable"/> of primetive types. An enumeration may be iterated multiple times.</param>
         public abstract void SetAttribute(string key, object value);
 
         /// <summary>

--- a/src/OpenTelemetry/Trace/SpanSdk.cs
+++ b/src/OpenTelemetry/Trace/SpanSdk.cs
@@ -834,18 +834,25 @@ namespace OpenTelemetry.Trace
 
             if (attributeValue is IEnumerable enumerable)
             {
-                Type entryType = null;
-                foreach (var entry in enumerable)
+                try
                 {
-                    if (entryType == null)
+                    Type entryType = null;
+                    foreach (var entry in enumerable)
                     {
-                        entryType = entry.GetType();
-                    }
+                        if (entryType == null)
+                        {
+                            entryType = entry.GetType();
+                        }
 
-                    if (!this.IsNumericBoolOrString(entry) || entryType != entry.GetType())
-                    {
-                        return false;
+                        if (!this.IsNumericBoolOrString(entry) || entryType != entry.GetType())
+                        {
+                            return false;
+                        }
                     }
+                }
+                catch
+                {
+                    return false;
                 }
 
                 return true;

--- a/src/OpenTelemetry/Trace/SpanSdk.cs
+++ b/src/OpenTelemetry/Trace/SpanSdk.cs
@@ -322,7 +322,7 @@ namespace OpenTelemetry.Trace
             else if (!this.IsAttributeValueTypeSupported(value))
             {
                 OpenTelemetrySdkEventSource.Log.InvalidArgument("SetAttribute", nameof(value), $"Type '{value.GetType()}' of attribute '{key}' is not supported");
-                sanitizedValue = value.ToString();
+                sanitizedValue = string.Empty;
             }
 
             lock (this.lck)

--- a/src/OpenTelemetry/Trace/SpanSdk.cs
+++ b/src/OpenTelemetry/Trace/SpanSdk.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -827,14 +828,12 @@ namespace OpenTelemetry.Trace
                 return true;
             }
 
-            if (attributeValue is Array array)
+            if (attributeValue is IEnumerable enumerable)
             {
                 Type entryType = null;
-                for (int i = 0; i < array.Length; i++)
+                foreach (var entry in enumerable)
                 {
-                    var entry = array.GetValue(i);
-
-                    if (i == 0)
+                    if (entryType == null)
                     {
                         entryType = entry.GetType();
                     }

--- a/src/OpenTelemetry/Trace/SpanSdk.cs
+++ b/src/OpenTelemetry/Trace/SpanSdk.cs
@@ -827,7 +827,26 @@ namespace OpenTelemetry.Trace
                 return true;
             }
 
-            // TODO add array support
+            if (attributeValue is Array array)
+            {
+                Type entryType = null;
+                for (int i = 0; i < array.Length; i++)
+                {
+                    var entry = array.GetValue(i);
+
+                    if (i == 0)
+                    {
+                        entryType = entry.GetType();
+                    }
+
+                    if (!this.IsNumericBoolOrString(entry) || entryType != entry.GetType())
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
 
             return false;
         }

--- a/src/OpenTelemetry/Trace/SpanSdk.cs
+++ b/src/OpenTelemetry/Trace/SpanSdk.cs
@@ -321,7 +321,7 @@ namespace OpenTelemetry.Trace
             }
             else if (!this.IsAttributeValueTypeSupported(value))
             {
-                OpenTelemetrySdkEventSource.Log.InvalidArgument("SetAttribute", nameof(value), $"Type '{value?.GetType()}' of attribute '{key}' is not supported");
+                OpenTelemetrySdkEventSource.Log.InvalidArgument("SetAttribute", nameof(value), $"Type '{value.GetType()}' of attribute '{key}' is not supported");
                 sanitizedValue = value.ToString();
             }
 

--- a/src/OpenTelemetry/Trace/SpanSdk.cs
+++ b/src/OpenTelemetry/Trace/SpanSdk.cs
@@ -315,10 +315,14 @@ namespace OpenTelemetry.Trace
             }
 
             object sanitizedValue = value;
-            if (value == null || !this.IsAttributeValueTypeSupported(value))
+            if (value == null)
+            {
+                sanitizedValue = string.Empty;
+            }
+            else if (!this.IsAttributeValueTypeSupported(value))
             {
                 OpenTelemetrySdkEventSource.Log.InvalidArgument("SetAttribute", nameof(value), $"Type '{value?.GetType()}' of attribute '{key}' is not supported");
-                sanitizedValue = string.Empty;
+                sanitizedValue = value.ToString();
             }
 
             lock (this.lck)

--- a/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
@@ -1078,6 +1078,21 @@ namespace OpenTelemetry.Trace.Test
         }
 
         [Fact]
+        public void SetAttribute_Array_IEnumerable()
+        {
+            var tracer = tracerFactory.GetTracer(null);
+            var span = (SpanSdk)tracer.StartRootSpan(SpanName);
+
+            IEnumerable<int> array = new List<int> {1,2,3};
+            span.SetAttribute("array", array);
+
+            Assert.Equal(1, span.Attributes.Count());
+
+            var attribute = span.Attributes.Single(kvp => kvp.Key == "array");
+            Assert.Equal(array, attribute.Value);
+        }
+
+        [Fact]
         public void SetAttribute_Array_Cant_Mix_Types()
         {
             var tracer = tracerFactory.GetTracer(null);

--- a/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
@@ -453,7 +453,7 @@ namespace OpenTelemetry.Trace.Test
             Assert.Contains(span.Context.Tracestate, pair => pair.Key == "k1" && pair.Value == "v1");
             Assert.Contains(span.Context.Tracestate, pair => pair.Key == "k2" && pair.Value == "v2");
 
-            // activity is not a parent and sampling decision is made 
+            // activity is not a parent and sampling decision is made
             // based on sampler alone
             Assert.True(span.IsRecording);
             Assert.Equal(SpanKind.Internal, span.Kind);
@@ -542,7 +542,7 @@ namespace OpenTelemetry.Trace.Test
         public void StartSpan_Recorded_FromActivity_Null_Kind_Links()
         {
             var linkContext = new SpanContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded);
-                    
+
             var tracer = tracerFactory.GetTracer(null);
 
             var startTime = DateTimeOffset.UtcNow;
@@ -637,7 +637,7 @@ namespace OpenTelemetry.Trace.Test
         public void StartSpanFrom_Recorded_ImplicitParentActivity()
         {
             var tracer = tracerFactory.GetTracer(null);
-            
+
             var parentActivity = new Activity("foo").SetIdFormat(ActivityIdFormat.W3C).Start();
             parentActivity.TraceStateString = "k1=v1,k2=v2";
             parentActivity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
@@ -658,7 +658,7 @@ namespace OpenTelemetry.Trace.Test
             Assert.Equal(SpanKind.Internal, span.Kind);
             AssertApproxSameTimestamp(startTimestamp, span.StartTimestamp);
             Assert.Null(span.Links);
-            
+
             parentActivity.Stop();
         }
 
@@ -1021,6 +1021,96 @@ namespace OpenTelemetry.Trace.Test
             Assert.Single(span.Attributes.Where(kvp => kvp.Key == "decimal" && kvp.Value is decimal dv && dv == 0.3M));
         }
 
+        [Theory]
+        [InlineData(new bool[] {true, false, true})]
+        [InlineData(new long[] {1L, 2L, 3L})]
+        [InlineData(new ulong[] {1UL, 2UL, 3UL})]
+        [InlineData(new uint[] {1U, 2U, 3U})]
+        [InlineData(new int[] {1, 2, 3})]
+        [InlineData(new sbyte[] {(sbyte)1, (sbyte)2, (sbyte)3})]
+        [InlineData(new byte[] {(byte)1, (byte)2, (byte)3})]
+        [InlineData(new short[] {(short)1, (short)2, (short)3})]
+        [InlineData(new ushort[] {(ushort)1, (ushort)2, (ushort)3})]
+        [InlineData(new double[] {1.1d,2.2d,3.3d})]
+        [InlineData(new float[] {1.1f,2.2f,3.3f})]
+        public void SetAttribute_Array(object array)
+        {
+            var tracer = tracerFactory.GetTracer(null);
+            var span = (SpanSdk)tracer.StartRootSpan(SpanName);
+
+            span.SetAttribute("intArray", array);
+
+            Assert.Equal(1, span.Attributes.Count());
+
+            var attribute = span.Attributes.Single(kvp => kvp.Key == "intArray");
+            Assert.Equal(array, attribute.Value);
+        }
+
+        [Fact]
+        public void SetAttribute_Array_String()
+        {
+            var tracer = tracerFactory.GetTracer(null);
+            var span = (SpanSdk)tracer.StartRootSpan(SpanName);
+
+            var array = new string[] {"1","2","3"};
+            span.SetAttribute("array", array);
+
+            Assert.Equal(1, span.Attributes.Count());
+
+            var attribute = span.Attributes.Single(kvp => kvp.Key == "array");
+            Assert.Equal(array, attribute.Value);
+
+        }
+
+        [Fact]
+        public void SetAttribute_Array_Decimal()
+        {
+            var tracer = tracerFactory.GetTracer(null);
+            var span = (SpanSdk)tracer.StartRootSpan(SpanName);
+
+            var array = new Decimal[] {1.1M, 2.2M, 3.3M};
+            span.SetAttribute("array", array);
+
+            Assert.Equal(1, span.Attributes.Count());
+
+            var attribute = span.Attributes.Single(kvp => kvp.Key == "array");
+            Assert.Equal(array, attribute.Value);
+        }
+
+        [Fact]
+        public void SetAttribute_Array_Cant_Mix_Types()
+        {
+            var tracer = tracerFactory.GetTracer(null);
+            var span = (SpanSdk)tracer.StartRootSpan(SpanName);
+
+            var array = new object[] {1, "2", false};
+            span.SetAttribute("array", array);
+
+            Assert.Equal(1, span.Attributes.Count());
+
+            var attribute = span.Attributes.Single(kvp => kvp.Key == "array");
+            Assert.NotNull(attribute);
+            Assert.Equal("array", attribute.Key);
+            Assert.Equal(string.Empty, attribute.Value);
+        }
+
+        [Fact]
+        public void SetAttribute_Array_Sets_Empty_String_For_Emtpy_Array()
+        {
+            var tracer = tracerFactory.GetTracer(null);
+            var span = (SpanSdk)tracer.StartRootSpan(SpanName);
+
+            var array = new object[0];
+            span.SetAttribute("array", array);
+
+            Assert.Equal(1, span.Attributes.Count());
+
+            var attribute = span.Attributes.Single(kvp => kvp.Key == "array");
+            Assert.NotNull(attribute);
+            Assert.Equal("array", attribute.Key);
+            Assert.Equal(string.Empty, attribute.Value);
+        }
+
         [Fact]
         public void BadArguments_SetAttribute_NullOrEmptyValue()
         {
@@ -1194,7 +1284,7 @@ namespace OpenTelemetry.Trace.Test
 
             var startTimestamp = DateTimeOffset.Now.AddSeconds(-1);
             var parentSpan = (SpanSdk)tracer.StartSpan(SpanName);
-            using (var scope = tracer.StartActiveSpan(SpanName, parentSpan, SpanKind.Producer, new SpanCreationOptions { StartTimestamp = startTimestamp }, 
+            using (var scope = tracer.StartActiveSpan(SpanName, parentSpan, SpanKind.Producer, new SpanCreationOptions { StartTimestamp = startTimestamp },
                 out var ispan))
             {
                 Assert.NotNull(scope);
@@ -1313,7 +1403,7 @@ namespace OpenTelemetry.Trace.Test
             var linkContext = new SpanContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded);
             var startTimestamp = DateTimeOffset.Now.AddSeconds(-1);
             var parentContext = new SpanContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded);
-            using (var scope = tracer.StartActiveSpan(SpanName, parentContext, SpanKind.Producer, 
+            using (var scope = tracer.StartActiveSpan(SpanName, parentContext, SpanKind.Producer,
                 new SpanCreationOptions { StartTimestamp = startTimestamp, Links = new[] { new Link(linkContext) }, }, out var ispan))
             {
                 Assert.NotNull(scope);
@@ -1383,7 +1473,7 @@ namespace OpenTelemetry.Trace.Test
 
             var startTimestamp = DateTimeOffset.Now.AddSeconds(-1);
             using (var parentScope = tracer.StartActiveSpan(SpanName, out var parentspan))
-            using (var scope = tracer.StartActiveSpan(SpanName, SpanKind.Producer, 
+            using (var scope = tracer.StartActiveSpan(SpanName, SpanKind.Producer,
                 new SpanCreationOptions { StartTimestamp = startTimestamp }, out var childSpan))
             {
                 Assert.NotNull(scope);
@@ -1409,7 +1499,7 @@ namespace OpenTelemetry.Trace.Test
             var linkContext = new SpanContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded);
             var startTimestamp = DateTimeOffset.Now.AddSeconds(-1);
             using (var parentScope = tracer.StartActiveSpan(SpanName, out _))
-            using (var scope = tracer.StartActiveSpan(SpanName, SpanKind.Producer, 
+            using (var scope = tracer.StartActiveSpan(SpanName, SpanKind.Producer,
                 new SpanCreationOptions { StartTimestamp = startTimestamp, Links = new[] { new Link(linkContext) }, }, out var ispan))
             {
                 Assert.NotNull(scope);

--- a/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
@@ -1040,7 +1040,7 @@ namespace OpenTelemetry.Trace.Test
 
             span.SetAttribute("intArray", array);
 
-            Assert.Equal(1, span.Attributes.Count());
+            Assert.Single(span.Attributes);
 
             var attribute = span.Attributes.Single(kvp => kvp.Key == "intArray");
             Assert.Equal(array, attribute.Value);
@@ -1055,7 +1055,7 @@ namespace OpenTelemetry.Trace.Test
             var array = new string[] {"1","2","3"};
             span.SetAttribute("array", array);
 
-            Assert.Equal(1, span.Attributes.Count());
+            Assert.Single(span.Attributes);
 
             var attribute = span.Attributes.Single(kvp => kvp.Key == "array");
             Assert.Equal(array, attribute.Value);
@@ -1071,7 +1071,7 @@ namespace OpenTelemetry.Trace.Test
             var array = new Decimal[] {1.1M, 2.2M, 3.3M};
             span.SetAttribute("array", array);
 
-            Assert.Equal(1, span.Attributes.Count());
+            Assert.Single(span.Attributes);
 
             var attribute = span.Attributes.Single(kvp => kvp.Key == "array");
             Assert.Equal(array, attribute.Value);
@@ -1086,7 +1086,7 @@ namespace OpenTelemetry.Trace.Test
             IEnumerable<int> array = new List<int> {1,2,3};
             span.SetAttribute("array", array);
 
-            Assert.Equal(1, span.Attributes.Count());
+            Assert.Single(span.Attributes);
 
             var attribute = span.Attributes.Single(kvp => kvp.Key == "array");
             Assert.Equal(array, attribute.Value);
@@ -1101,10 +1101,9 @@ namespace OpenTelemetry.Trace.Test
             var array = new object[] {1, "2", false};
             span.SetAttribute("array", array);
 
-            Assert.Equal(1, span.Attributes.Count());
+            Assert.Single(span.Attributes);
 
             var attribute = span.Attributes.Single(kvp => kvp.Key == "array");
-            Assert.NotNull(attribute);
             Assert.Equal("array", attribute.Key);
             Assert.Equal(string.Empty, attribute.Value);
         }
@@ -1118,10 +1117,9 @@ namespace OpenTelemetry.Trace.Test
             var array = new object[0];
             span.SetAttribute("array", array);
 
-            Assert.Equal(1, span.Attributes.Count());
+            Assert.Single(span.Attributes);
 
             var attribute = span.Attributes.Single(kvp => kvp.Key == "array");
-            Assert.NotNull(attribute);
             Assert.Equal("array", attribute.Key);
             Assert.Equal(string.Empty, attribute.Value);
         }


### PR DESCRIPTION
Fixes #496.

Span Attributes should allow arrays of allowed types, as described in this [spec change](open-telemetry/opentelemetry-specification#368).