### PR TITLE
Fix broken instruction

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,7 +22,7 @@ Install the
 package:
 
 ```sh
-dotnet add package OpenTelemetry.Exporter.Console
+dotnet add package OpenTelemetry.Exporter.Console -v 0.4.0-beta.2
 ```
 
 Update the `Program.cs` file with the following code:


### PR DESCRIPTION
I was running the getting started document with @cijothomas and noticed the instruction was broken as the dotnet package installer would fail saying that it doesn't want pre-release package unless you specify the exact version.