### PR TITLE
fixed timeout issue

### DIFF
--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpClient.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpClient.cs
@@ -66,7 +66,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
                 waitObject: asyncResult.AsyncWaitHandle,
                 callBack: (s, t) => tcs.SetResult(socket.EndSend(asyncResult)),
                 state: null,
-                timeout: TimeSpan.MaxValue,
+                millisecondsTimeOutInterval: -1,
                 executeOnlyOnce: true);
 
             return new ValueTask<int>(tcs.Task);


### PR DESCRIPTION
Fixes #518 

```
Failure is `ex = {"Cannot flush closed transport. Argument must be less than or equal to 2^31 - 1 milliseconds.\r\nParameter name: timeout"}`
```

It was intermittent because only happened when task didn't complete immediately. Seems like an issue in .NET