### PR TITLE
.NET 5 package downgrade warning/error

### DIFF
--- a/examples/AspNet/Examples.AspNet.csproj
+++ b/examples/AspNet/Examples.AspNet.csproj
@@ -78,9 +78,6 @@
     <PackageReference Include="Microsoft.AspNet.WebApi.WebHost" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNet.WebPages" Version="3.2.7" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
-      <Version>5.0.0-rc.1.20428.3</Version>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Api\OpenTelemetry.Api.csproj">


### PR DESCRIPTION
I started getting a package downgrade warning after the .NET 5 RC1 upgrade (#1265) on the System.Runtime.CompilerServices.Unsafe package ref in the Examples.AspNet app. I removed the reference and it seems to build & run fine.