### PR TITLE
Renaming SemanticConvention constants

### DIFF
--- a/src/OpenTelemetry.Api/Trace/SemanticConventions.cs
+++ b/src/OpenTelemetry.Api/Trace/SemanticConventions.cs
@@ -30,16 +30,16 @@ namespace OpenTelemetry.Trace
         public const string AttributeServiceInstance = "service.instance.id";
         public const string AttributeServiceVersion = "service.version";
 
-        public const string AttributeTelemetrySDKName = "telemetry.sdk.name";
-        public const string AttributeTelemetrySDKLanguage = "telemetry.sdk.language";
-        public const string AttributeTelemetrySDKVersion = "telemetry.sdk.version";
+        public const string AttributeTelemetrySdkName = "telemetry.sdk.name";
+        public const string AttributeTelemetrySdkLanguage = "telemetry.sdk.language";
+        public const string AttributeTelemetrySdkVersion = "telemetry.sdk.version";
 
         public const string AttributeContainerName = "container.name";
         public const string AttributeContainerImage = "container.image.name";
         public const string AttributeContainerTag = "container.image.tag";
 
         public const string AttributeFaasName = "faas.name";
-        public const string AttributeFaasID = "faas.id";
+        public const string AttributeFaasId = "faas.id";
         public const string AttributeFaasVersion = "faas.version";
         public const string AttributeFaasInstance = "faas.instance";
 
@@ -49,14 +49,14 @@ namespace OpenTelemetry.Trace
         public const string AttributeK8sDeployment = "k8s.deployment.name";
 
         public const string AttributeHostHostname = "host.hostname";
-        public const string AttributeHostID = "host.id";
+        public const string AttributeHostId = "host.id";
         public const string AttributeHostName = "host.name";
         public const string AttributeHostType = "host.type";
         public const string AttributeHostImageName = "host.image.name";
-        public const string AttributeHostImageID = "host.image.id";
+        public const string AttributeHostImageId = "host.image.id";
         public const string AttributeHostImageVersion = "host.image.version";
 
-        public const string AttributeProcessID = "process.id";
+        public const string AttributeProcessId = "process.id";
         public const string AttributeProcessExecutableName = "process.executable.name";
         public const string AttributeProcessExecutablePath = "process.executable.path";
         public const string AttributeProcessCommand = "process.command";
@@ -70,70 +70,70 @@ namespace OpenTelemetry.Trace
         public const string AttributeComponent = "component";
 
         public const string AttributeNetTransport = "net.transport";
-        public const string AttributeNetPeerIP = "net.peer.ip";
+        public const string AttributeNetPeerIp = "net.peer.ip";
         public const string AttributeNetPeerPort = "net.peer.port";
         public const string AttributeNetPeerName = "net.peer.name";
-        public const string AttributeNetHostIP = "net.host.ip";
+        public const string AttributeNetHostIp = "net.host.ip";
         public const string AttributeNetHostPort = "net.host.port";
         public const string AttributeNetHostName = "net.host.name";
 
-        public const string AttributeEnduserID = "enduser.id";
+        public const string AttributeEnduserId = "enduser.id";
         public const string AttributeEnduserRole = "enduser.role";
         public const string AttributeEnduserScope = "enduser.scope";
 
         public const string AttributePeerService = "peer.service";
 
-        public const string AttributeHTTPMethod = "http.method";
-        public const string AttributeHTTPURL = "http.url";
-        public const string AttributeHTTPTarget = "http.target";
-        public const string AttributeHTTPHost = "http.host";
-        public const string AttributeHTTPScheme = "http.scheme";
-        public const string AttributeHTTPStatusCode = "http.status_code";
-        public const string AttributeHTTPStatusText = "http.status_text";
-        public const string AttributeHTTPFlavor = "http.flavor";
-        public const string AttributeHTTPServerName = "http.server_name";
-        public const string AttributeHTTPHostName = "host.name";
-        public const string AttributeHTTPHostPort = "host.port";
-        public const string AttributeHTTPRoute = "http.route";
-        public const string AttributeHTTPClientIP = "http.client_ip";
-        public const string AttributeHTTPUserAgent = "http.user_agent";
-        public const string AttributeHTTPRequestContentLength = "http.request_content_length";
-        public const string AttributeHTTPRequestContentLengthUncompressed = "http.request_content_length_uncompressed";
-        public const string AttributeHTTPResponseContentLength = "http.response_content_length";
-        public const string AttributeHTTPResponseContentLengthUncompressed = "http.response_content_length_uncompressed";
+        public const string AttributeHttpMethod = "http.method";
+        public const string AttributeHttpUrl = "http.url";
+        public const string AttributeHttpTarget = "http.target";
+        public const string AttributeHttpHost = "http.host";
+        public const string AttributeHttpScheme = "http.scheme";
+        public const string AttributeHttpStatusCode = "http.status_code";
+        public const string AttributeHttpStatusText = "http.status_text";
+        public const string AttributeHttpFlavor = "http.flavor";
+        public const string AttributeHttpServerName = "http.server_name";
+        public const string AttributeHttpHostName = "host.name";
+        public const string AttributeHttpHostPort = "host.port";
+        public const string AttributeHttpRoute = "http.route";
+        public const string AttributeHttpClientIP = "http.client_ip";
+        public const string AttributeHttpUserAgent = "http.user_agent";
+        public const string AttributeHttpRequestContentLength = "http.request_content_length";
+        public const string AttributeHttpRequestContentLengthUncompressed = "http.request_content_length_uncompressed";
+        public const string AttributeHttpResponseContentLength = "http.response_content_length";
+        public const string AttributeHttpResponseContentLengthUncompressed = "http.response_content_length_uncompressed";
 
-        public const string AttributeDBSystem = "db.system";
-        public const string AttributeDBConnectionString = "db.connection_string";
-        public const string AttributeDBUser = "db.user";
-        public const string AttributeDBMSSQLInstanceName = "db.mssql.instance_name";
-        public const string AttributeDBJDBCDriverClassName = "db.jdbc.driver_classname";
-        public const string AttributeDBName = "db.name";
-        public const string AttributeDBStatement = "db.statement";
-        public const string AttributeDBOperation = "db.operation";
-        public const string AttributeDBInstance = "db.instance";
-        public const string AttributeDBURL = "db.url";
-        public const string AttributeDBCassandraKeyspace = "db.cassandra.keyspace";
-        public const string AttributeDBHBaseNamespace = "db.hbase.namespace";
-        public const string AttributeDBRedisDatabaseIndex = "db.redis.database_index";
-        public const string AttributeDBMongoDBCollection = "db.mongodb.collection";
+        public const string AttributeDbSystem = "db.system";
+        public const string AttributeDbConnectionString = "db.connection_string";
+        public const string AttributeDbUser = "db.user";
+        public const string AttributeDbMsSqlInstanceName = "db.mssql.instance_name";
+        public const string AttributeDbJdbcDriverClassName = "db.jdbc.driver_classname";
+        public const string AttributeDbName = "db.name";
+        public const string AttributeDbStatement = "db.statement";
+        public const string AttributeDbOperation = "db.operation";
+        public const string AttributeDbInstance = "db.instance";
+        public const string AttributeDbUrl = "db.url";
+        public const string AttributeDbCassandraKeyspace = "db.cassandra.keyspace";
+        public const string AttributeDbHBaseNamespace = "db.hbase.namespace";
+        public const string AttributeDbRedisDatabaseIndex = "db.redis.database_index";
+        public const string AttributeDbMongoDbCollection = "db.mongodb.collection";
 
-        public const string AttributeRPCSystem = "rpc.system";
-        public const string AttributeRPCService = "rpc.service";
-        public const string AttributeRPCMethod = "rpc.method";
+        public const string AttributeRpcSystem = "rpc.system";
+        public const string AttributeRpcService = "rpc.service";
+        public const string AttributeRpcMethod = "rpc.method";
 
         public const string AttributeMessageType = "message.type";
-        public const string AttributeMessageID = "message.id";
+        public const string AttributeMessageId = "message.id";
         public const string AttributeMessageCompressedSize = "message.compressed_size";
         public const string AttributeMessageUncompressedSize = "message.uncompressed_size";
 
-        public const string AttributeFaaSTrigger = "faas.trigger";
-        public const string AttributeFaaSExecution = "faas.execution";
-        public const string AttributeFaaSDocumentCollection = "faas.document.collection";
-        public const string AttributeFaaSDocumentOperation = "faas.document.operation";
-        public const string AttributeFaaSDocumentTime = "faas.document.time";
-        public const string AttributeFaaSDocumentName = "faas.document.name";
-        public const string AttributeFaaSTime = "faas.time";
-        public const string AttributeFaaSCron = "faas.cron";
+        public const string AttributeFaasTrigger = "faas.trigger";
+        public const string AttributeFaasExecution = "faas.execution";
+        public const string AttributeFaasDocumentCollection = "faas.document.collection";
+        public const string AttributeFaasDocumentOperation = "faas.document.operation";
+        public const string AttributeFaasDocumentTime = "faas.document.time";
+        public const string AttributeFaasDocumentName = "faas.document.name";
+        public const string AttributeFaasTime = "faas.time";
+        public const string AttributeFaasCron = "faas.cron";
 
         public const string AttributeMessagingSystem = "messaging.system";
         public const string AttributeMessagingDestination = "messaging.destination";
@@ -141,9 +141,9 @@ namespace OpenTelemetry.Trace
         public const string AttributeMessagingTempDestination = "messaging.temp_destination";
         public const string AttributeMessagingProtocol = "messaging.protocol";
         public const string AttributeMessagingProtocolVersion = "messaging.protocol_version";
-        public const string AttributeMessagingURL = "messaging.url";
-        public const string AttributeMessagingMessageID = "messaging.message_id";
-        public const string AttributeMessagingConversationID = "messaging.conversation_id";
+        public const string AttributeMessagingUrl = "messaging.url";
+        public const string AttributeMessagingMessageId = "messaging.message_id";
+        public const string AttributeMessagingConversationId = "messaging.conversation_id";
         public const string AttributeMessagingPayloadSize = "messaging.message_payload_size_bytes";
         public const string AttributeMessagingPayloadCompressedSize = "messaging.message_payload_compressed_size_bytes";
         public const string AttributeMessagingOperation = "messaging.operation";

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerActivityExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerActivityExtensions.cs
@@ -45,7 +45,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
         {
             [SemanticConventions.AttributePeerService] = 0, // priority 0 (highest).
             [SemanticConventions.AttributeNetPeerName] = 1,
-            [SemanticConventions.AttributeNetPeerIP] = 2,
+            [SemanticConventions.AttributeNetPeerIp] = 2,
             ["peer.hostname"] = 2,
             ["peer.address"] = 2,
             ["http.host"] = 3, // peer.service for Http.

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinActivityConversionExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinActivityConversionExtensions.cs
@@ -34,7 +34,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
         {
             [SemanticConventions.AttributePeerService] = 0, // priority 0 (highest).
             [SemanticConventions.AttributeNetPeerName] = 1,
-            [SemanticConventions.AttributeNetPeerIP] = 2,
+            [SemanticConventions.AttributeNetPeerIp] = 2,
             ["peer.hostname"] = 2,
             ["peer.address"] = 2,
             ["http.host"] = 3, // RemoteEndpoint.ServiceName for Http.

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -95,17 +95,17 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
             {
                 if (request.Url.Port == 80 || request.Url.Port == 443)
                 {
-                    activity.AddTag(SemanticConventions.AttributeHTTPHost, request.Url.Host);
+                    activity.AddTag(SemanticConventions.AttributeHttpHost, request.Url.Host);
                 }
                 else
                 {
-                    activity.AddTag(SemanticConventions.AttributeHTTPHost, request.Url.Host + ":" + request.Url.Port);
+                    activity.AddTag(SemanticConventions.AttributeHttpHost, request.Url.Host + ":" + request.Url.Port);
                 }
 
-                activity.AddTag(SemanticConventions.AttributeHTTPMethod, request.HttpMethod);
+                activity.AddTag(SemanticConventions.AttributeHttpMethod, request.HttpMethod);
                 activity.AddTag(SpanAttributeConstants.HttpPathKey, path);
-                activity.AddTag(SemanticConventions.AttributeHTTPUserAgent, request.UserAgent);
-                activity.AddTag(SemanticConventions.AttributeHTTPURL, request.Url.ToString());
+                activity.AddTag(SemanticConventions.AttributeHttpUserAgent, request.UserAgent);
+                activity.AddTag(SemanticConventions.AttributeHttpUrl, request.Url.ToString());
             }
         }
 
@@ -140,7 +140,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
 
                 var response = context.Response;
 
-                activityToEnrich.AddTag(SemanticConventions.AttributeHTTPStatusCode, response.StatusCode.ToString());
+                activityToEnrich.AddTag(SemanticConventions.AttributeHttpStatusCode, response.StatusCode.ToString());
 
                 activityToEnrich.SetStatus(
                     SpanHelper
@@ -172,7 +172,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
                 {
                     // Override the name that was previously set to the path part of URL.
                     activityToEnrich.DisplayName = template;
-                    activityToEnrich.AddTag(SemanticConventions.AttributeHTTPRoute, template);
+                    activityToEnrich.AddTag(SemanticConventions.AttributeHttpRoute, template);
                 }
             }
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -100,21 +100,21 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
 
                 if (request.Host.Port == 80 || request.Host.Port == 443)
                 {
-                    activity.AddTag(SemanticConventions.AttributeHTTPHost, request.Host.Host);
+                    activity.AddTag(SemanticConventions.AttributeHttpHost, request.Host.Host);
                 }
                 else
                 {
-                    activity.AddTag(SemanticConventions.AttributeHTTPHost, request.Host.Host + ":" + request.Host.Port);
+                    activity.AddTag(SemanticConventions.AttributeHttpHost, request.Host.Host + ":" + request.Host.Port);
                 }
 
-                activity.AddTag(SemanticConventions.AttributeHTTPMethod, request.Method);
+                activity.AddTag(SemanticConventions.AttributeHttpMethod, request.Method);
                 activity.AddTag(SpanAttributeConstants.HttpPathKey, path);
-                activity.AddTag(SemanticConventions.AttributeHTTPURL, GetUri(request));
+                activity.AddTag(SemanticConventions.AttributeHttpUrl, GetUri(request));
 
                 var userAgent = request.Headers["User-Agent"].FirstOrDefault();
                 if (!string.IsNullOrEmpty(userAgent))
                 {
-                    activity.AddTag(SemanticConventions.AttributeHTTPUserAgent, userAgent);
+                    activity.AddTag(SemanticConventions.AttributeHttpUserAgent, userAgent);
                 }
             }
         }
@@ -130,7 +130,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
                 }
 
                 var response = context.Response;
-                activity.AddTag(SemanticConventions.AttributeHTTPStatusCode, response.StatusCode.ToString());
+                activity.AddTag(SemanticConventions.AttributeHttpStatusCode, response.StatusCode.ToString());
 
                 Status status = SpanHelper.ResolveSpanStatusForHttpStatusCode(response.StatusCode);
                 activity.SetStatus(status.WithDescription(response.HttpContext.Features.Get<IHttpResponseFeature>()?.ReasonPhrase));
@@ -176,7 +176,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
                     {
                         // override the span name that was previously set to the path part of URL.
                         activity.DisplayName = template;
-                        activity.AddTag(SemanticConventions.AttributeHTTPRoute, template);
+                        activity.AddTag(SemanticConventions.AttributeHttpRoute, template);
                     }
 
                     // TODO: Should we get values from RouteData?

--- a/src/OpenTelemetry.Instrumentation.Dependencies/HttpClientInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Dependencies/HttpClientInstrumentationOptions.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies
     public class HttpClientInstrumentationOptions
     {
         /// <summary>
-        /// Gets or sets a value indicating whether or not the HTTP version should be added as the <see cref="SemanticConventions.AttributeHTTPFlavor"/> tag. Default value: False.
+        /// Gets or sets a value indicating whether or not the HTTP version should be added as the <see cref="SemanticConventions.AttributeHttpFlavor"/> tag. Default value: False.
         /// </summary>
         public bool SetHttpFlavor { get; set; } = false;
 

--- a/src/OpenTelemetry.Instrumentation.Dependencies/HttpWebRequestInstrumentationOptions.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Dependencies/HttpWebRequestInstrumentationOptions.netfx.cs
@@ -27,7 +27,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies
     public class HttpWebRequestInstrumentationOptions
     {
         /// <summary>
-        /// Gets or sets a value indicating whether or not the HTTP version should be added as the <see cref="SemanticConventions.AttributeHTTPFlavor"/> tag. Default value: False.
+        /// Gets or sets a value indicating whether or not the HTTP version should be added as the <see cref="SemanticConventions.AttributeHttpFlavor"/> tag. Default value: False.
         /// </summary>
         public bool SetHttpFlavor { get; set; } = false;
 

--- a/src/OpenTelemetry.Instrumentation.Dependencies/Implementation/GrpcClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Dependencies/Implementation/GrpcClientDiagnosticListener.cs
@@ -54,18 +54,18 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Implementation
 
             if (activity.IsAllDataRequested)
             {
-                activity.AddTag(SemanticConventions.AttributeRPCSystem, "grpc");
+                activity.AddTag(SemanticConventions.AttributeRpcSystem, "grpc");
 
                 if (GrpcTagHelper.TryParseRpcServiceAndRpcMethod(grpcMethod, out var rpcService, out var rpcMethod))
                 {
-                    activity.AddTag(SemanticConventions.AttributeRPCService, rpcService);
-                    activity.AddTag(SemanticConventions.AttributeRPCMethod, rpcMethod);
+                    activity.AddTag(SemanticConventions.AttributeRpcService, rpcService);
+                    activity.AddTag(SemanticConventions.AttributeRpcMethod, rpcMethod);
                 }
 
                 var uriHostNameType = Uri.CheckHostName(request.RequestUri.Host);
                 if (uriHostNameType == UriHostNameType.IPv4 || uriHostNameType == UriHostNameType.IPv6)
                 {
-                    activity.AddTag(SemanticConventions.AttributeNetPeerIP, request.RequestUri.Host);
+                    activity.AddTag(SemanticConventions.AttributeNetPeerIp, request.RequestUri.Host);
                 }
                 else
                 {

--- a/src/OpenTelemetry.Instrumentation.Dependencies/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Dependencies/Implementation/HttpHandlerDiagnosticListener.cs
@@ -95,13 +95,13 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Implementation
 
             if (activity.IsAllDataRequested)
             {
-                activity.AddTag(SemanticConventions.AttributeHTTPMethod, HttpTagHelper.GetNameForHttpMethod(request.Method));
-                activity.AddTag(SemanticConventions.AttributeHTTPHost, HttpTagHelper.GetHostTagValueFromRequestUri(request.RequestUri));
-                activity.AddTag(SemanticConventions.AttributeHTTPURL, request.RequestUri.OriginalString);
+                activity.AddTag(SemanticConventions.AttributeHttpMethod, HttpTagHelper.GetNameForHttpMethod(request.Method));
+                activity.AddTag(SemanticConventions.AttributeHttpHost, HttpTagHelper.GetHostTagValueFromRequestUri(request.RequestUri));
+                activity.AddTag(SemanticConventions.AttributeHttpUrl, request.RequestUri.OriginalString);
 
                 if (this.options.SetHttpFlavor)
                 {
-                    activity.AddTag(SemanticConventions.AttributeHTTPFlavor, HttpTagHelper.GetFlavorTagValueFromProtocolVersion(request.Version));
+                    activity.AddTag(SemanticConventions.AttributeHttpFlavor, HttpTagHelper.GetFlavorTagValueFromProtocolVersion(request.Version));
                 }
             }
 
@@ -136,7 +136,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Implementation
                 if (this.stopResponseFetcher.Fetch(payload) is HttpResponseMessage response)
                 {
                     // response could be null for DNS issues, timeouts, etc...
-                    activity.AddTag(SemanticConventions.AttributeHTTPStatusCode, response.StatusCode.ToString());
+                    activity.AddTag(SemanticConventions.AttributeHttpStatusCode, response.StatusCode.ToString());
 
                     activity.SetStatus(
                         SpanHelper

--- a/src/OpenTelemetry.Instrumentation.Dependencies/Implementation/HttpWebRequestActivitySource.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Dependencies/Implementation/HttpWebRequestActivitySource.netfx.cs
@@ -102,12 +102,12 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Implementation
 
             if (activity.IsAllDataRequested)
             {
-                activity.AddTag(SemanticConventions.AttributeHTTPMethod, request.Method);
-                activity.AddTag(SemanticConventions.AttributeHTTPHost, HttpTagHelper.GetHostTagValueFromRequestUri(request.RequestUri));
-                activity.AddTag(SemanticConventions.AttributeHTTPURL, request.RequestUri.OriginalString);
+                activity.AddTag(SemanticConventions.AttributeHttpMethod, request.Method);
+                activity.AddTag(SemanticConventions.AttributeHttpHost, HttpTagHelper.GetHostTagValueFromRequestUri(request.RequestUri));
+                activity.AddTag(SemanticConventions.AttributeHttpUrl, request.RequestUri.OriginalString);
                 if (Options.SetHttpFlavor)
                 {
-                    activity.AddTag(SemanticConventions.AttributeHTTPFlavor, HttpTagHelper.GetFlavorTagValueFromProtocolVersion(request.ProtocolVersion));
+                    activity.AddTag(SemanticConventions.AttributeHttpFlavor, HttpTagHelper.GetFlavorTagValueFromProtocolVersion(request.ProtocolVersion));
                 }
             }
         }
@@ -119,7 +119,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Implementation
 
             if (activity.IsAllDataRequested)
             {
-                activity.AddTag(SemanticConventions.AttributeHTTPStatusCode, HttpTagHelper.GetStatusCodeTagValueFromHttpStatusCode(response.StatusCode));
+                activity.AddTag(SemanticConventions.AttributeHttpStatusCode, HttpTagHelper.GetStatusCodeTagValueFromHttpStatusCode(response.StatusCode));
 
                 activity.SetStatus(
                     SpanHelper
@@ -143,7 +143,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Implementation
             {
                 if (wexc.Response is HttpWebResponse response)
                 {
-                    activity.AddTag(SemanticConventions.AttributeHTTPStatusCode, HttpTagHelper.GetStatusCodeTagValueFromHttpStatusCode(response.StatusCode));
+                    activity.AddTag(SemanticConventions.AttributeHttpStatusCode, HttpTagHelper.GetStatusCodeTagValueFromHttpStatusCode(response.StatusCode));
 
                     status = SpanHelper.ResolveSpanStatusForHttpStatusCode((int)response.StatusCode).WithDescription(response.StatusDescription);
                 }

--- a/src/OpenTelemetry.Instrumentation.Dependencies/Implementation/SqlClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Dependencies/Implementation/SqlClientDiagnosticListener.cs
@@ -91,8 +91,8 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Implementation
                             var dataSource = this.dataSourceFetcher.Fetch(connection);
                             var commandText = this.commandTextFetcher.Fetch(command);
 
-                            activity.AddTag(SemanticConventions.AttributeDBSystem, MicrosoftSqlServerDatabaseSystemName);
-                            activity.AddTag(SemanticConventions.AttributeDBName, (string)database);
+                            activity.AddTag(SemanticConventions.AttributeDbSystem, MicrosoftSqlServerDatabaseSystemName);
+                            activity.AddTag(SemanticConventions.AttributeDbName, (string)database);
 
                             this.options.AddConnectionLevelDetailsToActivity((string)dataSource, activity);
 
@@ -104,7 +104,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Implementation
                                         activity.AddTag(SpanAttributeConstants.DatabaseStatementTypeKey, nameof(CommandType.StoredProcedure));
                                         if (this.options.SetStoredProcedureCommandName)
                                         {
-                                            activity.AddTag(SemanticConventions.AttributeDBStatement, (string)commandText);
+                                            activity.AddTag(SemanticConventions.AttributeDbStatement, (string)commandText);
                                         }
 
                                         break;
@@ -113,7 +113,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Implementation
                                         activity.AddTag(SpanAttributeConstants.DatabaseStatementTypeKey, nameof(CommandType.Text));
                                         if (this.options.SetTextCommandContent)
                                         {
-                                            activity.AddTag(SemanticConventions.AttributeDBStatement, (string)commandText);
+                                            activity.AddTag(SemanticConventions.AttributeDbStatement, (string)commandText);
                                         }
 
                                         break;

--- a/src/OpenTelemetry.Instrumentation.Dependencies/Implementation/SqlEventSourceListener.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Dependencies/Implementation/SqlEventSourceListener.netfx.cs
@@ -110,8 +110,8 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Implementation
 
             if (activity.IsAllDataRequested)
             {
-                activity.AddTag(SemanticConventions.AttributeDBSystem, SqlClientDiagnosticListener.MicrosoftSqlServerDatabaseSystemName);
-                activity.AddTag(SemanticConventions.AttributeDBName, databaseName);
+                activity.AddTag(SemanticConventions.AttributeDbSystem, SqlClientDiagnosticListener.MicrosoftSqlServerDatabaseSystemName);
+                activity.AddTag(SemanticConventions.AttributeDbName, databaseName);
 
                 this.options.AddConnectionLevelDetailsToActivity((string)eventData.Payload[1], activity);
 
@@ -125,7 +125,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Implementation
                     activity.AddTag(SpanAttributeConstants.DatabaseStatementTypeKey, nameof(CommandType.StoredProcedure));
                     if (this.options.SetStoredProcedureCommandName)
                     {
-                        activity.AddTag(SemanticConventions.AttributeDBStatement, commandText);
+                        activity.AddTag(SemanticConventions.AttributeDbStatement, commandText);
                     }
                 }
             }

--- a/src/OpenTelemetry.Instrumentation.Dependencies/SqlClientInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Dependencies/SqlClientInstrumentationOptions.cs
@@ -39,12 +39,12 @@ namespace OpenTelemetry.Instrumentation.Dependencies
         private static readonly ConcurrentDictionary<string, SqlConnectionDetails> ConnectionDetailCache = new ConcurrentDictionary<string, SqlConnectionDetails>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
-        /// Gets or sets a value indicating whether or not the <see cref="SqlClientInstrumentation"/> should add the names of <see cref="CommandType.StoredProcedure"/> commands as the <see cref="SemanticConventions.AttributeDBStatement"/> tag. Default value: True.
+        /// Gets or sets a value indicating whether or not the <see cref="SqlClientInstrumentation"/> should add the names of <see cref="CommandType.StoredProcedure"/> commands as the <see cref="SemanticConventions.AttributeDbStatement"/> tag. Default value: True.
         /// </summary>
         public bool SetStoredProcedureCommandName { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets a value indicating whether or not the <see cref="SqlClientInstrumentation"/> should add the text of <see cref="CommandType.Text"/> commands as the <see cref="SemanticConventions.AttributeDBStatement"/> tag. Default value: False.
+        /// Gets or sets a value indicating whether or not the <see cref="SqlClientInstrumentation"/> should add the text of <see cref="CommandType.Text"/> commands as the <see cref="SemanticConventions.AttributeDbStatement"/> tag. Default value: False.
         /// </summary>
         public bool SetTextCommandContent { get; set; }
 
@@ -52,7 +52,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies
         /// Gets or sets a value indicating whether or not the <see cref="SqlClientInstrumentation"/> should parse the DataSource on a SqlConnection into server name, instance name, and/or port connection-level attribute tags. Default value: False.
         /// </summary>
         /// <remarks>
-        /// The default behavior is to set the SqlConnection DataSource as the <see cref="SemanticConventions.AttributePeerService"/> tag. If enabled, SqlConnection DataSource will be parsed and the server name will be sent as the <see cref="SemanticConventions.AttributeNetPeerName"/> or <see cref="SemanticConventions.AttributeNetPeerIP"/> tag, the instance name will be sent as the <see cref="SemanticConventions.AttributeDBMSSQLInstanceName"/> tag, and the port will be sent as the <see cref="SemanticConventions.AttributeNetPeerPort"/> tag if it is not 1433 (the default port).
+        /// The default behavior is to set the SqlConnection DataSource as the <see cref="SemanticConventions.AttributePeerService"/> tag. If enabled, SqlConnection DataSource will be parsed and the server name will be sent as the <see cref="SemanticConventions.AttributeNetPeerName"/> or <see cref="SemanticConventions.AttributeNetPeerIp"/> tag, the instance name will be sent as the <see cref="SemanticConventions.AttributeDbMsSqlInstanceName"/> tag, and the port will be sent as the <see cref="SemanticConventions.AttributeNetPeerPort"/> tag if it is not 1433 (the default port).
         /// </remarks>
         public bool EnableConnectionLevelAttributes { get; set; } = false;
 
@@ -127,12 +127,12 @@ namespace OpenTelemetry.Instrumentation.Dependencies
                 }
                 else
                 {
-                    sqlActivity.AddTag(SemanticConventions.AttributeNetPeerIP, connectionDetails.ServerIpAddress);
+                    sqlActivity.AddTag(SemanticConventions.AttributeNetPeerIp, connectionDetails.ServerIpAddress);
                 }
 
                 if (!string.IsNullOrEmpty(connectionDetails.InstanceName))
                 {
-                    sqlActivity.AddTag(SemanticConventions.AttributeDBMSSQLInstanceName, connectionDetails.InstanceName);
+                    sqlActivity.AddTag(SemanticConventions.AttributeDbMsSqlInstanceName, connectionDetails.InstanceName);
                 }
 
                 if (!string.IsNullOrEmpty(connectionDetails.Port))

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
@@ -59,20 +59,20 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Implementation
 
                 activity.SetStatus(Status.Ok);
 
-                activity.AddTag(SemanticConventions.AttributeDBSystem, "redis");
+                activity.AddTag(SemanticConventions.AttributeDbSystem, "redis");
                 activity.AddTag(StackExchangeRedisCallsInstrumentation.RedisFlagsKeyName, command.Flags.ToString());
 
                 if (command.Command != null)
                 {
                     // Example: "db.statement": SET;
-                    activity.AddTag(SemanticConventions.AttributeDBStatement, command.Command);
+                    activity.AddTag(SemanticConventions.AttributeDbStatement, command.Command);
                 }
 
                 if (command.EndPoint != null)
                 {
                     if (command.EndPoint is IPEndPoint ipEndPoint)
                     {
-                        activity.AddTag(SemanticConventions.AttributeNetPeerIP, ipEndPoint.Address.ToString());
+                        activity.AddTag(SemanticConventions.AttributeNetPeerIp, ipEndPoint.Address.ToString());
                         activity.AddTag(SemanticConventions.AttributeNetPeerPort, ipEndPoint.Port.ToString());
                     }
                     else if (command.EndPoint is DnsEndPoint dnsEndPoint)

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -204,7 +204,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
 
             Assert.Equal(
                 "200",
-                span.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHTTPStatusCode).Value);
+                span.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHttpStatusCode).Value);
 
             Assert.Equal(
                 "Ok",
@@ -215,7 +215,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
                 span.Tags.FirstOrDefault(i => i.Key == SpanAttributeConstants.StatusDescriptionKey).Value);
 
             var expectedUri = new Uri(url);
-            var actualUrl = span.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHTTPURL).Value;
+            var actualUrl = span.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHttpUrl).Value;
 
             Assert.Equal(expectedUri.ToString(), actualUrl);
 
@@ -234,24 +234,24 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
             {
                 Assert.Equal(
                     expectedUri.Host,
-                    span.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHTTPHost).Value as string);
+                    span.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHttpHost).Value as string);
             }
             else
             {
                 Assert.Equal(
                     $"{expectedUri.Host}:{expectedUri.Port}",
-                    span.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHTTPHost).Value as string);
+                    span.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHttpHost).Value as string);
             }
 
             Assert.Equal(
                 HttpContext.Current.Request.HttpMethod,
-                span.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHTTPMethod).Value as string);
+                span.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHttpMethod).Value as string);
             Assert.Equal(
                 HttpContext.Current.Request.Path,
                 span.Tags.FirstOrDefault(i => i.Key == SpanAttributeConstants.HttpPathKey).Value as string);
             Assert.Equal(
                 HttpContext.Current.Request.UserAgent,
-                span.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHTTPUserAgent).Value as string);
+                span.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHttpUserAgent).Value as string);
 
             Assert.Equal(expectedResource, span.GetResource());
         }

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
@@ -103,16 +103,16 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             var span = (Activity)spanProcessor.Invocations[1].Arguments[0];
 
             Assert.Equal(ActivityKind.Server, span.Kind);
-            Assert.Equal("localhost:", span.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHTTPHost).Value);
-            Assert.Equal("GET", span.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHTTPMethod).Value);
+            Assert.Equal("localhost:", span.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHttpHost).Value);
+            Assert.Equal("GET", span.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHttpMethod).Value);
             Assert.Equal(urlPath, span.Tags.FirstOrDefault(i => i.Key == SpanAttributeConstants.HttpPathKey).Value);
-            Assert.Equal($"http://localhost{urlPath}", span.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHTTPURL).Value);
-            Assert.Equal(statusCode.ToString(), span.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHTTPStatusCode).Value);
+            Assert.Equal($"http://localhost{urlPath}", span.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHttpUrl).Value);
+            Assert.Equal(statusCode.ToString(), span.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHttpStatusCode).Value);
 
             Status status = SpanHelper.ResolveSpanStatusForHttpStatusCode(statusCode);
             Assert.Equal(SpanHelper.GetCachedCanonicalCodeString(status.CanonicalCode), span.Tags.FirstOrDefault(i => i.Key == SpanAttributeConstants.StatusCodeKey).Value);
             this.ValidateTagValue(span, SpanAttributeConstants.StatusDescriptionKey, reasonPhrase);
-            this.ValidateTagValue(span, SemanticConventions.AttributeHTTPUserAgent, userAgent);
+            this.ValidateTagValue(span, SemanticConventions.AttributeHttpUserAgent, userAgent);
         }
 
         private void ValidateTagValue(Activity activity, string attribute, string expectedValue)

--- a/test/OpenTelemetry.Instrumentation.Dependencies.Tests/HttpWebRequestActivitySourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Dependencies.Tests/HttpWebRequestActivitySourceTests.netfx.cs
@@ -887,18 +887,18 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Tests
         private static void VerifyActivityStartTags(string hostNameAndPort, string method, string url, Activity activity)
         {
             Assert.NotNull(activity.Tags);
-            Assert.Equal(method, activity.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHTTPMethod).Value);
+            Assert.Equal(method, activity.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHttpMethod).Value);
             if (hostNameAndPort != null)
             {
-                Assert.Equal(hostNameAndPort, activity.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHTTPHost).Value);
+                Assert.Equal(hostNameAndPort, activity.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHttpHost).Value);
             }
 
-            Assert.Equal(url, activity.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHTTPURL).Value);
+            Assert.Equal(url, activity.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHttpUrl).Value);
         }
 
         private static void VerifyActivityStopTags(string statusCode, string statusText, Activity activity)
         {
-            Assert.Equal(statusCode, activity.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHTTPStatusCode).Value);
+            Assert.Equal(statusCode, activity.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeHttpStatusCode).Value);
             Assert.Equal(statusText, activity.Tags.FirstOrDefault(i => i.Key == SpanAttributeConstants.StatusDescriptionKey).Value);
         }
 

--- a/test/OpenTelemetry.Instrumentation.Dependencies.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Dependencies.Tests/SqlClientTests.cs
@@ -242,19 +242,19 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Tests
                 Assert.Contains(activity.Tags, i => i.Key == SpanAttributeConstants.StatusDescriptionKey);
             }
 
-            Assert.Equal(SqlClientDiagnosticListener.MicrosoftSqlServerDatabaseSystemName, activity.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeDBSystem).Value);
-            Assert.Equal("master", activity.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeDBName).Value);
+            Assert.Equal(SqlClientDiagnosticListener.MicrosoftSqlServerDatabaseSystemName, activity.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeDbSystem).Value);
+            Assert.Equal("master", activity.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeDbName).Value);
 
             switch (commandType)
             {
                 case CommandType.StoredProcedure:
                     if (captureStoredProcedureCommandName)
                     {
-                        Assert.Equal(commandText, activity.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeDBStatement).Value);
+                        Assert.Equal(commandText, activity.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeDbStatement).Value);
                     }
                     else
                     {
-                        Assert.Null(activity.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeDBStatement).Value);
+                        Assert.Null(activity.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeDbStatement).Value);
                     }
 
                     break;
@@ -262,11 +262,11 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Tests
                 case CommandType.Text:
                     if (captureTextCommandContent)
                     {
-                        Assert.Equal(commandText, activity.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeDBStatement).Value);
+                        Assert.Equal(commandText, activity.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeDbStatement).Value);
                     }
                     else
                     {
-                        Assert.Null(activity.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeDBStatement).Value);
+                        Assert.Null(activity.Tags.FirstOrDefault(i => i.Key == SemanticConventions.AttributeDbStatement).Value);
                     }
 
                     break;

--- a/test/OpenTelemetry.Instrumentation.Dependencies.Tests/SqlEventSourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Dependencies.Tests/SqlEventSourceTests.netfx.cs
@@ -186,7 +186,7 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Tests
         {
             Assert.Equal("master", activity.DisplayName);
             Assert.Equal(ActivityKind.Client, activity.Kind);
-            Assert.Equal(SqlClientDiagnosticListener.MicrosoftSqlServerDatabaseSystemName, activity.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeDBSystem).Value);
+            Assert.Equal(SqlClientDiagnosticListener.MicrosoftSqlServerDatabaseSystemName, activity.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeDbSystem).Value);
 
             if (!enableConnectionLevelAttributes)
             {
@@ -202,12 +202,12 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Tests
                 }
                 else
                 {
-                    Assert.Equal(connectionDetails.ServerIpAddress, activity.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeNetPeerIP).Value);
+                    Assert.Equal(connectionDetails.ServerIpAddress, activity.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeNetPeerIp).Value);
                 }
 
                 if (!string.IsNullOrEmpty(connectionDetails.InstanceName))
                 {
-                    Assert.Equal(connectionDetails.InstanceName, activity.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeDBMSSQLInstanceName).Value);
+                    Assert.Equal(connectionDetails.InstanceName, activity.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeDbMsSqlInstanceName).Value);
                 }
 
                 if (!string.IsNullOrEmpty(connectionDetails.Port))
@@ -216,17 +216,17 @@ namespace OpenTelemetry.Instrumentation.Dependencies.Tests
                 }
             }
 
-            Assert.Equal("master", activity.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeDBName).Value);
+            Assert.Equal("master", activity.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeDbName).Value);
             Assert.Equal(commandType.ToString(), activity.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.DatabaseStatementTypeKey).Value);
             if (commandType == CommandType.StoredProcedure)
             {
                 if (captureText)
                 {
-                    Assert.Equal(commandText, activity.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeDBStatement).Value);
+                    Assert.Equal(commandText, activity.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeDbStatement).Value);
                 }
                 else
                 {
-                    Assert.DoesNotContain(activity.Tags, t => t.Key == SemanticConventions.AttributeDBStatement);
+                    Assert.DoesNotContain(activity.Tags, t => t.Key == SemanticConventions.AttributeDbStatement);
                 }
             }
 

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToActivityConverterTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToActivityConverterTests.cs
@@ -88,8 +88,8 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Implementation
 
             var result = RedisProfilerEntryToActivityConverter.ProfilerCommandToActivity(activity, profiledCommand.Object);
 
-            Assert.Contains(result.Tags, kvp => kvp.Key == SemanticConventions.AttributeDBSystem);
-            Assert.Equal("redis", result.Tags.FirstOrDefault(kvp => kvp.Key == SemanticConventions.AttributeDBSystem).Value);
+            Assert.Contains(result.Tags, kvp => kvp.Key == SemanticConventions.AttributeDbSystem);
+            Assert.Equal("redis", result.Tags.FirstOrDefault(kvp => kvp.Key == SemanticConventions.AttributeDbSystem).Value);
         }
 
         [Fact]
@@ -102,8 +102,8 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Implementation
 
             var result = RedisProfilerEntryToActivityConverter.ProfilerCommandToActivity(activity, profiledCommand.Object);
 
-            Assert.Contains(result.Tags, kvp => kvp.Key == SemanticConventions.AttributeDBStatement);
-            Assert.Equal("SET", result.Tags.FirstOrDefault(kvp => kvp.Key == SemanticConventions.AttributeDBStatement).Value);
+            Assert.Contains(result.Tags, kvp => kvp.Key == SemanticConventions.AttributeDbStatement);
+            Assert.Equal("SET", result.Tags.FirstOrDefault(kvp => kvp.Key == SemanticConventions.AttributeDbStatement).Value);
         }
 
         [Fact]
@@ -135,8 +135,8 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Implementation
 
             var result = RedisProfilerEntryToActivityConverter.ProfilerCommandToActivity(activity, profiledCommand.Object);
 
-            Assert.Contains(result.Tags, kvp => kvp.Key == SemanticConventions.AttributeNetPeerIP);
-            Assert.Equal($"{address}.0.0.0", result.Tags.FirstOrDefault(kvp => kvp.Key == SemanticConventions.AttributeNetPeerIP).Value);
+            Assert.Contains(result.Tags, kvp => kvp.Key == SemanticConventions.AttributeNetPeerIp);
+            Assert.Equal($"{address}.0.0.0", result.Tags.FirstOrDefault(kvp => kvp.Key == SemanticConventions.AttributeNetPeerIp).Value);
             Assert.Contains(result.Tags, kvp => kvp.Key == SemanticConventions.AttributeNetPeerPort);
             Assert.Equal($"{port}", result.Tags.FirstOrDefault(kvp => kvp.Key == SemanticConventions.AttributeNetPeerPort).Value);
         }

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
@@ -108,21 +108,21 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Tests
             if (isSet)
             {
                 Assert.Equal("SETEX", activity.DisplayName);
-                Assert.Equal("SETEX", activity.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeDBStatement).Value);
+                Assert.Equal("SETEX", activity.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeDbStatement).Value);
             }
             else
             {
                 Assert.Equal("GET", activity.DisplayName);
-                Assert.Equal("GET", activity.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeDBStatement).Value);
+                Assert.Equal("GET", activity.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeDbStatement).Value);
             }
 
             Assert.Equal(SpanHelper.GetCachedCanonicalCodeString(StatusCanonicalCode.Ok), activity.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.StatusCodeKey).Value);
-            Assert.Equal("redis", activity.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeDBSystem).Value);
+            Assert.Equal("redis", activity.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeDbSystem).Value);
             Assert.Equal("0", activity.Tags.FirstOrDefault(t => t.Key == StackExchangeRedisCallsInstrumentation.RedisDatabaseIndexKeyName).Value);
 
             if (endPoint is IPEndPoint ipEndPoint)
             {
-                Assert.Equal(ipEndPoint.Address.ToString(), activity.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeNetPeerIP).Value);
+                Assert.Equal(ipEndPoint.Address.ToString(), activity.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeNetPeerIp).Value);
                 Assert.Equal(ipEndPoint.Port.ToString(), activity.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeNetPeerPort).Value);
             }
             else if (endPoint is DnsEndPoint dnsEndPoint)


### PR DESCRIPTION
This PR addresses a bit of a nit, though given that the `SemanticConventions` class is currently public, I personally feel it makes sense to conform to the [design guidelines](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/capitalization-conventions#capitalization-rules-for-identifiers) for capitalization of acronyms like `Http`, `Db`, `Rpc`, `Id`, and others.

That said, having discussed this with @cijothomas, there is also the question of whether this class even ought to be public. We could make it internal, though a fair number of projects depend on this class, so would we want to be doing something like this everywhere?:

```xml
<ItemGroup>
    <Compile Include="..\OpenTelemetry.Api\SemanticConventions.cs" />
</ItemGroup>
```

Or are there better ways of dealing with this? Or do we just leave the class as public?