### PR TITLE
Check if TraceState is null

### DIFF
--- a/src/OpenTelemetry.Api/Context/Propagation/TraceContextFormatActivity.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceContextFormatActivity.cs
@@ -108,7 +108,7 @@ namespace OpenTelemetry.Context.Propagation
             setter(carrier, TraceParent, traceparent);
 
             string tracestateStr = activityContext.TraceState;
-            if (tracestateStr.Length > 0)
+            if (tracestateStr?.Length > 0)
             {
                 setter(carrier, TraceState, tracestateStr);
             }

--- a/test/OpenTelemetry.Tests/Implementation/Trace/Propagation/TraceContextActivityTest.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Trace/Propagation/TraceContextActivityTest.cs
@@ -153,14 +153,36 @@ namespace OpenTelemetry.Impl.Trace.Propagation
         {
             var traceId = ActivityTraceId.CreateRandom();
             var spanId = ActivitySpanId.CreateRandom();
-            var activityContext = new ActivityContext(traceId, spanId, ActivityTraceFlags.Recorded);
+            var expectedHeaders = new Dictionary<string, string>
+            {
+                { TraceParent, $"00-{traceId}-{spanId}-01" },
+            };
 
+            var activityContext = new ActivityContext(traceId, spanId, ActivityTraceFlags.Recorded, traceState: null);
             var carrier = new Dictionary<string, string>();
             var f = new TraceContextFormatActivity();
             f.Inject(activityContext, carrier, Setter);
 
-            var expected = new Dictionary<string, string> { { "traceparent", $"00-{traceId.ToHexString()}-{spanId.ToHexString()}-01" } };
-            Assert.Equal(expected, carrier);
+            Assert.Equal(expectedHeaders, carrier);
+        }
+
+        [Fact]
+        public void TraceContextFormat_Inject_WithTracestate()
+        {
+            var traceId = ActivityTraceId.CreateRandom();
+            var spanId = ActivitySpanId.CreateRandom();
+            var expectedHeaders = new Dictionary<string, string>
+            {
+                { TraceParent, $"00-{traceId}-{spanId}-01" },
+                { TraceState, $"congo=lZWRzIHRoNhcm5hbCBwbGVhc3VyZS4,rojo=00-{traceId}-00f067aa0ba902b7-01" },
+            };
+
+            var activityContext = new ActivityContext(traceId, spanId, ActivityTraceFlags.Recorded, expectedHeaders[TraceState]);
+            var carrier = new Dictionary<string, string>();
+            var f = new TraceContextFormatActivity();
+            f.Inject(activityContext, carrier, Setter);
+
+            Assert.Equal(expectedHeaders, carrier);
         }
     }
 }


### PR DESCRIPTION
I came across this as I was debugging some tests. When `activityContext.TraceState` is null an exception is thrown. For example, the exception is caught and logged [here](https://github.com/open-telemetry/opentelemetry-dotnet/blob/master/src/OpenTelemetry/Instrumentation/DiagnosticSourceListener.cs#L69) when running this [test suite]( https://github.com/open-telemetry/opentelemetry-dotnet/blob/master/test/OpenTelemetry.Instrumentation.Dependencies.Tests/HttpClientTests.netcore31.cs#L42).

Have there been any thought around checking for the presence of any errors logged from unit tests?

## Changes
* Check for null tracestate in `TraceContextFormatActivity.Inject`

### Checklist
- [x] I ran Unit Tests locally.