### PR TITLE
Treat warning as warning for debug build

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -5,12 +5,15 @@
     <RepoRoot>$([System.IO.Directory]::GetParent($(MSBuildThisFileDirectory)).Parent.FullName)</RepoRoot>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)debug.snk</AssemblyOriginatorKeyFile>
     <DefineConstants>$(DefineConstants);SIGNED</DefineConstants>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Label="Package versions used in this repository">


### PR DESCRIPTION
Addresses @CodeBlanch's [comment](https://github.com/open-telemetry/opentelemetry-dotnet/pull/971/files#r464095447).

Makes contributor's life easier. Instead of introducing another flag, I think it makes sense to reuse the debug flag to keep things simple.
