### PR TITLE
Make Activity.SetStatus internal as users set Resource on a different level

### DIFF
--- a/src/OpenTelemetry/Trace/ActivityExtensions.cs
+++ b/src/OpenTelemetry/Trace/ActivityExtensions.cs
@@ -29,16 +29,6 @@ namespace OpenTelemetry.Trace
         /// Checks whether activity needs to be created and tracked.
         /// </summary>
         /// <param name="activity">Activity instance.</param>
-        /// <param name="resource">Resource to set to.</param>
-        public static void SetResource(this Activity activity, Resource resource)
-        {
-            activity.SetCustomProperty(ResourcePropertyName, resource);
-        }
-
-        /// <summary>
-        /// Checks whether activity needs to be created and tracked.
-        /// </summary>
-        /// <param name="activity">Activity instance.</param>
         /// <returns>The resource.</returns>
         public static Resource GetResource(this Activity activity)
         {
@@ -50,6 +40,16 @@ namespace OpenTelemetry.Trace
             {
                 return Resource.Empty;
             }
+        }
+
+        /// <summary>
+        /// Checks whether activity needs to be created and tracked.
+        /// </summary>
+        /// <param name="activity">Activity instance.</param>
+        /// <param name="resource">Resource to set to.</param>
+        internal static void SetResource(this Activity activity, Resource resource)
+        {
+            activity.SetCustomProperty(ResourcePropertyName, resource);
         }
     }
 }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/ActivityExtensionsTest.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/ActivityExtensionsTest.cs
@@ -66,6 +66,12 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
                     new KeyValuePair<string, object>(Resources.Resource.ServiceNamespaceKey, "ns1"),
                 });
 
+            // This following is done just to set Resource to Activity.
+            using var openTelemetrySdk = OpenTelemetrySdk.EnableOpenTelemetry(b => b
+                .AddActivitySource(sources[0].Name)
+                .AddActivitySource(sources[1].Name)
+                .SetResource(resource));
+
             var activities = new List<Activity>();
             Activity activity = null;
             const int numOfSpans = 10;
@@ -78,11 +84,6 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
                 var activityTags = isEven ? evenTags : oddTags;
 
                 activity = source.StartActivity($"span-{i}", activityKind, activity?.Context ?? default, activityTags);
-
-                // TODO: Refactor this tests to properly set resource without
-                // doing it directly on activity.
-                activity.SetCustomProperty("ot.resource", resource);
-
                 activities.Add(activity);
             }
 

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/ActivityExtensionsTest.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/ActivityExtensionsTest.cs
@@ -78,7 +78,10 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
                 var activityTags = isEven ? evenTags : oddTags;
 
                 activity = source.StartActivity($"span-{i}", activityKind, activity?.Context ?? default, activityTags);
-                activity.SetResource(resource);
+
+                // TODO: Refactor this tests to properly set resource without
+                // doing it directly on activity.
+                activity.SetCustomProperty("ot.resource", resource);
 
                 activities.Add(activity);
             }


### PR DESCRIPTION
OT SDK users set resource using OpenTelemetryBuilder. Activity.SetStatus() is not required to be public.
The GetStatus() is public, as Exporters need to retrieve status.

## Changes
Activity.SetStatus() made internal


Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
