### PR TITLE
Normalizing format

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,12 +5,12 @@
 # All files 
 [*] 
 indent_style = space 
+insert_final_newline = true 
 # Code files 
 [*.{cs,csx,vb,vbx}] 
 indent_size = 4 
-insert_final_newline = true 
 trim_trailing_whitespace = true 
-charset = utf-8-bom 
+charset = utf-8 
 # maintain DOS/Windows style line endings in md files
 [*.md]
 end_of_line = crlf

--- a/docs/logs/correlation/Program.cs
+++ b/docs/logs/correlation/Program.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Program.cs" company="OpenTelemetry Authors">
+// <copyright file="Program.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/docs/trace/extending-the-sdk/MyExporter.cs
+++ b/docs/trace/extending-the-sdk/MyExporter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MyExporter.cs" company="OpenTelemetry Authors">
+// <copyright file="MyExporter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/docs/trace/extending-the-sdk/MyExporterHelperExtensions.cs
+++ b/docs/trace/extending-the-sdk/MyExporterHelperExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MyExporterHelperExtensions.cs" company="OpenTelemetry Authors">
+// <copyright file="MyExporterHelperExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/docs/trace/extending-the-sdk/MyProcessor.cs
+++ b/docs/trace/extending-the-sdk/MyProcessor.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MyProcessor.cs" company="OpenTelemetry Authors">
+// <copyright file="MyProcessor.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/docs/trace/extending-the-sdk/MySampler.cs
+++ b/docs/trace/extending-the-sdk/MySampler.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MySampler.cs" company="OpenTelemetry Authors">
+// <copyright file="MySampler.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/docs/trace/extending-the-sdk/Program.cs
+++ b/docs/trace/extending-the-sdk/Program.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Program.cs" company="OpenTelemetry Authors">
+// <copyright file="Program.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/docs/trace/getting-started/Program.cs
+++ b/docs/trace/getting-started/Program.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Program.cs" company="OpenTelemetry Authors">
+// <copyright file="Program.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/AspNet/App_Start/RouteConfig.cs
+++ b/examples/AspNet/App_Start/RouteConfig.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="RouteConfig.cs" company="OpenTelemetry Authors">
+// <copyright file="RouteConfig.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/AspNet/App_Start/WebApiConfig.cs
+++ b/examples/AspNet/App_Start/WebApiConfig.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="WebApiConfig.cs" company="OpenTelemetry Authors">
+// <copyright file="WebApiConfig.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/AspNet/Controllers/HomeController.cs
+++ b/examples/AspNet/Controllers/HomeController.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HomeController.cs" company="OpenTelemetry Authors">
+// <copyright file="HomeController.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/AspNet/Controllers/WeatherForecastController.cs
+++ b/examples/AspNet/Controllers/WeatherForecastController.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="WeatherForecastController.cs" company="OpenTelemetry Authors">
+// <copyright file="WeatherForecastController.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/AspNet/Global.asax.cs
+++ b/examples/AspNet/Global.asax.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Global.asax.cs" company="OpenTelemetry Authors">
+// <copyright file="Global.asax.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/AspNet/Models/WeatherForecast.cs
+++ b/examples/AspNet/Models/WeatherForecast.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="WeatherForecast.cs" company="OpenTelemetry Authors">
+// <copyright file="WeatherForecast.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/AspNet/Properties/AssemblyInfo.cs
+++ b/examples/AspNet/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
+// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/AspNetCore/Controllers/WeatherForecastController.cs
+++ b/examples/AspNetCore/Controllers/WeatherForecastController.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="WeatherForecastController.cs" company="OpenTelemetry Authors">
+// <copyright file="WeatherForecastController.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/AspNetCore/Models/WeatherForecast.cs
+++ b/examples/AspNetCore/Models/WeatherForecast.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="WeatherForecast.cs" company="OpenTelemetry Authors">
+// <copyright file="WeatherForecast.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/AspNetCore/Program.cs
+++ b/examples/AspNetCore/Program.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Program.cs" company="OpenTelemetry Authors">
+// <copyright file="Program.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/AspNetCore/Startup.cs
+++ b/examples/AspNetCore/Startup.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Startup.cs" company="OpenTelemetry Authors">
+// <copyright file="Startup.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/Console/InstrumentationWithActivitySource.cs
+++ b/examples/Console/InstrumentationWithActivitySource.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="InstrumentationWithActivitySource.cs" company="OpenTelemetry Authors">
+// <copyright file="InstrumentationWithActivitySource.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/Console/Program.cs
+++ b/examples/Console/Program.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Program.cs" company="OpenTelemetry Authors">
+// <copyright file="Program.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/Console/TestConsoleExporter.cs
+++ b/examples/Console/TestConsoleExporter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TestConsoleExporter.cs" company="OpenTelemetry Authors">
+// <copyright file="TestConsoleExporter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/Console/TestGrpcNetClient.cs
+++ b/examples/Console/TestGrpcNetClient.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TestGrpcNetClient.cs" company="OpenTelemetry Authors">
+// <copyright file="TestGrpcNetClient.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/Console/TestHttpClient.cs
+++ b/examples/Console/TestHttpClient.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TestHttpClient.cs" company="OpenTelemetry Authors">
+// <copyright file="TestHttpClient.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/Console/TestJaegerExporter.cs
+++ b/examples/Console/TestJaegerExporter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TestJaegerExporter.cs" company="OpenTelemetry Authors">
+// <copyright file="TestJaegerExporter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/Console/TestOTelShimWithConsoleExporter.cs
+++ b/examples/Console/TestOTelShimWithConsoleExporter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TestOTelShimWithConsoleExporter.cs" company="OpenTelemetry Authors">
+// <copyright file="TestOTelShimWithConsoleExporter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/Console/TestOpenTracingWithConsoleExporter.cs
+++ b/examples/Console/TestOpenTracingWithConsoleExporter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TestOpenTracingWithConsoleExporter.cs" company="OpenTelemetry Authors">
+// <copyright file="TestOpenTracingWithConsoleExporter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/Console/TestOtlpExporter.cs
+++ b/examples/Console/TestOtlpExporter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TestOtlpExporter.cs" company="OpenTelemetry Authors">
+// <copyright file="TestOtlpExporter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/Console/TestPrometheusExporter.cs
+++ b/examples/Console/TestPrometheusExporter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TestPrometheusExporter.cs" company="OpenTelemetry Authors">
+// <copyright file="TestPrometheusExporter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/Console/TestRedis.cs
+++ b/examples/Console/TestRedis.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TestRedis.cs" company="OpenTelemetry Authors">
+// <copyright file="TestRedis.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/Console/TestZPagesExporter.cs
+++ b/examples/Console/TestZPagesExporter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TestZPagesExporter.cs" company="OpenTelemetry Authors">
+// <copyright file="TestZPagesExporter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/Console/TestZipkinExporter.cs
+++ b/examples/Console/TestZipkinExporter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TestZipkinExporter.cs" company="OpenTelemetry Authors">
+// <copyright file="TestZipkinExporter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/GrpcService/Program.cs
+++ b/examples/GrpcService/Program.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Program.cs" company="OpenTelemetry Authors">
+// <copyright file="Program.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/GrpcService/Services/GreeterService.cs
+++ b/examples/GrpcService/Services/GreeterService.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="GreeterService.cs" company="OpenTelemetry Authors">
+// <copyright file="GreeterService.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/GrpcService/Startup.cs
+++ b/examples/GrpcService/Startup.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Startup.cs" company="OpenTelemetry Authors">
+// <copyright file="Startup.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/MicroserviceExample/Utils/Messaging/MessageReceiver.cs
+++ b/examples/MicroserviceExample/Utils/Messaging/MessageReceiver.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MessageReceiver.cs" company="OpenTelemetry Authors">
+// <copyright file="MessageReceiver.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/MicroserviceExample/Utils/Messaging/MessageSender.cs
+++ b/examples/MicroserviceExample/Utils/Messaging/MessageSender.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MessageSender.cs" company="OpenTelemetry Authors">
+// <copyright file="MessageSender.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/MicroserviceExample/Utils/Messaging/RabbitMqHelper.cs
+++ b/examples/MicroserviceExample/Utils/Messaging/RabbitMqHelper.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="RabbitMqHelper.cs" company="OpenTelemetry Authors">
+// <copyright file="RabbitMqHelper.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/MicroserviceExample/WebApi/Controllers/SendMessageController.cs
+++ b/examples/MicroserviceExample/WebApi/Controllers/SendMessageController.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SendMessageController.cs" company="OpenTelemetry Authors">
+// <copyright file="SendMessageController.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/MicroserviceExample/WebApi/Program.cs
+++ b/examples/MicroserviceExample/WebApi/Program.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Program.cs" company="OpenTelemetry Authors">
+// <copyright file="Program.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/MicroserviceExample/WebApi/Startup.cs
+++ b/examples/MicroserviceExample/WebApi/Startup.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Startup.cs" company="OpenTelemetry Authors">
+// <copyright file="Startup.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/MicroserviceExample/WorkerService/Program.cs
+++ b/examples/MicroserviceExample/WorkerService/Program.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Program.cs" company="OpenTelemetry Authors">
+// <copyright file="Program.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/MicroserviceExample/WorkerService/Worker.cs
+++ b/examples/MicroserviceExample/WorkerService/Worker.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Worker.cs" company="OpenTelemetry Authors">
+// <copyright file="Worker.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Api/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
+// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Baggage.cs
+++ b/src/OpenTelemetry.Api/Baggage.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Baggage.cs" company="OpenTelemetry Authors">
+// <copyright file="Baggage.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Context/AsyncLocalRuntimeContextSlot.cs
+++ b/src/OpenTelemetry.Api/Context/AsyncLocalRuntimeContextSlot.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AsyncLocalRuntimeContextSlot.cs" company="OpenTelemetry Authors">
+// <copyright file="AsyncLocalRuntimeContextSlot.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Context/Propagation/ActivityContextExtensions.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/ActivityContextExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ActivityContextExtensions.cs" company="OpenTelemetry Authors">
+// <copyright file="ActivityContextExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Context/Propagation/B3Propagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/B3Propagator.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="B3Propagator.cs" company="OpenTelemetry Authors">
+// <copyright file="B3Propagator.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="BaggagePropagator.cs" company="OpenTelemetry Authors">
+// <copyright file="BaggagePropagator.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Context/Propagation/BaseHeaderParser.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/BaseHeaderParser.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="BaseHeaderParser.cs" company="OpenTelemetry Authors">
+// <copyright file="BaseHeaderParser.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Context/Propagation/CompositePropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/CompositePropagator.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="CompositePropagator.cs" company="OpenTelemetry Authors">
+// <copyright file="CompositePropagator.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Context/Propagation/GenericHeaderParser.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/GenericHeaderParser.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="GenericHeaderParser.cs" company="OpenTelemetry Authors">
+// <copyright file="GenericHeaderParser.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Context/Propagation/HeaderUtilities.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/HeaderUtilities.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HeaderUtilities.cs" company="OpenTelemetry Authors">
+// <copyright file="HeaderUtilities.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Context/Propagation/HttpHeaderParser.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/HttpHeaderParser.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HttpHeaderParser.cs" company="OpenTelemetry Authors">
+// <copyright file="HttpHeaderParser.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Context/Propagation/HttpParseResult.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/HttpParseResult.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HttpParseResult.cs" company="OpenTelemetry Authors">
+// <copyright file="HttpParseResult.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Context/Propagation/HttpRuleParser.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/HttpRuleParser.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HttpRuleParser.cs" company="OpenTelemetry Authors">
+// <copyright file="HttpRuleParser.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Context/Propagation/IPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/IPropagator.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="IPropagator.cs" company="OpenTelemetry Authors">
+// <copyright file="IPropagator.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Context/Propagation/NameValueHeaderValue.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/NameValueHeaderValue.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="NameValueHeaderValue.cs" company="OpenTelemetry Authors">
+// <copyright file="NameValueHeaderValue.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Context/Propagation/PropagationContext.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/PropagationContext.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="PropagationContext.cs" company="OpenTelemetry Authors">
+// <copyright file="PropagationContext.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Context/Propagation/TextMapPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TextMapPropagator.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TextMapPropagator.cs" company="OpenTelemetry Authors">
+// <copyright file="TextMapPropagator.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceStateUtilsNew.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceStateUtilsNew.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TraceStateUtilsNew.cs" company="OpenTelemetry Authors">
+// <copyright file="TraceStateUtilsNew.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Context/RemotingRuntimeContextSlot.cs
+++ b/src/OpenTelemetry.Api/Context/RemotingRuntimeContextSlot.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="RemotingRuntimeContextSlot.cs" company="OpenTelemetry Authors">
+// <copyright file="RemotingRuntimeContextSlot.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Context/RuntimeContext.cs
+++ b/src/OpenTelemetry.Api/Context/RuntimeContext.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="RuntimeContext.cs" company="OpenTelemetry Authors">
+// <copyright file="RuntimeContext.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Context/RuntimeContextSlot.cs
+++ b/src/OpenTelemetry.Api/Context/RuntimeContextSlot.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="RuntimeContextSlot.cs" company="OpenTelemetry Authors">
+// <copyright file="RuntimeContextSlot.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Context/ThreadLocalRuntimeContextSlot.cs
+++ b/src/OpenTelemetry.Api/Context/ThreadLocalRuntimeContextSlot.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ThreadLocalRuntimeContextSlot.cs" company="OpenTelemetry Authors">
+// <copyright file="ThreadLocalRuntimeContextSlot.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Internal/ExceptionExtensions.cs
+++ b/src/OpenTelemetry.Api/Internal/ExceptionExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ExceptionExtensions.cs" company="OpenTelemetry Authors">
+// <copyright file="ExceptionExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Internal/OpenTelemetryApiEventSource.cs
+++ b/src/OpenTelemetry.Api/Internal/OpenTelemetryApiEventSource.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="OpenTelemetryApiEventSource.cs" company="OpenTelemetry Authors">
+// <copyright file="OpenTelemetryApiEventSource.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Metrics/BlankLabelSet.cs
+++ b/src/OpenTelemetry.Api/Metrics/BlankLabelSet.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="BlankLabelSet.cs" company="OpenTelemetry Authors">
+// <copyright file="BlankLabelSet.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Metrics/BoundCounterMetric.cs
+++ b/src/OpenTelemetry.Api/Metrics/BoundCounterMetric.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="BoundCounterMetric.cs" company="OpenTelemetry Authors">
+// <copyright file="BoundCounterMetric.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Metrics/BoundMeasureMetric.cs
+++ b/src/OpenTelemetry.Api/Metrics/BoundMeasureMetric.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="BoundMeasureMetric.cs" company="OpenTelemetry Authors">
+// <copyright file="BoundMeasureMetric.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Metrics/CounterMetric.cs
+++ b/src/OpenTelemetry.Api/Metrics/CounterMetric.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="CounterMetric.cs" company="OpenTelemetry Authors">
+// <copyright file="CounterMetric.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Metrics/DoubleObserverMetric.cs
+++ b/src/OpenTelemetry.Api/Metrics/DoubleObserverMetric.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DoubleObserverMetric.cs" company="OpenTelemetry Authors">
+// <copyright file="DoubleObserverMetric.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Metrics/DoubleObserverMetricHandle.cs
+++ b/src/OpenTelemetry.Api/Metrics/DoubleObserverMetricHandle.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DoubleObserverMetricHandle.cs" company="OpenTelemetry Authors">
+// <copyright file="DoubleObserverMetricHandle.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Metrics/Int64ObserverMetric.cs
+++ b/src/OpenTelemetry.Api/Metrics/Int64ObserverMetric.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Int64ObserverMetric.cs" company="OpenTelemetry Authors">
+// <copyright file="Int64ObserverMetric.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Metrics/Int64ObserverMetricHandle.cs
+++ b/src/OpenTelemetry.Api/Metrics/Int64ObserverMetricHandle.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Int64ObserverMetricHandle.cs" company="OpenTelemetry Authors">
+// <copyright file="Int64ObserverMetricHandle.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Metrics/LabelSet.cs
+++ b/src/OpenTelemetry.Api/Metrics/LabelSet.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="LabelSet.cs" company="OpenTelemetry Authors">
+// <copyright file="LabelSet.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Metrics/MeasureMetric.cs
+++ b/src/OpenTelemetry.Api/Metrics/MeasureMetric.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MeasureMetric.cs" company="OpenTelemetry Authors">
+// <copyright file="MeasureMetric.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Metrics/Meter.cs
+++ b/src/OpenTelemetry.Api/Metrics/Meter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Meter.cs" company="OpenTelemetry Authors">
+// <copyright file="Meter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Metrics/MeterFactoryBase.cs
+++ b/src/OpenTelemetry.Api/Metrics/MeterFactoryBase.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MeterFactoryBase.cs" company="OpenTelemetry Authors">
+// <copyright file="MeterFactoryBase.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Metrics/MeterProvider.cs
+++ b/src/OpenTelemetry.Api/Metrics/MeterProvider.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MeterProvider.cs" company="OpenTelemetry Authors">
+// <copyright file="MeterProvider.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Metrics/NoopBoundCounterMetric.cs
+++ b/src/OpenTelemetry.Api/Metrics/NoopBoundCounterMetric.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="NoopBoundCounterMetric.cs" company="OpenTelemetry Authors">
+// <copyright file="NoopBoundCounterMetric.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Metrics/NoopBoundMeasureMetric.cs
+++ b/src/OpenTelemetry.Api/Metrics/NoopBoundMeasureMetric.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="NoopBoundMeasureMetric.cs" company="OpenTelemetry Authors">
+// <copyright file="NoopBoundMeasureMetric.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Metrics/NoopCounterMetric.cs
+++ b/src/OpenTelemetry.Api/Metrics/NoopCounterMetric.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="NoopCounterMetric.cs" company="OpenTelemetry Authors">
+// <copyright file="NoopCounterMetric.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Metrics/NoopDoubleObserverMetric.cs
+++ b/src/OpenTelemetry.Api/Metrics/NoopDoubleObserverMetric.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="NoopDoubleObserverMetric.cs" company="OpenTelemetry Authors">
+// <copyright file="NoopDoubleObserverMetric.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Metrics/NoopDoubleObserverMetricHandle.cs
+++ b/src/OpenTelemetry.Api/Metrics/NoopDoubleObserverMetricHandle.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="NoopDoubleObserverMetricHandle.cs" company="OpenTelemetry Authors">
+// <copyright file="NoopDoubleObserverMetricHandle.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Metrics/NoopInt64ObserverMetric.cs
+++ b/src/OpenTelemetry.Api/Metrics/NoopInt64ObserverMetric.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="NoopInt64ObserverMetric.cs" company="OpenTelemetry Authors">
+// <copyright file="NoopInt64ObserverMetric.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Metrics/NoopInt64ObserverMetricHandle.cs
+++ b/src/OpenTelemetry.Api/Metrics/NoopInt64ObserverMetricHandle.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="NoopInt64ObserverMetricHandle.cs" company="OpenTelemetry Authors">
+// <copyright file="NoopInt64ObserverMetricHandle.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Metrics/NoopMeasureMetric.cs
+++ b/src/OpenTelemetry.Api/Metrics/NoopMeasureMetric.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="NoopMeasureMetric.cs" company="OpenTelemetry Authors">
+// <copyright file="NoopMeasureMetric.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Metrics/ProxyMeter.cs
+++ b/src/OpenTelemetry.Api/Metrics/ProxyMeter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ProxyMeter.cs" company="OpenTelemetry Authors">
+// <copyright file="ProxyMeter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ActivityExtensions.cs" company="OpenTelemetry Authors">
+// <copyright file="ActivityExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Trace/IActivityTagEnumerator.cs
+++ b/src/OpenTelemetry.Api/Trace/IActivityTagEnumerator.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="IActivityTagEnumerator.cs" company="OpenTelemetry Authors">
+// <copyright file="IActivityTagEnumerator.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Trace/Link.cs
+++ b/src/OpenTelemetry.Api/Trace/Link.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Link.cs" company="OpenTelemetry Authors">
+// <copyright file="Link.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Trace/SemanticConventions.cs
+++ b/src/OpenTelemetry.Api/Trace/SemanticConventions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SemanticConventions.cs" company="OpenTelemetry Authors">
+// <copyright file="SemanticConventions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Trace/SpanAttributeConstants.cs
+++ b/src/OpenTelemetry.Api/Trace/SpanAttributeConstants.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SpanAttributeConstants.cs" company="OpenTelemetry Authors">
+// <copyright file="SpanAttributeConstants.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Trace/SpanAttributes.cs
+++ b/src/OpenTelemetry.Api/Trace/SpanAttributes.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SpanAttributes.cs" company="OpenTelemetry Authors">
+// <copyright file="SpanAttributes.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Trace/SpanContext.cs
+++ b/src/OpenTelemetry.Api/Trace/SpanContext.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SpanContext.cs" company="OpenTelemetry Authors">
+// <copyright file="SpanContext.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Trace/SpanHelper.cs
+++ b/src/OpenTelemetry.Api/Trace/SpanHelper.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SpanHelper.cs" company="OpenTelemetry Authors">
+// <copyright file="SpanHelper.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Trace/SpanKind.cs
+++ b/src/OpenTelemetry.Api/Trace/SpanKind.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SpanKind.cs" company="OpenTelemetry Authors">
+// <copyright file="SpanKind.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Trace/Status.cs
+++ b/src/OpenTelemetry.Api/Trace/Status.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Status.cs" company="OpenTelemetry Authors">
+// <copyright file="Status.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Trace/StatusCanonicalCode.cs
+++ b/src/OpenTelemetry.Api/Trace/StatusCanonicalCode.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="StatusCanonicalCode.cs" company="OpenTelemetry Authors">
+// <copyright file="StatusCanonicalCode.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Trace/TelemetrySpan.cs
+++ b/src/OpenTelemetry.Api/Trace/TelemetrySpan.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TelemetrySpan.cs" company="OpenTelemetry Authors">
+// <copyright file="TelemetrySpan.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Trace/Tracer.cs
+++ b/src/OpenTelemetry.Api/Trace/Tracer.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Tracer.cs" company="OpenTelemetry Authors">
+// <copyright file="Tracer.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Api/Trace/TracerProvider.cs
+++ b/src/OpenTelemetry.Api/Trace/TracerProvider.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TracerProvider.cs" company="OpenTelemetry Authors">
+// <copyright file="TracerProvider.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Console/ActivitySpanIdConverter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ActivitySpanIdConverter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ActivitySpanIdConverter.cs" company="OpenTelemetry Authors">
+// <copyright file="ActivitySpanIdConverter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Console/ActivityTraceIdConverter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ActivityTraceIdConverter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ActivityTraceIdConverter.cs" company="OpenTelemetry Authors">
+// <copyright file="ActivityTraceIdConverter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ConsoleExporter.cs" company="OpenTelemetry Authors">
+// <copyright file="ConsoleExporter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterHelperExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ConsoleExporterHelperExtensions.cs" company="OpenTelemetry Authors">
+// <copyright file="ConsoleExporterHelperExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterOptions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ConsoleExporterOptions.cs" company="OpenTelemetry Authors">
+// <copyright file="ConsoleExporterOptions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Jaeger/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
+// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/Batch.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/Batch.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Batch.cs" company="OpenTelemetry Authors">
+// <copyright file="Batch.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/BufferWriter.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/BufferWriter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="BufferWriter.cs" company="OpenTelemetry Authors">
+// <copyright file="BufferWriter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/BufferWriterMemory.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/BufferWriterMemory.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="BufferWriterMemory.cs" company="OpenTelemetry Authors">
+// <copyright file="BufferWriterMemory.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/EmitBatchArgs.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/EmitBatchArgs.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="EmitBatchArgs.cs" company="OpenTelemetry Authors">
+// <copyright file="EmitBatchArgs.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/IJaegerClient.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/IJaegerClient.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="IJaegerClient.cs" company="OpenTelemetry Authors">
+// <copyright file="IJaegerClient.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/InMemoryTransport.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/InMemoryTransport.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="InMemoryTransport.cs" company="OpenTelemetry Authors">
+// <copyright file="InMemoryTransport.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/Int128.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/Int128.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Int128.cs" company="OpenTelemetry Authors">
+// <copyright file="Int128.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerActivityExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerActivityExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="JaegerActivityExtensions.cs" company="OpenTelemetry Authors">
+// <copyright file="JaegerActivityExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerExporterEventSource.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="JaegerExporterEventSource.cs" company="OpenTelemetry Authors">
+// <copyright file="JaegerExporterEventSource.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerExporterException.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerExporterException.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="JaegerExporterException.cs" company="OpenTelemetry Authors">
+// <copyright file="JaegerExporterException.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerLog.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerLog.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="JaegerLog.cs" company="OpenTelemetry Authors">
+// <copyright file="JaegerLog.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerSpan.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerSpan.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="JaegerSpan.cs" company="OpenTelemetry Authors">
+// <copyright file="JaegerSpan.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerSpanRef.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerSpanRef.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="JaegerSpanRef.cs" company="OpenTelemetry Authors">
+// <copyright file="JaegerSpanRef.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerSpanRefType.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerSpanRefType.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="JaegerSpanRefType.cs" company="OpenTelemetry Authors">
+// <copyright file="JaegerSpanRefType.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerTag.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerTag.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="JaegerTag.cs" company="OpenTelemetry Authors">
+// <copyright file="JaegerTag.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerTagType.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerTagType.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="JaegerTagType.cs" company="OpenTelemetry Authors">
+// <copyright file="JaegerTagType.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerThriftClient.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerThriftClient.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="JaegerThriftClient.cs" company="OpenTelemetry Authors">
+// <copyright file="JaegerThriftClient.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerThriftClientTransport.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerThriftClientTransport.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="JaegerThriftClientTransport.cs" company="OpenTelemetry Authors">
+// <copyright file="JaegerThriftClientTransport.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpClient.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpClient.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="JaegerUdpClient.cs" company="OpenTelemetry Authors">
+// <copyright file="JaegerUdpClient.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="JaegerExporter.cs" company="OpenTelemetry Authors">
+// <copyright file="JaegerExporter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterHelperExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="JaegerExporterHelperExtensions.cs" company="OpenTelemetry Authors">
+// <copyright file="JaegerExporterHelperExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="JaegerExporterOptions.cs" company="OpenTelemetry Authors">
+// <copyright file="JaegerExporterOptions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Jaeger/Process.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Process.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Process.cs" company="OpenTelemetry Authors">
+// <copyright file="Process.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
+// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ActivityExtensions.cs" company="OpenTelemetry Authors">
+// <copyright file="ActivityExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OpenTelemetryProtocolExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OpenTelemetryProtocolExporterEventSource.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="OpenTelemetryProtocolExporterEventSource.cs" company="OpenTelemetry Authors">
+// <copyright file="OpenTelemetryProtocolExporterEventSource.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/TimestampHelpers.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/TimestampHelpers.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TimestampHelpers.cs" company="OpenTelemetry Authors">
+// <copyright file="TimestampHelpers.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="OtlpExporter.cs" company="OpenTelemetry Authors">
+// <copyright file="OtlpExporter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterHelperExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="OtlpExporterHelperExtensions.cs" company="OpenTelemetry Authors">
+// <copyright file="OtlpExporterHelperExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="OtlpExporterOptions.cs" company="OpenTelemetry Authors">
+// <copyright file="OtlpExporterOptions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Prometheus/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
+// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterEventSource.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="PrometheusExporterEventSource.cs" company="OpenTelemetry Authors">
+// <copyright file="PrometheusExporterEventSource.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusMetricBuilder.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusMetricBuilder.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="PrometheusMetricBuilder.cs" company="OpenTelemetry Authors">
+// <copyright file="PrometheusMetricBuilder.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporter.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="PrometheusExporter.cs" company="OpenTelemetry Authors">
+// <copyright file="PrometheusExporter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="PrometheusExporterExtensions.cs" company="OpenTelemetry Authors">
+// <copyright file="PrometheusExporterExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterMetricsHttpServer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterMetricsHttpServer.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="PrometheusExporterMetricsHttpServer.cs" company="OpenTelemetry Authors">
+// <copyright file="PrometheusExporterMetricsHttpServer.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterMiddleware.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterMiddleware.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="PrometheusExporterMiddleware.cs" company="OpenTelemetry Authors">
+// <copyright file="PrometheusExporterMiddleware.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterOptions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="PrometheusExporterOptions.cs" company="OpenTelemetry Authors">
+// <copyright file="PrometheusExporterOptions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusRouteBuilderExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusRouteBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="PrometheusRouteBuilderExtensions.cs" company="OpenTelemetry Authors">
+// <copyright file="PrometheusRouteBuilderExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.ZPages/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
+// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.ZPages/Implementation/ZPagesActivityAggregate.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/Implementation/ZPagesActivityAggregate.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ZPagesActivityAggregate.cs" company="OpenTelemetry Authors">
+// <copyright file="ZPagesActivityAggregate.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.ZPages/Implementation/ZPagesActivityTracker.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/Implementation/ZPagesActivityTracker.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ZPagesActivityTracker.cs" company="OpenTelemetry Authors">
+// <copyright file="ZPagesActivityTracker.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.ZPages/Implementation/ZPagesExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/Implementation/ZPagesExporterEventSource.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ZPagesExporterEventSource.cs" company="OpenTelemetry Authors">
+// <copyright file="ZPagesExporterEventSource.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.ZPages/Implementation/ZPagesStatsBuilder.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/Implementation/ZPagesStatsBuilder.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ZPagesStatsBuilder.cs" company="OpenTelemetry Authors">
+// <copyright file="ZPagesStatsBuilder.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.ZPages/ZPagesExporter.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/ZPagesExporter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ZPagesExporter.cs" company="OpenTelemetry Authors">
+// <copyright file="ZPagesExporter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.ZPages/ZPagesExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/ZPagesExporterHelperExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ZPagesExporterHelperExtensions.cs" company="OpenTelemetry Authors">
+// <copyright file="ZPagesExporterHelperExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.ZPages/ZPagesExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/ZPagesExporterOptions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ZPagesExporterOptions.cs" company="OpenTelemetry Authors">
+// <copyright file="ZPagesExporterOptions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.ZPages/ZPagesExporterStatsHttpServer.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/ZPagesExporterStatsHttpServer.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ZPagesExporterStatsHttpServer.cs" company="OpenTelemetry Authors">
+// <copyright file="ZPagesExporterStatsHttpServer.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.ZPages/ZPagesProcessor.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/ZPagesProcessor.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ZPagesProcessor.cs" company="OpenTelemetry Authors">
+// <copyright file="ZPagesProcessor.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Zipkin/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
+// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinActivityConversionExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinActivityConversionExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ZipkinActivityConversionExtensions.cs" company="OpenTelemetry Authors">
+// <copyright file="ZipkinActivityConversionExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinAnnotation.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinAnnotation.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ZipkinAnnotation.cs" company="OpenTelemetry Authors">
+// <copyright file="ZipkinAnnotation.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinEndpoint.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinEndpoint.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ZipkinEndpoint.cs" company="OpenTelemetry Authors">
+// <copyright file="ZipkinEndpoint.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinExporterEventSource.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ZipkinExporterEventSource.cs" company="OpenTelemetry Authors">
+// <copyright file="ZipkinExporterEventSource.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinSpan.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinSpan.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ZipkinSpan.cs" company="OpenTelemetry Authors">
+// <copyright file="ZipkinSpan.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporter.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ZipkinExporter.cs" company="OpenTelemetry Authors">
+// <copyright file="ZipkinExporter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporterHelperExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ZipkinExporterHelperExtensions.cs" company="OpenTelemetry Authors">
+// <copyright file="ZipkinExporterHelperExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporterOptions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ZipkinExporterOptions.cs" company="OpenTelemetry Authors">
+// <copyright file="ZipkinExporterOptions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Extensions.Hosting/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
+// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Extensions.Hosting/Implementation/HostingExtensionsEventSource.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Implementation/HostingExtensionsEventSource.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HostingExtensionsEventSource.cs" company="OpenTelemetry Authors">
+// <copyright file="HostingExtensionsEventSource.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Extensions.Hosting/Implementation/TelemetryHostedService.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Implementation/TelemetryHostedService.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TelemetryHostedService.cs" company="OpenTelemetry Authors">
+// <copyright file="TelemetryHostedService.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryServicesExtensions.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryServicesExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="OpenTelemetryServicesExtensions.cs" company="OpenTelemetry Authors">
+// <copyright file="OpenTelemetryServicesExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentation.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AspNetInstrumentation.cs" company="OpenTelemetry Authors">
+// <copyright file="AspNetInstrumentation.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationOptions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AspNetInstrumentationOptions.cs" company="OpenTelemetry Authors">
+// <copyright file="AspNetInstrumentationOptions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.AspNet/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
+// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/AspNetInstrumentationEventSource.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/AspNetInstrumentationEventSource.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AspNetInstrumentationEventSource.cs" company="OpenTelemetry Authors">
+// <copyright file="AspNetInstrumentationEventSource.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HttpInListener.cs" company="OpenTelemetry Authors">
+// <copyright file="HttpInListener.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.AspNet/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/TracerProviderBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TracerProviderBuilderExtensions.cs" company="OpenTelemetry Authors">
+// <copyright file="TracerProviderBuilderExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentation.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AspNetCoreInstrumentation.cs" company="OpenTelemetry Authors">
+// <copyright file="AspNetCoreInstrumentation.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationOptions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AspNetCoreInstrumentationOptions.cs" company="OpenTelemetry Authors">
+// <copyright file="AspNetCoreInstrumentationOptions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
+// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/AspNetCoreInstrumentationEventSource.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/AspNetCoreInstrumentationEventSource.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AspNetCoreInstrumentationEventSource.cs" company="OpenTelemetry Authors">
+// <copyright file="AspNetCoreInstrumentationEventSource.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HttpInListener.cs" company="OpenTelemetry Authors">
+// <copyright file="HttpInListener.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/TracerProviderBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TracerProviderBuilderExtensions.cs" company="OpenTelemetry Authors">
+// <copyright file="TracerProviderBuilderExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
+// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/GrpcClientInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/GrpcClientInstrumentation.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="GrpcClientInstrumentation.cs" company="OpenTelemetry Authors">
+// <copyright file="GrpcClientInstrumentation.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/GrpcClientInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/GrpcClientInstrumentationOptions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="GrpcClientInstrumentationOptions.cs" company="OpenTelemetry Authors">
+// <copyright file="GrpcClientInstrumentationOptions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/GrpcTagHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/GrpcTagHelper.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="GrpcTagHelper.cs" company="OpenTelemetry Authors">
+// <copyright file="GrpcTagHelper.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="GrpcClientDiagnosticListener.cs" company="OpenTelemetry Authors">
+// <copyright file="GrpcClientDiagnosticListener.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcInstrumentationEventSource.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcInstrumentationEventSource.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="GrpcInstrumentationEventSource.cs" company="OpenTelemetry Authors">
+// <copyright file="GrpcInstrumentationEventSource.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/TracerProviderBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TracerProviderBuilderExtensions.cs" company="OpenTelemetry Authors">
+// <copyright file="TracerProviderBuilderExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.Http/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
+// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.Http/HttpClientInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/HttpClientInstrumentation.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HttpClientInstrumentation.cs" company="OpenTelemetry Authors">
+// <copyright file="HttpClientInstrumentation.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.Http/HttpClientInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/HttpClientInstrumentationOptions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HttpClientInstrumentationOptions.cs" company="OpenTelemetry Authors">
+// <copyright file="HttpClientInstrumentationOptions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.Http/HttpWebRequestInstrumentationOptions.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/HttpWebRequestInstrumentationOptions.netfx.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HttpWebRequestInstrumentationOptions.netfx.cs" company="OpenTelemetry Authors">
+// <copyright file="HttpWebRequestInstrumentationOptions.netfx.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HttpHandlerDiagnosticListener.cs" company="OpenTelemetry Authors">
+// <copyright file="HttpHandlerDiagnosticListener.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpInstrumentationEventSource.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpInstrumentationEventSource.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HttpInstrumentationEventSource.cs" company="OpenTelemetry Authors">
+// <copyright file="HttpInstrumentationEventSource.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpTagHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpTagHelper.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HttpTagHelper.cs" company="OpenTelemetry Authors">
+// <copyright file="HttpTagHelper.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HttpWebRequestActivitySource.netfx.cs" company="OpenTelemetry Authors">
+// <copyright file="HttpWebRequestActivitySource.netfx.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.Http/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/TracerProviderBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TracerProviderBuilderExtensions.cs" company="OpenTelemetry Authors">
+// <copyright file="TracerProviderBuilderExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.SqlClient/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
+// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SqlClientDiagnosticListener.cs" company="OpenTelemetry Authors">
+// <copyright file="SqlClientDiagnosticListener.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientInstrumentationEventSource.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientInstrumentationEventSource.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SqlClientInstrumentationEventSource.cs" company="OpenTelemetry Authors">
+// <copyright file="SqlClientInstrumentationEventSource.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SqlEventSourceListener.netfx.cs" company="OpenTelemetry Authors">
+// <copyright file="SqlEventSourceListener.netfx.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentation.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SqlClientInstrumentation.cs" company="OpenTelemetry Authors">
+// <copyright file="SqlClientInstrumentation.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentationOptions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SqlClientInstrumentationOptions.cs" company="OpenTelemetry Authors">
+// <copyright file="SqlClientInstrumentationOptions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.SqlClient/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/TracerProviderBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TracerProviderBuilderExtensions.cs" company="OpenTelemetry Authors">
+// <copyright file="TracerProviderBuilderExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
+// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="RedisProfilerEntryToActivityConverter.cs" company="OpenTelemetry Authors">
+// <copyright file="RedisProfilerEntryToActivityConverter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisCallsInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisCallsInstrumentation.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="StackExchangeRedisCallsInstrumentation.cs" company="OpenTelemetry Authors">
+// <copyright file="StackExchangeRedisCallsInstrumentation.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisCallsInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisCallsInstrumentationOptions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="StackExchangeRedisCallsInstrumentationOptions.cs" company="OpenTelemetry Authors">
+// <copyright file="StackExchangeRedisCallsInstrumentationOptions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/TracerProviderBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TracerProviderBuilderExtensions.cs" company="OpenTelemetry Authors">
+// <copyright file="TracerProviderBuilderExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ScopeManagerShim.cs" company="OpenTelemetry Authors">
+// <copyright file="ScopeManagerShim.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SpanBuilderShim.cs" company="OpenTelemetry Authors">
+// <copyright file="SpanBuilderShim.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanContextShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanContextShim.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SpanContextShim.cs" company="OpenTelemetry Authors">
+// <copyright file="SpanContextShim.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanShim.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SpanShim.cs" company="OpenTelemetry Authors">
+// <copyright file="SpanShim.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry.Shims.OpenTracing/TracerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/TracerShim.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TracerShim.cs" company="OpenTelemetry Authors">
+// <copyright file="TracerShim.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/AssemblyInfo.cs
+++ b/src/OpenTelemetry/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
+// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Batch.cs
+++ b/src/OpenTelemetry/Batch.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Batch.cs" company="OpenTelemetry Authors">
+// <copyright file="Batch.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Instrumentation/DiagnosticSourceListener.cs
+++ b/src/OpenTelemetry/Instrumentation/DiagnosticSourceListener.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DiagnosticSourceListener.cs" company="OpenTelemetry Authors">
+// <copyright file="DiagnosticSourceListener.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Instrumentation/DiagnosticSourceSubscriber.cs
+++ b/src/OpenTelemetry/Instrumentation/DiagnosticSourceSubscriber.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DiagnosticSourceSubscriber.cs" company="OpenTelemetry Authors">
+// <copyright file="DiagnosticSourceSubscriber.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Instrumentation/InstrumentationEventSource.cs
+++ b/src/OpenTelemetry/Instrumentation/InstrumentationEventSource.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="InstrumentationEventSource.cs" company="OpenTelemetry Authors">
+// <copyright file="InstrumentationEventSource.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Instrumentation/ListenerHandler.cs
+++ b/src/OpenTelemetry/Instrumentation/ListenerHandler.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ListenerHandler.cs" company="OpenTelemetry Authors">
+// <copyright file="ListenerHandler.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Instrumentation/PropertyFetcher.cs
+++ b/src/OpenTelemetry/Instrumentation/PropertyFetcher.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="PropertyFetcher.cs" company="OpenTelemetry Authors">
+// <copyright file="PropertyFetcher.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Internal/CircularBuffer.cs
+++ b/src/OpenTelemetry/Internal/CircularBuffer.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="CircularBuffer.cs" company="OpenTelemetry Authors">
+// <copyright file="CircularBuffer.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Internal/DateTimeOffsetExtensions.net452.cs
+++ b/src/OpenTelemetry/Internal/DateTimeOffsetExtensions.net452.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DateTimeOffsetExtensions.net452.cs" company="OpenTelemetry Authors">
+// <copyright file="DateTimeOffsetExtensions.net452.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="OpenTelemetrySdkEventSource.cs" company="OpenTelemetry Authors">
+// <copyright file="OpenTelemetrySdkEventSource.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Internal/PooledList.cs
+++ b/src/OpenTelemetry/Internal/PooledList.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="PooledList.cs" company="OpenTelemetry Authors">
+// <copyright file="PooledList.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Internal/VarInt.cs
+++ b/src/OpenTelemetry/Internal/VarInt.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="VarInt.cs" company="OpenTelemetry Authors">
+// <copyright file="VarInt.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/Aggregators/Aggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregators/Aggregator.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Aggregator.cs" company="OpenTelemetry Authors">
+// <copyright file="Aggregator.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/Aggregators/DoubleCounterSumAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregators/DoubleCounterSumAggregator.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DoubleCounterSumAggregator.cs" company="OpenTelemetry Authors">
+// <copyright file="DoubleCounterSumAggregator.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/Aggregators/DoubleLastValueAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregators/DoubleLastValueAggregator.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DoubleLastValueAggregator.cs" company="OpenTelemetry Authors">
+// <copyright file="DoubleLastValueAggregator.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/Aggregators/DoubleMeasureMinMaxSumCountAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregators/DoubleMeasureMinMaxSumCountAggregator.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DoubleMeasureMinMaxSumCountAggregator.cs" company="OpenTelemetry Authors">
+// <copyright file="DoubleMeasureMinMaxSumCountAggregator.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/Aggregators/Int64CounterSumAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregators/Int64CounterSumAggregator.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Int64CounterSumAggregator.cs" company="OpenTelemetry Authors">
+// <copyright file="Int64CounterSumAggregator.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/Aggregators/Int64LastValueAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregators/Int64LastValueAggregator.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Int64LastValueAggregator.cs" company="OpenTelemetry Authors">
+// <copyright file="Int64LastValueAggregator.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/Aggregators/Int64MeasureMinMaxSumCountAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregators/Int64MeasureMinMaxSumCountAggregator.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Int64MeasureMinMaxSumCountAggregator.cs" company="OpenTelemetry Authors">
+// <copyright file="Int64MeasureMinMaxSumCountAggregator.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/BoundCounterMetricSdkBase.cs
+++ b/src/OpenTelemetry/Metrics/BoundCounterMetricSdkBase.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="BoundCounterMetricSdkBase.cs" company="OpenTelemetry Authors">
+// <copyright file="BoundCounterMetricSdkBase.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/BoundMeasureMetricSdkBase.cs
+++ b/src/OpenTelemetry/Metrics/BoundMeasureMetricSdkBase.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="BoundMeasureMetricSdkBase.cs" company="OpenTelemetry Authors">
+// <copyright file="BoundMeasureMetricSdkBase.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/CounterMetricSdkBase.cs
+++ b/src/OpenTelemetry/Metrics/CounterMetricSdkBase.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="CounterMetricSdkBase.cs" company="OpenTelemetry Authors">
+// <copyright file="CounterMetricSdkBase.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/DoubleBoundCounterMetricSdk.cs
+++ b/src/OpenTelemetry/Metrics/DoubleBoundCounterMetricSdk.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DoubleBoundCounterMetricSdk.cs" company="OpenTelemetry Authors">
+// <copyright file="DoubleBoundCounterMetricSdk.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/DoubleBoundMeasureMetricSdk.cs
+++ b/src/OpenTelemetry/Metrics/DoubleBoundMeasureMetricSdk.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DoubleBoundMeasureMetricSdk.cs" company="OpenTelemetry Authors">
+// <copyright file="DoubleBoundMeasureMetricSdk.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/DoubleCounterMetricSdk.cs
+++ b/src/OpenTelemetry/Metrics/DoubleCounterMetricSdk.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DoubleCounterMetricSdk.cs" company="OpenTelemetry Authors">
+// <copyright file="DoubleCounterMetricSdk.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/DoubleMeasureMetricSdk.cs
+++ b/src/OpenTelemetry/Metrics/DoubleMeasureMetricSdk.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DoubleMeasureMetricSdk.cs" company="OpenTelemetry Authors">
+// <copyright file="DoubleMeasureMetricSdk.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/DoubleObserverMetricHandleSdk.cs
+++ b/src/OpenTelemetry/Metrics/DoubleObserverMetricHandleSdk.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DoubleObserverMetricHandleSdk.cs" company="OpenTelemetry Authors">
+// <copyright file="DoubleObserverMetricHandleSdk.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/DoubleObserverMetricSdk.cs
+++ b/src/OpenTelemetry/Metrics/DoubleObserverMetricSdk.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DoubleObserverMetricSdk.cs" company="OpenTelemetry Authors">
+// <copyright file="DoubleObserverMetricSdk.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/Export/AggregationType.cs
+++ b/src/OpenTelemetry/Metrics/Export/AggregationType.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AggregationType.cs" company="OpenTelemetry Authors">
+// <copyright file="AggregationType.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/Export/DoubleSumData.cs
+++ b/src/OpenTelemetry/Metrics/Export/DoubleSumData.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DoubleSumData.cs" company="OpenTelemetry Authors">
+// <copyright file="DoubleSumData.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/Export/DoubleSummaryData.cs
+++ b/src/OpenTelemetry/Metrics/Export/DoubleSummaryData.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DoubleSummaryData.cs" company="OpenTelemetry Authors">
+// <copyright file="DoubleSummaryData.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/Export/Int64SumData.cs
+++ b/src/OpenTelemetry/Metrics/Export/Int64SumData.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Int64SumData.cs" company="OpenTelemetry Authors">
+// <copyright file="Int64SumData.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/Export/Int64SummaryData.cs
+++ b/src/OpenTelemetry/Metrics/Export/Int64SummaryData.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Int64SummaryData.cs" company="OpenTelemetry Authors">
+// <copyright file="Int64SummaryData.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/Export/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Export/Metric.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Metric.cs" company="OpenTelemetry Authors">
+// <copyright file="Metric.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/Export/MetricData.cs
+++ b/src/OpenTelemetry/Metrics/Export/MetricData.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MetricData.cs" company="OpenTelemetry Authors">
+// <copyright file="MetricData.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/Export/MetricExporter.cs
+++ b/src/OpenTelemetry/Metrics/Export/MetricExporter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MetricExporter.cs" company="OpenTelemetry Authors">
+// <copyright file="MetricExporter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/Export/MetricProcessor.cs
+++ b/src/OpenTelemetry/Metrics/Export/MetricProcessor.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MetricProcessor.cs" company="OpenTelemetry Authors">
+// <copyright file="MetricProcessor.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/Export/NoopMetricExporter.cs
+++ b/src/OpenTelemetry/Metrics/Export/NoopMetricExporter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="NoopMetricExporter.cs" company="OpenTelemetry Authors">
+// <copyright file="NoopMetricExporter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/Export/NoopMetricProcessor.cs
+++ b/src/OpenTelemetry/Metrics/Export/NoopMetricProcessor.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="NoopMetricProcessor.cs" company="OpenTelemetry Authors">
+// <copyright file="NoopMetricProcessor.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/Export/PushMetricController.cs
+++ b/src/OpenTelemetry/Metrics/Export/PushMetricController.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="PushMetricController.cs" company="OpenTelemetry Authors">
+// <copyright file="PushMetricController.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/Export/UngroupedBatcher.cs
+++ b/src/OpenTelemetry/Metrics/Export/UngroupedBatcher.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="UngroupedBatcher.cs" company="OpenTelemetry Authors">
+// <copyright file="UngroupedBatcher.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/Int64BoundCounterMetricSdk.cs
+++ b/src/OpenTelemetry/Metrics/Int64BoundCounterMetricSdk.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Int64BoundCounterMetricSdk.cs" company="OpenTelemetry Authors">
+// <copyright file="Int64BoundCounterMetricSdk.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/Int64BoundMeasureMetricSdk.cs
+++ b/src/OpenTelemetry/Metrics/Int64BoundMeasureMetricSdk.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Int64BoundMeasureMetricSdk.cs" company="OpenTelemetry Authors">
+// <copyright file="Int64BoundMeasureMetricSdk.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/Int64CounterMetricSdk.cs
+++ b/src/OpenTelemetry/Metrics/Int64CounterMetricSdk.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Int64CounterMetricSdk.cs" company="OpenTelemetry Authors">
+// <copyright file="Int64CounterMetricSdk.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/Int64MeasureMetricSdk.cs
+++ b/src/OpenTelemetry/Metrics/Int64MeasureMetricSdk.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Int64MeasureMetricSdk.cs" company="OpenTelemetry Authors">
+// <copyright file="Int64MeasureMetricSdk.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/Int64ObserverMetricHandleSdk.cs
+++ b/src/OpenTelemetry/Metrics/Int64ObserverMetricHandleSdk.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Int64ObserverMetricHandleSdk.cs" company="OpenTelemetry Authors">
+// <copyright file="Int64ObserverMetricHandleSdk.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/Int64ObserverMetricSdk.cs
+++ b/src/OpenTelemetry/Metrics/Int64ObserverMetricSdk.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Int64ObserverMetricSdk.cs" company="OpenTelemetry Authors">
+// <copyright file="Int64ObserverMetricSdk.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/LabelSetSdk.cs
+++ b/src/OpenTelemetry/Metrics/LabelSetSdk.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="LabelSetSdk.cs" company="OpenTelemetry Authors">
+// <copyright file="LabelSetSdk.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/MeasureMetricSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeasureMetricSdk.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MeasureMetricSdk.cs" company="OpenTelemetry Authors">
+// <copyright file="MeasureMetricSdk.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/MeterProviderBuilder.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderBuilder.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MeterProviderBuilder.cs" company="OpenTelemetry Authors">
+// <copyright file="MeterProviderBuilder.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MeterProviderSdk.cs" company="OpenTelemetry Authors">
+// <copyright file="MeterProviderSdk.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/MeterSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterSdk.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MeterSdk.cs" company="OpenTelemetry Authors">
+// <copyright file="MeterSdk.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/RecordStatus.cs
+++ b/src/OpenTelemetry/Metrics/RecordStatus.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="RecordStatus.cs" company="OpenTelemetry Authors">
+// <copyright file="RecordStatus.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Resources/Resource.cs
+++ b/src/OpenTelemetry/Resources/Resource.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Resource.cs" company="OpenTelemetry Authors">
+// <copyright file="Resource.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Resources/Resources.cs
+++ b/src/OpenTelemetry/Resources/Resources.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Resources.cs" company="OpenTelemetry Authors">
+// <copyright file="Resources.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Sdk.cs
+++ b/src/OpenTelemetry/Sdk.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Sdk.cs" company="OpenTelemetry Authors">
+// <copyright file="Sdk.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/SuppressInstrumentationScope.cs
+++ b/src/OpenTelemetry/SuppressInstrumentationScope.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SuppressInstrumentationScope.cs" company="OpenTelemetry Authors">
+// <copyright file="SuppressInstrumentationScope.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Trace/ActivityExporter.cs
+++ b/src/OpenTelemetry/Trace/ActivityExporter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ActivityExporter.cs" company="OpenTelemetry Authors">
+// <copyright file="ActivityExporter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Trace/ActivityExtensions.cs
+++ b/src/OpenTelemetry/Trace/ActivityExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ActivityExtensions.cs" company="OpenTelemetry Authors">
+// <copyright file="ActivityExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Trace/ActivityProcessor.cs
+++ b/src/OpenTelemetry/Trace/ActivityProcessor.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ActivityProcessor.cs" company="OpenTelemetry Authors">
+// <copyright file="ActivityProcessor.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
+++ b/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ActivitySourceAdapter.cs" company="OpenTelemetry Authors">
+// <copyright file="ActivitySourceAdapter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Trace/AlwaysOffSampler.cs
+++ b/src/OpenTelemetry/Trace/AlwaysOffSampler.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AlwaysOffSampler.cs" company="OpenTelemetry Authors">
+// <copyright file="AlwaysOffSampler.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Trace/AlwaysOnSampler.cs
+++ b/src/OpenTelemetry/Trace/AlwaysOnSampler.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AlwaysOnSampler.cs" company="OpenTelemetry Authors">
+// <copyright file="AlwaysOnSampler.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Trace/BaseExportActivityProcessor.cs
+++ b/src/OpenTelemetry/Trace/BaseExportActivityProcessor.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="BaseExportActivityProcessor.cs" company="OpenTelemetry Authors">
+// <copyright file="BaseExportActivityProcessor.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Trace/BatchExportActivityProcessor.cs
+++ b/src/OpenTelemetry/Trace/BatchExportActivityProcessor.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="BatchExportActivityProcessor.cs" company="OpenTelemetry Authors">
+// <copyright file="BatchExportActivityProcessor.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Trace/CompositeActivityProcessor.cs
+++ b/src/OpenTelemetry/Trace/CompositeActivityProcessor.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="CompositeActivityProcessor.cs" company="OpenTelemetry Authors">
+// <copyright file="CompositeActivityProcessor.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Trace/ParentBasedSampler.cs
+++ b/src/OpenTelemetry/Trace/ParentBasedSampler.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ParentBasedSampler.cs" company="OpenTelemetry Authors">
+// <copyright file="ParentBasedSampler.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Trace/ReentrantExportActivityProcessor.cs
+++ b/src/OpenTelemetry/Trace/ReentrantExportActivityProcessor.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ReentrantExportActivityProcessor.cs" company="OpenTelemetry Authors">
+// <copyright file="ReentrantExportActivityProcessor.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Trace/Sampler.cs
+++ b/src/OpenTelemetry/Trace/Sampler.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Sampler.cs" company="OpenTelemetry Authors">
+// <copyright file="Sampler.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Trace/SamplingDecision.cs
+++ b/src/OpenTelemetry/Trace/SamplingDecision.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SamplingDecision.cs" company="OpenTelemetry Authors">
+// <copyright file="SamplingDecision.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Trace/SamplingParameters.cs
+++ b/src/OpenTelemetry/Trace/SamplingParameters.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SamplingParameters.cs" company="OpenTelemetry Authors">
+// <copyright file="SamplingParameters.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Trace/SamplingResult.cs
+++ b/src/OpenTelemetry/Trace/SamplingResult.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SamplingResult.cs" company="OpenTelemetry Authors">
+// <copyright file="SamplingResult.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Trace/SimpleExportActivityProcessor.cs
+++ b/src/OpenTelemetry/Trace/SimpleExportActivityProcessor.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SimpleExportActivityProcessor.cs" company="OpenTelemetry Authors">
+// <copyright file="SimpleExportActivityProcessor.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Trace/TraceIdRatioBasedSampler.cs
+++ b/src/OpenTelemetry/Trace/TraceIdRatioBasedSampler.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TraceIdRatioBasedSampler.cs" company="OpenTelemetry Authors">
+// <copyright file="TraceIdRatioBasedSampler.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Trace/TracerProviderBuilder.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderBuilder.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TracerProviderBuilder.cs" company="OpenTelemetry Authors">
+// <copyright file="TracerProviderBuilder.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Trace/TracerProviderExtensions.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TracerProviderExtensions.cs" company="OpenTelemetry Authors">
+// <copyright file="TracerProviderExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TracerProviderSdk.cs" company="OpenTelemetry Authors">
+// <copyright file="TracerProviderSdk.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/Benchmarks/ActivityBenchmarks.cs
+++ b/test/Benchmarks/ActivityBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ActivityBenchmarks.cs" company="OpenTelemetry Authors">
+// <copyright file="ActivityBenchmarks.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/Benchmarks/Exporter/JaegerExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/JaegerExporterBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="JaegerExporterBenchmarks.cs" company="OpenTelemetry Authors">
+// <copyright file="JaegerExporterBenchmarks.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/Benchmarks/Exporter/ZipkinExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/ZipkinExporterBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ZipkinExporterBenchmarks.cs" company="OpenTelemetry Authors">
+// <copyright file="ZipkinExporterBenchmarks.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/Benchmarks/Helper/LocalServer.cs
+++ b/test/Benchmarks/Helper/LocalServer.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="LocalServer.cs" company="OpenTelemetry Authors">
+// <copyright file="LocalServer.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/Benchmarks/Instrumentation/InstrumentedAspNetCoreBenchmark.cs
+++ b/test/Benchmarks/Instrumentation/InstrumentedAspNetCoreBenchmark.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="InstrumentedAspNetCoreBenchmark.cs" company="OpenTelemetry Authors">
+// <copyright file="InstrumentedAspNetCoreBenchmark.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/Benchmarks/Instrumentation/InstrumentedHttpClientBenchmark.cs
+++ b/test/Benchmarks/Instrumentation/InstrumentedHttpClientBenchmark.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="InstrumentedHttpClientBenchmark.cs" company="OpenTelemetry Authors">
+// <copyright file="InstrumentedHttpClientBenchmark.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/Benchmarks/Instrumentation/UninstrumentedAspNetCoreBenchmark.cs
+++ b/test/Benchmarks/Instrumentation/UninstrumentedAspNetCoreBenchmark.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="UninstrumentedAspNetCoreBenchmark.cs" company="OpenTelemetry Authors">
+// <copyright file="UninstrumentedAspNetCoreBenchmark.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/Benchmarks/Instrumentation/UninstrumentedHttpClientBenchmark.cs
+++ b/test/Benchmarks/Instrumentation/UninstrumentedHttpClientBenchmark.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="UninstrumentedHttpClientBenchmark.cs" company="OpenTelemetry Authors">
+// <copyright file="UninstrumentedHttpClientBenchmark.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/Benchmarks/Program.cs
+++ b/test/Benchmarks/Program.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Program.cs" company="OpenTelemetry Authors">
+// <copyright file="Program.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/Benchmarks/Tracing/ActivityCreationScenarios.cs
+++ b/test/Benchmarks/Tracing/ActivityCreationScenarios.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ActivityCreationScenarios.cs" company="OpenTelemetry Authors">
+// <copyright file="ActivityCreationScenarios.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/Benchmarks/Tracing/ActivitySourceAdapterBenchmark.cs
+++ b/test/Benchmarks/Tracing/ActivitySourceAdapterBenchmark.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ActivitySourceAdapterBenchmark.cs" company="OpenTelemetry Authors">
+// <copyright file="ActivitySourceAdapterBenchmark.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/Benchmarks/Tracing/OpenTelemetrySdkBenchmarks.cs
+++ b/test/Benchmarks/Tracing/OpenTelemetrySdkBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="OpenTelemetrySdkBenchmarks.cs" company="OpenTelemetry Authors">
+// <copyright file="OpenTelemetrySdkBenchmarks.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/Benchmarks/Tracing/OpenTelemetrySdkBenchmarksActivity.cs
+++ b/test/Benchmarks/Tracing/OpenTelemetrySdkBenchmarksActivity.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="OpenTelemetrySdkBenchmarksActivity.cs" company="OpenTelemetry Authors">
+// <copyright file="OpenTelemetrySdkBenchmarksActivity.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/Benchmarks/Tracing/SpanCreationScenarios.cs
+++ b/test/Benchmarks/Tracing/SpanCreationScenarios.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SpanCreationScenarios.cs" company="OpenTelemetry Authors">
+// <copyright file="SpanCreationScenarios.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/Benchmarks/Tracing/TraceBenchmarks.cs
+++ b/test/Benchmarks/Tracing/TraceBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TraceBenchmarks.cs" company="OpenTelemetry Authors">
+// <copyright file="TraceBenchmarks.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/Benchmarks/Tracing/TraceShimBenchmarks.cs
+++ b/test/Benchmarks/Tracing/TraceShimBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TraceShimBenchmarks.cs" company="OpenTelemetry Authors">
+// <copyright file="TraceShimBenchmarks.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/EventSourceTest.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/EventSourceTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="EventSourceTest.cs" company="OpenTelemetry Authors">
+// <copyright file="EventSourceTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/Int128Test.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/Int128Test.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Int128Test.cs" company="OpenTelemetry Authors">
+// <copyright file="Int128Test.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerActivityConversionTest.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerActivityConversionTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="JaegerActivityConversionTest.cs" company="OpenTelemetry Authors">
+// <copyright file="JaegerActivityConversionTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/ThriftUdpClientTransportTests.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/ThriftUdpClientTransportTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ThriftUdpClientTransportTests.cs" company="OpenTelemetry Authors">
+// <copyright file="ThriftUdpClientTransportTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="JaegerExporterTests.cs" company="OpenTelemetry Authors">
+// <copyright file="JaegerExporterTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/EventSourceTest.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/EventSourceTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="EventSourceTest.cs" company="OpenTelemetry Authors">
+// <copyright file="EventSourceTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterTest.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="OtlpExporterTest.cs" company="OpenTelemetry Authors">
+// <copyright file="OtlpExporterTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/EventSourceTest.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/EventSourceTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="EventSourceTest.cs" company="OpenTelemetry Authors">
+// <copyright file="EventSourceTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/Implementation/PrometheusMetricBuilderTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/Implementation/PrometheusMetricBuilderTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="PrometheusMetricBuilderTests.cs" company="OpenTelemetry Authors">
+// <copyright file="PrometheusMetricBuilderTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="PrometheusExporterTests.cs" company="OpenTelemetry Authors">
+// <copyright file="PrometheusExporterTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Exporter.ZPages.Tests/EventSourceTest.cs
+++ b/test/OpenTelemetry.Exporter.ZPages.Tests/EventSourceTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="EventSourceTest.cs" company="OpenTelemetry Authors">
+// <copyright file="EventSourceTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Exporter.ZPages.Tests/ZPagesActivityTrackerTests.cs
+++ b/test/OpenTelemetry.Exporter.ZPages.Tests/ZPagesActivityTrackerTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ZPagesActivityTrackerTests.cs" company="OpenTelemetry Authors">
+// <copyright file="ZPagesActivityTrackerTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Exporter.ZPages.Tests/ZPagesExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.ZPages.Tests/ZPagesExporterTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ZPagesExporterTests.cs" company="OpenTelemetry Authors">
+// <copyright file="ZPagesExporterTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/EventSourceTest.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/EventSourceTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="EventSourceTest.cs" company="OpenTelemetry Authors">
+// <copyright file="EventSourceTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionExtensionsTest.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionExtensionsTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ZipkinActivityConversionExtensionsTest.cs" company="OpenTelemetry Authors">
+// <copyright file="ZipkinActivityConversionExtensionsTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionTest.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ZipkinActivityConversionTest.cs" company="OpenTelemetry Authors">
+// <copyright file="ZipkinActivityConversionTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityExporterRemoteEndpointTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityExporterRemoteEndpointTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ZipkinActivityExporterRemoteEndpointTests.cs" company="OpenTelemetry Authors">
+// <copyright file="ZipkinActivityExporterRemoteEndpointTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ZipkinExporterTests.cs" company="OpenTelemetry Authors">
+// <copyright file="ZipkinExporterTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/EventSourceTest.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/EventSourceTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="EventSourceTest.cs" company="OpenTelemetry Authors">
+// <copyright file="EventSourceTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/HostingExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/HostingExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HostingExtensionsTests.cs" company="OpenTelemetry Authors">
+// <copyright file="HostingExtensionsTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/BasicTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="BasicTests.cs" company="OpenTelemetry Authors">
+// <copyright file="BasicTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/EventSourceTest.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/EventSourceTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="EventSourceTest.cs" company="OpenTelemetry Authors">
+// <copyright file="EventSourceTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HttpInListenerTests.cs" company="OpenTelemetry Authors">
+// <copyright file="HttpInListenerTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/AttributesExtensions.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/AttributesExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AttributesExtensions.cs" company="OpenTelemetry Authors">
+// <copyright file="AttributesExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="BasicTests.cs" company="OpenTelemetry Authors">
+// <copyright file="BasicTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/EventSourceTest.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/EventSourceTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="EventSourceTest.cs" company="OpenTelemetry Authors">
+// <copyright file="EventSourceTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs" company="OpenTelemetry Authors">
+// <copyright file="IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/EventSourceTest.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/EventSourceTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="EventSourceTest.cs" company="OpenTelemetry Authors">
+// <copyright file="EventSourceTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcFixture.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcFixture.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="GrpcFixture.cs" company="OpenTelemetry Authors">
+// <copyright file="GrpcFixture.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTagHelperTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTagHelperTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="GrpcTagHelperTests.cs" company="OpenTelemetry Authors">
+// <copyright file="GrpcTagHelperTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.client.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.client.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="GrpcTests.client.cs" company="OpenTelemetry Authors">
+// <copyright file="GrpcTests.client.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.server.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.server.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="GrpcTests.server.cs" company="OpenTelemetry Authors">
+// <copyright file="GrpcTests.server.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/Services/GreeterService.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/Services/GreeterService.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="GreeterService.cs" company="OpenTelemetry Authors">
+// <copyright file="GreeterService.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/EventSourceTest.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/EventSourceTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="EventSourceTest.cs" company="OpenTelemetry Authors">
+// <copyright file="EventSourceTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.netcore31.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.netcore31.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HttpClientTests.Basic.netcore31.cs" company="OpenTelemetry Authors">
+// <copyright file="HttpClientTests.Basic.netcore31.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.netcore31.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.netcore31.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HttpClientTests.netcore31.cs" company="OpenTelemetry Authors">
+// <copyright file="HttpClientTests.netcore31.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpTestData.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpTestData.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HttpTestData.cs" company="OpenTelemetry Authors">
+// <copyright file="HttpTestData.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestActivitySourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestActivitySourceTests.netfx.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HttpWebRequestActivitySourceTests.netfx.cs" company="OpenTelemetry Authors">
+// <copyright file="HttpWebRequestActivitySourceTests.netfx.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.Basic.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.Basic.netfx.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HttpWebRequestTests.Basic.netfx.cs" company="OpenTelemetry Authors">
+// <copyright file="HttpWebRequestTests.Basic.netfx.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.netfx.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HttpWebRequestTests.netfx.cs" company="OpenTelemetry Authors">
+// <copyright file="HttpWebRequestTests.netfx.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/EventSourceTest.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/EventSourceTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="EventSourceTest.cs" company="OpenTelemetry Authors">
+// <copyright file="EventSourceTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientInstrumentationOptionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientInstrumentationOptionsTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SqlClientInstrumentationOptionsTests.cs" company="OpenTelemetry Authors">
+// <copyright file="SqlClientInstrumentationOptionsTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SqlClientTests.cs" company="OpenTelemetry Authors">
+// <copyright file="SqlClientTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SqlEventSourceTests.netfx.cs" company="OpenTelemetry Authors">
+// <copyright file="SqlEventSourceTests.netfx.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToActivityConverterTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToActivityConverterTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="RedisProfilerEntryToActivityConverterTests.cs" company="OpenTelemetry Authors">
+// <copyright file="RedisProfilerEntryToActivityConverterTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="StackExchangeRedisCallsInstrumentationTests.cs" company="OpenTelemetry Authors">
+// <copyright file="StackExchangeRedisCallsInstrumentationTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/InProcessServer.cs
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/InProcessServer.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="InProcessServer.cs" company="OpenTelemetry Authors">
+// <copyright file="InProcessServer.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/W3CTraceContextTests.cs
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/W3CTraceContextTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="W3CTraceContextTests.cs" company="OpenTelemetry Authors">
+// <copyright file="W3CTraceContextTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/ScopeManagerShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/ScopeManagerShimTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ScopeManagerShimTests.cs" company="OpenTelemetry Authors">
+// <copyright file="ScopeManagerShimTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanBuilderShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanBuilderShimTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SpanBuilderShimTests.cs" company="OpenTelemetry Authors">
+// <copyright file="SpanBuilderShimTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanContextShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanContextShimTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SpanContextShimTests.cs" company="OpenTelemetry Authors">
+// <copyright file="SpanContextShimTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SpanShimTests.cs" company="OpenTelemetry Authors">
+// <copyright file="SpanShimTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/TracerShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/TracerShimTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TracerShimTests.cs" company="OpenTelemetry Authors">
+// <copyright file="TracerShimTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/BaggageTests.cs
+++ b/test/OpenTelemetry.Tests/BaggageTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="BaggageTests.cs" company="OpenTelemetry Authors">
+// <copyright file="BaggageTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Context/RuntimeContextTest.cs
+++ b/test/OpenTelemetry.Tests/Context/RuntimeContextTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="RuntimeContextTest.cs" company="OpenTelemetry Authors">
+// <copyright file="RuntimeContextTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/EventSourceTest.cs
+++ b/test/OpenTelemetry.Tests/EventSourceTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="EventSourceTest.cs" company="OpenTelemetry Authors">
+// <copyright file="EventSourceTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Instrumentation/DiagnosticSourceListenerTest.cs
+++ b/test/OpenTelemetry.Tests/Instrumentation/DiagnosticSourceListenerTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DiagnosticSourceListenerTest.cs" company="OpenTelemetry Authors">
+// <copyright file="DiagnosticSourceListenerTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Instrumentation/PropertyFetcherTest.cs
+++ b/test/OpenTelemetry.Tests/Instrumentation/PropertyFetcherTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="PropertyFetcherTest.cs" company="OpenTelemetry Authors">
+// <copyright file="PropertyFetcherTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Instrumentation/TestListenerHandler.cs
+++ b/test/OpenTelemetry.Tests/Instrumentation/TestListenerHandler.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TestListenerHandler.cs" company="OpenTelemetry Authors">
+// <copyright file="TestListenerHandler.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Internal/CircularBufferTest.cs
+++ b/test/OpenTelemetry.Tests/Internal/CircularBufferTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="CircularBufferTest.cs" company="OpenTelemetry Authors">
+// <copyright file="CircularBufferTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Metrics/Aggregators/CounterAggregatorTest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/Aggregators/CounterAggregatorTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="CounterAggregatorTest.cs" company="OpenTelemetry Authors">
+// <copyright file="CounterAggregatorTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Metrics/Aggregators/LastValueAggregatorTest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/Aggregators/LastValueAggregatorTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="LastValueAggregatorTest.cs" company="OpenTelemetry Authors">
+// <copyright file="LastValueAggregatorTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Metrics/Aggregators/MinMaxSumCountAggregatorTest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/Aggregators/MinMaxSumCountAggregatorTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MinMaxSumCountAggregatorTest.cs" company="OpenTelemetry Authors">
+// <copyright file="MinMaxSumCountAggregatorTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Metrics/CounterCleanUpTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/CounterCleanUpTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="CounterCleanUpTests.cs" company="OpenTelemetry Authors">
+// <copyright file="CounterCleanUpTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Metrics/LabelSetTest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/LabelSetTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="LabelSetTest.cs" company="OpenTelemetry Authors">
+// <copyright file="LabelSetTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Metrics/MeterFactoryTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MeterFactoryTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MeterFactoryTests.cs" company="OpenTelemetry Authors">
+// <copyright file="MeterFactoryTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Metrics/MeterProviderTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MeterProviderTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MeterProviderTests.cs" company="OpenTelemetry Authors">
+// <copyright file="MeterProviderTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Metrics/MetricsTest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricsTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MetricsTest.cs" company="OpenTelemetry Authors">
+// <copyright file="MetricsTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Metrics/PushControllerTest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/PushControllerTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="PushControllerTest.cs" company="OpenTelemetry Authors">
+// <copyright file="PushControllerTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Metrics/TestMeter.cs
+++ b/test/OpenTelemetry.Tests/Metrics/TestMeter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TestMeter.cs" company="OpenTelemetry Authors">
+// <copyright file="TestMeter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Metrics/TestMetricExporter.cs
+++ b/test/OpenTelemetry.Tests/Metrics/TestMetricExporter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TestMetricExporter.cs" company="OpenTelemetry Authors">
+// <copyright file="TestMetricExporter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Metrics/TestMetricProcessor.cs
+++ b/test/OpenTelemetry.Tests/Metrics/TestMetricProcessor.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TestMetricProcessor.cs" company="OpenTelemetry Authors">
+// <copyright file="TestMetricProcessor.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Resources/ResourceTest.cs
+++ b/test/OpenTelemetry.Tests/Resources/ResourceTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ResourceTest.cs" company="OpenTelemetry Authors">
+// <copyright file="ResourceTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Resources/ResourcesTests.cs
+++ b/test/OpenTelemetry.Tests/Resources/ResourcesTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ResourcesTests.cs" company="OpenTelemetry Authors">
+// <copyright file="ResourcesTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Shared/EventSourceTestHelper.cs
+++ b/test/OpenTelemetry.Tests/Shared/EventSourceTestHelper.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="EventSourceTestHelper.cs" company="OpenTelemetry Authors">
+// <copyright file="EventSourceTestHelper.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Shared/InMemoryEventListener.cs
+++ b/test/OpenTelemetry.Tests/Shared/InMemoryEventListener.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="InMemoryEventListener.cs" company="OpenTelemetry Authors">
+// <copyright file="InMemoryEventListener.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Shared/SkipUnlessEnvVarFoundTheoryAttribute.cs
+++ b/test/OpenTelemetry.Tests/Shared/SkipUnlessEnvVarFoundTheoryAttribute.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SkipUnlessEnvVarFoundTheoryAttribute.cs" company="OpenTelemetry Authors">
+// <copyright file="SkipUnlessEnvVarFoundTheoryAttribute.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Shared/TestActivityExporter.cs
+++ b/test/OpenTelemetry.Tests/Shared/TestActivityExporter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TestActivityExporter.cs" company="OpenTelemetry Authors">
+// <copyright file="TestActivityExporter.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Shared/TestActivityProcessor.cs
+++ b/test/OpenTelemetry.Tests/Shared/TestActivityProcessor.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TestActivityProcessor.cs" company="OpenTelemetry Authors">
+// <copyright file="TestActivityProcessor.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Shared/TestEventListener.cs
+++ b/test/OpenTelemetry.Tests/Shared/TestEventListener.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TestEventListener.cs" company="OpenTelemetry Authors">
+// <copyright file="TestEventListener.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Shared/TestHttpServer.cs
+++ b/test/OpenTelemetry.Tests/Shared/TestHttpServer.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TestHttpServer.cs" company="OpenTelemetry Authors">
+// <copyright file="TestHttpServer.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Shared/TestSampler.cs
+++ b/test/OpenTelemetry.Tests/Shared/TestSampler.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TestSampler.cs" company="OpenTelemetry Authors">
+// <copyright file="TestSampler.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/SuppressInstrumentationTest.cs
+++ b/test/OpenTelemetry.Tests/SuppressInstrumentationTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SuppressInstrumentationTest.cs" company="OpenTelemetry Authors">
+// <copyright file="SuppressInstrumentationTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Trace/ActivityExtensionsTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ActivityExtensionsTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ActivityExtensionsTest.cs" company="OpenTelemetry Authors">
+// <copyright file="ActivityExtensionsTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Trace/ActivitySourceAdapterTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ActivitySourceAdapterTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ActivitySourceAdapterTest.cs" company="OpenTelemetry Authors">
+// <copyright file="ActivitySourceAdapterTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Trace/AttributesExtensions.cs
+++ b/test/OpenTelemetry.Tests/Trace/AttributesExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AttributesExtensions.cs" company="OpenTelemetry Authors">
+// <copyright file="AttributesExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="BatchExportActivityProcessorTest.cs" company="OpenTelemetry Authors">
+// <copyright file="BatchExportActivityProcessorTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Trace/BatchTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/BatchTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="BatchTest.cs" company="OpenTelemetry Authors">
+// <copyright file="BatchTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Trace/CompositeActivityProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/CompositeActivityProcessorTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="CompositeActivityProcessorTests.cs" company="OpenTelemetry Authors">
+// <copyright file="CompositeActivityProcessorTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Trace/CurrentSpanTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/CurrentSpanTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="CurrentSpanTests.cs" company="OpenTelemetry Authors">
+// <copyright file="CurrentSpanTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Trace/LinkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/LinkTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="LinkTest.cs" company="OpenTelemetry Authors">
+// <copyright file="LinkTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Trace/OpenTelemetrySdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/OpenTelemetrySdkTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="OpenTelemetrySdkTest.cs" company="OpenTelemetry Authors">
+// <copyright file="OpenTelemetrySdkTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Trace/ParentBasedSamplerTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/ParentBasedSamplerTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ParentBasedSamplerTests.cs" company="OpenTelemetry Authors">
+// <copyright file="ParentBasedSamplerTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Trace/Propagation/B3PropagatorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/B3PropagatorTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="B3PropagatorTest.cs" company="OpenTelemetry Authors">
+// <copyright file="B3PropagatorTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Trace/Propagation/BaggagePropagatorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/BaggagePropagatorTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="BaggagePropagatorTest.cs" company="OpenTelemetry Authors">
+// <copyright file="BaggagePropagatorTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Trace/Propagation/CompositePropagatorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/CompositePropagatorTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="CompositePropagatorTest.cs" company="OpenTelemetry Authors">
+// <copyright file="CompositePropagatorTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Trace/Propagation/TestPropagator.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/TestPropagator.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TestPropagator.cs" company="OpenTelemetry Authors">
+// <copyright file="TestPropagator.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Trace/Propagation/TextMapPropagatorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/TextMapPropagatorTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TextMapPropagatorTest.cs" company="OpenTelemetry Authors">
+// <copyright file="TextMapPropagatorTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Trace/Propagation/TracestateUtilsTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/TracestateUtilsTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TracestateUtilsTests.cs" company="OpenTelemetry Authors">
+// <copyright file="TracestateUtilsTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Trace/ReentrantExportActivityProcessorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ReentrantExportActivityProcessorTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ReentrantExportActivityProcessorTest.cs" company="OpenTelemetry Authors">
+// <copyright file="ReentrantExportActivityProcessorTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Trace/SamplersTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/SamplersTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SamplersTest.cs" company="OpenTelemetry Authors">
+// <copyright file="SamplersTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Trace/SimpleExportActivityProcessorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/SimpleExportActivityProcessorTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SimpleExportActivityProcessorTest.cs" company="OpenTelemetry Authors">
+// <copyright file="SimpleExportActivityProcessorTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Trace/SpanAttributesTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/SpanAttributesTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SpanAttributesTest.cs" company="OpenTelemetry Authors">
+// <copyright file="SpanAttributesTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Trace/SpanContextTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/SpanContextTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SpanContextTest.cs" company="OpenTelemetry Authors">
+// <copyright file="SpanContextTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Trace/StatusTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/StatusTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="StatusTest.cs" company="OpenTelemetry Authors">
+// <copyright file="StatusTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Trace/TelemetrySpanTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TelemetrySpanTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TelemetrySpanTest.cs" company="OpenTelemetry Authors">
+// <copyright file="TelemetrySpanTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Trace/TraceIdRatioBasedSamplerTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TraceIdRatioBasedSamplerTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TraceIdRatioBasedSamplerTest.cs" company="OpenTelemetry Authors">
+// <copyright file="TraceIdRatioBasedSamplerTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TracerProviderSdkTest.cs" company="OpenTelemetry Authors">
+// <copyright file="TracerProviderSdkTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Trace/TracerTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TracerTest.cs" company="OpenTelemetry Authors">
+// <copyright file="TracerTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Utils/CanonicalCodeExtensions.cs
+++ b/test/OpenTelemetry.Tests/Utils/CanonicalCodeExtensions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="CanonicalCodeExtensions.cs" company="OpenTelemetry Authors">
+// <copyright file="CanonicalCodeExtensions.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/TestApp.AspNetCore.2.1/AssemblyInfo.cs
+++ b/test/TestApp.AspNetCore.2.1/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
+// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/TestApp.AspNetCore.2.1/CallbackMiddleware.cs
+++ b/test/TestApp.AspNetCore.2.1/CallbackMiddleware.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="CallbackMiddleware.cs" company="OpenTelemetry Authors">
+// <copyright file="CallbackMiddleware.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/TestApp.AspNetCore.2.1/Controllers/ForwardController.cs
+++ b/test/TestApp.AspNetCore.2.1/Controllers/ForwardController.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ForwardController.cs" company="OpenTelemetry Authors">
+// <copyright file="ForwardController.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/TestApp.AspNetCore.2.1/Controllers/ValuesController.cs
+++ b/test/TestApp.AspNetCore.2.1/Controllers/ValuesController.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ValuesController.cs" company="OpenTelemetry Authors">
+// <copyright file="ValuesController.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/TestApp.AspNetCore.2.1/Program.cs
+++ b/test/TestApp.AspNetCore.2.1/Program.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Program.cs" company="OpenTelemetry Authors">
+// <copyright file="Program.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/TestApp.AspNetCore.2.1/Startup.cs
+++ b/test/TestApp.AspNetCore.2.1/Startup.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Startup.cs" company="OpenTelemetry Authors">
+// <copyright file="Startup.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/TestApp.AspNetCore.3.1/AssemblyInfo.cs
+++ b/test/TestApp.AspNetCore.3.1/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
+// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/TestApp.AspNetCore.3.1/CallbackMiddleware.cs
+++ b/test/TestApp.AspNetCore.3.1/CallbackMiddleware.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="CallbackMiddleware.cs" company="OpenTelemetry Authors">
+// <copyright file="CallbackMiddleware.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/TestApp.AspNetCore.3.1/Controllers/ForwardController.cs
+++ b/test/TestApp.AspNetCore.3.1/Controllers/ForwardController.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ForwardController.cs" company="OpenTelemetry Authors">
+// <copyright file="ForwardController.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/TestApp.AspNetCore.3.1/Controllers/ValuesController.cs
+++ b/test/TestApp.AspNetCore.3.1/Controllers/ValuesController.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ValuesController.cs" company="OpenTelemetry Authors">
+// <copyright file="ValuesController.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/TestApp.AspNetCore.3.1/Program.cs
+++ b/test/TestApp.AspNetCore.3.1/Program.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Program.cs" company="OpenTelemetry Authors">
+// <copyright file="Program.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/TestApp.AspNetCore.3.1/Startup.cs
+++ b/test/TestApp.AspNetCore.3.1/Startup.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Startup.cs" company="OpenTelemetry Authors">
+// <copyright file="Startup.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This is a follow-up work from what @reyang have been doing from formatting the files using:
- utf8 (without bom)
- new line at end

Right now, with the changes in the editorconfig, this will be enforced with `dotnet-format`. All the changes below are just a normalization of the format, so no change in code.

To do that we can simple use: `dotnet-format --folder`, it will update all files that aren't compliant.

If you just want to check, you should use: `dotnet-format --folder --check`

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
