### PR TITLE
Changing namespace for otlp / console exporters

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/OpenTelemetryBuilderExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Console/OpenTelemetryBuilderExtensions.cs
@@ -15,9 +15,9 @@
 // </copyright>
 
 using System;
-using OpenTelemetry.Trace.Configuration;
+using OpenTelemetry.Exporter.Console;
 
-namespace OpenTelemetry.Exporter.Console
+namespace OpenTelemetry.Trace.Configuration
 {
     public static class OpenTelemetryBuilderExtensions
     {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OpenTelemetryBuilderExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OpenTelemetryBuilderExtensions.cs
@@ -15,9 +15,10 @@
 // </copyright>
 
 using System;
+using OpenTelemetry.Exporter.OpenTelemetryProtocol;
 using OpenTelemetry.Trace.Configuration;
 
-namespace OpenTelemetry.Exporter.OpenTelemetryProtocol
+namespace OpenTelemetry.Trace.Configuration
 {
     /// <summary>
     /// Extension methods to simplify registering of the OpenTelemetry Protocol (OTLP) exporter.


### PR DESCRIPTION
Fixes #712 .

## Changes
- changing the namespace of Oltp / Console Exporters to `OpenTelemetryBuilderExtensions`. So it will be similar to Jaeger / Zipkin

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
