### PR TITLE
Adding step to add dotnet version 2.1.x

### DIFF
--- a/.vsts/ci-myget-update.yml
+++ b/.vsts/ci-myget-update.yml
@@ -17,12 +17,12 @@ pool:
 
 steps:
 - task: UseDotNet@2
-  displayName: force use of desired dotnet version
+  displayName: force use of dotnet 2.1.x
   inputs:
     version: $(DotNetVersion2)
 
 - task: UseDotNet@2
-  displayName: force use of desired dotnet version
+  displayName: force use of dotnet 3.1.x
   inputs:
     version: $(DotNetVersion3)
 

--- a/.vsts/ci-myget-update.yml
+++ b/.vsts/ci-myget-update.yml
@@ -1,7 +1,8 @@
 # CI build with the upload to MyGet
 
 variables:
-  DotNetVersion: "3.1.101"
+  DotNetVersion2: "2.1.x"
+  DotNetVersion3: "3.1.x"
 
 trigger:
   branches:
@@ -18,7 +19,12 @@ steps:
 - task: UseDotNet@2
   displayName: force use of desired dotnet version
   inputs:
-    version: $(DotNetVersion)
+    version: $(DotNetVersion2)
+
+- task: UseDotNet@2
+  displayName: force use of desired dotnet version
+  inputs:
+    version: $(DotNetVersion3)
 
 # "restore" is run automatically by "build"
 - task: VSBuild@1


### PR DESCRIPTION
Fixes #812.

## Changes
- adding step to install dotnet version 2.1.x

## Reference
- https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/dotnet-core-tool-installer?view=azure-devops

For significant contributions please make sure you have completed the following items:

* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
