### PR TITLE
Refactor exporter - step 2

### DIFF
--- a/docs/trace/building-your-own-processor/Program.cs
+++ b/docs/trace/building-your-own-processor/Program.cs
@@ -16,7 +16,6 @@
 
 using System.Diagnostics;
 using OpenTelemetry;
-using OpenTelemetry.Trace;
 
 public class Program
 {

--- a/examples/Console/TestConsoleExporter.cs
+++ b/examples/Console/TestConsoleExporter.cs
@@ -16,8 +16,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
 using OpenTelemetry;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerThriftClient.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerThriftClient.cs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerThriftClient.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerThriftClient.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/OpenTelemetry/Trace/ActivityExporterSync.cs
+++ b/src/OpenTelemetry/Trace/ActivityExporterSync.cs
@@ -17,8 +17,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace OpenTelemetry.Trace
 {

--- a/src/OpenTelemetry/Trace/BatchExportActivityProcessor.cs
+++ b/src/OpenTelemetry/Trace/BatchExportActivityProcessor.cs
@@ -15,8 +15,6 @@
 // </copyright>
 
 using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/OpenTelemetry/Trace/BatchExportActivityProcessor.cs
+++ b/src/OpenTelemetry/Trace/BatchExportActivityProcessor.cs
@@ -1,0 +1,127 @@
+﻿// <copyright file="BatchExportActivityProcessor.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Trace
+{
+    /// <summary>
+    /// Implements processor that batches activities before calling exporter.
+    /// </summary>
+    public class BatchExportActivityProcessor : ActivityProcessor
+    {
+        private readonly ActivityExporterSync exporter;
+        private readonly int maxQueueSize;
+        private readonly TimeSpan scheduledDelay;
+        private readonly TimeSpan exporterTimeout;
+        private readonly int maxExportBatchSize;
+        private bool disposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BatchExportActivityProcessor"/> class with custom settings.
+        /// </summary>
+        /// <param name="exporter">Exporter instance.</param>
+        /// <param name="maxQueueSize">The maximum queue size. After the size is reached data are dropped. The default value is 2048.</param>
+        /// <param name="scheduledDelayMillis">The delay interval in milliseconds between two consecutive exports. The default value is 5000.</param>
+        /// <param name="exporterTimeoutMillis">How long the export can run before it is cancelled. The default value is 30000.</param>
+        /// <param name="maxExportBatchSize">The maximum batch size of every export. It must be smaller or equal to maxQueueSize. The default value is 512.</param>
+        public BatchExportActivityProcessor(
+            ActivityExporterSync exporter,
+            int maxQueueSize = 2048,
+            int scheduledDelayMillis = 5000,
+            int exporterTimeoutMillis = 30000,
+            int maxExportBatchSize = 512)
+        {
+            if (maxQueueSize <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxQueueSize));
+            }
+
+            if (maxExportBatchSize <= 0 || maxExportBatchSize > maxQueueSize)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxExportBatchSize));
+            }
+
+            if (scheduledDelayMillis <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(scheduledDelayMillis));
+            }
+
+            if (exporterTimeoutMillis < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(exporterTimeoutMillis));
+            }
+
+            this.exporter = exporter ?? throw new ArgumentNullException(nameof(exporter));
+            this.maxQueueSize = maxQueueSize;
+            this.scheduledDelay = TimeSpan.FromMilliseconds(scheduledDelayMillis);
+            this.exporterTimeout = TimeSpan.FromMilliseconds(exporterTimeoutMillis);
+            this.maxExportBatchSize = maxExportBatchSize;
+        }
+
+        /// <inheritdoc/>
+        public override void OnEnd(Activity activity)
+        {
+            // TODO
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        /// <exception cref="OperationCanceledException">If the <paramref name="cancellationToken"/> is canceled.</exception>
+        public override Task ForceFlushAsync(CancellationToken cancellationToken)
+        {
+            // TODO
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        /// <exception cref="OperationCanceledException">If the <paramref name="cancellationToken"/> is canceled.</exception>
+        public override Task ShutdownAsync(CancellationToken cancellationToken)
+        {
+            // TODO
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Releases the unmanaged resources used by this class and optionally releases the managed resources.
+        /// </summary>
+        /// <param name="disposing"><see langword="true"/> to release both managed and unmanaged resources; <see langword="false"/> to release only unmanaged resources.</param>
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing && !this.disposed)
+            {
+                try
+                {
+                    this.exporter.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    OpenTelemetrySdkEventSource.Log.SpanProcessorException(nameof(this.Dispose), ex);
+                }
+
+                this.disposed = true;
+            }
+        }
+    }
+}

--- a/src/OpenTelemetry/Trace/SimpleExportActivityProcessor.cs
+++ b/src/OpenTelemetry/Trace/SimpleExportActivityProcessor.cs
@@ -1,0 +1,93 @@
+﻿// <copyright file="SimpleExportActivityProcessor.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Trace
+{
+    /// <summary>
+    /// Implements simple activity processor that exports activities in OnEnd call without batching.
+    /// </summary>
+    public class SimpleExportActivityProcessor : ActivityProcessor
+    {
+        private readonly ActivityExporterSync exporter;
+        private bool stopped;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SimpleExportActivityProcessor"/> class.
+        /// </summary>
+        /// <param name="exporter">Activity exporter instance.</param>
+        public SimpleExportActivityProcessor(ActivityExporterSync exporter)
+        {
+            this.exporter = exporter ?? throw new ArgumentNullException(nameof(exporter));
+        }
+
+        /// <inheritdoc />
+        public override void OnEnd(Activity activity)
+        {
+            try
+            {
+                // TODO: avoid heap allocation
+                _ = this.exporter.Export(new[] { activity });
+            }
+            catch (Exception ex)
+            {
+                OpenTelemetrySdkEventSource.Log.SpanProcessorException(nameof(this.OnEnd), ex);
+            }
+        }
+
+        /// <inheritdoc />
+        public override Task ShutdownAsync(CancellationToken cancellationToken)
+        {
+            if (!this.stopped)
+            {
+                this.exporter.Shutdown();
+                this.stopped = true;
+            }
+
+#if NET452
+            return Task.FromResult(0);
+#else
+            return Task.CompletedTask;
+#endif
+        }
+
+        /// <summary>
+        /// Releases the unmanaged resources used by this class and optionally releases the managed resources.
+        /// </summary>
+        /// <param name="disposing"><see langword="true"/> to release both managed and unmanaged resources; <see langword="false"/> to release only unmanaged resources.</param>
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing)
+            {
+                try
+                {
+                    this.exporter.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    OpenTelemetrySdkEventSource.Log.SpanProcessorException(nameof(this.Dispose), ex);
+                }
+            }
+        }
+    }
+}

--- a/test/OpenTelemetry.Tests/Resources/ResourceTest.cs
+++ b/test/OpenTelemetry.Tests/Resources/ResourceTest.cs
@@ -16,7 +16,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using OpenTelemetry.Resources;
 using Xunit;
 
 namespace OpenTelemetry.Resources.Tests

--- a/test/OpenTelemetry.Tests/Resources/ResourcesTests.cs
+++ b/test/OpenTelemetry.Tests/Resources/ResourcesTests.cs
@@ -17,7 +17,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using OpenTelemetry.Resources;
 using Xunit;
 
 namespace OpenTelemetry.Resources.Tests

--- a/test/OpenTelemetry.Tests/Trace/OpenTelemetrySdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/OpenTelemetrySdkTest.cs
@@ -16,7 +16,6 @@
 
 using System.Diagnostics;
 using OpenTelemetry.Resources;
-using OpenTelemetry.Trace;
 using Xunit;
 
 namespace OpenTelemetry.Trace.Tests

--- a/test/OpenTelemetry.Tests/Trace/Propagation/CompositePropagatorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/CompositePropagatorTest.cs
@@ -18,7 +18,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using OpenTelemetry.Context.Propagation;
 using Xunit;
 
 namespace OpenTelemetry.Context.Propagation.Tests

--- a/test/OpenTelemetry.Tests/Trace/Propagation/TestPropagator.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/TestPropagator.cs
@@ -18,7 +18,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using OpenTelemetry.Context.Propagation;
 
 namespace OpenTelemetry.Context.Propagation.Tests
 {

--- a/test/OpenTelemetry.Tests/Trace/Propagation/TraceContextTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/TraceContextTest.cs
@@ -16,7 +16,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using OpenTelemetry.Context.Propagation;
 using Xunit;
 
 namespace OpenTelemetry.Context.Propagation.Tests

--- a/test/OpenTelemetry.Tests/Trace/Propagation/TracestateUtilsTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/TracestateUtilsTests.cs
@@ -16,7 +16,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using OpenTelemetry.Context.Propagation;
 using Xunit;
 
 namespace OpenTelemetry.Context.Propagation.Tests

--- a/test/OpenTelemetry.Tests/Trace/SpanAttributesTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/SpanAttributesTest.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
 using Xunit;
 
 namespace OpenTelemetry.Trace.Tests

--- a/test/OpenTelemetry.Tests/Trace/TestSampler.cs
+++ b/test/OpenTelemetry.Tests/Trace/TestSampler.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 using System;
-using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Trace.Tests
 {


### PR DESCRIPTION
This is a follow up PR of #1078.

## Changes

* Added `SimpleExportActivityProcessor`.
* Added skeleton of `BatchExportActivityProcessor`.
* The reason why these names are picked was covered in [bullet point 6 of PR #1078](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1078#issue-467617824).
* Removed unused `using` statements.

For significant contributions please make sure you have completed the following items:

* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
