### PR TITLE
Use GetSafeMetricName on PrometheusMetricValueBuilder

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusMetricBuilder.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusMetricBuilder.cs
@@ -147,7 +147,7 @@ namespace OpenTelemetry.Exporter.Prometheus.Implementation
             foreach (var m in this.values)
             {
                 // metric_name and label_name carry the usual Prometheus expression language restrictions.
-                writer.Write(m.Name ?? this.name);
+                writer.Write(m.Name != null ? GetSafeMetricName(m.Name) : this.name);
 
                 // label_value can be any sequence of UTF-8 characters, but the backslash
                 // (\, double-quote ("}, and line feed (\n) characters have to be escaped

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/Implementation/PrometheusMetricBuilderTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/Implementation/PrometheusMetricBuilderTests.cs
@@ -45,7 +45,7 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests.Implementation
             builder.WithType("test-type");
 
             var metricValueBuilder = builder.AddValue();
-            metricValueBuilder = metricValueBuilder.WithValue(10.0123);
+            metricValueBuilder = metricValueBuilder.WithName("test-builder-value").WithValue(10.0123);
             metricValueBuilder.WithLabel("test-double", "double");
             builder.Write(writer);
 
@@ -56,7 +56,7 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests.Implementation
             string[] lines = actual.Split('\n');
             Assert.Equal("# HELP test_buildertest-description", lines[0]);
             Assert.Equal("# TYPE test_builder test-type", lines[1]);
-            Assert.StartsWith("test_builder{test_double=\"double\"} 10.01", lines[2]);
+            Assert.StartsWith("test_builder_value{test_double=\"double\"} 10.01", lines[2]);
         }
     }
 }


### PR DESCRIPTION
Another small Prometheus related bug that had me confused for longer than I would have liked 😄.

Example output from `PrometheusMetricBuilder` before/after this fix:

**Before**
```text
# HELP http_server_durationhttp.server.duration
# TYPE http_server_duration summary
http.server.duration_sum{http_flavor="HTTP/1.1"} 9994.504799999997 1604105643783
http.server.duration_count{http_flavor="HTTP/1.1"} 68 1604105643783
http.server.duration{http_flavor="HTTP/1.1",quantile="0"} 124.484 1604105643783
http.server.duration{http_flavor="HTTP/1.1",quantile="1"} 699.5007 1604105643783
```

**After**
```text
# HELP http_server_durationhttp.server.duration
# TYPE http_server_duration summary
http_server_duration_sum{http_flavor="HTTP/1.1"} 10216.350800000002 1604104312195
http_server_duration_count{http_flavor="HTTP/1.1"} 70 1604104312195
http_server_duration{http_flavor="HTTP/1.1",quantile="0"} 127.8049 1604104312195
http_server_duration{http_flavor="HTTP/1.1",quantile="1"} 536.3335 1604104312195
```
