### PR TITLE
Add misspell to CI

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,21 @@
+name: spellcheck
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: check out code
+      uses: actions/checkout@v2
+
+    - name: install misspell
+      run: |
+        curl -L -o ./install-misspell.sh https://git.io/misspell
+        sh ./install-misspell.sh
+
+    - name: run misspell
+      run: ./bin/misspell -error .

--- a/samples/Exporters/Console/TestPrometheus.cs
+++ b/samples/Exporters/Console/TestPrometheus.cs
@@ -52,7 +52,7 @@ namespace Samples
             var metricsHttpServer = new PrometheusExporterMetricsHttpServer(promExporter);
             metricsHttpServer.Start();
 
-            // Creater Processor (called Batcher in Metric spec, this is still not decided)
+            // Create Processor (called Batcher in Metric spec, this is still not decided)
             var processor = new UngroupedBatcher();
 
             // MeterFactory is from where one can obtain Meters.

--- a/src/OpenTelemetry.Api/Context/Propagation/ITextFormat.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/ITextFormat.cs
@@ -21,7 +21,7 @@ namespace OpenTelemetry.Context.Propagation
 {
     /// <summary>
     /// Text format wire context propagator. Helps to extract and inject context from textual
-    /// representation (typically http headers or metadata colleciton).
+    /// representation (typically http headers or metadata collection).
     /// </summary>
     public interface ITextFormat
     {

--- a/src/OpenTelemetry.Api/Context/Propagation/ITextFormatActivity.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/ITextFormatActivity.cs
@@ -21,7 +21,7 @@ namespace OpenTelemetry.Context.Propagation
 {
     /// <summary>
     /// Text format wire context propagator. Helps to extract and inject context from textual
-    /// representation (typically http headers or metadata colleciton).
+    /// representation (typically http headers or metadata collection).
     /// </summary>
     public interface ITextFormatActivity
     {

--- a/src/OpenTelemetry.Api/Trace/Status.cs
+++ b/src/OpenTelemetry.Api/Trace/Status.cs
@@ -166,7 +166,7 @@ namespace OpenTelemetry.Trace
         public string Description { get; }
 
         /// <summary>
-        /// Gets a value indicating whether span completed sucessfully.
+        /// Gets a value indicating whether span completed successfully.
         /// </summary>
         public bool IsOk => this.CanonicalCode == StatusCanonicalCode.Ok;
 

--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -183,7 +183,7 @@ namespace OpenTelemetry.Internal
             this.WriteEvent(15, spanName);
         }
 
-        [Event(16, Message = "Exception occuring while invoking Metric Observer callback. '{0}' Exception: '{1}'", Level = EventLevel.Warning)]
+        [Event(16, Message = "Exception occurring while invoking Metric Observer callback. '{0}' Exception: '{1}'", Level = EventLevel.Warning)]
         public void MetricObserverCallbackError(string metricName, string exception)
         {
             this.WriteEvent(16, metricName, exception);

--- a/src/OpenTelemetry/Metrics/CounterMetricSdkBase.cs
+++ b/src/OpenTelemetry/Metrics/CounterMetricSdkBase.cs
@@ -85,7 +85,7 @@ namespace OpenTelemetry.Metrics
                          * Additional notes:
                          * This lock is never taken for bound instruments, and they offer the fastest performance.
                          * This lock is only taken for those labelsets which are marked CandidateForRemoval.
-                         * It means the the 1st time a labelset is re-encountered after two Collect() has occured,
+                         * It means the the 1st time a labelset is re-encountered after two Collect() has occurred,
                          * this lock must be taken. Subsequent usage of this labelset before the next two Collect()
                          * will already have status promoted, and no lock is taken.
                          * In effect, the lock is only taken for those labelsets
@@ -121,7 +121,7 @@ namespace OpenTelemetry.Metrics
                 if (this.counterBoundInstruments.TryGetValue(labelSet, out var boundInstrument))
                 {
                     // Check status again, inside lock as an instrument update
-                    // might have occured which promoted this record.
+                    // might have occurred which promoted this record.
                     if (boundInstrument.Status == RecordStatus.CandidateForRemoval)
                     {
                         this.counterBoundInstruments.Remove(labelSet);

--- a/src/OpenTelemetry/Metrics/MeterSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterSdk.cs
@@ -52,7 +52,7 @@ namespace OpenTelemetry.Metrics
                 OpenTelemetrySdkEventSource.Log.MeterCollectInvoked(this.meterName);
 
                 // collect all pending metric updates and send to batcher.
-                // must sync to prevent multiple Collect occuring at same time.
+                // must sync to prevent multiple Collect occurring at same time.
                 var boundInstrumentsToRemove = new List<LabelSet>();
                 foreach (var longCounter in this.longCounters)
                 {

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterTests.cs
@@ -177,7 +177,7 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
             // Though the above are Prometheus Server requirements, we haven't enforced it in code.
             // This is because we have implemented Prometheus using a Push Controller, where
             // we accumulate metrics from each Push into exporter, and is used to construct
-            // out for /metrics call. Because of this, its possible that multiple Push has occured
+            // out for /metrics call. Because of this, its possible that multiple Push has occurred
             // before Prometheus server makes /metrics call. (i.e Prometheus scrape interval is much more
             // than Push interval scenario)
             // Once a pull model is implemented, we'll not have this issue and we need to add tests

--- a/test/OpenTelemetry.Instrumentation.Dependencies.Tests/HttpWebRequestActivitySourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Dependencies.Tests/HttpWebRequestActivitySourceTests.netfx.cs
@@ -792,7 +792,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Tests
             // Examine the result. Make sure we got all successful requests.
 
             // Just make sure some events are written, to confirm we successfully subscribed to it. We should have
-            // exactly 1 Start event per request and exaclty 1 Stop event per response (if request succeeded)
+            // exactly 1 Start event per request and exactly 1 Stop event per response (if request succeeded)
             var successfulTasks = tasks.Where(t => t.Value.Status == TaskStatus.RanToCompletion);
 
             Assert.Equal(tasks.Count, eventRecords.Records.Count(rec => rec.Key == "Start"));

--- a/test/OpenTelemetry.Tests/Implementation/Trace/SpanTest.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Trace/SpanTest.cs
@@ -1114,7 +1114,7 @@ namespace OpenTelemetry.Trace.Test
         }
 
         [Fact]
-        public void SetAttribute_Array_Sets_Empty_String_For_Emtpy_Array()
+        public void SetAttribute_Array_Sets_Empty_String_For_Empty_Array()
         {
             var tracer = this.tracerFactory.GetTracer(null);
             var span = (SpanSdk)tracer.StartRootSpan(SpanName);


### PR DESCRIPTION
As part of the Beta release preparation, I'm cleaning up the documents.
This should help to capture obvious spelling mistakes / typo during CI, covering markdown files, source code, and other text files.
I've also fixed the error captured by `misspell`.

Related to #837.