### PR TITLE
Add a value type version of CircularBuffer

### DIFF
--- a/src/OpenTelemetry/Internal/CircularBuffer.cs
+++ b/src/OpenTelemetry/Internal/CircularBuffer.cs
@@ -174,7 +174,7 @@ namespace OpenTelemetry.Internal
             var index = (int)(this.tail % this.Capacity);
             while (true)
             {
-                T value = this.trait[index];
+                var value = this.trait[index];
                 if (value == null)
                 {
                     // If we got here it means a writer isn't done.

--- a/src/OpenTelemetry/Internal/CircularBufferStruct.cs
+++ b/src/OpenTelemetry/Internal/CircularBufferStruct.cs
@@ -1,0 +1,190 @@
+// <copyright file="CircularBuffer.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace OpenTelemetry.Internal
+{
+    /// <summary>
+    /// Lock-free implementation of single-reader multi-writer circular buffer.
+    /// </summary>
+    /// <typeparam name="T">The type of the underlying value.</typeparam>
+    internal class CircularBuffer<T>
+        where T : class
+    {
+        private readonly T[] trait;
+        private long head;
+        private long tail;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CircularBuffer{T}"/> class.
+        /// </summary>
+        /// <param name="capacity">The capacity of the circular buffer, must be a positive integer.</param>
+        public CircularBuffer(int capacity)
+        {
+            if (capacity <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(capacity));
+            }
+
+            this.Capacity = capacity;
+            this.trait = new T[capacity];
+        }
+
+        /// <summary>
+        /// Gets the capacity of the <see cref="CircularBuffer{T}"/>.
+        /// </summary>
+        public int Capacity { get; }
+
+        /// <summary>
+        /// Gets the number of items contained in the <see cref="CircularBuffer{T}"/>.
+        /// </summary>
+        public int Count
+        {
+            get
+            {
+                var tailSnapshot = this.tail;
+                return (int)(this.head - tailSnapshot);
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of items added to the <see cref="CircularBuffer{T}"/>.
+        /// </summary>
+        public long AddedCount => this.head;
+
+        /// <summary>
+        /// Gets the number of items removed from the <see cref="CircularBuffer{T}"/>.
+        /// </summary>
+        public long RemovedCount => this.tail;
+
+        /// <summary>
+        /// Adds the specified item to the buffer.
+        /// </summary>
+        /// <param name="value">The value to add.</param>
+        /// <returns>
+        /// Returns <c>true</c> if the item was added to the buffer successfully;
+        /// <c>false</c> if the buffer is full.
+        /// </returns>
+        public bool Add(T value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            while (true)
+            {
+                var tailSnapshot = this.tail;
+                var headSnapshot = this.head;
+
+                if (headSnapshot - tailSnapshot >= this.Capacity)
+                {
+                    return false; // buffer is full
+                }
+
+                var head = Interlocked.CompareExchange(ref this.head, headSnapshot + 1, headSnapshot);
+                if (head != headSnapshot)
+                {
+                    continue;
+                }
+
+                var index = (int)(head % this.Capacity);
+                this.trait[index] = value;
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Attempts to add the specified item to the buffer.
+        /// </summary>
+        /// <param name="value">The value to add.</param>
+        /// <param name="maxSpinCount">The maximum allowed spin count, when set to a negative number or zero, will spin indefinitely.</param>
+        /// <returns>
+        /// Returns <c>true</c> if the item was added to the buffer successfully;
+        /// <c>false</c> if the buffer is full or the spin count exceeded <paramref name="maxSpinCount"/>.
+        /// </returns>
+        public bool TryAdd(T value, int maxSpinCount)
+        {
+            if (maxSpinCount <= 0)
+            {
+                return this.Add(value);
+            }
+
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            var spinCountDown = maxSpinCount;
+
+            while (true)
+            {
+                var tailSnapshot = this.tail;
+                var headSnapshot = this.head;
+
+                if (headSnapshot - tailSnapshot >= this.Capacity)
+                {
+                    return false; // buffer is full
+                }
+
+                var head = Interlocked.CompareExchange(ref this.head, headSnapshot + 1, headSnapshot);
+                if (head != headSnapshot)
+                {
+                    if (spinCountDown-- == 0)
+                    {
+                        return false; // exceeded maximum spin count
+                    }
+
+                    continue;
+                }
+
+                var index = (int)(head % this.Capacity);
+                this.trait[index] = value;
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Reads an item from the <see cref="CircularBuffer{T}"/>.
+        /// </summary>
+        /// <remarks>
+        /// This function is not reentrant-safe, only one reader is allowed at any given time.
+        /// Warning: There is no bounds check in this method. Do not call unless you have verified Count > 0.
+        /// </remarks>
+        /// <returns>Item read.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public T Read()
+        {
+            var index = (int)(this.tail % this.Capacity);
+            while (true)
+            {
+                T value = this.trait[index];
+                if (value == null)
+                {
+                    // If we got here it means a writer isn't done.
+                    continue;
+                }
+
+                this.trait[index] = null;
+                this.tail++;
+                return value;
+            }
+        }
+    }
+}

--- a/src/OpenTelemetry/Internal/CircularBufferStruct.cs
+++ b/src/OpenTelemetry/Internal/CircularBufferStruct.cs
@@ -174,8 +174,8 @@ namespace OpenTelemetry.Internal
 
                 // TODO: we are doing an extra copy from the buffer, this can be optimized if Read() could take a callback
                 var value = this.trait[index].Value;
-                this.trait[index].Value = default(T);
                 this.trait[index].IsReady = false;
+                this.trait[index].Value = default(T);
                 this.tail++;
                 return value;
             }

--- a/src/OpenTelemetry/Internal/CircularBufferStruct.cs
+++ b/src/OpenTelemetry/Internal/CircularBufferStruct.cs
@@ -1,4 +1,4 @@
-// <copyright file="CircularBuffer.cs" company="OpenTelemetry Authors">
+// <copyright file="CircularBufferStruct.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,18 +24,18 @@ namespace OpenTelemetry.Internal
     /// Lock-free implementation of single-reader multi-writer circular buffer.
     /// </summary>
     /// <typeparam name="T">The type of the underlying value.</typeparam>
-    internal class CircularBuffer<T>
-        where T : class
+    internal class CircularBufferStruct<T>
+        where T : struct
     {
-        private readonly T[] trait;
+        private readonly Trait[] trait;
         private long head;
         private long tail;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CircularBuffer{T}"/> class.
+        /// Initializes a new instance of the <see cref="CircularBufferStruct{T}"/> class.
         /// </summary>
         /// <param name="capacity">The capacity of the circular buffer, must be a positive integer.</param>
-        public CircularBuffer(int capacity)
+        public CircularBufferStruct(int capacity)
         {
             if (capacity <= 0)
             {
@@ -43,16 +43,16 @@ namespace OpenTelemetry.Internal
             }
 
             this.Capacity = capacity;
-            this.trait = new T[capacity];
+            this.trait = new Trait[capacity];
         }
 
         /// <summary>
-        /// Gets the capacity of the <see cref="CircularBuffer{T}"/>.
+        /// Gets the capacity of the <see cref="CircularBufferStruct{T}"/>.
         /// </summary>
         public int Capacity { get; }
 
         /// <summary>
-        /// Gets the number of items contained in the <see cref="CircularBuffer{T}"/>.
+        /// Gets the number of items contained in the <see cref="CircularBufferStruct{T}"/>.
         /// </summary>
         public int Count
         {
@@ -64,12 +64,12 @@ namespace OpenTelemetry.Internal
         }
 
         /// <summary>
-        /// Gets the number of items added to the <see cref="CircularBuffer{T}"/>.
+        /// Gets the number of items added to the <see cref="CircularBufferStruct{T}"/>.
         /// </summary>
         public long AddedCount => this.head;
 
         /// <summary>
-        /// Gets the number of items removed from the <see cref="CircularBuffer{T}"/>.
+        /// Gets the number of items removed from the <see cref="CircularBufferStruct{T}"/>.
         /// </summary>
         public long RemovedCount => this.tail;
 
@@ -83,11 +83,6 @@ namespace OpenTelemetry.Internal
         /// </returns>
         public bool Add(T value)
         {
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-
             while (true)
             {
                 var tailSnapshot = this.tail;
@@ -105,7 +100,8 @@ namespace OpenTelemetry.Internal
                 }
 
                 var index = (int)(head % this.Capacity);
-                this.trait[index] = value;
+                this.trait[index].Value = value;
+                this.trait[index].IsReady = true;
                 return true;
             }
         }
@@ -124,11 +120,6 @@ namespace OpenTelemetry.Internal
             if (maxSpinCount <= 0)
             {
                 return this.Add(value);
-            }
-
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
             }
 
             var spinCountDown = maxSpinCount;
@@ -155,13 +146,14 @@ namespace OpenTelemetry.Internal
                 }
 
                 var index = (int)(head % this.Capacity);
-                this.trait[index] = value;
+                this.trait[index].Value = value;
+                this.trait[index].IsReady = true;
                 return true;
             }
         }
 
         /// <summary>
-        /// Reads an item from the <see cref="CircularBuffer{T}"/>.
+        /// Reads an item from the <see cref="CircularBufferStruct{T}"/>.
         /// </summary>
         /// <remarks>
         /// This function is not reentrant-safe, only one reader is allowed at any given time.
@@ -174,17 +166,25 @@ namespace OpenTelemetry.Internal
             var index = (int)(this.tail % this.Capacity);
             while (true)
             {
-                T value = this.trait[index];
-                if (value == null)
+                if (!this.trait[index].IsReady)
                 {
                     // If we got here it means a writer isn't done.
                     continue;
                 }
 
-                this.trait[index] = null;
+                // TODO: we are doing an extra copy from the buffer, this can be optimized if Read() could take a callback
+                var value = this.trait[index].Value;
+                this.trait[index].Value = default(T);
+                this.trait[index].IsReady = false;
                 this.tail++;
                 return value;
             }
+        }
+
+        private struct Trait
+        {
+            internal bool IsReady;
+            internal T Value;
         }
     }
 }


### PR DESCRIPTION
Related to #1315.

To make it easier, please review the 2nd commit which has the diff (the 1st commit is a direct copy of the existing CircularBuffer<T>).

## Changes

* Introduced a CircularBufferStruct<T> for value types, which helps to avoid heap allocation.
* Each element in the circular buffer is a struct of a flag and the actual value, the flag is used to indicate whether the value has been fully written/ready.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
