### PR TITLE
Clean up doc structure

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -16,4 +16,4 @@ jobs:
       run: sudo npm install -g markdownlint-cli
 
     - name: run markdownlint
-      run: markdownlint **/*.md
+      run: markdownlint .

--- a/src/OpenTelemetry.Api/README.md
+++ b/src/OpenTelemetry.Api/README.md
@@ -1,16 +1,30 @@
-# Getting Started
+# OpenTelemetry .NET API
 
-- [Getting Started](#getting-started)
-  - [OpenTelemetry API](#opentelemetry-api)
-    - [Tracer API](#tracer-api)
-    - [Metric API](#metric-api)
-  - [Introduction to OpenTelemetry .NET Tracer API](#introduction-to-opentelemetry-net-tracer-api)
-  - [Instrumenting a library/application with .NET Activity API](#instrumenting-a-libraryapplication-with-net-activity-api)
-    - [Basic usage](#basic-usage)
-    - [Activity creation options](#activity-creation-options)
-    - [Adding Events](#adding-events)
-    - [Setting Status](#setting-status)
-  - [Instrumenting a library/application with OpenTelemetry.API Shim](#instrumenting-a-libraryapplication-with-opentelemetryapi-shim)
+[![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.Api.svg)](https://www.nuget.org/packages/OpenTelemetry.Api)
+[![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.Api.svg)](https://www.nuget.org/packages/OpenTelemetry.Api)
+
+## Installation
+
+```shell
+dotnet add package OpenTelemetry.Api
+```
+
+## Getting Started
+
+* [Getting Started](#getting-started)
+  * [OpenTelemetry API](#opentelemetry-api)
+    * [Tracer API](#tracer-api)
+    * [Metric API](#metric-api)
+  * [Introduction to OpenTelemetry .NET Tracer
+    API](#introduction-to-opentelemetry-net-tracer-api)
+  * [Instrumenting a library/application with .NET Activity
+    API](#instrumenting-a-libraryapplication-with-net-activity-api)
+    * [Basic usage](#basic-usage)
+    * [Activity creation options](#activity-creation-options)
+    * [Adding Events](#adding-events)
+    * [Setting Status](#setting-status)
+  * [Instrumenting a library/application with OpenTelemetry.API
+    Shim](#instrumenting-a-libraryapplication-with-opentelemetryapi-shim)
 
 ## OpenTelemetry API
 
@@ -33,8 +47,8 @@ conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/
 API](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md)
 allows users to generate
 [Spans](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#span),
-which represent a single operation within a trace. Spans can be nested to form a
-trace tree. Each trace contains a root span, which typically describes the
+which represent a single operation within a trace. Spans can be nested to form
+a trace tree. Each trace contains a root span, which typically describes the
 entire operation and, optionally one or more sub-spans for its sub-operations.
 
 ### Metric API
@@ -52,8 +66,8 @@ for tracing purposes and represents the equivalent of the OpenTelemetry
 [Span](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#span).
 OpenTelemetry .NET is reusing the existing `Activity` and associated classes to
 represent the OpenTelemetry `Span`. This means, users can instrument their
-applications/libraries to emit OpenTelemetry compatible traces by using just the
-.NET Runtime.
+applications/libraries to emit OpenTelemetry compatible traces by using just
+the .NET Runtime.
 
 The `Activity` and associated classes are shipped as part of
 `System.Diagnostics.DiagnosticSource` nuget package. Version 5.0.0 of this
@@ -64,9 +78,9 @@ specification](https://github.com/open-telemetry/opentelemetry-specification/blo
 Even though `Activity` enables all the scenarios OpenTelemetry supports, users
 who are already familiar with OpenTelemetry terminology may find it easy to
 operate with that terminology. For instance, `StartSpan` may be preferred over
-`StartActivity`. To help with this transition, the OpenTelemetry.API package has
-[shim](#instrumenting-a-libraryapplication-with-opentelemetryapi-shim) classes
-to wrap around the .NET `Activity` classes.
+`StartActivity`. To help with this transition, the OpenTelemetry.API package
+has [shim](#instrumenting-a-libraryapplication-with-opentelemetryapi-shim)
+classes to wrap around the .NET `Activity` classes.
 
 The shim exist only in the API. OpenTelemetry SDK for .NET will be operating
 entirely with `Activity` only. Irrespective of whether shim classes or
@@ -77,131 +91,154 @@ Processors/Exporters see the same data.
 
 ### Basic usage
 
-As mentioned in the introduction, the instrumentation API for OpenTelemetry .NET
-is the .NET `Activity` API. Guidance for instrumenting using this API is
+As mentioned in the introduction, the instrumentation API for OpenTelemetry
+.NET is the .NET `Activity` API. Guidance for instrumenting using this API is
 documented fully in the TBD(dotnet activity user guide link), but is described
 here as well.
 
 1. Install the `System.Diagnostics.DiagnosticSource` package version
    5.0.0-preview.7.20308.13 or above to your application or library.
 
-```xml
-    <ItemGroup>
-        <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0-preview.7.20308.13" />
-    </ItemGroup>
-```
+    ```xml
+        <ItemGroup>
+            <PackageReference
+                Include="System.Diagnostics.DiagnosticSource"
+                Version="5.0.0-preview.7.20308.13" />
+        </ItemGroup>
+    ```
 
 2. Create an `ActivitySource`, providing the name and version of the
    library/application being instrumented. `ActivitySource` instance is
    typically created once and is reused throughout the application/library.
 
-```csharp
-    static ActivitySource activitySource = new ActivitySource("companyname.product.library", "semver1.0.0");
-```
+    ```csharp
+        static ActivitySource activitySource = new ActivitySource(
+            "companyname.product.library",
+            "semver1.0.0");
+    ```
+
     The above requires import of the `System.Diagnostics` namespace.
 
 3. Use the `ActivitySource` instance from above to create `Activity` instances,
    which represent a single operation within a trace. The parameter passed is
    the `DisplayName` of the activity.
 
-```csharp
-    var activity = source.StartActivity("ActivityName");
-```
+    ```csharp
+        var activity = source.StartActivity("ActivityName");
+    ```
 
-    If there are no listeners interested in this activity, the activity above will be null. Ensure that all subsequent calls using this activity is protected with a null check.
+    If there are no listeners interested in this activity, the activity above
+    will be null. Ensure that all subsequent calls using this activity is
+    protected with a null check.
 
 4. Populate activity with tags following the [OpenTelemetry semantic
    conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/trace/semantic_conventions).
    It is highly recommended to check `activity.IsAllDataRequested`, before
    populating any tags which are not readily available.
 
-```csharp
-    parent?.AddTag("http.method", "GET");
-    if (parent?.IsAllDataRequested ?? false)
-    {
-        parent.AddTag("http.url", "http://www.mywebsite.com");
-    }
-```
+    ```csharp
+        parent?.AddTag("http.method", "GET");
+        if (parent?.IsAllDataRequested ?? false)
+        {
+            parent.AddTag("http.url", "http://www.mywebsite.com");
+        }
+    ```
 
 5. Perform application/library logic.
 
 6. Stop the activity when done.
 
-```csharp
-    activity?.Stop();
-```
+    ```csharp
+        activity?.Stop();
+    ```
 
-Alternately, as `Activity` implements `IDisposable`, it can be used with a
-`using` block, which ensures activity gets stopped upon disposal. This is shown
-below.
-```csharp
-    using (var activity = source.StartActivity("ActivityName")
-    {
-        parent?.AddTag("http.method", "GET");
-    } // Activity gets stopped automatically at end of this block during dispose.
-```
+    Alternately, as `Activity` implements `IDisposable`, it can be used with a
+    `using` block, which ensures activity gets stopped upon disposal. This is
+    shown below.
+
+    ```csharp
+        using (var activity = source.StartActivity("ActivityName")
+        {
+            parent?.AddTag("http.method", "GET");
+        } // Activity gets stopped automatically at end of this block during dispose.
+    ```
 
 The above showed the basic usage of instrumenting using `Activity`. The
 following sections describes more features.
 
 ### Activity creation options
 
-Basic usage example above showed how `StartActivity` method can be used to start
-an `Activity`. The started activity will automatically becomes the `Current`
-activity. It is important to note that the `StartActivity` returns `null`, if no
-listeners are interested in the activity to be created. This happens when the
-final application does not enable OpenTelemetry, or when OpenTelemetry samplers
-chose not to sample this activity.
+Basic usage example above showed how `StartActivity` method can be used to
+start an `Activity`. The started activity will automatically becomes the
+`Current` activity. It is important to note that the `StartActivity` returns
+`null`, if no listeners are interested in the activity to be created. This
+happens when the final application does not enable OpenTelemetry, or when
+OpenTelemetry samplers chose not to sample this activity.
 
 `StartActivity` has many overloads to control the activity creation.
+
 1. `ActivityKind`
 
-`Activity` has a property called `ActivityKind` which represents OpenTelemetry
-[SpanKind](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#spankind).
-The default value will be `Internal`. `StartActivity` allows passing the
-`ActivityKind` while starting an `Activity`.
+    `Activity` has a property called `ActivityKind` which represents
+    OpenTelemetry
+    [SpanKind](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#spankind).
+    The default value will be `Internal`. `StartActivity` allows passing the
+    `ActivityKind` while starting an `Activity`.
 
-```csharp
-    var activity = source.StartActivity("ActivityName", ActivityKind.Server);
-```
+    ```csharp
+        var activity = source.StartActivity("ActivityName", ActivityKind.Server);
+    ```
 
 2. Parent using `ActivityContext`
 
-`ActivityContext` represents the OpenTelemetry
-[SpanContext](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#spancontext).
-While starting a new `Activity`, the currently active `Activity` is
-automatically taken as the parent of the new activity being created.
-`StartActivity` allows passing explicit `ActivityContext` to override this
-behavior.
+    `ActivityContext` represents the OpenTelemetry
+    [SpanContext](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#spancontext).
+    While starting a new `Activity`, the currently active `Activity` is
+    automatically taken as the parent of the new activity being created.
+    `StartActivity` allows passing explicit `ActivityContext` to override this
+    behavior.
 
-```csharp
-    var parentContext = new ActivityContext(ActivityTraceId.CreateFromString("0af7651916cd43dd8448eb211c80319c"), ActivitySpanId.CreateFromString("b7ad6b7169203331"), ActivityTraceFlags.None);
-    var activity = source.StartActivity("ActivityName", ActivityKind.Server, parentContext);
-```
+    ```csharp
+        var parentContext = new ActivityContext(
+            ActivityTraceId.CreateFromString("0af7651916cd43dd8448eb211c80319c"),
+            ActivitySpanId.CreateFromString("b7ad6b7169203331"),
+            ActivityTraceFlags.None);
+        var activity = source.StartActivity(
+            "ActivityName",
+            ActivityKind.Server,
+            parentContext);
+    ```
 
-As `ActivityContext` follows the [W3C
-Trace-Context](https://w3c.github.io/trace-context), it is also possible to
-provide the parent context as a single string matching the `traceparent` header
-of the W3C Trace-Context. This is shown below.
+    As `ActivityContext` follows the [W3C
+    Trace-Context](https://w3c.github.io/trace-context), it is also possible to
+    provide the parent context as a single string matching the `traceparent`
+    header of the W3C Trace-Context. This is shown below.
 
-```csharp
-    var activity = source.StartActivity("ActivityName", ActivityKind.Server, "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01");
-```
+    ```csharp
+        var activity = source.StartActivity(
+            "ActivityName",
+            ActivityKind.Server,
+            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01");
+    ```
 
 3. Initial Tags
 
    `Tags` in `Activity` represents the OpenTelemetry [Span
    Attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#set-attributes).
-   Earlier sample showed the usage of `AddTag` method of `Activity` to add tags.
-   It is also possible to provide an initial set of tags during activity
+   Earlier sample showed the usage of `AddTag` method of `Activity` to add
+   tags. It is also possible to provide an initial set of tags during activity
    creation, as shown below.
 
-```csharp
-    var initialTags = new List<KeyValuePair<string, string>>();
-    initialTags.Add(new KeyValuePair<string, string>("tag1", "tagValue1"));
-    initialTags.Add(new KeyValuePair<string, string>("tag2", "tagValue2"));
-    var activity = source.StartActivity("ActivityName", ActivityKind.Server, "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01", initialTags);
-```
+    ```csharp
+        var initialTags = new List<KeyValuePair<string, string>>();
+        initialTags.Add(new KeyValuePair<string, string>("tag1", "tagValue1"));
+        initialTags.Add(new KeyValuePair<string, string>("tag2", "tagValue2"));
+        var activity = source.StartActivity(
+            "ActivityName",
+            ActivityKind.Server,
+            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+            initialTags);
+    ```
 
 4. Activity Links
 
@@ -211,14 +248,25 @@ of the W3C Trace-Context. This is shown below.
    The linked activities must be provided during the creation time, as shown
    below.
 
-```csharp
-    var activityLinks = new List<ActivityLink>();
-    var linkedContext1 = new ActivityContext(ActivityTraceId.CreateFromString("0af7651916cd43dd8448eb211c80319c"), ActivitySpanId.CreateFromString("b7ad6b7169203331"), ActivityTraceFlags.None);
-    var linkedContext2 = new ActivityContext(ActivityTraceId.CreateFromString("4bf92f3577b34da6a3ce929d0e0e4736"), ActivitySpanId.CreateFromString("00f067aa0ba902b7"), ActivityTraceFlags.Recorded);
-    activityLinks.Add(new ActivityLink(linkedContext1));
-    activityLinks.Add(new ActivityLink(linkedContext2));
-    var activity = source.StartActivity("ActivityName", ActivityKind.Server, "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01", initialTags, activityLinks);
-```
+    ```csharp
+        var activityLinks = new List<ActivityLink>();
+        var linkedContext1 = new ActivityContext(
+            ActivityTraceId.CreateFromString("0af7651916cd43dd8448eb211c80319c"),
+            ActivitySpanId.CreateFromString("b7ad6b7169203331"),
+            ActivityTraceFlags.None);
+        var linkedContext2 = new ActivityContext(
+            ActivityTraceId.CreateFromString("4bf92f3577b34da6a3ce929d0e0e4736"),
+            ActivitySpanId.CreateFromString("00f067aa0ba902b7"),
+            ActivityTraceFlags.Recorded);
+        activityLinks.Add(new ActivityLink(linkedContext1));
+        activityLinks.Add(new ActivityLink(linkedContext2));
+        var activity = source.StartActivity(
+            "ActivityName",
+            ActivityKind.Server,
+            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+            initialTags,
+            activityLinks);
+    ```
 
 ### Adding Events
 
@@ -255,3 +303,7 @@ Example:
 ## Instrumenting a library/application with OpenTelemetry.API Shim
 
 This section to be filled after shim is shipped.
+
+## References
+
+* [OpenTelemetry Project](https://opentelemetry.io/)

--- a/src/OpenTelemetry.Exporter.Console/README.md
+++ b/src/OpenTelemetry.Exporter.Console/README.md
@@ -1,9 +1,20 @@
-# OpenTelemetry.Exporter.Console
+# Console Exporter for OpenTelemetry .NET
 
-This is a simple exporter that that JSON serializes collected activities and
-prints them to the Console and is intended to be used during learning how
-activities are created and exported.
+[![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.Exporter.Console.svg)](https://www.nuget.org/packages/OpenTelemetry.Exporter.Console)
+[![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.Exporter.Console.svg)](https://www.nuget.org/packages/OpenTelemetry.Exporter.Console)
 
-**Note** This is not intended as a production tool
+The console exporter prints data to the Console in a JSON serialized format.
 
-TODO: Add example here?
+**Note:** this exporter is intended to be used during learning how telemetry
+data are created and exported. It is not recommended for any production
+environment.
+
+## Installation
+
+```shell
+dotnet add package OpenTelemetry.Exporter.Console
+```
+
+## References
+
+* [OpenTelemetry Project](https://opentelemetry.io/)

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
@@ -1,0 +1,18 @@
+# OTLP Exporter for OpenTelemetry .NET
+
+[![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.Exporter.OpenTelemetryProtocol.svg)](https://www.nuget.org/packages/OpenTelemetry.Exporter.OpenTelemetryProtocol)
+[![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.Exporter.OpenTelemetryProtocol.svg)](https://www.nuget.org/packages/OpenTelemetry.Exporter.OpenTelemetryProtocol)
+
+The OTLP (OpenTelemetry Protocol) exporter communicates to an OpenTelemetry Collector through a gRPC protocol.
+
+## Installation
+
+```shell
+dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
+```
+
+## References
+
+* [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector)
+* [OpenTelemetry Project](https://opentelemetry.io/)
+* [OpenTelemetry Protocol](https://github.com/open-telemetry/opentelemetry-proto)

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
@@ -3,7 +3,8 @@
 [![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.Exporter.OpenTelemetryProtocol.svg)](https://www.nuget.org/packages/OpenTelemetry.Exporter.OpenTelemetryProtocol)
 [![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.Exporter.OpenTelemetryProtocol.svg)](https://www.nuget.org/packages/OpenTelemetry.Exporter.OpenTelemetryProtocol)
 
-The OTLP (OpenTelemetry Protocol) exporter communicates to an OpenTelemetry Collector through a gRPC protocol.
+The OTLP (OpenTelemetry Protocol) exporter communicates to an OpenTelemetry
+Collector through a gRPC protocol.
 
 ## Installation
 
@@ -13,6 +14,9 @@ dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
 
 ## References
 
-* [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector)
+* [OpenTelemetry
+  Collector](https://github.com/open-telemetry/opentelemetry-collector)
 * [OpenTelemetry Project](https://opentelemetry.io/)
-* [OpenTelemetry Protocol](https://github.com/open-telemetry/opentelemetry-proto)
+* [OpenTelemetry
+  Protocol](https://github.com/open-telemetry/opentelemetry-proto)
+  

--- a/src/OpenTelemetry.Exporter.Prometheus/README.md
+++ b/src/OpenTelemetry.Exporter.Prometheus/README.md
@@ -1,13 +1,21 @@
 # Prometheus Exporter for OpenTelemetry .NET
 
-Configure Prometheus exporter to have stats collected by Prometheus.
+[![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.Exporter.Prometheus.svg)](https://www.nuget.org/packages/OpenTelemetry.Exporter.Prometheus)
+[![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.Exporter.Prometheus.svg)](https://www.nuget.org/packages/OpenTelemetry.Exporter.Prometheus)
 
-1. Get Prometheus using [getting started
-   guide](https://prometheus.io/docs/introduction/first_steps/).
-2. Start `PrometheusExporter` as below.
-3. See
-   [sample](https://github.com/open-telemetry/opentelemetry-dotnet/blob/master/samples/Exporters/Console/TestPrometheus.cs)
-   for example use.
+## Prerequisite
+
+* [Get Prometheus](https://prometheus.io/docs/introduction/first_steps/)
+
+## Installation
+
+```shell
+dotnet add package OpenTelemetry.Exporter.Prometheus
+```
+
+## Configuration
+
+Start `PrometheusExporter` as below.
 
 ```csharp
 var exporter = new PrometheusExporter(
@@ -29,3 +37,12 @@ finally
     exporter.Stop();
 }
 ```
+
+See
+[sample](https://github.com/open-telemetry/opentelemetry-dotnet/blob/master/samples/Exporters/Console/TestPrometheus.cs)
+for example use.
+
+## References
+
+* [OpenTelemetry Project](https://opentelemetry.io/)
+* [Prometheus](https://prometheus.io)

--- a/src/OpenTelemetry.Exporter.ZPages/README.md
+++ b/src/OpenTelemetry.Exporter.ZPages/README.md
@@ -1,0 +1,14 @@
+# ZPages Exporter for OpenTelemetry .NET
+
+[![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.Exporter.ZPages.svg)](https://www.nuget.org/packages/OpenTelemetry.Exporter.ZPages)
+[![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.Exporter.ZPages.svg)](https://www.nuget.org/packages/OpenTelemetry.Exporter.ZPages)
+
+## Installation
+
+```shell
+dotnet add package OpenTelemetry.Exporter.ZPages
+```
+
+## References
+
+* [OpenTelemetry Project](https://opentelemetry.io/)

--- a/src/OpenTelemetry.Exporter.Zipkin/README.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/README.md
@@ -1,13 +1,21 @@
 # Zipkin Exporter for OpenTelemetry .NET
 
-Configure Zipkin exporter to see traces in Zipkin UI.
+[![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.Exporter.Zipkin.svg)](https://www.nuget.org/packages/OpenTelemetry.Exporter.Zipkin)
+[![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.Exporter.Zipkin.svg)](https://www.nuget.org/packages/OpenTelemetry.Exporter.Zipkin)
 
-1. Get Zipkin using [getting started
-   guide](https://zipkin.io/pages/quickstart.html).
-2. Configure `ZipkinTraceExporter` as below:
-3. See
-   [sample](https://github.com/open-telemetry/opentelemetry-dotnet/blob/master/samples/Exporters/Console/TestZipkin.cs)
-   for example use.
+## Prerequisite
+
+* [Get Zipkin](https://zipkin.io/pages/quickstart.html)
+
+## Installation
+
+```shell
+dotnet add package OpenTelemetry.Exporter.Zipkin
+```
+
+## Configuration
+
+Configure `ZipkinTraceExporter` as below:
 
 ```csharp
 using (var tracerFactory = TracerFactory.Create(builder => builder
@@ -30,3 +38,10 @@ using (var tracerFactory = TracerFactory.Create(builder => builder
     }
 }
 ```
+
+See [sample](https://github.com/open-telemetry/opentelemetry-dotnet/blob/master/samples/Exporters/Console/TestZipkin.cs) for example use.
+
+## References
+
+* [OpenTelemetry Project](https://opentelemetry.io/)
+* [Zipkin](https://zipkin.io)

--- a/src/OpenTelemetry.Exporter.Zipkin/README.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/README.md
@@ -39,7 +39,9 @@ using (var tracerFactory = TracerFactory.Create(builder => builder
 }
 ```
 
-See [sample](https://github.com/open-telemetry/opentelemetry-dotnet/blob/master/samples/Exporters/Console/TestZipkin.cs) for example use.
+See
+[sample](https://github.com/open-telemetry/opentelemetry-dotnet/blob/master/samples/Exporters/Console/TestZipkin.cs)
+for example use.
 
 ## References
 

--- a/src/OpenTelemetry.Extensions.Hosting/README.md
+++ b/src/OpenTelemetry.Extensions.Hosting/README.md
@@ -1,0 +1,14 @@
+# OpenTelemetry.Extensions.Hosting
+
+[![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.Extensions.Hosting.svg)](https://www.nuget.org/packages/OpenTelemetry.Extensions.Hosting)
+[![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.Extensions.Hosting.svg)](https://www.nuget.org/packages/OpenTelemetry.Extensions.Hosting)
+
+## Installation
+
+```shell
+dotnet add package OpenTelemetry.Extensions.Hosting
+```
+
+## References
+
+* [OpenTelemetry Project](https://opentelemetry.io/)

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
@@ -1,0 +1,14 @@
+# OpenTelemetry.Instrumentation.AspNetCore
+
+[![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.AspNetCore.svg)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNetCore)
+[![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.AspNetCore.svg)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AspNetCore)
+
+## Installation
+
+```shell
+dotnet add package OpenTelemetry.Instrumentation.AspNetCore
+```
+
+## References
+
+* [OpenTelemetry Project](https://opentelemetry.io/)

--- a/src/OpenTelemetry.Instrumentation.Dependencies/README.md
+++ b/src/OpenTelemetry.Instrumentation.Dependencies/README.md
@@ -1,0 +1,14 @@
+# OpenTelemetry.Instrumentation.Dependencies
+
+[![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.Dependencies.svg)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Dependencies)
+[![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.Dependencies.svg)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Dependencies)
+
+## Installation
+
+```shell
+dotnet add package OpenTelemetry.Instrumentation.Dependencies
+```
+
+## References
+
+* [OpenTelemetry Project](https://opentelemetry.io/)

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/README.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/README.md
@@ -1,23 +1,33 @@
-# Using StackExchange.Redis instrumentation
+# StackExchange.Redis Instrumentation for OpenTelemetry .NET
 
-Outgoing calls to Redis made using `StackExchange.Redis` library can be
-automatically tracked.
+[![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.Instrumentation.StackExchangeRedis.svg)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.StackExchangeRedis)
+[![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.Instrumentation.StackExchangeRedis.svg)](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.StackExchangeRedis)
 
-1. Install package to your project:
-   [OpenTelemetry.Instrumentation.StackExchangeRedis](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.StackExchangeRedis)
+Automatically instruments the outgoing calls to Redis made using
+`StackExchange.Redis` library.
 
-2. Configure Redis instrumentation:
+## Installation
 
-    ```csharp
-    // Connect to the server.
-    using var connection = ConnectionMultiplexer.Connect("localhost:6379");
+```shell
+dotnet add package OpenTelemetry.Instrumentation.StackExchangeRedis
+```
 
-    // Pass the connection to AddRedisInstrumentation.
-    using var openTelemetry = OpenTelemetrySdk.EnableOpenTelemetry(b => b
-        .AddRedisInstrumentation(connection)
-        .UseZipkinExporter()
-        .SetResource(Resources.CreateServiceResource("my-service"));
-    ```
+## Configuration
+
+```csharp
+// Connect to the server.
+using var connection = ConnectionMultiplexer.Connect("localhost:6379");
+
+// Pass the connection to AddRedisInstrumentation.
+using var openTelemetry = OpenTelemetrySdk.EnableOpenTelemetry(b => b
+    .AddRedisInstrumentation(connection)
+    .UseZipkinExporter()
+    .SetResource(Resources.CreateServiceResource("my-service"));
+```
 
 For a more detailed example see
 [TestRedis](../../samples/Exporters/Console/TestRedis.cs).
+
+## References
+
+* [OpenTelemetry Project](https://opentelemetry.io/)

--- a/src/OpenTelemetry.Shims.OpenTracing/README.md
+++ b/src/OpenTelemetry.Shims.OpenTracing/README.md
@@ -1,0 +1,15 @@
+# OpenTracing Shim for OpenTelemetry .NET
+
+[![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.Shims.OpenTracing.svg)](https://www.nuget.org/packages/OpenTelemetry.Shims.OpenTracing)
+[![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.Shims.OpenTracing.svg)](https://www.nuget.org/packages/OpenTelemetry.Shims.OpenTracing)
+
+## Installation
+
+```shell
+dotnet add package OpenTelemetry.Shims.OpenTracing
+```
+
+## References
+
+* [OpenTelemetry Project](https://opentelemetry.io/)
+* [OpenTracing](https://opentracing.io)

--- a/src/OpenTelemetry/README.md
+++ b/src/OpenTelemetry/README.md
@@ -1,0 +1,14 @@
+# OpenTelemetry .NET SDK
+
+[![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.svg)](https://www.nuget.org/packages/OpenTelemetry)
+[![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.svg)](https://www.nuget.org/packages/OpenTelemetry)
+
+## Installation
+
+```shell
+dotnet add package OpenTelemetry
+```
+
+## References
+
+* [OpenTelemetry Project](https://opentelemetry.io/)


### PR DESCRIPTION
For beta release, I suggest that each nuget package to have its own README.md file following a consistent structure.
In this PR I followed what I did in #849 by covering more components.