### PR TITLE
Add UseExporter config option to AspNetCore example app

### DIFF
--- a/examples/AspNetCore/Program.cs
+++ b/examples/AspNetCore/Program.cs
@@ -31,13 +31,7 @@ namespace Examples.AspNetCore
             Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
-                    var config = new ConfigurationBuilder()
-                        .AddCommandLine(args)
-                        .Build();
-
-                    webBuilder
-                        .UseConfiguration(config)
-                        .UseStartup<Startup>();
+                    webBuilder.UseStartup<Startup>();
                 });
     }
 }

--- a/examples/AspNetCore/Program.cs
+++ b/examples/AspNetCore/Program.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
 namespace Examples.AspNetCore
@@ -30,7 +31,13 @@ namespace Examples.AspNetCore
             Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
-                    webBuilder.UseStartup<Startup>();
+                    var config = new ConfigurationBuilder()
+                        .AddCommandLine(args)
+                        .Build();
+
+                    webBuilder
+                        .UseConfiguration(config)
+                        .UseStartup<Startup>();
                 });
     }
 }

--- a/examples/AspNetCore/Program.cs
+++ b/examples/AspNetCore/Program.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
 namespace Examples.AspNetCore

--- a/examples/AspNetCore/Startup.cs
+++ b/examples/AspNetCore/Startup.cs
@@ -52,8 +52,7 @@ namespace Examples.AspNetCore
                 }
             });
 
-            // To choose which exporter to use, run this example with the UseExporter option (defaults to the ConsoleExporter):
-            //     example: dotnet run --UseExporter=zipkin
+            // Switch between Zipkin/Jaeger by setting UseExporter in appsettings.json.
             var exporter = this.Configuration.GetValue<string>("UseExporter").ToLowerInvariant();
             switch (exporter)
             {

--- a/examples/AspNetCore/Startup.cs
+++ b/examples/AspNetCore/Startup.cs
@@ -52,35 +52,39 @@ namespace Examples.AspNetCore
                 }
             });
 
-            // Switch between Zipkin/Jaeger by commenting out one of the following.
-
-            /*
-            services.AddOpenTelemetry((builder) => builder
-                .AddAspNetCoreInstrumentation()
-                .AddHttpInstrumentation()
-                .UseJaegerActivityExporter(o =>
-                {
-                    o.ServiceName = this.Configuration.GetValue<string>("Jaeger:ServiceName");
-                    o.AgentHost = this.Configuration.GetValue<string>("Jaeger:Host");
-                    o.AgentPort = this.Configuration.GetValue<int>("Jaeger:Port");
-                }));
-            */
-
-            /*
-            services.AddOpenTelemetry((builder) => builder
-                .AddAspNetCoreInstrumentation()
-                .AddHttpInstrumentation()
-                .UseZipkinExporter(o =>
-                {
-                    o.ServiceName = this.Configuration.GetValue<string>("Zipkin:ServiceName");
-                    o.Endpoint = new Uri(this.Configuration.GetValue<string>("Zipkin:Endpoint"));
-                }));
-            */
-
-            services.AddOpenTelemetry((builder) => builder
-                .AddAspNetCoreInstrumentation()
-                .AddHttpClientInstrumentation()
-                .UseConsoleExporter());
+            // To choose which exporter to use, run this example with the UseExporter option (defaults to the ConsoleExporter):
+            //     example: dotnet run --UseExporter=zipkin
+            var exporter = this.Configuration.GetValue<string>("UseExporter").ToLowerInvariant();
+            switch (exporter)
+            {
+                case "jaeger":
+                    services.AddOpenTelemetry((builder) => builder
+                        .AddAspNetCoreInstrumentation()
+                        .AddHttpClientInstrumentation()
+                        .UseJaegerExporter(o =>
+                        {
+                            o.ServiceName = this.Configuration.GetValue<string>("Jaeger:ServiceName");
+                            o.AgentHost = this.Configuration.GetValue<string>("Jaeger:Host");
+                            o.AgentPort = this.Configuration.GetValue<int>("Jaeger:Port");
+                        }));
+                    break;
+                case "zipkin":
+                    services.AddOpenTelemetry((builder) => builder
+                        .AddAspNetCoreInstrumentation()
+                        .AddHttpClientInstrumentation()
+                        .UseZipkinExporter(o =>
+                        {
+                            o.ServiceName = this.Configuration.GetValue<string>("Zipkin:ServiceName");
+                            o.Endpoint = new Uri(this.Configuration.GetValue<string>("Zipkin:Endpoint"));
+                        }));
+                    break;
+                default:
+                    services.AddOpenTelemetry((builder) => builder
+                        .AddAspNetCoreInstrumentation()
+                        .AddHttpClientInstrumentation()
+                        .UseConsoleExporter());
+                    break;
+            }
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)

--- a/examples/AspNetCore/appsettings.json
+++ b/examples/AspNetCore/appsettings.json
@@ -7,6 +7,7 @@
     }
   },
   "AllowedHosts": "*",
+  "UseExporter":  "console",
   "Jaeger": {
     "ServiceName": "jaeger-test",
     "Host": "localhost",


### PR DESCRIPTION
I noted that the AspNetCore example app had some commented out code that got missed in a few renaming refactors. For example, the rename of `AddHttpInstrumentation` -> `AddHttpClientInstrumentation`.

Adding a command line option `UseExporter` is one way to mitigate for this. Another simpler option could be to stay with the "uncomment this" approach and just have something like:

```
var exporter = "console";
// var exporter = "zipkin";
// var exporter = "jaeger";

if (exporter == "console") ...
else if (exporter == "zipkin") ...
...
```

Thoughts?