### PR TITLE
Fix console output format

### DIFF
--- a/docs/trace/getting-started/Program.cs
+++ b/docs/trace/getting-started/Program.cs
@@ -33,6 +33,7 @@ public class Program
         {
             activity?.SetTag("foo", 1);
             activity?.SetTag("bar", "Hello, World!");
+            activity?.SetTag("baz", new int[] { 1, 2, 3 });
         }
     }
 }

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporter.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -71,17 +72,23 @@ namespace OpenTelemetry.Exporter.Console
                         System.Console.WriteLine("Activity Tags");
                         foreach (var tag in activity.TagObjects)
                         {
-                            if (!(tag.Value is IEnumerable array))
+                            var array = tag.Value as Array;
+
+                            if (array == null)
                             {
                                 System.Console.WriteLine($"\t {tag.Key} : {tag.Value}");
+                                continue;
                             }
-                            else
+
+                            System.Console.Write($"\t {tag.Key} : [");
+
+                            for (int i = 0; i < array.Length; i++)
                             {
-                                foreach (var item in array)
-                                {
-                                    System.Console.WriteLine($"\t {tag.Key} : {item}");
-                                }
+                                System.Console.Write(i != 0 ? ", " : string.Empty);
+                                System.Console.Write($"{array.GetValue(i)}");
                             }
+
+                            System.Console.WriteLine($"]");
                         }
                     }
 


### PR DESCRIPTION
Without the fix, string would be treated as IEnumerable so we get something like this:
```text
Activity Tags
         foo : 1
         bar : H
         bar : e
         bar : l
         bar : l
         bar : o
         bar : ,
         bar :
         bar : W
         bar : o
         bar : r
         bar : l
         bar : d
         bar : !
         baz : 1
         baz : 2
         baz : 3
```

With the fix:
```text
Activity Tags
         foo : 1
         bar : Hello, World!
         baz : [1, 2, 3]
```