### PR TITLE
Temporarily disable code coverage

### DIFF
--- a/.github/workflows/dotnet-core-cov.yml
+++ b/.github/workflows/dotnet-core-cov.yml
@@ -2,9 +2,9 @@ name: .NET Code Coverage
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master1 ]
   pull_request:
-    branches: [ master ]
+    branches: [ master1 ]
 
 jobs:
   build-test-report:
@@ -24,7 +24,7 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.301
-            
+
     - name: Install dependencies
       run: dotnet restore
 
@@ -36,7 +36,7 @@ jobs:
 
     - name: Install report tool
       run: dotnet tool install -g dotnet-reportgenerator-globaltool
-    
+
     - name: Merging test results
       run: reportgenerator -reports:TestResults/**/*.xml -targetdir:TestResults -reporttypes:Cobertura
 


### PR DESCRIPTION
For this week only.
1. GH Actions has hard limits of maximum parallel workflows. Given intense PR activity in prep for Beta, we want to spend less time in GH Action queue. We have been seeing extended wait time for PRs to be merged due to hitting limits. 
2. CodeCoverage is not a required CI for merge today.

