### PR TITLE
Make the SDK compile on .NET Framework 4.5.2

### DIFF
--- a/src/OpenTelemetry/Context/AsyncLocalDistributedContextCarrier.cs
+++ b/src/OpenTelemetry/Context/AsyncLocalDistributedContextCarrier.cs
@@ -32,6 +32,16 @@ namespace OpenTelemetry.Context
     {
 #if NET452
         // A special workaround to suppress context propagation cross AppDomains.
+        //
+        // By default the value added to System.Runtime.Remoting.Messaging.CallContext
+        // will be marshalled/unmarshalled across AppDomain boundary. This will cause
+        // serious issue if the destination AppDomain doesn't have the corresponding type
+        // to unmarshal data (which is DistributedContext in this case).
+        // The worst case is AppDomain crash with ReflectionLoadTypeException.
+        //
+        // The workaround is to use a well known type that exists in all AppDomains, and
+        // put the actual payload (DistributedContext instance) as a non-public field so
+        // the field is ignored during marshalling.
         private const string ContextSlotName = "OpenTelemetry.DistributedContext";
         private static readonly FieldInfo WrapperField = typeof(BitArray).GetField("_syncRoot", BindingFlags.Instance | BindingFlags.NonPublic);
 #else

--- a/src/OpenTelemetry/Context/AsyncLocalDistributedContextCarrier.cs
+++ b/src/OpenTelemetry/Context/AsyncLocalDistributedContextCarrier.cs
@@ -15,6 +15,11 @@
 // </copyright>
 
 using System;
+#if NET452
+using System.Collections;
+using System.Reflection;
+using System.Runtime.Remoting.Messaging;
+#endif
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -25,7 +30,13 @@ namespace OpenTelemetry.Context
     /// </summary>
     public sealed class AsyncLocalDistributedContextCarrier : DistributedContextCarrier
     {
+#if NET452
+        // A special workaround to suppress context propagation cross AppDomains.
+        private const string ContextSlotName = "OpenTelemetry.DistributedContext";
+        private static readonly FieldInfo WrapperField = typeof(BitArray).GetField("_syncRoot", BindingFlags.Instance | BindingFlags.NonPublic);
+#else
         private static AsyncLocal<DistributedContext> carrier = new AsyncLocal<DistributedContext>();
+#endif
 
         private AsyncLocalDistributedContextCarrier()
         {
@@ -40,7 +51,26 @@ namespace OpenTelemetry.Context
         /// <summary>
         /// Gets the current <see cref="DistributedContext"/>.
         /// </summary>
-        public override DistributedContext Current => carrier.Value;
+        public override DistributedContext Current
+        {
+            get
+            {
+#if NET452
+                var wrapper = CallContext.LogicalGetData(ContextSlotName) as BitArray;
+
+                if (wrapper == null)
+                {
+                    var context = default(DistributedContext);
+                    this.OverwriteCurrent(context);
+                    return context;
+                }
+
+                return (DistributedContext)WrapperField.GetValue(wrapper);
+#else
+                return carrier.Value;
+#endif
+            }
+        }
 
         /// <summary>
         /// Sets the current <see cref="DistributedContext"/>.
@@ -49,6 +79,15 @@ namespace OpenTelemetry.Context
         /// <returns>Scope object. On disposal - original context will be restored.</returns>
         public override IDisposable SetCurrent(in DistributedContext context) => new DistributedContextState(in context);
 
-        internal void OverwriteCurrent(in DistributedContext context) => carrier.Value = context;
+        internal void OverwriteCurrent(in DistributedContext context)
+        {
+#if NET452
+            var wrapper = new BitArray(0);
+            WrapperField.SetValue(wrapper, context);
+            CallContext.LogicalSetData(ContextSlotName, wrapper);
+#else
+            carrier.Value = context;
+#endif
+        }
     }
 }

--- a/src/OpenTelemetry/Instrumentation/InstrumentationEventSource.cs
+++ b/src/OpenTelemetry/Instrumentation/InstrumentationEventSource.cs
@@ -32,7 +32,7 @@ namespace OpenTelemetry.Instrumentation
         [NonEvent]
         public void ExceptionInCustomSampler(Exception ex)
         {
-            if (this.IsEnabled(EventLevel.Warning, EventKeywords.All))
+            if (this.IsEnabled(EventLevel.Warning, (EventKeywords)(-1)))
             {
                 this.ExceptionInCustomSampler(ToInvariantString(ex));
             }
@@ -59,7 +59,7 @@ namespace OpenTelemetry.Instrumentation
         [NonEvent]
         public void UnknownErrorProcessingEvent(string handlerName, string eventName, Exception ex)
         {
-            if (!this.IsEnabled(EventLevel.Error, EventKeywords.All))
+            if (!this.IsEnabled(EventLevel.Error, (EventKeywords)(-1)))
             {
                 return;
             }
@@ -88,7 +88,7 @@ namespace OpenTelemetry.Instrumentation
         [NonEvent]
         public void ExceptionInitializingInstrumentation(string instrumentationType, Exception ex)
         {
-            if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
+            if (this.IsEnabled(EventLevel.Error, (EventKeywords)(-1)))
             {
                 this.ExceptionInitializingInstrumentation(instrumentationType, ToInvariantString(ex));
             }

--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -34,7 +34,7 @@ namespace OpenTelemetry.Internal
         [NonEvent]
         public void SpanProcessorException(string evnt, Exception ex)
         {
-            if (this.IsEnabled(EventLevel.Warning, EventKeywords.All))
+            if (this.IsEnabled(EventLevel.Warning, (EventKeywords)(-1)))
             {
                 this.SpanProcessorException(evnt, ToInvariantString(ex));
             }
@@ -43,7 +43,7 @@ namespace OpenTelemetry.Internal
         [NonEvent]
         public void ContextExtractException(Exception ex)
         {
-            if (this.IsEnabled(EventLevel.Warning, EventKeywords.All))
+            if (this.IsEnabled(EventLevel.Warning, (EventKeywords)(-1)))
             {
                 this.FailedToExtractContext(ToInvariantString(ex));
             }

--- a/src/OpenTelemetry/OpenTelemetry.csproj
+++ b/src/OpenTelemetry/OpenTelemetry.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;net46;netstandard2.0</TargetFrameworks>
     <Description>OpenTelemetry .NET SDK.</Description>
   </PropertyGroup>
 

--- a/src/OpenTelemetry/Trace/Export/Internal/NoopActivityProcessor.cs
+++ b/src/OpenTelemetry/Trace/Export/Internal/NoopActivityProcessor.cs
@@ -32,7 +32,11 @@ namespace OpenTelemetry.Trace.Export
 
         public override Task ShutdownAsync(CancellationToken cancellationToken)
         {
+#if NET452
+            return Task.FromResult(0);
+#else
             return Task.CompletedTask;
+#endif
         }
     }
 }

--- a/src/OpenTelemetry/Trace/Export/Internal/NoopSpanProcessor.cs
+++ b/src/OpenTelemetry/Trace/Export/Internal/NoopSpanProcessor.cs
@@ -31,7 +31,11 @@ namespace OpenTelemetry.Trace.Export
 
         public override Task ShutdownAsync(CancellationToken cancellationToken)
         {
+#if NET452
+            return Task.FromResult(0);
+#else
             return Task.CompletedTask;
+#endif
         }
     }
 }

--- a/src/OpenTelemetry/Trace/Export/SimpleActivityProcessor.cs
+++ b/src/OpenTelemetry/Trace/Export/SimpleActivityProcessor.cs
@@ -68,7 +68,11 @@ namespace OpenTelemetry.Trace.Export
                 return this.exporter.ShutdownAsync(cancellationToken);
             }
 
+#if NET452
+            return Task.FromResult(0);
+#else
             return Task.CompletedTask;
+#endif
         }
 
         public void Dispose()

--- a/src/OpenTelemetry/Trace/Export/SimpleSpanProcessor.cs
+++ b/src/OpenTelemetry/Trace/Export/SimpleSpanProcessor.cs
@@ -68,7 +68,11 @@ namespace OpenTelemetry.Trace.Export
                 return this.exporter.ShutdownAsync(cancellationToken);
             }
 
+#if NET452
+            return Task.FromResult(0);
+#else
             return Task.CompletedTask;
+#endif
         }
 
         public void Dispose()


### PR DESCRIPTION
The first step to address #716.
After this, will need to address the unit tests and other packages (e.g. exporters, integrations).