### PR TITLE
Added Activity.EnumerateLinks extension

### DIFF
--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Added `ILogger`/`Microsoft.Extensions.Logging` integration
   ([#1308](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1308))
+* `IActivityTagEnumerator` is now `IActivityEnumerator<T>`. Added
+  `EnumerateLinks` extension method on `Activity` for retrieving links
+  efficiently
+  ([#1314](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1314))
 
 ## 0.6.0-beta.1
 

--- a/src/OpenTelemetry.Api/Trace/IActivityEnumerator.cs
+++ b/src/OpenTelemetry.Api/Trace/IActivityEnumerator.cs
@@ -1,4 +1,4 @@
-// <copyright file="IActivityTagEnumerator.cs" company="OpenTelemetry Authors">
+// <copyright file="IActivityEnumerator.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,21 +14,21 @@
 // limitations under the License.
 // </copyright>
 
-using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace OpenTelemetry.Trace
 {
     /// <summary>
-    /// An interface used to perform zero-allocation enumeration of <see cref="Activity"/> tags. Implementation must be a struct.
+    /// An interface used to perform zero-allocation enumeration of <see cref="Activity"/> elements. Implementation must be a struct.
     /// </summary>
-    public interface IActivityTagEnumerator
+    /// <typeparam name="T">Enumerated item type.</typeparam>
+    public interface IActivityEnumerator<T>
     {
         /// <summary>
-        /// Called for each <see cref="Activity"/> tag while the enumeration is executing.
+        /// Called for each <see cref="Activity"/> item while the enumeration is executing.
         /// </summary>
-        /// <param name="item">Tag key/value pair.</param>
+        /// <param name="item">Enumeration item.</param>
         /// <returns><see langword="true"/> to continue the enumeration of records or <see langword="false"/> to stop (break) the enumeration.</returns>
-        bool ForEach(KeyValuePair<string, object> item);
+        bool ForEach(T item);
     }
 }

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinActivityConversionExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinActivityConversionExtensions.cs
@@ -201,7 +201,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
             return true;
         }
 
-        internal struct AttributeEnumerationState : IActivityTagEnumerator
+        internal struct AttributeEnumerationState : IActivityEnumerator<KeyValuePair<string, object>>
         {
             public PooledList<KeyValuePair<string, object>> Tags;
 

--- a/test/OpenTelemetry.Tests/Trace/ActivityExtensionsTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ActivityExtensionsTest.cs
@@ -141,7 +141,7 @@ namespace OpenTelemetry.Trace.Tests
         {
             Activity activity = new Activity("Test");
 
-            Enumerator state = default;
+            TagEnumerator state = default;
 
             activity.EnumerateTagValues(ref state);
 
@@ -157,7 +157,7 @@ namespace OpenTelemetry.Trace.Tests
             activity.SetTag("Tag2", "Value2");
             activity.SetTag("Tag3", "Value3");
 
-            Enumerator state = default;
+            TagEnumerator state = default;
 
             activity.EnumerateTagValues(ref state);
 
@@ -175,7 +175,7 @@ namespace OpenTelemetry.Trace.Tests
             activity.SetTag("Tag2", "Value2");
             activity.SetTag("Tag3", "Value3");
 
-            Enumerator state = default;
+            TagEnumerator state = default;
             state.BreakOnCount = 1;
 
             activity.EnumerateTagValues(ref state);
@@ -186,7 +186,44 @@ namespace OpenTelemetry.Trace.Tests
             Assert.Equal("Value1", state.LastTag?.Value);
         }
 
-        private struct Enumerator : IActivityTagEnumerator
+        [Fact]
+        public void EnumerateLinksEmpty()
+        {
+            Activity activity = new Activity("Test");
+
+            LinkEnumerator state = default;
+
+            activity.EnumerateLinks(ref state);
+
+            Assert.Equal(0, state.Count);
+            Assert.False(state.LastLink.HasValue);
+        }
+
+        [Fact]
+        public void EnumerateLinksNonempty()
+        {
+            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+                .AddSource(ActivitySourceName)
+                .Build();
+
+            var link = new ActivityLink(default);
+
+            using var source = new ActivitySource(ActivitySourceName);
+            using var activity = source.StartActivity(
+                ActivityName,
+                ActivityKind.Internal,
+                parentContext: default,
+                links: new[] { link });
+
+            LinkEnumerator state = default;
+
+            activity.EnumerateLinks(ref state);
+
+            Assert.Equal(1, state.Count);
+            Assert.Equal(link, state.LastLink);
+        }
+
+        private struct TagEnumerator : IActivityEnumerator<KeyValuePair<string, object>>
         {
             public int BreakOnCount { get; set; }
 
@@ -202,6 +239,22 @@ namespace OpenTelemetry.Trace.Tests
                 {
                     return false;
                 }
+
+                return true;
+            }
+        }
+
+        private struct LinkEnumerator : IActivityEnumerator<ActivityLink>
+        {
+            public ActivityLink? LastLink { get; private set; }
+
+            public int Count { get; private set; }
+
+            public bool ForEach(ActivityLink item)
+            {
+                this.LastLink = item;
+
+                this.Count++;
 
                 return true;
             }

--- a/test/OpenTelemetry.Tests/Trace/ActivityExtensionsTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ActivityExtensionsTest.cs
@@ -206,21 +206,26 @@ namespace OpenTelemetry.Trace.Tests
                 .AddSource(ActivitySourceName)
                 .Build();
 
-            var link = new ActivityLink(default);
+            var links = new[]
+            {
+                new ActivityLink(default),
+                new ActivityLink(default),
+                new ActivityLink(default),
+            };
 
             using var source = new ActivitySource(ActivitySourceName);
             using var activity = source.StartActivity(
                 ActivityName,
                 ActivityKind.Internal,
                 parentContext: default,
-                links: new[] { link });
+                links: links);
 
             LinkEnumerator state = default;
 
             activity.EnumerateLinks(ref state);
 
-            Assert.Equal(1, state.Count);
-            Assert.Equal(link, state.LastLink);
+            Assert.Equal(3, state.Count);
+            Assert.Equal(links.Last(), state.LastLink);
         }
 
         private struct TagEnumerator : IActivityEnumerator<KeyValuePair<string, object>>


### PR DESCRIPTION
Added an extension method for enumerating Activity Links without an allocation. Updated Jaeger to use it.

|                               Method |          Mean |       Error |     StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------------------- |--------------:|------------:|-----------:|-------:|------:|------:|----------:|
|       EnumerateNonemptyActivityLinks |     94.488 ns |   0.6160 ns |  0.5762 ns | 0.0076 |     - |     - |      64 B |
|  EnumerateLinksNonemptyActivityLinks |     48.164 ns |   0.4717 ns |  0.4181 ns |      - |     - |     - |         - |

TODOs:

* [X] `CHANGELOG.md` updated for non-trivial changes
* [ ] Changes in public API reviewed
