### PR TITLE
Suppress instrumentation upon calling ActivityExporter.ExportAsync

### DIFF
--- a/examples/Console/TestConsoleExporter.cs
+++ b/examples/Console/TestConsoleExporter.cs
@@ -108,12 +108,22 @@ namespace Examples.Console
                 this.next = next;
             }
 
-            public override void OnEnd(Activity activity)
+            public override Task ShutdownAsync(CancellationToken cancellationToken)
+            {
+                return this.next.ShutdownAsync(cancellationToken);
+            }
+
+            public override Task ForceFlushAsync(CancellationToken cancellationToken)
+            {
+                return this.next.ForceFlushAsync(cancellationToken);
+            }
+
+            protected override void OnEndInternal(Activity activity)
             {
                 this.next.OnEnd(activity);
             }
 
-            public override void OnStart(Activity activity)
+            protected override void OnStartInternal(Activity activity)
             {
                 if (activity.IsAllDataRequested)
                 {
@@ -128,16 +138,6 @@ namespace Examples.Console
                 }
 
                 this.next.OnStart(activity);
-            }
-
-            public override Task ShutdownAsync(CancellationToken cancellationToken)
-            {
-                return this.next.ShutdownAsync(cancellationToken);
-            }
-
-            public override Task ForceFlushAsync(CancellationToken cancellationToken)
-            {
-                return this.next.ForceFlushAsync(cancellationToken);
             }
         }
     }

--- a/src/OpenTelemetry.Exporter.ZPages/ZPagesProcessor.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/ZPagesProcessor.cs
@@ -43,7 +43,25 @@ namespace OpenTelemetry.Exporter.ZPages
         }
 
         /// <inheritdoc />
-        public override void OnStart(Activity activity)
+        public override Task ShutdownAsync(CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public override Task ForceFlushAsync(CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        protected override void OnStartInternal(Activity activity)
         {
             if (!ZPagesActivityTracker.ProcessingList.ContainsKey(activity.DisplayName))
             {
@@ -65,7 +83,7 @@ namespace OpenTelemetry.Exporter.ZPages
         }
 
         /// <inheritdoc />
-        public override void OnEnd(Activity activity)
+        protected override void OnEndInternal(Activity activity)
         {
             try
             {
@@ -119,24 +137,6 @@ namespace OpenTelemetry.Exporter.ZPages
                 ZPagesExporterEventSource.Log.FailedProcess(ex);
                 Console.Write("OnEnd", ex);
             }
-        }
-
-        /// <inheritdoc />
-        public override Task ShutdownAsync(CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <inheritdoc />
-        public override Task ForceFlushAsync(CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <inheritdoc />
-        public void Dispose()
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/src/OpenTelemetry.Instrumentation.Http/HttpClientInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/HttpClientInstrumentationOptions.cs
@@ -44,12 +44,6 @@ namespace OpenTelemetry.Instrumentation.Http
         {
             var originalString = requestUri.OriginalString;
 
-            // zipkin
-            if (originalString.Contains(":9411/api/v2/spans"))
-            {
-                return true;
-            }
-
             // applicationinsights
             if (originalString.StartsWith("https://dc.services.visualstudio") ||
                 originalString.StartsWith("https://rt.services.visualstudio") ||

--- a/src/OpenTelemetry/Trace/ActivityProcessor.cs
+++ b/src/OpenTelemetry/Trace/ActivityProcessor.cs
@@ -28,13 +28,29 @@ namespace OpenTelemetry.Trace
         /// Activity start hook.
         /// </summary>
         /// <param name="activity">Instance of activity to process.</param>
-        public abstract void OnStart(Activity activity);
+        public void OnStart(Activity activity)
+        {
+            if (Sdk.SuppressInstrumentation)
+            {
+                return;
+            }
+
+            this.OnStartInternal(activity);
+        }
 
         /// <summary>
         /// Activity end hook.
         /// </summary>
         /// <param name="activity">Instance of activity to process.</param>
-        public abstract void OnEnd(Activity activity);
+        public void OnEnd(Activity activity)
+        {
+            if (Sdk.SuppressInstrumentation)
+            {
+                return;
+            }
+
+            this.OnEndInternal(activity);
+        }
 
         /// <summary>
         /// Shuts down Activity processor asynchronously.
@@ -49,5 +65,9 @@ namespace OpenTelemetry.Trace
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Returns <see cref="Task"/>.</returns>
         public abstract Task ForceFlushAsync(CancellationToken cancellationToken);
+
+        protected abstract void OnStartInternal(Activity activity);
+
+        protected abstract void OnEndInternal(Activity activity);
     }
 }

--- a/src/OpenTelemetry/Trace/BatchingActivityProcessor.cs
+++ b/src/OpenTelemetry/Trace/BatchingActivityProcessor.cs
@@ -137,52 +137,6 @@ namespace OpenTelemetry.Trace
         }
 
         /// <inheritdoc/>
-        public override void OnStart(Activity activity)
-        {
-        }
-
-        /// <inheritdoc/>
-        public override void OnEnd(Activity activity)
-        {
-            // because of race-condition between checking the size and enqueueing,
-            // we might end up with a bit more activities than maxQueueSize.
-            // Let's just tolerate it to avoid extra synchronization.
-            if (this.currentQueueSize >= this.maxQueueSize)
-            {
-                OpenTelemetrySdkEventSource.Log.SpanProcessorQueueIsExhausted();
-                return;
-            }
-
-            var size = Interlocked.Increment(ref this.currentQueueSize);
-
-            this.exportQueue.Enqueue(activity);
-
-            if (size >= this.maxExportBatchSize)
-            {
-                bool lockTaken = this.flushLock.Wait(0);
-                if (lockTaken)
-                {
-                    Task.Run(async () =>
-                    {
-                        try
-                        {
-                            await this.FlushAsyncInternal(drain: false, lockAlreadyHeld: true, CancellationToken.None).ConfigureAwait(false);
-                        }
-                        catch (Exception ex)
-                        {
-                            OpenTelemetrySdkEventSource.Log.SpanProcessorException(nameof(this.OnEnd), ex);
-                        }
-                        finally
-                        {
-                            this.flushLock.Release();
-                        }
-                    });
-                    return;
-                }
-            }
-        }
-
-        /// <inheritdoc/>
         /// <exception cref="OperationCanceledException">If the <paramref name="cancellationToken"/> is canceled.</exception>
         public override async Task ShutdownAsync(CancellationToken cancellationToken)
         {
@@ -236,6 +190,52 @@ namespace OpenTelemetry.Trace
                 this.flushTimer.Dispose();
                 this.flushLock.Dispose();
                 this.isDisposed = true;
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void OnStartInternal(Activity activity)
+        {
+        }
+
+        /// <inheritdoc/>
+        protected override void OnEndInternal(Activity activity)
+        {
+            // because of race-condition between checking the size and enqueueing,
+            // we might end up with a bit more activities than maxQueueSize.
+            // Let's just tolerate it to avoid extra synchronization.
+            if (this.currentQueueSize >= this.maxQueueSize)
+            {
+                OpenTelemetrySdkEventSource.Log.SpanProcessorQueueIsExhausted();
+                return;
+            }
+
+            var size = Interlocked.Increment(ref this.currentQueueSize);
+
+            this.exportQueue.Enqueue(activity);
+
+            if (size >= this.maxExportBatchSize)
+            {
+                bool lockTaken = this.flushLock.Wait(0);
+                if (lockTaken)
+                {
+                    Task.Run(async () =>
+                    {
+                        try
+                        {
+                            await this.FlushAsyncInternal(drain: false, lockAlreadyHeld: true, CancellationToken.None).ConfigureAwait(false);
+                        }
+                        catch (Exception ex)
+                        {
+                            OpenTelemetrySdkEventSource.Log.SpanProcessorException(nameof(this.OnEnd), ex);
+                        }
+                        finally
+                        {
+                            this.flushLock.Release();
+                        }
+                    });
+                    return;
+                }
             }
         }
 
@@ -334,7 +334,11 @@ namespace OpenTelemetry.Trace
                     this.batch.Add(nextActivity);
                 }
 
+                var previous = Sdk.SuppressInstrumentation;
+                Sdk.SuppressInstrumentation = true;
                 var result = await this.exporter.ExportAsync(this.batch, cancellationToken).ConfigureAwait(false);
+                Sdk.SuppressInstrumentation = previous;
+
                 if (result != ExportResult.Success)
                 {
                     OpenTelemetrySdkEventSource.Log.ExporterErrorResult(result);

--- a/src/OpenTelemetry/Trace/Internal/BroadcastActivityProcessor.cs
+++ b/src/OpenTelemetry/Trace/Internal/BroadcastActivityProcessor.cs
@@ -44,36 +44,6 @@ namespace OpenTelemetry.Trace.Internal
             this.processors = processors;
         }
 
-        public override void OnEnd(Activity activity)
-        {
-            foreach (var processor in this.processors)
-            {
-                try
-                {
-                    processor.OnEnd(activity);
-                }
-                catch (Exception e)
-                {
-                    OpenTelemetrySdkEventSource.Log.SpanProcessorException("OnEnd", e);
-                }
-            }
-        }
-
-        public override void OnStart(Activity activity)
-        {
-            foreach (var processor in this.processors)
-            {
-                try
-                {
-                    processor.OnStart(activity);
-                }
-                catch (Exception e)
-                {
-                    OpenTelemetrySdkEventSource.Log.SpanProcessorException("OnStart", e);
-                }
-            }
-        }
-
         public override Task ShutdownAsync(CancellationToken cancellationToken)
         {
             var tasks = new List<Task>();
@@ -130,6 +100,41 @@ namespace OpenTelemetry.Trace.Internal
                 }
 
                 this.isDisposed = true;
+            }
+        }
+
+        protected override void OnEndInternal(Activity activity)
+        {
+            foreach (var processor in this.processors)
+            {
+                try
+                {
+                    processor.OnEnd(activity);
+                }
+                catch (Exception e)
+                {
+                    OpenTelemetrySdkEventSource.Log.SpanProcessorException("OnEnd", e);
+                }
+            }
+        }
+
+        protected override void OnStartInternal(Activity activity)
+        {
+            if (Sdk.SuppressInstrumentation)
+            {
+                return;
+            }
+
+            foreach (var processor in this.processors)
+            {
+                try
+                {
+                    processor.OnStart(activity);
+                }
+                catch (Exception e)
+                {
+                    OpenTelemetrySdkEventSource.Log.SpanProcessorException("OnStart", e);
+                }
             }
         }
     }

--- a/src/OpenTelemetry/Trace/Internal/NoopActivityProcessor.cs
+++ b/src/OpenTelemetry/Trace/Internal/NoopActivityProcessor.cs
@@ -22,14 +22,6 @@ namespace OpenTelemetry.Trace.Internal
 {
     internal sealed class NoopActivityProcessor : ActivityProcessor
     {
-        public override void OnStart(Activity activity)
-        {
-        }
-
-        public override void OnEnd(Activity activity)
-        {
-        }
-
         public override Task ShutdownAsync(CancellationToken cancellationToken)
         {
 #if NET452
@@ -46,6 +38,14 @@ namespace OpenTelemetry.Trace.Internal
 #else
             return Task.CompletedTask;
 #endif
+        }
+
+        protected override void OnStartInternal(Activity activity)
+        {
+        }
+
+        protected override void OnEndInternal(Activity activity)
+        {
         }
     }
 }

--- a/src/OpenTelemetry/Trace/SimpleActivityProcessor.cs
+++ b/src/OpenTelemetry/Trace/SimpleActivityProcessor.cs
@@ -39,27 +39,6 @@ namespace OpenTelemetry.Trace
         }
 
         /// <inheritdoc />
-        public override void OnStart(Activity activity)
-        {
-        }
-
-        /// <inheritdoc />
-        public override void OnEnd(Activity activity)
-        {
-            try
-            {
-                // do not await, just start export
-                // it can still throw in synchronous part
-
-                _ = this.exporter.ExportAsync(new[] { activity }, CancellationToken.None);
-            }
-            catch (Exception ex)
-            {
-                OpenTelemetrySdkEventSource.Log.SpanProcessorException(nameof(this.OnEnd), ex);
-            }
-        }
-
-        /// <inheritdoc />
         public override Task ShutdownAsync(CancellationToken cancellationToken)
         {
             if (!this.stopped)
@@ -115,6 +94,30 @@ namespace OpenTelemetry.Trace
                         OpenTelemetrySdkEventSource.Log.SpanProcessorException(nameof(this.Dispose), e);
                     }
                 }
+            }
+        }
+
+        /// <inheritdoc />
+        protected override void OnStartInternal(Activity activity)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override void OnEndInternal(Activity activity)
+        {
+            try
+            {
+                // do not await, just start export
+                // it can still throw in synchronous part
+
+                var previous = Sdk.SuppressInstrumentation;
+                Sdk.SuppressInstrumentation = true;
+                _ = this.exporter.ExportAsync(new[] { activity }, CancellationToken.None);
+                Sdk.SuppressInstrumentation = previous;
+            }
+            catch (Exception ex)
+            {
+                OpenTelemetrySdkEventSource.Log.SpanProcessorException(nameof(this.OnEnd), ex);
             }
         }
     }

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/TestActivityProcessor.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/TestActivityProcessor.cs
@@ -43,16 +43,6 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests
 
         public bool DisposedCalled { get; private set; } = false;
 
-        public override void OnStart(Activity activity)
-        {
-            this.StartAction?.Invoke(activity);
-        }
-
-        public override void OnEnd(Activity activity)
-        {
-            this.EndAction?.Invoke(activity);
-        }
-
         public override Task ShutdownAsync(CancellationToken cancellationToken)
         {
             this.ShutdownCalled = true;
@@ -76,6 +66,16 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests
         public void Dispose()
         {
             this.DisposedCalled = true;
+        }
+
+        protected override void OnStartInternal(Activity activity)
+        {
+            this.StartAction?.Invoke(activity);
+        }
+
+        protected override void OnEndInternal(Activity activity)
+        {
+            this.EndAction?.Invoke(activity);
         }
     }
 }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/TestActivityProcessor.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/TestActivityProcessor.cs
@@ -43,16 +43,6 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
 
         public bool DisposedCalled { get; private set; } = false;
 
-        public override void OnStart(Activity span)
-        {
-            this.StartAction?.Invoke(span);
-        }
-
-        public override void OnEnd(Activity span)
-        {
-            this.EndAction?.Invoke(span);
-        }
-
         public override Task ShutdownAsync(CancellationToken cancellationToken)
         {
             this.ShutdownCalled = true;
@@ -76,6 +66,16 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
         public void Dispose()
         {
             this.DisposedCalled = true;
+        }
+
+        protected override void OnStartInternal(Activity span)
+        {
+            this.StartAction?.Invoke(span);
+        }
+
+        protected override void OnEndInternal(Activity span)
+        {
+            this.EndAction?.Invoke(span);
         }
     }
 }

--- a/test/OpenTelemetry.Exporter.ZPages.Tests/TestActivityProcessor.cs
+++ b/test/OpenTelemetry.Exporter.ZPages.Tests/TestActivityProcessor.cs
@@ -44,16 +44,6 @@ namespace OpenTelemetry.Exporter.ZPages.Tests
 
         public bool DisposedCalled { get; private set; } = false;
 
-        public override void OnStart(Activity activity)
-        {
-            this.StartAction?.Invoke(activity);
-        }
-
-        public override void OnEnd(Activity activity)
-        {
-            this.EndAction?.Invoke(activity);
-        }
-
         public override Task ShutdownAsync(CancellationToken cancellationToken)
         {
             this.ShutdownCalled = true;
@@ -77,6 +67,16 @@ namespace OpenTelemetry.Exporter.ZPages.Tests
         public void Dispose()
         {
             this.DisposedCalled = true;
+        }
+
+        protected override void OnStartInternal(Activity activity)
+        {
+            this.StartAction?.Invoke(activity);
+        }
+
+        protected override void OnEndInternal(Activity activity)
+        {
+            this.EndAction?.Invoke(activity);
         }
     }
 }

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/TestActivityProcessor.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/TestActivityProcessor.cs
@@ -43,16 +43,6 @@ namespace OpenTelemetry.Exporter.Zipkin.Tests
 
         public bool DisposedCalled { get; private set; } = false;
 
-        public override void OnStart(Activity span)
-        {
-            this.StartAction?.Invoke(span);
-        }
-
-        public override void OnEnd(Activity span)
-        {
-            this.EndAction?.Invoke(span);
-        }
-
         public override Task ShutdownAsync(CancellationToken cancellationToken)
         {
             this.ShutdownCalled = true;
@@ -76,6 +66,16 @@ namespace OpenTelemetry.Exporter.Zipkin.Tests
         public void Dispose()
         {
             this.DisposedCalled = true;
+        }
+
+        protected override void OnStartInternal(Activity span)
+        {
+            this.StartAction?.Invoke(span);
+        }
+
+        protected override void OnEndInternal(Activity span)
+        {
+            this.EndAction?.Invoke(span);
         }
     }
 }

--- a/test/OpenTelemetry.Tests/Implementation/Testing/Export/TestActivityProcessor.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Testing/Export/TestActivityProcessor.cs
@@ -43,16 +43,6 @@ namespace OpenTelemetry.Tests.Implementation.Testing.Export
 
         public bool DisposedCalled { get; private set; } = false;
 
-        public override void OnStart(Activity span)
-        {
-            this.StartAction?.Invoke(span);
-        }
-
-        public override void OnEnd(Activity span)
-        {
-            this.EndAction?.Invoke(span);
-        }
-
         public override Task ShutdownAsync(CancellationToken cancellationToken)
         {
             this.ShutdownCalled = true;
@@ -76,6 +66,16 @@ namespace OpenTelemetry.Tests.Implementation.Testing.Export
         public void Dispose()
         {
             this.DisposedCalled = true;
+        }
+
+        protected override void OnStartInternal(Activity span)
+        {
+            this.StartAction?.Invoke(span);
+        }
+
+        protected override void OnEndInternal(Activity span)
+        {
+            this.EndAction?.Invoke(span);
         }
     }
 }

--- a/test/OpenTelemetry.Tests/Implementation/Trace/Config/ActivityProcessorPipelineTests.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Trace/Config/ActivityProcessorPipelineTests.cs
@@ -238,14 +238,6 @@ namespace OpenTelemetry.Tests.Impl.Trace.Config
                 this.Name = name;
             }
 
-            public override void OnStart(Activity span)
-            {
-            }
-
-            public override void OnEnd(Activity span)
-            {
-            }
-
             public override Task ShutdownAsync(CancellationToken cancellationToken)
             {
 #if NET452
@@ -262,6 +254,14 @@ namespace OpenTelemetry.Tests.Impl.Trace.Config
 #else
                 return Task.CompletedTask;
 #endif
+            }
+
+            protected override void OnStartInternal(Activity span)
+            {
+            }
+
+            protected override void OnEndInternal(Activity span)
+            {
             }
         }
     }


### PR DESCRIPTION
Draft PR, currently targeting @reyang's currently unmerged PR #960 

Sorry, it's a bit of a noisy diff because I made some changes to the abstract `ActivityProcessor` class trying out the idea of checking the `SuppressInstrumentation` bit in one spot. I think this will work (??). Though, perf may be the concern here.

This only touches tracing at this point, though will want the same kind of thing for metric export as well.