### PR TITLE
Adding lock to dispose

### DIFF
--- a/src/OpenTelemetry/Trace/Export/BatchingActivityProcessor.cs
+++ b/src/OpenTelemetry/Trace/Export/BatchingActivityProcessor.cs
@@ -42,6 +42,7 @@ namespace OpenTelemetry.Trace.Export
         private readonly List<Activity> batch = new List<Activity>();
         private CancellationTokenSource cts;
         private volatile int currentQueueSize;
+        private object disposing = new object();
         private bool stopping = false;
 
         /// <summary>
@@ -175,7 +176,13 @@ namespace OpenTelemetry.Trace.Export
         {
             if (!this.stopping)
             {
-                this.ShutdownAsync(CancellationToken.None).ContinueWith(_ => { }).GetAwaiter().GetResult();
+                lock (this.disposing)
+                {
+                    if (!this.stopping)
+                    {
+                        this.ShutdownAsync(CancellationToken.None).ContinueWith(_ => { }).GetAwaiter().GetResult();
+                    }
+                }
             }
 
             if (isDisposing)

--- a/src/OpenTelemetry/Trace/Export/BatchingSpanProcessor.cs
+++ b/src/OpenTelemetry/Trace/Export/BatchingSpanProcessor.cs
@@ -38,6 +38,7 @@ namespace OpenTelemetry.Trace.Export
         private readonly SpanExporter exporter;
         private CancellationTokenSource cts;
         private volatile int currentQueueSize;
+        private object disposing = new object();
         private bool stopping = false;
 
         /// <summary>
@@ -159,7 +160,13 @@ namespace OpenTelemetry.Trace.Export
         {
             if (!this.stopping)
             {
-                this.ShutdownAsync(CancellationToken.None).ContinueWith(_ => { }).GetAwaiter().GetResult();
+                lock (this.disposing)
+                {
+                    if (!this.stopping)
+                    {
+                        this.ShutdownAsync(CancellationToken.None).ContinueWith(_ => { }).GetAwaiter().GetResult();
+                    }
+                }
             }
 
             if (isDisposing)


### PR DESCRIPTION
Fixes #769 .

## Changes
- Adding lock to prevent issue while shutdown occurs

## References
- `If an object's Dispose method is called more than once, the object must ignore all calls after the first one. The object must not throw an exception if its Dispose method is called multiple times. Instance methods other than Dispose can throw an ObjectDisposedException when resources are already disposed.`
- https://docs.microsoft.com/en-us/dotnet/api/system.idisposable.dispose?expand=1&view=netcore-3.1#remarks

For significant contributions please make sure you have completed the following items:

* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
