### PR TITLE
Clean up TracerProviderSdk

### DIFF
--- a/src/OpenTelemetry/Trace/TracerProviderExtensions.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderExtensions.cs
@@ -39,24 +39,7 @@ namespace OpenTelemetry.Trace
                 throw new ArgumentException($"{nameof(provider)} is not an instance of TracerProviderSdk");
             }
 
-            if (trait.ActivityProcessor == null)
-            {
-                trait.ActivityProcessor = processor;
-            }
-            else if (trait.ActivityProcessor is CompositeActivityProcessor compositeProcessor)
-            {
-                compositeProcessor.AddProcessor(processor);
-            }
-            else
-            {
-                trait.ActivityProcessor = new CompositeActivityProcessor(new[]
-                {
-                    trait.ActivityProcessor,
-                    processor,
-                });
-            }
-
-            return provider;
+            return trait.AddProcessor(processor);
         }
     }
 }


### PR DESCRIPTION
No change from the user perspective, just improve the encapsulation and how code is organized.

## Changes

* Moved the AddProcessor core logic to TracerProviderSdk.
* Dropped rights by making most of the fields private.