### PR TITLE
Adding Cijo as a maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Approvers ([@open-telemetry/dotnet-approvers](https://github.com/orgs/open-telem
 
 - [Bruno Garcia](https://github.com/bruno-garcia), Sentry
 - [Christoph Neumueller](https://github.com/discostu105), Dynatrace
-- [Cijo Thomas](https://github.com/cijothomas), Microsoft
 - [Liudmila Molkova](https://github.com/lmolkova), Microsoft
 - [Paulo Janotti](https://github.com/pjanotti), Splunk
 
@@ -57,6 +56,7 @@ Triagers:
 
 Maintainers ([@open-telemetry/dotnet-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-maintainers)):
 
+- [Cijo Thomas](https://github.com/cijothomas), Microsoft
 - [Mike Goldsmith](https://github.com/MikeGoldsmith), LightStep
 - [Sergey Kanzhelev](https://github.com/SergeyKanzhelev), Google
 

--- a/README.md
+++ b/README.md
@@ -80,3 +80,4 @@ See the [project
 milestones](https://github.com/open-telemetry/opentelemetry-dotnet/milestones)
 for details on upcoming releases. The dates and features described in issues
 and milestones are estimates, and subject to change.
+

--- a/README.md
+++ b/README.md
@@ -80,4 +80,3 @@ See the [project
 milestones](https://github.com/open-telemetry/opentelemetry-dotnet/milestones)
 for details on upcoming releases. The dates and features described in issues
 and milestones are estimates, and subject to change.
-


### PR DESCRIPTION
Cijo has been driving the metrics implementation in OpenTelemetry .NET SDK, and actively contributing to the metrics API spec.
Recently Cijo has been acting as the maintainer running the SIG meetings, coordinating the design and integration with .NET Activity API, and representing the .NET SDK in the maintainers meeting.
These are all the PRs from Cijo: https://github.com/open-telemetry/opentelemetry-dotnet/pulls?q=is%3Apr+author%3Acijothomas.

@bogdandrutu @carlosalberto @cijothomas @tedsuo 