### PR TITLE
Disable flaky patch coverage check

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -5,6 +5,8 @@ coverage:
   precision: 2
   round: down
   range: "70...100"
+  status:
+    patch: off
 
 parsers:
   gcov:


### PR DESCRIPTION
## Changes

* Disabled the patch coverage check since it is not stable - https://docs.codecov.io/docs/commit-status#disabling-a-status

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
