### PR TITLE
Added GetTagValue Activity Extension

### DIFF
--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 * Updated System.Diagnostics.DiagnosticSource to version 5.0.0-rc.1.20428.3
+* Added `GetTagValue` extension method on `Activity` for retrieving tag values
+  efficiently
+  ([#1221](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1221))
 
 ## 0.5.0-beta.2
 

--- a/src/OpenTelemetry.Api/OpenTelemetry.Api.csproj
+++ b/src/OpenTelemetry.Api/OpenTelemetry.Api.csproj
@@ -7,7 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\OpenTelemetry\Internal\EnumerationHelper.cs" Link="Internal\EnumerationHelper.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticSourcePkgVer)" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="$(SystemReflectionEmitLightweightPkgVer)" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
@@ -17,7 +17,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using OpenTelemetry.Internal;
@@ -71,8 +70,8 @@ namespace OpenTelemetry.Trace
         {
             Debug.Assert(activity != null, "Activity should not be null");
 
-            var statusCanonicalCode = activity.Tags.FirstOrDefault(k => k.Key == SpanAttributeConstants.StatusCodeKey).Value;
-            var statusDescription = activity.Tags.FirstOrDefault(d => d.Key == SpanAttributeConstants.StatusDescriptionKey).Value;
+            var statusCanonicalCode = activity.GetTagValue(SpanAttributeConstants.StatusCodeKey) as string;
+            var statusDescription = activity.GetTagValue(SpanAttributeConstants.StatusDescriptionKey) as string;
 
             var status = SpanHelper.ResolveCanonicalCodeToStatus(statusCanonicalCode);
 

--- a/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
@@ -15,9 +15,10 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Linq.Expressions;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using OpenTelemetry.Internal;
 
@@ -28,6 +29,14 @@ namespace OpenTelemetry.Trace
     /// </summary>
     public static class ActivityExtensions
     {
+        private static readonly object EmptyActivityTagObjects = typeof(Activity).GetField("s_emptyTagObjects", BindingFlags.Static | BindingFlags.NonPublic).GetValue(null);
+
+        private static readonly Enumerator<IEnumerable<KeyValuePair<string, object>>, KeyValuePair<string, object>, KeyValuePair<string, object>>.AllocationFreeForEachDelegate
+            ActivityTagObjectsEnumerator = DictionaryEnumerator<string, object, KeyValuePair<string, object>>.BuildAllocationFreeForEachDelegate(
+                typeof(Activity).GetField("_tags", BindingFlags.Instance | BindingFlags.NonPublic).FieldType);
+
+        private static readonly DictionaryEnumerator<string, object, KeyValuePair<string, object>>.ForEachDelegate GetTagValueCallbackRef = GetTagValueCallback;
+
         /// <summary>
         /// Sets the status of activity execution.
         /// Activity class in .NET does not support 'Status'.
@@ -76,6 +85,31 @@ namespace OpenTelemetry.Trace
         }
 
         /// <summary>
+        /// Gets the value of a specific tag on an <see cref="Activity"/>.
+        /// </summary>
+        /// <param name="activity">Activity instance.</param>
+        /// <param name="tagName">Case-sensitive tag name to retrieve.</param>
+        /// <returns>Tag value or null if a match was not found.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static object GetTagValue(this Activity activity, string tagName)
+        {
+            var tagObjects = activity.TagObjects;
+            if (ReferenceEquals(tagObjects, EmptyActivityTagObjects))
+            {
+                return null;
+            }
+
+            KeyValuePair<string, object> state = new KeyValuePair<string, object>(tagName, null);
+
+            ActivityTagObjectsEnumerator(
+                tagObjects,
+                ref state,
+                GetTagValueCallbackRef);
+
+            return state.Value;
+        }
+
+        /// <summary>
         /// Record Exception.
         /// </summary>
         /// <param name="activity">Activity instance.</param>
@@ -100,6 +134,17 @@ namespace OpenTelemetry.Trace
             }
 
             activity?.AddEvent(new ActivityEvent(SemanticConventions.AttributeExceptionEventName, default, tagsCollection));
+        }
+
+        private static bool GetTagValueCallback(ref KeyValuePair<string, object> state, KeyValuePair<string, object> item)
+        {
+            if (item.Key == state.Key)
+            {
+                state = item;
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/GrpcTagHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/GrpcTagHelper.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 using System.Diagnostics;
-using System.Linq;
 using System.Text.RegularExpressions;
 using OpenTelemetry.Trace;
 
@@ -33,15 +32,15 @@ namespace OpenTelemetry.Instrumentation.GrpcNetClient
 
         public static string GetGrpcMethodFromActivity(Activity activity)
         {
-            return activity.Tags.FirstOrDefault(tag => tag.Key == GrpcMethodTagName).Value;
+            return activity.GetTagValue(GrpcMethodTagName) as string;
         }
 
         public static Status GetGrpcStatusCodeFromActivity(Activity activity)
         {
             var status = Status.Unknown;
 
-            var grpcStatusCodeTag = activity.Tags.FirstOrDefault(tag => tag.Key == GrpcStatusCodeTagName).Value;
-            if (int.TryParse(grpcStatusCodeTag, out var statusCode))
+            var grpcStatusCodeTag = activity.GetTagValue(GrpcStatusCodeTagName);
+            if (int.TryParse(grpcStatusCodeTag as string, out var statusCode))
             {
                 status = SpanHelper.ResolveSpanStatusForGrpcStatusCode(statusCode);
             }

--- a/src/OpenTelemetry/Internal/EnumerationHelper.cs
+++ b/src/OpenTelemetry/Internal/EnumerationHelper.cs
@@ -58,7 +58,7 @@ namespace OpenTelemetry.Internal
         private static readonly ConcurrentDictionary<Type, AllocationFreeForEachDelegate> AllocationFreeForEachDelegates = new ConcurrentDictionary<Type, AllocationFreeForEachDelegate>();
         private static readonly Func<Type, AllocationFreeForEachDelegate> BuildAllocationFreeForEachDelegateRef = BuildAllocationFreeForEachDelegate;
 
-        private delegate void AllocationFreeForEachDelegate(TEnumerable instance, ref TState state, ForEachDelegate itemCallback);
+        public delegate void AllocationFreeForEachDelegate(TEnumerable instance, ref TState state, ForEachDelegate itemCallback);
 
         public delegate bool ForEachDelegate(ref TState state, TItem item);
 
@@ -93,7 +93,7 @@ namespace OpenTelemetry.Internal
             }
             ...because it takes advantage of the struct Enumerator on the built-in types which give an allocation-free way to enumerate.
         */
-        private static AllocationFreeForEachDelegate BuildAllocationFreeForEachDelegate(Type enumerableType)
+        public static AllocationFreeForEachDelegate BuildAllocationFreeForEachDelegate(Type enumerableType)
         {
             var itemCallbackType = typeof(ForEachDelegate);
 

--- a/test/Benchmarks/ActivityBenchmarks.cs
+++ b/test/Benchmarks/ActivityBenchmarks.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/test/Benchmarks/ActivityBenchmarks.cs
+++ b/test/Benchmarks/ActivityBenchmarks.cs
@@ -1,0 +1,92 @@
+﻿// <copyright file="ActivityBenchmarks.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using OpenTelemetry.Trace;
+
+namespace OpenTelemetry.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class ActivityBenchmarks
+    {
+        private static readonly Activity EmptyActivity;
+        private static readonly Activity Activity;
+
+        static ActivityBenchmarks()
+        {
+            EmptyActivity = new Activity("EmptyActivity");
+
+            Activity = new Activity("Activity");
+            Activity.AddTag("Tag1", "Value1");
+            Activity.AddTag("Tag2", 2);
+            Activity.AddTag("Tag3", false);
+        }
+
+        [Benchmark]
+        public void EnumerateEmptyTagObjects()
+        {
+            object value;
+            foreach (KeyValuePair<string, object> tag in EmptyActivity.TagObjects)
+            {
+                if (tag.Key == "Tag3")
+                {
+                    value = tag.Value;
+                    break;
+                }
+            }
+        }
+
+        [Benchmark]
+        public void LinqEmptyTagObjects()
+        {
+            EmptyActivity.TagObjects.FirstOrDefault(i => i.Key == "Tag3");
+        }
+
+        [Benchmark]
+        public void GetTagValueEmptyTagObjects()
+        {
+            EmptyActivity.GetTagValue("Tag3");
+        }
+
+        [Benchmark]
+        public void EnumerateNonemptyTagObjects()
+        {
+            object value;
+            foreach (KeyValuePair<string, object> tag in Activity.TagObjects)
+            {
+                if (tag.Key == "Tag3")
+                {
+                    value = tag.Value;
+                    break;
+                }
+            }
+        }
+
+        [Benchmark]
+        public void LinqNonemptyTagObjects()
+        {
+            Activity.TagObjects.FirstOrDefault(i => i.Key == "Tag3");
+        }
+
+        [Benchmark]
+        public void GetTagValueNonemptyTagObjects()
+        {
+            Activity.GetTagValue("Tag3");
+        }
+    }
+}

--- a/test/OpenTelemetry.Tests/Trace/ActivityExtensionsTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ActivityExtensionsTest.cs
@@ -115,5 +115,24 @@ namespace OpenTelemetry.Trace.Tests
             Assert.Equal(message, @event.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeExceptionMessage).Value);
             Assert.Equal(exception.GetType().Name, @event.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeExceptionType).Value);
         }
+
+        [Fact]
+        public void GetTagValueEmpty()
+        {
+            Activity activity = new Activity("Test");
+
+            Assert.Null(activity.GetTagValue("Tag1"));
+        }
+
+        [Fact]
+        public void GetTagValue()
+        {
+            Activity activity = new Activity("Test");
+            activity.AddTag("Tag1", "Value1");
+
+            Assert.Equal("Value1", activity.GetTagValue("Tag1"));
+            Assert.Null(activity.GetTagValue("tag1"));
+            Assert.Null(activity.GetTagValue("Tag2"));
+        }
     }
 }


### PR DESCRIPTION
All the struct enumerators I worked with the .NET team to introduce are available in RC1 so now we can have some fun with the perf.

## Changes

This adds a GetTagValue extension on Activity for finding a tag value by key very efficiently.

## Benchmarks

|                        Method |      Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------------ |----------:|----------:|----------:|-------:|------:|------:|----------:|
|      EnumerateEmptyTagObjects |  8.776 ns | 0.1528 ns | 0.1355 ns |      - |     - |     - |         - |
|           LinqEmptyTagObjects | 21.909 ns | 0.4546 ns | 0.4465 ns |      - |     - |     - |         - |
|    GetTagValueEmptyTagObjects |  1.826 ns | 0.0335 ns | 0.0297 ns |      - |     - |     - |         - |
|   EnumerateNonemptyTagObjects | 69.014 ns | 1.3853 ns | 1.2958 ns | 0.0048 |     - |     - |      40 B |
|        LinqNonemptyTagObjects | 89.760 ns | 1.6389 ns | 1.5331 ns | 0.0048 |     - |     - |      40 B |
| GetTagValueNonemptyTagObjects | 49.510 ns | 0.2616 ns | 0.2042 ns |      - |     - |     - |         - |

For significant contributions please make sure you have completed the following items:

* [X] `CHANGELOG.md` updated for non-trivial changes
* [ ] Changes in public API reviewed
