### PR TITLE
Use ConcurrentDictionary to fix thread safety issues

### DIFF
--- a/src/OpenTelemetry/Metrics/DoubleObserverMetricSdk.cs
+++ b/src/OpenTelemetry/Metrics/DoubleObserverMetricSdk.cs
@@ -22,7 +22,7 @@ namespace OpenTelemetry.Metrics
 {
     internal class DoubleObserverMetricSdk : DoubleObserverMetric
     {
-        private readonly IDictionary<LabelSet, DoubleObserverMetricHandleSdk> observerHandles = new ConcurrentDictionary<LabelSet, DoubleObserverMetricHandleSdk>();
+        private readonly ConcurrentDictionary<LabelSet, DoubleObserverMetricHandleSdk> observerHandles = new ConcurrentDictionary<LabelSet, DoubleObserverMetricHandleSdk>();
         private readonly string metricName;
         private readonly Action<DoubleObserverMetric> callback;
 
@@ -34,13 +34,9 @@ namespace OpenTelemetry.Metrics
 
         public override void Observe(double value, LabelSet labelset)
         {
-            if (!this.observerHandles.TryGetValue(labelset, out var boundInstrument))
-            {
-                boundInstrument = new DoubleObserverMetricHandleSdk();
-
-                // TODO cleanup of handle/aggregator.   Issue #530
-                this.observerHandles.Add(labelset, boundInstrument);
-            }
+            // TODO cleanup of handle/aggregator.   Issue #530
+            var boundInstrument =
+                this.observerHandles.GetOrAdd(labelset, new DoubleObserverMetricHandleSdk());
 
             boundInstrument.Observe(value);
         }
@@ -55,7 +51,7 @@ namespace OpenTelemetry.Metrics
             this.callback(this);
         }
 
-        internal IDictionary<LabelSet, DoubleObserverMetricHandleSdk> GetAllHandles()
+        internal ConcurrentDictionary<LabelSet, DoubleObserverMetricHandleSdk> GetAllHandles()
         {
             return this.observerHandles;
         }

--- a/src/OpenTelemetry/Metrics/Int64ObserverMetricSdk.cs
+++ b/src/OpenTelemetry/Metrics/Int64ObserverMetricSdk.cs
@@ -22,7 +22,7 @@ namespace OpenTelemetry.Metrics
 {
     internal class Int64ObserverMetricSdk : Int64ObserverMetric
     {
-        private readonly IDictionary<LabelSet, Int64ObserverMetricHandleSdk> observerHandles = new ConcurrentDictionary<LabelSet, Int64ObserverMetricHandleSdk>();
+        private readonly ConcurrentDictionary<LabelSet, Int64ObserverMetricHandleSdk> observerHandles = new ConcurrentDictionary<LabelSet, Int64ObserverMetricHandleSdk>();
         private readonly string metricName;
         private readonly Action<Int64ObserverMetric> callback;
 
@@ -34,13 +34,9 @@ namespace OpenTelemetry.Metrics
 
         public override void Observe(long value, LabelSet labelset)
         {
-            if (!this.observerHandles.TryGetValue(labelset, out var boundInstrument))
-            {
-                boundInstrument = new Int64ObserverMetricHandleSdk();
-
-                // TODO cleanup of handle/aggregator.   Issue #530
-                this.observerHandles.Add(labelset, boundInstrument);
-            }
+            // TODO cleanup of handle/aggregator.   Issue #530
+            var boundInstrument =
+                this.observerHandles.GetOrAdd(labelset, new Int64ObserverMetricHandleSdk());
 
             boundInstrument.Observe(value);
         }
@@ -55,7 +51,7 @@ namespace OpenTelemetry.Metrics
             this.callback(this);
         }
 
-        internal IDictionary<LabelSet, Int64ObserverMetricHandleSdk> GetAllHandles()
+        internal ConcurrentDictionary<LabelSet, Int64ObserverMetricHandleSdk> GetAllHandles()
         {
             return this.observerHandles;
         }

--- a/src/OpenTelemetry/Metrics/MeasureMetricSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeasureMetricSdk.cs
@@ -22,7 +22,7 @@ namespace OpenTelemetry.Metrics
     internal abstract class MeasureMetricSdk<T> : MeasureMetric<T>
         where T : struct
     {
-        private readonly IDictionary<LabelSet, BoundMeasureMetricSdkBase<T>> measureBoundInstruments = new ConcurrentDictionary<LabelSet, BoundMeasureMetricSdkBase<T>>();
+        private readonly ConcurrentDictionary<LabelSet, BoundMeasureMetricSdkBase<T>> measureBoundInstruments = new ConcurrentDictionary<LabelSet, BoundMeasureMetricSdkBase<T>>();
         private string metricName;
 
         public MeasureMetricSdk(string name)
@@ -32,14 +32,7 @@ namespace OpenTelemetry.Metrics
 
         public override BoundMeasureMetric<T> Bind(LabelSet labelset)
         {
-            if (!this.measureBoundInstruments.TryGetValue(labelset, out var boundInstrument))
-            {
-                boundInstrument = this.CreateMetric();
-
-                this.measureBoundInstruments.Add(labelset, boundInstrument);
-            }
-
-            return boundInstrument;
+            return this.measureBoundInstruments.GetOrAdd(labelset, this.CreateMetric());
         }
 
         public override BoundMeasureMetric<T> Bind(IEnumerable<KeyValuePair<string, string>> labels)
@@ -47,7 +40,7 @@ namespace OpenTelemetry.Metrics
             return this.Bind(new LabelSetSdk(labels));
         }
 
-        internal IDictionary<LabelSet, BoundMeasureMetricSdkBase<T>> GetAllBoundInstruments()
+        internal ConcurrentDictionary<LabelSet, BoundMeasureMetricSdkBase<T>> GetAllBoundInstruments()
         {
             return this.measureBoundInstruments;
         }

--- a/src/OpenTelemetry/Metrics/MeterSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterSdk.cs
@@ -26,12 +26,12 @@ namespace OpenTelemetry.Metrics
     {
         private readonly string meterName;
         private readonly MetricProcessor metricProcessor;
-        private readonly IDictionary<string, Int64CounterMetricSdk> longCounters = new ConcurrentDictionary<string, Int64CounterMetricSdk>();
-        private readonly IDictionary<string, DoubleCounterMetricSdk> doubleCounters = new ConcurrentDictionary<string, DoubleCounterMetricSdk>();
-        private readonly IDictionary<string, Int64MeasureMetricSdk> longMeasures = new ConcurrentDictionary<string, Int64MeasureMetricSdk>();
-        private readonly IDictionary<string, DoubleMeasureMetricSdk> doubleMeasures = new ConcurrentDictionary<string, DoubleMeasureMetricSdk>();
-        private readonly IDictionary<string, Int64ObserverMetricSdk> longObservers = new ConcurrentDictionary<string, Int64ObserverMetricSdk>();
-        private readonly IDictionary<string, DoubleObserverMetricSdk> doubleObservers = new ConcurrentDictionary<string, DoubleObserverMetricSdk>();
+        private readonly ConcurrentDictionary<string, Int64CounterMetricSdk> longCounters = new ConcurrentDictionary<string, Int64CounterMetricSdk>();
+        private readonly ConcurrentDictionary<string, DoubleCounterMetricSdk> doubleCounters = new ConcurrentDictionary<string, DoubleCounterMetricSdk>();
+        private readonly ConcurrentDictionary<string, Int64MeasureMetricSdk> longMeasures = new ConcurrentDictionary<string, Int64MeasureMetricSdk>();
+        private readonly ConcurrentDictionary<string, DoubleMeasureMetricSdk> doubleMeasures = new ConcurrentDictionary<string, DoubleMeasureMetricSdk>();
+        private readonly ConcurrentDictionary<string, Int64ObserverMetricSdk> longObservers = new ConcurrentDictionary<string, Int64ObserverMetricSdk>();
+        private readonly ConcurrentDictionary<string, DoubleObserverMetricSdk> doubleObservers = new ConcurrentDictionary<string, DoubleObserverMetricSdk>();
         private readonly object collectLock = new object();
 
         internal MeterSdk(string meterName, MetricProcessor metricProcessor)
@@ -244,73 +244,34 @@ namespace OpenTelemetry.Metrics
 
         public override CounterMetric<long> CreateInt64Counter(string name, bool monotonic = true)
         {
-            if (!this.longCounters.TryGetValue(name, out var counter))
-            {
-                counter = new Int64CounterMetricSdk(name);
-
-                this.longCounters.Add(name, counter);
-            }
-
-            return counter;
+            return this.longCounters.GetOrAdd(name, new Int64CounterMetricSdk(name));
         }
 
         public override CounterMetric<double> CreateDoubleCounter(string name, bool monotonic = true)
         {
-            if (!this.doubleCounters.TryGetValue(name, out var counter))
-            {
-                counter = new DoubleCounterMetricSdk(name);
-                this.doubleCounters.Add(name, counter);
-            }
-
-            return counter;
+            return this.doubleCounters.GetOrAdd(name, new DoubleCounterMetricSdk(name));
         }
 
         public override MeasureMetric<double> CreateDoubleMeasure(string name, bool absolute = true)
         {
-            if (!this.doubleMeasures.TryGetValue(name, out var measure))
-            {
-                measure = new DoubleMeasureMetricSdk(name);
-
-                this.doubleMeasures.Add(name, measure);
-            }
-
-            return measure;
+            return this.doubleMeasures.GetOrAdd(name, new DoubleMeasureMetricSdk(name));
         }
 
         public override MeasureMetric<long> CreateInt64Measure(string name, bool absolute = true)
         {
-            if (!this.longMeasures.TryGetValue(name, out var measure))
-            {
-                measure = new Int64MeasureMetricSdk(name);
-
-                this.longMeasures.Add(name, measure);
-            }
-
-            return measure;
+            return this.longMeasures.GetOrAdd(name, new Int64MeasureMetricSdk(name));
         }
 
         /// <inheritdoc/>
         public override Int64ObserverMetric CreateInt64Observer(string name, Action<Int64ObserverMetric> callback, bool absolute = true)
         {
-            if (!this.longObservers.TryGetValue(name, out var observer))
-            {
-                observer = new Int64ObserverMetricSdk(name, callback);
-                this.longObservers.Add(name, observer);
-            }
-
-            return observer;
+            return this.longObservers.GetOrAdd(name, new Int64ObserverMetricSdk(name, callback));
         }
 
         /// <inheritdoc/>
         public override DoubleObserverMetric CreateDoubleObserver(string name, Action<DoubleObserverMetric> callback, bool absolute = true)
         {
-            if (!this.doubleObservers.TryGetValue(name, out var observer))
-            {
-                observer = new DoubleObserverMetricSdk(name, callback);
-                this.doubleObservers.Add(name, observer);
-            }
-
-            return observer;
+            return this.doubleObservers.GetOrAdd(name, new DoubleObserverMetricSdk(name, callback));
         }
     }
 }


### PR DESCRIPTION
Fixes #.

Fix use of ConcurrentDictionary.

## Changes

Assign new ConcurrentDictionary to ConcurrentDictionary rather than IDictionary. By assigning to IDictionary, access to the concurrent methods of ConcurrentDictionary are lost. Swap .Add() for concurrent GetOrAdd()
