### PR TITLE
Revert "Fix ActivitySourceAdapter to respect SuppressInstrumentation"

### DIFF
--- a/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
+++ b/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
@@ -82,11 +82,6 @@ namespace OpenTelemetry.Trace
         /// <param name="activity"><see cref="Activity"/> to be started.</param>
         public void Start(Activity activity)
         {
-            if (Sdk.SuppressInstrumentation)
-            {
-                return;
-            }
-
             this.getRequestedDataAction(activity);
             if (activity.IsAllDataRequested)
             {
@@ -101,11 +96,6 @@ namespace OpenTelemetry.Trace
         /// <param name="activity"><see cref="Activity"/> to be stopped.</param>
         public void Stop(Activity activity)
         {
-            if (Sdk.SuppressInstrumentation)
-            {
-                return;
-            }
-
             if (activity?.IsAllDataRequested ?? false)
             {
                 this.activityProcessor?.OnEnd(activity);

--- a/test/OpenTelemetry.Tests/Trace/ActivitySourceAdapterTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ActivitySourceAdapterTest.cs
@@ -232,32 +232,6 @@ namespace OpenTelemetry.Trace.Tests
             activityLocalParent.Stop();
         }
 
-        [Fact]
-        public void ActivitySourceAdapterDoesNotInvokeProcessorWhenSuppressInstrumentationIsTrue()
-        {
-            using var scope = SuppressInstrumentationScope.Begin();
-            bool startCalled = false, stopCalled = false;
-            this.testProcessor.StartAction =
-                (a) =>
-                {
-                    startCalled = true;
-                };
-
-            this.testProcessor.EndAction =
-                (a) =>
-                {
-                    stopCalled = true;
-                };
-
-            var activity = new Activity("test");
-            activity.Start();
-            this.activitySourceAdapter.Start(activity);
-            Assert.False(startCalled);
-            activity.Stop();
-            this.activitySourceAdapter.Stop(activity);
-            Assert.False(stopCalled);
-        }
-
         public void Dispose()
         {
             Activity.Current = null;

--- a/test/OpenTelemetry.Tests/Trace/TelemetrySpanTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TelemetrySpanTest.cs
@@ -17,9 +17,10 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using OpenTelemetry.Trace;
 using Xunit;
 
-namespace OpenTelemetry.Trace.Tests
+namespace OpenTelemetry.Tests.Trace
 {
     public class TelemetrySpanTest
     {


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-dotnet#1151

The check is done at the DiagnosticSourcelistener level itself: https://github.com/open-telemetry/opentelemetry-dotnet/blob/master/src/OpenTelemetry/Instrumentation/DiagnosticSourceListener.cs#L42

Thanks @alanwest for correcting me here.