### PR TITLE
Updated Jaeger & Zipkin exporters to check for default activity.ParentSpanId

### DIFF
--- a/examples/AspNet/Examples.AspNet.csproj
+++ b/examples/AspNet/Examples.AspNet.csproj
@@ -44,6 +44,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup>
@@ -99,6 +100,14 @@
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry\OpenTelemetry.csproj">
       <Project>{ae3e3df5-4083-4c6e-a840-8271b0acde7e}</Project>
       <Name>OpenTelemetry</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Console\OpenTelemetry.Exporter.Console.csproj">
+      <Project>{1afff251-3b0c-47ca-be94-937083732c0a}</Project>
+      <Name>OpenTelemetry.Exporter.Console</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Zipkin\OpenTelemetry.Exporter.Zipkin.csproj">
+      <Project>{7edae7fa-b44e-42ca-80fa-7df2faa2c5dd}</Project>
+      <Name>OpenTelemetry.Exporter.Zipkin</Name>
     </ProjectReference>
   </ItemGroup>
   <PropertyGroup>

--- a/examples/AspNet/Web.config
+++ b/examples/AspNet/Web.config
@@ -5,10 +5,10 @@
 		<add key="webpages:Enabled" value="false"/>
 		<add key="ClientValidationEnabled" value="true"/>
 		<add key="UnobtrusiveJavaScriptEnabled" value="true"/>
-    <add key="UseExporter" value="console"/>
-    <add key="JaegerHost" value="localhost"/>
-    <add key="JaegerPort" value="6831"/>
-    <add key="ZipkinEndpoint" value="http://localhost:9411/api/v2/spans"/>
+		<add key="UseExporter" value="console"/>
+		<add key="JaegerHost" value="localhost"/>
+		<add key="JaegerPort" value="6831"/>
+		<add key="ZipkinEndpoint" value="http://localhost:9411/api/v2/spans"/>
 	</appSettings>
 	<system.web>
 		<compilation debug="true" targetFramework="4.8"/>
@@ -43,10 +43,10 @@
 				<assemblyIdentity name="System.Memory" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
 				<bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1"/>
 			</dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
-      </dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
+			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
 				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>

--- a/examples/AspNet/Web.config
+++ b/examples/AspNet/Web.config
@@ -5,6 +5,10 @@
 		<add key="webpages:Enabled" value="false"/>
 		<add key="ClientValidationEnabled" value="true"/>
 		<add key="UnobtrusiveJavaScriptEnabled" value="true"/>
+    <add key="UseExporter" value="console"/>
+    <add key="JaegerHost" value="localhost"/>
+    <add key="JaegerPort" value="6831"/>
+    <add key="ZipkinEndpoint" value="http://localhost:9411/api/v2/spans"/>
 	</appSettings>
 	<system.web>
 		<compilation debug="true" targetFramework="4.8"/>
@@ -23,6 +27,18 @@
 	</system.webServer>
 	<runtime>
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="System.ValueTuple" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Buffers" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
+			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Memory" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
 				<bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1"/>

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerActivityExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerActivityExtensions.cs
@@ -111,7 +111,10 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
                 // TODO: The check above should be enforced by the usage of the exporter. Perhaps enforce at higher-level.
                 traceId = new Int128(activity.TraceId);
                 spanId = new Int128(activity.SpanId);
-                parentSpanId = new Int128(activity.ParentSpanId);
+                if (activity.ParentSpanId != default)
+                {
+                    parentSpanId = new Int128(activity.ParentSpanId);
+                }
             }
 
             return new JaegerSpan(

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinActivityConversionExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinActivityConversionExtensions.cs
@@ -29,8 +29,6 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
         private const long UnixEpochTicks = 621355968000000000L; // = DateTimeOffset.FromUnixTimeMilliseconds(0).Ticks
         private const long UnixEpochMicroseconds = UnixEpochTicks / TicksPerMicrosecond;
 
-        private static readonly string InvalidSpanId = default(ActivitySpanId).ToHexString();
-
 #if !NET452
         private static readonly ConcurrentDictionary<(string, int), ZipkinEndpoint> RemoteEndpointCache = new ConcurrentDictionary<(string, int), ZipkinEndpoint>();
 #else
@@ -41,11 +39,9 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
         {
             var context = activity.Context;
 
-            string parentId = EncodeSpanId(activity.ParentSpanId);
-            if (string.Equals(parentId, InvalidSpanId, StringComparison.Ordinal))
-            {
-                parentId = null;
-            }
+            string parentId = activity.ParentSpanId == default ?
+                null
+                : EncodeSpanId(activity.ParentSpanId);
 
             var tagState = new TagEnumerationState
             {

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerActivityConversionTest.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerActivityConversionTest.cs
@@ -41,10 +41,12 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
             ActivitySource.AddActivityListener(listener);
         }
 
-        [Fact]
-        public void JaegerActivityConverterTest_ConvertActivityToJaegerSpan_AllPropertiesSet()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void JaegerActivityConverterTest_ConvertActivityToJaegerSpan_AllPropertiesSet(bool isRootSpan)
         {
-            var activity = CreateTestActivity();
+            var activity = CreateTestActivity(isRootSpan: isRootSpan);
             var traceIdAsInt = new Int128(activity.Context.TraceId);
             var spanIdAsInt = new Int128(activity.Context.SpanId);
             var linkTraceIdAsInt = new Int128(activity.Links.Single().Context.TraceId);
@@ -438,14 +440,15 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
             bool addEvents = true,
             bool addLinks = true,
             Resource resource = null,
-            ActivityKind kind = ActivityKind.Client)
+            ActivityKind kind = ActivityKind.Client,
+            bool isRootSpan = false)
         {
             var startTimestamp = DateTime.UtcNow;
             var endTimestamp = startTimestamp.AddSeconds(60);
             var eventTimestamp = DateTime.UtcNow;
             var traceId = ActivityTraceId.CreateFromString("e8ea7e9ac72de94e91fabc613f9686b2".AsSpan());
 
-            var parentSpanId = ActivitySpanId.CreateFromBytes(new byte[] { 12, 23, 34, 45, 56, 67, 78, 89 });
+            var parentSpanId = isRootSpan ? default : ActivitySpanId.CreateFromBytes(new byte[] { 12, 23, 34, 45, 56, 67, 78, 89 });
 
             var attributes = new Dictionary<string, object>
             {

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
@@ -133,10 +133,11 @@ namespace OpenTelemetry.Exporter.Zipkin.Tests
         }
 
         [Theory]
-        [InlineData(true, false)]
-        [InlineData(false, false)]
-        [InlineData(false, true)]
-        public void IntegrationTest(bool useShortTraceIds, bool useTestResource)
+        [InlineData(true, false, false)]
+        [InlineData(false, false, false)]
+        [InlineData(false, true, false)]
+        [InlineData(false, false, true)]
+        public void IntegrationTest(bool useShortTraceIds, bool useTestResource, bool isRootSpan)
         {
             Guid requestId = Guid.NewGuid();
 
@@ -149,7 +150,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Tests
 
             var serviceName = ZipkinExporterOptions.DefaultServiceName;
             var resoureTags = string.Empty;
-            var activity = CreateTestActivity();
+            var activity = CreateTestActivity(isRootSpan: isRootSpan);
             if (useTestResource)
             {
                 serviceName = "MyService";
@@ -183,14 +184,17 @@ namespace OpenTelemetry.Exporter.Zipkin.Tests
                 ipInformation.Append($@",""ipv6"":""{exporter.LocalEndpoint.Ipv6}""");
             }
 
+            var parentId = isRootSpan ? string.Empty : $@"""parentId"":""{ZipkinActivityConversionExtensions.EncodeSpanId(activity.ParentSpanId)}"",";
+
             var traceId = useShortTraceIds ? TraceId.Substring(TraceId.Length - 16, 16) : TraceId;
 
             Assert.Equal(
-                $@"[{{""traceId"":""{traceId}"",""name"":""Name"",""parentId"":""{ZipkinActivityConversionExtensions.EncodeSpanId(activity.ParentSpanId)}"",""id"":""{ZipkinActivityConversionExtensions.EncodeSpanId(context.SpanId)}"",""kind"":""CLIENT"",""timestamp"":{timestamp},""duration"":60000000,""localEndpoint"":{{""serviceName"":""{serviceName}""{ipInformation}}},""remoteEndpoint"":{{""serviceName"":""http://localhost:44312/""}},""annotations"":[{{""timestamp"":{eventTimestamp},""value"":""Event1""}},{{""timestamp"":{eventTimestamp},""value"":""Event2""}}],""tags"":{{{resoureTags}""stringKey"":""value"",""longKey"":""1"",""longKey2"":""1"",""doubleKey"":""1"",""doubleKey2"":""1"",""longArrayKey"":""1,2"",""boolKey"":""True"",""http.host"":""http://localhost:44312/"",""library.name"":""CreateTestActivity"",""peer.service"":""http://localhost:44312/""}}}}]",
+                $@"[{{""traceId"":""{traceId}"",""name"":""Name"",{parentId}""id"":""{ZipkinActivityConversionExtensions.EncodeSpanId(context.SpanId)}"",""kind"":""CLIENT"",""timestamp"":{timestamp},""duration"":60000000,""localEndpoint"":{{""serviceName"":""{serviceName}""{ipInformation}}},""remoteEndpoint"":{{""serviceName"":""http://localhost:44312/""}},""annotations"":[{{""timestamp"":{eventTimestamp},""value"":""Event1""}},{{""timestamp"":{eventTimestamp},""value"":""Event2""}}],""tags"":{{{resoureTags}""stringKey"":""value"",""longKey"":""1"",""longKey2"":""1"",""doubleKey"":""1"",""doubleKey2"":""1"",""longArrayKey"":""1,2"",""boolKey"":""True"",""http.host"":""http://localhost:44312/"",""library.name"":""CreateTestActivity"",""peer.service"":""http://localhost:44312/""}}}}]",
                 Responses[requestId]);
         }
 
         internal static Activity CreateTestActivity(
+           bool isRootSpan = false,
            bool setAttributes = true,
            Dictionary<string, object> additionalAttributes = null,
            bool addEvents = true,
@@ -203,7 +207,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Tests
             var eventTimestamp = DateTime.UtcNow;
             var traceId = ActivityTraceId.CreateFromString("e8ea7e9ac72de94e91fabc613f9686b2".AsSpan());
 
-            var parentSpanId = ActivitySpanId.CreateFromBytes(new byte[] { 12, 23, 34, 45, 56, 67, 78, 89 });
+            var parentSpanId = isRootSpan ? default : ActivitySpanId.CreateFromBytes(new byte[] { 12, 23, 34, 45, 56, 67, 78, 89 });
 
             var attributes = new Dictionary<string, object>
             {


### PR DESCRIPTION
## Changes

OtlpExporter was slightly smarter than Zipkin and Jaeger in how it handled activity.ParentSpanId. This makes the logic the same which should be a slight performance boost for root spans.