### PR TITLE
Add activitycreation from parent scenario to Benchmark

### DIFF
--- a/benchmarks/OpenTelemetrySdkBenchmarksActivity.cs
+++ b/benchmarks/OpenTelemetrySdkBenchmarksActivity.cs
@@ -25,6 +25,8 @@ namespace Benchmarks
     public class OpenTelemetrySdkBenchmarksActivity
     {
         private readonly ActivitySource BenchMarkSource = new ActivitySource("BenchMark");
+        private readonly ActivityContext ParentCtx = new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.None);
+        private readonly string ParentId = $"00-{ActivityTraceId.CreateRandom()}.{ActivitySpanId.CreateRandom()}.00";
 
         public OpenTelemetrySdkBenchmarksActivity()
         {
@@ -40,6 +42,17 @@ namespace Benchmarks
             return ActivityCreationScenarios.CreateActivity(this.BenchMarkSource);
         }
 
+        [Benchmark]
+        public Activity CreateActivity_WithParentContext_NoOpProcessor()
+        {
+            return ActivityCreationScenarios.CreateActivityFromParentContext(this.BenchMarkSource, ParentCtx);
+        }
+
+        [Benchmark]
+        public Activity CreateActivity_WithParentId_NoOpProcessor()
+        {
+            return ActivityCreationScenarios.CreateActivityFromParentId(this.BenchMarkSource, ParentId);
+        }
 
         [Benchmark]
         public Activity CreateActivity_WithAttributes_NoOpProcessor()

--- a/benchmarks/Tracing/ActivityCreationScenarios.cs
+++ b/benchmarks/Tracing/ActivityCreationScenarios.cs
@@ -28,6 +28,20 @@ namespace Benchmarks.Tracing
             return activity;
         }
 
+        public static Activity CreateActivityFromParentContext(ActivitySource source, ActivityContext parentCtx)
+        {
+            var activity = source.StartActivity("name", ActivityKind.Internal, parentCtx);
+            activity?.Stop();
+            return activity;
+        }
+
+        public static Activity CreateActivityFromParentId(ActivitySource source, string parentId)
+        {
+            var activity = source.StartActivity("name", ActivityKind.Internal, parentId);
+            activity?.Stop();
+            return activity;
+        }
+
         public static Activity CreateActivityWithAttributes(ActivitySource source)
         {
             var activity = source.StartActivity("name");


### PR DESCRIPTION
## Changes
Added 2 more scenarios for benchmark - activity creation with parentContext, parentId

### Checklist
- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public API reviewed

The PR will automatically request reviews from [code owners](https://github.com/open-telemetry/opentelemetry-dotnet/blob/master/CODEOWNERS#L15) and trigger CI build and tests.