### PR TITLE
Skeleton for adding metric distribution aggregators

### DIFF
--- a/src/OpenTelemetry.Api/Metrics/AggregationType.cs
+++ b/src/OpenTelemetry.Api/Metrics/AggregationType.cs
@@ -14,27 +14,27 @@
 // limitations under the License.
 // </copyright>
 
-namespace OpenTelemetry.Metrics.Export
+namespace OpenTelemetry.Metrics
 {
     public enum AggregationType
     {
         /// <summary>
-        /// Sum of type Double which is reported with <see cref="DoubleSumData"/>
+        /// Sum of type Double which is reported with OpenTelemetry.Metrics.Export.DoubleSumData />
         /// </summary>
         DoubleSum,
 
         /// <summary>
-        /// Sum of type Long which is reported with <see cref="Int64SumData"/>
+        /// Sum of type Long which is reported with OpenTelemetry.Metrics.Export.Int64SumData/>
         /// </summary>
         LongSum,
 
         /// <summary>
-        /// Summary of measurements (Min, Max, Sum, Count), which is reported with <see cref="DoubleSummaryData"/>
+        /// Summary of measurements (Min, Max, Sum, Count), which is reported with OpenTelemetry.Metrics.Export.DoubleSummaryData/>
         /// </summary>
         DoubleSummary,
 
         /// <summary>
-        /// Summary of measurements (Min, Max, Sum, Count), which is reported with <see cref="Int64SummaryData"/>
+        /// Summary of measurements (Min, Max, Sum, Count), which is reported with OpenTelemetry.Metrics.Export.Int64SummaryData/>
         /// </summary>
         Int64Summary,
     }

--- a/src/OpenTelemetry.Api/Metrics/AggregationType.cs
+++ b/src/OpenTelemetry.Api/Metrics/AggregationType.cs
@@ -37,5 +37,15 @@ namespace OpenTelemetry.Metrics
         /// Summary of measurements (Min, Max, Sum, Count), which is reported with OpenTelemetry.Metrics.Export.Int64SummaryData/>
         /// </summary>
         Int64Summary,
+
+        /// <summary>
+        /// Distribution of measurements, which is reported with OpenTelemetry.Metrics.Export.DoubleDistributionData/>
+        /// </summary>
+        DoubleDistribution,
+
+        /// <summary>
+        /// Summary of measurements (Min, Max, Sum, Count), which is reported with OpenTelemetry.Metrics.Export.Int64DistributionData/>
+        /// </summary>
+        Int64Distribution,
     }
 }

--- a/src/OpenTelemetry.Api/Metrics/Meter.cs
+++ b/src/OpenTelemetry.Api/Metrics/Meter.cs
@@ -41,7 +41,7 @@ namespace OpenTelemetry.Metrics
         public abstract CounterMetric<double> CreateDoubleCounter(string name, bool monotonic = true);
 
         /// <summary>
-        /// Creates Int64 Measure with given name.
+        /// Creates Int64 Measure with given name defaulting to Int64SummaryData aggregation.
         /// </summary>
         /// <param name="name">The name of the measure.</param>
         /// <param name="absolute">indicates if only positive values are expected.</param>
@@ -49,12 +49,36 @@ namespace OpenTelemetry.Metrics
         public abstract MeasureMetric<long> CreateInt64Measure(string name, bool absolute = true);
 
         /// <summary>
-        /// Creates double Measure with given name.
+        /// Creates Int64 Measure with given name and aggregation type.
+        /// </summary>
+        /// <param name="name">The name of the measure.</param>
+        /// <param name="aggregationType">The type of aggregation.</param>
+        /// <param name="absolute">indicates if only positive values are expected.</param>
+        /// <returns>The measure instance.</returns>
+        public abstract MeasureMetric<long> CreateInt64Measure(
+            string name,
+            AggregationType aggregationType,
+            bool absolute = true);
+
+        /// <summary>
+        /// Creates double Measure with given name defaulting to DoubleSummaryData aggregation.
         /// </summary>
         /// <param name="name">The name of the measure.</param>
         /// <param name="absolute">indicates if only positive values are expected.</param>
         /// <returns>The measure instance.</returns>
         public abstract MeasureMetric<double> CreateDoubleMeasure(string name, bool absolute = true);
+
+        /// <summary>
+        /// Creates double Measure with given name and aggregation type.
+        /// </summary>
+        /// <param name="name">The name of the measure.</param>
+        /// <param name="aggregationType">The type of aggregation.</param>
+        /// <param name="absolute">indicates if only positive values are expected.</param>
+        /// <returns>The measure instance.</returns>
+        public abstract MeasureMetric<double> CreateDoubleMeasure(
+            string name,
+            AggregationType aggregationType,
+            bool absolute = true);
 
         /// <summary>
         /// Creates Int64 Observer with given name.

--- a/src/OpenTelemetry.Api/Metrics/ProxyMeter.cs
+++ b/src/OpenTelemetry.Api/Metrics/ProxyMeter.cs
@@ -40,6 +40,16 @@ namespace OpenTelemetry.Metrics
             return this.realMeter != null ? this.realMeter.CreateDoubleMeasure(name, absolute) : NoopMeasureMetric<double>.Instance;
         }
 
+        public override MeasureMetric<double> CreateDoubleMeasure(
+            string name,
+            AggregationType aggregationType,
+            bool absolute = true)
+        {
+            return this.realMeter != null
+                ? this.realMeter.CreateDoubleMeasure(name, aggregationType, absolute)
+                : NoopMeasureMetric<double>.Instance;
+        }
+
         public override DoubleObserverMetric CreateDoubleObserver(string name, Action<DoubleObserverMetric> callback, bool absolute = true)
         {
             return this.realMeter != null ? this.realMeter.CreateDoubleObserver(name, callback, absolute) : NoopDoubleObserverMetric.Instance;
@@ -53,6 +63,16 @@ namespace OpenTelemetry.Metrics
         public override MeasureMetric<long> CreateInt64Measure(string name, bool absolute = true)
         {
             return this.realMeter != null ? this.realMeter.CreateInt64Measure(name, absolute) : NoopMeasureMetric<long>.Instance;
+        }
+
+        public override MeasureMetric<long> CreateInt64Measure(
+            string name,
+            AggregationType aggregationType,
+            bool absolute = true)
+        {
+            return this.realMeter != null
+                ? this.realMeter.CreateInt64Measure(name, aggregationType, absolute)
+                : NoopMeasureMetric<long>.Instance;
         }
 
         public override Int64ObserverMetric CreateInt64Observer(string name, Action<Int64ObserverMetric> callback, bool absolute = true)

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterExtensions.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using OpenTelemetry.Exporter.Prometheus.Implementation;
+using OpenTelemetry.Metrics;
 using OpenTelemetry.Metrics.Export;
 
 namespace OpenTelemetry.Exporter.Prometheus

--- a/src/OpenTelemetry/Metrics/Aggregators/DoubleMeasureDistributionAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregators/DoubleMeasureDistributionAggregator.cs
@@ -1,0 +1,47 @@
+﻿// <copyright file="DoubleMeasureDistributionAggregator.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using OpenTelemetry.Metrics.Export;
+
+namespace OpenTelemetry.Metrics.Aggregators
+{
+    public class DoubleMeasureDistributionAggregator : Aggregator<double>
+    {
+        /// <inheritdoc/>
+        public override void Update(double value)
+        {
+            // TODO
+        }
+
+        /// <inheritdoc/>
+        public override void Checkpoint()
+        {
+            // TODO
+        }
+
+        /// <inheritdoc/>
+        public override MetricData ToMetricData()
+        {
+            return new DoubleDistributionData();
+        }
+
+        /// <inheritdoc/>
+        public override AggregationType GetAggregationType()
+        {
+            return AggregationType.DoubleDistribution;
+        }
+    }
+}

--- a/src/OpenTelemetry/Metrics/Aggregators/Int64MeasureDistributionAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregators/Int64MeasureDistributionAggregator.cs
@@ -1,0 +1,47 @@
+﻿// <copyright file="Int64MeasureDistributionAggregator.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using OpenTelemetry.Metrics.Export;
+
+namespace OpenTelemetry.Metrics.Aggregators
+{
+    public class Int64MeasureDistributionAggregator : Aggregator<long>
+    {
+        /// <inheritdoc/>
+        public override void Update(long value)
+        {
+            // TODO
+        }
+
+        /// <inheritdoc/>
+        public override void Checkpoint()
+        {
+            // TODO
+        }
+
+        /// <inheritdoc/>
+        public override MetricData ToMetricData()
+        {
+            return new Int64DistributionData();
+        }
+
+        /// <inheritdoc/>
+        public override AggregationType GetAggregationType()
+        {
+            return AggregationType.DoubleDistribution;
+        }
+    }
+}

--- a/src/OpenTelemetry/Metrics/DoubleBoundMeasureMetricSdk.cs
+++ b/src/OpenTelemetry/Metrics/DoubleBoundMeasureMetricSdk.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using OpenTelemetry.Metrics.Aggregators;
 using OpenTelemetry.Trace;
 
@@ -21,7 +22,22 @@ namespace OpenTelemetry.Metrics
 {
     internal class DoubleBoundMeasureMetricSdk : BoundMeasureMetricSdkBase<double>
     {
-        private readonly DoubleMeasureMinMaxSumCountAggregator measureAggregator = new DoubleMeasureMinMaxSumCountAggregator();
+        private readonly Aggregator<double> measureAggregator;
+
+        internal DoubleBoundMeasureMetricSdk(AggregationType aggregationType)
+        {
+            switch (aggregationType)
+            {
+                case AggregationType.DoubleSummary:
+                    this.measureAggregator = new DoubleMeasureMinMaxSumCountAggregator();
+                    break;
+                case AggregationType.DoubleDistribution:
+                    this.measureAggregator = new DoubleMeasureDistributionAggregator();
+                    break;
+                default:
+                    throw new NotSupportedException("Unrecognized AggregationType");
+            }
+        }
 
         public override void Record(in SpanContext context, double value)
         {

--- a/src/OpenTelemetry/Metrics/DoubleMeasureMetricSdk.cs
+++ b/src/OpenTelemetry/Metrics/DoubleMeasureMetricSdk.cs
@@ -21,11 +21,18 @@ namespace OpenTelemetry.Metrics
         public DoubleMeasureMetricSdk(string name)
             : base(name)
         {
+            this.MetricAggregationType = AggregationType.DoubleSummary;
+        }
+
+        public DoubleMeasureMetricSdk(string name, AggregationType aggregationType)
+            : base(name)
+        {
+            this.MetricAggregationType = aggregationType;
         }
 
         protected override BoundMeasureMetricSdkBase<double> CreateMetric()
         {
-            return new DoubleBoundMeasureMetricSdk();
+            return new DoubleBoundMeasureMetricSdk(this.MetricAggregationType);
         }
     }
 }

--- a/src/OpenTelemetry/Metrics/DoubleMeasureMetricSdk.cs
+++ b/src/OpenTelemetry/Metrics/DoubleMeasureMetricSdk.cs
@@ -19,15 +19,13 @@ namespace OpenTelemetry.Metrics
     internal class DoubleMeasureMetricSdk : MeasureMetricSdk<double>
     {
         public DoubleMeasureMetricSdk(string name)
-            : base(name)
+            : base(name, AggregationType.DoubleSummary)
         {
-            this.MetricAggregationType = AggregationType.DoubleSummary;
         }
 
         public DoubleMeasureMetricSdk(string name, AggregationType aggregationType)
-            : base(name)
+            : base(name, aggregationType)
         {
-            this.MetricAggregationType = aggregationType;
         }
 
         protected override BoundMeasureMetricSdkBase<double> CreateMetric()

--- a/src/OpenTelemetry/Metrics/Export/DoubleDistributionData.cs
+++ b/src/OpenTelemetry/Metrics/Export/DoubleDistributionData.cs
@@ -1,0 +1,22 @@
+﻿// <copyright file="DoubleDistributionData.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Metrics.Export
+{
+    public class DoubleDistributionData : MetricData
+    {
+    }
+}

--- a/src/OpenTelemetry/Metrics/Export/Int64DistributionData.cs
+++ b/src/OpenTelemetry/Metrics/Export/Int64DistributionData.cs
@@ -1,0 +1,22 @@
+﻿// <copyright file="Int64DistributionData.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Metrics.Export
+{
+    public class Int64DistributionData : MetricData
+    {
+    }
+}

--- a/src/OpenTelemetry/Metrics/Int64BoundMeasureMetricSdk.cs
+++ b/src/OpenTelemetry/Metrics/Int64BoundMeasureMetricSdk.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using OpenTelemetry.Metrics.Aggregators;
 using OpenTelemetry.Trace;
 
@@ -21,7 +22,22 @@ namespace OpenTelemetry.Metrics
 {
     internal class Int64BoundMeasureMetricSdk : BoundMeasureMetricSdkBase<long>
     {
-        private readonly Int64MeasureMinMaxSumCountAggregator measureAggregator = new Int64MeasureMinMaxSumCountAggregator();
+        private readonly Aggregator<long> measureAggregator;
+
+        internal Int64BoundMeasureMetricSdk(AggregationType aggregationType)
+        {
+            switch (aggregationType)
+            {
+                case AggregationType.Int64Summary:
+                    this.measureAggregator = new Int64MeasureMinMaxSumCountAggregator();
+                    break;
+                case AggregationType.Int64Distribution:
+                    this.measureAggregator = new Int64MeasureDistributionAggregator();
+                    break;
+                default:
+                    throw new NotSupportedException("Unrecognized AggregationType");
+            }
+        }
 
         public override void Record(in SpanContext context, long value)
         {

--- a/src/OpenTelemetry/Metrics/Int64MeasureMetricSdk.cs
+++ b/src/OpenTelemetry/Metrics/Int64MeasureMetricSdk.cs
@@ -21,11 +21,18 @@ namespace OpenTelemetry.Metrics
         public Int64MeasureMetricSdk(string name)
             : base(name)
         {
+            this.MetricAggregationType = AggregationType.Int64Summary;
+        }
+
+        public Int64MeasureMetricSdk(string name, AggregationType aggregationType)
+            : base(name)
+        {
+            this.MetricAggregationType = aggregationType;
         }
 
         protected override BoundMeasureMetricSdkBase<long> CreateMetric()
         {
-            return new Int64BoundMeasureMetricSdk();
+            return new Int64BoundMeasureMetricSdk(this.MetricAggregationType);
         }
     }
 }

--- a/src/OpenTelemetry/Metrics/Int64MeasureMetricSdk.cs
+++ b/src/OpenTelemetry/Metrics/Int64MeasureMetricSdk.cs
@@ -19,15 +19,13 @@ namespace OpenTelemetry.Metrics
     internal class Int64MeasureMetricSdk : MeasureMetricSdk<long>
     {
         public Int64MeasureMetricSdk(string name)
-            : base(name)
+            : base(name, AggregationType.Int64Summary)
         {
-            this.MetricAggregationType = AggregationType.Int64Summary;
         }
 
         public Int64MeasureMetricSdk(string name, AggregationType aggregationType)
-            : base(name)
+            : base(name, aggregationType)
         {
-            this.MetricAggregationType = aggregationType;
         }
 
         protected override BoundMeasureMetricSdkBase<long> CreateMetric()

--- a/src/OpenTelemetry/Metrics/MeasureMetricSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeasureMetricSdk.cs
@@ -30,6 +30,8 @@ namespace OpenTelemetry.Metrics
             this.metricName = name;
         }
 
+        public AggregationType MetricAggregationType { get; internal set; }
+
         public override BoundMeasureMetric<T> Bind(LabelSet labelset)
         {
             return this.measureBoundInstruments.GetOrAdd(labelset, this.CreateMetric());

--- a/src/OpenTelemetry/Metrics/MeasureMetricSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeasureMetricSdk.cs
@@ -25,12 +25,12 @@ namespace OpenTelemetry.Metrics
         private readonly ConcurrentDictionary<LabelSet, BoundMeasureMetricSdkBase<T>> measureBoundInstruments = new ConcurrentDictionary<LabelSet, BoundMeasureMetricSdkBase<T>>();
         private string metricName;
 
-        public MeasureMetricSdk(string name)
+        public MeasureMetricSdk(string name, AggregationType aggregationType)
         {
             this.metricName = name;
         }
 
-        public AggregationType MetricAggregationType { get; internal set; }
+        public AggregationType MetricAggregationType { get; }
 
         public override BoundMeasureMetric<T> Bind(LabelSet labelset)
         {

--- a/src/OpenTelemetry/Metrics/MeterSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterSdk.cs
@@ -152,7 +152,7 @@ namespace OpenTelemetry.Metrics
                 {
                     var metricName = longMeasure.Key;
                     var measureInstrument = longMeasure.Value;
-                    var metric = new Metric(this.meterName, metricName, this.meterName + metricName, AggregationType.Int64Summary);
+                    var metric = new Metric(this.meterName, metricName, this.meterName + metricName, measureInstrument.MetricAggregationType);
                     foreach (var handle in measureInstrument.GetAllBoundInstruments())
                     {
                         var labelSet = handle.Key;
@@ -170,7 +170,7 @@ namespace OpenTelemetry.Metrics
                 {
                     var metricName = doubleMeasure.Key;
                     var measureInstrument = doubleMeasure.Value;
-                    var metric = new Metric(this.meterName, metricName, this.meterName + metricName, AggregationType.DoubleSummary);
+                    var metric = new Metric(this.meterName, metricName, this.meterName + metricName, measureInstrument.MetricAggregationType);
                     foreach (var handle in measureInstrument.GetAllBoundInstruments())
                     {
                         var labelSet = handle.Key;
@@ -252,14 +252,28 @@ namespace OpenTelemetry.Metrics
             return this.doubleCounters.GetOrAdd(name, new DoubleCounterMetricSdk(name));
         }
 
+        /// <inheritdoc/>
         public override MeasureMetric<double> CreateDoubleMeasure(string name, bool absolute = true)
         {
             return this.doubleMeasures.GetOrAdd(name, new DoubleMeasureMetricSdk(name));
         }
 
+        /// <inheritdoc/>
+        public override MeasureMetric<double> CreateDoubleMeasure(string name, AggregationType aggregationType, bool absolute = true)
+        {
+            return this.doubleMeasures.GetOrAdd(name, new DoubleMeasureMetricSdk(name, aggregationType));
+        }
+
+        /// <inheritdoc/>
         public override MeasureMetric<long> CreateInt64Measure(string name, bool absolute = true)
         {
             return this.longMeasures.GetOrAdd(name, new Int64MeasureMetricSdk(name));
+        }
+
+        /// <inheritdoc/>
+        public override MeasureMetric<long> CreateInt64Measure(string name, AggregationType aggregationType, bool absolute = true)
+        {
+            return this.longMeasures.GetOrAdd(name, new Int64MeasureMetricSdk(name, aggregationType));
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
## Changes

Adds the skeleton as a proposal for adding new aggregators for metric distribution. Currently the Metric SDK doesn't really allow the user to specify any aggregation methods when creating gauge metrics. For example, `Meter.CreateInt64Measure` provides no param for any aggregation type and results in the default `Int64Summary` (only sum, count, min, max). For many use cases this will be dissatisfactory. For example, with GCP metrics, in order to convert the OpenTelemetry metrics, the resulting metric is simply to an average over the entire aggregation window. For our use case, we would really like to have distributions, which would give us much more accurate metrics. 

This work is basically a proposal to make sure I'm on the right path and not going in a different direction than intended. I have exposed the `AggregationType` such that it can be supplied by the user. This is only partial as there's no implementation currently to actually aggregate the metrics for the distribution. And that being said, I would like to supply 3 different distribution aggregation options (linear, exponential, explicit), which will require an additional param (an options object I am imagining) to the `Create..Measure(..., AggregationType ....)` method. But this is a good place to start and get feedback.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
