### PR TITLE
Wire up the Activity Resource to the OTLP exporter

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
@@ -143,7 +143,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
                     continue;
                 }
 
-                var resource = activity.GetResource() ?? Resource.Empty;
+                var resource = activity.GetResource();
                 if (!result.TryGetValue(resource, out var libraryToSpans))
                 {
                     libraryToSpans = new Dictionary<ActivitySource, List<OtlpTrace.Span>>();

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
@@ -22,7 +22,7 @@ using System.Linq;
 using Google.Protobuf;
 
 using OpenTelemetry.Resources;
-
+using OpenTelemetry.Trace;
 using OtlpCommon = Opentelemetry.Proto.Common.V1;
 using OtlpResource = Opentelemetry.Proto.Resource.V1;
 using OtlpTrace = Opentelemetry.Proto.Trace.V1;
@@ -132,9 +132,6 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
         private static Dictionary<Resource, Dictionary<ActivitySource, List<OtlpTrace.Span>>> GroupByResourceAndLibrary(
             IEnumerable<Activity> activityBatch)
         {
-            // TODO: there is no Resource associated here, other SDKs associate it to the span, that's not an option here.
-            var fakeResource = Resource.Empty;
-
             var result = new Dictionary<Resource, Dictionary<ActivitySource, List<OtlpTrace.Span>>>();
             foreach (var activity in activityBatch)
             {
@@ -146,8 +143,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
                     continue;
                 }
 
-                // TODO: Retrieve resources for trace (not library/ActivitySource)
-                var resource = fakeResource;
+                var resource = activity.GetResource() ?? Resource.Empty;
                 if (!result.TryGetValue(resource, out var libraryToSpans))
                 {
                     libraryToSpans = new Dictionary<ActivitySource, List<OtlpTrace.Span>>();

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/ActivityExtensionsTest.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/ActivityExtensionsTest.cs
@@ -24,6 +24,7 @@ using Opentelemetry.Proto.Common.V1;
 #if NET452
 using OpenTelemetry.Internal;
 #endif
+using OpenTelemetry.Trace;
 using OpenTelemetry.Trace.Configuration;
 using Xunit;
 using OtlpCommon = Opentelemetry.Proto.Common.V1;
@@ -59,6 +60,12 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
                 new ActivitySource("odd", "1.3.5"),
             };
 
+            var resource = new Resources.Resource(
+                new List<KeyValuePair<string, object>>
+                {
+                    new KeyValuePair<string, object>(Resources.Resource.ServiceNamespaceKey, "ns1"),
+                });
+
             var activities = new List<Activity>();
             Activity activity = null;
             const int numOfSpans = 10;
@@ -71,6 +78,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
                 var activityTags = isEven ? evenTags : oddTags;
 
                 activity = source.StartActivity($"span-{i}", activityKind, activity?.Context ?? default, activityTags);
+                activity.SetResource(resource);
 
                 activities.Add(activity);
             }
@@ -80,6 +88,9 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
             var otlpResourceSpans = activities.ToOtlpResourceSpans();
 
             Assert.Single(otlpResourceSpans);
+            var oltpResource = otlpResourceSpans.First().Resource;
+            Assert.Equal(resource.Attributes.First().Key, oltpResource.Attributes.First().Key);
+            Assert.Equal(resource.Attributes.First().Value, oltpResource.Attributes.First().Value.StringValue);
 
             foreach (var instrumentationLibrarySpans in otlpResourceSpans.First().InstrumentationLibrarySpans)
             {


### PR DESCRIPTION
This change injects the real Resource from the Activity instead of the empty one. I verified that Spans sent to the collector have the Resource values set.