### PR TITLE
Modify CI to remove publish test task as its done automatically.

### DIFF
--- a/.vsts/ci-build.yml
+++ b/.vsts/ci-build.yml
@@ -39,8 +39,6 @@ jobs:
         test/**/*.Tests.Win.csproj
       arguments: "--configuration Release"
 
-  - task: PublishTestResults@2
-
 - job: Linux
   pool:
     vmImage: 'ubuntu-latest'
@@ -64,5 +62,3 @@ jobs:
       command: "test"
       projects: "test/**/*.Tests.csproj"
       arguments: "--configuration Release"
-
-  - task: PublishTestResults@2


### PR DESCRIPTION
Dotnet Test task is already publishing results automatically in right format.
https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/build/dotnet-core-cli?view=azure-devops#test

This should also get ride of the warning:
![image](https://user-images.githubusercontent.com/5232798/79798599-18f96600-830e-11ea-9229-cef3661e1d30.png)
