### PR TITLE
A single AddHttpClientInstrumentation extension.

### DIFF
--- a/examples/AspNet/Global.asax.cs
+++ b/examples/AspNet/Global.asax.cs
@@ -16,7 +16,7 @@ namespace Examples.AspNet
         {
             this.openTelemetry = Sdk.CreateTracerProvider(
                  (builder) => builder
-                 .AddHttpInstrumentation()
+                 .AddHttpClientInstrumentation()
                  .AddAspNetInstrumentation()
                 .UseJaegerExporter(c =>
                 {

--- a/examples/AspNetCore/Startup.cs
+++ b/examples/AspNetCore/Startup.cs
@@ -63,7 +63,7 @@ namespace Examples.AspNetCore
 
             services.AddOpenTelemetry((builder) => builder
                 .AddAspNetCoreInstrumentation()
-                .AddHttpInstrumentation()
+                .AddHttpClientInstrumentation()
                 .UseConsoleExporter());
         }
 

--- a/src/OpenTelemetry.Instrumentation.AspNet/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/README.md
@@ -50,7 +50,7 @@ Configuration with ASP.NET (Full .NET Framework) running in IIS or IIS Express
                         c.AgentPort = 6831;
                     })
                     .AddAspNetCoreInstrumentation()
-                    .AddHttpInstrumentation();
+                    .AddHttpClientInstrumentation();
             });
         }
         protected void Application_End()

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Removed `AddHttpInstrumentation` and `AddHttpWebRequestInstrumentation` (.NET
+  Framework) `TracerProviderBuilderExtensions`. `AddHttpClientInstrumentation`
+  will now register `HttpClient` instrumentation on .NET Core and `HttpClient` +
+  `HttpWebRequest` instrumentation on .NET Framework.
+
 ## 0.3.0-beta
 
 Released 2020-07-23

--- a/src/OpenTelemetry.Instrumentation.Http/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/TracerProviderBuilderExtensions.cs
@@ -16,7 +16,9 @@
 
 using System;
 using OpenTelemetry.Instrumentation.Http;
+#if NETFRAMEWORK
 using OpenTelemetry.Instrumentation.Http.Implementation;
+#endif
 
 namespace OpenTelemetry.Trace
 {
@@ -25,28 +27,19 @@ namespace OpenTelemetry.Trace
     /// </summary>
     public static class TracerProviderBuilderExtensions
     {
+#if NETFRAMEWORK
         /// <summary>
         /// Enables HttpClient and HttpWebRequest instrumentation.
         /// </summary>
         /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
         /// <param name="configureHttpClientInstrumentationOptions">HttpClient configuration options.</param>
+        /// <param name="configureHttpWebRequestInstrumentationOptions">HttpWebRequest configuration options.</param>
         /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
-        public static TracerProviderBuilder AddHttpInstrumentation(
+        public static TracerProviderBuilder AddHttpClientInstrumentation(
             this TracerProviderBuilder builder,
-            Action<HttpClientInstrumentationOptions> configureHttpClientInstrumentationOptions = null)
-        {
-            if (builder == null)
-            {
-                throw new ArgumentNullException(nameof(builder));
-            }
-
-            builder.AddHttpClientInstrumentation(configureHttpClientInstrumentationOptions);
-#if NETFRAMEWORK
-            builder.AddHttpWebRequestInstrumentation();
-#endif
-            return builder;
-        }
-
+            Action<HttpClientInstrumentationOptions> configureHttpClientInstrumentationOptions = null,
+            Action<HttpWebRequestInstrumentationOptions> configureHttpWebRequestInstrumentationOptions = null)
+#else
         /// <summary>
         /// Enables HttpClient instrumentation.
         /// </summary>
@@ -56,6 +49,7 @@ namespace OpenTelemetry.Trace
         public static TracerProviderBuilder AddHttpClientInstrumentation(
             this TracerProviderBuilder builder,
             Action<HttpClientInstrumentationOptions> configureHttpClientInstrumentationOptions = null)
+#endif
         {
             if (builder == null)
             {
@@ -63,29 +57,24 @@ namespace OpenTelemetry.Trace
             }
 
             var httpClientOptions = new HttpClientInstrumentationOptions();
+
             configureHttpClientInstrumentationOptions?.Invoke(httpClientOptions);
 
             builder.AddInstrumentation((activitySource) => new HttpClientInstrumentation(activitySource, httpClientOptions));
+
+#if NETFRAMEWORK
+            builder.AddHttpWebRequestInstrumentation(configureHttpWebRequestInstrumentationOptions);
+#endif
             return builder;
         }
 
 #if NETFRAMEWORK
-        /// <summary>
-        /// Enables HttpWebRequest instrumentation.
-        /// </summary>
-        /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
-        /// <param name="configureOptions">HttpWebRequest configuration options.</param>
-        /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
-        public static TracerProviderBuilder AddHttpWebRequestInstrumentation(
+        internal static TracerProviderBuilder AddHttpWebRequestInstrumentation(
             this TracerProviderBuilder builder,
             Action<HttpWebRequestInstrumentationOptions> configureOptions = null)
         {
-            if (builder == null)
-            {
-                throw new ArgumentNullException(nameof(builder));
-            }
-
             HttpWebRequestInstrumentationOptions options = new HttpWebRequestInstrumentationOptions();
+
             configureOptions?.Invoke(options);
 
             HttpWebRequestActivitySource.Options = options;

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.netcore31.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.netcore31.cs
@@ -53,7 +53,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         {
             TracerProviderBuilder builder = null;
             Assert.Throws<ArgumentNullException>(() => builder.AddHttpClientInstrumentation());
-            Assert.Throws<ArgumentNullException>(() => builder.AddHttpInstrumentation());
+            Assert.Throws<ArgumentNullException>(() => builder.AddHttpClientInstrumentation());
         }
 
         [Fact]

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.netcore31.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.netcore31.cs
@@ -53,7 +53,6 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         {
             TracerProviderBuilder builder = null;
             Assert.Throws<ArgumentNullException>(() => builder.AddHttpClientInstrumentation());
-            Assert.Throws<ArgumentNullException>(() => builder.AddHttpClientInstrumentation());
         }
 
         [Fact]


### PR DESCRIPTION
Just porting some code to the new beta. This is really confusing:

![HttpInstrumentation](https://user-images.githubusercontent.com/28367120/88595810-97a22580-d018-11ea-9e65-72b3e46c5782.png)

## Changes

I combined the 3 extensions for registering Http instrumentation into 1 which will mutate description & parameters depending on .NET Core or .NET Framework. Might be unpopular but I thought it was worth discussing.