### PR TITLE
Fix: BatchingActivityProcessor test flakiness

### DIFF
--- a/test/OpenTelemetry.Tests/Implementation/Trace/Export/BatchingActivityProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Trace/Export/BatchingActivityProcessorTests.cs
@@ -270,39 +270,40 @@ namespace OpenTelemetry.Trace.Export.Test
             var activityExporter = new TestActivityExporter(_ => Interlocked.Increment(ref exportCalledCount));
             using var activityProcessor =
                 new BatchingActivityProcessor(activityExporter, 128, TimeSpan.FromMilliseconds(100), DefaultTimeout, batchSize);
-            using var openTelemetrySdk = OpenTelemetrySdk.EnableOpenTelemetry(b => b
-                                        .AddActivitySource(ActivitySourceName)
-                                        .SetSampler(new AlwaysOnActivitySampler())
-                                        .AddProcessorPipeline(pp => pp.AddProcessor(ap => activityProcessor)));
-
-            using var inMemoryEventListener = new InMemoryEventListener();
-            var activities = new List<Activity>();
-            for (int i = 0; i < 100; i++)
+            using (var openTelemetrySdk = OpenTelemetrySdk.EnableOpenTelemetry(b => b
+                                         .AddActivitySource(ActivitySourceName)
+                                         .SetSampler(new AlwaysOnActivitySampler())
+                                         .AddProcessorPipeline(pp => pp.AddProcessor(ap => activityProcessor))))
             {
-                activities.Add(this.CreateActivity(i.ToString()));
+                using var inMemoryEventListener = new InMemoryEventListener();
+                var activities = new List<Activity>();
+                for (int i = 0; i < 100; i++)
+                {
+                    activities.Add(this.CreateActivity(i.ToString()));
+                }
+
+                Assert.True(activityExporter.ExportedActivities.Length < activities.Count);
+                using (var cts = new CancellationTokenSource(DefaultTimeout))
+                {
+                    await activityProcessor.ShutdownAsync(cts.Token);
+                }
+
+                // Get the shutdown event.
+                // 22 is the EventId for OpenTelemetrySdkEventSource.ForceFlushCompleted
+                // TODO: Expose event ids as internal, so tests can access them more reliably.
+                var shutdownEvent = inMemoryEventListener.Events.Where((e) => e.EventId == 22).First();
+
+                int droppedCount = 0;
+                if (shutdownEvent != null)
+                {
+                    // There is a single payload which is the number of items left in buffer at shutdown.
+                    droppedCount = (int)shutdownEvent.Payload[0];
+                }
+
+                Assert.True(activityExporter.WasShutDown);
+                Assert.Equal(activities.Count, droppedCount + activityExporter.ExportedActivities.Length);
+                Assert.InRange(exportCalledCount, activities.Count / batchSize, activities.Count);
             }
-
-            Assert.True(activityExporter.ExportedActivities.Length < activities.Count);
-            using (var cts = new CancellationTokenSource(DefaultTimeout))
-            {
-                await activityProcessor.ShutdownAsync(cts.Token);
-            }
-
-            // Get the shutdown event.
-            // 22 is the EventId for OpenTelemetrySdkEventSource.ForceFlushCompleted
-            // TODO: Expose event ids as internal, so tests can access them more reliably.
-            var shutdownEvent = inMemoryEventListener.Events.Where((e) => e.EventId == 22).First();
-
-            int droppedCount = 0;
-            if (shutdownEvent != null)
-            {
-                // There is a single payload which is the number of items left in buffer at shutdown.
-                droppedCount = (int)shutdownEvent.Payload[0];
-            }
-
-            Assert.True(activityExporter.WasShutDown);
-            Assert.Equal(activities.Count, droppedCount + activityExporter.ExportedActivities.Length);
-            Assert.InRange(exportCalledCount, activities.Count / batchSize, activities.Count);
         }
 
         [Fact]
@@ -321,26 +322,28 @@ namespace OpenTelemetry.Trace.Export.Test
 
             using var activityProcessor =
                 new BatchingActivityProcessor(activityExporter, 128, TimeSpan.FromMilliseconds(100), DefaultTimeout, batchSize);
-            using var openTelemetrySdk = OpenTelemetrySdk.EnableOpenTelemetry(b => b
-                                    .AddActivitySource(ActivitySourceName)
-                                    .SetSampler(new AlwaysOnActivitySampler())
-                                    .AddProcessorPipeline(pp => pp.AddProcessor(ap => activityProcessor)));
-            var activities = new List<Activity>();
-            for (int i = 0; i < 100; i++)
+            using (var openTelemetrySdk = OpenTelemetrySdk.EnableOpenTelemetry(b => b
+                                     .AddActivitySource(ActivitySourceName)
+                                     .SetSampler(new AlwaysOnActivitySampler())
+                                     .AddProcessorPipeline(pp => pp.AddProcessor(ap => activityProcessor))))
             {
-                activities.Add(this.CreateActivity(i.ToString()));
+                var activities = new List<Activity>();
+                for (int i = 0; i < 100; i++)
+                {
+                    activities.Add(this.CreateActivity(i.ToString()));
+                }
+
+                Assert.True(activityExporter.ExportedActivities.Length < activities.Count);
+
+                // we won't be able to export all before cancellation will fire
+                using (var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200)))
+                {
+                    await activityProcessor.ShutdownAsync(cts.Token);
+                }
+
+                var exportedCount = activityExporter.ExportedActivities.Length;
+                Assert.True(exportedCount < activities.Count);
             }
-
-            Assert.True(activityExporter.ExportedActivities.Length < activities.Count);
-
-            // we won't be able to export all before cancellation will fire
-            using (var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200)))
-            {
-                await activityProcessor.ShutdownAsync(cts.Token);
-            }
-
-            var exportedCount = activityExporter.ExportedActivities.Length;
-            Assert.True(exportedCount < activities.Count);
         }
 
         [Fact]
@@ -350,38 +353,39 @@ namespace OpenTelemetry.Trace.Export.Test
             int exportCalledCount = 0;
             var activityExporter = new TestActivityExporter(_ => Interlocked.Increment(ref exportCalledCount));
             using var activityProcessor = new BatchingActivityProcessor(activityExporter, 128, TimeSpan.FromMilliseconds(100), DefaultTimeout, batchSize);
-            using var openTelemetrySdk = OpenTelemetrySdk.EnableOpenTelemetry(b => b
+            using (var openTelemetrySdk = OpenTelemetrySdk.EnableOpenTelemetry(b => b
                 .AddActivitySource(ActivitySourceName)
                 .SetSampler(new AlwaysOnActivitySampler())
-                .AddProcessorPipeline(pp => pp.AddProcessor(ap => activityProcessor)));
-
-            using var inMemoryEventListener = new InMemoryEventListener();
-            var activities = new List<Activity>();
-            for (int i = 0; i < 100; i++)
+                .AddProcessorPipeline(pp => pp.AddProcessor(ap => activityProcessor))))
             {
-                activities.Add(this.CreateActivity(i.ToString()));
+                using var inMemoryEventListener = new InMemoryEventListener();
+                var activities = new List<Activity>();
+                for (int i = 0; i < 100; i++)
+                {
+                    activities.Add(this.CreateActivity(i.ToString()));
+                }
+
+                Assert.True(activityExporter.ExportedActivities.Length < activities.Count);
+                using (var cts = new CancellationTokenSource(DefaultTimeout))
+                {
+                    await activityProcessor.ForceFlushAsync(cts.Token);
+                }
+
+                // Get the shutdown event.
+                // 22 is the EventId for OpenTelemetrySdkEventSource.ForceFlushCompleted
+                // TODO: Expose event ids as internal, so tests can access them more reliably.
+                var shutdownEvent = inMemoryEventListener.Events.Where((e) => e.EventId == 22).First();
+
+                int droppedCount = 0;
+                if (shutdownEvent != null)
+                {
+                    // There is a single payload which is the number of items left in buffer at shutdown.
+                    droppedCount = (int)shutdownEvent.Payload[0];
+                }
+
+                Assert.Equal(activities.Count, activityExporter.ExportedActivities.Length + droppedCount);
+                Assert.InRange(exportCalledCount, activities.Count / batchSize, activities.Count);
             }
-
-            Assert.True(activityExporter.ExportedActivities.Length < activities.Count);
-            using (var cts = new CancellationTokenSource(DefaultTimeout))
-            {
-                await activityProcessor.ForceFlushAsync(cts.Token);
-            }
-
-            // Get the shutdown event.
-            // 22 is the EventId for OpenTelemetrySdkEventSource.ForceFlushCompleted
-            // TODO: Expose event ids as internal, so tests can access them more reliably.
-            var shutdownEvent = inMemoryEventListener.Events.Where((e) => e.EventId == 22).First();
-
-            int droppedCount = 0;
-            if (shutdownEvent != null)
-            {
-                // There is a single payload which is the number of items left in buffer at shutdown.
-                droppedCount = (int)shutdownEvent.Payload[0];
-            }
-
-            Assert.Equal(activities.Count, activityExporter.ExportedActivities.Length + droppedCount);
-            Assert.InRange(exportCalledCount, activities.Count / batchSize, activities.Count);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #830.

## Changes

- Issue is not reproducible in local environment, upon investigation looks like the dispose pattern gets counted in export. Modified the dispose pattern used for fail tests.