### PR TITLE
Make PropertyFetcher work for multiple target object types

### DIFF
--- a/src/OpenTelemetry/Instrumentation/PropertyFetcher.cs
+++ b/src/OpenTelemetry/Instrumentation/PropertyFetcher.cs
@@ -57,8 +57,7 @@ namespace OpenTelemetry.Instrumentation
                 var property = type.DeclaredProperties.FirstOrDefault(p => string.Equals(p.Name, this.propertyName, StringComparison.InvariantCultureIgnoreCase));
                 if (property == null)
                 {
-                    property = type.GetProperty(this.propertyName, BindingFlags.Public | BindingFlags.NonPublic);
-                    var field = type.GetField(this.propertyName, BindingFlags.Public | BindingFlags.NonPublic);
+                    property = type.GetProperty(this.propertyName, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
                 }
 
                 return PropertyFetch.FetcherForProperty(property);

--- a/src/OpenTelemetry/Instrumentation/PropertyFetcher.cs
+++ b/src/OpenTelemetry/Instrumentation/PropertyFetcher.cs
@@ -46,6 +46,11 @@ namespace OpenTelemetry.Instrumentation
         /// <returns>Property fetched.</returns>
         public T Fetch(object obj)
         {
+            if (obj == null)
+            {
+                return default(T);
+            }
+
             var type = obj.GetType().GetTypeInfo();
             var fetcher = this.innerFetcher.GetOrAdd(type, t =>
             {

--- a/test/OpenTelemetry.Tests/Instrumentation/PropertyFetcherTest.cs
+++ b/test/OpenTelemetry.Tests/Instrumentation/PropertyFetcherTest.cs
@@ -45,5 +45,20 @@ namespace OpenTelemetry.Tests.Instrumentation
             Assert.Equal(default, result);
             Assert.Equal(default, resultInt);
         }
+
+        [Fact]
+        public void FetchPropertyFromMultipeTypes()
+        {
+            var activity = new Activity("test");
+            var fetch = new PropertyFetcher<string>("DisplayName");
+            var result = fetch.Fetch(activity);
+
+            Assert.Equal(activity.DisplayName, result);
+
+            var test = new { DisplayName = "Test" };
+            result = fetch.Fetch(test);
+
+            Assert.Equal(test.DisplayName, result);
+        }
     }
 }

--- a/test/OpenTelemetry.Tests/Instrumentation/PropertyFetcherTest.cs
+++ b/test/OpenTelemetry.Tests/Instrumentation/PropertyFetcherTest.cs
@@ -60,5 +60,14 @@ namespace OpenTelemetry.Tests.Instrumentation
 
             Assert.Equal(test.DisplayName, result);
         }
+
+        [Fact]
+        public void FetchPropertyHandlesNullObject()
+        {
+            var fetch = new PropertyFetcher<string>("DisplayName");
+            var result = fetch.Fetch(null);
+
+            Assert.Null(result);
+        }
     }
 }


### PR DESCRIPTION
The Elasticsearch instrumentation is passing in various different object types as the payload from their event source. When that happens the PropertyFetcher fails because it is caching the innerFetcher based on the first object type it sees. This changes adds a concurrent dictionary of fetchers for any target types that are passed in. I think what the Elasticsearch client is doing is considered bad practice so you may not want to take this change, but I can say though that it is super confusing when this happens and it seems like the property fetcher is randomly failing. Thoughts?