### PR TITLE
Suspend/remove me (@discostu105) as an approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ Approvers
 ([@open-telemetry/dotnet-approvers](https://github.com/orgs/open-telemetry/teams/dotnet-approvers)):
 
 * [Bruno Garcia](https://github.com/bruno-garcia), Sentry
-* [Christoph Neumueller](https://github.com/discostu105), Dynatrace
 * [Eddy Nakamura](https://github.com/eddynaka), Microsoft
 * [Paulo Janotti](https://github.com/pjanotti), Splunk
 * [Reiley Yang](https://github.com/reyang), Microsoft


### PR DESCRIPTION
@open-telemetry/dotnet-maintainers

For quite a long time now, I have unfortunately been inactive in opentelemetry-dotnet. While I think the project is going well 🚀, I don't think I will be able to allocate much time for it in the near future. So, I don't really deserve the approver role, thus I'd like to waive it.