### PR TITLE
Update MyExporter example

### DIFF
--- a/docs/trace/building-your-own-exporter/MyExporterExtensions.cs
+++ b/docs/trace/building-your-own-exporter/MyExporterExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TracerProviderBuilderExtensions.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="MyExporterExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,10 +16,25 @@
 
 using OpenTelemetry.Trace;
 
-internal static class TracerProviderBuilderExtensions
+internal static class MyExporterExtensions
 {
+    public static TracerProvider AddMyExporter(this TracerProvider provider)
+    {
+        if (provider == null)
+        {
+            throw new ArgumentNullException(nameof(provider));
+        }
+
+        return provider.AddProcessor(new SimpleActivityProcessor(new MyExporter()));
+    }
+
     public static TracerProviderBuilder AddMyExporter(this TracerProviderBuilder builder)
     {
-        return builder?.AddProcessor(new SimpleActivityProcessor(new MyExporter()));
+        if (builder == null)
+        {
+            throw new ArgumentNullException(nameof(builder));
+        }
+
+        return builder.AddProcessor(new SimpleActivityProcessor(new MyExporter()));
     }
 }

--- a/docs/trace/building-your-own-exporter/MyExporterExtensions.cs
+++ b/docs/trace/building-your-own-exporter/MyExporterExtensions.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using OpenTelemetry.Trace;
 
 internal static class MyExporterExtensions

--- a/docs/trace/building-your-own-exporter/MyExporterHelperExtensions.cs
+++ b/docs/trace/building-your-own-exporter/MyExporterHelperExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MyExporterExtensions.cs" company="OpenTelemetry Authors">
+﻿// <copyright file="MyExporterHelperExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,18 +17,8 @@
 using System;
 using OpenTelemetry.Trace;
 
-internal static class MyExporterExtensions
+internal static class MyExporterHelperExtensions
 {
-    public static TracerProvider AddMyExporter(this TracerProvider provider)
-    {
-        if (provider == null)
-        {
-            throw new ArgumentNullException(nameof(provider));
-        }
-
-        return provider.AddProcessor(new SimpleActivityProcessor(new MyExporter()));
-    }
-
     public static TracerProviderBuilder AddMyExporter(this TracerProviderBuilder builder)
     {
         if (builder == null)


### PR DESCRIPTION
Trying to get feedback and see if folks like the approach.
If it looks good, I'll open a separate PR to change the ConsoleExporter while addressing #896.

## Changes

* Added the recommended way of providing exporter extensions.
* Renamed `TracerProviderBuilderExtensions.cs` to `MyExporterHelperExtensions.cs`, which allows us to have extensions for more than one class, and also mitigate the docfx ref doc warning.
* Alternative names @CodeBlanch and I discussed:
  * `MyExporterTracerProviderBuilderExtensions` seems to be TL;DR.
  * `MyExporterExtensionMethods` could be misleading as it sounds like extension methods on `MyExporter`.

To give an idea what is the docfx ref doc build waring, it is currently part of the CI. I didn't turn warning into error at this moment. These warnings need to be resolved if we need to automatically generate API reference docs.

![image](https://user-images.githubusercontent.com/17327289/89931777-897c0980-dbc1-11ea-9c3e-94847b849f10.png)
