### PR TITLE
Modified sample to include Zipkin activity exporter + Fixed time precision for annotation

### DIFF
--- a/samples/Exporters/Console/Program.cs
+++ b/samples/Exporters/Console/Program.cs
@@ -28,7 +28,7 @@ namespace Samples
         /// For example:
         ///
         /// dotnet Exporters.dll zipkin -u http://localhost:9411/api/v2/spans
-        /// dotnet Exporters.dll jaeger -h localhost -o 6831
+        /// dotnet Exporters.dll jaeger -h localhost -p 6831
         /// dotnet Exporters.dll prometheus -i 15 -p 9184 -d 2
         ///
         /// The above must be run from the project bin folder
@@ -40,7 +40,7 @@ namespace Samples
             Parser.Default.ParseArguments<JaegerOptions, ZipkinOptions, PrometheusOptions, HttpClientOptions, ZPagesOptions, ConsoleOptions, ConsoleActivityOptions, OtlpOptions>(args)
                 .MapResult(
                     (JaegerOptions options) => TestJaeger.Run(options.Host, options.Port, options.UseActivitySource),
-                    (ZipkinOptions options) => TestZipkin.Run(options.Uri),
+                    (ZipkinOptions options) => TestZipkin.Run(options.Uri, options.UseActivitySource),
                     (PrometheusOptions options) => TestPrometheus.RunAsync(options.Port, options.PushIntervalInSecs, options.DurationInMins),
                     (HttpClientOptions options) => TestHttpClient.Run(),
                     (RedisOptions options) => TestRedis.Run(options.Uri),
@@ -74,6 +74,9 @@ namespace Samples
     {
         [Option('u', "uri", HelpText = "Please specify the uri of Zipkin backend", Required = true)]
         public string Uri { get; set; }
+
+        [Option('a', "activity", HelpText = "Set it to true to export ActivitySource data", Default = false)]
+        public bool UseActivitySource { get; set; }
     }
 
     [Verb("prometheus", HelpText = "Specify the options required to test Prometheus")]

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinActivityConversionExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinActivityConversionExtensions.cs
@@ -27,6 +27,8 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
     internal static class ZipkinActivityConversionExtensions
     {
         private const long TicksPerMicrosecond = TimeSpan.TicksPerMillisecond / 1000;
+        private const long UnixEpochTicks = 621355968000000000L; // = DateTimeOffset.FromUnixTimeMilliseconds(0).Ticks
+        private const long UnixEpochMicroseconds = UnixEpochTicks / TicksPerMicrosecond;
 
         private static readonly Dictionary<string, int> RemoteEndpointServiceNameKeyResolutionDictionary = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
         {
@@ -125,7 +127,10 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
 
         internal static long ToEpochMicroseconds(this DateTimeOffset dateTimeOffset)
         {
-            return dateTimeOffset.Ticks / TicksPerMicrosecond;
+            // Truncate sub-microsecond precision before offsetting by the Unix Epoch to avoid
+            // the last digit being off by one for dates that result in negative Unix times
+            long microseconds = dateTimeOffset.Ticks / TicksPerMicrosecond;
+            return microseconds - UnixEpochMicroseconds;
         }
 
         internal static long ToEpochMicroseconds(this TimeSpan timeSpan)

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinActivityConversionExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinActivityConversionExtensions.cs
@@ -140,9 +140,6 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
 
         internal static long ToEpochMicroseconds(this DateTime utcDateTime)
         {
-            const long UnixEpochTicks = 621355968000000000L; // = DateTimeOffset.FromUnixTimeMilliseconds(0).Ticks
-            const long UnixEpochMicroseconds = UnixEpochTicks / TicksPerMicrosecond;
-
             // Truncate sub-microsecond precision before offsetting by the Unix Epoch to avoid
             // the last digit being off by one for dates that result in negative Unix times
             long microseconds = utcDateTime.Ticks / TicksPerMicrosecond;


### PR DESCRIPTION
## Changes

- Modified `Exporters` sample console app to include support for Zipkin Activity Exporter
- Fixed time precision bug for Zipkin annotation. Converting a DateTimeOffSet to mircoseconds won't help, it needs to be subtracted from UnixEpochMicroseconds.

### Checklist
- [X] I ran Unit Tests locally.
