### PR TITLE
Remove external dependency for tests

### DIFF
--- a/test/OpenTelemetry.Instrumentation.Http.Tests/http-out-test-cases.json
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/http-out-test-cases.json
@@ -1,30 +1,30 @@
 ﻿[
   {
-    "name": "Successful GET call to https://example.com",
+    "name": "Successful GET call to localhost",
     "method": "GET",
-    "url": "https://example.com/",
+    "url": "http://{host}:{port}/",
     "spanName": "HTTP GET",
     "spanStatus": "OK",
     "spanKind": "Client",
     "spanAttributes": {
       "http.method": "GET",
-      "http.host": "example.com",
+      "http.host": "{host}:{port}",
       "http.status_code": "200",
-      "http.url": "https://example.com/"
+      "http.url": "http://{host}:{port}/"
     }
   },
   {
-    "name": "Successfully POST call to https://example.com",
+    "name": "Successfully POST call to localhost",
     "method": "POST",
-    "url": "https://example.com/",
+    "url": "http://{host}:{port}/",
     "spanName": "HTTP POST",
     "spanStatus": "OK",
     "spanKind": "Client",
     "spanAttributes": {
       "http.method": "POST",
-      "http.host": "example.com",
+      "http.host": "{host}:{port}",
       "http.status_code": "200",
-      "http.url": "https://example.com/"
+      "http.url": "http://{host}:{port}/"
     }
   },
   {


### PR DESCRIPTION
Fixes #1131 
We were depending on http://example.com. Replaced with locally spun up test server.

## Changes

Please provide a brief description of the changes here. Update the
`CHANGELOG.md` for non-trivial changes.

For significant contributions please make sure you have completed the following items:

* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
