### PR TITLE
ActivitySourceAdapter sampling parameter fix

### DIFF
--- a/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
+++ b/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
@@ -75,7 +75,7 @@ namespace OpenTelemetry.Trace
                 }
                 else
                 {
-                    parentContext = new ActivityContext(activity.TraceId, activity.ParentSpanId, activity.ActivityTraceFlags);
+                    parentContext = new ActivityContext(activity.TraceId, activity.ParentSpanId, activity.ActivityTraceFlags, activity.TraceStateString);
 
                     // TODO: once IsRemote is exposed on ActivityContext set parentContext's IsRemote=true
                 }

--- a/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
+++ b/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
@@ -62,8 +62,29 @@ namespace OpenTelemetry.Trace
 
         private void RunGetRequestedData(Activity activity)
         {
+            ActivityContext parentContext;
+            if (string.IsNullOrEmpty(activity.ParentId))
+            {
+                parentContext = default(ActivityContext);
+            }
+            else
+            {
+                if (activity.Parent != null)
+                {
+                    parentContext = new ActivityContext(activity.Parent.TraceId, activity.Parent.SpanId, activity.Parent.ActivityTraceFlags);
+                }
+                else
+                {
+                    // parse parent activityTraceFlags from parentid?
+                    string parentId = activity.ParentId;
+                    parentContext = new ActivityContext(activity.TraceId, activity.ParentSpanId, activity.ActivityTraceFlags);
+
+                    // TODO: once IsRemote is exposed on ActivityContext set parentContext's IsRemote=true
+                }
+            }
+
             var samplingParameters = new ActivitySamplingParameters(
-                activity.Context,
+                parentContext,
                 activity.TraceId,
                 activity.DisplayName,
                 activity.Kind,

--- a/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
+++ b/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
@@ -71,12 +71,10 @@ namespace OpenTelemetry.Trace
             {
                 if (activity.Parent != null)
                 {
-                    parentContext = new ActivityContext(activity.Parent.TraceId, activity.Parent.SpanId, activity.Parent.ActivityTraceFlags);
+                    parentContext = activity.Parent.Context;
                 }
                 else
                 {
-                    // parse parent activityTraceFlags from parentid?
-                    string parentId = activity.ParentId;
                     parentContext = new ActivityContext(activity.TraceId, activity.ParentSpanId, activity.ActivityTraceFlags);
 
                     // TODO: once IsRemote is exposed on ActivityContext set parentContext's IsRemote=true

--- a/test/OpenTelemetry.Tests/Implementation/Testing/Export/TestActivityProcessor.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Testing/Export/TestActivityProcessor.cs
@@ -27,10 +27,14 @@ namespace OpenTelemetry.Tests.Implementation.Testing.Export
         public Action<Activity> StartAction;
         public Action<Activity> EndAction;
 
+        public TestActivityProcessor()
+        {
+        }
+
         public TestActivityProcessor(Action<Activity> onStart, Action<Activity> onEnd)
         {
-            this.OnStart = onStart;
-            this.OnEnd = onEnd;
+            this.StartAction = onStart;
+            this.EndAction = onEnd;
         }
 
         public bool ShutdownCalled { get; private set; } = false;
@@ -39,12 +43,12 @@ namespace OpenTelemetry.Tests.Implementation.Testing.Export
 
         public override void OnStart(Activity span)
         {
-            this.OnStart?.Invoke(span);
+            this.StartAction?.Invoke(span);
         }
 
         public override void OnEnd(Activity span)
         {
-            this.OnEnd?.Invoke(span);
+            this.EndAction?.Invoke(span);
         }
 
         public override Task ShutdownAsync(CancellationToken cancellationToken)

--- a/test/OpenTelemetry.Tests/Implementation/Testing/Export/TestActivityProcessor.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Testing/Export/TestActivityProcessor.cs
@@ -1,0 +1,65 @@
+﻿// <copyright file="TestActivityProcessor.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenTelemetry.Trace.Export;
+
+namespace OpenTelemetry.Tests.Implementation.Testing.Export
+{
+    public class TestActivityProcessor : ActivityProcessor, IDisposable
+    {
+        public Action<Activity> StartAction;
+        public Action<Activity> EndAction;
+
+        public TestActivityProcessor(Action<Activity> onStart, Action<Activity> onEnd)
+        {
+            this.OnStart = onStart;
+            this.OnEnd = onEnd;
+        }
+
+        public bool ShutdownCalled { get; private set; } = false;
+
+        public bool DisposedCalled { get; private set; } = false;
+
+        public override void OnStart(Activity span)
+        {
+            this.OnStart?.Invoke(span);
+        }
+
+        public override void OnEnd(Activity span)
+        {
+            this.OnEnd?.Invoke(span);
+        }
+
+        public override Task ShutdownAsync(CancellationToken cancellationToken)
+        {
+            this.ShutdownCalled = true;
+#if NET452
+            return Task.FromResult(0);
+#else
+            return Task.CompletedTask;
+#endif
+        }
+
+        public void Dispose()
+        {
+            this.DisposedCalled = true;
+        }
+    }
+}

--- a/test/OpenTelemetry.Tests/Implementation/Trace/ActivitySourceAdapterTest.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Trace/ActivitySourceAdapterTest.cs
@@ -57,14 +57,10 @@ namespace OpenTelemetry.Tests.Implementation.Trace
                 (a) =>
                 {
                     startCalled = true;
-                    if (isSampled)
-                    {
-                        Assert.Equal(ActivityTraceFlags.Recorded, a.ActivityTraceFlags);
-                    }
-                    else
-                    {
-                        Assert.Equal(ActivityTraceFlags.None, a.ActivityTraceFlags);
-                    }
+
+                    // If start is called, that means activity is sampled,
+                    // and TraceFlag is set to Recorded.
+                    Assert.Equal(ActivityTraceFlags.Recorded, a.ActivityTraceFlags);
                 };
 
             this.testProcessor.EndAction =

--- a/test/OpenTelemetry.Tests/Implementation/Trace/ActivitySourceAdapterTest.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Trace/ActivitySourceAdapterTest.cs
@@ -1,0 +1,90 @@
+﻿// <copyright file="ActivitySourceAdapterTest.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using OpenTelemetry.Tests.Implementation.Testing.Export;
+using OpenTelemetry.Trace;
+using Xunit;
+
+namespace OpenTelemetry.Tests.Implementation.Trace
+{
+    public class ActivitySourceAdapterTest
+    {
+        private TestSampler testSampler;
+        private TestActivityProcessor testProcessor;
+
+        static ActivitySourceAdapterTest()
+        {
+            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+            Activity.ForceDefaultIdFormat = true;
+        }
+
+        public ActivitySourceAdapterTest()
+        {
+            this.testSampler = new TestSampler();
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("00-e4d9d231de64d6408047ad4757e95422-05d365cd170e544d-00")]
+        public void ActivitySourceAdapterSamplesCorrectly(string activityParentId)
+        {
+            this.testSampler.SamplingAction = (samplingParameters) =>
+            {
+                Assert.Equal(default, samplingParameters.ParentContext);
+                return new SamplingResult(true);
+            }
+
+            bool startCalled = false;
+            bool endCalled = false;
+            TestActivityProcessor testProcessor = new TestActivityProcessor(
+                ss =>
+                {
+                    startCalled = true;
+                    Assert.True(startCalled);
+                }, se =>
+                {
+                    endCalled = true;
+                    Assert.False(endCalled);
+                });
+
+            ActivitySourceAdapter activitySourceAdapter = new ActivitySourceAdapter(testSampler, testProcessor);
+            var activity = new Activity("test");
+            if (!string.IsNullOrEmpty(activityParentId))
+            {
+                activity.SetParentId(activityParentId);
+            }
+
+            activity.Start();
+            activitySourceAdapter.Start(activity);
+            activity.Stop();
+            activitySourceAdapter.Stop(activity);
+        }
+
+        private class TestSampler : ActivitySampler
+        {
+            public Func<ActivitySamplingParameters, SamplingResult> SamplingAction { get; set; }
+
+            public override string Description { get; } = nameof(TestSampler);
+
+            public override SamplingResult ShouldSample(in ActivitySamplingParameters samplingParameters)
+            {
+                return this.SamplingAction?.Invoke(samplingParameters) ?? new SamplingResult(true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Following up from https://github.com/open-telemetry/opentelemetry-dotnet/pull/730

## Changes
`ActivitySourceAdapter` is the class responsible for running sampling pipeline for legacy activities. (i.e activities created without using ActivitySource). This class passed activity's own context, instead of parent activity context to the sampling pipeline. This PR fixes it, and adds unit tests for the whole class.

### Checklist
- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public API reviewed

The PR will automatically request reviews from [code owners](https://github.com/open-telemetry/opentelemetry-dotnet/blob/master/CODEOWNERS#L15) and trigger CI build and tests.