### PR TITLE
Minor improvements over consistency

### DIFF
--- a/src/OpenTelemetry.Api/OpenTelemetry.Api.csproj
+++ b/src/OpenTelemetry.Api/OpenTelemetry.Api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
-    <Description>OpenTelemetry .NET instrumentation API.</Description>
+    <Description>OpenTelemetry .NET API</Description>
     <RootNamespace>OpenTelemetry</RootNamespace>
     <DefineConstants>$(DefineConstants);API</DefineConstants>
   </PropertyGroup>

--- a/src/OpenTelemetry.Exporter.Console/OpenTelemetry.Exporter.Console.csproj
+++ b/src/OpenTelemetry.Exporter.Console/OpenTelemetry.Exporter.Console.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
-    <Description>Console exporter for Open Telemetry.</Description>
-    <PackageTags>$(PackageTags);Console;distributed-tracing;Debug;Experimental</PackageTags>
+    <Description>Console exporter for OpenTelemetry .NET</Description>
+    <PackageTags>$(PackageTags);Console;distributed-tracing</PackageTags>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenTelemetry.Exporter.Jaeger/OpenTelemetry.Exporter.Jaeger.csproj
+++ b/src/OpenTelemetry.Exporter.Jaeger/OpenTelemetry.Exporter.Jaeger.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net46;netstandard2.0;netstandard2.1</TargetFrameworks>
-    <Description>Jaeger exporter for Open Telemetry.</Description>
+    <Description>Jaeger exporter for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);Jaeger;distributed-tracing</PackageTags>
   </PropertyGroup>
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net452;net46;netstandard2.0</TargetFrameworks>
-    <Description>OpenTelemetry exporter to the OpenTelemetry collector (otelcol).</Description>
-    <PackageTags>$(PackageTags);otelcol;distributed-tracing</PackageTags>
+    <Description>OpenTelemetry protocol exporter for OpenTelemetry .NET</Description>
+    <PackageTags>$(PackageTags);distributed-tracing</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Exporter.Prometheus/OpenTelemetry.Exporter.Prometheus.csproj
+++ b/src/OpenTelemetry.Exporter.Prometheus/OpenTelemetry.Exporter.Prometheus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net452;net46;netstandard2.0;</TargetFrameworks>
-    <Description>OpenTelemetry to Prometheus exporter.</Description>
+    <Description>Prometheus exporter for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);Prometheus</PackageTags>
   </PropertyGroup>
 

--- a/src/OpenTelemetry.Exporter.Prometheus/OpenTelemetry.Exporter.Prometheus.csproj
+++ b/src/OpenTelemetry.Exporter.Prometheus/OpenTelemetry.Exporter.Prometheus.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;net46;netstandard2.0;</TargetFrameworks>
+    <TargetFrameworks>net452;net46;netstandard2.0</TargetFrameworks>
     <Description>Prometheus exporter for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);Prometheus</PackageTags>
   </PropertyGroup>

--- a/src/OpenTelemetry.Exporter.ZPages/OpenTelemetry.Exporter.ZPages.csproj
+++ b/src/OpenTelemetry.Exporter.ZPages/OpenTelemetry.Exporter.ZPages.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net452;net46;netstandard2.0</TargetFrameworks>
-    <Description>ZPages exporter for OpenTelemetry.</Description>
+    <Description>ZPages exporter for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);ZPages;distributed-tracing</PackageTags>
   </PropertyGroup>
 

--- a/src/OpenTelemetry.Exporter.Zipkin/OpenTelemetry.Exporter.Zipkin.csproj
+++ b/src/OpenTelemetry.Exporter.Zipkin/OpenTelemetry.Exporter.Zipkin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net452;net461;netstandard2.0</TargetFrameworks>
-    <Description>Zipkin exporter for OpenTelemetry.</Description>
+    <Description>Zipkin exporter for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);Zipkin;distributed-tracing</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/OpenTelemetry.Extensions.Hosting/OpenTelemetry.Extensions.Hosting.csproj
+++ b/src/OpenTelemetry.Extensions.Hosting/OpenTelemetry.Extensions.Hosting.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Description>Startup extensions to register OpenTelemetry into .NET applications using Microsoft.Extensions.DependencyInjection and Microsoft.Extensions.Hosting</Description>
+    <Description>Startup extensions to register OpenTelemetry into the applications using Microsoft.Extensions.DependencyInjection and Microsoft.Extensions.Hosting</Description>
     <RootNamespace>OpenTelemetry</RootNamespace>
   </PropertyGroup>
 

--- a/src/OpenTelemetry.Extensions.Hosting/OpenTelemetry.Extensions.Hosting.csproj
+++ b/src/OpenTelemetry.Extensions.Hosting/OpenTelemetry.Extensions.Hosting.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Description>Startup extensions to register OpenTelemetry into .NET Core applications</Description>
+    <Description>Startup extensions to register OpenTelemetry into .NET applications using Microsoft.Extensions.DependencyInjection and Microsoft.Extensions.Hosting</Description>
     <RootNamespace>OpenTelemetry</RootNamespace>
   </PropertyGroup>
 

--- a/src/OpenTelemetry.Extensions.Hosting/OpenTelemetry.Extensions.Hosting.csproj
+++ b/src/OpenTelemetry.Extensions.Hosting/OpenTelemetry.Extensions.Hosting.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Description>OpenTelemetry hosting integration adds startup extensions to register OpenTelemetry into .NET Core applications.</Description>
+    <Description>Startup extensions to register OpenTelemetry into .NET Core applications</Description>
     <RootNamespace>OpenTelemetry</RootNamespace>
   </PropertyGroup>
 

--- a/src/OpenTelemetry.Instrumentation.AspNet.Win/OpenTelemetry.Instrumentation.AspNet.Win.csproj
+++ b/src/OpenTelemetry.Instrumentation.AspNet.Win/OpenTelemetry.Instrumentation.AspNet.Win.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net452;net46</TargetFrameworks>
-    <Description>OpenTelemetry instrumentation for ASP.NET requests.</Description>
+    <Description>ASP.NET instrumentation for OpenTelemetry .NET</Description>
     <AssemblyName>OpenTelemetry.Instrumentation.AspNet</AssemblyName>
     <PackageTags>$(PackageTags);distributed-tracing;AspNet;MVC;WebAPI</PackageTags>
   </PropertyGroup>

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Description>OpenTelemetry instrumentation for ASP.NET Core requests.</Description>
+    <Description>ASP.NET Core instrumentation for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);distributed-tracing;AspNetCore</PackageTags>
   </PropertyGroup>
 

--- a/src/OpenTelemetry.Instrumentation.Dependencies/OpenTelemetry.Instrumentation.Dependencies.csproj
+++ b/src/OpenTelemetry.Instrumentation.Dependencies/OpenTelemetry.Instrumentation.Dependencies.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net452;net461</TargetFrameworks>
-    <Description>OpenTelemetry instrumentation for Http, Sql, &amp; Azure dependencies.</Description>
-    <PackageTags>$(PackageTags);distributed-tracing;HttpClient</PackageTags>
+    <Description>HTTP, SQL and gRPC client instrumentation for OpenTelemetry .NET</Description>
+    <PackageTags>$(PackageTags);distributed-tracing</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/OpenTelemetry.Instrumentation.StackExchangeRedis.csproj
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/OpenTelemetry.Instrumentation.StackExchangeRedis.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <Description>OpenTelemetry instrumentation for Redis calls made by the StackExchange.Redis library.</Description>
+    <Description>StackExchange.Redis instrumentation for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);distributed-tracing;Redis;StackExchange.Redis</PackageTags>
   </PropertyGroup>
 

--- a/src/OpenTelemetry.Shims.OpenTracing/OpenTelemetry.Shims.OpenTracing.csproj
+++ b/src/OpenTelemetry.Shims.OpenTracing/OpenTelemetry.Shims.OpenTracing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net452;net46;netstandard2.0</TargetFrameworks>
-    <Description>OpenTelemetry shim for OpenTracing</Description>
+    <Description>OpenTracing shim for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);distributed-tracing;OpenTracing</PackageTags>
     <IsPackable>true</IsPackable>
   </PropertyGroup>

--- a/src/OpenTelemetry/OpenTelemetry.csproj
+++ b/src/OpenTelemetry/OpenTelemetry.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net452;net46;netstandard2.0</TargetFrameworks>
-    <Description>OpenTelemetry .NET SDK.</Description>
+    <Description>OpenTelemetry .NET SDK</Description>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
* Make package description consistent
  * I've removed the ending period from description per guidance from the official nuget document.
  * I've made `OpenTelemetry .NET` instead of `OpenTelemetry` as NuGet allows C++ components.