### PR TITLE
JaegerExporter GenerateServiceSpecificBatches option

### DIFF
--- a/src/OpenTelemetry.Exporter.Jaeger/.publicApi/net46/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Jaeger/.publicApi/net46/PublicAPI.Unshipped.txt
@@ -4,6 +4,8 @@ OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentHost.get -> string
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentHost.set -> void
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentPort.get -> int
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentPort.set -> void
+OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.GenerateServiceSpecificBatches.get -> bool
+OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.GenerateServiceSpecificBatches.set -> void
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.JaegerExporterOptions() -> void
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.MaxPayloadSizeInBytes.get -> int?
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.MaxPayloadSizeInBytes.set -> void

--- a/src/OpenTelemetry.Exporter.Jaeger/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Jaeger/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -4,6 +4,8 @@ OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentHost.get -> string
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentHost.set -> void
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentPort.get -> int
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentPort.set -> void
+OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.GenerateServiceSpecificBatches.get -> bool
+OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.GenerateServiceSpecificBatches.set -> void
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.JaegerExporterOptions() -> void
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.MaxPayloadSizeInBytes.get -> int?
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.MaxPayloadSizeInBytes.set -> void

--- a/src/OpenTelemetry.Exporter.Jaeger/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Jaeger/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
@@ -4,6 +4,8 @@ OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentHost.get -> string
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentHost.set -> void
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentPort.get -> int
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentPort.set -> void
+OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.GenerateServiceSpecificBatches.get -> bool
+OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.GenerateServiceSpecificBatches.set -> void
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.JaegerExporterOptions() -> void
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.MaxPayloadSizeInBytes.get -> int?
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.MaxPayloadSizeInBytes.set -> void

--- a/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added `GenerateServiceSpecificBatches` option.
+  ([#1498](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1498))
+
 ## 0.8.0-beta.1
 
 Released 2020-Nov-5

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptions.cs
@@ -48,5 +48,20 @@ namespace OpenTelemetry.Exporter.Jaeger
         /// Gets or sets the tags that should be sent with telemetry.
         /// </summary>
         public IEnumerable<KeyValuePair<string, object>> ProcessTags { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not a batch should be sent to the Jaeger agent for each service. Default value: true.
+        /// </summary>
+        /// <remarks>
+        /// Jaeger UI will only detect &amp; color dependency spans when both
+        /// the client &amp; server processes report data to the same Jaeger
+        /// instance. For processes that make calls to non-instrumented services
+        /// (third parties, SQL, legacy systems, etc.) the
+        /// GenerateServiceSpecificBatches flag is provided to trick Jaeger into
+        /// correctly detecting and displaying all dependent spans as if both
+        /// sides reported data. For more details, see <a
+        /// href="https://github.com/jaegertracing/jaeger-ui/issues/594">jaeger-ui/issues/594</a>.
+        /// </remarks>
+        public bool GenerateServiceSpecificBatches { get; set; } = true;
     }
 }


### PR DESCRIPTION
Fixes #1388.

## Public API Changes

Makes the JaegerExporter batch behavior configurable by adding a new option:

```csharp
        /// <summary>
        /// Gets or sets a value indicating whether or not a batch should be sent to the Jaeger agent for each service. Default value: true.
        /// </summary>
        /// <remarks>
        /// Jaeger UI will only detect &amp; color dependency spans when both
        /// the client &amp; server processes report data to the same Jaeger
        /// instance. For processes that make calls to non-instrumented services
        /// (third parties, SQL, legacy systems, etc.) the
        /// GenerateServiceSpecificBatches flag is provided to trick Jaeger into
        /// correctly detecting and displaying all dependent spans as if both
        /// sides reported data. For more details, see <a
        /// href="https://github.com/jaegertracing/jaeger-ui/issues/594">jaeger-ui/issues/594</a>.
        /// </remarks>
        public bool GenerateServiceSpecificBatches { get; set; } = true;
```

## Examples

### `GenerateServiceSpecificBatches = true`

![image](https://user-images.githubusercontent.com/28367120/98617990-144dcc80-22b5-11eb-8cf1-716aa68055ab.png)

### `GenerateServiceSpecificBatches = false`

![image](https://user-images.githubusercontent.com/28367120/98618010-1dd73480-22b5-11eb-9e33-557714fd24c4.png)

## TODOs

* [X] `CHANGELOG.md` updated for non-trivial changes
* [ ] Changes in public API reviewed
