### PR TITLE
[Tiny]: Treat warnings as errors for test projects

### DIFF
--- a/build/Common.test.props
+++ b/build/Common.test.props
@@ -4,6 +4,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)/debug.snk</AssemblyOriginatorKeyFile>
     <DefineConstants>$(DefineConstants);SIGNED</DefineConstants>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterTests.cs
@@ -121,12 +121,12 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
 
             var labels1 = new List<KeyValuePair<string, string>>
             {
-                new KeyValuePair<string, string>("dim1", "value1"), new KeyValuePair<string, string>("dim2", "value1")
+                new KeyValuePair<string, string>("dim1", "value1"), new KeyValuePair<string, string>("dim2", "value1"),
             };
 
             var labels2 = new List<KeyValuePair<string, string>>
             {
-                new KeyValuePair<string, string>("dim1", "value2"), new KeyValuePair<string, string>("dim2", "value2")
+                new KeyValuePair<string, string>("dim1", "value2"), new KeyValuePair<string, string>("dim2", "value2"),
             };
 
             var defaultContext = default(SpanContext);


### PR DESCRIPTION
## Changes
Treat warnings as errors for test projects. Per conversation on [gitter](https://gitter.im/open-telemetry/opentelemetry-dotnet?at=5ed6bec49da05a060a496e02) test projects should also fail on warnings. 

### Checklist
- [X] I ran Unit Tests locally.

