### PR TITLE
[SelfDiagnostics] Update config refresh period to 10 seconds

### DIFF
--- a/src/OpenTelemetry/Internal/SelfDiagnosticsConfigRefresher.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnosticsConfigRefresher.cs
@@ -33,7 +33,7 @@ namespace OpenTelemetry.Internal
     /// </summary>
     internal class SelfDiagnosticsConfigRefresher : IDisposable
     {
-        private const int ConfigurationUpdatePeriodMilliSeconds = 3000;
+        private const int ConfigurationUpdatePeriodMilliSeconds = 10000;
 
         private readonly CancellationTokenSource cancellationTokenSource;
         private readonly Task worker;


### PR DESCRIPTION
Addressing comments in https://github.com/open-telemetry/opentelemetry-dotnet/pull/1468#discussion_r518502446.

## Changes

Update config refresh period to 10 seconds in self diagnostics module