### PR TITLE
Use IConnectionMultiplexer instead of implementation

### DIFF
--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisCallsInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisCallsInstrumentation.cs
@@ -48,9 +48,9 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis
         /// <summary>
         /// Initializes a new instance of the <see cref="StackExchangeRedisCallsInstrumentation"/> class.
         /// </summary>
-        /// <param name="connection"><see cref="ConnectionMultiplexer"/> to instrument.</param>
+        /// <param name="connection"><see cref="IConnectionMultiplexer"/> to instrument.</param>
         /// <param name="options">Configuration options for redis instrumentation.</param>
-        public StackExchangeRedisCallsInstrumentation(ConnectionMultiplexer connection, StackExchangeRedisCallsInstrumentationOptions options)
+        public StackExchangeRedisCallsInstrumentation(IConnectionMultiplexer connection, StackExchangeRedisCallsInstrumentationOptions options)
         {
             if (connection == null)
             {

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/TracerProviderBuilderExtensions.cs
@@ -29,12 +29,12 @@ namespace OpenTelemetry.Trace
         /// Enables the outgoing requests automatic data collection for Redis.
         /// </summary>
         /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
-        /// <param name="connection"><see cref="ConnectionMultiplexer"/> to instrument.</param>
+        /// <param name="connection"><see cref="IConnectionMultiplexer"/> to instrument.</param>
         /// <param name="configureOptions">Redis configuration options.</param>
         /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
         public static TracerProviderBuilder AddRedisInstrumentation(
             this TracerProviderBuilder builder,
-            ConnectionMultiplexer connection,
+            IConnectionMultiplexer connection,
             Action<StackExchangeRedisCallsInstrumentationOptions> configureOptions = null)
         {
             if (builder == null)


### PR DESCRIPTION
## Changes

It allows passing `IConnectionMultiplexer` instead of specific implementation `ConnectionMultiplexer`
