### PR TITLE
Eventsource perf

### DIFF
--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -17,9 +17,9 @@
 using System;
 #if DEBUG
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 #endif
+using System.Diagnostics;
 using System.Diagnostics.Tracing;
 
 namespace OpenTelemetry.Internal
@@ -86,6 +86,24 @@ namespace OpenTelemetry.Internal
             if (this.IsEnabled(EventLevel.Warning, (EventKeywords)(-1)))
             {
                 this.MetricControllerException(ex.ToInvariantString());
+            }
+        }
+
+        [NonEvent]
+        public void ActivityStarted(Activity activity)
+        {
+            if (this.IsEnabled(EventLevel.Verbose, (EventKeywords)(-1)))
+            {
+                this.ActivityStarted(activity.OperationName, activity.Id);
+            }
+        }
+
+        [NonEvent]
+        public void ActivityStopped(Activity activity)
+        {
+            if (this.IsEnabled(EventLevel.Verbose, (EventKeywords)(-1)))
+            {
+                this.ActivityStopped(activity.OperationName, activity.Id);
             }
         }
 

--- a/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
+++ b/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
@@ -77,7 +77,7 @@ namespace OpenTelemetry.Trace
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "ActivityProcessor is hot path")]
         public void Start(Activity activity, ActivityKind kind)
         {
-            OpenTelemetrySdkEventSource.Log.ActivityStarted(activity.OperationName, activity.Id);
+            OpenTelemetrySdkEventSource.Log.ActivityStarted(activity);
 
             SetKindProperty(activity, kind);
             this.getRequestedDataAction(activity);
@@ -94,7 +94,7 @@ namespace OpenTelemetry.Trace
         /// <param name="activity"><see cref="Activity"/> to be stopped.</param>
         public void Stop(Activity activity)
         {
-            OpenTelemetrySdkEventSource.Log.ActivityStopped(activity.OperationName, activity.Id);
+            OpenTelemetrySdkEventSource.Log.ActivityStopped(activity);
 
             if (activity?.IsAllDataRequested ?? false)
             {

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -69,7 +69,7 @@ namespace OpenTelemetry.Trace
                 // Callback when Activity is started.
                 ActivityStarted = (activity) =>
                 {
-                    OpenTelemetrySdkEventSource.Log.ActivityStarted(activity.OperationName, activity.Id);
+                    OpenTelemetrySdkEventSource.Log.ActivityStarted(activity);
 
                     if (!activity.IsAllDataRequested)
                     {
@@ -86,7 +86,7 @@ namespace OpenTelemetry.Trace
                 // Callback when Activity is stopped.
                 ActivityStopped = (activity) =>
                 {
-                    OpenTelemetrySdkEventSource.Log.ActivityStopped(activity.OperationName, activity.Id);
+                    OpenTelemetrySdkEventSource.Log.ActivityStopped(activity);
 
                     if (!activity.IsAllDataRequested)
                     {

--- a/test/Benchmarks/EventSourceBenchmarks.cs
+++ b/test/Benchmarks/EventSourceBenchmarks.cs
@@ -14,121 +14,35 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.Tracing;
-using System.Reflection;
-using System.Reflection.Emit;
 using BenchmarkDotNet.Attributes;
+using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Benchmarks
 {
     [MemoryDiagnoser]
     public class EventSourceBenchmarks
     {
-        internal static OpenTelemetryEventListener Listener;
-        private static readonly Func<Activity, string> TraceIdGetter = CreateFieldGetter<Activity, string>("_traceId", BindingFlags.Instance | BindingFlags.NonPublic);
-        private static readonly Func<Activity, string> SpanIdGetter = CreateFieldGetter<Activity, string>("_spanId", BindingFlags.Instance | BindingFlags.NonPublic);
-
-        [Params(false, true)]
-        public bool Listen { get; set; }
-
-        [GlobalSetup]
-        public void GlobalSetup()
-        {
-            if (this.Listen)
-            {
-                Listener = new OpenTelemetryEventListener();
-            }
-        }
-
         [Benchmark]
-        public void EventWithId()
+        public void EventWithIdAllocation()
         {
             Activity activity = new Activity("TestActivity");
             activity.SetIdFormat(ActivityIdFormat.W3C);
             activity.Start();
             activity.Stop();
 
-            OpenTelemetryBenchmarksEventSource.Log.ActivityStarted(activity.OperationName, activity.Id);
+            OpenTelemetrySdkEventSource.Log.ActivityStarted(activity.OperationName, activity.Id);
         }
 
         [Benchmark]
-        public void EventWithValues()
+        public void EventWithCheck()
         {
             Activity activity = new Activity("TestActivity");
             activity.SetIdFormat(ActivityIdFormat.W3C);
             activity.Start();
             activity.Stop();
 
-            OpenTelemetryBenchmarksEventSource.Log.ActivityStartedSimple(activity.OperationName, TraceIdGetter(activity), SpanIdGetter(activity));
-        }
-
-        private static Func<TClass, TField> CreateFieldGetter<TClass, TField>(string fieldName, BindingFlags flags)
-            where TClass : class
-        {
-            FieldInfo field = typeof(TClass).GetField(fieldName, flags);
-            if (field == null)
-            {
-                throw new InvalidOperationException($"Field [{fieldName}] could not be found.");
-            }
-
-            string methodName = field.ReflectedType.FullName + ".get_" + field.Name;
-            DynamicMethod getterMethod = new DynamicMethod(methodName, typeof(TField), new[] { typeof(TClass) }, true);
-            ILGenerator generator = getterMethod.GetILGenerator();
-            generator.Emit(OpCodes.Ldarg_0);
-            generator.Emit(OpCodes.Ldfld, field);
-            generator.Emit(OpCodes.Ret);
-            return (Func<TClass, TField>)getterMethod.CreateDelegate(typeof(Func<TClass, TField>));
-        }
-
-        [EventSource(Name = "OpenTelemetry-Benchmarks")]
-        internal class OpenTelemetryBenchmarksEventSource : EventSource
-        {
-            public static OpenTelemetryBenchmarksEventSource Log = new OpenTelemetryBenchmarksEventSource();
-
-            [Event(1, Message = "Activity started. OperationName = '{0}', Id = '{1}'.", Level = EventLevel.Verbose)]
-            public void ActivityStarted(string operationName, string id)
-            {
-                this.WriteEvent(1, operationName, id);
-            }
-
-            [Event(2, Message = "Activity started. OperationName = '{0}', TraceId = '{1}', SpanId = '{2}'.", Level = EventLevel.Verbose)]
-            public void ActivityStartedSimple(string operationName, string traceId, string spanId)
-            {
-                this.WriteEvent(2, operationName, traceId, spanId);
-            }
-        }
-
-        internal class OpenTelemetryEventListener : EventListener
-        {
-            private readonly List<EventSource> eventSources = new List<EventSource>();
-
-            public override void Dispose()
-            {
-                foreach (EventSource eventSource in this.eventSources)
-                {
-                    this.DisableEvents(eventSource);
-                }
-
-                base.Dispose();
-            }
-
-            protected override void OnEventSourceCreated(EventSource eventSource)
-            {
-                if (eventSource?.Name.StartsWith("OpenTelemetry", StringComparison.OrdinalIgnoreCase) == true)
-                {
-                    this.eventSources.Add(eventSource);
-                    this.EnableEvents(eventSource, EventLevel.Verbose, (EventKeywords)(-1));
-                }
-
-                base.OnEventSourceCreated(eventSource);
-            }
-
-            protected override void OnEventWritten(EventWrittenEventArgs e)
-            {
-            }
+            OpenTelemetrySdkEventSource.Log.ActivityStarted(activity);
         }
     }
 }

--- a/test/Benchmarks/EventSourceBenchmarks.cs
+++ b/test/Benchmarks/EventSourceBenchmarks.cs
@@ -1,0 +1,134 @@
+// <copyright file="EventSourceBenchmarks.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using System.Reflection;
+using System.Reflection.Emit;
+using BenchmarkDotNet.Attributes;
+
+namespace OpenTelemetry.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class EventSourceBenchmarks
+    {
+        internal static OpenTelemetryEventListener Listener;
+        private static readonly Func<Activity, string> TraceIdGetter = CreateFieldGetter<Activity, string>("_traceId", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static readonly Func<Activity, string> SpanIdGetter = CreateFieldGetter<Activity, string>("_spanId", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        [Params(false, true)]
+        public bool Listen { get; set; }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            if (this.Listen)
+            {
+                Listener = new OpenTelemetryEventListener();
+            }
+        }
+
+        [Benchmark]
+        public void EventWithId()
+        {
+            Activity activity = new Activity("TestActivity");
+            activity.SetIdFormat(ActivityIdFormat.W3C);
+            activity.Start();
+            activity.Stop();
+
+            OpenTelemetryBenchmarksEventSource.Log.ActivityStarted(activity.OperationName, activity.Id);
+        }
+
+        [Benchmark]
+        public void EventWithValues()
+        {
+            Activity activity = new Activity("TestActivity");
+            activity.SetIdFormat(ActivityIdFormat.W3C);
+            activity.Start();
+            activity.Stop();
+
+            OpenTelemetryBenchmarksEventSource.Log.ActivityStartedSimple(activity.OperationName, TraceIdGetter(activity), SpanIdGetter(activity));
+        }
+
+        private static Func<TClass, TField> CreateFieldGetter<TClass, TField>(string fieldName, BindingFlags flags)
+            where TClass : class
+        {
+            FieldInfo field = typeof(TClass).GetField(fieldName, flags);
+            if (field == null)
+            {
+                throw new InvalidOperationException($"Field [{fieldName}] could not be found.");
+            }
+
+            string methodName = field.ReflectedType.FullName + ".get_" + field.Name;
+            DynamicMethod getterMethod = new DynamicMethod(methodName, typeof(TField), new[] { typeof(TClass) }, true);
+            ILGenerator generator = getterMethod.GetILGenerator();
+            generator.Emit(OpCodes.Ldarg_0);
+            generator.Emit(OpCodes.Ldfld, field);
+            generator.Emit(OpCodes.Ret);
+            return (Func<TClass, TField>)getterMethod.CreateDelegate(typeof(Func<TClass, TField>));
+        }
+
+        [EventSource(Name = "OpenTelemetry-Benchmarks")]
+        internal class OpenTelemetryBenchmarksEventSource : EventSource
+        {
+            public static OpenTelemetryBenchmarksEventSource Log = new OpenTelemetryBenchmarksEventSource();
+
+            [Event(1, Message = "Activity started. OperationName = '{0}', Id = '{1}'.", Level = EventLevel.Verbose)]
+            public void ActivityStarted(string operationName, string id)
+            {
+                this.WriteEvent(1, operationName, id);
+            }
+
+            [Event(2, Message = "Activity started. OperationName = '{0}', TraceId = '{1}', SpanId = '{2}'.", Level = EventLevel.Verbose)]
+            public void ActivityStartedSimple(string operationName, string traceId, string spanId)
+            {
+                this.WriteEvent(2, operationName, traceId, spanId);
+            }
+        }
+
+        internal class OpenTelemetryEventListener : EventListener
+        {
+            private readonly List<EventSource> eventSources = new List<EventSource>();
+
+            public override void Dispose()
+            {
+                foreach (EventSource eventSource in this.eventSources)
+                {
+                    this.DisableEvents(eventSource);
+                }
+
+                base.Dispose();
+            }
+
+            protected override void OnEventSourceCreated(EventSource eventSource)
+            {
+                if (eventSource?.Name.StartsWith("OpenTelemetry", StringComparison.OrdinalIgnoreCase) == true)
+                {
+                    this.eventSources.Add(eventSource);
+                    this.EnableEvents(eventSource, EventLevel.Verbose, (EventKeywords)(-1));
+                }
+
+                base.OnEventSourceCreated(eventSource);
+            }
+
+            protected override void OnEventWritten(EventWrittenEventArgs e)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
I put in these `ActivityStarted` and `ActivityStopped` events in on #1376. It occurred to me afterward that accessing `Activity.Id` is probably very expensive. Turns out it is not expensive because it is always allocated when `Stop` is called (see: https://github.com/dotnet/runtime/issues/43704). But it _should_ be expensive.

This PR is moving that event behind an IsEnabled check so in the future when that is fixed everything will be happy. We may want to remove these events completely though because they are on the hot path. Basically, this could be useful information debugging, maybe the most useful, but is it worth the cost?