### PR TITLE
Solving Incorrect assembly version in NuGet package

### DIFF
--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <ItemGroup>
-    <PackageReference Include="MinVer" Version="2.0.0">
+    <PackageReference Include="MinVer" Version="2.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -21,6 +21,13 @@
     <DefineConstants>$(DefineConstants);SIGNED</DefineConstants>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+
+  <Target Name="AssemblyVersionTarget" AfterTargets="MinVer">
+    <PropertyGroup>
+      <RevisionNumber>$(MinVerVersion.Split(`.`)[3])</RevisionNumber>
+      <AssemblyVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(RevisionNumber)</AssemblyVersion>      
+    </PropertyGroup>
+  </Target>
 
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)/stylecop.json" />


### PR DESCRIPTION
Closes #745.

## Changes
- updated the version of MinVer that we use from 2.0.0 to 2.3.0, since the old version contained a bug which prevented minver from updating the correct tags
- added a tag in common.props to update version manually

### Checklist
- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public API reviewed

The PR will automatically request reviews from [code owners](https://github.com/open-telemetry/opentelemetry-dotnet/blob/master/CODEOWNERS#L15) and trigger CI build and tests.