### PR TITLE
Adds HostingProject extension method to support new Activity based api.

### DIFF
--- a/samples/Exporters/AspNet/Controllers/WeatherForecastController.cs
+++ b/samples/Exporters/AspNet/Controllers/WeatherForecastController.cs
@@ -43,7 +43,9 @@ namespace OpenTelemetry.Exporter.AspNet.Controllers
                 throw new ArgumentException();
             }
 
-            // Build some dependency spans.
+            // Making http calls here to serve as an example of
+            // how dependency calls will be captured and treated
+            // automatically as child of incoming request.
 
             RequestGoogleHomPageViaHttpWebRequestLegacySync();
 

--- a/samples/Exporters/AspNet/Global.asax.cs
+++ b/samples/Exporters/AspNet/Global.asax.cs
@@ -10,12 +10,11 @@ namespace OpenTelemetry.Exporter.AspNet
 {
     public class WebApiApplication : HttpApplication
     {
-        private TracerFactory tracerFactory;
         private IDisposable openTelemetry;
 
         protected void Application_Start()
         {
-            this.openTelemetry = OpenTelemetrySdk.Default.EnableOpenTelemetry(
+            this.openTelemetry = OpenTelemetrySdk.EnableOpenTelemetry(
                 (builder) => builder.AddDependencyInstrumentation()
                 .AddRequestInstrumentation()
                 .UseJaegerActivityExporter(c =>
@@ -32,7 +31,6 @@ namespace OpenTelemetry.Exporter.AspNet
 
         protected void Application_End()
         {
-            this.tracerFactory?.Dispose();
             this.openTelemetry?.Dispose();
         }
     }

--- a/samples/Exporters/Console/TestConsoleActivity.cs
+++ b/samples/Exporters/Console/TestConsoleActivity.cs
@@ -27,7 +27,7 @@ namespace Samples
         {
             // Enable OpenTelemetry for the source "MyCompany.MyProduct.MyWebServer"
             // and use Console exporter
-            OpenTelemetrySdk.Default.EnableOpenTelemetry(
+            OpenTelemetrySdk.EnableOpenTelemetry(
                 (builder) => builder.AddActivitySource("MyCompany.MyProduct.MyWebServer")
                 .UseConsoleActivityExporter(opt => opt.DisplayAsJson = options.DisplayAsJson));
 

--- a/samples/Exporters/Console/TestConsoleActivity.cs
+++ b/samples/Exporters/Console/TestConsoleActivity.cs
@@ -27,7 +27,7 @@ namespace Samples
         {
             // Enable OpenTelemetry for the source "MyCompany.MyProduct.MyWebServer"
             // and use Console exporter
-            OpenTelemetrySdk.EnableOpenTelemetry(
+            using var openTelemetry = OpenTelemetrySdk.EnableOpenTelemetry(
                 (builder) => builder.AddActivitySource("MyCompany.MyProduct.MyWebServer")
                 .UseConsoleActivityExporter(opt => opt.DisplayAsJson = options.DisplayAsJson));
 

--- a/samples/Exporters/Console/TestHttpClient.cs
+++ b/samples/Exporters/Console/TestHttpClient.cs
@@ -27,7 +27,7 @@ namespace Samples
         {
             Console.WriteLine("Hello World!");
 
-            OpenTelemetrySdk.Default.EnableOpenTelemetry(
+            using var openTelemetry = OpenTelemetrySdk.EnableOpenTelemetry(
                 (builder) => builder.AddHttpClientDependencyInstrumentation()
                 .AddActivitySource("http-client-test")
                 .UseConsoleActivityExporter(opt => opt.DisplayAsJson = false));

--- a/samples/Exporters/Console/TestJaeger.cs
+++ b/samples/Exporters/Console/TestJaeger.cs
@@ -37,7 +37,7 @@ namespace Samples
         {
             // Enable OpenTelemetry for the sources "Samples.SampleServer" and "Samples.SampleClient"
             // and use the Jaeger exporter.
-            OpenTelemetrySdk.Default.EnableOpenTelemetry(
+            using var openTelemetry = OpenTelemetrySdk.EnableOpenTelemetry(
                 builder => builder
                     .AddActivitySource("Samples.SampleServer")
                     .AddActivitySource("Samples.SampleClient")

--- a/samples/Exporters/Console/TestOtlp.cs
+++ b/samples/Exporters/Console/TestOtlp.cs
@@ -62,7 +62,7 @@ namespace Samples
         {
             // Enable OpenTelemetry for the sources "Samples.SampleServer" and "Samples.SampleClient"
             // and use OTLP exporter.
-            OpenTelemetrySdk.Default.EnableOpenTelemetry(
+            using var openTelemetry = OpenTelemetrySdk.EnableOpenTelemetry(
                 builder => builder
                     .AddActivitySource("Samples.SampleServer")
                     .AddActivitySource("Samples.SampleClient")

--- a/samples/Exporters/Web/Controllers/WeatherForecastController.cs
+++ b/samples/Exporters/Web/Controllers/WeatherForecastController.cs
@@ -21,6 +21,9 @@ namespace API.Controllers
         [HttpGet]
         public IEnumerable<WeatherForecast> Get()
         {
+            // Making an http call here to serve as an example of
+            // how dependency calls will be captured and treated
+            // automatically as child of incoming request.
             var res = httpClient.GetStringAsync("http://google.com").Result;
             var rng = new Random();
             return Enumerable.Range(1, 5).Select(index => new WeatherForecast

--- a/samples/Exporters/Web/Startup.cs
+++ b/samples/Exporters/Web/Startup.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
-using OpenTelemetry.Exporter.Console;
 using OpenTelemetry.Trace.Configuration;
 
 namespace API
@@ -37,15 +36,13 @@ namespace API
                 }
             });
 
-            OpenTelemetrySdk.Default.EnableOpenTelemetry(
-                (builder) => builder.AddRequestInstrumentation().AddDependencyInstrumentation()
+            services.AddOpenTelemetrySdk((builder) => builder.AddRequestInstrumentation().AddDependencyInstrumentation()
                 .UseJaegerActivityExporter(o =>
                 {
                     o.ServiceName = this.Configuration.GetValue<string>("Jaeger:ServiceName");
                     o.AgentHost = this.Configuration.GetValue<string>("Jaeger:Host");
                     o.AgentPort = this.Configuration.GetValue<int>("Jaeger:Port");
-                })
-                );
+                }));
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)

--- a/src/OpenTelemetry.Extensions.Hosting/Implementation/TelemetryHostedService.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Implementation/TelemetryHostedService.cs
@@ -36,7 +36,7 @@ namespace OpenTelemetry.Extensions.Hosting.Implementation
         {
             // Ensure the factory was created when the app starts.
             // This will create and start any configured instrumentations.
-            this.serviceProvider.GetService<OpenTelemetrySdk>();
+            this.serviceProvider.GetRequiredService<OpenTelemetrySdk>();
 
             return Task.CompletedTask;
         }

--- a/src/OpenTelemetry.Extensions.Hosting/Implementation/TelemetryHostedService.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Implementation/TelemetryHostedService.cs
@@ -1,0 +1,49 @@
+﻿// <copyright file="TelemetryHostedService.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Extensions.Hosting.Implementation
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
+    using OpenTelemetry.Trace.Configuration;
+
+    internal class TelemetryHostedService : IHostedService
+    {
+        private readonly IServiceProvider serviceProvider;
+
+        public TelemetryHostedService(IServiceProvider serviceProvider)
+        {
+            this.serviceProvider = serviceProvider;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            // Ensure the factory was created when the app starts.
+            // This will create and start any configured instrumentations.
+            this.serviceProvider.GetService<OpenTelemetrySdk>();
+
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/HostingIntergrationOpenTelemetrySdkTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/HostingIntergrationOpenTelemetrySdkTests.cs
@@ -1,0 +1,117 @@
+﻿// <copyright file="HostingIntergrationOpenTelemetrySdkTests.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using OpenTelemetry.Trace.Configuration;
+using Xunit;
+
+namespace OpenTelemetry.Extensions.Hosting
+{
+    public class HostingIntergrationOpenTelemetrySdkTests
+    {
+        [Fact]
+        public async Task AddOpenTelemetry_RegisterInstrumentation_InstrumentationCreatedAndDisposed()
+        {
+            var testInstrumentation = new TestInstrumentation();
+            var callbackRun = false;
+
+            var builder = new HostBuilder().ConfigureServices(services =>
+            {
+                services.AddOpenTelemetrySdk(builder =>
+                {
+                    builder.AddInstrumentation(() =>
+                    {
+                        callbackRun = true;
+                        return testInstrumentation;
+                    });
+                });
+            });
+
+            var host = builder.Build();
+
+            Assert.False(callbackRun);
+            Assert.False(testInstrumentation.Disposed);
+
+            await host.StartAsync();
+
+            Assert.True(callbackRun);
+            Assert.False(testInstrumentation.Disposed);
+
+            await host.StopAsync();
+
+            Assert.True(callbackRun);
+            Assert.False(testInstrumentation.Disposed);
+
+            host.Dispose();
+
+            Assert.True(callbackRun);
+            Assert.True(testInstrumentation.Disposed);
+        }
+
+        [Fact]
+        public void AddOpenTelemetry_HostBuilt_OpenTelemetrySdk_RegisteredAsSingleton()
+        {
+            var builder = new HostBuilder().ConfigureServices(services =>
+            {
+                services.AddOpenTelemetrySdk();
+            });
+
+            var host = builder.Build();
+
+            var tracerFactoryBase1 = host.Services.GetRequiredService<OpenTelemetrySdk>();
+            var tracerFactoryBase2 = host.Services.GetRequiredService<OpenTelemetrySdk>();
+
+            Assert.Same(tracerFactoryBase1, tracerFactoryBase2);
+        }
+
+        [Fact]
+        public void AddOpenTelemetry_ServiceProviderArgument_ServicesRegistered()
+        {
+            var testInstrumentation = new TestInstrumentation();
+
+            var services = new ServiceCollection();
+            services.AddSingleton(testInstrumentation);
+            services.AddOpenTelemetrySdk((provider, builder) =>
+            {
+                builder.AddInstrumentation<TestInstrumentation>(() => provider.GetRequiredService<TestInstrumentation>());
+            });
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var tracerFactory = serviceProvider.GetRequiredService<OpenTelemetrySdk>();
+            Assert.NotNull(tracerFactory);
+
+            Assert.False(testInstrumentation.Disposed);
+
+            serviceProvider.Dispose();
+
+            Assert.True(testInstrumentation.Disposed);
+        }
+
+        internal class TestInstrumentation : IDisposable
+        {
+            public bool Disposed { get; private set; }
+
+            public void Dispose()
+            {
+                this.Disposed = true;
+            }
+        }
+    }
+}

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests.Win/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests.Win/HttpInListenerTests.cs
@@ -121,7 +121,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
             try
             {
                 var activityProcessor = new Mock<ActivityProcessor>();
-                openTelemetry = OpenTelemetrySdk.Default.EnableOpenTelemetry(
+                openTelemetry = OpenTelemetrySdk.EnableOpenTelemetry(
                 (builder) => builder.AddRequestInstrumentation()
                 .SetProcessorPipeline(p => p.AddProcessor(_ => activityProcessor.Object)));
 

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
@@ -61,17 +61,9 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
 
             void ConfigureTestServices(IServiceCollection services)
             {
-                var openTelemetry = OpenTelemetrySdk.Default.EnableOpenTelemetry(
+                var openTelemetry = OpenTelemetrySdk.EnableOpenTelemetry(
                 (builder) => builder.AddRequestInstrumentation()
                 .SetProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object)));
-
-                /*
-                services.AddSingleton<TracerFactory>(_ =>
-                    TracerFactory.Create(b => b
-                        .SetSampler(new AlwaysOnSampler())
-                        .AddProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object))
-                        .AddRequestInstrumentation()));
-                */
             }
 
             // Arrange
@@ -109,7 +101,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
                 .WithWebHostBuilder(builder =>
                     builder.ConfigureTestServices(services =>
                     {
-                        OpenTelemetrySdk.Default.EnableOpenTelemetry(
+                        OpenTelemetrySdk.EnableOpenTelemetry(
                         (builder) => builder.AddRequestInstrumentation()
                         .SetProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object)));
 
@@ -164,7 +156,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
                 .WithWebHostBuilder(builder =>
                     builder.ConfigureTestServices(services =>
                     {
-                        OpenTelemetrySdk.Default.EnableOpenTelemetry(
+                        OpenTelemetrySdk.EnableOpenTelemetry(
                         (builder) => builder.AddRequestInstrumentation()
                         .SetProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object)));
 
@@ -200,7 +192,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
 
             void ConfigureTestServices(IServiceCollection services)
             {
-                var openTelemetry = OpenTelemetrySdk.Default.EnableOpenTelemetry(
+                var openTelemetry = OpenTelemetrySdk.EnableOpenTelemetry(
                 (builder) => builder.AddRequestInstrumentation()
                 .SetProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object)));
 

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
@@ -38,9 +38,10 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
 {
     // See https://github.com/aspnet/Docs/tree/master/aspnetcore/test/integration-tests/samples/2.x/IntegrationTestsSample
     public class BasicTests
-        : IClassFixture<WebApplicationFactory<Startup>>
+        : IClassFixture<WebApplicationFactory<Startup>>, IDisposable
     {
         private readonly WebApplicationFactory<Startup> factory;
+        private OpenTelemetrySdk openTelemetrySdk = null;
 
         public BasicTests(WebApplicationFactory<Startup> factory)
         {
@@ -58,11 +59,9 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
         public async Task SuccessfulTemplateControllerCallGeneratesASpan()
         {
             var spanProcessor = new Mock<ActivityProcessor>();
-
             void ConfigureTestServices(IServiceCollection services)
             {
-                var openTelemetry = OpenTelemetrySdk.EnableOpenTelemetry(
-                (builder) => builder.AddRequestInstrumentation()
+                this.openTelemetrySdk = OpenTelemetrySdk.EnableOpenTelemetry((builder) => builder.AddRequestInstrumentation()
                 .SetProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object)));
             }
 
@@ -101,15 +100,8 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
                 .WithWebHostBuilder(builder =>
                     builder.ConfigureTestServices(services =>
                     {
-                        OpenTelemetrySdk.EnableOpenTelemetry(
-                        (builder) => builder.AddRequestInstrumentation()
-                        .SetProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object)));
-
-                        /*
-                        services.AddSingleton<TracerFactory>(_ =>
-                            TracerFactory.Create(b => b
-                                .AddProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object))
-                                .AddRequestInstrumentation())); */
+                        this.openTelemetrySdk = OpenTelemetrySdk.EnableOpenTelemetry((builder) => builder.AddRequestInstrumentation()
+                .SetProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object)));
                     })))
             {
                 using var client = testFactory.CreateClient();
@@ -156,15 +148,8 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
                 .WithWebHostBuilder(builder =>
                     builder.ConfigureTestServices(services =>
                     {
-                        OpenTelemetrySdk.EnableOpenTelemetry(
-                        (builder) => builder.AddRequestInstrumentation()
-                        .SetProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object)));
-
-                        /*
-                        services.AddSingleton<TracerFactory>(_ =>
-                            TracerFactory.Create(b => b
-                                .AddProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object))
-                                .AddRequestInstrumentation(o => o.TextFormat = textFormat.Object)));*/
+                        this.openTelemetrySdk = OpenTelemetrySdk.EnableOpenTelemetry((builder) => builder.AddRequestInstrumentation()
+                .SetProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object)));
                     })))
             {
                 using var client = testFactory.CreateClient();
@@ -192,15 +177,8 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
 
             void ConfigureTestServices(IServiceCollection services)
             {
-                var openTelemetry = OpenTelemetrySdk.EnableOpenTelemetry(
-                (builder) => builder.AddRequestInstrumentation()
+                this.openTelemetrySdk = OpenTelemetrySdk.EnableOpenTelemetry((builder) => builder.AddRequestInstrumentation()
                 .SetProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object)));
-
-                /*services.AddSingleton<TracerFactory>(_ =>
-                    TracerFactory.Create(b => b
-                        .AddProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object))
-                        .AddRequestInstrumentation(o => o.RequestFilter = (httpContext) => httpContext.Request.Path != "/api/values/2")));
-                */
             }
 
             // Arrange
@@ -227,6 +205,11 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
 
             Assert.Equal(SpanKind.Server, span.Kind);
             Assert.Equal("/api/values", span.Attributes.GetValue("http.path"));
+        }
+
+        public void Dispose()
+        {
+            this.openTelemetrySdk?.Dispose();
         }
 
         private static void WaitForProcessorInvocations(Mock<ActivityProcessor> spanProcessor, int invocationCount)

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
@@ -52,17 +52,8 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
                     builder.ConfigureTestServices((IServiceCollection services) =>
                     {
                         services.AddSingleton<CallbackMiddleware.CallbackMiddlewareImpl>(new TestCallbackMiddlewareImpl());
-
-                        OpenTelemetrySdk.EnableOpenTelemetry(
-                        (builder) => builder.AddRequestInstrumentation()
+                        services.AddOpenTelemetrySdk((builder) => builder.AddRequestInstrumentation()
                         .SetProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object)));
-
-                        /*
-                        services.AddSingleton<TracerFactory>(_ =>
-                            TracerFactory.Create(b => b
-                                .AddProcessorPipeline(p => p.AddProcessor(e => spanProcessor.Object))
-                                .AddRequestInstrumentation()));
-                        */
                     }))
                 .CreateClient())
             {

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
@@ -53,7 +53,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
                     {
                         services.AddSingleton<CallbackMiddleware.CallbackMiddlewareImpl>(new TestCallbackMiddlewareImpl());
 
-                        OpenTelemetrySdk.Default.EnableOpenTelemetry(
+                        OpenTelemetrySdk.EnableOpenTelemetry(
                         (builder) => builder.AddRequestInstrumentation()
                         .SetProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object)));
 

--- a/test/OpenTelemetry.Instrumentation.Dependencies.Tests/HttpClientTests.Basic.netcore31.cs
+++ b/test/OpenTelemetry.Instrumentation.Dependencies.Tests/HttpClientTests.Basic.netcore31.cs
@@ -72,7 +72,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Tests
             parent.TraceStateString = "k1=v1,k2=v2";
             parent.ActivityTraceFlags = ActivityTraceFlags.Recorded;
 
-            using (OpenTelemetrySdk.Default.EnableOpenTelemetry(
+            using (OpenTelemetrySdk.EnableOpenTelemetry(
                         (builder) => builder.AddHttpClientDependencyInstrumentation()
                         .SetProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object))))
             {
@@ -122,7 +122,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Tests
             parent.TraceStateString = "k1=v1,k2=v2";
             parent.ActivityTraceFlags = ActivityTraceFlags.Recorded;
 
-            using (OpenTelemetrySdk.Default.EnableOpenTelemetry(
+            using (OpenTelemetrySdk.EnableOpenTelemetry(
                    (builder) => builder.AddHttpClientDependencyInstrumentation((opt) => opt.TextFormat = textFormat.Object)
                    .SetProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object))))
             {
@@ -152,7 +152,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Tests
         {
             var spanProcessor = new Mock<ActivityProcessor>();
 
-            using (OpenTelemetrySdk.Default.EnableOpenTelemetry(
+            using (OpenTelemetrySdk.EnableOpenTelemetry(
                         (builder) => builder.AddHttpClientDependencyInstrumentation()
                         .SetProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object))))
             {
@@ -170,7 +170,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Tests
         {
             var spanProcessor = new Mock<ActivityProcessor>();
 
-            using (OpenTelemetrySdk.Default.EnableOpenTelemetry(
+            using (OpenTelemetrySdk.EnableOpenTelemetry(
                         (builder) => builder.AddHttpClientDependencyInstrumentation()
                         .SetProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object))))
             {
@@ -196,7 +196,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Tests
 
             request.Headers.Add("traceparent", "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01");
 
-            using (OpenTelemetrySdk.Default.EnableOpenTelemetry(
+            using (OpenTelemetrySdk.EnableOpenTelemetry(
                         (builder) => builder.AddHttpClientDependencyInstrumentation()
                         .SetProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object))))
             {
@@ -232,7 +232,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Tests
         {
             var spanProcessor = new Mock<ActivityProcessor>();
 
-            using (OpenTelemetrySdk.Default.EnableOpenTelemetry(
+            using (OpenTelemetrySdk.EnableOpenTelemetry(
                         (builder) => builder.AddHttpClientDependencyInstrumentation()
                         .SetProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object))))
             {

--- a/test/OpenTelemetry.Instrumentation.Dependencies.Tests/HttpClientTests.netcore31.cs
+++ b/test/OpenTelemetry.Instrumentation.Dependencies.Tests/HttpClientTests.netcore31.cs
@@ -55,7 +55,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Tests
 
             using (serverLifeTime)
 
-            using (OpenTelemetrySdk.Default.EnableOpenTelemetry(
+            using (OpenTelemetrySdk.EnableOpenTelemetry(
                     (builder) => builder.AddHttpClientDependencyInstrumentation((opt) => opt.SetHttpFlavor = tc.SetHttpFlavor)
                     .SetProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object))))
             {

--- a/test/OpenTelemetry.Instrumentation.Dependencies.Tests/HttpWebRequestTests.Basic.net461.cs
+++ b/test/OpenTelemetry.Instrumentation.Dependencies.Tests/HttpWebRequestTests.Basic.net461.cs
@@ -63,7 +63,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Tests
         public async Task HttpDependenciesInstrumentationInjectsHeadersAsync()
         {
             var activityProcessor = new Mock<ActivityProcessor>();
-            using var shutdownSignal = OpenTelemetrySdk.Default.EnableOpenTelemetry(b =>
+            using var shutdownSignal = OpenTelemetrySdk.EnableOpenTelemetry(b =>
             {
                 b.SetProcessorPipeline(c => c.AddProcessor(ap => activityProcessor.Object));
                 b.AddHttpWebRequestDependencyInstrumentation();
@@ -151,7 +151,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Tests
         public async Task HttpDependenciesInstrumentationBacksOffIfAlreadyInstrumented()
         {
             var activityProcessor = new Mock<ActivityProcessor>();
-            using var shutdownSignal = OpenTelemetrySdk.Default.EnableOpenTelemetry(b =>
+            using var shutdownSignal = OpenTelemetrySdk.EnableOpenTelemetry(b =>
             {
                 b.SetProcessorPipeline(c => c.AddProcessor(ap => activityProcessor.Object));
                 b.AddHttpWebRequestDependencyInstrumentation();

--- a/test/OpenTelemetry.Instrumentation.Dependencies.Tests/HttpWebRequestTests.net461.cs
+++ b/test/OpenTelemetry.Instrumentation.Dependencies.Tests/HttpWebRequestTests.net461.cs
@@ -48,7 +48,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Tests
                 out var port);
 
             var activityProcessor = new Mock<ActivityProcessor>();
-            using var shutdownSignal = OpenTelemetrySdk.Default.EnableOpenTelemetry(b =>
+            using var shutdownSignal = OpenTelemetrySdk.EnableOpenTelemetry(b =>
             {
                 b.SetProcessorPipeline(c => c.AddProcessor(ap => activityProcessor.Object));
                 b.AddHttpWebRequestDependencyInstrumentation();

--- a/test/OpenTelemetry.Instrumentation.Dependencies.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Dependencies.Tests/SqlClientTests.cs
@@ -60,7 +60,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Tests
             var activity = new Activity("Current").AddBaggage("Stuff", "123");
 
             var spanProcessor = new Mock<ActivityProcessor>();
-            using (OpenTelemetrySdk.Default.EnableOpenTelemetry(
+            using (OpenTelemetrySdk.EnableOpenTelemetry(
                     (builder) => builder.AddSqlClientDependencyInstrumentation(
                         (opt) =>
                         {
@@ -154,7 +154,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Tests
             var activity = new Activity("Current").AddBaggage("Stuff", "123");
             var spanProcessor = new Mock<ActivityProcessor>();
 
-            using (OpenTelemetrySdk.Default.EnableOpenTelemetry(
+            using (OpenTelemetrySdk.EnableOpenTelemetry(
                 (builder) => builder.AddSqlClientDependencyInstrumentation()
                 .SetProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object))))
             {

--- a/test/TestApp.AspNetCore.3.1/Startup.cs
+++ b/test/TestApp.AspNetCore.3.1/Startup.cs
@@ -41,9 +41,7 @@ namespace TestApp.AspNetCore._3._1
             services.AddSingleton<HttpClient>();
             services.AddSingleton(
                 new CallbackMiddleware.CallbackMiddlewareImpl());
-
-            OpenTelemetrySdk.Default.EnableOpenTelemetry(
-                (builder) => builder.AddRequestInstrumentation().AddDependencyInstrumentation());
+            services.AddOpenTelemetrySdk((builder) => builder.AddRequestInstrumentation().AddDependencyInstrumentation());
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/test/TestApp.AspNetCore.3.1/Startup.cs
+++ b/test/TestApp.AspNetCore.3.1/Startup.cs
@@ -41,7 +41,6 @@ namespace TestApp.AspNetCore._3._1
             services.AddSingleton<HttpClient>();
             services.AddSingleton(
                 new CallbackMiddleware.CallbackMiddlewareImpl());
-            services.AddOpenTelemetrySdk((builder) => builder.AddRequestInstrumentation().AddDependencyInstrumentation());
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
Fixes 5b from https://github.com/open-telemetry/opentelemetry-dotnet/issues/684

## Changes
Expose static method `OpenTelemetrySdk.EnableOpenTelemetry` to enable OT. This returns an instance of OpenTelemetrySDK, which must be disposed.

Made extension methods on `IServiceCollection`, as part of Hosting project to have easy way to enable OpenTelemetry in Asp.Net Core projects (or others using DI model)


### Checklist
- [x] I ran Unit Tests locally