### PR TITLE
Added EnumerateTagValues Activity Extension

### DIFF
--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Added `GetTagValue` extension method on `Activity` for retrieving tag values
   efficiently
   ([#1221](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1221))
+* Added `EnumerateTagValues` extension method on `Activity` for enumerating tag
+  values efficiently
+  ([#1236](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1236))
 
 ## 0.5.0-beta.2
 

--- a/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
@@ -66,9 +66,7 @@ namespace OpenTelemetry.Trace
 
             ActivityStatusTagEnumerator state = default;
 
-            ActivityTagObjectsEnumeratorFactory<ActivityStatusTagEnumerator>.Enumerate(
-                activity.TagObjects,
-                ref state);
+            ActivityTagObjectsEnumeratorFactory<ActivityStatusTagEnumerator>.Enumerate(activity, ref state);
 
             var status = SpanHelper.ResolveCanonicalCodeToStatus(state.StatusCode);
 
@@ -93,7 +91,7 @@ namespace OpenTelemetry.Trace
 
             ActivitySingleTagEnumerator state = new ActivitySingleTagEnumerator(tagName);
 
-            ActivityTagObjectsEnumeratorFactory<ActivitySingleTagEnumerator>.Enumerate(activity.TagObjects, ref state);
+            ActivityTagObjectsEnumeratorFactory<ActivitySingleTagEnumerator>.Enumerate(activity, ref state);
 
             return state.Value;
         }
@@ -110,7 +108,7 @@ namespace OpenTelemetry.Trace
         {
             Debug.Assert(activity != null, "Activity should not be null");
 
-            ActivityTagObjectsEnumeratorFactory<T>.Enumerate(activity.TagObjects, ref tagEnumerator);
+            ActivityTagObjectsEnumeratorFactory<T>.Enumerate(activity, ref tagEnumerator);
         }
 
         /// <summary>
@@ -196,8 +194,10 @@ namespace OpenTelemetry.Trace
             private static readonly DictionaryEnumerator<string, object, TState>.ForEachDelegate ForEachTagValueCallbackRef = ForEachTagValueCallback;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static void Enumerate(IEnumerable<KeyValuePair<string, object>> tagObjects, ref TState state)
+            public static void Enumerate(Activity activity, ref TState state)
             {
+                var tagObjects = activity.TagObjects;
+
                 if (ReferenceEquals(tagObjects, EmptyActivityTagObjects))
                 {
                     return;

--- a/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
@@ -30,12 +30,6 @@ namespace OpenTelemetry.Trace
     {
         private static readonly object EmptyActivityTagObjects = typeof(Activity).GetField("s_emptyTagObjects", BindingFlags.Static | BindingFlags.NonPublic).GetValue(null);
 
-        private static readonly Enumerator<IEnumerable<KeyValuePair<string, object>>, KeyValuePair<string, object>, KeyValuePair<string, object>>.AllocationFreeForEachDelegate
-            ActivityTagObjectsEnumerator = DictionaryEnumerator<string, object, KeyValuePair<string, object>>.BuildAllocationFreeForEachDelegate(
-                typeof(Activity).GetField("_tags", BindingFlags.Instance | BindingFlags.NonPublic).FieldType);
-
-        private static readonly DictionaryEnumerator<string, object, KeyValuePair<string, object>>.ForEachDelegate GetTagValueCallbackRef = GetTagValueCallback;
-
         /// <summary>
         /// Sets the status of activity execution.
         /// Activity class in .NET does not support 'Status'.
@@ -70,14 +64,17 @@ namespace OpenTelemetry.Trace
         {
             Debug.Assert(activity != null, "Activity should not be null");
 
-            var statusCanonicalCode = activity.GetTagValue(SpanAttributeConstants.StatusCodeKey) as string;
-            var statusDescription = activity.GetTagValue(SpanAttributeConstants.StatusDescriptionKey) as string;
+            ActivityStatusTagEnumerator state = default;
 
-            var status = SpanHelper.ResolveCanonicalCodeToStatus(statusCanonicalCode);
+            ActivityTagObjectsEnumeratorFactory<ActivityStatusTagEnumerator>.Enumerate(
+                activity.TagObjects,
+                ref state);
 
-            if (status.IsValid && !string.IsNullOrEmpty(statusDescription))
+            var status = SpanHelper.ResolveCanonicalCodeToStatus(state.StatusCode);
+
+            if (status.IsValid && !string.IsNullOrEmpty(state.StatusDescription))
             {
-                return status.WithDescription(statusDescription);
+                return status.WithDescription(state.StatusDescription);
             }
 
             return status;
@@ -92,20 +89,28 @@ namespace OpenTelemetry.Trace
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static object GetTagValue(this Activity activity, string tagName)
         {
-            var tagObjects = activity.TagObjects;
-            if (ReferenceEquals(tagObjects, EmptyActivityTagObjects))
-            {
-                return null;
-            }
+            Debug.Assert(activity != null, "Activity should not be null");
 
-            KeyValuePair<string, object> state = new KeyValuePair<string, object>(tagName, null);
+            ActivitySingleTagEnumerator state = new ActivitySingleTagEnumerator(tagName);
 
-            ActivityTagObjectsEnumerator(
-                tagObjects,
-                ref state,
-                GetTagValueCallbackRef);
+            ActivityTagObjectsEnumeratorFactory<ActivitySingleTagEnumerator>.Enumerate(activity.TagObjects, ref state);
 
             return state.Value;
+        }
+
+        /// <summary>
+        /// Enumerates all the key/value pairs on an <see cref="Activity"/> without performing an allocation.
+        /// </summary>
+        /// <typeparam name="T">The struct <see cref="IActivityTagEnumerator"/> implementation to use for the enumeration.</typeparam>
+        /// <param name="activity">Activity instance.</param>
+        /// <param name="tagEnumerator">Tag enumerator.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void EnumerateTagValues<T>(this Activity activity, ref T tagEnumerator)
+            where T : struct, IActivityTagEnumerator
+        {
+            Debug.Assert(activity != null, "Activity should not be null");
+
+            ActivityTagObjectsEnumeratorFactory<T>.Enumerate(activity.TagObjects, ref tagEnumerator);
         }
 
         /// <summary>
@@ -135,15 +140,77 @@ namespace OpenTelemetry.Trace
             activity?.AddEvent(new ActivityEvent(SemanticConventions.AttributeExceptionEventName, default, tagsCollection));
         }
 
-        private static bool GetTagValueCallback(ref KeyValuePair<string, object> state, KeyValuePair<string, object> item)
+        private struct ActivitySingleTagEnumerator : IActivityTagEnumerator
         {
-            if (item.Key == state.Key)
+            private readonly string tagName;
+
+            public ActivitySingleTagEnumerator(string tagName)
             {
-                state = item;
-                return false;
+                this.tagName = tagName;
+                this.Value = null;
             }
 
-            return true;
+            public object Value { get; private set; }
+
+            public bool ForEach(KeyValuePair<string, object> item)
+            {
+                if (item.Key == this.tagName)
+                {
+                    this.Value = item.Value;
+                    return false;
+                }
+
+                return true;
+            }
+        }
+
+        private struct ActivityStatusTagEnumerator : IActivityTagEnumerator
+        {
+            public string StatusCode { get; private set; }
+
+            public string StatusDescription { get; private set; }
+
+            public bool ForEach(KeyValuePair<string, object> item)
+            {
+                switch (item.Key)
+                {
+                    case SpanAttributeConstants.StatusCodeKey:
+                        this.StatusCode = item.Value as string;
+                        break;
+                    case SpanAttributeConstants.StatusDescriptionKey:
+                        this.StatusDescription = item.Value as string;
+                        break;
+                }
+
+                return this.StatusCode == null || this.StatusDescription == null;
+            }
+        }
+
+        private static class ActivityTagObjectsEnumeratorFactory<TState>
+            where TState : struct, IActivityTagEnumerator
+        {
+            private static readonly DictionaryEnumerator<string, object, TState>.AllocationFreeForEachDelegate
+                ActivityTagObjectsEnumerator = DictionaryEnumerator<string, object, TState>.BuildAllocationFreeForEachDelegate(
+                    typeof(Activity).GetField("_tags", BindingFlags.Instance | BindingFlags.NonPublic).FieldType);
+
+            private static readonly DictionaryEnumerator<string, object, TState>.ForEachDelegate ForEachTagValueCallbackRef = ForEachTagValueCallback;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static void Enumerate(IEnumerable<KeyValuePair<string, object>> tagObjects, ref TState state)
+            {
+                if (ReferenceEquals(tagObjects, EmptyActivityTagObjects))
+                {
+                    return;
+                }
+
+                ActivityTagObjectsEnumerator(
+                    tagObjects,
+                    ref state,
+                    ForEachTagValueCallbackRef);
+            }
+
+            private static bool ForEachTagValueCallback(ref TState state, KeyValuePair<string, object> item)
+                => state.ForEach(item);
         }
     }
 }

--- a/src/OpenTelemetry.Api/Trace/IActivityTagEnumerator.cs
+++ b/src/OpenTelemetry.Api/Trace/IActivityTagEnumerator.cs
@@ -1,0 +1,34 @@
+﻿// <copyright file="IActivityTagEnumerator.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace OpenTelemetry.Trace
+{
+    /// <summary>
+    /// An interface used to perform zero-allocation enumeration of <see cref="Activity"/> tags. Implementation must be a struct.
+    /// </summary>
+    public interface IActivityTagEnumerator
+    {
+        /// <summary>
+        /// Called for each <see cref="Activity"/> tag while the enumeration is executing.
+        /// </summary>
+        /// <param name="item">Tag key/value pair.</param>
+        /// <returns><see langword="true"/> to continue the enumeration of records or <see langword="false"/> to stop (break) the enumeration.</returns>
+        bool ForEach(KeyValuePair<string, object> item);
+    }
+}

--- a/test/Benchmarks/ActivityBenchmarks.cs
+++ b/test/Benchmarks/ActivityBenchmarks.cs
@@ -36,10 +36,15 @@ namespace OpenTelemetry.Benchmarks
             Activity.AddTag("Tag1", "Value1");
             Activity.AddTag("Tag2", 2);
             Activity.AddTag("Tag3", false);
+
+            for (int i = 0; i < 1024; i++)
+            {
+                Activity.AddTag($"AutoTag{i}", i);
+            }
         }
 
         [Benchmark]
-        public void EnumerateEmptyTagObjects()
+        public void SearchEnumerateEmptyTagObjects()
         {
             object value;
             foreach (KeyValuePair<string, object> tag in EmptyActivity.TagObjects)
@@ -53,19 +58,19 @@ namespace OpenTelemetry.Benchmarks
         }
 
         [Benchmark]
-        public void LinqEmptyTagObjects()
+        public void SearchLinqEmptyTagObjects()
         {
             EmptyActivity.TagObjects.FirstOrDefault(i => i.Key == "Tag3");
         }
 
         [Benchmark]
-        public void GetTagValueEmptyTagObjects()
+        public void SearchGetTagValueEmptyTagObjects()
         {
             EmptyActivity.GetTagValue("Tag3");
         }
 
         [Benchmark]
-        public void EnumerateNonemptyTagObjects()
+        public void SearchEnumerateNonemptyTagObjects()
         {
             object value;
             foreach (KeyValuePair<string, object> tag in Activity.TagObjects)
@@ -79,15 +84,44 @@ namespace OpenTelemetry.Benchmarks
         }
 
         [Benchmark]
-        public void LinqNonemptyTagObjects()
+        public void SearchLinqNonemptyTagObjects()
         {
             Activity.TagObjects.FirstOrDefault(i => i.Key == "Tag3");
         }
 
         [Benchmark]
-        public void GetTagValueNonemptyTagObjects()
+        public void SearchGetTagValueNonemptyTagObjects()
         {
             Activity.GetTagValue("Tag3");
+        }
+
+        [Benchmark]
+        public void EnumerateNonemptyTagObjects()
+        {
+            int count = 0;
+            foreach (KeyValuePair<string, object> tag in Activity.TagObjects)
+            {
+                count++;
+            }
+        }
+
+        [Benchmark]
+        public void EnumerateTagValuesNonemptyTagObjects()
+        {
+            Enumerator state = default;
+
+            Activity.EnumerateTagValues(ref state);
+        }
+
+        private struct Enumerator : IActivityTagEnumerator
+        {
+            public int Count { get; private set; }
+
+            public bool ForEach(KeyValuePair<string, object> item)
+            {
+                this.Count++;
+                return true;
+            }
         }
     }
 }

--- a/test/OpenTelemetry.Tests/Trace/ActivityExtensionsTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ActivityExtensionsTest.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Xunit;
@@ -133,6 +134,77 @@ namespace OpenTelemetry.Trace.Tests
             Assert.Equal("Value1", activity.GetTagValue("Tag1"));
             Assert.Null(activity.GetTagValue("tag1"));
             Assert.Null(activity.GetTagValue("Tag2"));
+        }
+
+        [Fact]
+        public void EnumerateTagValuesEmpty()
+        {
+            Activity activity = new Activity("Test");
+
+            Enumerator state = default;
+
+            activity.EnumerateTagValues(ref state);
+
+            Assert.Equal(0, state.Count);
+            Assert.False(state.LastTag.HasValue);
+        }
+
+        [Fact]
+        public void EnumerateTagValuesAll()
+        {
+            Activity activity = new Activity("Test");
+            activity.AddTag("Tag1", "Value1");
+            activity.AddTag("Tag2", "Value2");
+            activity.AddTag("Tag3", "Value3");
+
+            Enumerator state = default;
+
+            activity.EnumerateTagValues(ref state);
+
+            Assert.Equal(3, state.Count);
+            Assert.True(state.LastTag.HasValue);
+            Assert.Equal("Tag3", state.LastTag?.Key);
+            Assert.Equal("Value3", state.LastTag?.Value);
+        }
+
+        [Fact]
+        public void EnumerateTagValuesWithBreak()
+        {
+            Activity activity = new Activity("Test");
+            activity.AddTag("Tag1", "Value1");
+            activity.AddTag("Tag2", "Value2");
+            activity.AddTag("Tag3", "Value3");
+
+            Enumerator state = default;
+            state.BreakOnCount = 1;
+
+            activity.EnumerateTagValues(ref state);
+
+            Assert.Equal(1, state.Count);
+            Assert.True(state.LastTag.HasValue);
+            Assert.Equal("Tag1", state.LastTag?.Key);
+            Assert.Equal("Value1", state.LastTag?.Value);
+        }
+
+        private struct Enumerator : IActivityTagEnumerator
+        {
+            public int BreakOnCount { get; set; }
+
+            public KeyValuePair<string, object>? LastTag { get; private set; }
+
+            public int Count { get; private set; }
+
+            public bool ForEach(KeyValuePair<string, object> item)
+            {
+                this.LastTag = item;
+                this.Count++;
+                if (this.BreakOnCount == this.Count)
+                {
+                    return false;
+                }
+
+                return true;
+            }
         }
     }
 }


### PR DESCRIPTION
## Changes

The ask on #1221 was for a way to find multiple tags. What I thought would be more useful is an extension for performing the allocation free foreach that users can call to do _whatever_ they need with tags.

## Usage

1. Define your state struct and implement the ForEach body. This must be a struct:
   ```csharp
        private struct Enumerator : IActivityTagEnumerator
        {
            public int Count { get; private set; }

            public bool ForEach(KeyValuePair<string, object> item)
            {
                this.Count++;
                return true;
            }
        }
   ```

2. Call the extension, pass the state:
   ```csharp
            Enumerator state = default;

            Activity.EnumerateTagValues(ref state);
   ```

3. Use the state to retrieve any results you might need:
   ```csharp
        public static int CountTags(Activity activity)
        {
            Enumerator state = default;

            activity.EnumerateTagValues(ref state);

            return state.Count;
        }
   ```

## Benchmarks

|                               Method |          Mean |       Error |      StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------------------- |--------------:|------------:|------------:|-------:|------:|------:|----------:|
|          EnumerateNonemptyTagObjects | 16,142.977 ns | 308.3928 ns | 629.9648 ns |      - |     - |     - |      40 B |
| EnumerateTagValuesNonemptyTagObjects |  9,183.533 ns | 136.4799 ns | 120.9859 ns |      - |     - |     - |         - |

* [X] `CHANGELOG.md` updated for non-trivial changes
* [ ] Changes in public API reviewed
