### PR TITLE
Move Otel.Trace.Exporter namespace to just Otel.Trace

### DIFF
--- a/examples/Console/TestConsoleExporter.cs
+++ b/examples/Console/TestConsoleExporter.cs
@@ -20,7 +20,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
-using OpenTelemetry.Trace.Export;
 
 namespace Examples.Console
 {

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporter.cs
@@ -23,7 +23,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
-using OpenTelemetry.Trace.Export;
 
 namespace OpenTelemetry.Exporter.Console
 {

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
@@ -22,7 +22,6 @@ using System.Threading.Tasks;
 using OpenTelemetry.Exporter.Jaeger.Implementation;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
-using OpenTelemetry.Trace.Export;
 
 namespace OpenTelemetry.Exporter.Jaeger
 {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporter.cs
@@ -22,7 +22,7 @@ using System.Threading.Tasks;
 using Grpc.Core;
 
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
-using OpenTelemetry.Trace.Export;
+using OpenTelemetry.Trace;
 
 using OtlpCollector = Opentelemetry.Proto.Collector.Trace.V1;
 

--- a/src/OpenTelemetry.Exporter.ZPages/ZPagesExporter.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/ZPagesExporter.cs
@@ -20,7 +20,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
 using OpenTelemetry.Exporter.ZPages.Implementation;
-using OpenTelemetry.Trace.Export;
+using OpenTelemetry.Trace;
 using Timer = System.Timers.Timer;
 
 namespace OpenTelemetry.Exporter.ZPages

--- a/src/OpenTelemetry.Exporter.ZPages/ZPagesProcessor.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/ZPagesProcessor.cs
@@ -24,7 +24,6 @@ using OpenTelemetry.Exporter.ZPages.Implementation;
 using OpenTelemetry.Internal;
 #endif
 using OpenTelemetry.Trace;
-using OpenTelemetry.Trace.Export;
 
 namespace OpenTelemetry.Exporter.ZPages
 {

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporter.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporter.cs
@@ -30,7 +30,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using OpenTelemetry.Exporter.Zipkin.Implementation;
-using OpenTelemetry.Trace.Export;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Exporter.Zipkin
 {

--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -18,7 +18,7 @@ using System;
 using System.Diagnostics.Tracing;
 using System.Globalization;
 using System.Threading;
-using OpenTelemetry.Trace.Export;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Internal
 {

--- a/src/OpenTelemetry/OpenTelemetry.csproj
+++ b/src/OpenTelemetry/OpenTelemetry.csproj
@@ -10,11 +10,8 @@
 
   <ItemGroup>
     <Compile Remove="Implementation\**" />
-    <Compile Remove="Trace\Internal\**" />
     <EmbeddedResource Remove="Implementation\**" />
-    <EmbeddedResource Remove="Trace\Internal\**" />
     <None Remove="Implementation\**" />
-    <None Remove="Trace\Internal\**" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry/Trace/ActivityExporter.cs
+++ b/src/OpenTelemetry/Trace/ActivityExporter.cs
@@ -19,7 +19,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace OpenTelemetry.Trace.Export
+namespace OpenTelemetry.Trace
 {
     /// <summary>
     /// Enumeration used to define the result of an export operation.

--- a/src/OpenTelemetry/Trace/ActivityProcessor.cs
+++ b/src/OpenTelemetry/Trace/ActivityProcessor.cs
@@ -17,7 +17,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace OpenTelemetry.Trace.Export
+namespace OpenTelemetry.Trace
 {
     /// <summary>
     /// Activity processor base class.

--- a/src/OpenTelemetry/Trace/ActivityProcessorPipelineBuilder.cs
+++ b/src/OpenTelemetry/Trace/ActivityProcessorPipelineBuilder.cs
@@ -16,8 +16,7 @@
 
 using System;
 using System.Collections.Generic;
-using OpenTelemetry.Trace.Export;
-using OpenTelemetry.Trace.Export.Internal;
+using OpenTelemetry.Trace.Internal;
 
 namespace OpenTelemetry.Trace
 {

--- a/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
+++ b/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
@@ -16,7 +16,6 @@
 
 using System.Diagnostics;
 using OpenTelemetry.Resources;
-using OpenTelemetry.Trace.Export;
 
 namespace OpenTelemetry.Trace
 {

--- a/src/OpenTelemetry/Trace/BatchingActivityProcessor.cs
+++ b/src/OpenTelemetry/Trace/BatchingActivityProcessor.cs
@@ -22,7 +22,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using OpenTelemetry.Internal;
 
-namespace OpenTelemetry.Trace.Export
+namespace OpenTelemetry.Trace
 {
     /// <summary>
     /// Implements processor that batches activities before calling exporter.

--- a/src/OpenTelemetry/Trace/Internal/BroadcastActivityProcessor.cs
+++ b/src/OpenTelemetry/Trace/Internal/BroadcastActivityProcessor.cs
@@ -22,7 +22,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using OpenTelemetry.Internal;
 
-namespace OpenTelemetry.Trace.Export.Internal
+namespace OpenTelemetry.Trace.Internal
 {
     internal class BroadcastActivityProcessor : ActivityProcessor, IDisposable
     {

--- a/src/OpenTelemetry/Trace/Internal/NoopActivityProcessor.cs
+++ b/src/OpenTelemetry/Trace/Internal/NoopActivityProcessor.cs
@@ -18,7 +18,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace OpenTelemetry.Trace.Export.Internal
+namespace OpenTelemetry.Trace.Internal
 {
     internal sealed class NoopActivityProcessor : ActivityProcessor
     {

--- a/src/OpenTelemetry/Trace/OpenTelemetrySdk.cs
+++ b/src/OpenTelemetry/Trace/OpenTelemetrySdk.cs
@@ -16,8 +16,7 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
-using OpenTelemetry.Trace.Export;
-using OpenTelemetry.Trace.Export.Internal;
+using OpenTelemetry.Trace.Internal;
 using OpenTelemetry.Trace.Samplers;
 
 namespace OpenTelemetry.Trace

--- a/src/OpenTelemetry/Trace/SimpleActivityProcessor.cs
+++ b/src/OpenTelemetry/Trace/SimpleActivityProcessor.cs
@@ -19,7 +19,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using OpenTelemetry.Internal;
 
-namespace OpenTelemetry.Trace.Export
+namespace OpenTelemetry.Trace
 {
     /// <summary>
     /// Implements simple activity processor that exports activities in OnEnd call without batching.

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -18,7 +18,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using OpenTelemetry.Resources;
-using OpenTelemetry.Trace.Export;
 
 namespace OpenTelemetry.Trace
 {

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/TestActivityProcessor.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/TestActivityProcessor.cs
@@ -18,7 +18,7 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
-using OpenTelemetry.Trace.Export;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Exporter.Jaeger.Tests
 {

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/TestActivityProcessor.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/TestActivityProcessor.cs
@@ -18,7 +18,7 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
-using OpenTelemetry.Trace.Export;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
 {

--- a/test/OpenTelemetry.Exporter.ZPages.Tests/TestActivityProcessor.cs
+++ b/test/OpenTelemetry.Exporter.ZPages.Tests/TestActivityProcessor.cs
@@ -19,7 +19,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
-using OpenTelemetry.Trace.Export;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Exporter.ZPages.Tests
 {

--- a/test/OpenTelemetry.Exporter.ZPages.Tests/ZPagesExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.ZPages.Tests/ZPagesExporterTests.cs
@@ -23,7 +23,6 @@ using System.Threading.Tasks;
 
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
-using OpenTelemetry.Trace.Export;
 
 using Xunit;
 

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/TestActivityProcessor.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/TestActivityProcessor.cs
@@ -18,7 +18,7 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
-using OpenTelemetry.Trace.Export;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Exporter.Zipkin.Tests
 {

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -25,7 +25,6 @@ using System.Web.Routing;
 using Moq;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Trace;
-using OpenTelemetry.Trace.Export;
 using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AspNet.Tests

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
@@ -28,7 +28,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Trace;
-using OpenTelemetry.Trace.Export;
 #if NETCOREAPP2_1
 using TestApp.AspNetCore._2._1;
 #else

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
@@ -18,17 +18,13 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
-
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
-
 using Moq;
-
 using OpenTelemetry.Trace;
-using OpenTelemetry.Trace.Export;
 #if NETCOREAPP2_1
 using TestApp.AspNetCore._2._1;
 #else

--- a/test/OpenTelemetry.Instrumentation.GrpcClient.Tests/GrpcClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.GrpcClient.Tests/GrpcClientTests.cs
@@ -21,7 +21,6 @@ using Grpc.Net.Client;
 using Moq;
 using OpenTelemetry.Instrumentation.GrpcClient.Tests.Services;
 using OpenTelemetry.Trace;
-using OpenTelemetry.Trace.Export;
 using Xunit;
 
 namespace OpenTelemetry.Instrumentation.GrpcClient.Tests

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.netcore31.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.netcore31.cs
@@ -25,7 +25,6 @@ using Moq;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Internal.Test;
 using OpenTelemetry.Trace;
-using OpenTelemetry.Trace.Export;
 using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Http.Tests

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.netcore31.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.netcore31.cs
@@ -27,7 +27,6 @@ using Moq;
 using Newtonsoft.Json;
 using OpenTelemetry.Internal.Test;
 using OpenTelemetry.Trace;
-using OpenTelemetry.Trace.Export;
 using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Http.Tests

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.Basic.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.Basic.netfx.cs
@@ -23,7 +23,6 @@ using Moq;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Internal.Test;
 using OpenTelemetry.Trace;
-using OpenTelemetry.Trace.Export;
 using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Http.Tests

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.netfx.cs
@@ -24,7 +24,6 @@ using Moq;
 using Newtonsoft.Json;
 using OpenTelemetry.Internal.Test;
 using OpenTelemetry.Trace;
-using OpenTelemetry.Trace.Export;
 using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Http.Tests

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
@@ -28,7 +28,6 @@ using Moq;
 using OpenTelemetry.Instrumentation.SqlClient.Implementation;
 using OpenTelemetry.Internal.Test;
 using OpenTelemetry.Trace;
-using OpenTelemetry.Trace.Export;
 using Xunit;
 
 namespace OpenTelemetry.Instrumentation.SqlClient.Tests

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
@@ -26,7 +26,6 @@ using OpenTelemetry.Instrumentation.SqlClient;
 using OpenTelemetry.Instrumentation.SqlClient.Implementation;
 using OpenTelemetry.Internal.Test;
 using OpenTelemetry.Trace;
-using OpenTelemetry.Trace.Export;
 using Xunit;
 
 namespace OpenTelemetry.Instrumentation.SqlClient.Tests

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
@@ -21,7 +21,6 @@ using System.Threading.Tasks;
 using Moq;
 using OpenTelemetry.Internal.Test;
 using OpenTelemetry.Trace;
-using OpenTelemetry.Trace.Export;
 using StackExchange.Redis;
 using StackExchange.Redis.Profiling;
 using Xunit;

--- a/test/OpenTelemetry.Tests/Implementation/Testing/Export/TestActivityExporter.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Testing/Export/TestActivityExporter.cs
@@ -19,7 +19,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
-using OpenTelemetry.Trace.Export;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Testing.Export
 {

--- a/test/OpenTelemetry.Tests/Implementation/Testing/Export/TestActivityProcessor.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Testing/Export/TestActivityProcessor.cs
@@ -18,7 +18,7 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
-using OpenTelemetry.Trace.Export;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Tests.Implementation.Testing.Export
 {

--- a/test/OpenTelemetry.Tests/Implementation/Trace/Config/ActivityProcessorPipelineTests.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Trace/Config/ActivityProcessorPipelineTests.cs
@@ -21,8 +21,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using OpenTelemetry.Testing.Export;
 using OpenTelemetry.Trace;
-using OpenTelemetry.Trace.Export;
-using OpenTelemetry.Trace.Export.Internal;
+using OpenTelemetry.Trace.Internal;
 using Xunit;
 
 namespace OpenTelemetry.Tests.Impl.Trace.Config

--- a/test/OpenTelemetry.Tests/Implementation/Trace/Config/BroadcastActivityProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Trace/Config/BroadcastActivityProcessorTests.cs
@@ -17,8 +17,8 @@
 using System;
 using System.Diagnostics;
 using OpenTelemetry.Tests.Implementation.Testing.Export;
-using OpenTelemetry.Trace.Export;
-using OpenTelemetry.Trace.Export.Internal;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Trace.Internal;
 using Xunit;
 
 namespace OpenTelemetry.Tests.Impl.Trace.Config

--- a/test/OpenTelemetry.Tests/Implementation/Trace/Export/BatchingActivityProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Trace/Export/BatchingActivityProcessorTests.cs
@@ -25,7 +25,7 @@ using OpenTelemetry.Tests;
 using OpenTelemetry.Trace.Samplers;
 using Xunit;
 
-namespace OpenTelemetry.Trace.Export.Test
+namespace OpenTelemetry.Trace.Test
 {
     public class BatchingActivityProcessorTests : IDisposable
     {

--- a/test/OpenTelemetry.Tests/Implementation/Trace/Export/SimpleActivityProcessorTest.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Trace/Export/SimpleActivityProcessorTest.cs
@@ -23,7 +23,7 @@ using OpenTelemetry.Trace;
 using OpenTelemetry.Trace.Samplers;
 using Xunit;
 
-namespace OpenTelemetry.Trace.Export.Test
+namespace OpenTelemetry.Trace.Test
 {
     public class SimpleActivityProcessorTest : IDisposable
     {


### PR DESCRIPTION
Removes the need of multiple namespace imports.

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
