### PR TITLE
Circular buffer yields on single-core machines

### DIFF
--- a/src/OpenTelemetry/Internal/CircularBuffer.cs
+++ b/src/OpenTelemetry/Internal/CircularBuffer.cs
@@ -101,6 +101,7 @@ namespace OpenTelemetry.Internal
                 var head = Interlocked.CompareExchange(ref this.head, headSnapshot + 1, headSnapshot);
                 if (head != headSnapshot)
                 {
+                    Thread.Yield();
                     continue;
                 }
 
@@ -151,6 +152,7 @@ namespace OpenTelemetry.Internal
                         return false; // exceeded maximum spin count
                     }
 
+                    Thread.Yield();
                     continue;
                 }
 


### PR DESCRIPTION
Fixes #1169.

## Changes

Add Thread.Yield() to cover corner cases while using single-core machines (in such scenario it's better to give other threads a chance to complete their work instead of just spinning)
Use it conditionally, because on multi-core machines it leads to a performance hit
Check is moved into initialization to prevent unwanted operations in tight loops
