### PR TITLE
Renaming .NET 461 files to .NETFramework

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Dependencies/Implementation/HttpWebRequestActivitySource.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Dependencies/Implementation/HttpWebRequestActivitySource.netfx.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HttpWebRequestActivitySource.net461.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="HttpWebRequestActivitySource.netfx.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.Dependencies.Tests/HttpWebRequestActivitySourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Dependencies.Tests/HttpWebRequestActivitySourceTests.netfx.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HttpWebRequestActivitySourceTests.net461.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="HttpWebRequestActivitySourceTests.netfx.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.Dependencies.Tests/HttpWebRequestTests.Basic.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Dependencies.Tests/HttpWebRequestTests.Basic.netfx.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HttpWebRequestTests.Basic.net461.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="HttpWebRequestTests.Basic.netfx.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.Dependencies.Tests/HttpWebRequestTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Dependencies.Tests/HttpWebRequestTests.netfx.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HttpWebRequestTests.net461.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="HttpWebRequestTests.netfx.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Refs #722.

## Changes
- renaming .net461 files to .netframework

### Checklist
- [x] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public API reviewed

The PR will automatically request reviews from [code owners](https://github.com/open-telemetry/opentelemetry-dotnet/blob/master/CODEOWNERS#L15) and trigger CI build and tests.