### PR TITLE
Minor: simplify PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,10 @@
-Fixes # .
+Fixes #.
 
 ## Changes
-(Please provide a brief description of the changes here.)
 
-### Checklist
-- [ ] I ran Unit Tests locally.
+Please provide a brief description of the changes here.
 
 For significant contributions please make sure you have completed the following items:
 
-- [ ] Design discussion issue #
-- [ ] Changes in public API reviewed
-
-The PR will automatically request reviews from [code owners](https://github.com/open-telemetry/opentelemetry-dotnet/blob/master/CODEOWNERS#L15) and trigger CI build and tests.
+* [ ] Design discussion issue #
+* [ ] Changes in public API reviewed


### PR DESCRIPTION
1. Markdownlint.
2. Remove `I ran Unit Tests locally.` as we are always enforcing CI.
3. Remove `The PR will automatically request reviews from [code owners](https://github.com/open-telemetry/opentelemetry-dotnet/blob/master/CODEOWNERS#L15) and trigger CI build and tests.` as it is a common sense.