### PR TITLE
Increase time tolerance in EventTests

### DIFF
--- a/test/OpenTelemetry.Tests/Impl/Trace/EventTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/EventTest.cs
@@ -36,7 +36,7 @@ namespace OpenTelemetry.Trace.Test
             var @event = new Event("MyEventText");
             Assert.Equal("MyEventText", @event.Name);
             Assert.Equal(0, @event.Attributes.Count);
-            Assert.InRange(Math.Abs((approxTimestamp - @event.Timestamp).TotalMilliseconds), double.Epsilon, 20);
+            Assert.InRange(Math.Abs((approxTimestamp - @event.Timestamp).TotalMilliseconds), double.Epsilon, 50);
         }
 
         [Fact]
@@ -46,7 +46,7 @@ namespace OpenTelemetry.Trace.Test
             var @event = new Event("MyEventText", (DateTimeOffset)default);
             Assert.Equal("MyEventText", @event.Name);
             Assert.Equal(0, @event.Attributes.Count);
-            Assert.InRange(Math.Abs((approxTimestamp - @event.Timestamp).TotalMilliseconds), double.Epsilon, 20);
+            Assert.InRange(Math.Abs((approxTimestamp - @event.Timestamp).TotalMilliseconds), double.Epsilon, 50);
         }
 
         [Fact]
@@ -96,7 +96,7 @@ namespace OpenTelemetry.Trace.Test
             var @event = new Event("MyEventText", default, attributes);
             Assert.Equal("MyEventText", @event.Name);
             Assert.Equal(attributes, @event.Attributes);
-            Assert.InRange(Math.Abs((approxTimestamp - @event.Timestamp).TotalMilliseconds), double.Epsilon, 20);
+            Assert.InRange(Math.Abs((approxTimestamp - @event.Timestamp).TotalMilliseconds), double.Epsilon, 50);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #502 

There are three tests that assert the amount of elapsed time is within a given range, however this is quite short and occasionally fails. This change increases the tolerance from 20ms to 50ms.