### PR TITLE
Enable NET452 for OpenTelemetry.Tests

### DIFF
--- a/test/OpenTelemetry.Tests/Implementation/Testing/Export/TestExporter.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Testing/Export/TestExporter.cs
@@ -51,7 +51,11 @@ namespace OpenTelemetry.Testing.Export
         public override Task ShutdownAsync(CancellationToken cancellationToken)
         {
             this.WasShutDown = true;
+#if NET452
+            return Task.FromResult(0);
+#else
             return Task.CompletedTask;
+#endif
         }
     }
 }

--- a/test/OpenTelemetry.Tests/Implementation/Trace/Config/BroadcastProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Trace/Config/BroadcastProcessorTests.cs
@@ -185,7 +185,11 @@ namespace OpenTelemetry.Tests.Impl.Trace.Config
             public override Task ShutdownAsync(CancellationToken cancellationToken)
             {
                 this.ShutdownCalled = true;
+#if NET452
+                return Task.FromResult(0);
+#else
                 return Task.CompletedTask;
+#endif
             }
 
             public void Dispose()

--- a/test/OpenTelemetry.Tests/Implementation/Trace/Config/SpanProcessorPipelineTests.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Trace/Config/SpanProcessorPipelineTests.cs
@@ -247,7 +247,11 @@ namespace OpenTelemetry.Tests.Impl.Trace.Config
 
             public override Task ShutdownAsync(CancellationToken cancellationToken)
             {
+#if NET452
+                return Task.FromResult(0);
+#else
                 return Task.CompletedTask;
+#endif
             }
         }
     }

--- a/test/OpenTelemetry.Tests/Implementation/Trace/Config/TracerFactoryTest.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Trace/Config/TracerFactoryTest.cs
@@ -275,7 +275,11 @@ namespace OpenTelemetry.Trace.Test
 
             public override Task ShutdownAsync(CancellationToken cancellationToken)
             {
+#if NET452
+                return Task.FromResult(0);
+#else
                 return Task.CompletedTask;
+#endif
             }
         }
 

--- a/test/OpenTelemetry.Tests/OpenTelemetry.Tests.csproj
+++ b/test/OpenTelemetry.Tests/OpenTelemetry.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Unit test project for OpenTelemetry</Description>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net46</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net46;net452</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Refs #716

## Changes
- Add .NET 452 for OpenTelemetry.Tests

### Checklist
- [X] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public API reviewed

The PR will automatically request reviews from [code owners](https://github.com/open-telemetry/opentelemetry-dotnet/blob/master/CODEOWNERS#L15) and trigger CI build and tests.