### PR TITLE
Make HttpClientInstrumentation and SqlClientInstrumentation internal

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet.Win/AspNetInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.Win/AspNetInstrumentation.cs
@@ -22,7 +22,7 @@ namespace OpenTelemetry.Instrumentation.AspNet
     /// <summary>
     /// Asp.Net Requests instrumentation.
     /// </summary>
-    public class AspNetInstrumentation : IDisposable
+    internal class AspNetInstrumentation : IDisposable
     {
         internal const string AspNetDiagnosticListenerName = "Microsoft.AspNet.TelemetryCorrelation";
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentation.cs
@@ -22,7 +22,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore
     /// <summary>
     /// Asp.Net Core Requests instrumentation.
     /// </summary>
-    public class AspNetCoreInstrumentation : IDisposable
+    internal class AspNetCoreInstrumentation : IDisposable
     {
         private readonly DiagnosticSourceSubscriber diagnosticSourceSubscriber;
 

--- a/src/OpenTelemetry.Instrumentation.Dependencies/HttpClientInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.Dependencies/HttpClientInstrumentation.cs
@@ -22,7 +22,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies
     /// <summary>
     /// Dependencies instrumentation.
     /// </summary>
-    public class HttpClientInstrumentation : IDisposable
+    internal class HttpClientInstrumentation : IDisposable
     {
         private readonly DiagnosticSourceSubscriber diagnosticSourceSubscriber;
 

--- a/src/OpenTelemetry.Instrumentation.Dependencies/SqlClientInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.Dependencies/SqlClientInstrumentation.cs
@@ -22,7 +22,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies
     /// <summary>
     /// SqlClient instrumentation.
     /// </summary>
-    public class SqlClientInstrumentation : IDisposable
+    internal class SqlClientInstrumentation : IDisposable
     {
         internal const string SqlClientDiagnosticListenerName = "SqlClientDiagnosticListener";
 


### PR DESCRIPTION
## Changes
@cijothomas Address small thing you suggested recently. Makes HttpClient and SqlClient instrumentation internal since users should only configure instrumentation using the OpenTelemetryBuilder extension method.

### Checklist
- [X] I ran Unit Tests locally.