### PR TITLE
Correct check for activity is root in OTLP

### DIFF
--- a/.github/workflows/dotnet-core-linux.yml
+++ b/.github/workflows/dotnet-core-linux.yml
@@ -27,11 +27,6 @@ jobs:
       with:
         dotnet-version: 3.1.301
 
-    # For linux, we have to apply a workaround to enable both dotnet versions at same time
-    #- name: .net SxS
-    #  run: |
-    #    rsync -a ${DOTNET_ROOT/3.1.301/2.1.807}/* $DOTNET_ROOT/
-
     - name: Install dependencies
       run: dotnet restore
 

--- a/.github/workflows/dotnet-core-linux.yml
+++ b/.github/workflows/dotnet-core-linux.yml
@@ -28,9 +28,9 @@ jobs:
         dotnet-version: 3.1.301
 
     # For linux, we have to apply a workaround to enable both dotnet versions at same time
-    - name: .net SxS
-      run: |
-        rsync -a ${DOTNET_ROOT/3.1.301/2.1.807}/* $DOTNET_ROOT/
+    #- name: .net SxS
+    #  run: |
+    #    rsync -a ${DOTNET_ROOT/3.1.301/2.1.807}/* $DOTNET_ROOT/
 
     - name: Install dependencies
       run: dotnet restore

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
@@ -91,7 +91,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
             var parentSpanIdString = ByteString.Empty;
             if (activity.ParentSpanId.ToHexString() != EmptyActivitySpanId)
             {
-                // Once .NET fixes this https://github.com/dotnet/runtime/issues/42456
+                // TODO: Once .NET fixes this https://github.com/dotnet/runtime/issues/42456
                 // and Otel updates to the version containing the fix,
                 // the above check can be simplified to
                 // if (activity.ParentSpanId != default)

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
@@ -91,6 +91,10 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
             var parentSpanIdString = ByteString.Empty;
             if (activity.ParentSpanId.ToHexString() != EmptyActivitySpanId)
             {
+                // Once .NET fixes this https://github.com/dotnet/runtime/issues/42456
+                // and Otel updates to the version containing the fix,
+                // the above check can be simplified to
+                // if (activity.ParentSpanId != default)
                 Span<byte> parentSpanIdBytes = stackalloc byte[8];
                 activity.ParentSpanId.CopyTo(parentSpanIdBytes);
                 parentSpanIdString = ByteString.CopyFrom(parentSpanIdBytes.ToArray());

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
@@ -30,6 +30,8 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
 {
     internal static class ActivityExtensions
     {
+        private static readonly string EmptyActivitySpanId = default(ActivitySpanId).ToHexString();
+
         internal static IEnumerable<OtlpTrace.ResourceSpans> ToOtlpResourceSpans(this IEnumerable<Activity> activityBatch)
         {
             var resourceToLibraryAndSpans = GroupByResourceAndLibrary(activityBatch);
@@ -87,7 +89,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
             activity.SpanId.CopyTo(spanIdBytes);
 
             var parentSpanIdString = ByteString.Empty;
-            if (activity.ParentSpanId != default)
+            if (activity.ParentSpanId.ToHexString() != EmptyActivitySpanId)
             {
                 Span<byte> parentSpanIdBytes = stackalloc byte[8];
                 activity.ParentSpanId.CopyTo(parentSpanIdBytes);

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
@@ -43,8 +43,9 @@ namespace OpenTelemetry.Trace.Tests
             {
                 Assert.NotNull(rootActivity);
 
-                // TODO: Follow up with .NET on why ParentSpanId is != default here.
-                // Assert.True(rootActivity.ParentSpanId == default);
+                // Known issue: https://github.com/dotnet/runtime/issues/42456
+                // hence rootActivity.ParentSpanId == default, may not be true.
+                Assert.True(rootActivity.ParentSpanId == default || rootActivity.ParentSpanId.ToHexString() == default(ActivitySpanId).ToHexString());
 
                 // Validate that the TraceId seen by Sampler is same as the
                 // Activity when it got created.


### PR DESCRIPTION
Workaround and Fixes #1288.

Won't need workaround once this is fixed in .NET runtime itself :https://github.com/dotnet/runtime/issues/42456

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
