### PR TITLE
Rename AddActivitySource to AddSource, use params

### DIFF
--- a/docs/trace/building-your-own-exporter/Program.cs
+++ b/docs/trace/building-your-own-exporter/Program.cs
@@ -25,7 +25,7 @@ public class Program
     public static void Main()
     {
         using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddActivitySource("MyCompany.MyProduct.MyLibrary")
+            .AddSource("MyCompany.MyProduct.MyLibrary")
             .AddMyExporter()
             .Build();
 

--- a/docs/trace/building-your-own-processor/Program.cs
+++ b/docs/trace/building-your-own-processor/Program.cs
@@ -26,7 +26,7 @@ public class Program
     public static void Main()
     {
         using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddActivitySource("MyCompany.MyProduct.MyLibrary")
+            .AddSource("MyCompany.MyProduct.MyLibrary")
             .AddProcessor(new MyActivityProcessor("A"))
             .AddProcessor(new MyActivityProcessor("B"))
             .Build();

--- a/docs/trace/building-your-own-sampler/Program.cs
+++ b/docs/trace/building-your-own-sampler/Program.cs
@@ -27,7 +27,7 @@ public class Program
     public static void Main()
     {
         using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddActivitySource("MyCompany.MyProduct.MyLibrary")
+            .AddSource("MyCompany.MyProduct.MyLibrary")
             .SetSampler(new MySampler())
             .AddProcessor(new SimpleActivityProcessor(new ConsoleExporter(new ConsoleExporterOptions())))
             .Build();

--- a/docs/trace/getting-started/Program.cs
+++ b/docs/trace/getting-started/Program.cs
@@ -27,7 +27,7 @@ public class Program
     public static void Main()
     {
         using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddActivitySource("MyCompany.MyProduct.MyLibrary")
+            .AddSource("MyCompany.MyProduct.MyLibrary")
             .AddProcessor(new SimpleActivityProcessor(new ConsoleExporter(new ConsoleExporterOptions())))
             .Build();
 

--- a/examples/Console/TestConsoleExporter.cs
+++ b/examples/Console/TestConsoleExporter.cs
@@ -30,7 +30,8 @@ namespace Examples.Console
         {
             // Enable TracerProvider for the source "MyCompany.MyProduct.MyWebServer"
             // and use a custom MyProcessor, along with Console exporter.
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder().AddActivitySource("MyCompany.MyProduct.MyWebServer")
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                .AddSource("MyCompany.MyProduct.MyWebServer")
                 .SetResource(Resources.CreateServiceResource("MyServiceName"))
                 .AddProcessor(new MyProcessor()) // This must be added before ConsoleExporter
                 .UseConsoleExporter(opt => opt.DisplayAsJson = options.DisplayAsJson)

--- a/examples/Console/TestHttpClient.cs
+++ b/examples/Console/TestHttpClient.cs
@@ -30,7 +30,7 @@ namespace Examples.Console
             using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                 .AddHttpClientInstrumentation()
                 .SetResource(Resources.CreateServiceResource("http-service-example"))
-                .AddActivitySource("http-client-test")
+                .AddSource("http-client-test")
                 .UseConsoleExporter(opt => opt.DisplayAsJson = false)
                 .Build();
 

--- a/examples/Console/TestJaegerExporter.cs
+++ b/examples/Console/TestJaegerExporter.cs
@@ -30,8 +30,7 @@ namespace Examples.Console
             // Enable OpenTelemetry for the sources "Samples.SampleServer" and "Samples.SampleClient"
             // and use the Jaeger exporter.
             using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                    .AddActivitySource("Samples.SampleServer")
-                    .AddActivitySource("Samples.SampleClient")
+                    .AddSource("Samples.SampleClient", "Samples.SampleServer")
                     .UseJaegerExporter(o =>
                     {
                         o.ServiceName = "jaeger-test";

--- a/examples/Console/TestOTelShimWithConsoleExporter.cs
+++ b/examples/Console/TestOTelShimWithConsoleExporter.cs
@@ -27,7 +27,7 @@ namespace Examples.Console
             // Enable OpenTelemetry for the source "MyCompany.MyProduct.MyWebServer"
             // and use a single pipeline with a custom MyProcessor, and Console exporter.
             using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-                    .AddActivitySource("MyCompany.MyProduct.MyWebServer")
+                    .AddSource("MyCompany.MyProduct.MyWebServer")
                     .SetResource(Resources.CreateServiceResource("MyServiceName"))
                     .UseConsoleExporter(opt => opt.DisplayAsJson = options.DisplayAsJson)
                     .Build();

--- a/examples/Console/TestOpenTracingWithConsoleExporter.cs
+++ b/examples/Console/TestOpenTracingWithConsoleExporter.cs
@@ -30,7 +30,7 @@ namespace Examples.Console
             // Enable OpenTelemetry for the source "MyCompany.MyProduct.MyWebServer"
             // and use Console exporter.
             using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                    .AddActivitySource("MyCompany.MyProduct.MyWebServer")
+                    .AddSource("MyCompany.MyProduct.MyWebServer")
                     .SetResource(Resources.CreateServiceResource("MyServiceName"))
                     .UseConsoleExporter(opt => opt.DisplayAsJson = options.DisplayAsJson)
                     .Build();

--- a/examples/Console/TestOtlpExporter.cs
+++ b/examples/Console/TestOtlpExporter.cs
@@ -31,8 +31,7 @@ namespace Examples.Console
             // Enable OpenTelemetry for the sources "Samples.SampleServer" and "Samples.SampleClient"
             // and use OTLP exporter.
             using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                    .AddActivitySource("Samples.SampleServer")
-                    .AddActivitySource("Samples.SampleClient")
+                    .AddSource("Samples.SampleClient", "Samples.SampleServer")
                     .UseOtlpExporter(opt => opt.Endpoint = endpoint)
                     .Build();
 

--- a/examples/Console/TestRedis.cs
+++ b/examples/Console/TestRedis.cs
@@ -53,7 +53,7 @@ namespace Examples.Console
                         // changing flushinterval from 10s to 5s
                         options.FlushInterval = TimeSpan.FromSeconds(5);
                     })
-                    .AddActivitySource("redis-test")
+                    .AddSource("redis-test")
                     .Build();
 
             ActivitySource activitySource = new ActivitySource("redis-test");

--- a/examples/Console/TestZPagesExporter.cs
+++ b/examples/Console/TestZPagesExporter.cs
@@ -35,7 +35,7 @@ namespace Examples.Console
             httpServer.Start();
 
             using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                    .AddActivitySource("zpages-test")
+                    .AddSource("zpages-test")
                     .AddProcessor(zpagesProcessor)
                     .UseZPagesExporter()
                     .Build();

--- a/examples/Console/TestZipkinExporter.cs
+++ b/examples/Console/TestZipkinExporter.cs
@@ -34,8 +34,7 @@ namespace Examples.Console
             // Enable OpenTelemetry for the sources "Samples.SampleServer" and "Samples.SampleClient"
             // and use the Zipkin exporter.
             using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                    .AddActivitySource("Samples.SampleServer")
-                    .AddActivitySource("Samples.SampleClient")
+                    .AddSource("Samples.SampleClient", "Samples.SampleServer")
                     .UseZipkinExporter(o =>
                     {
                         o.ServiceName = "test-zipkin";

--- a/examples/MicroserviceExample/WebApi/Startup.cs
+++ b/examples/MicroserviceExample/WebApi/Startup.cs
@@ -42,7 +42,7 @@ namespace WebApi
 
             services.AddOpenTelemetry((builder) => builder
                 .AddAspNetCoreInstrumentation()
-                .AddActivitySource(nameof(MessageSender))
+                .AddSource(nameof(MessageSender))
                 .UseZipkinExporter(b =>
                 {
                     var zipkinHostName = Environment.GetEnvironmentVariable("ZIPKIN_HOSTNAME") ?? "localhost";

--- a/examples/MicroserviceExample/WorkerService/Program.cs
+++ b/examples/MicroserviceExample/WorkerService/Program.cs
@@ -40,7 +40,7 @@ namespace WorkerService
                     services.AddOpenTelemetry((builder) =>
                     {
                         builder
-                            .AddActivitySource(nameof(MessageReceiver))
+                            .AddSource(nameof(MessageReceiver))
                             .UseZipkinExporter(b =>
                             {
                                 var zipkinHostName = Environment.GetEnvironmentVariable("ZIPKIN_HOSTNAME") ?? "localhost";

--- a/src/OpenTelemetry.Instrumentation.Http/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/TracerProviderBuilderExtensions.cs
@@ -79,7 +79,7 @@ namespace OpenTelemetry.Trace
 
             HttpWebRequestActivitySource.Options = options;
 
-            builder.AddActivitySource(HttpWebRequestActivitySource.ActivitySourceName);
+            builder.AddSource(HttpWebRequestActivitySource.ActivitySourceName);
 
             return builder;
         }

--- a/src/OpenTelemetry.Instrumentation.SqlClient/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/TracerProviderBuilderExtensions.cs
@@ -44,7 +44,7 @@ namespace OpenTelemetry.Trace
             configureSqlClientInstrumentationOptions?.Invoke(sqlOptions);
 
             builder.AddInstrumentation((activitySource) => new SqlClientInstrumentation(sqlOptions));
-            builder.AddActivitySource(SqlClientDiagnosticListener.ActivitySourceName);
+            builder.AddSource(SqlClientDiagnosticListener.ActivitySourceName);
 
             return builder;
         }

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/TracerProviderBuilderExtensions.cs
@@ -47,7 +47,7 @@ namespace OpenTelemetry.Trace
 
             return builder
                 .AddInstrumentation((activitySourceAdapter) => new StackExchangeRedisCallsInstrumentation(connection, options))
-                .AddActivitySource(StackExchangeRedisCallsInstrumentation.ActivitySourceName);
+                .AddSource(StackExchangeRedisCallsInstrumentation.ActivitySourceName);
         }
     }
 }

--- a/src/OpenTelemetry/Trace/TracerProviderBuilder.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderBuilder.cs
@@ -62,30 +62,11 @@ namespace OpenTelemetry.Trace
         }
 
         /// <summary>
-        /// Adds given activitysource name to the list of subscribed sources.
-        /// </summary>
-        /// <param name="name">Activity source name.</param>
-        /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
-        public TracerProviderBuilder AddActivitySource(string name)
-        {
-            if (string.IsNullOrWhiteSpace(name))
-            {
-                throw new ArgumentException($"{nameof(name)} is null or whitespace.");
-            }
-
-            // TODO: We need to fix the listening model.
-            // Today it ignores version.
-            this.sources.Add(name);
-
-            return this;
-        }
-
-        /// <summary>
         /// Adds given activitysource names to the list of subscribed sources.
         /// </summary>
         /// <param name="names">Activity source names.</param>
         /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
-        public TracerProviderBuilder AddActivitySource(IEnumerable<string> names)
+        public TracerProviderBuilder AddSource(params string[] names)
         {
             if (names == null)
             {
@@ -94,7 +75,14 @@ namespace OpenTelemetry.Trace
 
             foreach (var name in names)
             {
-                this.AddActivitySource(name);
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    throw new ArgumentException($"{nameof(names)} contains null or whitespace string.");
+                }
+
+                // TODO: We need to fix the listening model.
+                // Today it ignores version.
+                this.sources.Add(name);
             }
 
             return this;

--- a/test/Benchmarks/OpenTelemetrySdkBenchmarks.cs
+++ b/test/Benchmarks/OpenTelemetrySdkBenchmarks.cs
@@ -31,11 +31,15 @@ namespace Benchmarks
 
         public OpenTelemetrySdkBenchmarks()
         {
-            using var openTelemetryAlwaysOnSample = Sdk.CreateTracerProviderBuilder().AddActivitySource("AlwaysOnSample")
-                .SetSampler(new AlwaysOnSampler()).Build();
+            using var openTelemetryAlwaysOnSample = Sdk.CreateTracerProviderBuilder()
+                .AddSource("AlwaysOnSample")
+                .SetSampler(new AlwaysOnSampler())
+                .Build();
 
-            using var openTelemetryAlwaysOffSample = Sdk.CreateTracerProviderBuilder().AddActivitySource("AlwaysOffSample")
-                .SetSampler(new AlwaysOffSampler()).Build();
+            using var openTelemetryAlwaysOffSample = Sdk.CreateTracerProviderBuilder()
+                .AddSource("AlwaysOffSample")
+                .SetSampler(new AlwaysOffSampler())
+                .Build();
 
             using var openTelemetryNoop = Sdk.CreateTracerProviderBuilder().Build();
 

--- a/test/Benchmarks/OpenTelemetrySdkBenchmarksActivity.cs
+++ b/test/Benchmarks/OpenTelemetrySdkBenchmarksActivity.cs
@@ -31,7 +31,9 @@ namespace Benchmarks
         public OpenTelemetrySdkBenchmarksActivity()
         {
             // Not configuring pipeline, which will result in default NoopActivityProcessor.
-            var openTel = Sdk.CreateTracerProviderBuilder().AddActivitySource("BenchMark");
+            var openTel = Sdk.CreateTracerProviderBuilder()
+                .AddSource("BenchMark")
+                .Build();
         }
 
         [Benchmark]

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterTests.cs
@@ -55,7 +55,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests
                 };
 
             var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
-                .AddActivitySource(ActivitySourceName)
+                .AddSource(ActivitySourceName)
                 .AddProcessor(testActivityProcessor)
                 .UseJaegerExporter()
                 .Build();

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterTest.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterTest.cs
@@ -74,8 +74,8 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
 
             // This following is done just to set Resource to Activity.
             using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
-                .AddActivitySource(sources[0].Name)
-                .AddActivitySource(sources[1].Name)
+                .AddSource(sources[0].Name)
+                .AddSource(sources[1].Name)
                 .SetResource(resource)
                 .Build();
 
@@ -260,7 +260,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
                 };
 
             var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
-                            .AddActivitySource(ActivitySourceName)
+                            .AddSource(ActivitySourceName)
                             .AddProcessor(testActivityProcessor)
                             .UseOtlpExporter()
                             .Build();

--- a/test/OpenTelemetry.Exporter.ZPages.Tests/ZPagesExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.ZPages.Tests/ZPagesExporterTests.cs
@@ -88,10 +88,10 @@ namespace OpenTelemetry.Exporter.ZPages.Tests
                 };
 
             var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
-                            .AddActivitySource(ActivitySourceName)
-                            .AddProcessor(testActivityProcessor)
-                            .UseZPagesExporter()
-                            .Build();
+                .AddSource(ActivitySourceName)
+                .AddProcessor(testActivityProcessor)
+                .UseZPagesExporter()
+                .Build();
 
             var source = new ActivitySource(ActivitySourceName);
             var activity = source.StartActivity("Test Zipkin Activity");
@@ -130,7 +130,7 @@ namespace OpenTelemetry.Exporter.ZPages.Tests
             var zpagesProcessor = new ZPagesProcessor(exporter);
 
             using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
-                            .AddActivitySource(ActivitySourceName)
+                            .AddSource(ActivitySourceName)
                             .AddProcessor(zpagesProcessor)
                             .UseZPagesExporter()
                             .Build();

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
@@ -158,15 +158,14 @@ namespace OpenTelemetry.Exporter.Zipkin.Tests
                 };
 
             var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
-                            .AddActivitySource(ActivitySourceName)
-                            .AddProcessor(testActivityProcessor)
-                            .UseZipkinExporter(
-                                o =>
-                            {
-                                o.ServiceName = "test-zipkin";
-                                o.Endpoint = new Uri($"http://{this.testServerHost}:{this.testServerPort}/api/v2/spans?requestId={requestId}");
-                            })
-                            .Build();
+                .AddSource(ActivitySourceName)
+                .AddProcessor(testActivityProcessor)
+                .UseZipkinExporter(o =>
+                {
+                    o.ServiceName = "test-zipkin";
+                    o.Endpoint = new Uri($"http://{this.testServerHost}:{this.testServerPort}/api/v2/spans?requestId={requestId}");
+                })
+                .Build();
 
             var source = new ActivitySource(ActivitySourceName);
             var activity = source.StartActivity("Test Zipkin Activity");

--- a/test/OpenTelemetry.Tests/Implementation/Trace/ActivityExtensionsTest.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Trace/ActivityExtensionsTest.cs
@@ -28,7 +28,7 @@ namespace OpenTelemetry.Trace.Test
         public void SetStatus()
         {
             using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
-                .AddActivitySource(ActivitySourceName)
+                .AddSource(ActivitySourceName)
                 .Build();
 
             using var source = new ActivitySource(ActivitySourceName);
@@ -43,7 +43,7 @@ namespace OpenTelemetry.Trace.Test
         public void SetStatusWithDescription()
         {
             using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
-                .AddActivitySource(ActivitySourceName)
+                .AddSource(ActivitySourceName)
                 .Build();
 
             using var source = new ActivitySource(ActivitySourceName);
@@ -60,7 +60,7 @@ namespace OpenTelemetry.Trace.Test
         public void SetCancelledStatus()
         {
             using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
-                .AddActivitySource(ActivitySourceName)
+                .AddSource(ActivitySourceName)
                 .Build();
 
             using var source = new ActivitySource(ActivitySourceName);
@@ -75,7 +75,7 @@ namespace OpenTelemetry.Trace.Test
         public void GetStatusWithNoStatusInActivity()
         {
             using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
-                .AddActivitySource(ActivitySourceName)
+                .AddSource(ActivitySourceName)
                 .Build();
 
             using var source = new ActivitySource(ActivitySourceName);
@@ -89,7 +89,7 @@ namespace OpenTelemetry.Trace.Test
         public void LastSetStatusWins()
         {
             using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
-                .AddActivitySource(ActivitySourceName)
+                .AddSource(ActivitySourceName)
                 .Build();
 
             using var source = new ActivitySource(ActivitySourceName);

--- a/test/OpenTelemetry.Tests/Implementation/Trace/Export/BatchingActivityProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Trace/Export/BatchingActivityProcessorTests.cs
@@ -90,10 +90,10 @@ namespace OpenTelemetry.Trace.Test
             var activityExporter = new TestActivityExporter(null, sleepMilliseconds: 5000);
             using var activityProcessor = new BatchingActivityProcessor(activityExporter, 128, TimeSpan.FromMilliseconds(1000), TimeSpan.FromMilliseconds(0), 1);
             using (var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
-                            .AddActivitySource(ActivitySourceName)
-                            .SetSampler(new AlwaysOnSampler())
-                            .AddProcessor(activityProcessor)
-                            .Build())
+                .AddSource(ActivitySourceName)
+                .SetSampler(new AlwaysOnSampler())
+                .AddProcessor(activityProcessor)
+                .Build())
             {
                 var activity1 = this.CreateActivity(ActivityName1);
             } // Force everything to flush out of the processor.
@@ -107,7 +107,7 @@ namespace OpenTelemetry.Trace.Test
             var activityExporter = new TestActivityExporter(null);
             using var activityProcessor = new BatchingActivityProcessor(activityExporter, 128, DefaultDelay, DefaultTimeout, 128);
             using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
-                            .AddActivitySource(ActivitySourceName)
+                            .AddSource(ActivitySourceName)
                             .SetSampler(new AlwaysOnSampler())
                             .AddProcessor(activityProcessor)
                             .Build();
@@ -136,7 +136,7 @@ namespace OpenTelemetry.Trace.Test
 
             using var activityProcessor = new BatchingActivityProcessor(activityExporter, 128, TimeSpan.FromMilliseconds(30), DefaultTimeout, 10);
             using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
-                            .AddActivitySource(ActivitySourceName)
+                            .AddSource(ActivitySourceName)
                             .SetSampler(new AlwaysOnSampler())
                             .AddProcessor(activityProcessor)
                             .Build();
@@ -169,7 +169,7 @@ namespace OpenTelemetry.Trace.Test
             });
             using var activityProcessor = new BatchingActivityProcessor(activityExporter, 1, TimeSpan.FromMilliseconds(100), DefaultTimeout, 1);
             using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
-                            .AddActivitySource(ActivitySourceName)
+                            .AddSource(ActivitySourceName)
                             .SetSampler(new AlwaysOnSampler())
                             .AddProcessor(activityProcessor)
                             .Build();
@@ -200,7 +200,7 @@ namespace OpenTelemetry.Trace.Test
 
             using var activityProcessor = new BatchingActivityProcessor(activityExporter, 128, DefaultDelay, DefaultTimeout, 3);
             using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
-                                        .AddActivitySource(ActivitySourceName)
+                                        .AddSource(ActivitySourceName)
                                         .SetSampler(new AlwaysOnSampler())
                                         .AddProcessor(activityProcessor)
                                         .Build();
@@ -235,7 +235,7 @@ namespace OpenTelemetry.Trace.Test
             var activityExporter = new TestActivityExporter(_ => Interlocked.Increment(ref exportCalledCount));
             using var activityProcessor = new BatchingActivityProcessor(activityExporter, 128, DefaultDelay, DefaultTimeout, 1);
             using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
-                                        .AddActivitySource(ActivitySourceName)
+                                        .AddSource(ActivitySourceName)
                                         .SetSampler(new ParentOrElseSampler(new AlwaysOffSampler()))
                                         .AddProcessor(activityProcessor)
                                         .Build();
@@ -264,7 +264,7 @@ namespace OpenTelemetry.Trace.Test
             using var activityProcessor = new BatchingActivityProcessor(activityExporter, 128, DefaultDelay, DefaultTimeout, 128);
 
             using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
-                                        .AddActivitySource(ActivitySourceName)
+                                        .AddSource(ActivitySourceName)
                                         .SetSampler(new AlwaysOnSampler())
                                         .AddProcessor(activityProcessor)
                                         .Build();
@@ -296,7 +296,7 @@ namespace OpenTelemetry.Trace.Test
             using var activityProcessor =
                 new BatchingActivityProcessor(activityExporter, 128, DefaultDelay, DefaultTimeout, batchSize);
             using (var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
-                            .AddActivitySource(ActivitySourceName)
+                            .AddSource(ActivitySourceName)
                             .SetSampler(new AlwaysOnSampler())
                             .AddProcessor(activityProcessor)
                             .Build())
@@ -343,7 +343,7 @@ namespace OpenTelemetry.Trace.Test
             using var activityProcessor =
                 new BatchingActivityProcessor(activityExporter, 128, DefaultDelay, DefaultTimeout, batchSize);
             using (var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
-                            .AddActivitySource(ActivitySourceName)
+                            .AddSource(ActivitySourceName)
                             .SetSampler(new AlwaysOnSampler())
                             .AddProcessor(activityProcessor)
                             .Build())
@@ -386,7 +386,7 @@ namespace OpenTelemetry.Trace.Test
             var activityExporter = new TestActivityExporter(_ => Interlocked.Increment(ref exportCalledCount));
             using var activityProcessor = new BatchingActivityProcessor(activityExporter, 128, DefaultDelay, DefaultTimeout, batchSize);
             using (var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
-                            .AddActivitySource(ActivitySourceName)
+                            .AddSource(ActivitySourceName)
                             .SetSampler(new AlwaysOnSampler())
                             .AddProcessor(activityProcessor)
                             .Build())
@@ -432,7 +432,7 @@ namespace OpenTelemetry.Trace.Test
             using (var batchingActivityProcessor = new BatchingActivityProcessor(activityExporter, 128, DefaultDelay, DefaultTimeout, batchSize))
             {
                 using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
-                            .AddActivitySource(ActivitySourceName)
+                            .AddSource(ActivitySourceName)
                             .SetSampler(new AlwaysOnSampler())
                             .AddProcessor(batchingActivityProcessor)
                             .Build();

--- a/test/OpenTelemetry.Tests/Implementation/Trace/Export/SimpleActivityProcessorTest.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Trace/Export/SimpleActivityProcessorTest.cs
@@ -38,10 +38,10 @@ namespace OpenTelemetry.Trace.Test
         {
             this.activityExporter = new TestActivityExporter(null);
             this.openTelemetry = Sdk.CreateTracerProviderBuilder()
-                        .AddActivitySource(ActivitySourceName)
-                        .SetSampler(new AlwaysOnSampler())
-                        .AddProcessor(new SimpleActivityProcessor(this.activityExporter))
-                        .Build();
+                .AddSource(ActivitySourceName)
+                .SetSampler(new AlwaysOnSampler())
+                .AddProcessor(new SimpleActivityProcessor(this.activityExporter))
+                .Build();
 
             this.activitySource = new ActivitySource(ActivitySourceName);
         }
@@ -57,7 +57,7 @@ namespace OpenTelemetry.Trace.Test
         {
             this.activityExporter = new TestActivityExporter(_ => throw new ArgumentException("123"));
             this.openTelemetry = Sdk.CreateTracerProviderBuilder()
-                        .AddActivitySource("random")
+                        .AddSource("random")
                         .SetSampler(new AlwaysOnSampler())
                         .AddProcessor(new SimpleActivityProcessor(this.activityExporter))
                         .Build();
@@ -74,7 +74,7 @@ namespace OpenTelemetry.Trace.Test
         {
             this.activityExporter = new TestActivityExporter(async _ => await Task.Delay(500));
             this.openTelemetry = Sdk.CreateTracerProviderBuilder()
-                        .AddActivitySource("random")
+                        .AddSource("random")
                         .AddProcessor(new SimpleActivityProcessor(this.activityExporter))
                         .Build();
 

--- a/test/OpenTelemetry.Tests/Implementation/Trace/OpenTelemetrySdkTest.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Trace/OpenTelemetrySdkTest.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Tests.Implementation.Trace
             var expectedResource = Resources.Resources.CreateServiceResource("ServiceNameAbc");
 
             using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                .AddActivitySource(nameof(this.ResourceGetsAssociatedWithActivity))
+                .AddSource(nameof(this.ResourceGetsAssociatedWithActivity))
                 .SetResource(expectedResource)
                 .Build();
 
@@ -47,7 +47,7 @@ namespace OpenTelemetry.Tests.Implementation.Trace
             var expectedResource = Resource.Empty;
 
             using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                .AddActivitySource(nameof(this.ResourceGetsAssociatedWithActivity))
+                .AddSource(nameof(this.ResourceGetsAssociatedWithActivity))
                 .Build();
 
             using (var root = activitySource.StartActivity("root"))

--- a/test/OpenTelemetry.Tests/Implementation/Trace/TraceSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Trace/TraceSdkTest.cs
@@ -30,9 +30,9 @@ namespace OpenTelemetry.Tests.Implementation.Trace
             var testSampler = new TestSampler();
             using var activitySource = new ActivitySource(ActivitySourceName);
             using var sdk = Sdk.CreateTracerProviderBuilder()
-                        .AddActivitySource(ActivitySourceName)
-                        .SetSampler(testSampler)
-                        .Build();
+                .AddSource(ActivitySourceName)
+                .SetSampler(testSampler)
+                .Build();
 
             // OpenTelemetry Sdk is expected to set default to W3C.
             Assert.True(Activity.DefaultIdFormat == ActivityIdFormat.W3C);
@@ -106,7 +106,7 @@ namespace OpenTelemetry.Tests.Implementation.Trace
             var testSampler = new TestSampler();
             using var activitySource = new ActivitySource(ActivitySourceName);
             using var sdk = Sdk.CreateTracerProviderBuilder()
-                    .AddActivitySource(ActivitySourceName)
+                    .AddSource(ActivitySourceName)
                     .SetSampler(testSampler)
                     .Build();
 

--- a/test/OpenTelemetry.Tests/Implementation/Trace/TracerTest.cs
+++ b/test/OpenTelemetry.Tests/Implementation/Trace/TracerTest.cs
@@ -60,7 +60,7 @@ namespace OpenTelemetry.Trace.Test
         public void Tracer_StartRootSpan_BadArgs_NullSpanName()
         {
             using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                .AddActivitySource("tracername")
+                .AddSource("tracername")
                 .Build();
 
             var span1 = this.tracer.StartRootSpan(null);
@@ -77,7 +77,7 @@ namespace OpenTelemetry.Trace.Test
         public void Tracer_StartSpan_BadArgs_NullSpanName()
         {
             using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                .AddActivitySource("tracername")
+                .AddSource("tracername")
                 .Build();
 
             var span1 = this.tracer.StartSpan(null);
@@ -94,7 +94,7 @@ namespace OpenTelemetry.Trace.Test
         public void Tracer_StartActiveSpan_BadArgs_NullSpanName()
         {
             using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                .AddActivitySource("tracername")
+                .AddSource("tracername")
                 .Build();
 
             var span1 = this.tracer.StartActiveSpan(null);
@@ -111,7 +111,7 @@ namespace OpenTelemetry.Trace.Test
         public void Tracer_StartSpan_FromParent_BadArgs_NullSpanName()
         {
             using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                .AddActivitySource("tracername")
+                .AddSource("tracername")
                 .Build();
 
             var span1 = this.tracer.StartSpan(null, SpanKind.Client, TelemetrySpan.NoopInstance);
@@ -125,7 +125,7 @@ namespace OpenTelemetry.Trace.Test
         public void Tracer_StartSpan_FromParentContext_BadArgs_NullSpanName()
         {
             using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                .AddActivitySource("tracername")
+                .AddSource("tracername")
                 .Build();
 
             var blankContext = default(SpanContext);
@@ -141,7 +141,7 @@ namespace OpenTelemetry.Trace.Test
         public void Tracer_StartActiveSpan_FromParent_BadArgs_NullSpanName()
         {
             using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                .AddActivitySource("tracername")
+                .AddSource("tracername")
                 .Build();
 
             var span1 = this.tracer.StartActiveSpan(null, SpanKind.Client, TelemetrySpan.NoopInstance);
@@ -155,7 +155,7 @@ namespace OpenTelemetry.Trace.Test
         public void Tracer_StartActiveSpan_FromParentContext_BadArgs_NullSpanName()
         {
             using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                .AddActivitySource("tracername")
+                .AddSource("tracername")
                 .Build();
 
             var blankContext = default(SpanContext);
@@ -171,7 +171,7 @@ namespace OpenTelemetry.Trace.Test
         public void Tracer_StartActiveSpan_CreatesActiveSpan()
         {
             using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                .AddActivitySource("tracername")
+                .AddSource("tracername")
                 .Build();
 
             var span1 = this.tracer.StartActiveSpan("Test");
@@ -195,7 +195,7 @@ namespace OpenTelemetry.Trace.Test
         public void GetCurrentSpanBlank()
         {
             using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                .AddActivitySource("tracername")
+                .AddSource("tracername")
                 .Build();
             Assert.False(this.tracer.CurrentSpan.Context.IsValid);
         }
@@ -204,7 +204,7 @@ namespace OpenTelemetry.Trace.Test
         public void GetCurrentSpanBlankWontThrowOnEnd()
         {
             using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                .AddActivitySource("tracername")
+                .AddSource("tracername")
                 .Build();
             var current = this.tracer.CurrentSpan;
             current.End();
@@ -214,7 +214,7 @@ namespace OpenTelemetry.Trace.Test
         public void GetCurrentSpan()
         {
             using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                .AddActivitySource("tracername")
+                .AddSource("tracername")
                 .Build();
 
             var span = this.tracer.StartSpan("foo");
@@ -228,7 +228,7 @@ namespace OpenTelemetry.Trace.Test
         public void CreateSpan_Sampled()
         {
             using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                .AddActivitySource("tracername")
+                .AddSource("tracername")
                 .Build();
             var span = this.tracer.StartSpan("foo");
             Assert.True(span.IsRecording);
@@ -238,7 +238,7 @@ namespace OpenTelemetry.Trace.Test
         public void CreateSpan_NotSampled()
         {
             using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                .AddActivitySource("tracername")
+                .AddSource("tracername")
                 .SetSampler(new AlwaysOffSampler())
                 .Build();
 


### PR DESCRIPTION
Follow up on:
* https://github.com/open-telemetry/opentelemetry-dotnet/pull/1027#discussion_r467374066
* https://github.com/open-telemetry/opentelemetry-dotnet/pull/1027#discussion_r467517152
* https://github.com/open-telemetry/opentelemetry-dotnet/pull/1032#discussion_r468084719

## Changes
* Renamed `AddActivitySource` to `AddSource`
* Take the `params` approach.

I will send a separate PR to clean up the `CHANGELOG.md` as it is becoming messy now.

Please provide a brief description of the changes here. Update the
`CHANGELOG.md` for non-trivial changes.

For significant contributions please make sure you have completed the following items:

* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
