### PR TITLE
Clean up Jaeger doc structure

### DIFF
--- a/src/OpenTelemetry.Exporter.Jaeger/README.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/README.md
@@ -1,20 +1,38 @@
 # Jaeger Exporter for OpenTelemetry .NET
 
+[![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.Exporter.Jaeger.svg)](https://www.nuget.org/packages/OpenTelemetry.Exporter.Jaeger)
 [![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.Exporter.Jaeger.svg)](https://www.nuget.org/packages/OpenTelemetry.Exporter.Jaeger)
 
 The Jaeger exporter communicates to a Jaeger Agent through the compact thrift
-protocol on the Compact Thrift API port. You can configure the Jaeger exporter
-by following the directions below:
+protocol on the Compact Thrift API port.
 
-1. [Get Jaeger](https://www.jaegertracing.io/docs/1.13/getting-started/).
-2. Configure the `JaegerExporter`
-    * `ServiceName`: The name of your application or service.
-    * `AgentHost`: Usually `localhost` since an agent should usually be running
-      on the same machine as your application or service.
-    * `AgentPort`: The compact thrift protocol port of the Jaeger Agent
-      (default `6831`)
-    * `MaxPacketSize`: The maximum size of each UDP packet that gets sent to
-      the agent. (default `65000`)
-3. See the
-   [`TestJaegerExporter.cs`](../../samples/Exporters/Console/TestJaegerExporter.cs)
-   for an example of how to use the exporter.
+## Prerequisite
+
+* [Get Jaeger](https://www.jaegertracing.io/docs/1.13/getting-started/)
+
+## Installation
+
+```shell
+dotnet add package OpenTelemetry.Exporter.Jaeger
+```
+
+## Configuration
+
+You can configure the `JaegerExporter` by following the directions below:
+
+* `ServiceName`: The name of your application or service.
+* `AgentHost`: Usually `localhost` since an agent should usually be running on
+  the same machine as your application or service.
+* `AgentPort`: The compact thrift protocol port of the Jaeger Agent (default
+  `6831`).
+* `MaxPacketSize`: The maximum size of each UDP packet that gets sent to the
+  agent. (default `65000`).
+
+See the
+[`TestJaegerExporter.cs`](../../samples/Exporters/Console/TestJaegerExporter.cs)
+for an example of how to use the exporter.
+
+## References
+
+* [Jaeger](https://www.jaegertracing.io)
+* [OpenTelemetry Project](https://opentelemetry.io/)


### PR DESCRIPTION
## Changes

For beta release, I suggest that each nuget package to have its own `README.md` file following a consistent structure.
This PR is using Jaeger Exporter doc to get feedback. Here goes the [preview doc](https://github.com/open-telemetry/opentelemetry-dotnet/blob/reyang/doc-structure/src/OpenTelemetry.Exporter.Jaeger/README.md).

Related to https://github.com/open-telemetry/opentelemetry-dotnet/pull/847#issuecomment-661250285.