### PR TITLE
Fix a bug in AspNetCore instrumentation where it ignored activity by AspNetCore

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -80,9 +80,15 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
             var request = context.Request;
             if (!this.hostingSupportsW3C || !(this.options.Propagator is TextMapPropagator))
             {
+                var parentContext = new ActivityContext(
+                    activity.Context.TraceId,
+                    activity.ParentSpanId,
+                    activity.Context.TraceFlags,
+                    activity.Context.TraceState,
+                    true);
                 var ctx = this.options.Propagator.Extract(default, request, HttpRequestHeaderValuesGetter);
 
-                if (ctx.ActivityContext.IsValid() && ctx.ActivityContext != activity.Context)
+                if (ctx.ActivityContext.IsValid() && ctx.ActivityContext != parentContext)
                 {
                     // Create a new activity with its parent set from the extracted context.
                     // This makes the new activity as a "sibling" of the activity created by

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
@@ -127,6 +127,15 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             Assert.Equal(2, activityProcessor.Invocations.Count); // begin and end was called
             var activity = (Activity)activityProcessor.Invocations[1].Arguments[0];
 
+#if !NETCOREAPP2_1
+            // ASP.NET Core after 2.x is W3C aware and hence Activity created by it
+            // must be used.
+            Assert.Equal("Microsoft.AspNetCore.Hosting.HttpRequestIn", activity.OperationName);
+#else
+            // ASP.NET Core before 3.x is not W3C aware and hence Activity created by it
+            // is always ignored and new one is created by the Instrumentation
+            Assert.Equal("ActivityCreatedByHttpInListener", activity.OperationName);
+#endif
             Assert.Equal(ActivityKind.Server, activity.Kind);
             Assert.Equal("api/Values/{id}", activity.DisplayName);
             Assert.Equal("/api/values/2", activity.GetTagValue(SpanAttributeConstants.HttpPathKey) as string);
@@ -173,6 +182,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             // begin and end was called once each.
             Assert.Equal(2, activityProcessor.Invocations.Count);
             var activity = (Activity)activityProcessor.Invocations[1].Arguments[0];
+            Assert.Equal("ActivityCreatedByHttpInListener", activity.OperationName);
 
             Assert.Equal(ActivityKind.Server, activity.Kind);
             Assert.True(activity.Duration != TimeSpan.Zero);


### PR DESCRIPTION
Related to #1242 
Might fix https://github.com/open-telemetry/opentelemetry-dotnet/issues/1280

## Changes
AspNetCore instrumentation was comparing the extracted activitycontext with the context of the current activity, instead of its parent. This PR fixes that.

More changes in follow up PRs.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
