### PR TITLE
Enable codecov for windows

### DIFF
--- a/.github/workflows/dotnet-core-cov.yml
+++ b/.github/workflows/dotnet-core-cov.yml
@@ -5,13 +5,15 @@ on:
     branches: [ master ]
 
 jobs:
-  build-test:
+  build-test-report:
     runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
+    env:
+      OS: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2
@@ -34,8 +36,10 @@ jobs:
       run: dotnet tool install -g dotnet-reportgenerator-globaltool
     
     - name: Merging test results
-      run: reportgenerator -reports:TestResults/**/*.xml -targetdir:TestResults -reporttypes:Cobertura -verbosity:Verbose
+      run: reportgenerator -reports:TestResults/**/*.xml -targetdir:TestResults -reporttypes:Cobertura
 
-    - uses: codecov/codecov-action@v1
+    - uses: codecov/codecov-action@v1.0.10
       with:
         file: TestResults/Cobertura.xml
+        env_vars: OS
+        name: Code Coverage for ${{ matrix.os }}

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build-test:
+  build-test-pack:
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -26,7 +26,7 @@ jobs:
       run: dotnet restore
 
     - name: dotnet build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build --configuration Release --no-restore -p:Deterministic=true
 
     - name: dotnet test
       run: dotnet test -p:CollectCoverage=false --configuration Release --no-build --logger:"console;verbosity=detailed"

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -22,7 +22,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <Target Name="AssemblyVersionTarget" AfterTargets="MinVer">
+  <Target Name="AssemblyVersionTarget" AfterTargets="MinVer" Condition="'$(Configuration)'=='Release'">
     <PropertyGroup>
       <RevisionNumber>$(MinVerVersion.Split(`.`)[3])</RevisionNumber>
       <AssemblyVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(RevisionNumber)</AssemblyVersion>      
@@ -58,6 +58,14 @@
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(Deterministic)'=='true'">
+    <SourceRoot Include="$(MSBuildThisFileDirectory)/"/>
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(Deterministic)'=='true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/Common.test.props
+++ b/build/Common.test.props
@@ -27,19 +27,6 @@
 
   <PropertyGroup Condition="$(MSBuildProjectName.Contains('.Tests'))">
     <IsTestProject>true</IsTestProject>
-    <CollectCoverage Condition="$(CollectCoverage) == '' AND $([MSBuild]::IsOSUnixLike())">true</CollectCoverage>
-  </PropertyGroup>
-
-  <PropertyGroup Label="CollectCodeCoverageResults" Condition="$(CollectCoverage) == 'true'">
-    <CoverletOutputFormat>cobertura</CoverletOutputFormat>
-    <_BaseDir>..\..\TestResults\</_BaseDir>
-    <CoverletBaseDir>$(_BaseDir)Coverage\</CoverletBaseDir>
-    <CoverletResultsDir>$(_BaseDir)Results\</CoverletResultsDir>
-    <CoverletBaseDir Condition="$([MSBuild]::IsOSUnixLike())">$(CoverletBaseDir.Replace('\', '/'))</CoverletBaseDir>
-    <CoverletResultsDir Condition="$([MSBuild]::IsOSUnixLike())">$(CoverletResultsDir.Replace('\', '/'))</CoverletResultsDir>
-    <CoverletOutput>$(CoverletBaseDir)$(MSBuildProjectName).xml</CoverletOutput>
-    <Exclude>[xunit*]*,[*.Tests]*</Exclude>
-    <DebugType>pdbonly</DebugType> <!-- Coverlet needs full debug symbols -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -3,20 +3,9 @@
 
   <ItemGroup>
     <DotNetCliToolReference Include="dotnet-reportgenerator-cli" Version="4.1.10" />
-    <!-- <PackageReference Include="coverlet.msbuild" Version="2.9.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference> -->
     <PackageReference Include="coverlet.collector" Version="1.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
-  <Target Name="CovertReportResults" AfterTargets="GenerateCoverageResult" Condition="$(CollectCoverage)">
-    <!-- Merges the reports into one -->
-    <Exec Command="dotnet reportgenerator -reports:$(CoverletBaseDir)*.xml -targetdir:$(CoverletResultsDir) -reporttypes:Cobertura -verbosity:Verbose" WorkingDirectory="$(ProjectDir)" />
-    <!-- Gives the summary in an Azure Pipelines look & feel -->
-    <Exec Command="dotnet reportgenerator -reports:$(CoverletResultsDir)Cobertura.xml -targetdir:$(CoverletResultsDir) -reporttypes:'HtmlInline_AzurePipelines;Cobertura' -verbosity:Verbose" WorkingDirectory="$(ProjectDir)" />
-  </Target>
 </Project>


### PR DESCRIPTION
Closes #778

## Changes
- now, we are applying codecov for windows / linux: https://codecov.io/gh/open-telemetry/opentelemetry-dotnet/pull/777/tree
- fixing an issue where it fails to build locally after adding the minVer condition
- adding deterministic build for release pack
- removing old tags from target/props

### Checklist
- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public API reviewed

The PR will automatically request reviews from [code owners](https://github.com/open-telemetry/opentelemetry-dotnet/blob/master/CODEOWNERS#L15) and trigger CI build and tests.