### PR TITLE
aspnet: enrich the correct activity

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -171,7 +171,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
 
                 try
                 {
-                    this.options.Enrich?.Invoke(activity, "OnStopActivity", response);
+                    this.options.Enrich?.Invoke(activityToEnrich, "OnStopActivity", response);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Changes

Under aspnet, the wrong activity was being enriched when Activities were created by the HttpInListener (remote spans)