### PR TITLE
Added Sql connection-level attributes (from spec) as an opt-in feature.

### DIFF
--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerActivityExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerActivityExtensions.cs
@@ -25,13 +25,13 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
     {
         private static readonly Dictionary<string, int> PeerServiceKeyResolutionDictionary = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
         {
-            [SpanAttributeConstants.PeerServiceKey] = 0, // peer.service primary.
-            [SpanAttributeConstants.NetPeerName] = 1, // peer.service first alternative.
-            [SpanAttributeConstants.NetPeerIp] = 2, // peer.service second alternative.
-            ["peer.hostname"] = 2, // peer.service second alternative.
-            ["peer.address"] = 2, // peer.service second alternative.
+            [SpanAttributeConstants.PeerServiceKey] = 0, // priority 0 (highest).
+            [SpanAttributeConstants.NetPeerName] = 1,
+            [SpanAttributeConstants.NetPeerIp] = 2,
+            ["peer.hostname"] = 2,
+            ["peer.address"] = 2,
             ["http.host"] = 3, // peer.service for Http.
-            ["db.instance"] = 4, // peer.service for Redis.
+            ["db.instance"] = 3, // peer.service for Redis.
         };
 
         private static readonly DictionaryEnumerator<string, string, TagState>.ForEachDelegate ProcessActivityTagRef = ProcessActivityTag;

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerActivityExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerActivityExtensions.cs
@@ -26,7 +26,8 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
         private static readonly Dictionary<string, int> PeerServiceKeyResolutionDictionary = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
         {
             [SpanAttributeConstants.PeerServiceKey] = 0, // peer.service primary.
-            ["net.peer.name"] = 1, // peer.service first alternative.
+            [SpanAttributeConstants.NetPeerName] = 1, // peer.service first alternative.
+            [SpanAttributeConstants.NetPeerIp] = 2, // peer.service second alternative.
             ["peer.hostname"] = 2, // peer.service second alternative.
             ["peer.address"] = 2, // peer.service second alternative.
             ["http.host"] = 3, // peer.service for Http.

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerConversionExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerConversionExtensions.cs
@@ -45,13 +45,13 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
 
         private static readonly Dictionary<string, int> PeerServiceKeyResolutionDictionary = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
         {
-            [SpanAttributeConstants.PeerServiceKey] = 0, // peer.service primary.
-            [SpanAttributeConstants.NetPeerName] = 1, // peer.service first alternative.
-            [SpanAttributeConstants.NetPeerIp] = 2, // peer.service second alternative.
-            ["peer.hostname"] = 2, // peer.service second alternative.
-            ["peer.address"] = 2, // peer.service second alternative.
+            [SpanAttributeConstants.PeerServiceKey] = 0, // priority 0 (highest).
+            [SpanAttributeConstants.NetPeerName] = 1,
+            [SpanAttributeConstants.NetPeerIp] = 2,
+            ["peer.hostname"] = 2,
+            ["peer.address"] = 2,
             ["http.host"] = 3, // peer.service for Http.
-            ["db.instance"] = 4, // peer.service for Redis.
+            ["db.instance"] = 3, // peer.service for Redis.
         };
 
         private static readonly DictionaryEnumerator<string, object, TagState>.ForEachDelegate ProcessAttributeRef = ProcessAttribute;

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerConversionExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerConversionExtensions.cs
@@ -46,7 +46,8 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
         private static readonly Dictionary<string, int> PeerServiceKeyResolutionDictionary = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
         {
             [SpanAttributeConstants.PeerServiceKey] = 0, // peer.service primary.
-            ["net.peer.name"] = 1, // peer.service first alternative.
+            [SpanAttributeConstants.NetPeerName] = 1, // peer.service first alternative.
+            [SpanAttributeConstants.NetPeerIp] = 2, // peer.service second alternative.
             ["peer.hostname"] = 2, // peer.service second alternative.
             ["peer.address"] = 2, // peer.service second alternative.
             ["http.host"] = 3, // peer.service for Http.

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinActivityConversionExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinActivityConversionExtensions.cs
@@ -33,7 +33,8 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
         private static readonly Dictionary<string, int> RemoteEndpointServiceNameKeyResolutionDictionary = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
         {
             [SpanAttributeConstants.PeerServiceKey] = 0, // RemoteEndpoint.ServiceName primary.
-            ["net.peer.name"] = 1, // RemoteEndpoint.ServiceName first alternative.
+            [SpanAttributeConstants.NetPeerName] = 1, // RemoteEndpoint.ServiceName first alternative.
+            [SpanAttributeConstants.NetPeerIp] = 2, // RemoteEndpoint.ServiceName second alternative.
             ["peer.hostname"] = 2, // RemoteEndpoint.ServiceName second alternative.
             ["peer.address"] = 2, // RemoteEndpoint.ServiceName second alternative.
             ["http.host"] = 3, // RemoteEndpoint.ServiceName for Http.

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinActivityConversionExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinActivityConversionExtensions.cs
@@ -32,13 +32,13 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
 
         private static readonly Dictionary<string, int> RemoteEndpointServiceNameKeyResolutionDictionary = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
         {
-            [SpanAttributeConstants.PeerServiceKey] = 0, // RemoteEndpoint.ServiceName primary.
-            [SpanAttributeConstants.NetPeerName] = 1, // RemoteEndpoint.ServiceName first alternative.
-            [SpanAttributeConstants.NetPeerIp] = 2, // RemoteEndpoint.ServiceName second alternative.
-            ["peer.hostname"] = 2, // RemoteEndpoint.ServiceName second alternative.
-            ["peer.address"] = 2, // RemoteEndpoint.ServiceName second alternative.
+            [SpanAttributeConstants.PeerServiceKey] = 0, // priority 0 (highest).
+            [SpanAttributeConstants.NetPeerName] = 1,
+            [SpanAttributeConstants.NetPeerIp] = 2,
+            ["peer.hostname"] = 2,
+            ["peer.address"] = 2,
             ["http.host"] = 3, // RemoteEndpoint.ServiceName for Http.
-            ["db.instance"] = 4, // RemoteEndpoint.ServiceName for Redis.
+            ["db.instance"] = 3, // RemoteEndpoint.ServiceName for Redis.
         };
 
         private static readonly string InvalidSpanId = default(ActivitySpanId).ToHexString();

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinConversionExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinConversionExtensions.cs
@@ -28,13 +28,13 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
     {
         private static readonly Dictionary<string, int> RemoteEndpointServiceNameKeyResolutionDictionary = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
         {
-            [SpanAttributeConstants.PeerServiceKey] = 0, // RemoteEndpoint.ServiceName primary.
-            [SpanAttributeConstants.NetPeerName] = 1, // RemoteEndpoint.ServiceName first alternative.
-            [SpanAttributeConstants.NetPeerIp] = 2, // RemoteEndpoint.ServiceName second alternative.
-            ["peer.hostname"] = 2, // RemoteEndpoint.ServiceName second alternative.
-            ["peer.address"] = 2, // RemoteEndpoint.ServiceName second alternative.
+            [SpanAttributeConstants.PeerServiceKey] = 0, // priority 0 (highest).
+            [SpanAttributeConstants.NetPeerName] = 1,
+            [SpanAttributeConstants.NetPeerIp] = 2,
+            ["peer.hostname"] = 2,
+            ["peer.address"] = 2,
             ["http.host"] = 3, // RemoteEndpoint.ServiceName for Http.
-            ["db.instance"] = 4, // RemoteEndpoint.ServiceName for Redis.
+            ["db.instance"] = 3, // RemoteEndpoint.ServiceName for Redis.
         };
 
         private static readonly ConcurrentDictionary<string, ZipkinEndpoint> LocalEndpointCache = new ConcurrentDictionary<string, ZipkinEndpoint>();

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinConversionExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinConversionExtensions.cs
@@ -29,7 +29,8 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
         private static readonly Dictionary<string, int> RemoteEndpointServiceNameKeyResolutionDictionary = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
         {
             [SpanAttributeConstants.PeerServiceKey] = 0, // RemoteEndpoint.ServiceName primary.
-            ["net.peer.name"] = 1, // RemoteEndpoint.ServiceName first alternative.
+            [SpanAttributeConstants.NetPeerName] = 1, // RemoteEndpoint.ServiceName first alternative.
+            [SpanAttributeConstants.NetPeerIp] = 2, // RemoteEndpoint.ServiceName second alternative.
             ["peer.hostname"] = 2, // RemoteEndpoint.ServiceName second alternative.
             ["peer.address"] = 2, // RemoteEndpoint.ServiceName second alternative.
             ["http.host"] = 3, // RemoteEndpoint.ServiceName for Http.

--- a/src/OpenTelemetry.Instrumentation.Dependencies/Implementation/SqlClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Dependencies/Implementation/SqlClientDiagnosticListener.cs
@@ -85,8 +85,9 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Implementation
 
                             activity.AddTag(SpanAttributeConstants.ComponentKey, "sql");
                             activity.AddTag(SpanAttributeConstants.DatabaseSystemKey, MicrosoftSqlServerDatabaseSystemName);
-                            activity.AddTag(SpanAttributeConstants.PeerServiceKey, (string)dataSource);
                             activity.AddTag(SpanAttributeConstants.DatabaseNameKey, (string)database);
+
+                            this.options.AddConnectionLevelDetailsToActivity((string)dataSource, activity);
 
                             if (this.commandTypeFetcher.Fetch(command) is CommandType commandType)
                             {

--- a/src/OpenTelemetry.Instrumentation.Dependencies/Implementation/SqlEventSourceListener.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Dependencies/Implementation/SqlEventSourceListener.netfx.cs
@@ -117,8 +117,9 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Implementation
                 activity.AddTag(SpanAttributeConstants.ComponentKey, "sql");
 
                 activity.AddTag(SpanAttributeConstants.DatabaseSystemKey, SqlClientDiagnosticListener.MicrosoftSqlServerDatabaseSystemName);
-                activity.AddTag(SpanAttributeConstants.PeerServiceKey, (string)eventData.Payload[1]);
                 activity.AddTag(SpanAttributeConstants.DatabaseNameKey, databaseName);
+
+                this.options.AddConnectionLevelDetailsToActivity((string)eventData.Payload[1], activity);
 
                 string commandText = (string)eventData.Payload[3];
                 if (string.IsNullOrEmpty(commandText))

--- a/src/OpenTelemetry.Instrumentation.Dependencies/SqlClientInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Dependencies/SqlClientInstrumentationOptions.cs
@@ -29,7 +29,15 @@ namespace OpenTelemetry.Instrumentation.Dependencies
     {
         internal const string MicrosoftSqlServerDatabaseInstanceName = "db.mssql.instance_name";
 
-        private static readonly Regex DataSourceRegex = new Regex("^(.*?)(?:[\\\\,]|$)\\s*(.*?)(?:,|$)\\s*(.*)$", RegexOptions.Compiled);
+        /*
+         * Match...
+         *  serverName
+         *  serverName[ ]\\[ ]instanceName
+         *  serverName[ ],[ ]port
+         *  serverName[ ]\\[ ]instanceName[ ],[ ]port
+         * [ ] can be any number of white-space, SQL allows it for some reason.
+         */
+        private static readonly Regex DataSourceRegex = new Regex("^(.*?)\\s*(?:[\\\\,]|$)\\s*(.*?)\\s*(?:,|$)\\s*(.*)$", RegexOptions.Compiled);
         private static readonly ConcurrentDictionary<string, SqlConnectionDetails> ConnectionDetailCache = new ConcurrentDictionary<string, SqlConnectionDetails>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>

--- a/src/OpenTelemetry.Instrumentation.Dependencies/SqlClientInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Dependencies/SqlClientInstrumentationOptions.cs
@@ -13,7 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System;
+using System.Collections.Concurrent;
 using System.Data;
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.Dependencies
 {
@@ -22,12 +27,10 @@ namespace OpenTelemetry.Instrumentation.Dependencies
     /// </summary>
     public class SqlClientInstrumentationOptions
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SqlClientInstrumentationOptions"/> class.
-        /// </summary>
-        public SqlClientInstrumentationOptions()
-        {
-        }
+        internal const string MicrosoftSqlServerDatabaseInstanceName = "db.mssql.instance_name";
+
+        private static readonly Regex DataSourceRegex = new Regex("^(.*?)(?:[\\\\,]|$)\\s*(.*?)(?:,|$)\\s*(.*)$", RegexOptions.Compiled);
+        private static readonly ConcurrentDictionary<string, SqlConnectionDetails> ConnectionDetailCache = new ConcurrentDictionary<string, SqlConnectionDetails>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Gets or sets a value indicating whether or not the <see cref="SqlClientInstrumentation"/> should capture the names of <see cref="CommandType.StoredProcedure"/> commands. Default value: True.
@@ -38,5 +41,110 @@ namespace OpenTelemetry.Instrumentation.Dependencies
         /// Gets or sets a value indicating whether or not the <see cref="SqlClientInstrumentation"/> should capture the text of <see cref="CommandType.Text"/> commands. Default value: False.
         /// </summary>
         public bool CaptureTextCommandContent { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not the <see cref="SqlClientInstrumentation"/> should parse the DataSource on a SqlConnection into server name, instance name, and/or port connection-level attributes. Default value: False.
+        /// </summary>
+        /// <remarks>
+        /// The default behavior is to set the SqlConnection DataSource as the peer.service tag. If enabled, SqlConnection DataSource will be parsed and the server name will be sent as the net.peer.name or net.peer.ip tag, the instance name will be sent as the db.mssql.instance_name tag, and the port will be sent as the net.peer.port tag if it is not 1433 (the default port).
+        /// </remarks>
+        public bool EnableConnectionLevelAttributes { get; set; } = false;
+
+        internal static SqlConnectionDetails ParseDataSource(string dataSource)
+        {
+            Match match = DataSourceRegex.Match(dataSource);
+
+            string serverHostName = match.Groups[1].Value;
+            string serverIpAddress = null;
+
+            var uriHostNameType = Uri.CheckHostName(serverHostName);
+            if (uriHostNameType == UriHostNameType.IPv4 || uriHostNameType == UriHostNameType.IPv6)
+            {
+                serverIpAddress = serverHostName;
+                serverHostName = null;
+            }
+
+            string instanceName;
+            string port;
+            if (match.Groups[3].Length > 0)
+            {
+                instanceName = match.Groups[2].Value;
+                port = match.Groups[3].Value;
+                if (port == "1433")
+                {
+                    port = null;
+                }
+            }
+            else if (int.TryParse(match.Groups[2].Value, out int parsedPort))
+            {
+                port = parsedPort == 1433 ? null : match.Groups[2].Value;
+                instanceName = null;
+            }
+            else
+            {
+                instanceName = match.Groups[2].Value;
+
+                if (string.IsNullOrEmpty(instanceName))
+                {
+                    instanceName = null;
+                }
+
+                port = null;
+            }
+
+            return new SqlConnectionDetails
+            {
+                ServerHostName = serverHostName,
+                ServerIpAddress = serverIpAddress,
+                InstanceName = instanceName,
+                Port = port,
+            };
+        }
+
+        internal void AddConnectionLevelDetailsToActivity(string dataSource, Activity sqlActivity)
+        {
+            if (!this.EnableConnectionLevelAttributes)
+            {
+                sqlActivity.AddTag(SpanAttributeConstants.PeerServiceKey, dataSource);
+            }
+            else
+            {
+                if (!ConnectionDetailCache.TryGetValue(dataSource, out SqlConnectionDetails connectionDetails))
+                {
+                    connectionDetails = ParseDataSource(dataSource);
+                    ConnectionDetailCache.TryAdd(dataSource, connectionDetails);
+                }
+
+                if (!string.IsNullOrEmpty(connectionDetails.ServerHostName))
+                {
+                    sqlActivity.AddTag(SpanAttributeConstants.NetPeerName, connectionDetails.ServerHostName);
+                }
+                else
+                {
+                    sqlActivity.AddTag(SpanAttributeConstants.NetPeerIp, connectionDetails.ServerIpAddress);
+                }
+
+                if (!string.IsNullOrEmpty(connectionDetails.InstanceName))
+                {
+                    sqlActivity.AddTag(MicrosoftSqlServerDatabaseInstanceName, connectionDetails.InstanceName);
+                }
+
+                if (!string.IsNullOrEmpty(connectionDetails.Port))
+                {
+                    sqlActivity.AddTag(SpanAttributeConstants.NetPeerPort, connectionDetails.Port);
+                }
+            }
+        }
+
+        internal class SqlConnectionDetails
+        {
+            public string ServerHostName { get; set; }
+
+            public string ServerIpAddress { get; set; }
+
+            public string InstanceName { get; set; }
+
+            public string Port { get; set; }
+        }
     }
 }

--- a/test/OpenTelemetry.Instrumentation.Dependencies.Tests/SqlClientInstrumentationOptionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Dependencies.Tests/SqlClientInstrumentationOptionsTests.cs
@@ -1,0 +1,46 @@
+﻿// <copyright file="SqlClientInstrumentationOptionsTests.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using Xunit;
+
+namespace OpenTelemetry.Instrumentation.Dependencies.Tests
+{
+    public class SqlClientInstrumentationOptionsTests
+    {
+        [Theory]
+        [InlineData("localhost", "localhost", null, null, null)]
+        [InlineData("127.0.0.1", null, "127.0.0.1", null, null)]
+        [InlineData("127.0.0.1,1433", null, "127.0.0.1", null, null)]
+        [InlineData("127.0.0.1, 1818", null, "127.0.0.1", null, "1818")]
+        [InlineData("127.0.0.1\\instanceName", null, "127.0.0.1", "instanceName", null)]
+        [InlineData("127.0.0.1\\instanceName, 1818", null, "127.0.0.1", "instanceName", "1818")]
+        public void ParseDataSourceTests(
+            string dataSource,
+            string expectedServerHostName,
+            string expectedServerIpAddress,
+            string expectedInstanceName,
+            string expectedPort)
+        {
+            var sqlConnectionDetails = SqlClientInstrumentationOptions.ParseDataSource(dataSource);
+
+            Assert.NotNull(sqlConnectionDetails);
+            Assert.Equal(expectedServerHostName, sqlConnectionDetails.ServerHostName);
+            Assert.Equal(expectedServerIpAddress, sqlConnectionDetails.ServerIpAddress);
+            Assert.Equal(expectedInstanceName, sqlConnectionDetails.InstanceName);
+            Assert.Equal(expectedPort, sqlConnectionDetails.Port);
+        }
+    }
+}

--- a/test/OpenTelemetry.Instrumentation.Dependencies.Tests/SqlClientInstrumentationOptionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Dependencies.Tests/SqlClientInstrumentationOptionsTests.cs
@@ -25,7 +25,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Tests
         [InlineData("127.0.0.1", null, "127.0.0.1", null, null)]
         [InlineData("127.0.0.1,1433", null, "127.0.0.1", null, null)]
         [InlineData("127.0.0.1, 1818", null, "127.0.0.1", null, "1818")]
-        [InlineData("127.0.0.1\\instanceName", null, "127.0.0.1", "instanceName", null)]
+        [InlineData("127.0.0.1  \\  instanceName", null, "127.0.0.1", "instanceName", null)]
         [InlineData("127.0.0.1\\instanceName, 1818", null, "127.0.0.1", "instanceName", "1818")]
         public void ParseDataSourceTests(
             string dataSource,


### PR DESCRIPTION
## Changes
You can now set `options.EnableConnectionLevelAttributes = true` when configuring Sql Instrumentation to send [connection-level attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/database.md#connection-level-attributes-for-specific-technologies). I went with the option because it does come with a slight perf hit, looking up cached values and then setting tags.

### Checklist
- [X] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [X] Design discussion via Gitter with @cijothomas.
- [ ] Changes in public API reviewed