### PR TITLE
Add checker for passing correct sampling decision for xray

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -19,8 +19,8 @@
   for Activity.Recorded in SimpleActivityExportProcessor and
   BatchActivityExportProcessor
   ([#1622](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1622))
-* Added check in `ActivitySourceAdapter` class for root activity if traceid is 
-  overriden by calling `SetParentId`
+* Added check in `ActivitySourceAdapter` class for root activity if traceid is
+  overridden by calling `SetParentId`
   ([#1355](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1355))
 
 ## 1.0.0-rc1.1

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -19,6 +19,9 @@
   for Activity.Recorded in SimpleActivityExportProcessor and
   BatchActivityExportProcessor
   ([#1622](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1622))
+* Added check in `ActivitySourceAdapter` class for root activity if traceid is 
+  overriden by calling `SetParentId`
+  ([#1355](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1355))
 
 ## 1.0.0-rc1.1
 

--- a/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
+++ b/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
@@ -136,6 +136,9 @@ namespace OpenTelemetry.Trace
         private void RunGetRequestedDataOtherSampler(Activity activity)
         {
             ActivityContext parentContext;
+
+            // Check activity.ParentId alone is sufficient to normally determine if a activity is root or not. But if one uses activity.SetParentId to override the TraceId (without intending to set an actual parent), then additional check of parentspanid being empty is required to confirm if an activity is root or not.
+            // This checker can be removed, once Activity exposes an API to customize ID Generation (https://github.com/dotnet/sdk/issues/15216) or issue https://github.com/dotnet/sdk/issues/15175 is addressed.
             if (string.IsNullOrEmpty(activity.ParentId) || this.IsParentSpanIdEmpty(activity))
             {
                 parentContext = default;
@@ -189,8 +192,6 @@ namespace OpenTelemetry.Trace
 
         private bool IsParentSpanIdEmpty(Activity activity)
         {
-            // Below can be simplified as activity.ParentSpanId == default
-            // once issue https://github.com/dotnet/runtime/issues/42456 is fixed.
             return activity.ParentSpanId.ToHexString() == "0000000000000000";
         }
     }

--- a/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
+++ b/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
@@ -189,6 +189,8 @@ namespace OpenTelemetry.Trace
 
         private bool IsParentSpanIdEmpty(Activity activity)
         {
+            // Below can be simplified as activity.ParentSpanId == default
+            // once issue https://github.com/dotnet/runtime/issues/42456 is fixed.
             return activity.ParentSpanId.ToHexString() == "0000000000000000";
         }
     }

--- a/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
+++ b/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
@@ -139,7 +139,7 @@ namespace OpenTelemetry.Trace
 
             // Check activity.ParentId alone is sufficient to normally determine if a activity is root or not. But if one uses activity.SetParentId to override the TraceId (without intending to set an actual parent), then additional check of parentspanid being empty is required to confirm if an activity is root or not.
             // This checker can be removed, once Activity exposes an API to customize ID Generation (https://github.com/dotnet/runtime/issues/46704) or issue https://github.com/dotnet/runtime/issues/46706 is addressed.
-            if (string.IsNullOrEmpty(activity.ParentId) || this.IsParentSpanIdEmpty(activity))
+            if (string.IsNullOrEmpty(activity.ParentId) || activity.ParentSpanId.ToHexString() == "0000000000000000")
             {
                 parentContext = default;
             }
@@ -188,11 +188,6 @@ namespace OpenTelemetry.Trace
                     activity.SetTag(att.Key, att.Value);
                 }
             }
-        }
-
-        private bool IsParentSpanIdEmpty(Activity activity)
-        {
-            return activity.ParentSpanId.ToHexString() == "0000000000000000";
         }
     }
 }

--- a/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
+++ b/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
@@ -136,7 +136,7 @@ namespace OpenTelemetry.Trace
         private void RunGetRequestedDataOtherSampler(Activity activity)
         {
             ActivityContext parentContext;
-            if (string.IsNullOrEmpty(activity.ParentId))
+            if (string.IsNullOrEmpty(activity.ParentId) || this.IsParentSpanIdEmpty(activity))
             {
                 parentContext = default;
             }
@@ -185,6 +185,11 @@ namespace OpenTelemetry.Trace
                     activity.SetTag(att.Key, att.Value);
                 }
             }
+        }
+
+        private bool IsParentSpanIdEmpty(Activity activity)
+        {
+            return activity.ParentSpanId.ToHexString() == "0000000000000000";
         }
     }
 }

--- a/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
+++ b/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
@@ -138,7 +138,7 @@ namespace OpenTelemetry.Trace
             ActivityContext parentContext;
 
             // Check activity.ParentId alone is sufficient to normally determine if a activity is root or not. But if one uses activity.SetParentId to override the TraceId (without intending to set an actual parent), then additional check of parentspanid being empty is required to confirm if an activity is root or not.
-            // This checker can be removed, once Activity exposes an API to customize ID Generation (https://github.com/dotnet/sdk/issues/15216) or issue https://github.com/dotnet/sdk/issues/15175 is addressed.
+            // This checker can be removed, once Activity exposes an API to customize ID Generation (https://github.com/dotnet/runtime/issues/46704) or issue https://github.com/dotnet/runtime/issues/46706 is addressed.
             if (string.IsNullOrEmpty(activity.ParentId) || this.IsParentSpanIdEmpty(activity))
             {
                 parentContext = default;


### PR DESCRIPTION
As discussed in https://github.com/open-telemetry/opentelemetry-dotnet/pull/1268#discussion_r489184960 and https://github.com/open-telemetry/opentelemetry-dotnet/issues/1240, added the checker for passing correct sampling decision while using xray's trace id generator.