### PR TITLE
Resource improvement - Option 1

### DIFF
--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerActivityExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerActivityExtensions.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using OpenTelemetry.Internal;
+using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Exporter.Jaeger.Implementation
@@ -259,6 +260,11 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
             else if (jaegerTag.VLong.HasValue)
             {
                 PeerServiceResolver.InspectTag(ref state, key, jaegerTag.VLong.Value);
+            }
+
+            if (key == Resource.ResourceTagName)
+            {
+                return;
             }
 
             PooledList<JaegerTag>.Add(ref state.Tags, jaegerTag);

--- a/src/OpenTelemetry/Resources/Resource.cs
+++ b/src/OpenTelemetry/Resources/Resource.cs
@@ -32,6 +32,7 @@ namespace OpenTelemetry.Resources
         public const string ServiceVersionKey = "service.version";
         public const string LibraryNameKey = "name";
         public const string LibraryVersionKey = "version";
+        public const string ResourceTagName = "otel.resource";
 
         // this implementation follows https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/sdk.md
 

--- a/src/OpenTelemetry/Trace/ActivityExtensions.cs
+++ b/src/OpenTelemetry/Trace/ActivityExtensions.cs
@@ -24,8 +24,6 @@ namespace OpenTelemetry.Trace
     /// </summary>
     public static class ActivityExtensions
     {
-        internal const string ResourcePropertyName = "OTel.Resource";
-
         /// <summary>
         /// Gets the Resource associated with the Activity.
         /// </summary>
@@ -34,7 +32,7 @@ namespace OpenTelemetry.Trace
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Resource GetResource(this Activity activity)
         {
-            return activity?.GetCustomProperty(ResourcePropertyName) is Resource res
+            return activity?.GetTagValue(Resource.ResourceTagName) is Resource res
                 ? res
                 : Resource.Empty;
         }
@@ -47,7 +45,7 @@ namespace OpenTelemetry.Trace
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void SetResource(this Activity activity, Resource resource)
         {
-            activity.SetCustomProperty(ResourcePropertyName, resource);
+            activity.SetTag(Resource.ResourceTagName, resource);
         }
     }
 }


### PR DESCRIPTION
Fixes #1397.

## Changes

Stores Resource on each Activity as a tag instead of as a custom property. This is to avoid an allocation on every Activity currently done to store Resource as a custom property.

This is by far the most expensive option from a performance perspective. We store Resource on every Activity. You have to enumerate on tags to retrieve it. And then you have to exclude the resource tag from being written out with other tags during export. Not a huge hit, but the other options avoid it all.

Also, every Exporter would have to know to exclude the special `otel.resource` tag. We could document to exclude all "otel.*" tags, but that carries an even more expensive comparison while looping, even bigger perf hit.

## TODOs:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [X] Design discussion issue #1397
* [ ] Changes in public API reviewed