### PR TITLE
Rename of Propagators

### DIFF
--- a/examples/Console/TestOpenTracingWithConsoleExporter.cs
+++ b/examples/Console/TestOpenTracingWithConsoleExporter.cs
@@ -40,7 +40,7 @@ namespace Examples.Console
 
             // Following shows how to use the OpenTracing shim
 
-            var tracer = new TracerShim(TracerProvider.Default.GetTracer("MyCompany.MyProduct.MyWebServer"), new TextMapPropagator());
+            var tracer = new TracerShim(TracerProvider.Default.GetTracer("MyCompany.MyProduct.MyWebServer"), new TraceContextPropagator());
 
             using (IScope parentScope = tracer.BuildSpan("Parent").StartActive(finishSpanOnDispose: true))
             {

--- a/examples/MicroserviceExample/Utils/Messaging/MessageReceiver.cs
+++ b/examples/MicroserviceExample/Utils/Messaging/MessageReceiver.cs
@@ -30,7 +30,7 @@ namespace Utils.Messaging
     public class MessageReceiver : IDisposable
     {
         private static readonly ActivitySource ActivitySource = new ActivitySource(nameof(MessageReceiver));
-        private static readonly ITextMapPropagator Propagator = new TraceContextPropagator();
+        private static readonly TextMapPropagator Propagator = new TraceContextPropagator();
 
         private readonly ILogger<MessageReceiver> logger;
         private readonly IConnection connection;

--- a/examples/MicroserviceExample/Utils/Messaging/MessageReceiver.cs
+++ b/examples/MicroserviceExample/Utils/Messaging/MessageReceiver.cs
@@ -30,7 +30,7 @@ namespace Utils.Messaging
     public class MessageReceiver : IDisposable
     {
         private static readonly ActivitySource ActivitySource = new ActivitySource(nameof(MessageReceiver));
-        private static readonly IPropagator Propagator = new TextMapPropagator();
+        private static readonly ITextMapPropagator Propagator = new TraceContextPropagator();
 
         private readonly ILogger<MessageReceiver> logger;
         private readonly IConnection connection;

--- a/examples/MicroserviceExample/Utils/Messaging/MessageSender.cs
+++ b/examples/MicroserviceExample/Utils/Messaging/MessageSender.cs
@@ -28,7 +28,7 @@ namespace Utils.Messaging
     public class MessageSender : IDisposable
     {
         private static readonly ActivitySource ActivitySource = new ActivitySource(nameof(MessageSender));
-        private static readonly ITextMapPropagator Propagator = new TraceContextPropagator();
+        private static readonly TextMapPropagator Propagator = new TraceContextPropagator();
 
         private readonly ILogger<MessageSender> logger;
         private readonly IConnection connection;

--- a/examples/MicroserviceExample/Utils/Messaging/MessageSender.cs
+++ b/examples/MicroserviceExample/Utils/Messaging/MessageSender.cs
@@ -28,7 +28,7 @@ namespace Utils.Messaging
     public class MessageSender : IDisposable
     {
         private static readonly ActivitySource ActivitySource = new ActivitySource(nameof(MessageSender));
-        private static readonly IPropagator Propagator = new TextMapPropagator();
+        private static readonly ITextMapPropagator Propagator = new TraceContextPropagator();
 
         private readonly ILogger<MessageSender> logger;
         private readonly IConnection connection;

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -9,7 +9,9 @@
 * `B3Propagator` now supports the value `true` to be passed in for the header
  `X-B3-Sampled`.
  ([#1413](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1413))
-* Renamed IPropagator to ITextMapPropagator, TextMapPropagator to TraceContextPropagator
+* Renamed TextMapPropagator to TraceContextPropagator, CompositePropapagor
+  to CompositeTextMapPropagator. IPropagator is renamed to TextMapPropagator
+  and changed from interface to abstract class.
   ([#1427](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1427))
 
 ## 0.7.0-beta.1

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -9,7 +9,7 @@
 * `B3Propagator` now supports the value `true` to be passed in for the header
  `X-B3-Sampled`.
  ([#1413](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1413))
- * Renamed IPropagator to ITextMapPropagator, TextMapPropagator to TraceContextPropagator
+* Renamed IPropagator to ITextMapPropagator, TextMapPropagator to TraceContextPropagator
   ([#1427](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1427))
 
 ## 0.7.0-beta.1

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -9,6 +9,8 @@
 * `B3Propagator` now supports the value `true` to be passed in for the header
  `X-B3-Sampled`.
  ([#1413](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1413))
+ * Renamed IPropagator to ITextMapPropagator, TextMapPropagator to TraceContextPropagator
+  ([#1427](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1427))
 
 ## 0.7.0-beta.1
 

--- a/src/OpenTelemetry.Api/Context/Propagation/B3Propagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/B3Propagator.cs
@@ -24,9 +24,9 @@ using OpenTelemetry.Internal;
 namespace OpenTelemetry.Context.Propagation
 {
     /// <summary>
-    /// B3 text propagator. See https://github.com/openzipkin/b3-propagation for the specification.
+    /// A text map propagator for B3. See https://github.com/openzipkin/b3-propagation.
     /// </summary>
-    public sealed class B3Propagator : IPropagator
+    public sealed class B3Propagator : ITextMapPropagator
     {
         internal const string XB3TraceId = "X-B3-TraceId";
         internal const string XB3SpanId = "X-B3-SpanId";

--- a/src/OpenTelemetry.Api/Context/Propagation/B3Propagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/B3Propagator.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Context.Propagation
     /// <summary>
     /// A text map propagator for B3. See https://github.com/openzipkin/b3-propagation.
     /// </summary>
-    public sealed class B3Propagator : ITextMapPropagator
+    public sealed class B3Propagator : TextMapPropagator
     {
         internal const string XB3TraceId = "X-B3-TraceId";
         internal const string XB3SpanId = "X-B3-SpanId";

--- a/src/OpenTelemetry.Api/Context/Propagation/B3Propagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/B3Propagator.cs
@@ -73,10 +73,10 @@ namespace OpenTelemetry.Context.Propagation
         }
 
         /// <inheritdoc/>
-        public ISet<string> Fields => AllFields;
+        public override ISet<string> Fields => AllFields;
 
         /// <inheritdoc/>
-        public PropagationContext Extract<T>(PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter)
+        public override PropagationContext Extract<T>(PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter)
         {
             if (context.ActivityContext.IsValid())
             {
@@ -107,7 +107,7 @@ namespace OpenTelemetry.Context.Propagation
         }
 
         /// <inheritdoc/>
-        public void Inject<T>(PropagationContext context, T carrier, Action<T, string, string> setter)
+        public override void Inject<T>(PropagationContext context, T carrier, Action<T, string, string> setter)
         {
             if (context.ActivityContext.TraceId == default || context.ActivityContext.SpanId == default)
             {

--- a/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
@@ -34,10 +34,10 @@ namespace OpenTelemetry.Context.Propagation
         private const int MaxBaggageItems = 180;
 
         /// <inheritdoc/>
-        public ISet<string> Fields => new HashSet<string> { BaggageHeaderName };
+        public override ISet<string> Fields => new HashSet<string> { BaggageHeaderName };
 
         /// <inheritdoc/>
-        public PropagationContext Extract<T>(PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter)
+        public override PropagationContext Extract<T>(PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter)
         {
             if (context.Baggage != default)
             {
@@ -79,7 +79,7 @@ namespace OpenTelemetry.Context.Propagation
         }
 
         /// <inheritdoc/>
-        public void Inject<T>(PropagationContext context, T carrier, Action<T, string, string> setter)
+        public override void Inject<T>(PropagationContext context, T carrier, Action<T, string, string> setter)
         {
             if (carrier == null)
             {

--- a/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Context.Propagation
     /// <summary>
     /// A text map propagator for W3C Baggage. See https://w3c.github.io/baggage/.
     /// </summary>
-    public class BaggagePropagator : ITextMapPropagator
+    public class BaggagePropagator : TextMapPropagator
     {
         internal const string BaggageHeaderName = "Baggage";
 

--- a/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
@@ -24,7 +24,7 @@ using OpenTelemetry.Internal;
 namespace OpenTelemetry.Context.Propagation
 {
     /// <summary>
-    /// A text map propagator for W3C Baggage. See https://w3c.github.io/baggage/
+    /// A text map propagator for W3C Baggage. See https://w3c.github.io/baggage/.
     /// </summary>
     public class BaggagePropagator : ITextMapPropagator
     {

--- a/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
@@ -24,9 +24,9 @@ using OpenTelemetry.Internal;
 namespace OpenTelemetry.Context.Propagation
 {
     /// <summary>
-    /// W3C baggage: https://github.com/w3c/baggage/blob/master/baggage/HTTP_HEADER_FORMAT.md.
+    /// A text map propagator for W3C Baggage. See https://w3c.github.io/baggage/
     /// </summary>
-    public class BaggagePropagator : IPropagator
+    public class BaggagePropagator : ITextMapPropagator
     {
         internal const string BaggageHeaderName = "Baggage";
 

--- a/src/OpenTelemetry.Api/Context/Propagation/CompositePropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/CompositePropagator.cs
@@ -22,18 +22,18 @@ namespace OpenTelemetry.Context.Propagation
     /// <summary>
     /// CompositePropagator provides a mechanism for combining multiple propagators into a single one.
     /// </summary>
-    public class CompositePropagator : IPropagator
+    public class CompositePropagator : ITextMapPropagator
     {
         private static readonly ISet<string> EmptyFields = new HashSet<string>();
-        private readonly List<IPropagator> propagators;
+        private readonly List<ITextMapPropagator> propagators;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CompositePropagator"/> class.
         /// </summary>
-        /// <param name="propagators">List of <see cref="IPropagator"/> wire context propagator.</param>
-        public CompositePropagator(IEnumerable<IPropagator> propagators)
+        /// <param name="propagators">List of <see cref="ITextMapPropagator"/> wire context propagator.</param>
+        public CompositePropagator(IEnumerable<ITextMapPropagator> propagators)
         {
-            this.propagators = new List<IPropagator>(propagators ?? throw new ArgumentNullException(nameof(propagators)));
+            this.propagators = new List<ITextMapPropagator>(propagators ?? throw new ArgumentNullException(nameof(propagators)));
         }
 
         /// <inheritdoc/>

--- a/src/OpenTelemetry.Api/Context/Propagation/CompositePropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/CompositePropagator.cs
@@ -22,18 +22,18 @@ namespace OpenTelemetry.Context.Propagation
     /// <summary>
     /// CompositePropagator provides a mechanism for combining multiple propagators into a single one.
     /// </summary>
-    public class CompositePropagator : ITextMapPropagator
+    public class CompositePropagator : TextMapPropagator
     {
         private static readonly ISet<string> EmptyFields = new HashSet<string>();
-        private readonly List<ITextMapPropagator> propagators;
+        private readonly List<TextMapPropagator> propagators;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CompositePropagator"/> class.
         /// </summary>
-        /// <param name="propagators">List of <see cref="ITextMapPropagator"/> wire context propagator.</param>
-        public CompositePropagator(IEnumerable<ITextMapPropagator> propagators)
+        /// <param name="propagators">List of <see cref="TextMapPropagator"/> wire context propagator.</param>
+        public CompositePropagator(IEnumerable<TextMapPropagator> propagators)
         {
-            this.propagators = new List<ITextMapPropagator>(propagators ?? throw new ArgumentNullException(nameof(propagators)));
+            this.propagators = new List<TextMapPropagator>(propagators ?? throw new ArgumentNullException(nameof(propagators)));
         }
 
         /// <inheritdoc/>

--- a/src/OpenTelemetry.Api/Context/Propagation/CompositePropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/CompositePropagator.cs
@@ -37,10 +37,10 @@ namespace OpenTelemetry.Context.Propagation
         }
 
         /// <inheritdoc/>
-        public ISet<string> Fields => EmptyFields;
+        public override ISet<string> Fields => EmptyFields;
 
         /// <inheritdoc/>
-        public PropagationContext Extract<T>(PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter)
+        public override PropagationContext Extract<T>(PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter)
         {
             foreach (var propagator in this.propagators)
             {
@@ -51,7 +51,7 @@ namespace OpenTelemetry.Context.Propagation
         }
 
         /// <inheritdoc/>
-        public void Inject<T>(PropagationContext context, T carrier, Action<T, string, string> setter)
+        public override void Inject<T>(PropagationContext context, T carrier, Action<T, string, string> setter)
         {
             foreach (var propagator in this.propagators)
             {

--- a/src/OpenTelemetry.Api/Context/Propagation/CompositeTextMapPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/CompositeTextMapPropagator.cs
@@ -1,4 +1,4 @@
-// <copyright file="CompositePropagator.cs" company="OpenTelemetry Authors">
+// <copyright file="CompositeTextMapPropagator.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,18 +20,19 @@ using System.Collections.Generic;
 namespace OpenTelemetry.Context.Propagation
 {
     /// <summary>
-    /// CompositePropagator provides a mechanism for combining multiple propagators into a single one.
+    /// CompositeTextMapPropagator provides a mechanism for combining multiple
+    /// textmap propagators into a single one.
     /// </summary>
-    public class CompositePropagator : TextMapPropagator
+    public class CompositeTextMapPropagator : TextMapPropagator
     {
         private static readonly ISet<string> EmptyFields = new HashSet<string>();
         private readonly List<TextMapPropagator> propagators;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CompositePropagator"/> class.
+        /// Initializes a new instance of the <see cref="CompositeTextMapPropagator"/> class.
         /// </summary>
         /// <param name="propagators">List of <see cref="TextMapPropagator"/> wire context propagator.</param>
-        public CompositePropagator(IEnumerable<TextMapPropagator> propagators)
+        public CompositeTextMapPropagator(IEnumerable<TextMapPropagator> propagators)
         {
             this.propagators = new List<TextMapPropagator>(propagators ?? throw new ArgumentNullException(nameof(propagators)));
         }

--- a/src/OpenTelemetry.Api/Context/Propagation/ITextMapPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/ITextMapPropagator.cs
@@ -24,14 +24,14 @@ namespace OpenTelemetry.Context.Propagation
     /// which uses string key/value pairs to inject and extract
     /// propagation data.
     /// </summary>
-    public interface ITextMapPropagator
+    public abstract class ITextMapPropagator
     {
         /// <summary>
         /// Gets the list of headers used by propagator. The use cases of this are:
         ///   * allow pre-allocation of fields, especially in systems like gRPC Metadata
         ///   * allow a single-pass over an iterator (ex OpenTracing has no getter in TextMap).
         /// </summary>
-        ISet<string> Fields { get; }
+        public abstract ISet<string> Fields { get; }
 
         /// <summary>
         /// Injects the context into a carrier.
@@ -40,7 +40,7 @@ namespace OpenTelemetry.Context.Propagation
         /// <param name="context">The default context to transmit over the wire.</param>
         /// <param name="carrier">Object to set context on. Instance of this object will be passed to setter.</param>
         /// <param name="setter">Action that will set name and value pair on the object.</param>
-        void Inject<T>(PropagationContext context, T carrier, Action<T, string, string> setter);
+        public abstract void Inject<T>(PropagationContext context, T carrier, Action<T, string, string> setter);
 
         /// <summary>
         /// Extracts the context from a carrier.
@@ -50,6 +50,6 @@ namespace OpenTelemetry.Context.Propagation
         /// <param name="carrier">Object to extract context from. Instance of this object will be passed to the getter.</param>
         /// <param name="getter">Function that will return string value of a key with the specified name.</param>
         /// <returns>Context from it's text representation.</returns>
-        PropagationContext Extract<T>(PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter);
+        public abstract PropagationContext Extract<T>(PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter);
     }
 }

--- a/src/OpenTelemetry.Api/Context/Propagation/ITextMapPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/ITextMapPropagator.cs
@@ -1,4 +1,4 @@
-// <copyright file="IPropagator.cs" company="OpenTelemetry Authors">
+// <copyright file="ITextMapPropagator.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,10 +20,11 @@ using System.Collections.Generic;
 namespace OpenTelemetry.Context.Propagation
 {
     /// <summary>
-    /// Defines an interface for Propagator, which is used to read and write
-    /// context data from and to message exchanges by the applications.
+    /// Defines an interface for a Propagator of TextMap type,
+    /// which uses string key/value pairs to inject and extract
+    /// propagation data.
     /// </summary>
-    public interface IPropagator
+    public interface ITextMapPropagator
     {
         /// <summary>
         /// Gets the list of headers used by propagator. The use cases of this are:

--- a/src/OpenTelemetry.Api/Context/Propagation/TextMapPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TextMapPropagator.cs
@@ -1,4 +1,4 @@
-// <copyright file="ITextMapPropagator.cs" company="OpenTelemetry Authors">
+// <copyright file="TextMapPropagator.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +24,7 @@ namespace OpenTelemetry.Context.Propagation
     /// which uses string key/value pairs to inject and extract
     /// propagation data.
     /// </summary>
-    public abstract class ITextMapPropagator
+    public abstract class TextMapPropagator
     {
         /// <summary>
         /// Gets the list of headers used by propagator. The use cases of this are:

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
@@ -40,10 +40,10 @@ namespace OpenTelemetry.Context.Propagation
         private static readonly int TraceparentLengthV0 = "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-00".Length;
 
         /// <inheritdoc/>
-        public ISet<string> Fields => new HashSet<string> { TraceState, TraceParent };
+        public override ISet<string> Fields => new HashSet<string> { TraceState, TraceParent };
 
         /// <inheritdoc/>
-        public PropagationContext Extract<T>(PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter)
+        public override PropagationContext Extract<T>(PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter)
         {
             if (context.ActivityContext.IsValid())
             {
@@ -102,7 +102,7 @@ namespace OpenTelemetry.Context.Propagation
         }
 
         /// <inheritdoc/>
-        public void Inject<T>(PropagationContext context, T carrier, Action<T, string, string> setter)
+        public override void Inject<T>(PropagationContext context, T carrier, Action<T, string, string> setter)
         {
             if (context.ActivityContext.TraceId == default || context.ActivityContext.SpanId == default)
             {

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Context.Propagation
     /// <summary>
     /// A text map propagator for W3C trace context. See https://w3c.github.io/trace-context/.
     /// </summary>
-    public class TraceContextPropagator : ITextMapPropagator
+    public class TraceContextPropagator : TextMapPropagator
     {
         private const string TraceParent = "traceparent";
         private const string TraceState = "tracestate";

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
@@ -1,4 +1,4 @@
-// <copyright file="TextMapPropagator.cs" company="OpenTelemetry Authors">
+// <copyright file="TraceContextPropagator.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,9 +24,9 @@ using OpenTelemetry.Internal;
 namespace OpenTelemetry.Context.Propagation
 {
     /// <summary>
-    /// W3C trace context text wire protocol formatter. See https://github.com/w3c/distributed-tracing/.
+    /// A text map propagator for W3C trace context. See https://w3c.github.io/trace-context/.
     /// </summary>
-    public class TextMapPropagator : IPropagator
+    public class TraceContextPropagator : ITextMapPropagator
     {
         private const string TraceParent = "traceparent";
         private const string TraceState = "tracestate";
@@ -53,13 +53,13 @@ namespace OpenTelemetry.Context.Propagation
 
             if (carrier == null)
             {
-                OpenTelemetryApiEventSource.Log.FailedToExtractActivityContext(nameof(TextMapPropagator), "null carrier");
+                OpenTelemetryApiEventSource.Log.FailedToExtractActivityContext(nameof(TraceContextPropagator), "null carrier");
                 return context;
             }
 
             if (getter == null)
             {
-                OpenTelemetryApiEventSource.Log.FailedToExtractActivityContext(nameof(TextMapPropagator), "null getter");
+                OpenTelemetryApiEventSource.Log.FailedToExtractActivityContext(nameof(TraceContextPropagator), "null getter");
                 return context;
             }
 
@@ -94,7 +94,7 @@ namespace OpenTelemetry.Context.Propagation
             }
             catch (Exception ex)
             {
-                OpenTelemetryApiEventSource.Log.ActivityContextExtractException(nameof(TextMapPropagator), ex);
+                OpenTelemetryApiEventSource.Log.ActivityContextExtractException(nameof(TraceContextPropagator), ex);
             }
 
             // in case of exception indicate to upstream that there is no parseable context from the top
@@ -106,19 +106,19 @@ namespace OpenTelemetry.Context.Propagation
         {
             if (context.ActivityContext.TraceId == default || context.ActivityContext.SpanId == default)
             {
-                OpenTelemetryApiEventSource.Log.FailedToInjectActivityContext(nameof(TextMapPropagator), "Invalid context");
+                OpenTelemetryApiEventSource.Log.FailedToInjectActivityContext(nameof(TraceContextPropagator), "Invalid context");
                 return;
             }
 
             if (carrier == null)
             {
-                OpenTelemetryApiEventSource.Log.FailedToInjectActivityContext(nameof(TextMapPropagator), "null carrier");
+                OpenTelemetryApiEventSource.Log.FailedToInjectActivityContext(nameof(TraceContextPropagator), "null carrier");
                 return;
             }
 
             if (setter == null)
             {
-                OpenTelemetryApiEventSource.Log.FailedToInjectActivityContext(nameof(TextMapPropagator), "null setter");
+                OpenTelemetryApiEventSource.Log.FailedToInjectActivityContext(nameof(TraceContextPropagator), "null setter");
                 return;
             }
 

--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationOptions.cs
@@ -27,9 +27,9 @@ namespace OpenTelemetry.Instrumentation.AspNet
     public class AspNetInstrumentationOptions
     {
         /// <summary>
-        /// Gets or sets <see cref="ITextMapPropagator"/> for context propagation. Default value: <see cref="CompositePropagator"/> with <see cref="TraceContextPropagator"/> &amp; <see cref="BaggagePropagator"/>.
+        /// Gets or sets <see cref="TextMapPropagator"/> for context propagation. Default value: <see cref="CompositePropagator"/> with <see cref="TraceContextPropagator"/> &amp; <see cref="BaggagePropagator"/>.
         /// </summary>
-        public ITextMapPropagator Propagator { get; set; } = new CompositePropagator(new ITextMapPropagator[]
+        public TextMapPropagator Propagator { get; set; } = new CompositePropagator(new TextMapPropagator[]
         {
             new TraceContextPropagator(),
             new BaggagePropagator(),

--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationOptions.cs
@@ -27,9 +27,9 @@ namespace OpenTelemetry.Instrumentation.AspNet
     public class AspNetInstrumentationOptions
     {
         /// <summary>
-        /// Gets or sets <see cref="TextMapPropagator"/> for context propagation. Default value: <see cref="CompositePropagator"/> with <see cref="TraceContextPropagator"/> &amp; <see cref="BaggagePropagator"/>.
+        /// Gets or sets <see cref="TextMapPropagator"/> for context propagation. Default value: <see cref="CompositeTextMapPropagator"/> with <see cref="TraceContextPropagator"/> &amp; <see cref="BaggagePropagator"/>.
         /// </summary>
-        public TextMapPropagator Propagator { get; set; } = new CompositePropagator(new TextMapPropagator[]
+        public TextMapPropagator Propagator { get; set; } = new CompositeTextMapPropagator(new TextMapPropagator[]
         {
             new TraceContextPropagator(),
             new BaggagePropagator(),

--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationOptions.cs
@@ -27,11 +27,11 @@ namespace OpenTelemetry.Instrumentation.AspNet
     public class AspNetInstrumentationOptions
     {
         /// <summary>
-        /// Gets or sets <see cref="IPropagator"/> for context propagation. Default value: <see cref="CompositePropagator"/> with <see cref="TextMapPropagator"/> &amp; <see cref="BaggagePropagator"/>.
+        /// Gets or sets <see cref="ITextMapPropagator"/> for context propagation. Default value: <see cref="CompositePropagator"/> with <see cref="TraceContextPropagator"/> &amp; <see cref="BaggagePropagator"/>.
         /// </summary>
-        public IPropagator Propagator { get; set; } = new CompositePropagator(new IPropagator[]
+        public ITextMapPropagator Propagator { get; set; } = new CompositePropagator(new ITextMapPropagator[]
         {
-            new TextMapPropagator(),
+            new TraceContextPropagator(),
             new BaggagePropagator(),
         });
 

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-* Renamed IPropagator to ITextMapPropagator, TextMapPropagator to TraceContextPropagator
+* Renamed TextMapPropagator to TraceContextPropagator, CompositePropapagor
+  to CompositeTextMapPropagator. IPropagator is renamed to TextMapPropagator
+  and changed from interface to abstract class.
   ([#1427](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1427))
 
 ## 0.7.0-beta.1

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Renamed IPropagator to ITextMapPropagator, TextMapPropagator to TraceContextPropagator
+  ([#1427](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1427))
+
 ## 0.7.0-beta.1
 
 Released 2020-Oct-16

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -70,7 +70,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
             var request = context.Request;
             var requestValues = request.Unvalidated;
 
-            if (!(this.options.Propagator is TextMapPropagator))
+            if (!(this.options.Propagator is TraceContextPropagator))
             {
                 var ctx = this.options.Propagator.Extract(default, request, HttpRequestHeaderValuesGetter);
 
@@ -139,7 +139,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
             Activity activityToEnrich = activity;
             Activity createdActivity = null;
 
-            bool isCustomPropagator = !(this.options.Propagator is TextMapPropagator);
+            bool isCustomPropagator = !(this.options.Propagator is TraceContextPropagator);
 
             if (isCustomPropagator)
             {

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationOptions.cs
@@ -27,11 +27,11 @@ namespace OpenTelemetry.Instrumentation.AspNetCore
     public class AspNetCoreInstrumentationOptions
     {
         /// <summary>
-        /// Gets or sets <see cref="IPropagator"/> for context propagation. Default value: <see cref="CompositePropagator"/> with <see cref="TextMapPropagator"/> &amp; <see cref="BaggagePropagator"/>.
+        /// Gets or sets <see cref="ITextMapPropagator"/> for context propagation. Default value: <see cref="CompositePropagator"/> with <see cref="TraceContextPropagator"/> &amp; <see cref="BaggagePropagator"/>.
         /// </summary>
-        public IPropagator Propagator { get; set; } = new CompositePropagator(new IPropagator[]
+        public ITextMapPropagator Propagator { get; set; } = new CompositePropagator(new ITextMapPropagator[]
         {
-            new TextMapPropagator(),
+            new TraceContextPropagator(),
             new BaggagePropagator(),
         });
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationOptions.cs
@@ -27,9 +27,9 @@ namespace OpenTelemetry.Instrumentation.AspNetCore
     public class AspNetCoreInstrumentationOptions
     {
         /// <summary>
-        /// Gets or sets <see cref="TextMapPropagator"/> for context propagation. Default value: <see cref="CompositePropagator"/> with <see cref="TraceContextPropagator"/> &amp; <see cref="BaggagePropagator"/>.
+        /// Gets or sets <see cref="TextMapPropagator"/> for context propagation. Default value: <see cref="CompositeTextMapPropagator"/> with <see cref="TraceContextPropagator"/> &amp; <see cref="BaggagePropagator"/>.
         /// </summary>
-        public TextMapPropagator Propagator { get; set; } = new CompositePropagator(new TextMapPropagator[]
+        public TextMapPropagator Propagator { get; set; } = new CompositeTextMapPropagator(new TextMapPropagator[]
         {
             new TraceContextPropagator(),
             new BaggagePropagator(),

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationOptions.cs
@@ -27,9 +27,9 @@ namespace OpenTelemetry.Instrumentation.AspNetCore
     public class AspNetCoreInstrumentationOptions
     {
         /// <summary>
-        /// Gets or sets <see cref="ITextMapPropagator"/> for context propagation. Default value: <see cref="CompositePropagator"/> with <see cref="TraceContextPropagator"/> &amp; <see cref="BaggagePropagator"/>.
+        /// Gets or sets <see cref="TextMapPropagator"/> for context propagation. Default value: <see cref="CompositePropagator"/> with <see cref="TraceContextPropagator"/> &amp; <see cref="BaggagePropagator"/>.
         /// </summary>
-        public ITextMapPropagator Propagator { get; set; } = new CompositePropagator(new ITextMapPropagator[]
+        public TextMapPropagator Propagator { get; set; } = new CompositePropagator(new TextMapPropagator[]
         {
             new TraceContextPropagator(),
             new BaggagePropagator(),

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -10,7 +10,9 @@
   [Grpc.AspNetCore](https://www.nuget.org/packages/Grpc.AspNetCore/).
   This option is enabled by default.
   ([#1423](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1423))
-* Renamed IPropagator to ITextMapPropagator, TextMapPropagator to TraceContextPropagator
+* Renamed TextMapPropagator to TraceContextPropagator, CompositePropapagor
+  to CompositeTextMapPropagator. IPropagator is renamed to TextMapPropagator
+  and changed from interface to abstract class.
   ([#1427](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1427))
 
 ## 0.7.0-beta.1

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -10,6 +10,8 @@
   [Grpc.AspNetCore](https://www.nuget.org/packages/Grpc.AspNetCore/).
   This option is enabled by default.
   ([#1423](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1423))
+* Renamed IPropagator to ITextMapPropagator, TextMapPropagator to TraceContextPropagator
+  ([#1427](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1427))
 
 ## 0.7.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -78,7 +78,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
             }
 
             var request = context.Request;
-            if (!this.hostingSupportsW3C || !(this.options.Propagator is TextMapPropagator))
+            if (!this.hostingSupportsW3C || !(this.options.Propagator is TraceContextPropagator))
             {
                 var ctx = this.options.Propagator.Extract(default, request, HttpRequestHeaderValuesGetter);
 

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -6,7 +6,9 @@
   `HttpWebRequest` in Activity.CustomProperty. To enrich activity, use the
   Enrich action on the instrumentation.
   ([#1407](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1407))
-* Renamed IPropagator to ITextMapPropagator, TextMapPropagator to TraceContextPropagator
+* Renamed TextMapPropagator to TraceContextPropagator, CompositePropapagor
+  to CompositeTextMapPropagator. IPropagator is renamed to TextMapPropagator
+  and changed from interface to abstract class.
   ([#1427](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1427))
 
 ## 0.7.0-beta.1

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -6,6 +6,8 @@
   `HttpWebRequest` in Activity.CustomProperty. To enrich activity, use the
   Enrich action on the instrumentation.
   ([#1407](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1407))
+* Renamed IPropagator to ITextMapPropagator, TextMapPropagator to TraceContextPropagator
+  ([#1427](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1427))
 
 ## 0.7.0-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.Http/HttpClientInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/HttpClientInstrumentationOptions.cs
@@ -35,9 +35,9 @@ namespace OpenTelemetry.Instrumentation.Http
         public bool SetHttpFlavor { get; set; }
 
         /// <summary>
-        /// Gets or sets <see cref="ITextMapPropagator"/> for context propagation. Default value: <see cref="CompositePropagator"/> with <see cref="TraceContextPropagator"/> &amp; <see cref="BaggagePropagator"/>.
+        /// Gets or sets <see cref="TextMapPropagator"/> for context propagation. Default value: <see cref="CompositePropagator"/> with <see cref="TraceContextPropagator"/> &amp; <see cref="BaggagePropagator"/>.
         /// </summary>
-        public ITextMapPropagator Propagator { get; set; } = new CompositePropagator(new ITextMapPropagator[]
+        public TextMapPropagator Propagator { get; set; } = new CompositePropagator(new TextMapPropagator[]
         {
             new TraceContextPropagator(),
             new BaggagePropagator(),

--- a/src/OpenTelemetry.Instrumentation.Http/HttpClientInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/HttpClientInstrumentationOptions.cs
@@ -35,9 +35,9 @@ namespace OpenTelemetry.Instrumentation.Http
         public bool SetHttpFlavor { get; set; }
 
         /// <summary>
-        /// Gets or sets <see cref="TextMapPropagator"/> for context propagation. Default value: <see cref="CompositePropagator"/> with <see cref="TraceContextPropagator"/> &amp; <see cref="BaggagePropagator"/>.
+        /// Gets or sets <see cref="TextMapPropagator"/> for context propagation. Default value: <see cref="CompositeTextMapPropagator"/> with <see cref="TraceContextPropagator"/> &amp; <see cref="BaggagePropagator"/>.
         /// </summary>
-        public TextMapPropagator Propagator { get; set; } = new CompositePropagator(new TextMapPropagator[]
+        public TextMapPropagator Propagator { get; set; } = new CompositeTextMapPropagator(new TextMapPropagator[]
         {
             new TraceContextPropagator(),
             new BaggagePropagator(),

--- a/src/OpenTelemetry.Instrumentation.Http/HttpClientInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/HttpClientInstrumentationOptions.cs
@@ -35,11 +35,11 @@ namespace OpenTelemetry.Instrumentation.Http
         public bool SetHttpFlavor { get; set; }
 
         /// <summary>
-        /// Gets or sets <see cref="IPropagator"/> for context propagation. Default value: <see cref="CompositePropagator"/> with <see cref="TextMapPropagator"/> &amp; <see cref="BaggagePropagator"/>.
+        /// Gets or sets <see cref="ITextMapPropagator"/> for context propagation. Default value: <see cref="CompositePropagator"/> with <see cref="TraceContextPropagator"/> &amp; <see cref="BaggagePropagator"/>.
         /// </summary>
-        public IPropagator Propagator { get; set; } = new CompositePropagator(new IPropagator[]
+        public ITextMapPropagator Propagator { get; set; } = new CompositePropagator(new ITextMapPropagator[]
         {
-            new TextMapPropagator(),
+            new TraceContextPropagator(),
             new BaggagePropagator(),
         });
 

--- a/src/OpenTelemetry.Instrumentation.Http/HttpWebRequestInstrumentationOptions.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/HttpWebRequestInstrumentationOptions.netfx.cs
@@ -35,9 +35,9 @@ namespace OpenTelemetry.Instrumentation.Http
         public bool SetHttpFlavor { get; set; }
 
         /// <summary>
-        /// Gets or sets <see cref="ITextMapPropagator"/> for context propagation. Default value: <see cref="CompositePropagator"/> with <see cref="TraceContextPropagator"/> &amp; <see cref="BaggagePropagator"/>.
+        /// Gets or sets <see cref="TextMapPropagator"/> for context propagation. Default value: <see cref="CompositePropagator"/> with <see cref="TraceContextPropagator"/> &amp; <see cref="BaggagePropagator"/>.
         /// </summary>
-        public ITextMapPropagator Propagator { get; set; } = new CompositePropagator(new ITextMapPropagator[]
+        public TextMapPropagator Propagator { get; set; } = new CompositePropagator(new TextMapPropagator[]
         {
             new TraceContextPropagator(),
             new BaggagePropagator(),

--- a/src/OpenTelemetry.Instrumentation.Http/HttpWebRequestInstrumentationOptions.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/HttpWebRequestInstrumentationOptions.netfx.cs
@@ -35,9 +35,9 @@ namespace OpenTelemetry.Instrumentation.Http
         public bool SetHttpFlavor { get; set; }
 
         /// <summary>
-        /// Gets or sets <see cref="TextMapPropagator"/> for context propagation. Default value: <see cref="CompositePropagator"/> with <see cref="TraceContextPropagator"/> &amp; <see cref="BaggagePropagator"/>.
+        /// Gets or sets <see cref="TextMapPropagator"/> for context propagation. Default value: <see cref="CompositeTextMapPropagator"/> with <see cref="TraceContextPropagator"/> &amp; <see cref="BaggagePropagator"/>.
         /// </summary>
-        public TextMapPropagator Propagator { get; set; } = new CompositePropagator(new TextMapPropagator[]
+        public TextMapPropagator Propagator { get; set; } = new CompositeTextMapPropagator(new TextMapPropagator[]
         {
             new TraceContextPropagator(),
             new BaggagePropagator(),

--- a/src/OpenTelemetry.Instrumentation.Http/HttpWebRequestInstrumentationOptions.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/HttpWebRequestInstrumentationOptions.netfx.cs
@@ -35,11 +35,11 @@ namespace OpenTelemetry.Instrumentation.Http
         public bool SetHttpFlavor { get; set; }
 
         /// <summary>
-        /// Gets or sets <see cref="IPropagator"/> for context propagation. Default value: <see cref="CompositePropagator"/> with <see cref="TextMapPropagator"/> &amp; <see cref="BaggagePropagator"/>.
+        /// Gets or sets <see cref="ITextMapPropagator"/> for context propagation. Default value: <see cref="CompositePropagator"/> with <see cref="TraceContextPropagator"/> &amp; <see cref="BaggagePropagator"/>.
         /// </summary>
-        public IPropagator Propagator { get; set; } = new CompositePropagator(new IPropagator[]
+        public ITextMapPropagator Propagator { get; set; } = new CompositePropagator(new ITextMapPropagator[]
         {
-            new TextMapPropagator(),
+            new TraceContextPropagator(),
             new BaggagePropagator(),
         });
 

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -115,7 +115,7 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
                 }
             }
 
-            if (!(this.httpClientSupportsW3C && this.options.Propagator is TextMapPropagator))
+            if (!(this.httpClientSupportsW3C && this.options.Propagator is TraceContextPropagator))
             {
                 this.options.Propagator.Inject(new PropagationContext(activity.Context, Baggage.Current), request, HttpRequestMessageHeaderValueSetter);
             }

--- a/src/OpenTelemetry.Shims.OpenTracing/CHANGELOG.md
+++ b/src/OpenTelemetry.Shims.OpenTracing/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-* Renamed IPropagator to ITextMapPropagator, TextMapPropagator to TraceContextPropagator
+* Renamed TextMapPropagator to TraceContextPropagator, CompositePropapagor
+  to CompositeTextMapPropagator. IPropagator is renamed to TextMapPropagator
+  and changed from interface to abstract class.
   ([#1427](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1427))
 
 ## 0.7.0-beta.1

--- a/src/OpenTelemetry.Shims.OpenTracing/CHANGELOG.md
+++ b/src/OpenTelemetry.Shims.OpenTracing/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+* Renamed IPropagator to ITextMapPropagator, TextMapPropagator to TraceContextPropagator
+  ([#1427](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1427))
 
 ## 0.7.0-beta.1
 

--- a/src/OpenTelemetry.Shims.OpenTracing/CHANGELOG.md
+++ b/src/OpenTelemetry.Shims.OpenTracing/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+
 * Renamed IPropagator to ITextMapPropagator, TextMapPropagator to TraceContextPropagator
   ([#1427](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1427))
 

--- a/src/OpenTelemetry.Shims.OpenTracing/TracerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/TracerShim.cs
@@ -24,9 +24,9 @@ namespace OpenTelemetry.Shims.OpenTracing
     public class TracerShim : global::OpenTracing.ITracer
     {
         private readonly Trace.Tracer tracer;
-        private readonly IPropagator propagator;
+        private readonly ITextMapPropagator propagator;
 
-        public TracerShim(Trace.Tracer tracer, IPropagator textFormat)
+        public TracerShim(Trace.Tracer tracer, ITextMapPropagator textFormat)
         {
             this.tracer = tracer ?? throw new ArgumentNullException(nameof(tracer));
             this.propagator = textFormat ?? throw new ArgumentNullException(nameof(textFormat));

--- a/src/OpenTelemetry.Shims.OpenTracing/TracerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/TracerShim.cs
@@ -24,9 +24,9 @@ namespace OpenTelemetry.Shims.OpenTracing
     public class TracerShim : global::OpenTracing.ITracer
     {
         private readonly Trace.Tracer tracer;
-        private readonly ITextMapPropagator propagator;
+        private readonly TextMapPropagator propagator;
 
-        public TracerShim(Trace.Tracer tracer, ITextMapPropagator textFormat)
+        public TracerShim(Trace.Tracer tracer, TextMapPropagator textFormat)
         {
             this.tracer = tracer ?? throw new ArgumentNullException(nameof(tracer));
             this.propagator = textFormat ?? throw new ArgumentNullException(nameof(textFormat));

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -128,7 +128,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
 
             var expectedTraceId = ActivityTraceId.CreateRandom();
             var expectedSpanId = ActivitySpanId.CreateRandom();
-            var propagator = new Mock<ITextMapPropagator>();
+            var propagator = new Mock<TextMapPropagator>();
             propagator.Setup(m => m.Extract<HttpRequest>(It.IsAny<PropagationContext>(), It.IsAny<HttpRequest>(), It.IsAny<Func<HttpRequest, string, IEnumerable<string>>>())).Returns(new PropagationContext(
                 new ActivityContext(
                     expectedTraceId,

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -128,7 +128,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
 
             var expectedTraceId = ActivityTraceId.CreateRandom();
             var expectedSpanId = ActivitySpanId.CreateRandom();
-            var propagator = new Mock<IPropagator>();
+            var propagator = new Mock<ITextMapPropagator>();
             propagator.Setup(m => m.Extract<HttpRequest>(It.IsAny<PropagationContext>(), It.IsAny<HttpRequest>(), It.IsAny<Func<HttpRequest, string, IEnumerable<string>>>())).Returns(new PropagationContext(
                 new ActivityContext(
                     expectedTraceId,

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
@@ -196,7 +196,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             var expectedTraceId = ActivityTraceId.CreateRandom();
             var expectedSpanId = ActivitySpanId.CreateRandom();
 
-            var propagator = new Mock<IPropagator>();
+            var propagator = new Mock<ITextMapPropagator>();
             propagator.Setup(m => m.Extract(It.IsAny<PropagationContext>(), It.IsAny<HttpRequest>(), It.IsAny<Func<HttpRequest, string, IEnumerable<string>>>())).Returns(
                 new PropagationContext(
                     new ActivityContext(

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
@@ -196,7 +196,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             var expectedTraceId = ActivityTraceId.CreateRandom();
             var expectedSpanId = ActivitySpanId.CreateRandom();
 
-            var propagator = new Mock<ITextMapPropagator>();
+            var propagator = new Mock<TextMapPropagator>();
             propagator.Setup(m => m.Extract(It.IsAny<PropagationContext>(), It.IsAny<HttpRequest>(), It.IsAny<Func<HttpRequest, string, IEnumerable<string>>>())).Returns(
                 new PropagationContext(
                     new ActivityContext(

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.netcore31.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.netcore31.cs
@@ -75,7 +75,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
             parent.ActivityTraceFlags = ActivityTraceFlags.Recorded;
 
             // Ensure that the header value func does not throw if the header key can't be found
-            var mockPropagator = new Mock<IPropagator>();
+            var mockPropagator = new Mock<ITextMapPropagator>();
 
             // var isInjectedHeaderValueGetterThrows = false;
             // mockTextFormat
@@ -133,7 +133,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         [InlineData(false)]
         public async Task HttpClientInstrumentationInjectsHeadersAsync_CustomFormat(bool shouldEnrich)
         {
-            var propagator = new Mock<IPropagator>();
+            var propagator = new Mock<ITextMapPropagator>();
             propagator.Setup(m => m.Inject<HttpRequestMessage>(It.IsAny<PropagationContext>(), It.IsAny<HttpRequestMessage>(), It.IsAny<Action<HttpRequestMessage, string, string>>()))
                 .Callback<PropagationContext, HttpRequestMessage, Action<HttpRequestMessage, string, string>>((context, message, action) =>
                 {

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.netcore31.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.netcore31.cs
@@ -75,7 +75,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
             parent.ActivityTraceFlags = ActivityTraceFlags.Recorded;
 
             // Ensure that the header value func does not throw if the header key can't be found
-            var mockPropagator = new Mock<ITextMapPropagator>();
+            var mockPropagator = new Mock<TextMapPropagator>();
 
             // var isInjectedHeaderValueGetterThrows = false;
             // mockTextFormat
@@ -133,7 +133,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         [InlineData(false)]
         public async Task HttpClientInstrumentationInjectsHeadersAsync_CustomFormat(bool shouldEnrich)
         {
-            var propagator = new Mock<ITextMapPropagator>();
+            var propagator = new Mock<TextMapPropagator>();
             propagator.Setup(m => m.Inject<HttpRequestMessage>(It.IsAny<PropagationContext>(), It.IsAny<HttpRequestMessage>(), It.IsAny<Action<HttpRequestMessage, string, string>>()))
                 .Callback<PropagationContext, HttpRequestMessage, Action<HttpRequestMessage, string, string>>((context, message, action) =>
                 {

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.Basic.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.Basic.netfx.cs
@@ -98,7 +98,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         [Fact]
         public async Task HttpWebRequestInstrumentationInjectsHeadersAsync_CustomFormat()
         {
-            var propagator = new Mock<IPropagator>();
+            var propagator = new Mock<ITextMapPropagator>();
             propagator.Setup(m => m.Inject(It.IsAny<PropagationContext>(), It.IsAny<HttpWebRequest>(), It.IsAny<Action<HttpWebRequest, string, string>>()))
                 .Callback<PropagationContext, HttpWebRequest, Action<HttpWebRequest, string, string>>((context, message, action) =>
                 {

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.Basic.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.Basic.netfx.cs
@@ -98,7 +98,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         [Fact]
         public async Task HttpWebRequestInstrumentationInjectsHeadersAsync_CustomFormat()
         {
-            var propagator = new Mock<ITextMapPropagator>();
+            var propagator = new Mock<TextMapPropagator>();
             propagator.Setup(m => m.Inject(It.IsAny<PropagationContext>(), It.IsAny<HttpWebRequest>(), It.IsAny<Action<HttpWebRequest, string, string>>()))
                 .Callback<PropagationContext, HttpWebRequest, Action<HttpWebRequest, string, string>>((context, message, action) =>
                 {

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/TracerShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/TracerShimTests.cs
@@ -39,7 +39,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
             Assert.Throws<ArgumentNullException>(() => new TracerShim(null, null));
 
             // null tracer
-            Assert.Throws<ArgumentNullException>(() => new TracerShim(null, new TextMapPropagator()));
+            Assert.Throws<ArgumentNullException>(() => new TracerShim(null, new TraceContextPropagator()));
 
             // null context format
             var tracerMock = new Mock<Trace.Tracer>();
@@ -50,7 +50,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
         public void ScopeManager_NotNull()
         {
             var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new TracerShim(tracer, new TextMapPropagator());
+            var shim = new TracerShim(tracer, new TraceContextPropagator());
 
             // Internals of the ScopeManagerShim tested elsewhere
             Assert.NotNull(shim.ScopeManager as ScopeManagerShim);
@@ -60,7 +60,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
         public void BuildSpan_NotNull()
         {
             var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new TracerShim(tracer, new TextMapPropagator());
+            var shim = new TracerShim(tracer, new TraceContextPropagator());
 
             // Internals of the SpanBuilderShim tested elsewhere
             Assert.NotNull(shim.BuildSpan("foo") as SpanBuilderShim);
@@ -70,7 +70,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
         public void Inject_ArgumentValidation()
         {
             var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new TracerShim(tracer, new TextMapPropagator());
+            var shim = new TracerShim(tracer, new TraceContextPropagator());
 
             var spanContextShim = new SpanContextShim(new SpanContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.None));
             var mockFormat = new Mock<IFormat<ITextMap>>();
@@ -86,7 +86,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
         public void Inject_UnknownFormatIgnored()
         {
             var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new TracerShim(tracer, new TextMapPropagator());
+            var shim = new TracerShim(tracer, new TraceContextPropagator());
 
             var spanContextShim = new SpanContextShim(new SpanContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded));
 
@@ -102,7 +102,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
         public void Extract_ArgumentValidation()
         {
             var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new TracerShim(tracer, new TextMapPropagator());
+            var shim = new TracerShim(tracer, new TraceContextPropagator());
 
             Assert.Throws<ArgumentNullException>(() => shim.Extract(null, new Mock<ITextMap>().Object));
             Assert.Throws<ArgumentNullException>(() => shim.Extract(new Mock<IFormat<ITextMap>>().Object, null));
@@ -112,7 +112,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
         public void Extract_UnknownFormatIgnored()
         {
             var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new TracerShim(tracer, new TextMapPropagator());
+            var shim = new TracerShim(tracer, new TraceContextPropagator());
 
             var spanContextShim = new SpanContextShim(new SpanContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.None));
 
@@ -128,11 +128,11 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
         public void Extract_InvalidTraceParent()
         {
             var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new TracerShim(tracer, new TextMapPropagator());
+            var shim = new TracerShim(tracer, new TraceContextPropagator());
 
             var mockCarrier = new Mock<ITextMap>();
 
-            // The ProxyTracer uses OpenTelemetry.Context.Propagation.TextMapPropagator, so we need to satisfy the traceparent key at the least
+            // The ProxyTracer uses OpenTelemetry.Context.Propagation.TraceContextPropagator, so we need to satisfy the traceparent key at the least
             var carrierMap = new Dictionary<string, string>
             {
                 // This is an invalid traceparent value
@@ -155,7 +155,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
 
             var spanContextShim = new SpanContextShim(new SpanContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.None));
 
-            var format = new TextMapPropagator();
+            var format = new TraceContextPropagator();
 
             var tracer = TracerProvider.Default.GetTracer(TracerName);
             var shim = new TracerShim(tracer, format);

--- a/test/OpenTelemetry.Tests/Trace/Propagation/CompositePropagatorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/CompositePropagatorTest.cs
@@ -49,13 +49,13 @@ namespace OpenTelemetry.Context.Propagation.Tests
         [Fact]
         public void CompositePropagator_NullTextFormatList()
         {
-            Assert.Throws<ArgumentNullException>(() => new CompositePropagator(null));
+            Assert.Throws<ArgumentNullException>(() => new CompositeTextMapPropagator(null));
         }
 
         [Fact]
         public void CompositePropagator_TestPropagator()
         {
-            var compositePropagator = new CompositePropagator(new List<TextMapPropagator>
+            var compositePropagator = new CompositeTextMapPropagator(new List<TextMapPropagator>
             {
                 new TestPropagator("custom-traceparent-1", "custom-tracestate-1"),
                 new TestPropagator("custom-traceparent-2", "custom-tracestate-2"),
@@ -77,7 +77,7 @@ namespace OpenTelemetry.Context.Propagation.Tests
             const string header01 = "custom-tracestate-01";
             const string header02 = "custom-tracestate-02";
 
-            var compositePropagator = new CompositePropagator(new List<TextMapPropagator>
+            var compositePropagator = new CompositeTextMapPropagator(new List<TextMapPropagator>
             {
                 new TestPropagator("custom-traceparent", header01, true),
                 new TestPropagator("custom-traceparent", header02),
@@ -106,7 +106,7 @@ namespace OpenTelemetry.Context.Propagation.Tests
         [Fact]
         public void CompositePropagator_ActivityContext_Baggage()
         {
-            var compositePropagator = new CompositePropagator(new List<TextMapPropagator>
+            var compositePropagator = new CompositeTextMapPropagator(new List<TextMapPropagator>
             {
                 new TraceContextPropagator(),
                 new BaggagePropagator(),

--- a/test/OpenTelemetry.Tests/Trace/Propagation/CompositePropagatorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/CompositePropagatorTest.cs
@@ -55,7 +55,7 @@ namespace OpenTelemetry.Context.Propagation.Tests
         [Fact]
         public void CompositePropagator_TestPropagator()
         {
-            var compositePropagator = new CompositePropagator(new List<ITextMapPropagator>
+            var compositePropagator = new CompositePropagator(new List<TextMapPropagator>
             {
                 new TestPropagator("custom-traceparent-1", "custom-tracestate-1"),
                 new TestPropagator("custom-traceparent-2", "custom-tracestate-2"),
@@ -77,7 +77,7 @@ namespace OpenTelemetry.Context.Propagation.Tests
             const string header01 = "custom-tracestate-01";
             const string header02 = "custom-tracestate-02";
 
-            var compositePropagator = new CompositePropagator(new List<ITextMapPropagator>
+            var compositePropagator = new CompositePropagator(new List<TextMapPropagator>
             {
                 new TestPropagator("custom-traceparent", header01, true),
                 new TestPropagator("custom-traceparent", header02),
@@ -106,7 +106,7 @@ namespace OpenTelemetry.Context.Propagation.Tests
         [Fact]
         public void CompositePropagator_ActivityContext_Baggage()
         {
-            var compositePropagator = new CompositePropagator(new List<ITextMapPropagator>
+            var compositePropagator = new CompositePropagator(new List<TextMapPropagator>
             {
                 new TraceContextPropagator(),
                 new BaggagePropagator(),

--- a/test/OpenTelemetry.Tests/Trace/Propagation/CompositePropagatorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/CompositePropagatorTest.cs
@@ -55,7 +55,7 @@ namespace OpenTelemetry.Context.Propagation.Tests
         [Fact]
         public void CompositePropagator_TestPropagator()
         {
-            var compositePropagator = new CompositePropagator(new List<IPropagator>
+            var compositePropagator = new CompositePropagator(new List<ITextMapPropagator>
             {
                 new TestPropagator("custom-traceparent-1", "custom-tracestate-1"),
                 new TestPropagator("custom-traceparent-2", "custom-tracestate-2"),
@@ -77,7 +77,7 @@ namespace OpenTelemetry.Context.Propagation.Tests
             const string header01 = "custom-tracestate-01";
             const string header02 = "custom-tracestate-02";
 
-            var compositePropagator = new CompositePropagator(new List<IPropagator>
+            var compositePropagator = new CompositePropagator(new List<ITextMapPropagator>
             {
                 new TestPropagator("custom-traceparent", header01, true),
                 new TestPropagator("custom-traceparent", header02),
@@ -106,9 +106,9 @@ namespace OpenTelemetry.Context.Propagation.Tests
         [Fact]
         public void CompositePropagator_ActivityContext_Baggage()
         {
-            var compositePropagator = new CompositePropagator(new List<IPropagator>
+            var compositePropagator = new CompositePropagator(new List<ITextMapPropagator>
             {
-                new TextMapPropagator(),
+                new TraceContextPropagator(),
                 new BaggagePropagator(),
             });
 

--- a/test/OpenTelemetry.Tests/Trace/Propagation/TestPropagator.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/TestPropagator.cs
@@ -34,9 +34,9 @@ namespace OpenTelemetry.Context.Propagation.Tests
             this.defaultContext = defaultContext;
         }
 
-        public ISet<string> Fields => new HashSet<string>() { this.idHeaderName, this.stateHeaderName };
+        public override ISet<string> Fields => new HashSet<string>() { this.idHeaderName, this.stateHeaderName };
 
-        public PropagationContext Extract<T>(PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter)
+        public override PropagationContext Extract<T>(PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter)
         {
             if (this.defaultContext)
             {
@@ -67,7 +67,7 @@ namespace OpenTelemetry.Context.Propagation.Tests
                 context.Baggage);
         }
 
-        public void Inject<T>(PropagationContext context, T carrier, Action<T, string, string> setter)
+        public override void Inject<T>(PropagationContext context, T carrier, Action<T, string, string> setter)
         {
             string headerNumber = this.stateHeaderName.Split('-').Last();
 

--- a/test/OpenTelemetry.Tests/Trace/Propagation/TestPropagator.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/TestPropagator.cs
@@ -21,7 +21,7 @@ using System.Linq;
 
 namespace OpenTelemetry.Context.Propagation.Tests
 {
-    public class TestPropagator : IPropagator
+    public class TestPropagator : ITextMapPropagator
     {
         private readonly string idHeaderName;
         private readonly string stateHeaderName;
@@ -49,7 +49,7 @@ namespace OpenTelemetry.Context.Propagation.Tests
                 return context;
             }
 
-            var traceparentParsed = TextMapPropagator.TryExtractTraceparent(id.First(), out var traceId, out var spanId, out var traceoptions);
+            var traceparentParsed = TraceContextPropagator.TryExtractTraceparent(id.First(), out var traceId, out var spanId, out var traceoptions);
             if (!traceparentParsed)
             {
                 return context;
@@ -59,7 +59,7 @@ namespace OpenTelemetry.Context.Propagation.Tests
             IEnumerable<string> tracestateCollection = getter(carrier, this.stateHeaderName);
             if (tracestateCollection?.Any() ?? false)
             {
-                TextMapPropagator.TryExtractTracestate(tracestateCollection.ToArray(), out tracestate);
+                TraceContextPropagator.TryExtractTracestate(tracestateCollection.ToArray(), out tracestate);
             }
 
             return new PropagationContext(

--- a/test/OpenTelemetry.Tests/Trace/Propagation/TestPropagator.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/TestPropagator.cs
@@ -21,7 +21,7 @@ using System.Linq;
 
 namespace OpenTelemetry.Context.Propagation.Tests
 {
-    public class TestPropagator : ITextMapPropagator
+    public class TestPropagator : TextMapPropagator
     {
         private readonly string idHeaderName;
         private readonly string stateHeaderName;

--- a/test/OpenTelemetry.Tests/Trace/Propagation/TextMapPropagatorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/TextMapPropagatorTest.cs
@@ -52,7 +52,7 @@ namespace OpenTelemetry.Context.Propagation.Tests
                 { TraceState, $"congo=lZWRzIHRoNhcm5hbCBwbGVhc3VyZS4,rojo=00-{TraceId}-00f067aa0ba902b7-01" },
             };
 
-            var f = new TextMapPropagator();
+            var f = new TraceContextPropagator();
             var ctx = f.Extract(default, headers, Getter);
 
             Assert.Equal(ActivityTraceId.CreateFromString(TraceId.AsSpan()), ctx.ActivityContext.TraceId);
@@ -73,7 +73,7 @@ namespace OpenTelemetry.Context.Propagation.Tests
                 { TraceParent, $"00-{TraceId}-{SpanId}-00" },
             };
 
-            var f = new TextMapPropagator();
+            var f = new TraceContextPropagator();
             var ctx = f.Extract(default, headers, Getter);
 
             Assert.Equal(ActivityTraceId.CreateFromString(TraceId.AsSpan()), ctx.ActivityContext.TraceId);
@@ -89,7 +89,7 @@ namespace OpenTelemetry.Context.Propagation.Tests
         {
             var headers = new Dictionary<string, string>();
 
-            var f = new TextMapPropagator();
+            var f = new TraceContextPropagator();
             var ctx = f.Extract(default, headers, Getter);
 
             Assert.False(ctx.ActivityContext.IsValid());
@@ -103,7 +103,7 @@ namespace OpenTelemetry.Context.Propagation.Tests
                 { TraceParent, $"00-xyz7651916cd43dd8448eb211c80319c-{SpanId}-01" },
             };
 
-            var f = new TextMapPropagator();
+            var f = new TraceContextPropagator();
             var ctx = f.Extract(default, headers, Getter);
 
             Assert.False(ctx.ActivityContext.IsValid());
@@ -117,7 +117,7 @@ namespace OpenTelemetry.Context.Propagation.Tests
                 { TraceParent, $"00-{TraceId}-{SpanId}-01" },
             };
 
-            var f = new TextMapPropagator();
+            var f = new TraceContextPropagator();
             var ctx = f.Extract(default, headers, Getter);
 
             Assert.Null(ctx.ActivityContext.TraceState);
@@ -132,7 +132,7 @@ namespace OpenTelemetry.Context.Propagation.Tests
                 { TraceState, "k1=v1,k2=v2,k3=v3" },
             };
 
-            var f = new TextMapPropagator();
+            var f = new TraceContextPropagator();
             var ctx = f.Extract(default, headers, Getter);
 
             Assert.Equal("k1=v1,k2=v2,k3=v3", ctx.ActivityContext.TraceState);
@@ -151,7 +151,7 @@ namespace OpenTelemetry.Context.Propagation.Tests
             var activityContext = new ActivityContext(traceId, spanId, ActivityTraceFlags.Recorded, traceState: null);
             PropagationContext propagationContext = new PropagationContext(activityContext, default);
             var carrier = new Dictionary<string, string>();
-            var f = new TextMapPropagator();
+            var f = new TraceContextPropagator();
             f.Inject(propagationContext, carrier, Setter);
 
             Assert.Equal(expectedHeaders, carrier);
@@ -171,7 +171,7 @@ namespace OpenTelemetry.Context.Propagation.Tests
             var activityContext = new ActivityContext(traceId, spanId, ActivityTraceFlags.Recorded, expectedHeaders[TraceState]);
             PropagationContext propagationContext = new PropagationContext(activityContext, default);
             var carrier = new Dictionary<string, string>();
-            var f = new TextMapPropagator();
+            var f = new TraceContextPropagator();
             f.Inject(propagationContext, carrier, Setter);
 
             Assert.Equal(expectedHeaders, carrier);


### PR DESCRIPTION
Renamed TextMapPropagator to TraceContextPropagator, CompositePropapagor
  to CompositeTextMapPropagator. IPropagator is renamed to TextMapPropagator
  and changed from interface to abstract class.

In prep for https://github.com/open-telemetry/opentelemetry-dotnet/issues/581.

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
