### PR TITLE
rename samplers and Decision to SamplingResult

### DIFF
--- a/benchmarks/OpenTelemetrySdkBenchmarks.cs
+++ b/benchmarks/OpenTelemetrySdkBenchmarks.cs
@@ -32,10 +32,10 @@ namespace Benchmarks
         public OpenTelemetrySdkBenchmarks()
         {
             this.alwaysSampleTracer = TracerFactory
-                .Create(b => b.SetSampler(new AlwaysSampleSampler()))
+                .Create(b => b.SetSampler(new AlwaysOnSampler()))
                 .GetTracer(null);
             this.neverSampleTracer = TracerFactory
-                .Create(b => b.SetSampler(new NeverSampleSampler()))
+                .Create(b => b.SetSampler(new AlwaysOffSampler()))
                 .GetTracer(null);
             this.noopTracer = TracerFactoryBase.Default.GetTracer(null);
         }

--- a/src/OpenTelemetry.Api/Trace/SamplingResult.cs
+++ b/src/OpenTelemetry.Api/Trace/SamplingResult.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Decision.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="SamplingResult.cs" company="OpenTelemetry Authors">
 // Copyright 2018, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,25 +21,25 @@ namespace OpenTelemetry.Trace
     /// <summary>
     /// Sampling decision.
     /// </summary>
-    public readonly struct Decision
+    public readonly struct SamplingResult
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Decision"/> struct.
+        /// Initializes a new instance of the <see cref="SamplingResult"/> struct.
         /// </summary>
         /// <param name="isSampled">True if sampled, false otherwise.</param>
-        public Decision(bool isSampled)
+        public SamplingResult(bool isSampled)
         {
             this.IsSampled = isSampled;
             this.Attributes = Enumerable.Empty<KeyValuePair<string, object>>();
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Decision"/> struct.
+        /// Initializes a new instance of the <see cref="SamplingResult"/> struct.
         /// </summary>
         /// <param name="isSampled">True if sampled, false otherwise.</param>
         /// <param name="attributes">Attributes associated with the sampling decision. Attributes list passed to
         /// this method must be immutable. Mutations of the collection and/or attribute values may lead to unexpected behavior.</param>
-        public Decision(bool isSampled, IEnumerable<KeyValuePair<string, object>> attributes)
+        public SamplingResult(bool isSampled, IEnumerable<KeyValuePair<string, object>> attributes)
         {
             this.IsSampled = isSampled;
 
@@ -61,28 +61,28 @@ namespace OpenTelemetry.Trace
         public IEnumerable<KeyValuePair<string, object>> Attributes { get; }
 
         /// <summary>
-        /// Compare two <see cref="Decision"/> for equality.
+        /// Compare two <see cref="SamplingResult"/> for equality.
         /// </summary>
         /// <param name="decision1">First Decision to compare.</param>
         /// <param name="decision2">Second Decision to compare.</param>
-        public static bool operator ==(Decision decision1, Decision decision2) => decision1.Equals(decision2);
+        public static bool operator ==(SamplingResult decision1, SamplingResult decision2) => decision1.Equals(decision2);
 
         /// <summary>
-        /// Compare two <see cref="Decision"/> for not equality.
+        /// Compare two <see cref="SamplingResult"/> for not equality.
         /// </summary>
         /// <param name="decision1">First Decision to compare.</param>
         /// <param name="decision2">Second Decision to compare.</param>
-        public static bool operator !=(Decision decision1, Decision decision2) => !decision1.Equals(decision2);
+        public static bool operator !=(SamplingResult decision1, SamplingResult decision2) => !decision1.Equals(decision2);
 
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (!(obj is Decision))
+            if (!(obj is SamplingResult))
             {
                 return false;
             }
 
-            var that = (Decision)obj;
+            var that = (SamplingResult)obj;
             return this.IsSampled == that.IsSampled && this.Attributes == that.Attributes;
         }
 

--- a/src/OpenTelemetry/Trace/Configuration/TracerFactory.cs
+++ b/src/OpenTelemetry/Trace/Configuration/TracerFactory.cs
@@ -40,7 +40,7 @@ namespace OpenTelemetry.Trace.Configuration
 
         private TracerFactory(TracerBuilder builder)
         {
-            this.sampler = builder.Sampler ?? new AlwaysSampleSampler();
+            this.sampler = builder.Sampler ?? new AlwaysOnSampler();
             this.defaultResource = builder.Resource;
 
             this.configurationOptions =

--- a/src/OpenTelemetry/Trace/Sampler.cs
+++ b/src/OpenTelemetry/Trace/Sampler.cs
@@ -43,6 +43,6 @@ namespace OpenTelemetry.Trace
         /// <param name="attributes">Initial set of Attributes for the Span being constructed.</param>
         /// <param name="links">Links associated with the span.</param>
         /// <returns>Sampling decision on whether Span needs to be sampled or not.</returns>
-        public abstract Decision ShouldSample(in SpanContext parentContext, in ActivityTraceId traceId, in ActivitySpanId spanId, string name, SpanKind spanKind, IDictionary<string, object> attributes, IEnumerable<Link> links);
+        public abstract SamplingResult ShouldSample(in SpanContext parentContext, in ActivityTraceId traceId, in ActivitySpanId spanId, string name, SpanKind spanKind, IDictionary<string, object> attributes, IEnumerable<Link> links);
     }
 }

--- a/src/OpenTelemetry/Trace/Samplers/AlwaysOffSampler.cs
+++ b/src/OpenTelemetry/Trace/Samplers/AlwaysOffSampler.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AlwaysSampleSampler.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="AlwaysOffSampler.cs" company="OpenTelemetry Authors">
 // Copyright 2018, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,14 +18,14 @@ using System.Diagnostics;
 
 namespace OpenTelemetry.Trace.Samplers
 {
-    public sealed class AlwaysSampleSampler : Sampler
+    public sealed class AlwaysOffSampler : Sampler
     {
-        public override string Description { get; } = nameof(AlwaysSampleSampler);
+        public override string Description { get; } = nameof(AlwaysOffSampler);
 
         /// <inheritdoc />
-        public override Decision ShouldSample(in SpanContext parentContext, in ActivityTraceId traceId, in ActivitySpanId spanId, string name, SpanKind spanKind, IDictionary<string, object> attributes, IEnumerable<Link> parentLinks)
+        public override SamplingResult ShouldSample(in SpanContext parentContext, in ActivityTraceId traceId, in ActivitySpanId spanId, string name, SpanKind spanKind, IDictionary<string, object> attributes, IEnumerable<Link> links)
         {
-            return new Decision(true);
+            return new SamplingResult(false);
         }
     }
 }

--- a/src/OpenTelemetry/Trace/Samplers/AlwaysOnSampler.cs
+++ b/src/OpenTelemetry/Trace/Samplers/AlwaysOnSampler.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="NeverSampleSampler.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="AlwaysOnSampler.cs" company="OpenTelemetry Authors">
 // Copyright 2018, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,14 +18,14 @@ using System.Diagnostics;
 
 namespace OpenTelemetry.Trace.Samplers
 {
-    public sealed class NeverSampleSampler : Sampler
+    public sealed class AlwaysOnSampler : Sampler
     {
-        public override string Description { get; } = nameof(NeverSampleSampler);
+        public override string Description { get; } = nameof(AlwaysOnSampler);
 
         /// <inheritdoc />
-        public override Decision ShouldSample(in SpanContext parentContext, in ActivityTraceId traceId, in ActivitySpanId spanId, string name, SpanKind spanKind, IDictionary<string, object> attributes, IEnumerable<Link> links)
+        public override SamplingResult ShouldSample(in SpanContext parentContext, in ActivityTraceId traceId, in ActivitySpanId spanId, string name, SpanKind spanKind, IDictionary<string, object> attributes, IEnumerable<Link> parentLinks)
         {
-            return new Decision(false);
+            return new SamplingResult(true);
         }
     }
 }

--- a/src/OpenTelemetry/Trace/Samplers/AlwaysParentSampler.cs
+++ b/src/OpenTelemetry/Trace/Samplers/AlwaysParentSampler.cs
@@ -23,14 +23,14 @@ namespace OpenTelemetry.Trace.Samplers
         public override string Description { get; } = nameof(AlwaysParentSampler);
 
         /// <inheritdoc />
-        public override Decision ShouldSample(in SpanContext parentContext, in ActivityTraceId traceId, in ActivitySpanId spanId, string name, SpanKind spanKind, IDictionary<string, object> attributes, IEnumerable<Link> parentLinks)
+        public override SamplingResult ShouldSample(in SpanContext parentContext, in ActivityTraceId traceId, in ActivitySpanId spanId, string name, SpanKind spanKind, IDictionary<string, object> attributes, IEnumerable<Link> parentLinks)
         {
             if (parentContext.IsValid && parentContext.TraceOptions.HasFlag(ActivityTraceFlags.Recorded))
             {
-                return new Decision(true);
+                return new SamplingResult(true);
             }
 
-            return new Decision(false);
+            return new SamplingResult(false);
         }
     }
 }

--- a/src/OpenTelemetry/Trace/Samplers/ProbabilitySampler.cs
+++ b/src/OpenTelemetry/Trace/Samplers/ProbabilitySampler.cs
@@ -57,13 +57,13 @@ namespace OpenTelemetry.Trace.Samplers
         public override string Description { get; }
 
         /// <inheritdoc />
-        public override Decision ShouldSample(in SpanContext parentContext, in ActivityTraceId traceId, in ActivitySpanId spanId, string name, SpanKind spanKind, IDictionary<string, object> attributes, IEnumerable<Link> links)
+        public override SamplingResult ShouldSample(in SpanContext parentContext, in ActivityTraceId traceId, in ActivitySpanId spanId, string name, SpanKind spanKind, IDictionary<string, object> attributes, IEnumerable<Link> links)
         {
             // If the parent is sampled keep the sampling decision.
             if (parentContext.IsValid &&
                 (parentContext.TraceOptions & ActivityTraceFlags.Recorded) != 0)
             {
-                return new Decision(true);
+                return new SamplingResult(true);
             }
 
             if (links != null)
@@ -73,7 +73,7 @@ namespace OpenTelemetry.Trace.Samplers
                 {
                     if ((parentLink.Context.TraceOptions & ActivityTraceFlags.Recorded) != 0)
                     {
-                        return new Decision(true);
+                        return new SamplingResult(true);
                     }
                 }
             }
@@ -87,7 +87,7 @@ namespace OpenTelemetry.Trace.Samplers
             // code is executed in-line for every Span creation).
             Span<byte> traceIdBytes = stackalloc byte[16];
             traceId.CopyTo(traceIdBytes);
-            return Math.Abs(this.GetLowerLong(traceIdBytes)) < this.idUpperBound ? new Decision(true) : new Decision(false);
+            return Math.Abs(this.GetLowerLong(traceIdBytes)) < this.idUpperBound ? new SamplingResult(true) : new SamplingResult(false);
         }
 
         private long GetLowerLong(ReadOnlySpan<byte> bytes)

--- a/test/OpenTelemetry.Collector.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Collector.AspNetCore.Tests/BasicTests.cs
@@ -63,7 +63,7 @@ namespace OpenTelemetry.Collector.AspNetCore.Tests
             {
                 services.AddSingleton<TracerFactory>(_ =>
                     TracerFactory.Create(b => b
-                        .SetSampler(new AlwaysSampleSampler())
+                        .SetSampler(new AlwaysOnSampler())
                         .AddProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object))
                         .AddRequestCollector()));
             }

--- a/test/OpenTelemetry.Tests/Impl/Trace/Config/TracerBuilderTests.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Config/TracerBuilderTests.cs
@@ -94,7 +94,7 @@ namespace OpenTelemetry.Tests.Impl.Trace
             Assert.Equal("semver:" + typeof(TestCollector).Assembly.GetName().Version, collectorFactory.Version);
 
             Assert.NotNull(collectorFactory.Factory);
-            collectorFactory.Factory(new TracerSdk(new SimpleSpanProcessor(exporter), new AlwaysSampleSampler(), options, Resource.Empty));
+            collectorFactory.Factory(new TracerSdk(new SimpleSpanProcessor(exporter), new AlwaysOnSampler(), options, Resource.Empty));
 
             Assert.True(collectorFactoryCalled);
         }

--- a/test/OpenTelemetry.Tests/Impl/Trace/Export/BatchingSpanProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Export/BatchingSpanProcessorTests.cs
@@ -38,7 +38,7 @@ namespace OpenTelemetry.Trace.Export.Test
         private SpanSdk CreateSampledEndedSpan(string spanName, SpanProcessor spanProcessor)
         {
             var tracer = TracerFactory.Create(b => b
-                .SetSampler(new AlwaysSampleSampler())
+                .SetSampler(new AlwaysOnSampler())
                 .AddProcessorPipeline(p => p.AddProcessor(e => spanProcessor))
                 .SetTracerOptions(new TracerConfiguration())).GetTracer(null);
 
@@ -51,7 +51,7 @@ namespace OpenTelemetry.Trace.Export.Test
         private SpanSdk CreateNotSampledEndedSpan(string spanName, SpanProcessor spanProcessor)
         {
             var tracer = TracerFactory.Create(b => b
-                .SetSampler(new NeverSampleSampler())
+                .SetSampler(new AlwaysOffSampler())
                 .AddProcessorPipeline(p => p.AddProcessor(_ => spanProcessor))
                 .SetTracerOptions(new TracerConfiguration())).GetTracer(null);
             var context = new SpanContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.None);

--- a/test/OpenTelemetry.Tests/Impl/Trace/Samplers/SamplersTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Samplers/SamplersTest.cs
@@ -47,7 +47,7 @@ namespace OpenTelemetry.Trace.Samplers.Test
         {
             // Sampled parent.
             Assert.True(
-                    new AlwaysSampleSampler()
+                    new AlwaysOnSampler()
                         .ShouldSample(
                             sampledSpanContext,
                             traceId,
@@ -59,7 +59,7 @@ namespace OpenTelemetry.Trace.Samplers.Test
 
             // Not sampled parent.
             Assert.True(
-                    new AlwaysSampleSampler()
+                    new AlwaysOnSampler()
                         .ShouldSample(
                             notSampledSpanContext,
                             traceId,
@@ -74,7 +74,7 @@ namespace OpenTelemetry.Trace.Samplers.Test
         [Fact]
         public void AlwaysSampleSampler_GetDescription()
         {
-            Assert.Equal("AlwaysSampleSampler", new AlwaysSampleSampler().Description);
+            Assert.Equal("AlwaysSampleSampler", new AlwaysOnSampler().Description);
         }
 
         [Fact]
@@ -82,7 +82,7 @@ namespace OpenTelemetry.Trace.Samplers.Test
         {
             // Sampled parent.
             Assert.False(
-                    new NeverSampleSampler()
+                    new AlwaysOffSampler()
                         .ShouldSample(
                             sampledSpanContext,
                             traceId,
@@ -93,7 +93,7 @@ namespace OpenTelemetry.Trace.Samplers.Test
                             null).IsSampled);
             // Not sampled parent.
             Assert.False(
-                    new NeverSampleSampler()
+                    new AlwaysOffSampler()
                         .ShouldSample(
                             notSampledSpanContext,
                             traceId,
@@ -107,7 +107,7 @@ namespace OpenTelemetry.Trace.Samplers.Test
         [Fact]
         public void NeverSampleSampler_GetDescription()
         {
-            Assert.Equal("NeverSampleSampler", new NeverSampleSampler().Description);
+            Assert.Equal("AlwaysOffSampler", new AlwaysOffSampler().Description);
         }
 
         [Fact]

--- a/test/OpenTelemetry.Tests/Impl/Trace/Samplers/SamplersTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Samplers/SamplersTest.cs
@@ -43,7 +43,7 @@ namespace OpenTelemetry.Trace.Samplers.Test
         }
 
         [Fact]
-        public void AlwaysSampleSampler_AlwaysReturnTrue()
+        public void AlwaysOnSampler_AlwaysReturnTrue()
         {
             // Sampled parent.
             Assert.True(
@@ -72,13 +72,13 @@ namespace OpenTelemetry.Trace.Samplers.Test
         }
 
         [Fact]
-        public void AlwaysSampleSampler_GetDescription()
+        public void AlwaysOnSampler_GetDescription()
         {
-            Assert.Equal("AlwaysSampleSampler", new AlwaysOnSampler().Description);
+            Assert.Equal("AlwaysOnSampler", new AlwaysOnSampler().Description);
         }
 
         [Fact]
-        public void NeverSampleSampler_AlwaysReturnFalse()
+        public void NeverOffSampler_AlwaysReturnFalse()
         {
             // Sampled parent.
             Assert.False(

--- a/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
@@ -742,7 +742,7 @@ namespace OpenTelemetry.Trace.Test
         public void NotRecordedSpan_NoAttributesOrEventsAdded()
         {
             var tracer = TracerFactory.Create(b => b
-                    .SetSampler(new NeverSampleSampler()))
+                    .SetSampler(new AlwaysOffSampler()))
                 .GetTracer(null);
 
             var span = (SpanSdk)tracer.StartRootSpan(SpanName, SpanKind.Client);
@@ -1615,7 +1615,7 @@ namespace OpenTelemetry.Trace.Test
                 It.IsAny<string>(),
                 It.IsAny<SpanKind>(),
                 It.IsAny<IDictionary<string, object>>(),
-                It.IsAny<IEnumerable<Link>>())).Returns(new Decision(true));
+                It.IsAny<IEnumerable<Link>>())).Returns(new SamplingResult(true));
 
             var span = (SpanSdk)tracer.StartSpan("test", SpanKind.Client, new SpanCreationOptions { Attributes = this.attributes, });
             span.Attributes.AssertAreSame(this.attributes);
@@ -1646,7 +1646,7 @@ namespace OpenTelemetry.Trace.Test
                 It.IsAny<string>(),
                 It.IsAny<SpanKind>(),
                 It.IsAny<IDictionary<string, object>>(),
-                It.IsAny<IEnumerable<Link>>())).Returns(new Decision(false));
+                It.IsAny<IEnumerable<Link>>())).Returns(new SamplingResult(false));
 
             var span = (SpanSdk)tracer.StartSpan("test", SpanKind.Client, new SpanCreationOptions { Attributes = this.attributes, });
             Assert.Null(span.Attributes);

--- a/test/OpenTelemetry.Tests/Impl/Trace/TracerTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/TracerTest.cs
@@ -52,9 +52,9 @@ namespace OpenTelemetry.Trace.Test
         public void BadConstructorArgumentsThrow()
         {
             var noopProc = new SimpleSpanProcessor(new TestExporter(null));
-            Assert.Throws<ArgumentNullException>(() => new TracerSdk(null, new AlwaysSampleSampler(), new TracerConfiguration(), Resource.Empty));
-            Assert.Throws<ArgumentNullException>(() => new TracerSdk(noopProc, new AlwaysSampleSampler(), null, Resource.Empty));
-            Assert.Throws<ArgumentNullException>(() => new TracerSdk(noopProc, new AlwaysSampleSampler(), new TracerConfiguration(), null));
+            Assert.Throws<ArgumentNullException>(() => new TracerSdk(null, new AlwaysOnSampler(), new TracerConfiguration(), Resource.Empty));
+            Assert.Throws<ArgumentNullException>(() => new TracerSdk(noopProc, new AlwaysOnSampler(), null, Resource.Empty));
+            Assert.Throws<ArgumentNullException>(() => new TracerSdk(noopProc, new AlwaysOnSampler(), new TracerConfiguration(), null));
         }
 
         [Fact]
@@ -155,7 +155,7 @@ namespace OpenTelemetry.Trace.Test
         public void CreateSpan_NotSampled()
         {
             var tracer = TracerFactory.Create(b => b
-                    .SetSampler(new NeverSampleSampler())
+                    .SetSampler(new AlwaysOffSampler())
                     .AddProcessorPipeline(p => p.AddProcessor(n => spanProcessor)))
                 .GetTracer(null);
 
@@ -192,7 +192,7 @@ namespace OpenTelemetry.Trace.Test
             var tracer = TracerFactory.Create(b => b
                     .AddProcessorPipeline(p => p.AddProcessor(n => spanProcessor))
                     .SetTracerOptions(traceConfig)
-                    .SetSampler(new AlwaysSampleSampler()))
+                    .SetSampler(new AlwaysOnSampler()))
                 .GetTracer(null);
 
             var span = (SpanSdk)tracer.StartRootSpan(SpanName);
@@ -244,7 +244,7 @@ namespace OpenTelemetry.Trace.Test
             var tracer = TracerFactory.Create(b => b
                     .AddProcessorPipeline(p => p.AddProcessor(n => spanProcessor))
                     .SetTracerOptions(traceConfig)
-                    .SetSampler(new AlwaysSampleSampler()))
+                    .SetSampler(new AlwaysOnSampler()))
                 .GetTracer(null);
 
             var span = (SpanSdk)tracer.StartRootSpan(SpanName);
@@ -283,7 +283,7 @@ namespace OpenTelemetry.Trace.Test
             var tracer = TracerFactory.Create(b => b
                     .AddProcessorPipeline(p => p.AddProcessor(n => spanProcessor))
                     .SetTracerOptions(traceConfig)
-                    .SetSampler(new AlwaysSampleSampler()))
+                    .SetSampler(new AlwaysOnSampler()))
                 .GetTracer(null);
 
             var overflowedLinks = new List<Link>();
@@ -325,7 +325,7 @@ namespace OpenTelemetry.Trace.Test
             var tracer = TracerFactory.Create(b => b
                     .AddProcessorPipeline(p => p.AddProcessor(n => spanProcessor))
                     .SetTracerOptions(traceConfig)
-                    .SetSampler(new AlwaysSampleSampler()))
+                    .SetSampler(new AlwaysOnSampler()))
                 .GetTracer(null);
 
             var overflowedLinks = new List<Link>();
@@ -364,7 +364,7 @@ namespace OpenTelemetry.Trace.Test
             var tracer = TracerFactory.Create(b => b
                     .AddProcessorPipeline(p => p.AddProcessor(_ => this.spanProcessor))
                     .SetTracerOptions(traceConfig)
-                    .SetSampler(new AlwaysSampleSampler()))
+                    .SetSampler(new AlwaysOnSampler()))
                 .GetTracer(null);
 
             var span = (SpanSdk)tracer.StartRootSpan(SpanName);


### PR DESCRIPTION
Towards #273 

Bigger change is ACTUALLY implement the `SamplingResult`. So keeping renames in a smaller PR 