### PR TITLE
Throw when SpanName is null

### DIFF
--- a/src/OpenTelemetry.Api/Trace/Tracer.cs
+++ b/src/OpenTelemetry.Api/Trace/Tracer.cs
@@ -147,6 +147,11 @@ namespace OpenTelemetry.Trace
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private TelemetrySpan StartSpanHelper(bool isActiveSpan, string name, SpanKind kind, in SpanContext parentContext = default, SpanAttributes initialAttributes = null, IEnumerable<Link> links = null, DateTimeOffset startTime = default)
         {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
             if (!this.ActivitySource.HasListeners())
             {
                 return TelemetrySpan.NoopInstance;

--- a/test/OpenTelemetry.Tests/Trace/TracerTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerTest.cs
@@ -35,10 +35,9 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void CurrentSpanNullByDefault()
         {
-            ActivitySource actSource = new ActivitySource("cijo");
-            actSource.StartActivity(null);
-            Activity act = new Activity(null);
-            Assert.Null(act.OperationName);
+            var current = this.tracer.CurrentSpan;
+            Assert.True(IsNoopSpan(current));
+            Assert.False(current.Context.IsValid);
         }
 
         [Fact]

--- a/test/OpenTelemetry.Tests/Trace/TracerTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerTest.cs
@@ -35,9 +35,10 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void CurrentSpanNullByDefault()
         {
-            var current = this.tracer.CurrentSpan;
-            Assert.True(IsNoopSpan(current));
-            Assert.False(current.Context.IsValid);
+            ActivitySource actSource = new ActivitySource("cijo");
+            actSource.StartActivity(null);
+            Activity act = new Activity(null);
+            Assert.Null(act.OperationName);
         }
 
         [Fact]
@@ -60,112 +61,29 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void Tracer_StartRootSpan_BadArgs_NullSpanName()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                .AddSource("tracername")
-                .Build();
-
-            var span1 = this.tracer.StartRootSpan(null);
-            Assert.Null(span1.Activity.DisplayName);
-
-            var span2 = this.tracer.StartRootSpan(null, SpanKind.Client);
-            Assert.Null(span2.Activity.DisplayName);
-
-            var span3 = this.tracer.StartRootSpan(null, SpanKind.Client, default);
-            Assert.Null(span3.Activity.DisplayName);
+            Assert.Throws<ArgumentNullException>(() => this.tracer.StartRootSpan(null));
+            Assert.Throws<ArgumentNullException>(() => this.tracer.StartRootSpan(null, SpanKind.Client));
+            Assert.Throws<ArgumentNullException>(() => this.tracer.StartRootSpan(null, SpanKind.Client, default));
         }
 
         [Fact]
         public void Tracer_StartSpan_BadArgs_NullSpanName()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                .AddSource("tracername")
-                .Build();
-
-            var span1 = this.tracer.StartSpan(null);
-            Assert.Null(span1.Activity.DisplayName);
-
-            var span2 = this.tracer.StartSpan(null, SpanKind.Client);
-            Assert.Null(span2.Activity.DisplayName);
-
-            var span3 = this.tracer.StartSpan(null, SpanKind.Client, null);
-            Assert.Null(span3.Activity.DisplayName);
+            Assert.Throws<ArgumentNullException>(() => this.tracer.StartSpan(null));
+            Assert.Throws<ArgumentNullException>(() => this.tracer.StartSpan(null, SpanKind.Client));
+            Assert.Throws<ArgumentNullException>(() => this.tracer.StartSpan(null, SpanKind.Client, null));
+            Assert.Throws<ArgumentNullException>(() => this.tracer.StartSpan(null, SpanKind.Client, TelemetrySpan.NoopInstance));
+            Assert.Throws<ArgumentNullException>(() => this.tracer.StartSpan(null, SpanKind.Client, default(SpanContext)));
         }
 
         [Fact]
         public void Tracer_StartActiveSpan_BadArgs_NullSpanName()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                .AddSource("tracername")
-                .Build();
-
-            var span1 = this.tracer.StartActiveSpan(null);
-            Assert.Null(span1.Activity.DisplayName);
-
-            var span2 = this.tracer.StartActiveSpan(null, SpanKind.Client);
-            Assert.Null(span2.Activity.DisplayName);
-
-            var span3 = this.tracer.StartActiveSpan(null, SpanKind.Client, null);
-            Assert.Null(span3.Activity.DisplayName);
-        }
-
-        [Fact]
-        public void Tracer_StartSpan_FromParent_BadArgs_NullSpanName()
-        {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                .AddSource("tracername")
-                .Build();
-
-            var span1 = this.tracer.StartSpan(null, SpanKind.Client, TelemetrySpan.NoopInstance);
-            Assert.Null(span1.Activity.DisplayName);
-
-            var span2 = this.tracer.StartSpan(null, SpanKind.Client, TelemetrySpan.NoopInstance, default);
-            Assert.Null(span2.Activity.DisplayName);
-        }
-
-        [Fact]
-        public void Tracer_StartSpan_FromParentContext_BadArgs_NullSpanName()
-        {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                .AddSource("tracername")
-                .Build();
-
-            var blankContext = default(SpanContext);
-
-            var span1 = this.tracer.StartSpan(null, SpanKind.Client, blankContext);
-            Assert.Null(span1.Activity.DisplayName);
-
-            var span2 = this.tracer.StartSpan(null, SpanKind.Client, blankContext, default);
-            Assert.Null(span2.Activity.DisplayName);
-        }
-
-        [Fact]
-        public void Tracer_StartActiveSpan_FromParent_BadArgs_NullSpanName()
-        {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                .AddSource("tracername")
-                .Build();
-
-            var span1 = this.tracer.StartActiveSpan(null, SpanKind.Client, TelemetrySpan.NoopInstance);
-            Assert.Null(span1.Activity.DisplayName);
-
-            var span2 = this.tracer.StartActiveSpan(null, SpanKind.Client, TelemetrySpan.NoopInstance, default);
-            Assert.Null(span2.Activity.DisplayName);
-        }
-
-        [Fact]
-        public void Tracer_StartActiveSpan_FromParentContext_BadArgs_NullSpanName()
-        {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                .AddSource("tracername")
-                .Build();
-
-            var blankContext = default(SpanContext);
-
-            var span1 = this.tracer.StartActiveSpan(null, SpanKind.Client, blankContext);
-            Assert.Null(span1.Activity.DisplayName);
-
-            var span2 = this.tracer.StartActiveSpan(null, SpanKind.Client, blankContext, default);
-            Assert.Null(span2.Activity.DisplayName);
+            Assert.Throws<ArgumentNullException>(() => this.tracer.StartActiveSpan(null));
+            Assert.Throws<ArgumentNullException>(() => this.tracer.StartActiveSpan(null, SpanKind.Client));
+            Assert.Throws<ArgumentNullException>(() => this.tracer.StartActiveSpan(null, SpanKind.Client, null));
+            Assert.Throws<ArgumentNullException>(() => this.tracer.StartActiveSpan(null, SpanKind.Client, TelemetrySpan.NoopInstance));
+            Assert.Throws<ArgumentNullException>(() => this.tracer.StartActiveSpan(null, SpanKind.Client, default(SpanContext)));
         }
 
         [Fact]


### PR DESCRIPTION
Opening a PR to get more opinion on this.
SpanName is a required argument. This PR modifies the Tracer API to throw when SpanName is null.

Question:
Should we throw if SpanName IsNullOrEmpty?

.NET runtime behavior is listed below:
new Activity(null) - does not throw (legacy/unknown reason. Cannot change this)
activitySource.StartActivity(null) - does not throw (follows above. But activitysource being a new API, I'd love to modify it to throw)
new ActivitySource(null) - throws ArgumentNullException. - Correct behavior.