### PR TITLE
Modify Metric record to not use generic.

### DIFF
--- a/src/OpenTelemetry.Api/Metrics/Meter.cs
+++ b/src/OpenTelemetry.Api/Metrics/Meter.cs
@@ -77,7 +77,7 @@ namespace OpenTelemetry.Metrics
         /// <summary>
         /// Constructs or retrieves the <see cref="LabelSet"/> from the given label key-value pairs.
         /// </summary>
-        /// <param name="labels">Label key value pairs.</param>
+        /// <param name="labels">Label key-value pairs.</param>
         /// <returns>The <see cref="LabelSet"/> with given label key value pairs.</returns>
         public abstract LabelSet GetLabelSet(IEnumerable<KeyValuePair<string, string>> labels);
     }

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterExtensions.cs
@@ -114,10 +114,11 @@ namespace OpenTelemetry.Exporter.Prometheus
         {
             builder = builder.WithType(PrometheusCounterType);
 
+            var metricValueBuilder = builder.AddValue();
+            metricValueBuilder = metricValueBuilder.WithValue(doubleValue);
+
             foreach (var label in labels)
             {
-                var metricValueBuilder = builder.AddValue();
-                metricValueBuilder = metricValueBuilder.WithValue(doubleValue);
                 metricValueBuilder.WithLabel(label.Key, label.Value);
             }
 

--- a/src/OpenTelemetry/Metrics/Aggregators/Aggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregators/Aggregator.cs
@@ -25,7 +25,7 @@ namespace OpenTelemetry.Metrics.Aggregators
 
         public abstract void Checkpoint();
 
-        public abstract MetricData<T> ToMetricData();
+        public abstract MetricData ToMetricData();
 
         public abstract AggregationType GetAggregationType();
     }

--- a/src/OpenTelemetry/Metrics/Aggregators/DoubleCounterSumAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregators/DoubleCounterSumAggregator.cs
@@ -35,9 +35,9 @@ namespace OpenTelemetry.Metrics.Aggregators
             this.checkPoint = Interlocked.Exchange(ref this.sum, 0.0);
         }
 
-        public override MetricData<double> ToMetricData()
+        public override MetricData ToMetricData()
         {
-            return new SumData<double>
+            return new DoubleSumData
             {
                 Sum = this.checkPoint,
                 Timestamp = DateTime.UtcNow,

--- a/src/OpenTelemetry/Metrics/Aggregators/DoubleLastValueAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregators/DoubleLastValueAggregator.cs
@@ -33,9 +33,9 @@ namespace OpenTelemetry.Metrics.Aggregators
             Interlocked.Exchange(ref this.checkpoint, this.value);
         }
 
-        public override MetricData<double> ToMetricData()
+        public override MetricData ToMetricData()
         {
-            return new SumData<double>
+            return new DoubleSumData
             {
                 Sum = this.checkpoint,
                 Timestamp = DateTime.UtcNow,

--- a/src/OpenTelemetry/Metrics/Aggregators/DoubleMeasureMinMaxSumCountAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregators/DoubleMeasureMinMaxSumCountAggregator.cs
@@ -36,12 +36,12 @@ namespace OpenTelemetry.Metrics.Aggregators
 
         public override AggregationType GetAggregationType()
         {
-            return AggregationType.Summary;
+            return AggregationType.DoubleSummary;
         }
 
-        public override MetricData<double> ToMetricData()
+        public override MetricData ToMetricData()
         {
-            return new SummaryData<double>
+            return new DoubleSummaryData
             {
                 Count = this.checkPoint.Count,
                 Sum = this.checkPoint.Sum,

--- a/src/OpenTelemetry/Metrics/Aggregators/Int64CounterSumAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregators/Int64CounterSumAggregator.cs
@@ -35,9 +35,9 @@ namespace OpenTelemetry.Metrics.Aggregators
             this.checkPoint = Interlocked.Exchange(ref this.sum, 0);
         }
 
-        public override MetricData<long> ToMetricData()
+        public override MetricData ToMetricData()
         {
-            return new SumData<long>
+            return new Int64SumData
             {
                 Sum = this.checkPoint,
                 Timestamp = DateTime.UtcNow,

--- a/src/OpenTelemetry/Metrics/Aggregators/Int64LastValueAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregators/Int64LastValueAggregator.cs
@@ -33,9 +33,9 @@ namespace OpenTelemetry.Metrics.Aggregators
             Interlocked.Exchange(ref this.checkpoint, this.value);
         }
 
-        public override MetricData<long> ToMetricData()
+        public override MetricData ToMetricData()
         {
-            return new SumData<long>
+            return new Int64SumData
             {
                 Sum = this.checkpoint,
                 Timestamp = DateTime.UtcNow,

--- a/src/OpenTelemetry/Metrics/Aggregators/Int64MeasureMinMaxSumCountAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregators/Int64MeasureMinMaxSumCountAggregator.cs
@@ -36,12 +36,12 @@ namespace OpenTelemetry.Metrics.Aggregators
 
         public override AggregationType GetAggregationType()
         {
-            return AggregationType.Summary;
+            return AggregationType.Int64Summary;
         }
 
-        public override MetricData<long> ToMetricData()
+        public override MetricData ToMetricData()
         {
-            return new SummaryData<long>
+            return new Int64SummaryData
             {
                 Count = this.checkPoint.Count,
                 Sum = this.checkPoint.Sum,

--- a/src/OpenTelemetry/Metrics/Export/AggregationType.cs
+++ b/src/OpenTelemetry/Metrics/Export/AggregationType.cs
@@ -19,18 +19,23 @@ namespace OpenTelemetry.Metrics.Export
     public enum AggregationType
     {
         /// <summary>
-        /// Sum of type Double which is reported with <see cref="SumData{T}"/>
+        /// Sum of type Double which is reported with <see cref="DoubleSumData"/>
         /// </summary>
         DoubleSum,
 
         /// <summary>
-        /// Sum of type Long which is reported with <see cref="SumData{T}"/>
+        /// Sum of type Long which is reported with <see cref="Int64SumData"/>
         /// </summary>
         LongSum,
 
         /// <summary>
-        /// Summary of measurements (Min, Max, Sum, Count), which is reported with <see cref="SummaryData{T}"/>
+        /// Summary of measurements (Min, Max, Sum, Count), which is reported with <see cref="DoubleSummaryData"/>
         /// </summary>
-        Summary,
+        DoubleSummary,
+
+        /// <summary>
+        /// Summary of measurements (Min, Max, Sum, Count), which is reported with <see cref="Int64SummaryData"/>
+        /// </summary>
+        Int64Summary,
     }
 }

--- a/src/OpenTelemetry/Metrics/Export/DoubleSumData.cs
+++ b/src/OpenTelemetry/Metrics/Export/DoubleSumData.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SumData.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="DoubleSumData.cs" company="OpenTelemetry Authors">
 // Copyright 2018, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,8 +16,8 @@
 
 namespace OpenTelemetry.Metrics.Export
 {
-    public class SumData<T> : MetricData<T>
+    public class DoubleSumData : MetricData
     {
-        public T Sum { get; set; }
+        public double Sum { get; set; }
     }
 }

--- a/src/OpenTelemetry/Metrics/Export/DoubleSummaryData.cs
+++ b/src/OpenTelemetry/Metrics/Export/DoubleSummaryData.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="NoOpMetricExporter.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="DoubleSummaryData.cs" company="OpenTelemetry Authors">
 // Copyright 2018, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,17 +14,16 @@
 // limitations under the License.
 // </copyright>
 
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace OpenTelemetry.Metrics.Export
 {
-    internal class NoOpMetricExporter : MetricExporter
+    public class DoubleSummaryData : MetricData
     {
-        public override Task<ExportResult> ExportAsync(IEnumerable<Metric> metrics, CancellationToken cancellationToken)
-        {
-            return Task.FromResult(ExportResult.Success);
-        }
+        public long Count { get; set; }
+
+        public double Sum { get; set; }
+
+        public double Min { get; set; }
+
+        public double Max { get; set; }
     }
 }

--- a/src/OpenTelemetry/Metrics/Export/Int64SumData.cs
+++ b/src/OpenTelemetry/Metrics/Export/Int64SumData.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="NoOpMetricExporter.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="Int64SumData.cs" company="OpenTelemetry Authors">
 // Copyright 2018, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,17 +14,10 @@
 // limitations under the License.
 // </copyright>
 
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace OpenTelemetry.Metrics.Export
 {
-    internal class NoOpMetricExporter : MetricExporter
+    public class Int64SumData : MetricData
     {
-        public override Task<ExportResult> ExportAsync(IEnumerable<Metric> metrics, CancellationToken cancellationToken)
-        {
-            return Task.FromResult(ExportResult.Success);
-        }
+        public long Sum { get; set; }
     }
 }

--- a/src/OpenTelemetry/Metrics/Export/Int64SummaryData.cs
+++ b/src/OpenTelemetry/Metrics/Export/Int64SummaryData.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SummaryData.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="Int64SummaryData.cs" company="OpenTelemetry Authors">
 // Copyright 2018, OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,23 +14,16 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace OpenTelemetry.Metrics.Export
 {
-    public class SummaryData<T> : MetricData<T>
+    public class Int64SummaryData : MetricData
     {
         public long Count { get; set; }
 
-        public T Sum { get; set; }
+        public long Sum { get; set; }
 
-        public T Min { get; set; }
+        public long Min { get; set; }
 
-        public T Max { get; set; }
+        public long Max { get; set; }
     }
 }

--- a/src/OpenTelemetry/Metrics/Export/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Export/Metric.cs
@@ -21,8 +21,7 @@ namespace OpenTelemetry.Metrics.Export
     /// <summary>
     /// This class would evolve to become the export record.
     /// </summary>
-    /// <typeparam name="T">Type of the metric - long or double currently.</typeparam>
-    public class Metric<T>
+    public class Metric
     {
         public Metric(
             string metricNamespace,
@@ -34,7 +33,7 @@ namespace OpenTelemetry.Metrics.Export
             this.MetricName = metricName;
             this.MetricDescription = desc;
             this.AggregationType = type;
-            this.Data = new List<MetricData<T>>();
+            this.Data = new List<MetricData>();
         }
 
         public string MetricNamespace { get; private set; }
@@ -45,6 +44,6 @@ namespace OpenTelemetry.Metrics.Export
 
         public AggregationType AggregationType { get; private set; }
 
-        public List<MetricData<T>> Data { get; internal set; }
+        public List<MetricData> Data { get; internal set; }
     }
 }

--- a/src/OpenTelemetry/Metrics/Export/MetricData.cs
+++ b/src/OpenTelemetry/Metrics/Export/MetricData.cs
@@ -19,7 +19,7 @@ using System.Collections.Generic;
 
 namespace OpenTelemetry.Metrics.Export
 {
-    public abstract class MetricData<T>
+    public abstract class MetricData
     {
         public DateTime Timestamp { get; set; }
 

--- a/src/OpenTelemetry/Metrics/Export/MetricExporter.cs
+++ b/src/OpenTelemetry/Metrics/Export/MetricExporter.cs
@@ -43,6 +43,6 @@ namespace OpenTelemetry.Metrics.Export
             FailedRetryable = 2,
         }
 
-        public abstract Task<ExportResult> ExportAsync<T>(IEnumerable<Metric<T>> metrics, CancellationToken cancellationToken);
+        public abstract Task<ExportResult> ExportAsync(IEnumerable<Metric> metrics, CancellationToken cancellationToken);
     }
 }

--- a/src/OpenTelemetry/Metrics/Export/MetricProcessor.cs
+++ b/src/OpenTelemetry/Metrics/Export/MetricProcessor.cs
@@ -25,20 +25,13 @@ namespace OpenTelemetry.Metrics.Export
         /// This is called at the end of one collection cycle by the Controller.
         /// MetricProcessor can use this to clear its Metrics (in case of stateless).
         /// </summary>
-        /// <param name="longMetrics">The list of long metrics from this cycle, which are to be exported.</param>
-        /// <param name="doubleMetrics">The list of double metrics from this cycle, which are to be exported.</param>
-        public abstract void FinishCollectionCycle(out IEnumerable<Metric<long>> longMetrics, out IEnumerable<Metric<double>> doubleMetrics);
+        /// <param name="metrics">The list of metrics from this cycle, which are to be exported.</param>
+        public abstract void FinishCollectionCycle(out IEnumerable<Metric> metrics);
 
         /// <summary>
         /// Process the metric. This method is called once every collection interval.
         /// </summary>
         /// <param name="metric">the metric record.</param>
-        public abstract void Process(Metric<long> metric);
-
-        /// <summary>
-        /// Process the metric. This method is called once every collection interval.
-        /// </summary>
-        /// <param name="metric">the metric record.</param>
-        public abstract void Process(Metric<double> metric);
+        public abstract void Process(Metric metric);
     }
 }

--- a/src/OpenTelemetry/Metrics/Export/NoOpMetricProcessor.cs
+++ b/src/OpenTelemetry/Metrics/Export/NoOpMetricProcessor.cs
@@ -14,26 +14,19 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using OpenTelemetry.Metrics.Aggregators;
 
 namespace OpenTelemetry.Metrics.Export
 {
     internal class NoOpMetricProcessor : MetricProcessor
     {
-        public override void FinishCollectionCycle(out IEnumerable<Metric<long>> longMetrics, out IEnumerable<Metric<double>> doubleMetrics)
+        public override void FinishCollectionCycle(out IEnumerable<Metric> metric)
         {
-            longMetrics = Enumerable.Empty<Metric<long>>();
-            doubleMetrics = Enumerable.Empty<Metric<double>>();
+            metric = Enumerable.Empty<Metric>();
         }
 
-        public override void Process(Metric<long> metric)
-        {
-        }
-
-        public override void Process(Metric<double> metric)
+        public override void Process(Metric metric)
         {
         }
     }

--- a/src/OpenTelemetry/Metrics/Export/UngroupedBatcher.cs
+++ b/src/OpenTelemetry/Metrics/Export/UngroupedBatcher.cs
@@ -16,7 +16,6 @@
 
 using System.Collections.Generic;
 using OpenTelemetry.Internal;
-using OpenTelemetry.Metrics.Aggregators;
 
 namespace OpenTelemetry.Metrics.Export
 {
@@ -25,41 +24,29 @@ namespace OpenTelemetry.Metrics.Export
     /// </summary>
     public class UngroupedBatcher : MetricProcessor
     {
-        private List<Metric<long>> longMetrics;
-        private List<Metric<double>> doubleMetrics;
+        private List<Metric> metrics;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UngroupedBatcher"/> class.
         /// </summary>
         public UngroupedBatcher()
         {
-            this.longMetrics = new List<Metric<long>>();
-            this.doubleMetrics = new List<Metric<double>>();
+            this.metrics = new List<Metric>();
         }
 
-        public override void FinishCollectionCycle(out IEnumerable<Metric<long>> longMetrics, out IEnumerable<Metric<double>> doubleMetrics)
+        public override void FinishCollectionCycle(out IEnumerable<Metric> metrics)
         {
             // The batcher is currently stateless. i.e it forgets state after collection is done.
             // Once the spec is ready for stateless vs stateful, we need to modify batcher
             // to remember or clear state after each cycle.
-            longMetrics = this.longMetrics;
-            doubleMetrics = this.doubleMetrics;
-
-            var count = this.longMetrics.Count + this.doubleMetrics.Count;
-            this.longMetrics = new List<Metric<long>>();
-            this.doubleMetrics = new List<Metric<double>>();
-
-            OpenTelemetrySdkEventSource.Log.BatcherCollectionCompleted(count);
+            metrics = this.metrics;
+            this.metrics = new List<Metric>();
+            OpenTelemetrySdkEventSource.Log.BatcherCollectionCompleted(this.metrics.Count);
         }
 
-        public override void Process(Metric<long> metric)
+        public override void Process(Metric metric)
         {
-            this.longMetrics.Add(metric);
-        }
-
-        public override void Process(Metric<double> metric)
-        {
-            this.doubleMetrics.Add(metric);
+            this.metrics.Add(metric);
         }
     }
 }

--- a/src/OpenTelemetry/Metrics/MeterSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterSdk.cs
@@ -58,7 +58,7 @@ namespace OpenTelemetry.Metrics
                 {
                     var metricName = longCounter.Key;
                     var counterInstrument = longCounter.Value;
-                    var metric = new Metric<long>(this.meterName, metricName, this.meterName + metricName, AggregationType.LongSum);
+                    var metric = new Metric(this.meterName, metricName, this.meterName + metricName, AggregationType.LongSum);
                     foreach (var handle in counterInstrument.GetAllBoundInstruments())
                     {
                         var labelSet = handle.Key;
@@ -105,7 +105,7 @@ namespace OpenTelemetry.Metrics
                 {
                     var metricName = doubleCounter.Key;
                     var counterInstrument = doubleCounter.Value;
-                    var metric = new Metric<double>(this.meterName, metricName, this.meterName + metricName, AggregationType.DoubleSum);
+                    var metric = new Metric(this.meterName, metricName, this.meterName + metricName, AggregationType.DoubleSum);
                     foreach (var handle in counterInstrument.GetAllBoundInstruments())
                     {
                         var labelSet = handle.Key;
@@ -152,7 +152,7 @@ namespace OpenTelemetry.Metrics
                 {
                     var metricName = longMeasure.Key;
                     var measureInstrument = longMeasure.Value;
-                    var metric = new Metric<long>(this.meterName, metricName, this.meterName + metricName, AggregationType.Summary);
+                    var metric = new Metric(this.meterName, metricName, this.meterName + metricName, AggregationType.Int64Summary);
                     foreach (var handle in measureInstrument.GetAllBoundInstruments())
                     {
                         var labelSet = handle.Key;
@@ -170,7 +170,7 @@ namespace OpenTelemetry.Metrics
                 {
                     var metricName = doubleMeasure.Key;
                     var measureInstrument = doubleMeasure.Value;
-                    var metric = new Metric<double>(this.meterName, metricName, this.meterName + metricName, AggregationType.Summary);
+                    var metric = new Metric(this.meterName, metricName, this.meterName + metricName, AggregationType.DoubleSummary);
                     foreach (var handle in measureInstrument.GetAllBoundInstruments())
                     {
                         var labelSet = handle.Key;
@@ -188,7 +188,7 @@ namespace OpenTelemetry.Metrics
                 {
                     var metricName = longObserver.Key;
                     var observerInstrument = longObserver.Value;
-                    var metric = new Metric<long>(this.meterName, metricName, this.meterName + metricName, AggregationType.LongSum);
+                    var metric = new Metric(this.meterName, metricName, this.meterName + metricName, AggregationType.LongSum);
                     try
                     {
                         // TODO: Decide if we want to enforce a timeout. Issue # 542
@@ -216,7 +216,7 @@ namespace OpenTelemetry.Metrics
                 {
                     var metricName = doubleObserver.Key;
                     var observerInstrument = doubleObserver.Value;
-                    var metric = new Metric<double>(this.meterName, metricName, this.meterName + metricName, AggregationType.LongSum);
+                    var metric = new Metric(this.meterName, metricName, this.meterName + metricName, AggregationType.LongSum);
                     try
                     {
                         // TODO: Decide if we want to enforce a timeout. Issue # 542

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterTests.cs
@@ -123,9 +123,11 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
 
             var labels1 = new List<KeyValuePair<string, string>>();
             labels1.Add(new KeyValuePair<string, string>("dim1", "value1"));
+            labels1.Add(new KeyValuePair<string, string>("dim2", "value1"));
 
             var labels2 = new List<KeyValuePair<string, string>>();
             labels2.Add(new KeyValuePair<string, string>("dim1", "value2"));
+            labels2.Add(new KeyValuePair<string, string>("dim2", "value2"));
 
 
             var defaultContext = default(SpanContext);
@@ -148,8 +150,8 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
         {
             // Validate counters.
             Assert.Contains("TYPE testCounter counter", responseText);
-            Assert.Contains("testCounter{dim1=\"value1\"}", responseText);
-            Assert.Contains("testCounter{dim1=\"value2\"}", responseText);
+            Assert.Contains("testCounter{dim1=\"value1\",dim2=\"value1\"}", responseText);
+            Assert.Contains("testCounter{dim1=\"value2\",dim2=\"value2\"}", responseText);
 
             // Validate measure.
             Assert.Contains("# TYPE testMeasure summary", responseText);

--- a/test/OpenTelemetry.Tests/Implementation/Metrics/Aggregators/CounterAggregatorTest.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Metrics/Aggregators/CounterAggregatorTest.cs
@@ -36,7 +36,7 @@ namespace OpenTelemetry.Metrics.Test
         {
             // create an aggregator
             var aggregator = new Int64CounterSumAggregator();
-            var sum = aggregator.ToMetricData() as SumData<long>;
+            var sum = aggregator.ToMetricData() as Int64SumData;
 
             // we start with 0.
             Assert.Equal(0, sum.Sum);
@@ -75,7 +75,7 @@ namespace OpenTelemetry.Metrics.Test
 
             // check point.
             aggregator.Checkpoint();
-            sum = aggregator.ToMetricData() as SumData<long>;
+            sum = aggregator.ToMetricData() as Int64SumData;
 
             // 1000000 times 10 by each thread. times 10 as there are 10 threads
             Assert.Equal(100000000, sum.Sum);
@@ -86,7 +86,7 @@ namespace OpenTelemetry.Metrics.Test
         {
             // create an aggregator
             var aggregator = new DoubleCounterSumAggregator();
-            var sum = aggregator.ToMetricData() as SumData<double>;
+            var sum = aggregator.ToMetricData() as DoubleSumData;
 
             // we start with 0.0
             Assert.Equal(0.0, sum.Sum);
@@ -125,7 +125,7 @@ namespace OpenTelemetry.Metrics.Test
 
             // check point.
             aggregator.Checkpoint();
-            sum = aggregator.ToMetricData() as SumData<double>;
+            sum = aggregator.ToMetricData() as DoubleSumData;
 
             // 1000000 times 10.5 by each thread. times 10 as there are 10 threads
             Assert.Equal(105000000, sum.Sum);

--- a/test/OpenTelemetry.Tests/Implementation/Metrics/Aggregators/LastValueAggregatorTest.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Metrics/Aggregators/LastValueAggregatorTest.cs
@@ -28,7 +28,7 @@ namespace OpenTelemetry.Metrics.Test
         {
             // create an aggregator
             var aggregator = new Int64LastValueAggregator();
-            var sum = aggregator.ToMetricData() as SumData<long>;
+            var sum = aggregator.ToMetricData() as Int64SumData;
 
             // we start with 0.
             Assert.Equal(0, sum.Sum);
@@ -39,7 +39,7 @@ namespace OpenTelemetry.Metrics.Test
             aggregator.Update(40);
 
             aggregator.Checkpoint();
-            sum = aggregator.ToMetricData() as SumData<long>;
+            sum = aggregator.ToMetricData() as Int64SumData;
             Assert.Equal(40, sum.Sum);
         }
     }

--- a/test/OpenTelemetry.Tests/Implementation/Metrics/Aggregators/MinMaxSumCountAggregatorTest.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Metrics/Aggregators/MinMaxSumCountAggregatorTest.cs
@@ -36,7 +36,7 @@ namespace OpenTelemetry.Metrics.Test
         {
             // create an aggregator
             var aggregator = new Int64MeasureMinMaxSumCountAggregator();
-            var summary = aggregator.ToMetricData() as SummaryData<long>;
+            var summary = aggregator.ToMetricData() as Int64SummaryData;
 
             // we start with 0.
             Assert.Equal(0, summary.Sum);
@@ -73,7 +73,7 @@ namespace OpenTelemetry.Metrics.Test
 
             // check point.
             aggregator.Checkpoint();
-            summary = aggregator.ToMetricData() as SummaryData<long>;
+            summary = aggregator.ToMetricData() as Int64SummaryData;
 
             // 1000000 times (10+50+100) by each thread. times 10 as there are 10 threads
             Assert.Equal(1600000000, summary.Sum);
@@ -91,7 +91,7 @@ namespace OpenTelemetry.Metrics.Test
         {
             // create an aggregator
             var aggregator = new DoubleMeasureMinMaxSumCountAggregator();
-            var summary = aggregator.ToMetricData() as SummaryData<double>;
+            var summary = aggregator.ToMetricData() as DoubleSummaryData;
 
             // we start with 0.
             Assert.Equal(0, summary.Sum);
@@ -128,7 +128,7 @@ namespace OpenTelemetry.Metrics.Test
 
             // check point.
             aggregator.Checkpoint();
-            summary = aggregator.ToMetricData() as SummaryData<double>;
+            summary = aggregator.ToMetricData() as DoubleSummaryData;
 
             // 1000000 times (10+50+100) by each thread. times 10 as there are 10 threads
             Assert.Equal(1600000000, summary.Sum);

--- a/test/OpenTelemetry.Tests/Implementation/Metrics/CounterCleanUpTests.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Metrics/CounterCleanUpTests.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System.Linq;
 using System.Collections.Generic;
 using OpenTelemetry.Metrics.Configuration;
 using OpenTelemetry.Trace;
@@ -232,9 +231,9 @@ namespace OpenTelemetry.Metrics.Test
             meter.Collect();
 
             long sum = 0;
-            foreach (var exportedData in testProcessor.longMetrics)
+            foreach (var exportedData in testProcessor.metrics)
             {
-                exportedData.Data.ForEach((data => sum += (data as SumData<long>).Sum));
+                exportedData.Data.ForEach((data => sum += (data as Int64SumData).Sum));
             }
 
             // 210 = 110 from initial update, 100 from the multi-thread test case.
@@ -302,9 +301,9 @@ namespace OpenTelemetry.Metrics.Test
 
             double sum = 0;
             
-            foreach (var exportedData in testProcessor.doubleMetrics)
+            foreach (var exportedData in testProcessor.metrics)
             {
-                exportedData.Data.ForEach((data => sum += (data as SumData<double>).Sum));
+                exportedData.Data.ForEach((data => sum += (data as DoubleSumData).Sum));
             }
 
             // 210 = 110 from initial update, 100 from the multi-thread test case.

--- a/test/OpenTelemetry.Tests/Implementation/Metrics/MetricsTest.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Metrics/MetricsTest.cs
@@ -53,8 +53,8 @@ namespace OpenTelemetry.Metrics.Test
 
             meter.Collect();
 
-            Assert.Single(testProcessor.longMetrics);
-            var metric = testProcessor.longMetrics[0];
+            Assert.Single(testProcessor.metrics);
+            var metric = testProcessor.metrics[0];
 
             Assert.Equal("testCounter", metric.MetricName);
             Assert.Equal("library1", metric.MetricNamespace);
@@ -62,15 +62,15 @@ namespace OpenTelemetry.Metrics.Test
             // 3 time series, as 3 unique label sets.
             Assert.Equal(3, metric.Data.Count);
             var metricSeries = metric.Data.Single(data => data.Labels.Any(l => l.Key == "dim1" && l.Value == "value1"));
-            var metricLong = metricSeries as SumData<long>;
+            var metricLong = metricSeries as Int64SumData;
             Assert.Equal(110, metricLong.Sum);
 
             metricSeries = metric.Data.Single(data => data.Labels.Any(l => l.Key == "dim1" && l.Value == "value2"));
-            metricLong = metricSeries as SumData<long>;
+            metricLong = metricSeries as Int64SumData;
             Assert.Equal(200, metricLong.Sum);
 
             metricSeries = metric.Data.Single(data => data.Labels.Any(l => l.Key == "dim1" && l.Value == "value3"));
-            metricLong = metricSeries as SumData<long>;
+            metricLong = metricSeries as Int64SumData;
             Assert.Equal(210, metricLong.Sum);
         }
         
@@ -96,8 +96,8 @@ namespace OpenTelemetry.Metrics.Test
 
             meter.Collect();
 
-            Assert.Single(testProcessor.longMetrics);
-            var metric = testProcessor.longMetrics[0];
+            Assert.Single(testProcessor.metrics);
+            var metric = testProcessor.metrics[0];
             Assert.Equal("testMeasure", metric.MetricName);
             Assert.Equal("library1", metric.MetricNamespace);
 
@@ -105,14 +105,14 @@ namespace OpenTelemetry.Metrics.Test
             Assert.Equal(2, metric.Data.Count);
 
             var metricSeries = metric.Data.Single(data => data.Labels.Any(l => l.Key == "dim1" && l.Value == "value1"));
-            var metricSummary = metricSeries as SummaryData<long>;
+            var metricSummary = metricSeries as Int64SummaryData;
             Assert.Equal(111, metricSummary.Sum);
             Assert.Equal(3, metricSummary.Count);
             Assert.Equal(1, metricSummary.Min);
             Assert.Equal(100, metricSummary.Max);
 
             metricSeries = metric.Data.Single(data => data.Labels.Any(l => l.Key == "dim1" && l.Value == "value2"));
-            metricSummary = metricSeries as SummaryData<long>;
+            metricSummary = metricSeries as Int64SummaryData;
             Assert.Equal(220, metricSummary.Sum);
             Assert.Equal(2, metricSummary.Count);
             Assert.Equal(20, metricSummary.Min);
@@ -128,8 +128,8 @@ namespace OpenTelemetry.Metrics.Test
 
             meter.Collect();
 
-            Assert.Single(testProcessor.longMetrics);
-            var metric = testProcessor.longMetrics[0];
+            Assert.Single(testProcessor.metrics);
+            var metric = testProcessor.metrics[0];
             Assert.Equal("testObserver", metric.MetricName);
             Assert.Equal("library1", metric.MetricNamespace);
 
@@ -137,11 +137,11 @@ namespace OpenTelemetry.Metrics.Test
             Assert.Equal(2, metric.Data.Count);
 
             var metricSeries = metric.Data.Single(data => data.Labels.Any(l => l.Key == "dim1" && l.Value == "value1"));
-            var metricLong = metricSeries as SumData<long>;
+            var metricLong = metricSeries as Int64SumData;
             Assert.Equal(30, metricLong.Sum);
 
             metricSeries = metric.Data.Single(data => data.Labels.Any(l => l.Key == "dim1" && l.Value == "value2"));
-            metricLong = metricSeries as SumData<long>;
+            metricLong = metricSeries as Int64SumData;
             Assert.Equal(300, metricLong.Sum);
         }
 
@@ -154,8 +154,8 @@ namespace OpenTelemetry.Metrics.Test
 
             meter.Collect();
 
-            Assert.Single(testProcessor.doubleMetrics);
-            var metric = testProcessor.doubleMetrics[0];
+            Assert.Single(testProcessor.metrics);
+            var metric = testProcessor.metrics[0];
             Assert.Equal("testObserver", metric.MetricName);
             Assert.Equal("library1", metric.MetricNamespace);
 
@@ -163,11 +163,11 @@ namespace OpenTelemetry.Metrics.Test
             Assert.Equal(2, metric.Data.Count);
 
             var metricSeries = metric.Data.Single(data => data.Labels.Any(l => l.Key == "dim1" && l.Value == "value1"));
-            var metricLong = metricSeries as SumData<double>;
+            var metricLong = metricSeries as DoubleSumData;
             Assert.Equal(30.5, metricLong.Sum);
 
             metricSeries = metric.Data.Single(data => data.Labels.Any(l => l.Key == "dim1" && l.Value == "value2"));
-            metricLong = metricSeries as SumData<double>;
+            metricLong = metricSeries as DoubleSumData;
             Assert.Equal(300.5, metricLong.Sum);
         }
 

--- a/test/OpenTelemetry.Tests/Implementation/Metrics/PushControllerTest.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Metrics/PushControllerTest.cs
@@ -14,16 +14,12 @@
 // limitations under the License.
 // </copyright>
 
-using System.Linq;
 using System.Collections.Generic;
-using OpenTelemetry.Metrics.Configuration;
-using OpenTelemetry.Trace;
 using Xunit;
 using OpenTelemetry.Metrics.Export;
 using System.Diagnostics;
 using System;
 using System.Threading;
-using System.Threading.Tasks;
 using static OpenTelemetry.Metrics.Configuration.MeterFactory;
 
 namespace OpenTelemetry.Metrics.Test
@@ -38,9 +34,8 @@ namespace OpenTelemetry.Metrics.Test
             var collectionCountExpectedMin = 3;
             var maxWaitInMsec = (controllerPushIntervalInMsec * collectionCountExpectedMin) + 2000;
 
-            int longExportCalledCount = 0;
-            int doubleExportCalledCount = 0;
-            var testExporter = new TestMetricExporter(() => longExportCalledCount++, () => doubleExportCalledCount++);
+            int exportCalledCount = 0;
+            var testExporter = new TestMetricExporter(() => exportCalledCount++);
 
             var testProcessor = new TestMetricProcessor();
 
@@ -65,8 +60,7 @@ namespace OpenTelemetry.Metrics.Test
             ValidateMeterCollect(ref meter2CollectCount, collectionCountExpectedMin, "meter2", TimeSpan.FromMilliseconds(maxWaitInMsec));
 
             // Export must be called same no: of times as Collect.
-            Assert.True(longExportCalledCount >= collectionCountExpectedMin);
-            Assert.True(doubleExportCalledCount >= collectionCountExpectedMin);
+            Assert.True(exportCalledCount >= collectionCountExpectedMin);
         }
 
         private void ValidateMeterCollect(ref int meterCollectCount, int expectedMeterCollectCount, string meterName, TimeSpan timeout)

--- a/test/OpenTelemetry.Tests/Implementation/Metrics/TestMetricExporter.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Metrics/TestMetricExporter.cs
@@ -15,50 +15,27 @@
 // </copyright>
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using OpenTelemetry.Metrics.Aggregators;
 using OpenTelemetry.Metrics.Export;
 
 namespace OpenTelemetry.Metrics.Test
 {
     internal class TestMetricExporter : MetricExporter
     {
-        public List<Metric<long>> LongMetrics = new List<Metric<long>>();
-        public List<Metric<double>> DoubleMetrics = new List<Metric<double>>();
-        private readonly Action onLongExport;
-        private readonly Action onDoubleExport;
+        public List<Metric> Metrics = new List<Metric>();
+        private readonly Action onExport;        
 
-        public TestMetricExporter(Action onLongExport, Action onDoubleExport)
+        public TestMetricExporter(Action onExport)
         {
-            this.onDoubleExport = onDoubleExport;
-            this.onLongExport = onLongExport;
+            this.onExport = onExport;
         }
 
-        public override Task<ExportResult> ExportAsync<T>(IEnumerable<Metric<T>> metrics, CancellationToken cancellationToken)
-        {            
-            if (typeof(T) == typeof(double))
-            {
-                this.onDoubleExport?.Invoke();
-                var doubleList = metrics
-                .Select(x => (x as Metric<double>))
-                .ToList();
-
-                this.DoubleMetrics.AddRange(doubleList);
-            }
-            else
-            {
-                this.onLongExport?.Invoke();
-                var longList = metrics
-                .Select(x => (x as Metric<long>))
-                .ToList();
-
-                this.LongMetrics.AddRange(longList);
-            }
-
+        public override Task<ExportResult> ExportAsync(IEnumerable<Metric> metrics, CancellationToken cancellationToken)
+        {
+            this.onExport?.Invoke();
+            this.Metrics.AddRange(metrics);
             return Task.FromResult(ExportResult.Success);
         }
     }

--- a/test/OpenTelemetry.Tests/Implementation/Metrics/TestMetricProcessor.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Metrics/TestMetricProcessor.cs
@@ -14,35 +14,24 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using OpenTelemetry.Metrics.Aggregators;
 using OpenTelemetry.Metrics.Export;
 
 namespace OpenTelemetry.Metrics.Test
 {
     internal class TestMetricProcessor : MetricProcessor
     {
-        public List<Metric<long>> longMetrics = new List<Metric<long>>();
-        public List<Metric<double>> doubleMetrics = new List<Metric<double>>();
+        public List<Metric> metrics = new List<Metric>();
 
-        public override void FinishCollectionCycle(out IEnumerable<Metric<long>> longMetrics, out IEnumerable<Metric<double>> doubleMetrics)
+        public override void FinishCollectionCycle(out IEnumerable<Metric> metrics)
         {
-            longMetrics = this.longMetrics;
-            doubleMetrics = this.doubleMetrics;
-            this.longMetrics = new List<Metric<long>>();
-            this.doubleMetrics = new List<Metric<double>>();
+            metrics = this.metrics;            
+            this.metrics = new List<Metric>();            
         }
 
-        public override void Process(Metric<long> metric)
+        public override void Process(Metric metric)
         {
-            this.longMetrics.Add(metric);
-        }
-
-        public override void Process(Metric<double> metric)
-        {
-            this.doubleMetrics.Add(metric);
+            this.metrics.Add(metric);
         }
     }
 }


### PR DESCRIPTION
## Changes
This removes generics from Metric record and instead have separate classes for Long and Double MetricData. To support this, additional AggregationType - DoubleSummary is introduced.
Refactoring a lot of code to be much simpler.

### Checklist
- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public API reviewed

The PR will automatically request reviews from [code owners](https://github.com/open-telemetry/opentelemetry-dotnet/blob/master/CODEOWNERS#L15) and trigger CI build and tests.