### PR TITLE
Add custom processor example and consoleexporter extension method.

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/OpenTelemetryBuilderExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Console/OpenTelemetryBuilderExtensions.cs
@@ -22,7 +22,7 @@ namespace OpenTelemetry.Exporter.Console
     public static class OpenTelemetryBuilderExtensions
     {
         /// <summary>
-        /// Registers a ConsoleActivity exporter.
+        /// Adds new processing pipeline and registers a ConsoleActivity exporter to it.
         /// </summary>
         /// <param name="builder">Open Telemetry builder to use.</param>
         /// <param name="configure">Exporter configuration options.</param>
@@ -43,6 +43,30 @@ namespace OpenTelemetry.Exporter.Console
             configure(exporterOptions);
             var consoleExporter = new ConsoleActivityExporter(exporterOptions);
             return builder.AddProcessorPipeline(pipeline => pipeline.SetExporter(consoleExporter));
+        }
+
+        /// <summary>
+        /// Registers a ConsoleActivity exporter to a processing pipeline.
+        /// </summary>
+        /// <param name="builder">ActivityProcessorPipelineBuilder to use.</param>
+        /// <param name="configure">Exporter configuration options.</param>
+        /// <returns>The instance of <see cref="ActivityProcessorPipelineBuilder"/> to chain the calls.</returns>
+        public static ActivityProcessorPipelineBuilder UseConsoleActivityExporter(this ActivityProcessorPipelineBuilder builder, Action<ConsoleActivityExporterOptions> configure)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            var exporterOptions = new ConsoleActivityExporterOptions();
+            configure(exporterOptions);
+            var consoleExporter = new ConsoleActivityExporter(exporterOptions);
+            return builder.SetExporter(consoleExporter);
         }
     }
 }


### PR DESCRIPTION
## Changes
This modifies the console activity example to show how to add a custom processor to the pipeline. Also added a new extension method on `ActivityProcessorPipelineBuilder` to enable `ConsoleActivityExporter`

Note: The whole pipeline configuration seems a bit complex? Need to see if we can make this easier to use.

### Checklist
- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public API reviewed

The PR will automatically request reviews from [code owners](https://github.com/open-telemetry/opentelemetry-dotnet/blob/master/CODEOWNERS#L15) and trigger CI build and tests.