### PR TITLE
Shutdown improvement

### DIFF
--- a/docs/trace/building-your-own-exporter/MyExporter.cs
+++ b/docs/trace/building-your-own-exporter/MyExporter.cs
@@ -36,4 +36,9 @@ internal class MyExporter : ActivityExporter
 
         return ExportResult.Success;
     }
+
+    protected override void OnShutdown(int timeoutMilliseconds)
+    {
+        Console.WriteLine($"MyExporter.OnShutdown(timeoutMilliseconds={timeoutMilliseconds})");
+    }
 }

--- a/docs/trace/building-your-own-exporter/README.md
+++ b/docs/trace/building-your-own-exporter/README.md
@@ -1,22 +1,26 @@
 # Building your own Exporter
 
-* To export telemetry to a specific destination, custom exporters must be
-  written.
-* Exporters should inherit from `ActivityExporter` and implement `Export` and
-  `Shutdown` methods. `ActivityExporter` is part of the [OpenTelemetry
-  Package](https://www.nuget.org/packages/opentelemetry).
+Custom exporters can be implemented to send telemetry data to places which are
+not covered by the built-in exporters.
+
+Here is the guidance for writing a custom exporter:
+
+* Exporters should derive from `ActivityExporter` (which belongs to the
+  [OpenTelemetry](https://www.nuget.org/packages/opentelemetry) package) and
+  implement `Export` method.
+* Exporters can optionally implement `OnShutdown`.
 * Depending on user's choice and load on the application, `Export` may get
-  called with zero or more activities.
+  called with one or more activities.
 * Exporters will only receive sampled-in and ended activities.
-* Exporters must not throw.
+* Exporters should not throw exceptions.
 * Exporters should not modify activities they receive (the same activity may be
   exported again by different exporter).
-* Any retry logic that is required by the exporter is the responsibility of the
-  exporter, as the SDK does not implement retry logic.
+* Exporters are responsible for any retry logic needed by the scenario. The SDK
+  does not implement any retry logic.
 
 ## Example
 
-A sample exporter, which simply writes activity name to the console is shown
+A demo exporter which simply writes activity name to the console is shown
 [here](./MyExporter.cs).
 
 Apart from the exporter itself, you should also provide extension methods as

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
@@ -61,12 +61,6 @@ namespace OpenTelemetry.Exporter.Jaeger
             return ExportResult.Success;
         }
 
-        /// <inheritdoc/>
-        protected override void OnShutdown(int timeoutMilliseconds)
-        {
-            _ = this.JaegerAgentUdpBatcher.FlushAsync(default).GetAwaiter().GetResult();
-        }
-
         internal void ApplyLibraryResource(Resource libraryResource)
         {
             if (libraryResource is null)
@@ -119,6 +113,13 @@ namespace OpenTelemetry.Exporter.Jaeger
             }
         }
 
+        /// <inheritdoc/>
+        protected override void OnShutdown(int timeoutMilliseconds)
+        {
+            _ = this.JaegerAgentUdpBatcher.FlushAsync(default).GetAwaiter().GetResult();
+        }
+
+        /// <inheritdoc/>
         protected override void Dispose(bool disposing)
         {
             if (!this.disposedValue)

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
@@ -62,7 +62,7 @@ namespace OpenTelemetry.Exporter.Jaeger
         }
 
         /// <inheritdoc/>
-        public override void Shutdown(int timeoutMilliseconds = Timeout.Infinite)
+        protected override void OnShutdown(int timeoutMilliseconds)
         {
             _ = this.JaegerAgentUdpBatcher.FlushAsync(default).GetAwaiter().GetResult();
         }

--- a/src/OpenTelemetry/Trace/ActivityExporter.cs
+++ b/src/OpenTelemetry/Trace/ActivityExporter.cs
@@ -66,7 +66,7 @@ namespace OpenTelemetry.Trace
         /// This function guarantees thread-safety. Only the first call will
         /// win, subsequent calls will be no-op.
         /// </remarks>
-        public virtual void Shutdown(int timeoutMilliseconds = Timeout.Infinite)
+        public void Shutdown(int timeoutMilliseconds = Timeout.Infinite)
         {
             if (timeoutMilliseconds < 0 && timeoutMilliseconds != Timeout.Infinite)
             {


### PR DESCRIPTION
This is a follow up to a left-over work in my previous PR #1142.

## Changes

* `BatchExportActivityProcessor` now calls exporter `Shutdown`.
* Changed `ActivityExporter.Shutdown` to non-virtual (I guess we want people to override `OnShutdown` instead of `Shutdown`?).
* Updated the docs / tutorial.

For significant contributions please make sure you have completed the following items:

* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
