### PR TITLE
Cleaning up options in dependency instrumentation.

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Dependencies/HttpClientInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Dependencies/HttpClientInstrumentationOptions.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Net.Http;
 using OpenTelemetry.Context.Propagation;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.Dependencies
 {
@@ -25,17 +26,17 @@ namespace OpenTelemetry.Instrumentation.Dependencies
     public class HttpClientInstrumentationOptions
     {
         /// <summary>
-        /// Gets or sets a value indicating whether add HTTP version to a trace.
+        /// Gets or sets a value indicating whether or not the HTTP version should be added as the <see cref="SemanticConventions.AttributeHTTPFlavor"/> tag. Default value: False.
         /// </summary>
         public bool SetHttpFlavor { get; set; } = false;
 
         /// <summary>
-        /// Gets or sets <see cref="ITextFormatActivity"/> for context propagation.
+        /// Gets or sets <see cref="ITextFormatActivity"/> for context propagation. Default value: <see cref="TraceContextFormatActivity"/>.
         /// </summary>
         public ITextFormatActivity TextFormat { get; set; } = new TraceContextFormatActivity();
 
         /// <summary>
-        /// Gets or sets an optional callback method for filtering HttpClient requests that are sent through the instrumentation.
+        /// Gets or sets an optional callback method for filtering <see cref="HttpRequestMessage"/> requests that are sent through the instrumentation.
         /// </summary>
         public Func<HttpRequestMessage, bool> FilterFunc { get; set; }
 

--- a/src/OpenTelemetry.Instrumentation.Dependencies/HttpWebRequestInstrumentationOptions.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Dependencies/HttpWebRequestInstrumentationOptions.netfx.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Net;
 using OpenTelemetry.Context.Propagation;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.Dependencies
 {
@@ -26,17 +27,17 @@ namespace OpenTelemetry.Instrumentation.Dependencies
     public class HttpWebRequestInstrumentationOptions
     {
         /// <summary>
-        /// Gets or sets a value indicating whether add HTTP version to a trace.
+        /// Gets or sets a value indicating whether or not the HTTP version should be added as the <see cref="SemanticConventions.AttributeHTTPFlavor"/> tag. Default value: False.
         /// </summary>
         public bool SetHttpFlavor { get; set; } = false;
 
         /// <summary>
-        /// Gets or sets <see cref="ITextFormat"/> for context propagation.
+        /// Gets or sets <see cref="ITextFormatActivity"/> for context propagation. Default value: <see cref="TraceContextFormatActivity"/>.
         /// </summary>
         public ITextFormatActivity TextFormat { get; set; } = new TraceContextFormatActivity();
 
         /// <summary>
-        /// Gets or sets an optional callback method for filtering HttpClient requests that are sent through the instrumentation.
+        /// Gets or sets an optional callback method for filtering <see cref="HttpWebRequest"/> requests that are sent through the instrumentation.
         /// </summary>
         public Func<HttpWebRequest, bool> FilterFunc { get; set; }
 

--- a/src/OpenTelemetry.Instrumentation.Dependencies/Implementation/SqlClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Dependencies/Implementation/SqlClientDiagnosticListener.cs
@@ -102,7 +102,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Implementation
                                 {
                                     case CommandType.StoredProcedure:
                                         activity.AddTag(SpanAttributeConstants.DatabaseStatementTypeKey, nameof(CommandType.StoredProcedure));
-                                        if (this.options.CaptureStoredProcedureCommandName)
+                                        if (this.options.SetStoredProcedureCommandName)
                                         {
                                             activity.AddTag(SemanticConventions.AttributeDBStatement, (string)commandText);
                                         }
@@ -111,7 +111,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Implementation
 
                                     case CommandType.Text:
                                         activity.AddTag(SpanAttributeConstants.DatabaseStatementTypeKey, nameof(CommandType.Text));
-                                        if (this.options.CaptureTextCommandContent)
+                                        if (this.options.SetTextCommandContent)
                                         {
                                             activity.AddTag(SemanticConventions.AttributeDBStatement, (string)commandText);
                                         }

--- a/src/OpenTelemetry.Instrumentation.Dependencies/Implementation/SqlEventSourceListener.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Dependencies/Implementation/SqlEventSourceListener.netfx.cs
@@ -123,7 +123,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Implementation
                 else
                 {
                     activity.AddTag(SpanAttributeConstants.DatabaseStatementTypeKey, nameof(CommandType.StoredProcedure));
-                    if (this.options.CaptureStoredProcedureCommandName)
+                    if (this.options.SetStoredProcedureCommandName)
                     {
                         activity.AddTag(SemanticConventions.AttributeDBStatement, commandText);
                     }

--- a/src/OpenTelemetry.Instrumentation.Dependencies/SqlClientInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Dependencies/SqlClientInstrumentationOptions.cs
@@ -27,8 +27,6 @@ namespace OpenTelemetry.Instrumentation.Dependencies
     /// </summary>
     public class SqlClientInstrumentationOptions
     {
-        internal const string MicrosoftSqlServerDatabaseInstanceName = "db.mssql.instance_name";
-
         /*
          * Match...
          *  serverName
@@ -41,20 +39,20 @@ namespace OpenTelemetry.Instrumentation.Dependencies
         private static readonly ConcurrentDictionary<string, SqlConnectionDetails> ConnectionDetailCache = new ConcurrentDictionary<string, SqlConnectionDetails>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
-        /// Gets or sets a value indicating whether or not the <see cref="SqlClientInstrumentation"/> should capture the names of <see cref="CommandType.StoredProcedure"/> commands. Default value: True.
+        /// Gets or sets a value indicating whether or not the <see cref="SqlClientInstrumentation"/> should add the names of <see cref="CommandType.StoredProcedure"/> commands as the <see cref="SemanticConventions.AttributeDBStatement"/> tag. Default value: True.
         /// </summary>
-        public bool CaptureStoredProcedureCommandName { get; set; } = true;
+        public bool SetStoredProcedureCommandName { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets a value indicating whether or not the <see cref="SqlClientInstrumentation"/> should capture the text of <see cref="CommandType.Text"/> commands. Default value: False.
+        /// Gets or sets a value indicating whether or not the <see cref="SqlClientInstrumentation"/> should add the text of <see cref="CommandType.Text"/> commands as the <see cref="SemanticConventions.AttributeDBStatement"/> tag. Default value: False.
         /// </summary>
-        public bool CaptureTextCommandContent { get; set; }
+        public bool SetTextCommandContent { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether or not the <see cref="SqlClientInstrumentation"/> should parse the DataSource on a SqlConnection into server name, instance name, and/or port connection-level attributes. Default value: False.
+        /// Gets or sets a value indicating whether or not the <see cref="SqlClientInstrumentation"/> should parse the DataSource on a SqlConnection into server name, instance name, and/or port connection-level attribute tags. Default value: False.
         /// </summary>
         /// <remarks>
-        /// The default behavior is to set the SqlConnection DataSource as the peer.service tag. If enabled, SqlConnection DataSource will be parsed and the server name will be sent as the net.peer.name or net.peer.ip tag, the instance name will be sent as the db.mssql.instance_name tag, and the port will be sent as the net.peer.port tag if it is not 1433 (the default port).
+        /// The default behavior is to set the SqlConnection DataSource as the <see cref="SemanticConventions.AttributePeerService"/> tag. If enabled, SqlConnection DataSource will be parsed and the server name will be sent as the <see cref="SemanticConventions.AttributeNetPeerName"/> or <see cref="SemanticConventions.AttributeNetPeerIP"/> tag, the instance name will be sent as the <see cref="SemanticConventions.AttributeDBMSSQLInstanceName"/> tag, and the port will be sent as the <see cref="SemanticConventions.AttributeNetPeerPort"/> tag if it is not 1433 (the default port).
         /// </remarks>
         public bool EnableConnectionLevelAttributes { get; set; } = false;
 
@@ -134,7 +132,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies
 
                 if (!string.IsNullOrEmpty(connectionDetails.InstanceName))
                 {
-                    sqlActivity.AddTag(MicrosoftSqlServerDatabaseInstanceName, connectionDetails.InstanceName);
+                    sqlActivity.AddTag(SemanticConventions.AttributeDBMSSQLInstanceName, connectionDetails.InstanceName);
                 }
 
                 if (!string.IsNullOrEmpty(connectionDetails.Port))

--- a/test/OpenTelemetry.Instrumentation.Dependencies.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Dependencies.Tests/SqlClientTests.cs
@@ -83,8 +83,8 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Tests
                 b.AddProcessorPipeline(c => c.AddProcessor(ap => activityProcessor.Object));
                 b.AddSqlClientDependencyInstrumentation(options =>
                 {
-                    options.CaptureStoredProcedureCommandName = captureStoredProcedureCommandName;
-                    options.CaptureTextCommandContent = captureTextCommandContent;
+                    options.SetStoredProcedureCommandName = captureStoredProcedureCommandName;
+                    options.SetTextCommandContent = captureTextCommandContent;
                 });
             });
 
@@ -137,8 +137,8 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Tests
                     (builder) => builder.AddSqlClientDependencyInstrumentation(
                         (opt) =>
                         {
-                            opt.CaptureTextCommandContent = captureTextCommandContent;
-                            opt.CaptureStoredProcedureCommandName = captureStoredProcedureCommandName;
+                            opt.SetTextCommandContent = captureTextCommandContent;
+                            opt.SetStoredProcedureCommandName = captureStoredProcedureCommandName;
                         })
                     .AddProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object))))
             {

--- a/test/OpenTelemetry.Instrumentation.Dependencies.Tests/SqlEventSourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Dependencies.Tests/SqlEventSourceTests.netfx.cs
@@ -58,7 +58,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Tests
                 b.AddProcessorPipeline(c => c.AddProcessor(ap => activityProcessor.Object));
                 b.AddSqlClientDependencyInstrumentation(options =>
                 {
-                    options.CaptureStoredProcedureCommandName = captureText;
+                    options.SetStoredProcedureCommandName = captureText;
                 });
             });
 
@@ -111,7 +111,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Tests
                 b.AddProcessorPipeline(c => c.AddProcessor(ap => activityProcessor.Object));
                 b.AddSqlClientDependencyInstrumentation(options =>
                 {
-                    options.CaptureStoredProcedureCommandName = captureText;
+                    options.SetStoredProcedureCommandName = captureText;
                     options.EnableConnectionLevelAttributes = enableConnectionLevelAttributes;
                 });
             });
@@ -208,7 +208,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Tests
 
                 if (!string.IsNullOrEmpty(connectionDetails.InstanceName))
                 {
-                    Assert.Equal(connectionDetails.InstanceName, activity.Tags.FirstOrDefault(t => t.Key == SqlClientInstrumentationOptions.MicrosoftSqlServerDatabaseInstanceName).Value);
+                    Assert.Equal(connectionDetails.InstanceName, activity.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeDBMSSQLInstanceName).Value);
                 }
 
                 if (!string.IsNullOrEmpty(connectionDetails.Port))


### PR DESCRIPTION
## Changes

Cleaned up some of the XML comments in the options classes in the Dependency Instrumentation assembly and made the "Capture" options in SQL "Set" to mirror the SetHttpFlavor option. Used new `SemanticConventions` constants where I could.
