### PR TITLE
Add benchmark for DiagnosticSourceSubscriber

### DIFF
--- a/test/Benchmarks/Instrumentation/DiagnosticSourceSubscriberBenchmark.cs
+++ b/test/Benchmarks/Instrumentation/DiagnosticSourceSubscriberBenchmark.cs
@@ -48,7 +48,7 @@ namespace Benchmarks.Instrumentation
                     this.UseIsEnabledFilter ? this.isEnabledFilter : null);
 
                 this.subscribers.Add(subscriber);
-                DiagnosticListener.AllListeners.Subscribe(subscriber);
+                subscriber.Subscribe();
             }
         }
 

--- a/test/Benchmarks/Instrumentation/DiagnosticSourceSubscriberBenchmark.cs
+++ b/test/Benchmarks/Instrumentation/DiagnosticSourceSubscriberBenchmark.cs
@@ -1,0 +1,91 @@
+// <copyright file="DiagnosticSourceSubscriberBenchmark.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using BenchmarkDotNet.Attributes;
+using OpenTelemetry.Instrumentation;
+
+namespace Benchmarks.Instrumentation
+{
+    [InProcess]
+    [MemoryDiagnoser]
+    public class DiagnosticSourceSubscriberBenchmark
+    {
+        [Params(1, 2)]
+        public int SubscriberCount;
+
+        [Params(false, true)]
+        public bool UseIsEnabledFilter;
+
+        private const string SourceName = "MySource";
+
+        private readonly DiagnosticListener listener = new DiagnosticListener(SourceName);
+        private readonly List<DiagnosticSourceSubscriber> subscribers = new List<DiagnosticSourceSubscriber>();
+        private readonly Func<string, object, object, bool> isEnabledFilter = (name, arg1, arg2) => ((EventPayload)arg1).Data == "Data";
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            for (var i = 0; i < this.SubscriberCount; ++i)
+            {
+                var subscriber = new DiagnosticSourceSubscriber(
+                    new TestListener(),
+                    this.UseIsEnabledFilter ? this.isEnabledFilter : null);
+
+                this.subscribers.Add(subscriber);
+                DiagnosticListener.AllListeners.Subscribe(subscriber);
+            }
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            foreach (var subscriber in this.subscribers)
+            {
+                subscriber.Dispose();
+            }
+        }
+
+        [Benchmark]
+        public void WriteDiagnosticSourceEvent()
+        {
+            var payload = new EventPayload("Data");
+            this.listener.Write("SomeEvent", payload);
+        }
+
+        private struct EventPayload
+        {
+            public EventPayload(string data)
+            {
+                this.Data = data;
+            }
+
+            public string Data { get; }
+        }
+
+        private class TestListener : ListenerHandler
+        {
+            public TestListener()
+                : base(DiagnosticSourceSubscriberBenchmark.SourceName)
+            {
+            }
+
+            public override bool SupportsNullActivity => true;
+        }
+    }
+}


### PR DESCRIPTION
Apologies for delay. Here are some benchmark results of DiagnosticSource per recent conversations in SIG meetings.

#1347 raised the question of the impact of multiple DiagnosticSource subscribers for a single source. Currently, #1347 sets up an additional DiagnosticSource subscriber to capture HTTP response time metrics for ASP.NET Core. Another approach would be to refactor things and capture these metrics with the existing subscriber used for traces.

| SubscriberCount | UseIsEnabledFilter |      Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------- |------------------- |----------:|---------:|---------:|-------:|------:|------:|----------:|
|               1 |              False |  82.34 ns | 1.635 ns | 1.529 ns | 0.0012 |     - |     - |      24 B |
|               1 |               True |  79.00 ns | 1.438 ns | 1.345 ns | 0.0012 |     - |     - |      24 B |
|               2 |              False | 143.92 ns | 2.064 ns | 1.931 ns | 0.0012 |     - |     - |      24 B |
|               2 |               True | 144.86 ns | 2.822 ns | 2.502 ns | 0.0012 |     - |     - |      24 B |

There does appear to be an increase in computation time when invoking multiple subscribers. It was mentioned in a SIG meeting that using an event filter may also have a significant impact, however, these results do not seem to suggest that (perhaps if the filter were less trivial).

**Questions**

1. Do people think the increase in computation time warrants solving capturing both metrics and traces with a single DiagnosticSource subscriber? I have some thoughts for how this could be done, though it will require some consideration of how to independently configure instrumentation to gather only metric data, only trace data, or both.
2. If yes, how would people feel about moving forward with #1347 as is with a separate subscriber and then refactor in a separate PR? I still have a little more work independent of the questions posed here to get #1347 wrapped up.