### PR TITLE
Fix misleading comments

### DIFF
--- a/src/OpenTelemetry/Trace/AlwaysOffSampler.cs
+++ b/src/OpenTelemetry/Trace/AlwaysOffSampler.cs
@@ -17,7 +17,7 @@
 namespace OpenTelemetry.Trace
 {
     /// <summary>
-    /// Sampler implementation which never samples any activity.
+    /// Sampler implementation which always returns <c>SamplingDecision.Drop</c>.
     /// </summary>
     public sealed class AlwaysOffSampler : Sampler
     {

--- a/src/OpenTelemetry/Trace/AlwaysOnSampler.cs
+++ b/src/OpenTelemetry/Trace/AlwaysOnSampler.cs
@@ -17,8 +17,7 @@
 namespace OpenTelemetry.Trace
 {
     /// <summary>
-    /// Sampler implementation which samples every activity.
-    /// This sampler will be used as the default Sampler, if no other Sampler is configured.
+    /// Sampler implementation which always returns <c>SamplingDecision.RecordAndSample</c>.
     /// </summary>
     public sealed class AlwaysOnSampler : Sampler
     {

--- a/src/OpenTelemetry/Trace/Sampler.cs
+++ b/src/OpenTelemetry/Trace/Sampler.cs
@@ -18,7 +18,7 @@ using System.Diagnostics;
 namespace OpenTelemetry.Trace
 {
     /// <summary>
-    /// Sampler to select data to be exported. This sampler executes before Activity object is created.
+    /// Controls the number of samples of traces collected and sent to the backend.
     /// </summary>
     public abstract class Sampler
     {

--- a/src/OpenTelemetry/Trace/TraceIdRatioBasedSampler.cs
+++ b/src/OpenTelemetry/Trace/TraceIdRatioBasedSampler.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using System;
 using System.Globalization;
 


### PR DESCRIPTION
The current `AlwaysOnSampler` has a wrong statement `This sampler will be used as the default Sampler, if no other Sampler is configured`.
I had it fixed and also did minor cleaned up.