### PR TITLE
Remove ununsed constants from Resource

### DIFF
--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
@@ -111,9 +111,6 @@ namespace OpenTelemetry.Exporter.Jaeger
                         case Resource.ServiceNamespaceKey:
                             serviceNamespace = strVal;
                             continue;
-                        case Resource.LibraryNameKey:
-                        case Resource.LibraryVersionKey:
-                            continue;
                     }
                 }
 

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporter.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporter.cs
@@ -122,9 +122,6 @@ namespace OpenTelemetry.Exporter.Zipkin
                     case Resource.ServiceNamespaceKey:
                         serviceNamespace = label.Value as string;
                         continue;
-                    case Resource.LibraryNameKey:
-                    case Resource.LibraryVersionKey:
-                        continue;
                 }
 
                 if (tags == null)

--- a/src/OpenTelemetry/.publicApi/net452/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net452/PublicAPI.Unshipped.txt
@@ -169,8 +169,6 @@ abstract OpenTelemetry.Metrics.Export.MetricExporter.ExportAsync(System.Collecti
 abstract OpenTelemetry.Metrics.Export.MetricProcessor.FinishCollectionCycle(out System.Collections.Generic.IEnumerable<OpenTelemetry.Metrics.Export.Metric> metrics) -> void
 abstract OpenTelemetry.Metrics.Export.MetricProcessor.Process(OpenTelemetry.Metrics.Export.Metric metric) -> void
 abstract OpenTelemetry.Trace.Sampler.ShouldSample(in OpenTelemetry.Trace.SamplingParameters samplingParameters) -> OpenTelemetry.Trace.SamplingResult
-const OpenTelemetry.Resources.Resource.LibraryNameKey = "name" -> string
-const OpenTelemetry.Resources.Resource.LibraryVersionKey = "version" -> string
 const OpenTelemetry.Resources.Resource.ServiceInstanceIdKey = "service.instance.id" -> string
 const OpenTelemetry.Resources.Resource.ServiceNameKey = "service.name" -> string
 const OpenTelemetry.Resources.Resource.ServiceNamespaceKey = "service.namespace" -> string

--- a/src/OpenTelemetry/.publicApi/net46/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net46/PublicAPI.Unshipped.txt
@@ -169,8 +169,6 @@ abstract OpenTelemetry.Metrics.Export.MetricExporter.ExportAsync(System.Collecti
 abstract OpenTelemetry.Metrics.Export.MetricProcessor.FinishCollectionCycle(out System.Collections.Generic.IEnumerable<OpenTelemetry.Metrics.Export.Metric> metrics) -> void
 abstract OpenTelemetry.Metrics.Export.MetricProcessor.Process(OpenTelemetry.Metrics.Export.Metric metric) -> void
 abstract OpenTelemetry.Trace.Sampler.ShouldSample(in OpenTelemetry.Trace.SamplingParameters samplingParameters) -> OpenTelemetry.Trace.SamplingResult
-const OpenTelemetry.Resources.Resource.LibraryNameKey = "name" -> string
-const OpenTelemetry.Resources.Resource.LibraryVersionKey = "version" -> string
 const OpenTelemetry.Resources.Resource.ServiceInstanceIdKey = "service.instance.id" -> string
 const OpenTelemetry.Resources.Resource.ServiceNameKey = "service.name" -> string
 const OpenTelemetry.Resources.Resource.ServiceNamespaceKey = "service.namespace" -> string

--- a/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -188,8 +188,6 @@ abstract OpenTelemetry.Metrics.Export.MetricExporter.ExportAsync(System.Collecti
 abstract OpenTelemetry.Metrics.Export.MetricProcessor.FinishCollectionCycle(out System.Collections.Generic.IEnumerable<OpenTelemetry.Metrics.Export.Metric> metrics) -> void
 abstract OpenTelemetry.Metrics.Export.MetricProcessor.Process(OpenTelemetry.Metrics.Export.Metric metric) -> void
 abstract OpenTelemetry.Trace.Sampler.ShouldSample(in OpenTelemetry.Trace.SamplingParameters samplingParameters) -> OpenTelemetry.Trace.SamplingResult
-const OpenTelemetry.Resources.Resource.LibraryNameKey = "name" -> string
-const OpenTelemetry.Resources.Resource.LibraryVersionKey = "version" -> string
 const OpenTelemetry.Resources.Resource.ServiceInstanceIdKey = "service.instance.id" -> string
 const OpenTelemetry.Resources.Resource.ServiceNameKey = "service.name" -> string
 const OpenTelemetry.Resources.Resource.ServiceNamespaceKey = "service.namespace" -> string

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -188,8 +188,6 @@ abstract OpenTelemetry.Metrics.Export.MetricExporter.ExportAsync(System.Collecti
 abstract OpenTelemetry.Metrics.Export.MetricProcessor.FinishCollectionCycle(out System.Collections.Generic.IEnumerable<OpenTelemetry.Metrics.Export.Metric> metrics) -> void
 abstract OpenTelemetry.Metrics.Export.MetricProcessor.Process(OpenTelemetry.Metrics.Export.Metric metric) -> void
 abstract OpenTelemetry.Trace.Sampler.ShouldSample(in OpenTelemetry.Trace.SamplingParameters samplingParameters) -> OpenTelemetry.Trace.SamplingResult
-const OpenTelemetry.Resources.Resource.LibraryNameKey = "name" -> string
-const OpenTelemetry.Resources.Resource.LibraryVersionKey = "version" -> string
 const OpenTelemetry.Resources.Resource.ServiceInstanceIdKey = "service.instance.id" -> string
 const OpenTelemetry.Resources.Resource.ServiceNameKey = "service.name" -> string
 const OpenTelemetry.Resources.Resource.ServiceNamespaceKey = "service.namespace" -> string

--- a/src/OpenTelemetry/Resources/Resource.cs
+++ b/src/OpenTelemetry/Resources/Resource.cs
@@ -30,8 +30,6 @@ namespace OpenTelemetry.Resources
         public const string ServiceNamespaceKey = "service.namespace";
         public const string ServiceInstanceIdKey = "service.instance.id";
         public const string ServiceVersionKey = "service.version";
-        public const string LibraryNameKey = "name";
-        public const string LibraryVersionKey = "version";
 
         // this implementation follows https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/sdk.md
 

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterTests.cs
@@ -102,15 +102,15 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests
         }
 
         [Fact]
-        public void JaegerTraceExporter_SetResource_IgnoreLibraryResources()
+        public void JaegerTraceExporter_SetResource_IgnoreServiceResources()
         {
             using var jaegerTraceExporter = new JaegerExporter(new JaegerExporterOptions());
             var process = jaegerTraceExporter.Process;
 
             jaegerTraceExporter.SetResource(new Resource(new Dictionary<string, object>
             {
-                [Resource.LibraryNameKey] = "libname",
-                [Resource.LibraryVersionKey] = "libversion",
+                [Resource.ServiceNameKey] = "servicename",
+                [Resource.ServiceNamespaceKey] = "servicenamespace",
             }));
 
             Assert.Null(process.Tags);


### PR DESCRIPTION
There is no spec/requirement to treat these resource key special. It must be a leftover from older implementations.

The instrumentationlibrary is coming via ActivitySource only, and is handled correctly by both exporters.

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
