### PR TITLE
Baggage.Current accross AppDomains.

### DIFF
--- a/src/OpenTelemetry.Api/Context/RemotingRuntimeContextSlot.cs
+++ b/src/OpenTelemetry.Api/Context/RemotingRuntimeContextSlot.cs
@@ -61,7 +61,13 @@ namespace OpenTelemetry.Context
                 return default(T);
             }
 
-            return (T)WrapperField.GetValue(wrapper);
+            var value = WrapperField.GetValue(wrapper);
+            if (value is T)
+            {
+                return (T)value;
+            }
+
+            return default(T);
         }
 
         /// <inheritdoc/>

--- a/test/OpenTelemetry.Tests/Context/RuntimeContextTest.cs
+++ b/test/OpenTelemetry.Tests/Context/RuntimeContextTest.cs
@@ -72,9 +72,67 @@ namespace OpenTelemetry.Context.Tests
             Assert.Equal(100, expectedSlot.Get());
         }
 
+#if NETFRAMEWORK
+        [Fact]
+        public void NetFrameworkGetSlotInAnotherAppDomain()
+        {
+            const string slotName = "testSlot";
+            var slot = RuntimeContext.RegisterSlot<int>(slotName);
+            slot.Set(100);
+
+            // Create an object in another AppDomain and try to access the slot
+            // value from it.
+
+            var domainSetup = AppDomain.CurrentDomain.SetupInformation;
+            var ad = AppDomain.CreateDomain("other-domain", null, domainSetup);
+
+            var remoteObjectTypeName = typeof(RemoteObject).FullName;
+            Assert.NotNull(remoteObjectTypeName);
+
+            var obj = (RemoteObject)ad.CreateInstanceAndUnwrap(
+                typeof(RemoteObject).Assembly.FullName,
+                remoteObjectTypeName);
+
+            // Value we previously put into the slot ("100") would not be propagated
+            // across AppDomains. We should get default(int) = 0 back.
+            Assert.Equal(0, obj.GetValueFromContextSlot(slotName));
+        }
+#endif
+
         public void Dispose()
         {
             RuntimeContext.Clear();
         }
+
+#if NETFRAMEWORK
+        private class RemoteObject : ContextBoundObject
+        {
+            public int GetValueFromContextSlot(string slotName)
+            {
+                // Slot is not propagated across AppDomains, attempting to get
+                // an existing slot here should throw an ArgumentException.
+                try
+                {
+                    RuntimeContext.GetSlot<int>(slotName);
+
+                    throw new Exception("Should not have found an existing slot: " + slotName);
+                }
+                catch (ArgumentException)
+                {
+                    // This is ok.
+                }
+
+                // Now re-register this slot.
+                RuntimeContext.RegisterSlot<int>(slotName);
+
+                var slot = RuntimeContext.GetSlot<int>(slotName);
+
+                // We didn't put any value into this slot, so default(int) should be returned.
+                // Previously an exception was thrown at this point.
+                return slot.Get();
+            }
+        }
+#endif
+
     }
 }


### PR DESCRIPTION
On net452 `Baggage.Current` is stored in the `CallContext` which uses a workaround to avoid marshaling Baggage instance across AppDomains. However, when trying to access it in a different AppDomain, the private field value is actually null, so just need to add a check to return a default there instead of a direct cast.

Fixes #1434.