### PR TITLE
Asp.Net Core Requests Instrumentation - change to use new Activity API

### DIFF
--- a/samples/Exporters/Web/OpenTelemetry.Exporter.Web.csproj
+++ b/samples/Exporters/Web/OpenTelemetry.Exporter.Web.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\OpenTelemetry.Exporter.Console\OpenTelemetry.Exporter.Console.csproj" />
     <ProjectReference Include="..\..\..\src\OpenTelemetry.Instrumentation.AspNetCore\OpenTelemetry.Instrumentation.AspNetCore.csproj" />
     <ProjectReference Include="..\..\..\src\OpenTelemetry.Instrumentation.Dependencies\OpenTelemetry.Instrumentation.Dependencies.csproj" />
     <ProjectReference Include="..\..\..\src\OpenTelemetry.Exporter.Zipkin\OpenTelemetry.Exporter.Zipkin.csproj" />

--- a/samples/Exporters/Web/Startup.cs
+++ b/samples/Exporters/Web/Startup.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
+using OpenTelemetry.Exporter.Console;
 using OpenTelemetry.Trace.Configuration;
 
 namespace API
@@ -35,6 +36,11 @@ namespace API
                     c.IncludeXmlComments(xmlPath);
                 }
             });
+
+
+            OpenTelemetrySdk.EnableOpenTelemetry(
+                (builder) => builder.AddActivitySource(string.Empty)
+                .UseConsoleActivityExporter(opt => opt.DisplayAsJson = opt.DisplayAsJson));
 
             services.AddOpenTelemetry((sp, builder) =>
             {

--- a/samples/Exporters/Web/Startup.cs
+++ b/samples/Exporters/Web/Startup.cs
@@ -39,7 +39,7 @@ namespace API
 
 
             OpenTelemetrySdk.EnableOpenTelemetry(
-                (builder) => builder.AddActivitySource(string.Empty)
+                (builder) => builder.AddActivitySource("Microsoft.AspNetCore")
                 .UseConsoleActivityExporter(opt => opt.DisplayAsJson = opt.DisplayAsJson));
 
             services.AddOpenTelemetry((sp, builder) =>

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -104,23 +104,26 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
                 span.PutHttpRawUrlAttribute(GetUri(request));
             }
 
-            if (newActivity.IsAllDataRequested)
+            if (newActivity != null)
             {
-                if (request.Host.Port == 80 || request.Host.Port == 443)
+                if (newActivity.IsAllDataRequested)
                 {
-                    newActivity.AddTag("http.host", request.Host.Host);
-                }
-                else
-                {
-                    newActivity.AddTag("http.host", request.Host.Host + ":" + request.Host.Port);
-                }
+                    if (request.Host.Port == 80 || request.Host.Port == 443)
+                    {
+                        newActivity.AddTag("http.host", request.Host.Host);
+                    }
+                    else
+                    {
+                        newActivity.AddTag("http.host", request.Host.Host + ":" + request.Host.Port);
+                    }
 
-                newActivity.AddTag("http.method", request.Method);
-                newActivity.AddTag("http.path", path);
+                    newActivity.AddTag("http.method", request.Method);
+                    newActivity.AddTag("http.path", path);
 
-                var userAgent = request.Headers["User-Agent"].FirstOrDefault();
-                newActivity.AddTag("http.user_agent", userAgent);
-                newActivity.AddTag("http.url", GetUri(request));
+                    var userAgent = request.Headers["User-Agent"].FirstOrDefault();
+                    newActivity.AddTag("http.user_agent", userAgent);
+                    newActivity.AddTag("http.url", GetUri(request));
+                }
             }
         }
 


### PR DESCRIPTION
Goal: Fixes 3-d from https://github.com/open-telemetry/opentelemetry-dotnet/issues/684


This is very draft PR to discuss with community/.NET team about the issues with adapting "old" with "new" DiagnosticSource instrumentation.

"old" - means instrumentation using DiagnosticSource.StartActivity() - currently implemented by Asp.Net Core, SqlClient, HttpClient .Net Core etc.

"new" means instrumentation using ActivitySource.StartActivity().

As all the existing libraries are implemening the old instrumentation method, we need adapters to translate them into new way. 
Conceptually, it involves the following:
1. Listen/Subscribe to old events using DiagnosticListeners.AllListeners.Subscrive.
2. Use reflection to extract span properties from payload.
3. Populate them into Activity.Tags.

Issues that need to be addressed:
1. The activity which is coming from the old instrumentation will have ActivityKind set to Internal (which is the default). This property is not mutable after activity start.

2. The activity from old instrumentation will not have any knowledge about sampling, and activity is always created and has activity.IsAllDataRequested = true all the time. The adapters will now need to call Samplers, and take action based on sampling outcome. But to do this, adapters will have to take dependency on OT SDK. (samplers are not part of API).

One proposal which solves the above 2 issues (but causes something else) is added in this PR. The proposal is:
Adapters keep listening to the old events in the current way.
Inside OnStart and OnEnd callbacks, adapters create a new activity using ActivitySource, and populate its tags. This new activity will conform to new usage pattern.

This obviously has the drawback of creating an additional activity. (bad perf , how bad I need to measure)


Opening this draft PR early to solicit feedback on this approach and alternates.