### PR TITLE
Update to ZipkinExporterOptions

### DIFF
--- a/src/OpenTelemetry.Exporter.Zipkin/README.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/README.md
@@ -21,7 +21,8 @@ You can configure the `ZipkinExporter` with the following options:
 * `Endpoint`: URI address to receive telemetry.
 * `UseShortTraceIds`: Whether the trace's ID should be shortened before
    sending to Zipkin (default false).
-* `MaxPayloadSizeInBytes`: Maximum payload size - for .NET versions **other** than 4.5.2 (default 4096).
+* `MaxPayloadSizeInBytes`: Maximum payload size - for .NET versions
+   **other** than 4.5.2 (default 4096).
 
 See
 [`TestZipkinExporter.cs`](../../examples/Console/TestZipkinExporter.cs)

--- a/src/OpenTelemetry.Exporter.Zipkin/README.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/README.md
@@ -21,8 +21,7 @@ You can configure the `ZipkinExporter` with the following options:
 * `Endpoint`: URI address to receive telemetry.
 * `UseShortTraceIds`: Whether the trace's ID should be shortened before
    sending to Zipkin (default false).
-* `MaxPayloadSizeInBytes`: Maximum payload size - for .NET versions below
-   4.5.2 ONLY (default 4096).
+* `MaxPayloadSizeInBytes`: Maximum payload size - for .NET versions **other** than 4.5.2 (default 4096).
 
 See
 [`TestZipkinExporter.cs`](../../examples/Console/TestZipkinExporter.cs)

--- a/src/OpenTelemetry.Exporter.Zipkin/README.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/README.md
@@ -15,12 +15,14 @@ dotnet add package OpenTelemetry.Exporter.Zipkin
 
 ## Configuration
 
-You can configure the `ZipkinExporter` by following the directions below:
+You can configure the `ZipkinExporter` with the following options:
 
-* `Endpoint`: Zipkin endpoint address.
-* `TimeoutSeconds`: Timeout in seconds.
 * `ServiceName`: Name of the service reporting telemetry.
-* `UseShortTraceIds`: Value indicating whether short trace id should be used.
+* `Endpoint`: URI address to receive telemetry.
+* `UseShortTraceIds`: Whether the trace's ID should be shortened before
+   sending to Zipkin (default false).
+* `MaxPayloadSizeInBytes`: Maximum payload size - for .NET versions below
+   4.5.2 ONLY (default 4096).
 
 See
 [`TestZipkinExporter.cs`](../../examples/Console/TestZipkinExporter.cs)


### PR DESCRIPTION
Fixes #1480 .

## Changes

Updates to the README of src/OpenTelemetry.Exporter.Zipkin only. Recent PR on Sept 22nd #1274 made major changes to Zipkin and Jaeger exporters, README was not updated for the new options.

markdownlint-cli was installed and used.