### PR TITLE
Packages pushing to MyGet are invalid.

### DIFF
--- a/.vsts/ci-myget-update.yml
+++ b/.vsts/ci-myget-update.yml
@@ -28,7 +28,7 @@ steps:
     vsVersion: "latest"
     platform: "AnyCPU"
     configuration: "Release"
-    msbuildArgs: "/p:OS=$(Agent.OS)"
+    msbuildArgs: "/target:build /p:OS=$(Agent.OS)"
 
 - task: DotNetCoreCLI@2
   displayName: test using CLI
@@ -48,7 +48,13 @@ steps:
     vsVersion: "latest"
     platform: "AnyCPU"
     configuration: "Release"
-    msbuildArgs: "/p:OS=$(Agent.OS) /p:SymbolPackageFormat=snupkg /target:pack /p:OutDir=$(build.artifactStagingDirectory)"
+    msbuildArgs: "/target:pack /p:OS=$(Agent.OS) /p:SymbolPackageFormat=snupkg /p:NoBuild=true"
+
+- task: CopyFiles@2
+  inputs:
+    contents: '**/bin/**/*.*nupkg'
+    targetFolder: $(Build.ArtifactStagingDirectory)
+    flattenFolders: true
 
 - task: NuGetCommand@2
   displayName: 'Publish nugets to MyGet'
@@ -56,10 +62,11 @@ steps:
     command: push
     nuGetFeedType: external
     publishFeedCredentials: 'myget-opentelemetry'
+    packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
 
 # this task is required as symbols packages needs to be published manually.
 - task: PublishBuildArtifacts@1
   inputs:
-    PathtoPublish: "$(build.artifactstagingdirectory)"
+    PathtoPublish: "$(Build.ArtifactStagingDirectory)"
     ArtifactName: "drop"
     ArtifactType: "Container"


### PR DESCRIPTION
This one took me on a journey today!

I consumed `OpenTelemetry.Collector.AspNet`, `OpenTelemetry.Collector.Dependencies`, & `OpenTelemetry.Exporter.Jaeger` from MyGet into a .NET 4.8 WebApplication.

On startup I would crash loading `OpenTelemetry.Exporter.Jaeger` because it was trying to load .NET Standard 2.1. That's weird, it should be loading .NET Standard 2.0. Project asset file looked good though, referencing `OpenTelemetry.Exporter.Jaeger` through the /lib/netstandard2.0/ path.

A bunch of Googling later, I decided to look at the assemblies in the package using a decompiler. Turns out the MyGet `OpenTelemetry.Exporter.Jaeger` nupkg /lib/netstandard2.0/ folder actually contains a binary targeting netstandard2.1!

I tracked this down to an issue in our MyGet pipeline. From [the last one](https://dev.azure.com/opentelemetry/pipelines/_build/results?buildId=1456&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=58b29dba-1c58-5441-f2a1-8b1882f87386):

```
Copying file from "D:\a\1\s\src\OpenTelemetry.Exporter.Jaeger\obj\Release\netstandard2.0\OpenTelemetry.Exporter.Jaeger.dll" to "D:\a\1\a\OpenTelemetry.Exporter.Jaeger.dll".
Copying file from "D:\a\1\s\src\OpenTelemetry.Exporter.Jaeger\obj\Release\netstandard2.1\OpenTelemetry.Exporter.Jaeger.dll" to "D:\a\1\a\OpenTelemetry.Exporter.Jaeger.dll".
```

Basically last target wins because the folder structure isn't capable of storing all the different outputs.

I took a stab at fixing it on this PR but I don't have a way to test the pipeline sorry!