### PR TITLE
Remove test from exporter which are testing something else

### DIFF
--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterTests.cs
@@ -35,41 +35,6 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests
         }
 
         [Fact]
-        public void UseJaegerExporterWithCustomActivityProcessor()
-        {
-            const string ActivitySourceName = "jaeger.test";
-            TestActivityProcessor testActivityProcessor = new TestActivityProcessor();
-
-            bool startCalled = false;
-            bool endCalled = false;
-
-            testActivityProcessor.StartAction =
-                (a) =>
-                {
-                    startCalled = true;
-                };
-
-            testActivityProcessor.EndAction =
-                (a) =>
-                {
-                    endCalled = true;
-                };
-
-            var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
-                .AddSource(ActivitySourceName)
-                .AddProcessor(testActivityProcessor)
-                .AddJaegerExporter()
-                .Build();
-
-            var source = new ActivitySource(ActivitySourceName);
-            var activity = source.StartActivity("Test Jaeger Activity");
-            activity?.Stop();
-
-            Assert.True(startCalled);
-            Assert.True(endCalled);
-        }
-
-        [Fact]
         public void JaegerTraceExporter_ctor_NullServiceNameAllowed()
         {
             using var jaegerTraceExporter = new JaegerExporter(new JaegerExporterOptions

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
@@ -131,46 +131,6 @@ namespace OpenTelemetry.Exporter.Zipkin.Tests
                 Responses[requestId]);
         }
 
-        [Fact]
-        public void UseZipkinExporterWithCustomActivityProcessor()
-        {
-            const string ActivitySourceName = "zipkin.test";
-            Guid requestId = Guid.NewGuid();
-            TestActivityProcessor testActivityProcessor = new TestActivityProcessor();
-
-            bool startCalled = false;
-            bool endCalled = false;
-
-            testActivityProcessor.StartAction =
-                (a) =>
-                {
-                    startCalled = true;
-                };
-
-            testActivityProcessor.EndAction =
-                (a) =>
-                {
-                    endCalled = true;
-                };
-
-            var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
-                .AddSource(ActivitySourceName)
-                .AddProcessor(testActivityProcessor)
-                .AddZipkinExporter(o =>
-                {
-                    o.ServiceName = "test-zipkin";
-                    o.Endpoint = new Uri($"http://{this.testServerHost}:{this.testServerPort}/api/v2/spans?requestId={requestId}");
-                })
-                .Build();
-
-            var source = new ActivitySource(ActivitySourceName);
-            var activity = source.StartActivity("Test Zipkin Activity");
-            activity?.Stop();
-
-            Assert.True(startCalled);
-            Assert.True(endCalled);
-        }
-
         internal static Activity CreateTestActivity(
            bool setAttributes = true,
            Dictionary<string, object> additionalAttributes = null,


### PR DESCRIPTION
Its not responsibility of Exporter to call any processors, so this must be tested elsewhere.

## Changes

Please provide a brief description of the changes here. Update the
`CHANGELOG.md` for non-trivial changes.

For significant contributions please make sure you have completed the following items:

* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
