### PR TITLE
Add extension method to add ConsoleExporter for logs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,6 +24,13 @@ jobs:
         # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
 
     steps:
+    - name: configure Pagefile
+      uses: al-cheb/configure-pagefile-action@v1.2
+      with:
+        minimum-size: 8GB
+        maximum-size: 32GB
+        disk-root: "D:"
+
     - name: Checkout repository
       uses: actions/checkout@v2
 

--- a/docs/logs/getting-started/Program.cs
+++ b/docs/logs/getting-started/Program.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using OpenTelemetry.Trace;
 #if NETCOREAPP2_1
 using Microsoft.Extensions.DependencyInjection;
 #endif
@@ -30,7 +31,7 @@ public class Program
 #endif
         {
             builder.AddOpenTelemetry(options => options
-                .AddInMemoryExporter()); // TODO: change to console output
+                .AddConsoleExporter());
         });
 
 #if NETCOREAPP2_1

--- a/docs/logs/getting-started/getting-started.csproj
+++ b/docs/logs/getting-started/getting-started.csproj
@@ -1,6 +1,5 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.InMemory\OpenTelemetry.Exporter.InMemory.csproj" />
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Console\OpenTelemetry.Exporter.Console.csproj" />
   </ItemGroup>
 

--- a/docs/logs/getting-started/getting-started.csproj
+++ b/docs/logs/getting-started/getting-started.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.InMemory\OpenTelemetry.Exporter.InMemory.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Console\OpenTelemetry.Exporter.Console.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Add extension method to add `ConsoleExporter` for logs
+  ([#1452](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1452))
+
 * Generalized `ConsoleExporter` to add support for logs
   ([#1438](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1438))
 

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Generalized `ConsoleExporter` to add support for logs
+  ([#1438](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1438))
+
 ## 0.7.0-beta.1
 
 Released 2020-Oct-16

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterLoggingExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterLoggingExtensions.cs
@@ -1,0 +1,45 @@
+// <copyright file="ConsoleExporterLoggingExtensions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET461 || NETSTANDARD2_0
+using System;
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Logs;
+
+namespace OpenTelemetry.Trace
+{
+    public static class ConsoleExporterLoggingExtensions
+    {
+        /// <summary>
+        /// Adds Console Exporter as a configuration to the OpenTelemetry ILoggingBuilder.
+        /// </summary>
+        /// <param name="loggerOptions"><see cref="OpenTelemetryLoggerOptions"/> options to use.</param>
+        /// <param name="configure">Exporter configuration options.</param>
+        /// <returns>The instance of <see cref="OpenTelemetryLoggerOptions"/> to chain the calls.</returns>
+        public static OpenTelemetryLoggerOptions AddConsoleExporter(this OpenTelemetryLoggerOptions loggerOptions, Action<ConsoleExporterOptions> configure = null)
+        {
+            if (loggerOptions == null)
+            {
+                throw new ArgumentNullException(nameof(loggerOptions));
+            }
+
+            var options = new ConsoleExporterOptions();
+            configure?.Invoke(options);
+            return loggerOptions.AddProcessor(new SimpleExportProcessor<LogRecord>(new ConsoleExporter<LogRecord>(options)));
+        }
+    }
+}
+#endif

--- a/src/OpenTelemetry.Exporter.Console/README.md
+++ b/src/OpenTelemetry.Exporter.Console/README.md
@@ -3,7 +3,7 @@
 [![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.Exporter.Console.svg)](https://www.nuget.org/packages/OpenTelemetry.Exporter.Console)
 [![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.Exporter.Console.svg)](https://www.nuget.org/packages/OpenTelemetry.Exporter.Console)
 
-The console exporter prints data to the Console in a JSON serialized format.
+The console exporter prints data to the Console window.
 
 **Note:** this exporter is intended to be used during learning how telemetry
 data are created and exported. It is not recommended for any production


### PR DESCRIPTION
- Added an extension method to add ConsoleExporter for logs
- Updated docs/logs/getting-started/Program.cs to use the new extension method to add ConsoleExporter for logs