### PR TITLE
Fixed a typo breaking non-signed builds of Jaeger.

### DIFF
--- a/src/OpenTelemetry.Exporter.Jaeger/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/AssemblyInfo.cs
@@ -24,5 +24,5 @@ using System.Runtime.CompilerServices;
 #else
 [assembly: InternalsVisibleTo("OpenTelemetry.Exporter.Jaeger.Tests")]
 [assembly: InternalsVisibleTo("Benchmarks")]
-[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2] // Used by Moq.
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")] // Used by Moq.
 #endif


### PR DESCRIPTION
Fixes: Jaeger Exporter has a typo that breaks the build when SIGNED constant is not present. Not sure why we have the ability to produce non-signed builds, but the fix was simple.
