### PR TITLE
Respect Sdk.SuppressInstrumentation flag on the logging path

### DIFF
--- a/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
@@ -42,6 +42,11 @@ namespace OpenTelemetry.Logs
                 return;
             }
 
+            if (Sdk.SuppressInstrumentation)
+            {
+                return;
+            }
+
             var record = new LogRecord(DateTime.UtcNow, this.categoryName, logLevel, eventId, state, exception);
 
             this.provider.Processor?.OnEnd(record);


### PR DESCRIPTION
## Changes

Just one minor change - the logger will look at the `Sdk.SuppressInstrumentation` flag to decide if it should create the record and call processors.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
