### PR TITLE
Remove unused using statements

### DIFF
--- a/examples/AspNet/Global.asax.cs
+++ b/examples/AspNet/Global.asax.cs
@@ -21,7 +21,6 @@ using System.Web.Http;
 using System.Web.Mvc;
 using System.Web.Routing;
 using OpenTelemetry;
-using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Trace;
 

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerThriftClientTransport.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerThriftClientTransport.cs
@@ -16,8 +16,6 @@
 using System;
 using System.IO;
 using System.Net.Sockets;
-using System.Threading;
-using System.Threading.Tasks;
 using Thrift.Transport;
 
 namespace OpenTelemetry.Exporter.Jaeger.Implementation

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -22,7 +22,6 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Instrumentation.GrpcNetClient;
 using OpenTelemetry.Trace;

--- a/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentation.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 using System;
-using System.Diagnostics;
 using OpenTelemetry.Instrumentation.SqlClient.Implementation;
 
 namespace OpenTelemetry.Instrumentation.SqlClient

--- a/src/OpenTelemetry/BatchExportProcessorOptions.cs
+++ b/src/OpenTelemetry/BatchExportProcessorOptions.cs
@@ -14,11 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Diagnostics;
-using System.Threading;
-using OpenTelemetry.Internal;
-
 namespace OpenTelemetry
 {
     public class BatchExportProcessorOptions<T>

--- a/src/OpenTelemetry/Metrics/Aggregators/Aggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregators/Aggregator.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 using System;
-using System.Diagnostics;
 using System.Threading;
 using OpenTelemetry.Metrics.Export;
 

--- a/test/Benchmarks/Exporter/ZipkinExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/ZipkinExporterBenchmarks.cs
@@ -20,7 +20,6 @@ using System.IO;
 using BenchmarkDotNet.Attributes;
 using Benchmarks.Helper;
 using OpenTelemetry;
-using OpenTelemetry.Benchmarks;
 using OpenTelemetry.Exporter.Zipkin;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Tests;

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTagHelperTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTagHelperTests.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 using System.Diagnostics;
-using System.Linq;
 using OpenTelemetry.Instrumentation.GrpcNetClient;
 using OpenTelemetry.Trace;
 using Xunit;

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.client.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.client.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Greet;


### PR DESCRIPTION
Just noticed the comment [here](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1504#discussion_r521116584) was not fully resolved.
Cleaned up the using statements for other files, too.

@utpilla