### PR TITLE
Added Activity.EnumerateEvents extension

### DIFF
--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -8,6 +8,9 @@
   `EnumerateLinks` extension method on `Activity` for retrieving links
   efficiently
   ([#1314](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1314))
+* Added `EnumerateEvents` extension method on `Activity` for retrieving events
+  efficiently
+  ([#1319](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1319))
 
 ## 0.6.0-beta.1
 

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionExtensionsTest.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionExtensionsTest.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Tests.Implementation
         [InlineData("double", 1.0)]
         public void CheckProcessTag(string key, object value)
         {
-            var attributeEnumerationState = new AttributeEnumerationState
+            var attributeEnumerationState = new TagEnumerationState
             {
                 Tags = PooledList<KeyValuePair<string, object>>.Create(),
             };
@@ -48,7 +48,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Tests.Implementation
         [InlineData("double", null)]
         public void CheckNullValueProcessTag(string key, object value)
         {
-            var attributeEnumerationState = new AttributeEnumerationState
+            var attributeEnumerationState = new TagEnumerationState
             {
                 Tags = PooledList<KeyValuePair<string, object>>.Create(),
             };

--- a/test/OpenTelemetry.Tests/Trace/ActivityExtensionsTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ActivityExtensionsTest.cs
@@ -228,6 +228,36 @@ namespace OpenTelemetry.Trace.Tests
             Assert.Equal(links.Last(), state.LastLink);
         }
 
+        [Fact]
+        public void EnumerateEventsEmpty()
+        {
+            Activity activity = new Activity("Test");
+
+            EventEnumerator state = default;
+
+            activity.EnumerateEvents(ref state);
+
+            Assert.Equal(0, state.Count);
+            Assert.False(state.LastEvent.HasValue);
+        }
+
+        [Fact]
+        public void EnumerateEventsNonempty()
+        {
+            Activity activity = new Activity("Test");
+
+            activity.AddEvent(new ActivityEvent("event1"));
+            activity.AddEvent(new ActivityEvent("event2"));
+            activity.AddEvent(new ActivityEvent("event3"));
+
+            EventEnumerator state = default;
+
+            activity.EnumerateEvents(ref state);
+
+            Assert.Equal(3, state.Count);
+            Assert.Equal("event3", state.LastEvent.Value.Name);
+        }
+
         private struct TagEnumerator : IActivityEnumerator<KeyValuePair<string, object>>
         {
             public int BreakOnCount { get; set; }
@@ -258,6 +288,22 @@ namespace OpenTelemetry.Trace.Tests
             public bool ForEach(ActivityLink item)
             {
                 this.LastLink = item;
+
+                this.Count++;
+
+                return true;
+            }
+        }
+
+        private struct EventEnumerator : IActivityEnumerator<ActivityEvent>
+        {
+            public ActivityEvent? LastEvent { get; private set; }
+
+            public int Count { get; private set; }
+
+            public bool ForEach(ActivityEvent item)
+            {
+                this.LastEvent = item;
 
                 this.Count++;
 


### PR DESCRIPTION
Added an extension method for enumerating Activity Events without an allocation. Updated Jaeger & Zipkin to use it. A bit of renaming inside Jaeger & Zipkin to make their usage of enumeration extensions consistent.

|                                Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------------------- |---------:|---------:|---------:|-------:|------:|------:|----------:|
|       EnumerateNonemptyActivityEvents | 79.39 ns | 1.429 ns | 2.427 ns | 0.0067 |     - |     - |      56 B |
| EnumerateEventsNonemptyActivityEvents | 46.03 ns | 0.502 ns | 0.445 ns |      - |     - |     - |         - |

TODOs:

* [X] `CHANGELOG.md` updated for non-trivial changes
* [ ] Changes in public API reviewed
