### PR TITLE
MicroService example to depend on project reference.

### DIFF
--- a/examples/MicroserviceExample/Utils/Messaging/MessageReceiver.cs
+++ b/examples/MicroserviceExample/Utils/Messaging/MessageReceiver.cs
@@ -57,7 +57,7 @@ namespace Utils.Messaging
         public void ReceiveMessage(BasicDeliverEventArgs ea)
         {
             // Extract the ActivityContext of the upstream parent from the message headers.
-            var parentContext = TextFormat.Extract(ea.BasicProperties, this.ExtractTraceContextFromBasicProperties);
+            var parentContext = TextFormat.Extract(default, ea.BasicProperties, this.ExtractTraceContextFromBasicProperties);
 
             // Start an activity with a name following the semantic convention of the OpenTelemetry messaging specification.
             // https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/messaging.md#span-name

--- a/examples/MicroserviceExample/Utils/Utils.csproj
+++ b/examples/MicroserviceExample/Utils/Utils.csproj
@@ -5,7 +5,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.6" />
-    <PackageReference Include="OpenTelemetry" Version="0.4.0-beta.2" />
     <PackageReference Include="RabbitMQ.Client" Version="6.1.0" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Api\OpenTelemetry.Api.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/examples/MicroserviceExample/WebApi/Dockerfile
+++ b/examples/MicroserviceExample/WebApi/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine AS build
 
 WORKDIR /app
 COPY . ./
-RUN dotnet publish WebApi -c Release -o /out
+RUN dotnet publish ./examples/MicroserviceExample/WebApi -c Release -o /out -p:IntegrationBuild=true
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-alpine AS runtime
 WORKDIR /app

--- a/examples/MicroserviceExample/WebApi/WebApi.csproj
+++ b/examples/MicroserviceExample/WebApi/WebApi.csproj
@@ -4,10 +4,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="0.4.0-beta.2" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="0.4.0-beta.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="0.4.0-beta.2" />
     <PackageReference Include="RabbitMQ.Client" Version="6.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.AspNetCore\OpenTelemetry.Instrumentation.AspNetCore.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Zipkin\OpenTelemetry.Exporter.Zipkin.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Extensions.Hosting\OpenTelemetry.Extensions.Hosting.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/MicroserviceExample/WorkerService/Dockerfile
+++ b/examples/MicroserviceExample/WorkerService/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine AS build
 
 WORKDIR /app
 COPY . ./
-RUN dotnet publish WorkerService -c Release -o /out
+RUN dotnet publish ./examples/MicroserviceExample/WorkerService -c Release -o /out -p:IntegrationBuild=true
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-alpine AS runtime
 WORKDIR /app

--- a/examples/MicroserviceExample/WorkerService/WorkerService.csproj
+++ b/examples/MicroserviceExample/WorkerService/WorkerService.csproj
@@ -5,10 +5,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.6" />
-    <PackageReference Include="OpenTelemetry" Version="0.4.0-beta.2" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="0.4.0-beta.2" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="0.4.0-beta.2" />
     <PackageReference Include="RabbitMQ.Client" Version="6.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry\OpenTelemetry.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Zipkin\OpenTelemetry.Exporter.Zipkin.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Extensions.Hosting\OpenTelemetry.Extensions.Hosting.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/examples/MicroserviceExample/docker-compose.yml
+++ b/examples/MicroserviceExample/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: openzipkin/zipkin
     ports:
       - 9411:9411
-      
+
   rabbitmq:
     image: rabbitmq:3-management-alpine
     environment:
@@ -17,8 +17,8 @@ services:
 
   webapi:
     build:
-      context: .
-      dockerfile: ./WebApi/Dockerfile
+      context: ../..
+      dockerfile: ./examples/MicroserviceExample/WebApi/Dockerfile
     image: opentelemetry-example-webapi
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
@@ -34,8 +34,8 @@ services:
 
   workerservice:
     build:
-      context: .
-      dockerfile: ./WorkerService/Dockerfile
+      context: ../..
+      dockerfile: ./examples/MicroserviceExample/WorkerService/Dockerfile
     image: opentelemetry-example-workerservice
     environment:
       - DOTNET_ENVIRONMENT=Development


### PR DESCRIPTION
All examples except Microservice one uses project reference to ref other projects. This PR modifies microservice example to use the same ref. This allows us to keep the example always upto date with master branch.

(Had to make a few other changes to docker build to copy the entire src instead of the example app alone, as it requires everything else to do the build)

Please provide a brief description of the changes here. Update the
`CHANGELOG.md` for non-trivial changes.

For significant contributions please make sure you have completed the following items:

* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
