### PR TITLE
Continue Refactoring TracerProvider.

### DIFF
--- a/docs/trace/building-your-own-exporter/Program.cs
+++ b/docs/trace/building-your-own-exporter/Program.cs
@@ -25,11 +25,7 @@ public class Program
     public static void Main()
     {
         using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddActivitySources(
-            new string[]
-            {
-                "MyCompany.MyProduct.MyLibrary",
-            })
+            .AddActivitySource("MyCompany.MyProduct.MyLibrary")
             .AddMyExporter()
             .Build();
 

--- a/docs/trace/building-your-own-processor/Program.cs
+++ b/docs/trace/building-your-own-processor/Program.cs
@@ -26,10 +26,7 @@ public class Program
     public static void Main()
     {
         using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddActivitySources(new string[]
-            {
-                "MyCompany.MyProduct.MyLibrary",
-            })
+            .AddActivitySource("MyCompany.MyProduct.MyLibrary")
             .AddProcessor(new MyActivityProcessor("A"))
             .AddProcessor(new MyActivityProcessor("B"))
             .Build();

--- a/docs/trace/building-your-own-sampler/Program.cs
+++ b/docs/trace/building-your-own-sampler/Program.cs
@@ -27,11 +27,7 @@ public class Program
     public static void Main()
     {
         using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddActivitySources(
-            new string[]
-            {
-                "MyCompany.MyProduct.MyLibrary",
-            })
+            .AddActivitySource("MyCompany.MyProduct.MyLibrary")
             .SetSampler(new MySampler())
             .AddProcessor(new SimpleActivityProcessor(new ConsoleExporter(new ConsoleExporterOptions())))
             .Build();

--- a/docs/trace/getting-started/Program.cs
+++ b/docs/trace/getting-started/Program.cs
@@ -27,11 +27,7 @@ public class Program
     public static void Main()
     {
         using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddActivitySources(
-            new string[]
-            {
-                "MyCompany.MyProduct.MyLibrary",
-            })
+            .AddActivitySource("MyCompany.MyProduct.MyLibrary")
             .AddProcessor(new SimpleActivityProcessor(new ConsoleExporter(new ConsoleExporterOptions())))
             .Build();
 

--- a/src/OpenTelemetry/Trace/TracerProviderBuilder.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderBuilder.cs
@@ -148,8 +148,7 @@ namespace OpenTelemetry.Trace
 
         public TracerProvider Build()
         {
-            var provider = new TracerProviderSdk(this.sources, this.processors, this.InstrumentationFactories, this.sampler, this.resource);
-            return provider;
+            return new TracerProviderSdk(this.sources, this.processors, this.InstrumentationFactories, this.sampler, this.resource);
         }
 
         internal readonly struct InstrumentationFactory

--- a/src/OpenTelemetry/Trace/TracerProviderBuilder.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderBuilder.cs
@@ -150,21 +150,11 @@ namespace OpenTelemetry.Trace
 
         public TracerProvider Build()
         {
-            var provider = new TracerProviderSdk(this.sources, null, this.sampler, this.resource);
+            var provider = new TracerProviderSdk(this.sources, this.InstrumentationFactories, this.sampler, this.resource);
 
             foreach (var processor in this.processors)
             {
                 provider.AddProcessor(processor);
-            }
-
-            var adapter = new ActivitySourceAdapter(this.sampler, provider.ActivityProcessor, this.resource);
-
-            if (this.InstrumentationFactories != null)
-            {
-                foreach (var instrumentation in this.InstrumentationFactories)
-                {
-                    this.instrumentations.Add(instrumentation.Factory(adapter));
-                }
             }
 
             return provider;

--- a/src/OpenTelemetry/Trace/TracerProviderBuilder.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderBuilder.cs
@@ -25,8 +25,6 @@ namespace OpenTelemetry.Trace
     /// </summary>
     public class TracerProviderBuilder
     {
-        private readonly List<object> instrumentations = new List<object>();
-
         private readonly List<ActivityProcessor> processors = new List<ActivityProcessor>();
 
         private readonly List<string> sources = new List<string>();
@@ -150,13 +148,7 @@ namespace OpenTelemetry.Trace
 
         public TracerProvider Build()
         {
-            var provider = new TracerProviderSdk(this.sources, this.InstrumentationFactories, this.sampler, this.resource);
-
-            foreach (var processor in this.processors)
-            {
-                provider.AddProcessor(processor);
-            }
-
+            var provider = new TracerProviderSdk(this.sources, this.processors, this.InstrumentationFactories, this.sampler, this.resource);
             return provider;
         }
 

--- a/src/OpenTelemetry/Trace/TracerProviderBuilder.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderBuilder.cs
@@ -15,7 +15,6 @@
 // </copyright>
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace.Samplers;
 
@@ -26,17 +25,19 @@ namespace OpenTelemetry.Trace
     /// </summary>
     public class TracerProviderBuilder
     {
+        private readonly List<object> instrumentations = new List<object>();
+
+        private readonly List<ActivityProcessor> processors = new List<ActivityProcessor>();
+
+        private readonly List<string> sources = new List<string>();
+
+        private Sampler sampler = new ParentOrElseSampler(new AlwaysOnSampler());
+
+        private Resource resource = Resource.Empty;
+
         internal TracerProviderBuilder()
         {
         }
-
-        internal Sampler Sampler { get; private set; }
-
-        internal Resource Resource { get; private set; } = Resource.Empty;
-
-        internal ActivityProcessor ActivityProcessor { get; private set; }
-
-        internal Dictionary<string, bool> ActivitySourceNames { get; private set; }
 
         internal List<InstrumentationFactory> InstrumentationFactories { get; private set; }
 
@@ -47,7 +48,7 @@ namespace OpenTelemetry.Trace
         /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
         public TracerProviderBuilder SetSampler(Sampler sampler)
         {
-            this.Sampler = sampler ?? throw new ArgumentNullException(nameof(sampler));
+            this.sampler = sampler;
             return this;
         }
 
@@ -58,45 +59,44 @@ namespace OpenTelemetry.Trace
         /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
         public TracerProviderBuilder SetResource(Resource resource)
         {
-            this.Resource = resource ?? Resource.Empty;
+            this.resource = resource ?? Resource.Empty;
             return this;
         }
 
         /// <summary>
         /// Adds given activitysource name to the list of subscribed sources.
         /// </summary>
-        /// <param name="activitySourceName">Activity source name.</param>
+        /// <param name="name">Activity source name.</param>
         /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
-        public TracerProviderBuilder AddActivitySource(string activitySourceName)
+        public TracerProviderBuilder AddActivitySource(string name)
         {
-            // TODO: We need to fix the listening model.
-            // Today it ignores version.
-            if (this.ActivitySourceNames == null)
+            if (string.IsNullOrWhiteSpace(name))
             {
-                this.ActivitySourceNames = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+                throw new ArgumentException($"{nameof(name)} is null or whitespace.");
             }
 
-            this.ActivitySourceNames[activitySourceName] = true;
+            // TODO: We need to fix the listening model.
+            // Today it ignores version.
+            this.sources.Add(name);
+
             return this;
         }
 
         /// <summary>
         /// Adds given activitysource names to the list of subscribed sources.
         /// </summary>
-        /// <param name="activitySourceNames">Activity source names.</param>
+        /// <param name="names">Activity source names.</param>
         /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
-        public TracerProviderBuilder AddActivitySources(IEnumerable<string> activitySourceNames)
+        public TracerProviderBuilder AddActivitySource(IEnumerable<string> names)
         {
-            // TODO: We need to fix the listening model.
-            // Today it ignores version.
-            if (this.ActivitySourceNames == null)
+            if (names == null)
             {
-                this.ActivitySourceNames = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+                throw new ArgumentNullException(nameof(names));
             }
 
-            foreach (var activitySourceName in activitySourceNames)
+            foreach (var name in names)
             {
-                this.ActivitySourceNames[activitySourceName] = true;
+                this.AddActivitySource(name);
             }
 
             return this;
@@ -109,22 +109,12 @@ namespace OpenTelemetry.Trace
         /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
         public TracerProviderBuilder AddProcessor(ActivityProcessor activityProcessor)
         {
-            if (this.ActivityProcessor == null)
+            if (activityProcessor == null)
             {
-                this.ActivityProcessor = activityProcessor;
+                throw new ArgumentNullException(nameof(activityProcessor));
             }
-            else if (this.ActivityProcessor is CompositeActivityProcessor compositeProcessor)
-            {
-                compositeProcessor.AddProcessor(activityProcessor);
-            }
-            else
-            {
-                this.ActivityProcessor = new CompositeActivityProcessor(new[]
-                {
-                    this.ActivityProcessor,
-                    activityProcessor,
-                });
-            }
+
+            this.processors.Add(activityProcessor);
 
             return this;
         }
@@ -160,104 +150,24 @@ namespace OpenTelemetry.Trace
 
         public TracerProvider Build()
         {
-            this.Sampler = this.Sampler ?? new ParentOrElseSampler(new AlwaysOnSampler());
+            var provider = new TracerProviderSdk(this.sources, null, this.sampler, this.resource);
 
-            var provider = new TracerProviderSdk
+            foreach (var processor in this.processors)
             {
-                Resource = this.Resource,
-                Sampler = this.Sampler,
-                ActivityProcessor = this.ActivityProcessor,
-            };
+                provider.AddProcessor(processor);
+            }
 
-            var activitySource = new ActivitySourceAdapter(provider.Sampler, provider.ActivityProcessor, provider.Resource);
+            var adapter = new ActivitySourceAdapter(this.sampler, provider.ActivityProcessor, this.resource);
 
             if (this.InstrumentationFactories != null)
             {
                 foreach (var instrumentation in this.InstrumentationFactories)
                 {
-                    provider.Instrumentations.Add(instrumentation.Factory(activitySource));
+                    this.instrumentations.Add(instrumentation.Factory(adapter));
                 }
             }
-
-            provider.ActivityListener = new ActivityListener
-            {
-                // Callback when Activity is started.
-                ActivityStarted = (activity) =>
-                {
-                    if (activity.IsAllDataRequested)
-                    {
-                        activity.SetResource(this.Resource);
-                    }
-
-                    provider.ActivityProcessor?.OnStart(activity);
-                },
-
-                // Callback when Activity is stopped.
-                ActivityStopped = (activity) =>
-                {
-                    provider.ActivityProcessor?.OnEnd(activity);
-                },
-
-                // Function which takes ActivitySource and returns true/false to indicate if it should be subscribed to
-                // or not.
-                ShouldListenTo = (activitySource) =>
-                {
-                    if (this.ActivitySourceNames == null)
-                    {
-                        return false;
-                    }
-
-                    return this.ActivitySourceNames.ContainsKey(activitySource.Name);
-                },
-
-                // Setting this to true means TraceId will be always
-                // available in sampling callbacks and will be the actual
-                // traceid used, if activity ends up getting created.
-                AutoGenerateRootContextTraceId = true,
-
-                // This delegate informs ActivitySource about sampling decision when the parent context is an ActivityContext.
-                GetRequestedDataUsingContext = (ref ActivityCreationOptions<ActivityContext> options) => ComputeActivityDataRequest(options, this.Sampler),
-            };
-
-            ActivitySource.AddActivityListener(provider.ActivityListener);
 
             return provider;
-        }
-
-        internal static ActivityDataRequest ComputeActivityDataRequest(
-            in ActivityCreationOptions<ActivityContext> options,
-            Sampler sampler)
-        {
-            var isRootSpan = /*TODO: Put back once AutoGenerateRootContextTraceId is removed.
-                              options.Parent.TraceId == default ||*/ options.Parent.SpanId == default;
-
-            if (sampler != null)
-            {
-                // As we set ActivityListener.AutoGenerateRootContextTraceId = true,
-                // Parent.TraceId will always be the TraceId of the to-be-created Activity,
-                // if it get created.
-                ActivityTraceId traceId = options.Parent.TraceId;
-
-                var samplingParameters = new SamplingParameters(
-                    options.Parent,
-                    traceId,
-                    options.Name,
-                    options.Kind,
-                    options.Tags,
-                    options.Links);
-
-                var shouldSample = sampler.ShouldSample(samplingParameters);
-                if (shouldSample.IsSampled)
-                {
-                    return ActivityDataRequest.AllDataAndRecorded;
-                }
-            }
-
-            // If it is the root span select PropagationData so the trace ID is preserved
-            // even if no activity of the trace is recorded (sampled per OpenTelemetry parlance).
-            return isRootSpan
-                ? ActivityDataRequest.PropagationData
-                : ActivityDataRequest.None;
         }
 
         internal readonly struct InstrumentationFactory

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -17,13 +17,15 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
+using System.Text.RegularExpressions;
 using OpenTelemetry.Resources;
 
 namespace OpenTelemetry.Trace
 {
     internal class TracerProviderSdk : TracerProvider
     {
-        public readonly List<object> Instrumentations = new List<object>();
+        public readonly List<object> Instrumentations;
         public Resource Resource;
         public ActivityProcessor ActivityProcessor;
         public ActivityListener ActivityListener;
@@ -35,8 +37,104 @@ namespace OpenTelemetry.Trace
             Activity.ForceDefaultIdFormat = true;
         }
 
-        internal TracerProviderSdk()
+        internal TracerProviderSdk(
+            IEnumerable<string> sources,
+            IEnumerable<object> instrumentations = null,
+            Sampler sampler = null,
+            Resource resource = null)
         {
+            if (sources == null)
+            {
+                throw new ArgumentNullException(nameof(sources));
+            }
+
+            if (!sources.Any())
+            {
+                throw new ArgumentException($"{nameof(sources)} collection is empty.");
+            }
+
+            var wildcardMode = false;
+
+            foreach (var name in sources)
+            {
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    throw new ArgumentException($"{nameof(sources)} collection contains null or whitespace strings.");
+                }
+
+                if (name.Contains('*'))
+                {
+                    wildcardMode = true;
+                }
+            }
+
+            if (instrumentations == null)
+            {
+                this.Instrumentations = new List<object>();
+            }
+            else
+            {
+                // TODO: check if individual element is null
+                this.Instrumentations = new List<object>(instrumentations);
+            }
+
+            this.Sampler = sampler;
+
+            this.Resource = resource;
+
+            var listener = new ActivityListener
+            {
+                // Callback when Activity is started.
+                ActivityStarted = (activity) =>
+                {
+                    if (activity.IsAllDataRequested)
+                    {
+                        activity.SetResource(this.Resource);
+                    }
+
+                    this.ActivityProcessor?.OnStart(activity);
+                },
+
+                // Callback when Activity is stopped.
+                ActivityStopped = (activity) =>
+                {
+                    this.ActivityProcessor?.OnEnd(activity);
+                },
+
+                // Setting this to true means TraceId will be always
+                // available in sampling callbacks and will be the actual
+                // traceid used, if activity ends up getting created.
+                AutoGenerateRootContextTraceId = true,
+
+                // This delegate informs ActivitySource about sampling decision when the parent context is an ActivityContext.
+                GetRequestedDataUsingContext = (ref ActivityCreationOptions<ActivityContext> options) => ComputeActivityDataRequest(options, this.Sampler),
+            };
+
+            if (wildcardMode)
+            {
+                var pattern = "^(" + string.Join("|", from name in sources select '(' + Regex.Escape(name).Replace("\\*", ".*") + ')') + ")$";
+                var regex = new Regex(pattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+                // Function which takes ActivitySource and returns true/false to indicate if it should be subscribed to
+                // or not.
+                listener.ShouldListenTo = (activitySource) => regex.IsMatch(activitySource.Name);
+            }
+            else
+            {
+                var activitySources = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+
+                foreach (var name in sources)
+                {
+                    activitySources[name] = true;
+                }
+
+                // Function which takes ActivitySource and returns true/false to indicate if it should be subscribed to
+                // or not.
+                listener.ShouldListenTo = (activitySource) => activitySources.ContainsKey(activitySource.Name);
+            }
+
+            ActivitySource.AddActivityListener(listener);
+            this.ActivityListener = listener;
         }
 
         protected override void Dispose(bool disposing)
@@ -56,6 +154,42 @@ namespace OpenTelemetry.Trace
             this.ActivityListener?.Dispose();
 
             base.Dispose(disposing);
+        }
+
+        private static ActivityDataRequest ComputeActivityDataRequest(
+            in ActivityCreationOptions<ActivityContext> options,
+            Sampler sampler)
+        {
+            var isRootSpan = /*TODO: Put back once AutoGenerateRootContextTraceId is removed.
+                              options.Parent.TraceId == default ||*/ options.Parent.SpanId == default;
+
+            if (sampler != null)
+            {
+                // As we set ActivityListener.AutoGenerateRootContextTraceId = true,
+                // Parent.TraceId will always be the TraceId of the to-be-created Activity,
+                // if it get created.
+                ActivityTraceId traceId = options.Parent.TraceId;
+
+                var samplingParameters = new SamplingParameters(
+                    options.Parent,
+                    traceId,
+                    options.Name,
+                    options.Kind,
+                    options.Tags,
+                    options.Links);
+
+                var shouldSample = sampler.ShouldSample(samplingParameters);
+                if (shouldSample.IsSampled)
+                {
+                    return ActivityDataRequest.AllDataAndRecorded;
+                }
+            }
+
+            // If it is the root span select PropagationData so the trace ID is preserved
+            // even if no activity of the trace is recorded (sampled per OpenTelemetry parlance).
+            return isRootSpan
+                ? ActivityDataRequest.PropagationData
+                : ActivityDataRequest.None;
         }
     }
 }

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -39,10 +39,12 @@ namespace OpenTelemetry.Trace
 
         internal TracerProviderSdk(
             IEnumerable<string> sources,
+            List<ActivityProcessor> processors,
             IEnumerable<TracerProviderBuilder.InstrumentationFactory> instrumentationFactories = null,
             Sampler sampler = null,
             Resource resource = null)
         {
+            /*
             if (sources == null)
             {
                 throw new ArgumentNullException(nameof(sources));
@@ -51,6 +53,12 @@ namespace OpenTelemetry.Trace
             if (!sources.Any())
             {
                 throw new ArgumentException($"{nameof(sources)} collection is empty.");
+            }
+            */
+
+            foreach (var processor in processors)
+            {
+                this.AddProcessor(processor);
             }
 
             var wildcardMode = false;


### PR DESCRIPTION
Built on top of https://github.com/open-telemetry/opentelemetry-dotnet/pull/1032

## Changes
Make "builder" just builder.. Keeps accumulating things to be later used for building the Tracer.
Every other logic is moved to TracerProviderSdk ctor.

Please provide a brief description of the changes here. Update the
`CHANGELOG.md` for non-trivial changes.

For significant contributions please make sure you have completed the following items:

* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
