### PR TITLE
PushController test stabilizing

### DIFF
--- a/test/OpenTelemetry.Tests/Impl/Metrics/TestMetricExporter.cs
+++ b/test/OpenTelemetry.Tests/Impl/Metrics/TestMetricExporter.cs
@@ -29,13 +29,20 @@ namespace OpenTelemetry.Metrics.Test
     {
         public List<Metric<long>> LongMetrics = new List<Metric<long>>();
         public List<Metric<double>> DoubleMetrics = new List<Metric<double>>();
-        public int count = 0;
+        private readonly Action onLongExport;
+        private readonly Action onDoubleExport;
+
+        public TestMetricExporter(Action onLongExport, Action onDoubleExport)
+        {
+            this.onDoubleExport = onDoubleExport;
+            this.onLongExport = onLongExport;
+        }
 
         public override Task<ExportResult> ExportAsync<T>(IEnumerable<Metric<T>> metrics, CancellationToken cancellationToken)
-        {
-            count++;
+        {            
             if (typeof(T) == typeof(double))
             {
+                this.onDoubleExport?.Invoke();
                 var doubleList = metrics
                 .Select(x => (x as Metric<double>))
                 .ToList();
@@ -44,6 +51,7 @@ namespace OpenTelemetry.Metrics.Test
             }
             else
             {
+                this.onLongExport?.Invoke();
                 var longList = metrics
                 .Select(x => (x as Metric<long>))
                 .ToList();


### PR DESCRIPTION
Current implementation has stability issues when running under .NET Framework. Instead of simply increasing `Task.Delay()`, this PR does short sleeps, and validation in a loop, until the max timeout occurs.