### PR TITLE
Default Sampler update + ParentOrElse fix

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -11,6 +11,8 @@
   disposes the containing exporter.
 * `BroadcastActivityProcessor`is disposable and it disposes the processors.
 * Samplers now get the actual TraceId of the Activity to be created.
+* Default Sampler changed from AlwaysOn to ParentOrElse(AlwaysOn) to match the
+  spec.
 
 ## 0.3.0-beta
 

--- a/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
+++ b/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
@@ -76,23 +76,20 @@ namespace OpenTelemetry.Trace
             ActivityContext parentContext;
             if (string.IsNullOrEmpty(activity.ParentId))
             {
-                parentContext = default(ActivityContext);
+                parentContext = default;
+            }
+            else if (activity.Parent != null)
+            {
+                parentContext = activity.Parent.Context;
             }
             else
             {
-                if (activity.Parent != null)
-                {
-                    parentContext = activity.Parent.Context;
-                }
-                else
-                {
-                    parentContext = new ActivityContext(
-                        activity.TraceId,
-                        activity.ParentSpanId,
-                        activity.ActivityTraceFlags,
-                        activity.TraceStateString,
-                        isRemote: true);
-                }
+                parentContext = new ActivityContext(
+                    activity.TraceId,
+                    activity.ParentSpanId,
+                    activity.ActivityTraceFlags,
+                    activity.TraceStateString,
+                    isRemote: true);
             }
 
             var samplingParameters = new SamplingParameters(

--- a/src/OpenTelemetry/Trace/Samplers/ParentOrElseSampler.cs
+++ b/src/OpenTelemetry/Trace/Samplers/ParentOrElseSampler.cs
@@ -41,7 +41,8 @@ namespace OpenTelemetry.Trace.Samplers
         public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
         {
             var parentContext = samplingParameters.ParentContext;
-            if (parentContext == default)
+            if (/* TODO: TraceId is always provided due to AutoGenerateRootContextTraceId. That is being removed in RC1 and this can be put back.
+                 parentContext.TraceId == default ||*/ parentContext.SpanId == default)
             {
                 // If no parent, use the delegate to determine sampling.
                 return this.delegateSampler.ShouldSample(samplingParameters);

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.client.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.client.cs
@@ -21,6 +21,7 @@ using Grpc.Net.Client;
 using Moq;
 using OpenTelemetry.Instrumentation.Grpc.Tests.Services;
 using OpenTelemetry.Trace;
+using OpenTelemetry.Trace.Samplers;
 using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Grpc.Tests
@@ -44,6 +45,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
 
             using (Sdk.CreateTracerProvider(
                 (builder) => builder
+                    .SetSampler(new AlwaysOnSampler())
                     .AddGrpcClientInstrumentation()
                     .SetResource(expectedResource)
                     .AddProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object))))
@@ -95,6 +97,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
 
             using (Sdk.CreateTracerProvider(
             (builder) => builder
+                .SetSampler(new AlwaysOnSampler())
                 .AddHttpClientInstrumentation()
                 .AddGrpcClientInstrumentation()
                 .AddProcessorPipeline(p => p.AddProcessor(n => spanProcessor.Object))))


### PR DESCRIPTION
Default sampler is now ParentOrElse(AlwaysOn) to match the spec: https://github.com/open-telemetry/opentelemetry-specification/pull/750

Fixes ParentOrElse break from #1007.
Relates to #941.