### PR TITLE
Rename TraceOptions to TraceFlags to match spec.

### DIFF
--- a/src/OpenTelemetry.Api/Context/Propagation/TraceContextFormat.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceContextFormat.cs
@@ -104,7 +104,7 @@ namespace OpenTelemetry.Context.Propagation
             }
 
             var traceparent = string.Concat("00-", spanContext.TraceId.ToHexString(), "-", spanContext.SpanId.ToHexString());
-            traceparent = string.Concat(traceparent, (spanContext.TraceOptions & ActivityTraceFlags.Recorded) != 0 ? "-01" : "-00");
+            traceparent = string.Concat(traceparent, (spanContext.TraceFlags & ActivityTraceFlags.Recorded) != 0 ? "-01" : "-00");
 
             setter(carrier, TraceParent, traceparent);
 

--- a/src/OpenTelemetry.Api/Trace/SpanContext.cs
+++ b/src/OpenTelemetry.Api/Trace/SpanContext.cs
@@ -22,7 +22,7 @@ namespace OpenTelemetry.Trace
     /// <summary>
     /// A class that represents a span context. A span context contains the state that must propagate to
     /// child <see cref="TelemetrySpan"/> and across process boundaries. It contains the identifiers <see cref="ActivityTraceId"/>
-    /// and <see cref="ActivitySpanId"/> associated with the <see cref="TelemetrySpan"/> and a set of <see cref="TraceOptions"/>.
+    /// and <see cref="ActivitySpanId"/> associated with the <see cref="TelemetrySpan"/> and a set of <see cref="TraceFlags"/>.
     /// </summary>
     public readonly struct SpanContext
     {
@@ -36,15 +36,15 @@ namespace OpenTelemetry.Trace
         /// </summary>
         /// <param name="traceId">The <see cref="ActivityTraceId"/> to associate with the <see cref="SpanContext"/>.</param>
         /// <param name="spanId">The <see cref="ActivitySpanId"/> to associate with the <see cref="SpanContext"/>.</param>
-        /// <param name="traceOptions">The <see cref="TraceOptions"/> to
+        /// <param name="traceFlags">The <see cref="TraceFlags"/> to
         /// associate with the <see cref="SpanContext"/>.</param>
         /// <param name="isRemote">The value indicating whether this <see cref="SpanContext"/> was propagated from the remote parent.</param>
         /// <param name="tracestate">The tracestate to associate with the <see cref="SpanContext"/>.</param>
-        public SpanContext(in ActivityTraceId traceId, in ActivitySpanId spanId, ActivityTraceFlags traceOptions, bool isRemote = false, IEnumerable<KeyValuePair<string, string>> tracestate = null)
+        public SpanContext(in ActivityTraceId traceId, in ActivitySpanId spanId, ActivityTraceFlags traceFlags, bool isRemote = false, IEnumerable<KeyValuePair<string, string>> tracestate = null)
         {
             this.TraceId = traceId;
             this.SpanId = spanId;
-            this.TraceOptions = traceOptions;
+            this.TraceFlags = traceFlags;
             this.IsRemote = isRemote;
             this.Tracestate = tracestate ?? Enumerable.Empty<KeyValuePair<string, string>>();
         }
@@ -62,7 +62,7 @@ namespace OpenTelemetry.Trace
         /// <summary>
         /// Gets the <see cref="ActivityTraceFlags"/> associated with this <see cref="SpanContext"/>.
         /// </summary>
-        public ActivityTraceFlags TraceOptions { get; }
+        public ActivityTraceFlags TraceFlags { get; }
 
         /// <summary>
         /// Gets a value indicating whether this <see cref="SpanContext" />
@@ -100,7 +100,7 @@ namespace OpenTelemetry.Trace
             var result = 1;
             result = (31 * result) + this.TraceId.GetHashCode();
             result = (31 * result) + this.SpanId.GetHashCode();
-            result = (31 * result) + this.TraceOptions.GetHashCode();
+            result = (31 * result) + this.TraceFlags.GetHashCode();
             result = (31 * result) + this.Tracestate.GetHashCode();
             return result;
         }
@@ -117,7 +117,7 @@ namespace OpenTelemetry.Trace
 
             return this.TraceId.Equals(that.TraceId)
                    && this.SpanId.Equals(that.SpanId)
-                   && this.TraceOptions.Equals(that.TraceOptions)
+                   && this.TraceFlags.Equals(that.TraceFlags)
                    && this.IsRemote == that.IsRemote
                    && ((this.Tracestate == null && that.Tracestate == null) || (this.Tracestate != null && this.Tracestate.Equals(that.Tracestate)));
         }

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerConversionExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerConversionExtensions.cs
@@ -159,7 +159,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
                 spanId: spanId.Low,
                 parentSpanId: parentSpanId.Low,
                 operationName: span.Name,
-                flags: (span.Context.TraceOptions & ActivityTraceFlags.Recorded) > 0 ? 0x1 : 0,
+                flags: (span.Context.TraceFlags & ActivityTraceFlags.Recorded) > 0 ? 0x1 : 0,
                 startTime: ToEpochMicroseconds(span.StartTimestamp),
                 duration: ToEpochMicroseconds(span.EndTimestamp) - ToEpochMicroseconds(span.StartTimestamp),
                 references: span.Links.ToJaegerSpanRefs(),

--- a/src/OpenTelemetry/Context/Propagation/B3Format.cs
+++ b/src/OpenTelemetry/Context/Propagation/B3Format.cs
@@ -123,7 +123,7 @@ namespace OpenTelemetry.Context.Propagation
                 sb.Append(spanContext.TraceId.ToHexString());
                 sb.Append(XB3CombinedDelimiter);
                 sb.Append(spanContext.SpanId.ToHexString());
-                if ((spanContext.TraceOptions & ActivityTraceFlags.Recorded) != 0)
+                if ((spanContext.TraceFlags & ActivityTraceFlags.Recorded) != 0)
                 {
                     sb.Append(XB3CombinedDelimiter);
                     sb.Append(SampledValue);
@@ -135,7 +135,7 @@ namespace OpenTelemetry.Context.Propagation
             {
                 setter(carrier, XB3TraceId, spanContext.TraceId.ToHexString());
                 setter(carrier, XB3SpanId, spanContext.SpanId.ToHexString());
-                if ((spanContext.TraceOptions & ActivityTraceFlags.Recorded) != 0)
+                if ((spanContext.TraceFlags & ActivityTraceFlags.Recorded) != 0)
                 {
                     setter(carrier, XB3Sampled, SampledValue);
                 }

--- a/src/OpenTelemetry/Trace/Samplers/AlwaysParentSampler.cs
+++ b/src/OpenTelemetry/Trace/Samplers/AlwaysParentSampler.cs
@@ -25,7 +25,7 @@ namespace OpenTelemetry.Trace.Samplers
         /// <inheritdoc />
         public override SamplingResult ShouldSample(in SpanContext parentContext, in ActivityTraceId traceId, in ActivitySpanId spanId, string name, SpanKind spanKind, IDictionary<string, object> attributes, IEnumerable<Link> parentLinks)
         {
-            if (parentContext.IsValid && parentContext.TraceOptions.HasFlag(ActivityTraceFlags.Recorded))
+            if (parentContext.IsValid && parentContext.TraceFlags.HasFlag(ActivityTraceFlags.Recorded))
             {
                 return new SamplingResult(true);
             }

--- a/src/OpenTelemetry/Trace/Samplers/ProbabilitySampler.cs
+++ b/src/OpenTelemetry/Trace/Samplers/ProbabilitySampler.cs
@@ -61,7 +61,7 @@ namespace OpenTelemetry.Trace.Samplers
         {
             // If the parent is sampled keep the sampling decision.
             if (parentContext.IsValid &&
-                (parentContext.TraceOptions & ActivityTraceFlags.Recorded) != 0)
+                (parentContext.TraceFlags & ActivityTraceFlags.Recorded) != 0)
             {
                 return new SamplingResult(true);
             }
@@ -71,7 +71,7 @@ namespace OpenTelemetry.Trace.Samplers
                 // If any parent link is sampled keep the sampling decision.
                 foreach (var parentLink in links)
                 {
-                    if ((parentLink.Context.TraceOptions & ActivityTraceFlags.Recorded) != 0)
+                    if ((parentLink.Context.TraceFlags & ActivityTraceFlags.Recorded) != 0)
                     {
                         return new SamplingResult(true);
                     }

--- a/src/OpenTelemetry/Trace/SpanSdk.cs
+++ b/src/OpenTelemetry/Trace/SpanSdk.cs
@@ -733,7 +733,7 @@ namespace OpenTelemetry.Trace
                 activity.SetParentId(
                     parentContext.TraceId,
                     parentContext.SpanId,
-                    parentContext.TraceOptions);
+                    parentContext.TraceFlags);
                 if (parentContext.Tracestate != null && parentContext.Tracestate.Any())
                 {
                     activity.TraceStateString = TracestateUtils.GetString(parentContext.Tracestate);

--- a/test/OpenTelemetry.Tests/Impl/Trace/Propagation/TraceContextTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/Propagation/TraceContextTest.cs
@@ -56,7 +56,7 @@ namespace OpenTelemetry.Impl.Trace.Propagation
             Assert.Equal(ActivitySpanId.CreateFromString(SpanId.AsSpan()), ctx.SpanId);
             Assert.True(ctx.IsRemote);
             Assert.True(ctx.IsValid);
-            Assert.True((ctx.TraceOptions & ActivityTraceFlags.Recorded) != 0);
+            Assert.True((ctx.TraceFlags & ActivityTraceFlags.Recorded) != 0);
 
             Assert.Equal(2, ctx.Tracestate.Count());
 
@@ -84,7 +84,7 @@ namespace OpenTelemetry.Impl.Trace.Propagation
 
             Assert.Equal(ActivityTraceId.CreateFromString(TraceId.AsSpan()), ctx.TraceId);
             Assert.Equal(ActivitySpanId.CreateFromString(SpanId.AsSpan()), ctx.SpanId);
-            Assert.True((ctx.TraceOptions & ActivityTraceFlags.Recorded) == 0);
+            Assert.True((ctx.TraceFlags & ActivityTraceFlags.Recorded) == 0);
             Assert.True(ctx.IsRemote);
             Assert.True(ctx.IsValid);
         }

--- a/test/OpenTelemetry.Tests/Impl/Trace/ProxyTracerTests.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/ProxyTracerTests.cs
@@ -120,7 +120,7 @@ namespace OpenTelemetry.Tests.Impl.Trace
             Assert.Equal(span.Activity.TraceId, span.Context.TraceId);
             Assert.Equal(span.Activity.SpanId, span.Context.SpanId);
             Assert.Equal(default, span.ParentSpanId);
-            Assert.Equal(span.Activity.ActivityTraceFlags, span.Context.TraceOptions);
+            Assert.Equal(span.Activity.ActivityTraceFlags, span.Context.TraceFlags);
             Assert.Empty(span.Context.Tracestate);
 
             Assert.True(span.IsRecording);
@@ -152,7 +152,7 @@ namespace OpenTelemetry.Tests.Impl.Trace
             Assert.Equal(parentSpan.Context.TraceId, span.Context.TraceId);
             Assert.Equal(span.Activity.SpanId, span.Context.SpanId);
             Assert.Equal(parentSpan.Context.SpanId, span.ParentSpanId);
-            Assert.Equal(parentSpan.Context.TraceOptions, span.Context.TraceOptions);
+            Assert.Equal(parentSpan.Context.TraceFlags, span.Context.TraceFlags);
 
             Assert.True(span.IsRecording);
 
@@ -183,7 +183,7 @@ namespace OpenTelemetry.Tests.Impl.Trace
             Assert.Equal(parentSpanContext.TraceId, span.Context.TraceId);
             Assert.Equal(span.Activity.SpanId, span.Context.SpanId);
             Assert.Equal(parentSpanContext.SpanId, span.ParentSpanId);
-            Assert.Equal(parentSpanContext.TraceOptions, span.Context.TraceOptions);
+            Assert.Equal(parentSpanContext.TraceFlags, span.Context.TraceFlags);
 
             Assert.True(span.IsRecording);
 
@@ -210,7 +210,7 @@ namespace OpenTelemetry.Tests.Impl.Trace
             Assert.Equal(activity.TraceId, span.Context.TraceId);
             Assert.Equal(activity.SpanId, span.Context.SpanId);
             Assert.Equal(activity.ParentSpanId, span.ParentSpanId);
-            Assert.Equal(activity.ActivityTraceFlags, span.Context.TraceOptions);
+            Assert.Equal(activity.ActivityTraceFlags, span.Context.TraceFlags);
 
             Assert.True(span.IsRecording);
             Assert.Equal(SpanKind.Server, span.Kind);
@@ -243,7 +243,7 @@ namespace OpenTelemetry.Tests.Impl.Trace
                 Assert.Equal(parentSpan.Context.TraceId, span.Context.TraceId);
                 Assert.Equal(span.Activity.SpanId, span.Context.SpanId);
                 Assert.Equal(parentSpan.Context.SpanId, span.ParentSpanId);
-                Assert.Equal(parentSpan.Context.TraceOptions, span.Context.TraceOptions);
+                Assert.Equal(parentSpan.Context.TraceFlags, span.Context.TraceFlags);
 
                 Assert.True(span.IsRecording);
 

--- a/test/OpenTelemetry.Tests/Impl/Trace/SpanContextTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/SpanContextTest.cs
@@ -44,7 +44,7 @@ namespace OpenTelemetry.Trace.Test
         {
             Assert.Equal(default, default(SpanContext).TraceId);
             Assert.Equal(default, default(SpanContext).SpanId);
-            Assert.Equal(ActivityTraceFlags.None, default(SpanContext).TraceOptions);
+            Assert.Equal(ActivityTraceFlags.None, default(SpanContext).TraceFlags);
         }
 
         [Fact]
@@ -80,8 +80,8 @@ namespace OpenTelemetry.Trace.Test
         [Fact]
         public void GetTraceOptions()
         {
-            Assert.Equal(ActivityTraceFlags.None, First.TraceOptions);
-            Assert.Equal(ActivityTraceFlags.Recorded, Second.TraceOptions);
+            Assert.Equal(ActivityTraceFlags.None, First.TraceFlags);
+            Assert.Equal(ActivityTraceFlags.Recorded, Second.TraceFlags);
         }
 
         [Fact]

--- a/test/OpenTelemetry.Tests/Impl/Trace/SpanDataTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/SpanDataTest.cs
@@ -63,7 +63,7 @@ namespace OpenTelemetry.Tests.Impl.Trace
 
             Assert.Equal(parentContext.TraceId, spanData.Context.TraceId);
             Assert.Equal(span.Context.SpanId, spanData.Context.SpanId);
-            Assert.Equal(ActivityTraceFlags.Recorded, spanData.Context.TraceOptions);
+            Assert.Equal(ActivityTraceFlags.Recorded, spanData.Context.TraceFlags);
             Assert.False(spanData.Context.IsRemote);
             Assert.Empty(spanData.Context.Tracestate);
 

--- a/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
+++ b/test/OpenTelemetry.Tests/Impl/Trace/SpanTest.cs
@@ -73,7 +73,7 @@ namespace OpenTelemetry.Trace.Test
             Assert.Equal(parentSpan.Context.TraceId, span.Context.TraceId);
             Assert.Equal(span.Activity.SpanId, span.Context.SpanId);
             Assert.Equal(parentSpan.Context.SpanId, span.ParentSpanId);
-            Assert.Equal(parentSpan.Context.TraceOptions, span.Context.TraceOptions);
+            Assert.Equal(parentSpan.Context.TraceFlags, span.Context.TraceFlags);
             Assert.Same(traceState, span.Context.Tracestate);
 
             Assert.True(span.IsRecording);
@@ -97,7 +97,7 @@ namespace OpenTelemetry.Trace.Test
                 Assert.Equal(parentSpan.Context.TraceId, span.Context.TraceId);
                 Assert.Equal(span.Activity.SpanId, span.Context.SpanId);
                 Assert.Equal(parentSpan.Context.SpanId, span.ParentSpanId);
-                Assert.Equal(parentSpan.Context.TraceOptions, span.Context.TraceOptions);
+                Assert.Equal(parentSpan.Context.TraceFlags, span.Context.TraceFlags);
             }
         }
 
@@ -182,7 +182,7 @@ namespace OpenTelemetry.Trace.Test
                 Assert.Equal(span.Activity.TraceId, span.Context.TraceId);
                 Assert.Equal(span.Activity.SpanId, span.Context.SpanId);
                 Assert.Equal(default, span.ParentSpanId);
-                Assert.Equal(span.Activity.ActivityTraceFlags, span.Context.TraceOptions);
+                Assert.Equal(span.Activity.ActivityTraceFlags, span.Context.TraceFlags);
             }
         }
 
@@ -199,7 +199,7 @@ namespace OpenTelemetry.Trace.Test
             Assert.Equal(span.Activity.TraceId, span.Context.TraceId);
             Assert.Equal(span.Activity.SpanId, span.Context.SpanId);
             Assert.Equal(default, span.ParentSpanId);
-            Assert.Equal(span.Activity.ActivityTraceFlags, span.Context.TraceOptions);
+            Assert.Equal(span.Activity.ActivityTraceFlags, span.Context.TraceFlags);
 
             outerActivity.Stop();
         }
@@ -216,7 +216,7 @@ namespace OpenTelemetry.Trace.Test
             Assert.Equal(span.Activity.TraceId, span.Context.TraceId);
             Assert.Equal(span.Activity.SpanId, span.Context.SpanId);
             Assert.Equal(default, span.ParentSpanId);
-            Assert.Equal(span.Activity.ActivityTraceFlags, span.Context.TraceOptions);
+            Assert.Equal(span.Activity.ActivityTraceFlags, span.Context.TraceFlags);
             Assert.Empty(span.Context.Tracestate);
 
             Assert.True(span.IsRecording);
@@ -289,7 +289,7 @@ namespace OpenTelemetry.Trace.Test
             Assert.Equal(parentContext.TraceId, span.Context.TraceId);
             Assert.Equal(span.Activity.SpanId, span.Context.SpanId);
             Assert.Equal(parentContext.SpanId, span.ParentSpanId);
-            Assert.Equal(parentContext.TraceOptions, span.Context.TraceOptions);
+            Assert.Equal(parentContext.TraceFlags, span.Context.TraceFlags);
             Assert.Same(traceState, span.Context.Tracestate);
 
             Assert.True(span.IsRecording);
@@ -312,7 +312,7 @@ namespace OpenTelemetry.Trace.Test
             Assert.Equal(default, span.ParentSpanId);
 
             // always sample sampler
-            Assert.Equal(ActivityTraceFlags.Recorded, span.Context.TraceOptions);
+            Assert.Equal(ActivityTraceFlags.Recorded, span.Context.TraceFlags);
             Assert.True(span.IsRecording);
         }
 
@@ -332,7 +332,7 @@ namespace OpenTelemetry.Trace.Test
                 Assert.Equal(parentContext.TraceId, span.Context.TraceId);
                 Assert.Equal(span.Activity.SpanId, span.Context.SpanId);
                 Assert.Equal(parentContext.SpanId, span.ParentSpanId);
-                Assert.Equal(parentContext.TraceOptions, span.Context.TraceOptions);
+                Assert.Equal(parentContext.TraceFlags, span.Context.TraceFlags);
             }
         }
 
@@ -404,7 +404,7 @@ namespace OpenTelemetry.Trace.Test
             Assert.Equal(activity.TraceId, span.Context.TraceId);
             Assert.Equal(activity.SpanId, span.Context.SpanId);
             Assert.Equal(activity.ParentSpanId, span.ParentSpanId);
-            Assert.Equal(activity.ActivityTraceFlags, span.Context.TraceOptions);
+            Assert.Equal(activity.ActivityTraceFlags, span.Context.TraceFlags);
             Assert.Equal(2, span.Context.Tracestate.Count());
             Assert.Contains(span.Context.Tracestate, pair => pair.Key == "k1" && pair.Value == "v1");
             Assert.Contains(span.Context.Tracestate, pair => pair.Key == "k2" && pair.Value == "v2");
@@ -430,7 +430,7 @@ namespace OpenTelemetry.Trace.Test
                 Assert.Equal(activity.TraceId, span.Context.TraceId);
                 Assert.Equal(activity.SpanId, span.Context.SpanId);
                 Assert.Equal(activity.ParentSpanId, span.ParentSpanId);
-                Assert.Equal(activity.ActivityTraceFlags, span.Context.TraceOptions);
+                Assert.Equal(activity.ActivityTraceFlags, span.Context.TraceFlags);
             }
         }
 
@@ -448,7 +448,7 @@ namespace OpenTelemetry.Trace.Test
             Assert.Equal(activity.TraceId, span.Context.TraceId);
             Assert.Equal(activity.SpanId, span.Context.SpanId);
             Assert.Equal(activity.ParentSpanId, span.ParentSpanId);
-            Assert.Equal(activity.ActivityTraceFlags, span.Context.TraceOptions);
+            Assert.Equal(activity.ActivityTraceFlags, span.Context.TraceFlags);
             Assert.Equal(2, span.Context.Tracestate.Count());
             Assert.Contains(span.Context.Tracestate, pair => pair.Key == "k1" && pair.Value == "v1");
             Assert.Contains(span.Context.Tracestate, pair => pair.Key == "k2" && pair.Value == "v2");
@@ -623,7 +623,7 @@ namespace OpenTelemetry.Trace.Test
                 Assert.Equal(parentSpan.Context.TraceId, span.Context.TraceId);
                 Assert.Equal(span.Activity.SpanId, span.Context.SpanId);
                 Assert.Equal(parentSpan.Context.SpanId, span.ParentSpanId);
-                Assert.Equal(parentSpan.Context.TraceOptions, span.Context.TraceOptions);
+                Assert.Equal(parentSpan.Context.TraceFlags, span.Context.TraceFlags);
                 Assert.Same(traceState, span.Context.Tracestate);
 
                 Assert.True(span.IsRecording);
@@ -649,7 +649,7 @@ namespace OpenTelemetry.Trace.Test
             Assert.Equal(parentActivity.TraceId, span.Context.TraceId);
             Assert.Equal(span.Activity.SpanId, span.Context.SpanId);
             Assert.Equal(parentActivity.SpanId, span.ParentSpanId);
-            Assert.Equal(parentActivity.ActivityTraceFlags, span.Context.TraceOptions);
+            Assert.Equal(parentActivity.ActivityTraceFlags, span.Context.TraceFlags);
             Assert.Equal(2, span.Context.Tracestate.Count());
             Assert.Contains(span.Context.Tracestate, pair => pair.Key == "k1" && pair.Value == "v1");
             Assert.Contains(span.Context.Tracestate, pair => pair.Key == "k2" && pair.Value == "v2");
@@ -829,7 +829,7 @@ namespace OpenTelemetry.Trace.Test
             Assert.Equal(span.Activity.TraceId, span.Context.TraceId);
             Assert.Equal(span.Activity.SpanId, span.Context.SpanId);
             Assert.Equal(span.Activity.ParentSpanId, span.ParentSpanId);
-            Assert.Equal(span.Activity.ActivityTraceFlags, span.Context.TraceOptions);
+            Assert.Equal(span.Activity.ActivityTraceFlags, span.Context.TraceFlags);
             Assert.Empty(span.Context.Tracestate);
 
             Assert.Equal(SpanName, span.Name);
@@ -899,7 +899,7 @@ namespace OpenTelemetry.Trace.Test
             Assert.Equal(span.Activity.TraceId, span.Context.TraceId);
             Assert.Equal(span.Activity.SpanId, span.Context.SpanId);
             Assert.Equal(span.Activity.ParentSpanId, span.ParentSpanId);
-            Assert.Equal(span.Activity.ActivityTraceFlags, span.Context.TraceOptions);
+            Assert.Equal(span.Activity.ActivityTraceFlags, span.Context.TraceFlags);
 
             Assert.Equal(SpanName, span.Name);
             Assert.Equal(span.Activity.ParentSpanId, span.ParentSpanId);


### PR DESCRIPTION
From Spec:
_TraceFlags contain details about the trace. Unlike Tracestate values, TraceFlags are present in all traces. Currently, the only TraceFlags is a boolean sampled flag._

https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#spancontext

Don't know if `TraceOptions` was used originally for some reason.