### PR TITLE
Support Resources in ZipkinExporter

### DIFF
--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
@@ -122,7 +122,7 @@ namespace OpenTelemetry.Exporter.Jaeger
                     process.Tags = new Dictionary<string, JaegerTag>();
                 }
 
-                process.Tags[label.Key] = label.ToJaegerTag();
+                process.Tags[key] = label.ToJaegerTag();
             }
 
             if (serviceName != null)

--- a/src/OpenTelemetry.Exporter.Jaeger/Process.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Process.cs
@@ -35,7 +35,7 @@ namespace OpenTelemetry.Exporter.Jaeger
         {
         }
 
-        internal Process(string serviceName, IDictionary<string, JaegerTag> processTags)
+        internal Process(string serviceName, Dictionary<string, JaegerTag> processTags)
             : this(serviceName)
         {
             if (processTags != null)
@@ -46,7 +46,7 @@ namespace OpenTelemetry.Exporter.Jaeger
 
         public string ServiceName { get; internal set; }
 
-        internal IDictionary<string, JaegerTag> Tags { get; set; }
+        internal Dictionary<string, JaegerTag> Tags { get; set; }
 
         internal byte[] Message { get; set; }
 

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* ZipkinExporter will now respect global Resource set via
+  `TracerProviderBuilder.SetResource`.
+  ([#1385](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1385))
+
 ## 0.7.0-beta.1
 
 Released 2020-Oct-16

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinEndpoint.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinEndpoint.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+using System.Collections.Generic;
 #if NET452
 using Newtonsoft.Json;
 #else
@@ -24,7 +25,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
     internal class ZipkinEndpoint
     {
         public ZipkinEndpoint(string serviceName)
-            : this(serviceName, null, null, null)
+            : this(serviceName, null, null, null, null)
         {
         }
 
@@ -32,12 +33,14 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
             string serviceName,
             string ipv4,
             string ipv6,
-            int? port)
+            int? port,
+            Dictionary<string, object> tags)
         {
             this.ServiceName = serviceName;
             this.Ipv4 = ipv4;
             this.Ipv6 = ipv6;
             this.Port = port;
+            this.Tags = tags;
         }
 
         public string ServiceName { get; }
@@ -47,6 +50,8 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
         public string Ipv6 { get; }
 
         public int? Port { get; }
+
+        public Dictionary<string, object> Tags { get; }
 
         public static ZipkinEndpoint Create(string serviceName)
         {
@@ -70,7 +75,8 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
                 serviceName,
                 this.Ipv4,
                 this.Ipv6,
-                this.Port);
+                this.Port,
+                this.Tags);
         }
 
 #if NET452

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinSpan.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinSpan.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 #if NET452
@@ -290,7 +291,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
                 writer.WriteEndArray();
             }
 
-            if (this.Tags.HasValue)
+            if (this.Tags.HasValue || this.LocalEndpoint.Tags != null)
             {
                 writer.WritePropertyName("tags");
                 writer.WriteStartObject();
@@ -301,7 +302,12 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
 
                 try
                 {
-                    foreach (var tag in this.Tags.Value)
+                    foreach (var tag in this.LocalEndpoint.Tags ?? Enumerable.Empty<KeyValuePair<string, object>>())
+                    {
+                        writer.WriteString(tag.Key, this.ConvertObjectToString(tag.Value));
+                    }
+
+                    foreach (var tag in this.Tags ?? Enumerable.Empty<KeyValuePair<string, object>>())
                     {
                         writer.WriteString(tag.Key, this.ConvertObjectToString(tag.Value));
                     }

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinSpan.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinSpan.cs
@@ -189,7 +189,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
                 writer.WriteEndArray();
             }
 
-            if (this.Tags.HasValue)
+            if (this.Tags.HasValue || this.LocalEndpoint.Tags != null)
             {
                 writer.WritePropertyName("tags");
                 writer.WriteStartObject();
@@ -200,7 +200,13 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
 
                 try
                 {
-                    foreach (var tag in this.Tags.Value)
+                    foreach (var tag in this.LocalEndpoint.Tags ?? Enumerable.Empty<KeyValuePair<string, object>>())
+                    {
+                        writer.WritePropertyName(tag.Key);
+                        writer.WriteValue(this.ConvertObjectToString(tag.Value));
+                    }
+
+                    foreach (var tag in this.Tags ?? Enumerable.Empty<KeyValuePair<string, object>>())
                     {
                         writer.WritePropertyName(tag.Key);
                         writer.WriteValue(this.ConvertObjectToString(tag.Value));

--- a/src/OpenTelemetry/Trace/ActivityExtensions.cs
+++ b/src/OpenTelemetry/Trace/ActivityExtensions.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using OpenTelemetry.Resources;
 
 namespace OpenTelemetry.Trace
@@ -30,24 +31,21 @@ namespace OpenTelemetry.Trace
         /// </summary>
         /// <param name="activity">Activity instance.</param>
         /// <returns>The resource.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Resource GetResource(this Activity activity)
         {
-            if (activity?.GetCustomProperty(ResourcePropertyName) is Resource res)
-            {
-                return res;
-            }
-            else
-            {
-                return Resource.Empty;
-            }
+            return activity?.GetCustomProperty(ResourcePropertyName) is Resource res
+                ? res
+                : Resource.Empty;
         }
 
         /// <summary>
-        /// Sets the Resource associated with the Activity..
+        /// Sets the Resource associated with the Activity.
         /// </summary>
         /// <param name="activity">Activity instance.</param>
         /// <param name="resource">Resource to set to.</param>
-        internal static void SetResource(this Activity activity, Resource resource)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void SetResource(this Activity activity, Resource resource)
         {
             activity.SetCustomProperty(ResourcePropertyName, resource);
         }


### PR DESCRIPTION
## Changes

ZipkinExporter will now take service name from Resource if set and apply any Resource attributes as tags on outgoing spans. This brings it into parity with JaegerExporter w.r.t. Resources.

## TODO
* [X] `CHANGELOG.md` updated for non-trivial changes
* [ ] Changes in public API reviewed
