### PR TITLE
Refactor gRPC tests

### DIFF
--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcServer.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcServer.cs
@@ -1,4 +1,4 @@
-// <copyright file="GrpcFixture.cs" company="OpenTelemetry Authors">
+// <copyright file="GrpcServer.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,27 +15,22 @@
 // </copyright>
 
 using System;
-using System.Diagnostics;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Moq;
-using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.Grpc.Tests
 {
-    public class GrpcFixture<TService> : IDisposable
+    public class GrpcServer<TService> : IDisposable
         where TService : class
     {
         private static readonly Random GlobalRandom = new Random();
 
         private readonly IHost host;
 
-        private TracerProvider openTelemetrySdk = null;
-
-        public GrpcFixture()
+        public GrpcServer()
         {
             // Allows gRPC client to call insecure gRPC services
             // https://docs.microsoft.com/en-us/aspnet/core/grpc/troubleshoot?view=aspnetcore-3.1#call-insecure-grpc-services-with-net-core-client
@@ -63,13 +58,10 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
 
         public int Port { get; }
 
-        public Mock<BaseProcessor<Activity>> GrpcServerSpanProcessor { get; } = new Mock<BaseProcessor<Activity>>();
-
         public void Dispose()
         {
             this.host.StopAsync(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult();
             this.host.Dispose();
-            this.openTelemetrySdk.Dispose();
         }
 
         private IHost CreateServer()
@@ -82,14 +74,6 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
                         {
                             // Setup a HTTP/2 endpoint without TLS.
                             options.ListenLocalhost(this.Port, o => o.Protocols = HttpProtocols.Http2);
-                        })
-                        .ConfigureServices(serviceCollection =>
-                        {
-                            this.openTelemetrySdk = Sdk
-                                .CreateTracerProviderBuilder()
-                                        .AddAspNetCoreInstrumentation()
-                                        .AddProcessor(this.GrpcServerSpanProcessor.Object)
-                                        .Build();
                         })
                         .UseStartup<Startup>();
                 });

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.client.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.client.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using System;
 using System.Diagnostics;
 using System.Net.Http;
@@ -20,14 +21,13 @@ using System.Threading.Tasks;
 using Greet;
 using Grpc.Net.Client;
 using Moq;
-using OpenTelemetry.Instrumentation.Grpc.Tests.Services;
 using OpenTelemetry.Instrumentation.GrpcNetClient;
 using OpenTelemetry.Trace;
 using Xunit;
 
 namespace OpenTelemetry.Instrumentation.Grpc.Tests
 {
-    public partial class GrpcTests : IClassFixture<GrpcFixture<GreeterService>>
+    public partial class GrpcTests
     {
         [Theory]
         [InlineData("http://localhost")]
@@ -38,7 +38,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
         [InlineData("http://[::1]", false)]
         public void GrpcClientCallsAreCollectedSuccessfully(string baseAddress, bool shouldEnrich = true)
         {
-            var uri = new Uri($"{baseAddress}:{this.fixture.Port}");
+            var uri = new Uri($"{baseAddress}:{this.server.Port}");
             var uriHostNameType = Uri.CheckHostName(uri.Host);
 
             var expectedResource = Resources.Resources.CreateServiceResource("test-service");
@@ -104,7 +104,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
         [InlineData(false)]
         public void GrpcAndHttpClientInstrumentationIsInvoked(bool shouldEnrich)
         {
-            var uri = new Uri($"http://localhost:{this.fixture.Port}");
+            var uri = new Uri($"http://localhost:{this.server.Port}");
             var expectedResource = Resources.Resources.CreateServiceResource("test-service");
             var processor = new Mock<BaseProcessor<Activity>>();
 
@@ -145,7 +145,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
         [InlineData(false)]
         public void GrpcAndHttpClientInstrumentationWithSuppressInstrumentation(bool shouldEnrich)
         {
-            var uri = new Uri($"http://localhost:{this.fixture.Port}");
+            var uri = new Uri($"http://localhost:{this.server.Port}");
             var expectedResource = Resources.Resources.CreateServiceResource("test-service");
             var processor = new Mock<BaseProcessor<Activity>>();
 


### PR DESCRIPTION
I plan to address #1403 which calls for a new configuration option for the server-side ASP.NET Core instrumentation. Though I wanted to land this small refactor of the gRPC tests first.

The primary motivation is that it better enables me to supply different configuration options when configuring the `TracerProvider` for the purposes of #1403.

However, there may be some additional benefits to this PR. That is, I do not think I designed things very well when I originally implemented these tests, and it has resulted in some strange test flickers at times. I've never experienced the flickers locally though #1082 reported that it has flickered in the past. Also, @eddynaka ran into some issues awhile back when expanding on some gRPC functionality.

I believe the flickers may have been due to my misuse of an xUnit ClassFixture. One instance of a fixture is used for all tests within a class. This meant that there was one ASP.NET Core server spun up for all the tests. I removed the usage of a ClassFixture and I now spin up a new server for each test.