### PR TITLE
Rename InstrumentationFilter to Filter

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Http/HttpWebRequestInstrumentationOptions.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/HttpWebRequestInstrumentationOptions.netfx.cs
@@ -48,13 +48,13 @@ namespace OpenTelemetry.Instrumentation.Http
         /// If Filter returns true, the request is collected.
         /// If Filter returns false or throw exception, the request is filtered out.
         /// </summary>
-        public Func<HttpWebRequest, bool> InstrumentationFilter { get; set; }
+        public Func<HttpWebRequest, bool> Filter { get; set; }
 
         internal bool EventFilter(HttpWebRequest request)
         {
             try
             {
-                return this.InstrumentationFilter?.Invoke(request) ?? true;
+                return this.Filter?.Invoke(request) ?? true;
             }
             catch (Exception ex)
             {

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.Basic.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.Basic.netfx.cs
@@ -172,7 +172,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
             using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpWebRequestInstrumentation(
-                    c => c.InstrumentationFilter = (req) => !req.RequestUri.OriginalString.Contains(this.url))
+                    c => c.Filter = (req) => !req.RequestUri.OriginalString.Contains(this.url))
                 .Build();
 
             using var c = new HttpClient();
@@ -188,7 +188,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
             using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpWebRequestInstrumentation(
-                    c => c.InstrumentationFilter = (req) => throw new Exception("From Instrumentation filter"))
+                    c => c.Filter = (req) => throw new Exception("From Instrumentation filter"))
                 .Build();
 
             using var c = new HttpClient();


### PR DESCRIPTION
This PR supposes that the name `InstrumentationFilter` on `HttpWebRequestOptions` was intended to be `Filter` since this is the name that is used for ASP.NET Core and HttpClient instrumentation. If this is incorrect, then disregard this PR and I will close it.