### PR TITLE
Catch exceptions in flush timer and write to EventSource

### DIFF
--- a/src/OpenTelemetry.Api/Internal/OpenTelemetryApiEventSource.cs
+++ b/src/OpenTelemetry.Api/Internal/OpenTelemetryApiEventSource.cs
@@ -39,7 +39,7 @@ namespace OpenTelemetry.Internal
         }
 
         [NonEvent]
-        public void TracestateExtractException(Exception ex)
+        public void TraceStateExtractException(Exception ex)
         {
             if (this.IsEnabled(EventLevel.Warning, (EventKeywords)(-1)))
             {
@@ -48,7 +48,7 @@ namespace OpenTelemetry.Internal
         }
 
         [NonEvent]
-        public void TracestateKeyIsInvalid(ReadOnlySpan<char> key)
+        public void TraceStateKeyIsInvalid(ReadOnlySpan<char> key)
         {
             if (this.IsEnabled(EventLevel.Warning, (EventKeywords)(-1)))
             {
@@ -57,7 +57,7 @@ namespace OpenTelemetry.Internal
         }
 
         [NonEvent]
-        public void TracestateValueIsInvalid(ReadOnlySpan<char> value)
+        public void TraceStateValueIsInvalid(ReadOnlySpan<char> value)
         {
             if (this.IsEnabled(EventLevel.Warning, (EventKeywords)(-1)))
             {

--- a/src/OpenTelemetry.Api/Internal/OpenTelemetryApiEventSource.cs
+++ b/src/OpenTelemetry.Api/Internal/OpenTelemetryApiEventSource.cs
@@ -39,7 +39,7 @@ namespace OpenTelemetry.Internal
         }
 
         [NonEvent]
-        public void TraceStateExtractException(Exception ex)
+        public void TracestateExtractException(Exception ex)
         {
             if (this.IsEnabled(EventLevel.Warning, (EventKeywords)(-1)))
             {
@@ -48,7 +48,7 @@ namespace OpenTelemetry.Internal
         }
 
         [NonEvent]
-        public void TraceStateKeyIsInvalid(ReadOnlySpan<char> key)
+        public void TracestateKeyIsInvalid(ReadOnlySpan<char> key)
         {
             if (this.IsEnabled(EventLevel.Warning, (EventKeywords)(-1)))
             {
@@ -57,7 +57,7 @@ namespace OpenTelemetry.Internal
         }
 
         [NonEvent]
-        public void TraceStateValueIsInvalid(ReadOnlySpan<char> value)
+        public void TracestateValueIsInvalid(ReadOnlySpan<char> value)
         {
             if (this.IsEnabled(EventLevel.Warning, (EventKeywords)(-1)))
             {

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerExporterEventSource.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Diagnostics.Tracing;
+using System.Globalization;
+using System.Threading;
+
+namespace OpenTelemetry.Exporter.Jaeger.Implementation
+{
+    /// <summary>
+    /// EventSource events emitted from the project.
+    /// </summary>
+    [EventSource(Name = "OpenTelemetry-Instrumentation")]
+    internal class JaegerExporterEventSource : EventSource
+    {
+        public static JaegerExporterEventSource Log = new JaegerExporterEventSource();
+
+        [NonEvent]
+        public void ExceptionOnSend(Exception ex)
+        {
+            if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
+            {
+                this.FailedSend(ToInvariantString(ex));
+            }
+        }
+
+        [Event(1, Message = "Failed spans send: '{0}'", Level = EventLevel.Error)]
+        public void FailedSend(string exception)
+        {
+            this.WriteEvent(1, exception);
+        }
+
+        /// <summary>
+        /// Returns a culture-independent string representation of the given <paramref name="exception"/> object,
+        /// appropriate for diagnostics tracing.
+        /// </summary>
+        private static string ToInvariantString(Exception exception)
+        {
+            var originalUICulture = Thread.CurrentThread.CurrentUICulture;
+
+            try
+            {
+                Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+                return exception.ToString();
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentUICulture = originalUICulture;
+            }
+        }
+    }
+}

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerExporterEventSource.cs
@@ -30,16 +30,31 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
         public static JaegerExporterEventSource Log = new JaegerExporterEventSource();
 
         [NonEvent]
-        public void FailedToSend(Exception ex)
+        public void FailedFlush(Exception ex)
         {
             if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
             {
-                this.FailedToSend(ToInvariantString(ex));
+                this.FailedFlush(ToInvariantString(ex));
+            }
+        }
+
+        [NonEvent]
+        public void UnexpectedError(Exception ex)
+        {
+            if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
+            {
+                this.UnexpectedError(ToInvariantString(ex));
             }
         }
 
         [Event(1, Message = "Failed to send spans: '{0}'", Level = EventLevel.Error)]
-        public void FailedToSend(string exception)
+        public void FailedFlush(string exception)
+        {
+            this.WriteEvent(1, exception);
+        }
+
+        [Event(2, Message = "Error: '{0}'", Level = EventLevel.Error)]
+        public void UnexpectedError(string exception)
         {
             this.WriteEvent(1, exception);
         }

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerExporterEventSource.cs
@@ -8,22 +8,22 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
     /// <summary>
     /// EventSource events emitted from the project.
     /// </summary>
-    [EventSource(Name = "OpenTelemetry-Instrumentation")]
+    [EventSource(Name = "OpenTelemetry-Exporter-Jaeger")]
     internal class JaegerExporterEventSource : EventSource
     {
         public static JaegerExporterEventSource Log = new JaegerExporterEventSource();
 
         [NonEvent]
-        public void ExceptionOnSend(Exception ex)
+        public void FailedToSend(Exception ex)
         {
             if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
             {
-                this.FailedSend(ToInvariantString(ex));
+                this.FailedToSend(ToInvariantString(ex));
             }
         }
 
-        [Event(1, Message = "Failed spans send: '{0}'", Level = EventLevel.Error)]
-        public void FailedSend(string exception)
+        [Event(1, Message = "Failed to send spans: '{0}'", Level = EventLevel.Error)]
+        public void FailedToSend(string exception)
         {
             this.WriteEvent(1, exception);
         }

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerExporterEventSource.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿// <copyright file="JaegerExporterEventSource.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
 using System.Diagnostics.Tracing;
 using System.Globalization;
 using System.Threading;

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpBatcher.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpBatcher.cs
@@ -79,7 +79,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
                 }
                 catch (Exception ex)
                 {
-                    JaegerExporterEventSource.Log.FailedToSend(ex);
+                    JaegerExporterEventSource.Log.UnexpectedError(ex);
                 }
             };
         }
@@ -247,6 +247,10 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
                 }
 
                 return n;
+            }
+            catch (Exception ex)
+            {
+                JaegerExporterEventSource.Log.FailedFlush(ex);
             }
             finally
             {

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpBatcher.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpBatcher.cs
@@ -251,6 +251,8 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
             catch (Exception ex)
             {
                 JaegerExporterEventSource.Log.FailedFlush(ex);
+
+                return 0;
             }
             finally
             {

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpBatcher.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpBatcher.cs
@@ -80,7 +80,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
                 }
                 catch (Exception ex)
                 {
-                    JaegerExporterEventSource.Log.ExceptionOnSend(ex);
+                    JaegerExporterEventSource.Log.FailedToSend(ex);
                 }
             };
         }

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpBatcher.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpBatcher.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using OpenTelemetry.Instrumentation;
 using OpenTelemetry.Trace.Export;
 using Thrift.Protocol;
 using Thrift.Transport;
@@ -73,7 +74,14 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
 
             this.maxFlushIntervalTimer.Elapsed += async (sender, args) =>
             {
-                await this.FlushAsyncInternal(false, CancellationToken.None).ConfigureAwait(false);
+                try
+                {
+                    await this.FlushAsyncInternal(false, CancellationToken.None).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    JaegerExporterEventSource.Log.ExceptionOnSend(ex);
+                }
             };
         }
 

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpBatcher.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpBatcher.cs
@@ -18,7 +18,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using OpenTelemetry.Instrumentation;
 using OpenTelemetry.Trace.Export;
 using Thrift.Protocol;
 using Thrift.Transport;


### PR DESCRIPTION
Fixes #695 .

## Changes
In JaegerUdpBatcher on flush timer tick exceptions in async void method cause application crash due to unhandled exception.
Add JaegerExporterEventSource and log handled exceptions on flush try from timer tick.

### Checklist
- [x] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public API reviewed

The PR will automatically request reviews from [code owners](https://github.com/open-telemetry/opentelemetry-dotnet/blob/master/CODEOWNERS#L15) and trigger CI build and tests.