### PR TITLE
Add max spin count limit to circular buffer

### DIFF
--- a/src/OpenTelemetry/Internal/CircularBuffer.cs
+++ b/src/OpenTelemetry/Internal/CircularBuffer.cs
@@ -168,7 +168,7 @@ namespace OpenTelemetry.Internal
 
                 if (spinCountDown == 0)
                 {
-                    return false; // exeeded maximum spin count
+                    return false; // exceeded maximum spin count
                 }
             }
         }

--- a/src/OpenTelemetry/Internal/CircularBuffer.cs
+++ b/src/OpenTelemetry/Internal/CircularBuffer.cs
@@ -87,11 +87,11 @@ namespace OpenTelemetry.Internal
         }
 
         /// <summary>
-        /// Attempts to add the specified item to the buffer.
+        /// Adds the specified item to the buffer.
         /// </summary>
         /// <param name="value">The value to add.</param>
         /// <returns>Returns true if the item was added to the buffer successfully; false if the buffer is full.</returns>
-        public bool TryAdd(T value)
+        public bool Add(T value)
         {
             if (value == null)
             {
@@ -118,6 +118,57 @@ namespace OpenTelemetry.Internal
                     }
 
                     this.trait[index] = null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Attempts to add the specified item to the buffer.
+        /// </summary>
+        /// <param name="value">The value to add.</param>
+        /// <param name="maxSpinCount">The maximum allowed spin count, when set to a negative number of zero, will spin indefinitely.</param>
+        /// <returns>Returns true if the item was added to the buffer successfully; false if the buffer is full or the spin count exeeded maxSpinCount.</returns>
+        public bool TryAdd(T value, int maxSpinCount)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            if (maxSpinCount <= 0)
+            {
+                return this.Add(value);
+            }
+
+            var spinCountDown = maxSpinCount;
+
+            while (true)
+            {
+                var tailSnapshot = this.tail;
+                var headSnapshot = this.head;
+
+                if (headSnapshot - tailSnapshot >= this.capacity)
+                {
+                    return false; // buffer is full
+                }
+
+                var index = (int)(headSnapshot % this.capacity);
+
+                if (this.SwapIfNull(index, value))
+                {
+                    if (Interlocked.CompareExchange(ref this.head, headSnapshot + 1, headSnapshot) == headSnapshot)
+                    {
+                        return true;
+                    }
+
+                    this.trait[index] = null;
+                }
+
+                spinCountDown--;
+
+                if (spinCountDown == 0)
+                {
+                    return false; // exeeded maximum spin count
                 }
             }
         }

--- a/src/OpenTelemetry/Trace/BatchExportActivityProcessor.cs
+++ b/src/OpenTelemetry/Trace/BatchExportActivityProcessor.cs
@@ -113,7 +113,7 @@ namespace OpenTelemetry.Trace
         /// <inheritdoc/>
         public override void OnEnd(Activity activity)
         {
-            if (this.queue.TryAdd(activity))
+            if (this.queue.TryAdd(activity, maxSpinCount: 50000))
             {
                 if (this.queue.Count >= this.maxExportBatchSize)
                 {
@@ -123,7 +123,7 @@ namespace OpenTelemetry.Trace
                 return; // enqueue succeeded
             }
 
-            // drop item on the floor
+            // either queue is full or exceeded spin count, drop item on the floor
             Interlocked.Increment(ref this.droppedCount);
         }
 


### PR DESCRIPTION
@ThomsonTan brought up a good point that we might want to [avoid spinning indefinitely](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1085#discussion_r471146599).

This could happen on a highly concurrent environment since spin lock does not guarantee ordering, so mathematically it is possible that one unfortunate thread ended up to be always spinning while in its own quorum, which is scary for customers who use telemetry SDK.
