### PR TITLE
 Clarify Activity parent in links example (readme)

### DIFF
--- a/src/OpenTelemetry.Api/README.md
+++ b/src/OpenTelemetry.Api/README.md
@@ -270,12 +270,15 @@ OpenTelemetry samplers chose not to sample this activity.
     activityLinks.Add(new ActivityLink(linkedContext2));
 
     var activity = activitySource.StartActivity(
-        "ActivityName",
+        "ActivityWithLinks",
         ActivityKind.Server,
-        "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+        default(ActivityContext), // this will create Activity without parent, specify parent if you have one
         initialTags,
         activityLinks);
     ```
+    
+    In case you have a parent and it's remote specify `traceaparent` string instead of the context, 
+    or if you have parent Activity, use `Activity.Current.Context` (check for null!).
 
 ### Adding Events
 

--- a/src/OpenTelemetry.Api/README.md
+++ b/src/OpenTelemetry.Api/README.md
@@ -272,13 +272,14 @@ OpenTelemetry samplers chose not to sample this activity.
     var activity = activitySource.StartActivity(
         "ActivityWithLinks",
         ActivityKind.Server,
-        default(ActivityContext), // this will create Activity without parent, specify parent if you have one
+        default(ActivityContext), // this creates Activity without parent
         initialTags,
         activityLinks);
     ```
-    
-    In case you have a parent and it's remote specify `traceaparent` string instead of the context, 
-    or if you have parent Activity, use `Activity.Current.Context` (check for null!).
+
+    In case you have a parent and it's remote specify `traceaparent` string
+    instead of the default context, or if you have parent Activity,
+    use `Activity.Current.Context` (check for null!).
 
 ### Adding Events
 

--- a/src/OpenTelemetry.Api/README.md
+++ b/src/OpenTelemetry.Api/README.md
@@ -287,7 +287,7 @@ OpenTelemetry samplers chose not to sample this activity.
         ActivityKind.Server,
         parentContext,
         initialTags,
-        activityLinks);    
+        activityLinks);
     ```
 
 ### Adding Events

--- a/src/OpenTelemetry.Api/README.md
+++ b/src/OpenTelemetry.Api/README.md
@@ -277,9 +277,18 @@ OpenTelemetry samplers chose not to sample this activity.
         activityLinks);
     ```
 
-    In case you have a parent and it's remote specify `traceaparent` string
-    instead of the default context, or if you have parent Activity,
-    use `Activity.Current.Context` (check for null!).
+    In case activity has parent, pass parent's context:
+
+    ```csharp
+    var parentContext = Activity.Current != null ? Activity.Current.Context : default(ActivityContext);
+
+    var activity = activitySource.StartActivity(
+        "ActivityWithLinks",
+        ActivityKind.Server,
+        parentContext,
+        initialTags,
+        activityLinks);    
+    ```
 
 ### Adding Events
 


### PR DESCRIPTION
Server activity had parent equal to one of the links - this is confusing, changed to default context (new trace) as likely this activity has no parent.

