### PR TITLE
Remove SpanID from sampling parameters

### DIFF
--- a/src/OpenTelemetry/Trace/Sampler.cs
+++ b/src/OpenTelemetry/Trace/Sampler.cs
@@ -33,16 +33,21 @@ namespace OpenTelemetry.Trace
         /// </summary>
         /// <param name="parentContext">Parent span context. Typically taken from the wire.</param>
         /// <param name="traceId">Trace ID of a span to be created.</param>
-        /// <param name="spanId">Span ID of a span to be created.</param>
         /// <param name="name"> Name of a span to be created. Note, that the name of the span is settable.
-        /// So this name can be changed later and Sampler implementation should assume that.
-        /// Typical example of a name change is when <see cref="TelemetrySpan"/> representing incoming http request
-        /// has a name of url path and then being updated with route name when routing complete.
+        ///     So this name can be changed later and Sampler implementation should assume that.
+        ///     Typical example of a name change is when <see cref="TelemetrySpan"/> representing incoming http request
+        ///     has a name of url path and then being updated with route name when routing complete.
         /// </param>
         /// <param name="spanKind">The type of the Span.</param>
         /// <param name="attributes">Initial set of Attributes for the Span being constructed.</param>
         /// <param name="links">Links associated with the span.</param>
         /// <returns>Sampling decision on whether Span needs to be sampled or not.</returns>
-        public abstract SamplingResult ShouldSample(in SpanContext parentContext, in ActivityTraceId traceId, in ActivitySpanId spanId, string name, SpanKind spanKind, IEnumerable<KeyValuePair<string, object>> attributes, IEnumerable<Link> links);
+        public abstract SamplingResult ShouldSample(
+            in SpanContext parentContext,
+            in ActivityTraceId traceId,
+            string name,
+            SpanKind spanKind,
+            IEnumerable<KeyValuePair<string, object>> attributes,
+            IEnumerable<Link> links);
     }
 }

--- a/src/OpenTelemetry/Trace/Samplers/AlwaysOffSampler.cs
+++ b/src/OpenTelemetry/Trace/Samplers/AlwaysOffSampler.cs
@@ -27,7 +27,13 @@ namespace OpenTelemetry.Trace.Samplers
         public override string Description { get; } = nameof(AlwaysOffSampler);
 
         /// <inheritdoc />
-        public override SamplingResult ShouldSample(in SpanContext parentContext, in ActivityTraceId traceId, in ActivitySpanId spanId, string name, SpanKind spanKind, IEnumerable<KeyValuePair<string, object>> attributes, IEnumerable<Link> links)
+        public override SamplingResult ShouldSample(
+            in SpanContext parentContext,
+            in ActivityTraceId traceId,
+            string name,
+            SpanKind spanKind,
+            IEnumerable<KeyValuePair<string, object>> attributes,
+            IEnumerable<Link> links)
         {
             return new SamplingResult(false);
         }

--- a/src/OpenTelemetry/Trace/Samplers/AlwaysOnSampler.cs
+++ b/src/OpenTelemetry/Trace/Samplers/AlwaysOnSampler.cs
@@ -28,7 +28,13 @@ namespace OpenTelemetry.Trace.Samplers
         public override string Description { get; } = nameof(AlwaysOnSampler);
 
         /// <inheritdoc />
-        public override SamplingResult ShouldSample(in SpanContext parentContext, in ActivityTraceId traceId, in ActivitySpanId spanId, string name, SpanKind spanKind, IEnumerable<KeyValuePair<string, object>> attributes, IEnumerable<Link> parentLinks)
+        public override SamplingResult ShouldSample(
+            in SpanContext parentContext,
+            in ActivityTraceId traceId,
+            string name,
+            SpanKind spanKind,
+            IEnumerable<KeyValuePair<string, object>> attributes,
+            IEnumerable<Link> parentLinks)
         {
             return new SamplingResult(true);
         }

--- a/src/OpenTelemetry/Trace/Samplers/AlwaysParentSampler.cs
+++ b/src/OpenTelemetry/Trace/Samplers/AlwaysParentSampler.cs
@@ -28,7 +28,13 @@ namespace OpenTelemetry.Trace.Samplers
         public override string Description { get; } = nameof(AlwaysParentSampler);
 
         /// <inheritdoc />
-        public override SamplingResult ShouldSample(in SpanContext parentContext, in ActivityTraceId traceId, in ActivitySpanId spanId, string name, SpanKind spanKind, IEnumerable<KeyValuePair<string, object>> attributes, IEnumerable<Link> parentLinks)
+        public override SamplingResult ShouldSample(
+            in SpanContext parentContext,
+            in ActivityTraceId traceId,
+            string name,
+            SpanKind spanKind,
+            IEnumerable<KeyValuePair<string, object>> attributes,
+            IEnumerable<Link> parentLinks)
         {
             if (parentContext.IsValid && parentContext.TraceFlags.HasFlag(ActivityTraceFlags.Recorded))
             {

--- a/src/OpenTelemetry/Trace/Samplers/ProbabilitySampler.cs
+++ b/src/OpenTelemetry/Trace/Samplers/ProbabilitySampler.cs
@@ -71,7 +71,13 @@ namespace OpenTelemetry.Trace.Samplers
         public override string Description { get; }
 
         /// <inheritdoc />
-        public override SamplingResult ShouldSample(in SpanContext parentContext, in ActivityTraceId traceId, in ActivitySpanId spanId, string name, SpanKind spanKind, IEnumerable<KeyValuePair<string, object>> attributes, IEnumerable<Link> links)
+        public override SamplingResult ShouldSample(
+            in SpanContext parentContext,
+            in ActivityTraceId traceId,
+            string name,
+            SpanKind spanKind,
+            IEnumerable<KeyValuePair<string, object>> attributes,
+            IEnumerable<Link> links)
         {
             // If the parent is sampled keep the sampling decision.
             if (parentContext.IsValid &&

--- a/src/OpenTelemetry/Trace/SpanSdk.cs
+++ b/src/OpenTelemetry/Trace/SpanSdk.cs
@@ -680,7 +680,7 @@ namespace OpenTelemetry.Trace
             ActivitySpanId spanId,
             Sampler sampler)
         {
-            return sampler.ShouldSample(parent, traceId, spanId, name, spanKind, attributes, parentLinks).IsSampled;
+            return sampler.ShouldSample(parent, traceId, name, spanKind, attributes, parentLinks).IsSampled;
         }
 
         private static ActivityAndTracestate FromCurrentParentActivity(string spanName, Activity current)

--- a/src/OpenTelemetry/Trace/SpanSdk.cs
+++ b/src/OpenTelemetry/Trace/SpanSdk.cs
@@ -164,7 +164,6 @@ namespace OpenTelemetry.Trace
                 spanCreationOptions?.Attributes,
                 links, // we'll enumerate again, but double enumeration over small collection is cheaper than allocation
                 this.Activity.TraceId,
-                this.Activity.SpanId,
                 this.sampler);
 
             this.Activity.ActivityTraceFlags =
@@ -677,7 +676,6 @@ namespace OpenTelemetry.Trace
             IEnumerable<KeyValuePair<string, object>> attributes,
             IEnumerable<Link> parentLinks,
             ActivityTraceId traceId,
-            ActivitySpanId spanId,
             Sampler sampler)
         {
             return sampler.ShouldSample(parent, traceId, name, spanKind, attributes, parentLinks).IsSampled;

--- a/test/OpenTelemetry.Tests/Implementation/Trace/Samplers/SamplersTest.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Trace/Samplers/SamplersTest.cs
@@ -26,7 +26,6 @@ namespace OpenTelemetry.Trace.Samplers.Test
         private const int NUM_SAMPLE_TRIES = 1000;
         private static readonly SpanKind SpanKindServer = SpanKind.Server;
         private readonly ActivityTraceId traceId;
-        private readonly ActivitySpanId spanId;
         private readonly SpanContext sampledSpanContext;
         private readonly SpanContext notSampledSpanContext;
         private readonly Link sampledLink;
@@ -34,7 +33,6 @@ namespace OpenTelemetry.Trace.Samplers.Test
         public SamplersTest()
         {
             traceId = ActivityTraceId.CreateRandom();
-            spanId = ActivitySpanId.CreateRandom();
             var parentSpanId = ActivitySpanId.CreateRandom();
             sampledSpanContext = new SpanContext(traceId, parentSpanId, ActivityTraceFlags.Recorded);
             notSampledSpanContext = new SpanContext(traceId, parentSpanId, ActivityTraceFlags.None);
@@ -50,7 +48,6 @@ namespace OpenTelemetry.Trace.Samplers.Test
                         .ShouldSample(
                             sampledSpanContext,
                             traceId,
-                            spanId,
                             "Another name",
                             SpanKindServer,
                             null,
@@ -62,7 +59,6 @@ namespace OpenTelemetry.Trace.Samplers.Test
                         .ShouldSample(
                             notSampledSpanContext,
                             traceId,
-                            spanId,
                             "Yet another name",
                             SpanKindServer,
                             null,
@@ -85,7 +81,6 @@ namespace OpenTelemetry.Trace.Samplers.Test
                         .ShouldSample(
                             sampledSpanContext,
                             traceId,
-                            spanId,
                             "bar",
                             SpanKindServer,
                             null,
@@ -96,7 +91,6 @@ namespace OpenTelemetry.Trace.Samplers.Test
                         .ShouldSample(
                             notSampledSpanContext,
                             traceId,
-                            spanId,
                             "quux",
                             SpanKindServer,
                             null,
@@ -212,7 +206,6 @@ namespace OpenTelemetry.Trace.Samplers.Test
                     defaultProbability.ShouldSample(
                         default,
                         notSampledtraceId,
-                        ActivitySpanId.CreateRandom(),
                         SpanName,
                         SpanKindServer,
                         null,
@@ -244,7 +237,6 @@ namespace OpenTelemetry.Trace.Samplers.Test
                     defaultProbability.ShouldSample(
                         default,
                         sampledtraceId,
-                        ActivitySpanId.CreateRandom(),
                         SpanName,
                         SpanKindServer,
                         null,
@@ -268,7 +260,6 @@ namespace OpenTelemetry.Trace.Samplers.Test
                 if (sampler.ShouldSample(
                     parent,
                     ActivityTraceId.CreateRandom(),
-                    ActivitySpanId.CreateRandom(),
                     SpanName,
                     SpanKindServer,
                     null,

--- a/test/OpenTelemetry.Tests/Implementation/Trace/SpanTest.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Trace/SpanTest.cs
@@ -1607,7 +1607,6 @@ namespace OpenTelemetry.Trace.Test
             samplerMock.Setup(s => s.ShouldSample(
                 in It.Ref<SpanContext>.IsAny,
                 in It.Ref<ActivityTraceId>.IsAny,
-                in It.Ref<ActivitySpanId>.IsAny,
                 It.IsAny<string>(),
                 It.IsAny<SpanKind>(),
                 It.IsAny<IDictionary<string, object>>(),
@@ -1619,7 +1618,6 @@ namespace OpenTelemetry.Trace.Test
             samplerMock.Verify(o => o.ShouldSample(
                 in It.Ref<SpanContext>.IsAny,
                 in It.Ref<ActivityTraceId>.IsAny,
-                in It.Ref<ActivitySpanId>.IsAny,
                 It.IsAny<string>(),
                 It.IsAny<SpanKind>(),
                 It.Is<IDictionary<string, object>>(a => a == this.attributes),
@@ -1638,7 +1636,6 @@ namespace OpenTelemetry.Trace.Test
             samplerMock.Setup(s => s.ShouldSample(
                 in It.Ref<SpanContext>.IsAny,
                 in It.Ref<ActivityTraceId>.IsAny,
-                in It.Ref<ActivitySpanId>.IsAny,
                 It.IsAny<string>(),
                 It.IsAny<SpanKind>(),
                 It.IsAny<IDictionary<string, object>>(),
@@ -1650,7 +1647,6 @@ namespace OpenTelemetry.Trace.Test
             samplerMock.Verify(o => o.ShouldSample(
                 in It.Ref<SpanContext>.IsAny,
                 in It.Ref<ActivityTraceId>.IsAny,
-                in It.Ref<ActivitySpanId>.IsAny,
                 It.IsAny<string>(),
                 It.IsAny<SpanKind>(),
                 It.Is<IDictionary<string, object>>(a => a == this.attributes),


### PR DESCRIPTION
Update code per latest spec, see:
https://github.com/open-telemetry/opentelemetry-specification/pull/621

The goal is to avoid any SDK implementation from taking a dependency on it. We are already removing it for `Activity` and even have a `ActivitySamplingParameters` but that optimization can come later when we decide about the OTel API wrapper around `Activity`.

### Checklist
- [X] I ran Unit Tests locally.
