### PR TITLE
Move Activity.SetKind to ActivitySourceAdapter

### DIFF
--- a/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
@@ -76,18 +76,6 @@ namespace OpenTelemetry.Trace
         }
 
         /// <summary>
-        /// Sets the kind of activity execution.
-        /// </summary>
-        /// <param name="activity">Activity instance.</param>
-        /// <param name="kind">Activity execution kind.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void SetKind(this Activity activity, ActivityKind kind)
-        {
-            Debug.Assert(activity != null, "Activity should not be null");
-            SetKindProperty(activity, kind);
-        }
-
-        /// <summary>
         /// Record Exception.
         /// </summary>
         /// <param name="activity">Activity instance.</param>
@@ -112,18 +100,6 @@ namespace OpenTelemetry.Trace
             }
 
             activity?.AddEvent(new ActivityEvent(SemanticConventions.AttributeExceptionEventName, default, tagsCollection));
-        }
-
-#pragma warning disable SA1201 // Elements should appear in the correct order
-        private static readonly Action<Activity, ActivityKind> SetKindProperty = CreateActivityKindSetter();
-#pragma warning restore SA1201 // Elements should appear in the correct order
-
-        private static Action<Activity, ActivityKind> CreateActivityKindSetter()
-        {
-            ParameterExpression instance = Expression.Parameter(typeof(Activity), "instance");
-            ParameterExpression propertyValue = Expression.Parameter(typeof(ActivityKind), "propertyValue");
-            var body = Expression.Assign(Expression.Property(instance, "Kind"), propertyValue);
-            return Expression.Lambda<Action<Activity, ActivityKind>>(body, instance, propertyValue).Compile();
         }
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -106,9 +106,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
             var path = requestValues.Path;
             activity.DisplayName = path;
 
-            activity.SetKind(ActivityKind.Server);
-
-            this.activitySource.Start(activity);
+            this.activitySource.Start(activity, ActivityKind.Server);
 
             if (activity.IsAllDataRequested)
             {

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -102,9 +102,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
                 }
             }
 
-            activity.SetKind(ActivityKind.Server);
-
-            this.activitySource.Start(activity);
+            this.activitySource.Start(activity, ActivityKind.Server);
 
             if (activity.IsAllDataRequested)
             {

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
@@ -49,10 +49,9 @@ namespace OpenTelemetry.Instrumentation.GrpcNetClient.Implementation
 
             var grpcMethod = GrpcTagHelper.GetGrpcMethodFromActivity(activity);
 
-            activity.SetKind(ActivityKind.Client);
             activity.DisplayName = grpcMethod?.Trim('/');
 
-            this.activitySource.Start(activity);
+            this.activitySource.Start(activity, ActivityKind.Client);
 
             if (activity.IsAllDataRequested)
             {

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -93,10 +93,9 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
                 return;
             }
 
-            activity.SetKind(ActivityKind.Client);
             activity.DisplayName = HttpTagHelper.GetOperationNameForHttpMethod(request.Method);
 
-            this.activitySource.Start(activity);
+            this.activitySource.Start(activity, ActivityKind.Client);
 
             if (activity.IsAllDataRequested)
             {

--- a/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
+++ b/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Linq.Expressions;
 using OpenTelemetry.Resources;
 
 namespace OpenTelemetry.Trace
@@ -37,6 +38,7 @@ namespace OpenTelemetry.Trace
     /// </remarks>
     public class ActivitySourceAdapter
     {
+        private static readonly Action<Activity, ActivityKind> SetKindProperty = CreateActivityKindSetter();
         private readonly Sampler sampler;
         private readonly Resource resource;
         private ActivityProcessor activityProcessor;
@@ -80,8 +82,10 @@ namespace OpenTelemetry.Trace
         /// Method that starts an <see cref="Activity"/>.
         /// </summary>
         /// <param name="activity"><see cref="Activity"/> to be started.</param>
-        public void Start(Activity activity)
+        /// <param name="kind">ActivityKind to be set of the activity.</param>
+        public void Start(Activity activity, ActivityKind kind)
         {
+            SetKindProperty(activity, kind);
             this.getRequestedDataAction(activity);
             if (activity.IsAllDataRequested)
             {
@@ -105,6 +109,14 @@ namespace OpenTelemetry.Trace
         internal void UpdateProcessor(ActivityProcessor processor)
         {
             this.activityProcessor = processor;
+        }
+
+        private static Action<Activity, ActivityKind> CreateActivityKindSetter()
+        {
+            ParameterExpression instance = Expression.Parameter(typeof(Activity), "instance");
+            ParameterExpression propertyValue = Expression.Parameter(typeof(ActivityKind), "propertyValue");
+            var body = Expression.Assign(Expression.Property(instance, "Kind"), propertyValue);
+            return Expression.Lambda<Action<Activity, ActivityKind>>(body, instance, propertyValue).Compile();
         }
 
         private void RunGetRequestedDataAlwaysOnSampler(Activity activity)

--- a/test/Benchmarks/Tracing/ActivitySourceAdapterBenchmark.cs
+++ b/test/Benchmarks/Tracing/ActivitySourceAdapterBenchmark.cs
@@ -56,7 +56,7 @@ namespace OpenTelemetry.Trace.Benchmarks
 
             public void Start(Activity activity)
             {
-                this.adapter.Start(activity);
+                this.adapter.Start(activity, ActivityKind.Internal);
             }
 
             public void Stop(Activity activity)

--- a/test/OpenTelemetry.Tests/Trace/ActivityExtensionsTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ActivityExtensionsTest.cs
@@ -103,20 +103,6 @@ namespace OpenTelemetry.Trace.Tests
             Assert.True(activity.GetStatus().IsOk);
         }
 
-        [Theory]
-        [InlineData(ActivityKind.Client)]
-        [InlineData(ActivityKind.Consumer)]
-        [InlineData(ActivityKind.Internal)]
-        [InlineData(ActivityKind.Producer)]
-        [InlineData(ActivityKind.Server)]
-        public void SetKindSimpleActivity(ActivityKind inputOutput)
-        {
-            var activity = new Activity("test-activity");
-            activity.SetKind(inputOutput);
-
-            Assert.Equal(inputOutput, activity.Kind);
-        }
-
         [Fact]
         public void CheckRecordException()
         {

--- a/test/OpenTelemetry.Tests/Trace/ActivitySourceAdapterTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ActivitySourceAdapterTest.cs
@@ -61,7 +61,7 @@ namespace OpenTelemetry.Trace.Tests
         {
             var activity = new Activity("test");
             activity.Start();
-            this.activitySourceAdapter.Start(activity);
+            this.activitySourceAdapter.Start(activity, ActivityKind.Internal);
             activity.Stop();
             this.activitySourceAdapter.Stop(activity);
 
@@ -101,10 +101,11 @@ namespace OpenTelemetry.Trace.Tests
 
             var activity = new Activity("test");
             activity.Start();
-            this.activitySourceAdapter.Start(activity);
+            this.activitySourceAdapter.Start(activity, ActivityKind.Producer);
             activity.Stop();
             this.activitySourceAdapter.Stop(activity);
 
+            Assert.Equal(ActivityKind.Producer, activity.Kind);
             Assert.Equal(activity.IsAllDataRequested, startCalled);
             Assert.Equal(activity.IsAllDataRequested, endCalled);
         }
@@ -141,7 +142,7 @@ namespace OpenTelemetry.Trace.Tests
 
             var activity = new Activity("test");
             activity.Start();
-            this.activitySourceAdapter.Start(activity);
+            this.activitySourceAdapter.Start(activity, ActivityKind.Internal);
             activity.Stop();
             this.activitySourceAdapter.Stop(activity);
 
@@ -162,7 +163,7 @@ namespace OpenTelemetry.Trace.Tests
             // and becomes root activity
             var activity = new Activity("test");
             activity.Start();
-            this.activitySourceAdapter.Start(activity);
+            this.activitySourceAdapter.Start(activity, ActivityKind.Internal);
             activity.Stop();
             this.activitySourceAdapter.Stop(activity);
         }
@@ -193,7 +194,7 @@ namespace OpenTelemetry.Trace.Tests
             var activity = new Activity("test").SetParentId(remoteParentId);
             activity.TraceStateString = tracestate;
             activity.Start();
-            this.activitySourceAdapter.Start(activity);
+            this.activitySourceAdapter.Start(activity, ActivityKind.Internal);
             activity.Stop();
             this.activitySourceAdapter.Stop(activity);
         }
@@ -216,6 +217,7 @@ namespace OpenTelemetry.Trace.Tests
                 Assert.Equal(activityLocalParent.SpanId, samplingParameters.ParentContext.SpanId);
                 Assert.Equal(activityLocalParent.ActivityTraceFlags, samplingParameters.ParentContext.TraceFlags);
                 Assert.Equal(tracestate, samplingParameters.ParentContext.TraceState);
+                Assert.Equal(ActivityKind.Client, samplingParameters.Kind);
                 return new SamplingResult(SamplingDecision.RecordAndSampled);
             };
 
@@ -225,7 +227,7 @@ namespace OpenTelemetry.Trace.Tests
             // i.e of the parent Activity
             var activity = new Activity("test");
             activity.Start();
-            this.activitySourceAdapter.Start(activity);
+            this.activitySourceAdapter.Start(activity, ActivityKind.Client);
             activity.Stop();
             this.activitySourceAdapter.Stop(activity);
 

--- a/test/OpenTelemetry.Tests/Trace/ActivitySourceAdapterTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ActivitySourceAdapterTest.cs
@@ -69,6 +69,21 @@ namespace OpenTelemetry.Trace.Tests
         }
 
         [Theory]
+        [InlineData(ActivityKind.Client)]
+        [InlineData(ActivityKind.Consumer)]
+        [InlineData(ActivityKind.Internal)]
+        [InlineData(ActivityKind.Producer)]
+        [InlineData(ActivityKind.Server)]
+        public void ActivitySourceAdapterSetsKind(ActivityKind kind)
+        {
+            var activity = new Activity("test");
+            activity.Start();
+            this.activitySourceAdapter.Start(activity, kind);
+
+            Assert.Equal(kind, activity.Kind);
+        }
+
+        [Theory]
         [InlineData(SamplingDecision.NotRecord)]
         [InlineData(SamplingDecision.Record)]
         [InlineData(SamplingDecision.RecordAndSampled)]

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
@@ -253,7 +253,7 @@ namespace OpenTelemetry.Trace.Tests
             var adapter = testInstrumentation.Adapter;
             Activity activity = new Activity("test");
             activity.Start();
-            adapter.Start(activity);
+            adapter.Start(activity, ActivityKind.Internal);
             adapter.Stop(activity);
             activity.Stop();
 
@@ -283,7 +283,7 @@ namespace OpenTelemetry.Trace.Tests
             tracerProvider.AddProcessor(testActivityProcessorNew);
             Activity activityNew = new Activity("test");
             activityNew.Start();
-            adapter.Start(activityNew);
+            adapter.Start(activityNew, ActivityKind.Internal);
             adapter.Stop(activityNew);
             activityNew.Stop();
 
@@ -306,7 +306,7 @@ namespace OpenTelemetry.Trace.Tests
             var adapter = testInstrumentation.Adapter;
             Activity activity = new Activity("test");
             activity.Start();
-            adapter.Start(activity);
+            adapter.Start(activity, ActivityKind.Internal);
             adapter.Stop(activity);
             activity.Stop();
 


### PR DESCRIPTION
ActivityKind setter is only required for activities created outside ActivitySource. For that, we already have ActivitySourceAdapter, so make it part of it is more correct. This avoids exposing public Setter for ActivityKind.

From: https://github.com/open-telemetry/opentelemetry-dotnet/pull/1179/files#r478761841


Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
