### PR TITLE
Add gRPC headers to OTLP requests

### DIFF
--- a/samples/Exporters/Console/TestOtlp.cs
+++ b/samples/Exporters/Console/TestOtlp.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 using System;
+using Grpc.Core;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -36,9 +37,18 @@ namespace Samples
 
         private static object RunWithSdk(string endpoint)
         {
+            var headers = new Metadata
+            {
+                { "test", "test-header" },
+            };
+
             using var tracerFactory = TracerFactory.Create(builder => builder
                 .SetResource(Resources.CreateServiceResource("otlp-test"))
-                .UseOpenTelemetryProtocolExporter(config => config.Endpoint = endpoint));
+                .UseOpenTelemetryProtocolExporter(config =>
+                {
+                    config.Endpoint = endpoint;
+                    config.Headers = headers;
+                }));
             var tracer = tracerFactory.GetTracer("otlp.test.tracer");
 
             using (tracer.StartActiveSpan("parent", out var parent))

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/ExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/ExporterOptions.cs
@@ -1,4 +1,4 @@
-// <copyright file="ExporterOptions.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="ExporterOptions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,5 +34,10 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol
         /// The default is "insecure". See detais at https://grpc.io/docs/guides/auth/#credential-types.
         /// </summary>
         public ChannelCredentials Credentials { get; set; } = ChannelCredentials.Insecure;
+
+        /// <summary>
+        /// Gets or sets optional headers for the connection.
+        /// </summary>
+        public Metadata Headers { get; set; } = new Metadata();
     }
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/TraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/TraceExporter.cs
@@ -35,6 +35,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol
     {
         private readonly Channel channel;
         private readonly OtlpCollector.TraceService.TraceServiceClient traceClient;
+        private readonly Metadata headers;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TraceExporter"/> class.
@@ -42,6 +43,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol
         /// <param name="options">Configuration options for the exporter.</param>
         internal TraceExporter(ExporterOptions options)
         {
+            this.headers = options.Headers;
             this.channel = new Channel(options.Endpoint, options.Credentials);
             this.traceClient = new OtlpCollector.TraceService.TraceServiceClient(this.channel);
         }
@@ -55,7 +57,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol
 
             try
             {
-                await this.traceClient.ExportAsync(spanExportRequest, cancellationToken: cancellationToken);
+                await this.traceClient.ExportAsync(spanExportRequest, headers: this.headers, cancellationToken: cancellationToken);
             }
             catch (RpcException ex)
             {


### PR DESCRIPTION
## Changes
Adds a new `Headers` field to the OpenTelemetry Exporter `ExporterOptions` that is sent with each request in order to pass non-standard gRPC headers.

### Checklist
- [X] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public API reviewed

The PR will automatically request reviews from [code owners](https://github.com/open-telemetry/opentelemetry-dotnet/blob/master/CODEOWNERS#L15) and trigger CI build and tests.