### PR TITLE
new benchmark looking at exporters

### DIFF
--- a/benchmarks/Exporter/NonExporterBenchmarks.cs
+++ b/benchmarks/Exporter/NonExporterBenchmarks.cs
@@ -36,18 +36,8 @@ namespace Benchmarks.Exporter
         {
             using var tracerFactory = TracerFactory.Create(builder => builder
                 .SetResource(Resources.CreateServiceResource("my-service-name")));
-            var tracer = tracerFactory.GetTracer("no-exporter-test");
 
-            for (int iTrace = 0; iTrace < this.NumberOfTraces; iTrace++)
-            {
-                using (tracer.StartActiveSpan("incoming request", out var span))
-                {
-                    for (int iSpan = 0; iSpan < this.NumberOfSpans; iSpan++)
-                    {
-                        span.AddEvent("internal span");
-                    }
-                }
-            }
+            this.RunTest(tracerFactory);
         }
 
         [Benchmark]
@@ -57,6 +47,12 @@ namespace Benchmarks.Exporter
                 .SetResource(Resources.CreateServiceResource("my-service-name"))
                 .AddProcessorPipeline(p => p.SetExporter(new NoOpExporter())));
 
+            this.RunTest(tracerFactory);
+        }
+
+
+        private void RunTest(TracerFactory tracerFactory)
+        {
             var tracer = tracerFactory.GetTracer("console-exporter-test");
 
             for (int iTrace = 0; iTrace < this.NumberOfTraces; iTrace++)

--- a/benchmarks/Exporter/NonExporterBenchmarks.cs
+++ b/benchmarks/Exporter/NonExporterBenchmarks.cs
@@ -1,0 +1,87 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using BenchmarkDotNet.Attributes;
+
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Trace.Configuration;
+using OpenTelemetry.Trace.Export;
+
+namespace Benchmarks.Exporter
+{
+    /// <summary>
+    /// These benchmarks compare OpenTelemetry without an Exporter vs with a NoOp Exporter
+    /// </summary>
+    /// <remarks>
+    /// To run: .\Benchmarks.exe --filter NonExporterBenchmarks
+    /// </remarks>
+    [MemoryDiagnoser]
+#if !NET462
+    [ThreadingDiagnoser]
+#endif
+    public class NonExporterBenchmarks
+    {
+
+        [Params(1, 10)]
+        public int NumberOfTraces { get; set; }
+
+        [Params(1, 10)]
+        public int NumberOfSpans { get; set; }
+
+
+        [Benchmark]
+        public void NoExporter()
+        {
+            using var tracerFactory = TracerFactory.Create(builder => builder
+                .SetResource(Resources.CreateServiceResource("my-service-name")));
+            var tracer = tracerFactory.GetTracer("no-exporter-test");
+
+            for (int iTrace = 0; iTrace < this.NumberOfTraces; iTrace++)
+            {
+                using (tracer.StartActiveSpan("incoming request", out var span))
+                {
+                    for (int iSpan = 0; iSpan < this.NumberOfSpans; iSpan++)
+                    {
+                        span.AddEvent("internal span");
+                    }
+                }
+            }
+        }
+
+        [Benchmark]
+        public void Exporter_NoOp()
+        {
+            using var tracerFactory = TracerFactory.Create(builder => builder
+                .SetResource(Resources.CreateServiceResource("my-service-name"))
+                .AddProcessorPipeline(p => p.SetExporter(new NoOpExporter())));
+
+            var tracer = tracerFactory.GetTracer("console-exporter-test");
+
+            for (int iTrace = 0; iTrace < this.NumberOfTraces; iTrace++)
+            {
+                using (tracer.StartActiveSpan("incoming request", out var span))
+                {
+                    for (int iSpan = 0; iSpan < this.NumberOfSpans; iSpan++)
+                    {
+                        span.AddEvent("internal span");
+                    }
+                }
+            }
+        }
+
+        private class NoOpExporter : SpanExporter
+        {
+            public override Task<ExportResult> ExportAsync(IEnumerable<SpanData> batch, CancellationToken cancellationToken)
+            {
+                return Task.FromResult(ExportResult.Success);
+            }
+
+            public override Task ShutdownAsync(CancellationToken cancellationToken)
+            {
+                return Task.CompletedTask;
+            }
+        }
+    }
+}


### PR DESCRIPTION
#441 

#### Description
I introduced a new benchmark to compare:
- OpenTelemetry without an exporter
- OpenTelemetry with a NoOp exporter

I would like to get some feedback on if this test is valid or useful.

#### These are the results:

> // * Summary *
> 
> BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
> Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
> .NET Core SDK=3.1.201
>   [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
>   DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
> 
> 
> |        Method | NumberOfTraces | NumberOfSpans |       Mean |     Error |    StdDev | Completed Work Items | Lock Contentions |  Gen 0 |  Gen 1 |  Gen 2 | Allocated |
> |-------------- |--------------- |-------------- |-----------:|----------:|----------:|---------------------:|-----------------:|-------:|-------:|-------:|----------:|
> |    NoExporter |              1 |             1 |   4.108 us | 0.0317 us | 0.0281 us |               0.0000 |                - | 1.0223 | 0.0153 |      - |   4.24 KB |
> | Exporter_NoOp |              1 |             1 |  57.222 us | 1.1354 us | 1.2620 us |               2.0037 |           0.0001 | 1.7090 |      - |      - |   7.14 KB |
> |    NoExporter |              1 |            10 |   5.406 us | 0.0746 us | 0.0661 us |               0.0000 |                - | 1.1215 | 0.0153 |      - |   4.66 KB |
> | Exporter_NoOp |              1 |            10 |  59.674 us | 0.9792 us | 0.9159 us |               2.0013 |                - | 1.8311 | 0.1221 |      - |   7.57 KB |
> |    NoExporter |             10 |             1 |  24.877 us | 0.2197 us | 0.1947 us |               0.0001 |           0.0002 | 5.1575 | 0.1526 | 0.0610 |  22.31 KB |
> | Exporter_NoOp |             10 |             1 |  93.695 us | 1.8327 us | 2.5692 us |               2.0002 |           0.0001 | 5.9814 | 0.2441 |      - |  25.46 KB |
> |    NoExporter |             10 |            10 |  35.829 us | 0.2486 us | 0.2204 us |               0.0001 |                - | 6.2866 | 0.1221 |      - |  26.53 KB |
> | Exporter_NoOp |             10 |            10 | 106.330 us | 2.3692 us | 3.3978 us |               2.0004 |                - | 6.9580 | 0.2441 |      - |  29.68 KB |
> 
> // * Legends *
>   NumberOfTraces       : Value of the 'NumberOfTraces' parameter
>   NumberOfSpans        : Value of the 'NumberOfSpans' parameter
>   Mean                 : Arithmetic mean of all measurements
>   Error                : Half of 99.9% confidence interval
>   StdDev               : Standard deviation of all measurements
>   Completed Work Items : The number of work items that have been processed in ThreadPool (per single operation)
>   Lock Contentions     : The number of times there was contention upon trying to take a Monitor's lock (per single operation)
>   Gen 0                : GC Generation 0 collects per 1000 operations
>   Gen 1                : GC Generation 1 collects per 1000 operations
>   Gen 2                : GC Generation 2 collects per 1000 operations
>   Allocated            : Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)
>   1 us                 : 1 Microsecond (0.000001 sec)
> 
> // * Diagnostic Output - ThreadingDiagnoser *
> 
> // * Diagnostic Output - MemoryDiagnoser *
> 
> 
> // ***** BenchmarkRunner: End *****
> // ** Remained 0 benchmark(s) to run **
> Run time: 00:02:58 (178.65 sec), executed benchmarks: 8
> 
> Global total time: 00:03:27 (207.24 sec), executed benchmarks: 8