### PR TITLE
HTTP client instrumentation using text representation of HTTP status code instead of integer

### DIFF
--- a/src/OpenTelemetry.Api/Trace/SpanHelper.cs
+++ b/src/OpenTelemetry.Api/Trace/SpanHelper.cs
@@ -72,7 +72,7 @@ namespace OpenTelemetry.Trace
         {
             var newStatus = Status.Unknown;
 
-            if (httpStatusCode >= 200 && httpStatusCode <= 399)
+            if (httpStatusCode >= 100 && httpStatusCode <= 399)
             {
                 newStatus = Status.Ok;
             }

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -136,7 +136,7 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
                 if (this.stopResponseFetcher.Fetch(payload) is HttpResponseMessage response)
                 {
                     // response could be null for DNS issues, timeouts, etc...
-                    activity.AddTag(SemanticConventions.AttributeHttpStatusCode, response.StatusCode.ToString());
+                    activity.AddTag(SemanticConventions.AttributeHttpStatusCode, HttpTagHelper.GetStatusCodeTagValueFromHttpStatusCode(response.StatusCode));
 
                     activity.SetStatus(
                         SpanHelper


### PR DESCRIPTION
HTTP client instrumentation using text representation of HTTP status code instead of integer

Other changes
- HTTP 100-200 status codes should map to OK.

see https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/http.md#status

Fixes #.
[#961] [#962]