### PR TITLE
Include ordinal of Char in exception

### DIFF
--- a/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
@@ -259,7 +259,7 @@ namespace OpenTelemetry.Context.Propagation
                 return Convert.ToByte(c);
             }
 
-            throw new ArgumentOutOfRangeException(nameof(c), c, $"Invalid character: {c}. Ordinal: {(int) c}.");
+            throw new ArgumentOutOfRangeException(nameof(c), c, $"Invalid character: {c}. Ordinal: {(int)c}.");
         }
     }
 }

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
@@ -259,7 +259,7 @@ namespace OpenTelemetry.Context.Propagation
                 return Convert.ToByte(c);
             }
 
-            throw new ArgumentOutOfRangeException(nameof(c), c, $"Invalid character: {c}.");
+            throw new ArgumentOutOfRangeException(nameof(c), c, $"Invalid character: {c}. Ordinal: {(int) c}.");
         }
     }
 }


### PR DESCRIPTION
Addendum to merged PR for #1316.

When giving error message about an invalid character, we should also include the ordinal of the character. 

One-liner, mostly trivial change.