### PR TITLE
Draft: Terminal SpanKind

### DIFF
--- a/src/OpenTelemetry.Api/Trace/SpanKind.cs
+++ b/src/OpenTelemetry.Api/Trace/SpanKind.cs
@@ -49,5 +49,10 @@ namespace OpenTelemetry.Trace
         /// spans.
         /// </summary>
         Consumer = 5,
+
+        /// <summary>
+        /// Terminal span represents outgoing telemetry data that is not typically recorded.
+        /// </summary>
+        Terminal = 6,
     }
 }

--- a/src/OpenTelemetry/Trace/Configuration/TracerFactory.cs
+++ b/src/OpenTelemetry/Trace/Configuration/TracerFactory.cs
@@ -82,8 +82,9 @@ namespace OpenTelemetry.Trace.Configuration
         /// Creates tracerSdk factory.
         /// </summary>
         /// <param name="configure">Function that configures tracerSdk factory.</param>
+        /// <param name="useAsDefaultFactory">Set to <see langword="true"/> to use the created Tracer as the <see cref="TracerFactoryBase.Default"/> instance.</param>
         /// <returns>Returns new <see cref="TracerFactory"/>.</returns>
-        public static TracerFactory Create(Action<TracerBuilder> configure)
+        public static TracerFactory Create(Action<TracerBuilder> configure, bool useAsDefaultFactory = true)
         {
             if (configure == null)
             {
@@ -101,6 +102,11 @@ namespace OpenTelemetry.Trace.Configuration
                     var tracer = factory.GetTracer(collector.Name, collector.Version);
                     factory.collectors.Add(collector.Factory(tracer));
                 }
+            }
+
+            if (useAsDefaultFactory)
+            {
+                SetDefault(factory);
             }
 
             return factory;


### PR DESCRIPTION
The goal is to have some kind of internal span that isn't collected by default. For example, Http POSTs to Zipkin. There was a comment in `HttpClientCollectorOptions` calling these "terminal spans" so I ran with it.

This PR is a potential design. Trying to gather some feedback before opening a PR into spec.

* Added SpanKind.Terminal. That's the spec bit.
* Updated SpanSdk so that IsRecording = false when SpanKind = Terminal. Also, if parent has IsRecording=false, so too will children. Fruit of the poison tree, so to speak.
* Zipkin and Jaeger updated to start Terminal spans in their export work. In order to do that I needed a reference to the TracerFactory.Default which didn't seem to be set ever, so I updated the factory Create method to do that. Not sure if that was a bug/oversight or done on purpose? I just noticed there is also #630 for this issue.
* AppInsights uses TelemetryClient, which itself acts as a kind of exporter (buffering, etc). Not quite sure how to get it to start a Terminal span when it actually goes to transmit data. Might need to have our own sink that is set on AppInsights TelmetryConfiguration?

Note: Haven't tried to run tests on this work yet. Updates are probably needed for the filter changes.

cc @SergeyKanzhelev @pakrym 
