### PR TITLE
Tweaked the PR template so it uses github "fixes" keyword by default.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Fix Issue # .
+Fixes # .
 
 ## Changes
 (Please provide a brief description of the changes here.)


### PR DESCRIPTION
I don't think GitHub auto links up "Fix Issue #[NNN]" like it does "Fixes #[NNN]" so I tweaked the default template text.

/cc @cijothomas 