### PR TITLE
Refactor TracerProviderBuilder to API

### DIFF
--- a/docs/logs/correlation/Program.cs
+++ b/docs/logs/correlation/Program.cs
@@ -17,6 +17,7 @@
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry;
+using OpenTelemetry.Trace;
 
 public class Program
 {

--- a/docs/trace/extending-the-sdk/Program.cs
+++ b/docs/trace/extending-the-sdk/Program.cs
@@ -16,6 +16,7 @@
 
 using System.Diagnostics;
 using OpenTelemetry;
+using OpenTelemetry.Trace;
 
 public class Program
 {

--- a/src/OpenTelemetry.Api/.publicApi/net452/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/net452/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 abstract OpenTelemetry.Context.Propagation.TextMapPropagator.Extract<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> OpenTelemetry.Context.Propagation.PropagationContext
 abstract OpenTelemetry.Context.Propagation.TextMapPropagator.Fields.get -> System.Collections.Generic.ISet<string>
 abstract OpenTelemetry.Context.Propagation.TextMapPropagator.Inject<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
+abstract OpenTelemetry.Trace.TracerProviderBuilder.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation> instrumentationFactory) -> OpenTelemetry.Trace.TracerProviderBuilder
+abstract OpenTelemetry.Trace.TracerProviderBuilder.AddSource(params string[] names) -> OpenTelemetry.Trace.TracerProviderBuilder
 OpenTelemetry.ActivityContextExtensions
 OpenTelemetry.Baggage
 OpenTelemetry.Baggage.Baggage() -> void
@@ -198,6 +200,7 @@ abstract OpenTelemetry.Metrics.Meter.CreateInt64Counter(string name, bool monoto
 abstract OpenTelemetry.Metrics.Meter.CreateInt64Measure(string name, bool absolute = true) -> OpenTelemetry.Metrics.MeasureMetric<long>
 abstract OpenTelemetry.Metrics.Meter.CreateInt64Observer(string name, System.Action<OpenTelemetry.Metrics.Int64ObserverMetric> callback, bool absolute = true) -> OpenTelemetry.Metrics.Int64ObserverMetric
 abstract OpenTelemetry.Metrics.Meter.GetLabelSet(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> labels) -> OpenTelemetry.Metrics.LabelSet
+OpenTelemetry.Trace.TracerProviderBuilder
 override OpenTelemetry.Baggage.Equals(object obj) -> bool
 override OpenTelemetry.Baggage.GetHashCode() -> int
 override OpenTelemetry.Context.Propagation.B3Propagator.Extract<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> OpenTelemetry.Context.Propagation.PropagationContext

--- a/src/OpenTelemetry.Api/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -2,6 +2,8 @@ abstract OpenTelemetry.Context.Propagation.TextMapPropagator.Extract<T>(OpenTele
 abstract OpenTelemetry.Context.Propagation.TextMapPropagator.Fields.get -> System.Collections.Generic.ISet<string>
 abstract OpenTelemetry.Context.Propagation.TextMapPropagator.Inject<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
 OpenTelemetry.ActivityContextExtensions
+abstract OpenTelemetry.Trace.TracerProviderBuilder.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation> instrumentationFactory) -> OpenTelemetry.Trace.TracerProviderBuilder
+abstract OpenTelemetry.Trace.TracerProviderBuilder.AddSource(params string[] names) -> OpenTelemetry.Trace.TracerProviderBuilder
 OpenTelemetry.Baggage
 OpenTelemetry.Baggage.Baggage() -> void
 OpenTelemetry.Baggage.ClearBaggage() -> OpenTelemetry.Baggage
@@ -200,6 +202,7 @@ abstract OpenTelemetry.Metrics.Meter.CreateInt64Observer(string name, System.Act
 abstract OpenTelemetry.Metrics.Meter.GetLabelSet(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> labels) -> OpenTelemetry.Metrics.LabelSet
 override OpenTelemetry.Baggage.Equals(object obj) -> bool
 override OpenTelemetry.Baggage.GetHashCode() -> int
+OpenTelemetry.Trace.TracerProviderBuilder
 override OpenTelemetry.Context.AsyncLocalRuntimeContextSlot<T>.Get() -> T
 override OpenTelemetry.Context.AsyncLocalRuntimeContextSlot<T>.Set(T value) -> void
 override OpenTelemetry.Context.Propagation.B3Propagator.Extract<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> OpenTelemetry.Context.Propagation.PropagationContext

--- a/src/OpenTelemetry.Api/Trace/TracerProviderBuilder.cs
+++ b/src/OpenTelemetry.Api/Trace/TracerProviderBuilder.cs
@@ -1,0 +1,46 @@
+// <copyright file="TracerProviderBuilder.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+using System;
+
+namespace OpenTelemetry.Trace
+{
+    /// <summary>
+    /// TracerProviderBuilder base class.
+    /// </summary>
+    public abstract class TracerProviderBuilder
+    {
+        internal TracerProviderBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Adds an instrumentation to the provider.
+        /// </summary>
+        /// <typeparam name="TInstrumentation">Type of instrumentation class.</typeparam>
+        /// <param name="instrumentationFactory">Function that builds instrumentation.</param>
+        /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
+        public abstract TracerProviderBuilder AddInstrumentation<TInstrumentation>(
+            Func<TInstrumentation> instrumentationFactory)
+            where TInstrumentation : class;
+
+        /// <summary>
+        /// Adds given activitysource names to the list of subscribed sources.
+        /// </summary>
+        /// <param name="names">Activity source names.</param>
+        /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
+        public abstract TracerProviderBuilder AddSource(params string[] names);
+    }
+}

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/OpenTelemetry.Instrumentation.StackExchangeRedis.csproj
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/OpenTelemetry.Instrumentation.StackExchangeRedis.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry\OpenTelemetry.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Api\OpenTelemetry.Api.csproj" />
     <PackageReference Include="StackExchange.Redis" Version="$(StackExchangeRedisPkgVer)" />
   </ItemGroup>
 

--- a/src/OpenTelemetry/.publicApi/net452/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net452/PublicAPI.Unshipped.txt
@@ -165,13 +165,7 @@ OpenTelemetry.Trace.SamplingResult.SamplingResult(OpenTelemetry.Trace.SamplingDe
 OpenTelemetry.Trace.SamplingResult.SamplingResult(bool isSampled) -> void
 OpenTelemetry.Trace.TraceIdRatioBasedSampler
 OpenTelemetry.Trace.TraceIdRatioBasedSampler.TraceIdRatioBasedSampler(double probability) -> void
-OpenTelemetry.Trace.TracerProviderBuilder
-OpenTelemetry.Trace.TracerProviderBuilder.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation> instrumentationFactory) -> OpenTelemetry.Trace.TracerProviderBuilder
-OpenTelemetry.Trace.TracerProviderBuilder.AddProcessor(OpenTelemetry.BaseProcessor<System.Diagnostics.Activity> processor) -> OpenTelemetry.Trace.TracerProviderBuilder
-OpenTelemetry.Trace.TracerProviderBuilder.AddSource(params string[] names) -> OpenTelemetry.Trace.TracerProviderBuilder
-OpenTelemetry.Trace.TracerProviderBuilder.Build() -> OpenTelemetry.Trace.TracerProvider
-OpenTelemetry.Trace.TracerProviderBuilder.SetResource(OpenTelemetry.Resources.Resource resource) -> OpenTelemetry.Trace.TracerProviderBuilder
-OpenTelemetry.Trace.TracerProviderBuilder.SetSampler(OpenTelemetry.Trace.Sampler sampler) -> OpenTelemetry.Trace.TracerProviderBuilder
+OpenTelemetry.Trace.TracerProviderBuilderExtensions
 OpenTelemetry.Trace.TracerProviderExtensions
 abstract OpenTelemetry.BaseExporter<T>.Export(in OpenTelemetry.Batch<T> batch) -> OpenTelemetry.ExportResult
 abstract OpenTelemetry.Metrics.Aggregators.Aggregator<T>.GetAggregationType() -> OpenTelemetry.Metrics.Export.AggregationType
@@ -243,6 +237,10 @@ static OpenTelemetry.SuppressInstrumentationScope.Begin(bool value = true) -> Sy
 static OpenTelemetry.SuppressInstrumentationScope.Enter() -> int
 static OpenTelemetry.Trace.SamplingResult.operator !=(OpenTelemetry.Trace.SamplingResult decision1, OpenTelemetry.Trace.SamplingResult decision2) -> bool
 static OpenTelemetry.Trace.SamplingResult.operator ==(OpenTelemetry.Trace.SamplingResult decision1, OpenTelemetry.Trace.SamplingResult decision2) -> bool
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddProcessor(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, OpenTelemetry.BaseProcessor<System.Diagnostics.Activity> processor) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.Build(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder) -> OpenTelemetry.Trace.TracerProvider
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.SetResource(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, OpenTelemetry.Resources.Resource resource) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.SetSampler(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, OpenTelemetry.Trace.Sampler sampler) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Trace.TracerProviderExtensions.AddProcessor(this OpenTelemetry.Trace.TracerProvider provider, OpenTelemetry.BaseProcessor<System.Diagnostics.Activity> processor) -> OpenTelemetry.Trace.TracerProvider
 static OpenTelemetry.Trace.TracerProviderExtensions.Shutdown(this OpenTelemetry.Trace.TracerProvider provider, int timeoutMilliseconds = -1) -> bool
 virtual OpenTelemetry.BaseExporter<T>.Dispose(bool disposing) -> void

--- a/src/OpenTelemetry/.publicApi/net46/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net46/PublicAPI.Unshipped.txt
@@ -165,13 +165,7 @@ OpenTelemetry.Trace.SamplingResult.SamplingResult(OpenTelemetry.Trace.SamplingDe
 OpenTelemetry.Trace.SamplingResult.SamplingResult(bool isSampled) -> void
 OpenTelemetry.Trace.TraceIdRatioBasedSampler
 OpenTelemetry.Trace.TraceIdRatioBasedSampler.TraceIdRatioBasedSampler(double probability) -> void
-OpenTelemetry.Trace.TracerProviderBuilder
-OpenTelemetry.Trace.TracerProviderBuilder.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation> instrumentationFactory) -> OpenTelemetry.Trace.TracerProviderBuilder
-OpenTelemetry.Trace.TracerProviderBuilder.AddProcessor(OpenTelemetry.BaseProcessor<System.Diagnostics.Activity> processor) -> OpenTelemetry.Trace.TracerProviderBuilder
-OpenTelemetry.Trace.TracerProviderBuilder.AddSource(params string[] names) -> OpenTelemetry.Trace.TracerProviderBuilder
-OpenTelemetry.Trace.TracerProviderBuilder.Build() -> OpenTelemetry.Trace.TracerProvider
-OpenTelemetry.Trace.TracerProviderBuilder.SetResource(OpenTelemetry.Resources.Resource resource) -> OpenTelemetry.Trace.TracerProviderBuilder
-OpenTelemetry.Trace.TracerProviderBuilder.SetSampler(OpenTelemetry.Trace.Sampler sampler) -> OpenTelemetry.Trace.TracerProviderBuilder
+OpenTelemetry.Trace.TracerProviderBuilderExtensions
 OpenTelemetry.Trace.TracerProviderExtensions
 abstract OpenTelemetry.BaseExporter<T>.Export(in OpenTelemetry.Batch<T> batch) -> OpenTelemetry.ExportResult
 abstract OpenTelemetry.Metrics.Aggregators.Aggregator<T>.GetAggregationType() -> OpenTelemetry.Metrics.Export.AggregationType
@@ -245,6 +239,10 @@ static OpenTelemetry.Trace.SamplingResult.operator !=(OpenTelemetry.Trace.Sampli
 static OpenTelemetry.Trace.SamplingResult.operator ==(OpenTelemetry.Trace.SamplingResult decision1, OpenTelemetry.Trace.SamplingResult decision2) -> bool
 static OpenTelemetry.Trace.TracerProviderExtensions.AddProcessor(this OpenTelemetry.Trace.TracerProvider provider, OpenTelemetry.BaseProcessor<System.Diagnostics.Activity> processor) -> OpenTelemetry.Trace.TracerProvider
 static OpenTelemetry.Trace.TracerProviderExtensions.Shutdown(this OpenTelemetry.Trace.TracerProvider provider, int timeoutMilliseconds = -1) -> bool
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddProcessor(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, OpenTelemetry.BaseProcessor<System.Diagnostics.Activity> processor) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.Build(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder) -> OpenTelemetry.Trace.TracerProvider
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.SetResource(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, OpenTelemetry.Resources.Resource resource) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.SetSampler(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, OpenTelemetry.Trace.Sampler sampler) -> OpenTelemetry.Trace.TracerProviderBuilder
 virtual OpenTelemetry.BaseExporter<T>.Dispose(bool disposing) -> void
 virtual OpenTelemetry.BaseExporter<T>.OnShutdown(int timeoutMilliseconds) -> bool
 virtual OpenTelemetry.BaseProcessor<T>.Dispose(bool disposing) -> void

--- a/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -184,13 +184,7 @@ OpenTelemetry.Trace.SamplingResult.SamplingResult(OpenTelemetry.Trace.SamplingDe
 OpenTelemetry.Trace.SamplingResult.SamplingResult(bool isSampled) -> void
 OpenTelemetry.Trace.TraceIdRatioBasedSampler
 OpenTelemetry.Trace.TraceIdRatioBasedSampler.TraceIdRatioBasedSampler(double probability) -> void
-OpenTelemetry.Trace.TracerProviderBuilder
-OpenTelemetry.Trace.TracerProviderBuilder.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation> instrumentationFactory) -> OpenTelemetry.Trace.TracerProviderBuilder
-OpenTelemetry.Trace.TracerProviderBuilder.AddProcessor(OpenTelemetry.BaseProcessor<System.Diagnostics.Activity> processor) -> OpenTelemetry.Trace.TracerProviderBuilder
-OpenTelemetry.Trace.TracerProviderBuilder.AddSource(params string[] names) -> OpenTelemetry.Trace.TracerProviderBuilder
-OpenTelemetry.Trace.TracerProviderBuilder.Build() -> OpenTelemetry.Trace.TracerProvider
-OpenTelemetry.Trace.TracerProviderBuilder.SetResource(OpenTelemetry.Resources.Resource resource) -> OpenTelemetry.Trace.TracerProviderBuilder
-OpenTelemetry.Trace.TracerProviderBuilder.SetSampler(OpenTelemetry.Trace.Sampler sampler) -> OpenTelemetry.Trace.TracerProviderBuilder
+OpenTelemetry.Trace.TracerProviderBuilderExtensions
 OpenTelemetry.Trace.TracerProviderExtensions
 abstract OpenTelemetry.BaseExporter<T>.Export(in OpenTelemetry.Batch<T> batch) -> OpenTelemetry.ExportResult
 abstract OpenTelemetry.Metrics.Aggregators.Aggregator<T>.GetAggregationType() -> OpenTelemetry.Metrics.Export.AggregationType
@@ -265,6 +259,10 @@ static OpenTelemetry.Trace.SamplingResult.operator !=(OpenTelemetry.Trace.Sampli
 static OpenTelemetry.Trace.SamplingResult.operator ==(OpenTelemetry.Trace.SamplingResult decision1, OpenTelemetry.Trace.SamplingResult decision2) -> bool
 static OpenTelemetry.Trace.TracerProviderExtensions.AddProcessor(this OpenTelemetry.Trace.TracerProvider provider, OpenTelemetry.BaseProcessor<System.Diagnostics.Activity> processor) -> OpenTelemetry.Trace.TracerProvider
 static OpenTelemetry.Trace.TracerProviderExtensions.Shutdown(this OpenTelemetry.Trace.TracerProvider provider, int timeoutMilliseconds = -1) -> bool
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddProcessor(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, OpenTelemetry.BaseProcessor<System.Diagnostics.Activity> processor) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.Build(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder) -> OpenTelemetry.Trace.TracerProvider
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.SetResource(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, OpenTelemetry.Resources.Resource resource) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.SetSampler(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, OpenTelemetry.Trace.Sampler sampler) -> OpenTelemetry.Trace.TracerProviderBuilder
 virtual OpenTelemetry.BaseExporter<T>.Dispose(bool disposing) -> void
 virtual OpenTelemetry.BaseExporter<T>.OnShutdown(int timeoutMilliseconds) -> bool
 virtual OpenTelemetry.BaseProcessor<T>.Dispose(bool disposing) -> void

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -184,13 +184,7 @@ OpenTelemetry.Trace.SamplingResult.SamplingResult(OpenTelemetry.Trace.SamplingDe
 OpenTelemetry.Trace.SamplingResult.SamplingResult(bool isSampled) -> void
 OpenTelemetry.Trace.TraceIdRatioBasedSampler
 OpenTelemetry.Trace.TraceIdRatioBasedSampler.TraceIdRatioBasedSampler(double probability) -> void
-OpenTelemetry.Trace.TracerProviderBuilder
-OpenTelemetry.Trace.TracerProviderBuilder.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation> instrumentationFactory) -> OpenTelemetry.Trace.TracerProviderBuilder
-OpenTelemetry.Trace.TracerProviderBuilder.AddProcessor(OpenTelemetry.BaseProcessor<System.Diagnostics.Activity> processor) -> OpenTelemetry.Trace.TracerProviderBuilder
-OpenTelemetry.Trace.TracerProviderBuilder.AddSource(params string[] names) -> OpenTelemetry.Trace.TracerProviderBuilder
-OpenTelemetry.Trace.TracerProviderBuilder.Build() -> OpenTelemetry.Trace.TracerProvider
-OpenTelemetry.Trace.TracerProviderBuilder.SetResource(OpenTelemetry.Resources.Resource resource) -> OpenTelemetry.Trace.TracerProviderBuilder
-OpenTelemetry.Trace.TracerProviderBuilder.SetSampler(OpenTelemetry.Trace.Sampler sampler) -> OpenTelemetry.Trace.TracerProviderBuilder
+OpenTelemetry.Trace.TracerProviderBuilderExtensions
 OpenTelemetry.Trace.TracerProviderExtensions
 abstract OpenTelemetry.BaseExporter<T>.Export(in OpenTelemetry.Batch<T> batch) -> OpenTelemetry.ExportResult
 abstract OpenTelemetry.Metrics.Aggregators.Aggregator<T>.GetAggregationType() -> OpenTelemetry.Metrics.Export.AggregationType
@@ -265,6 +259,10 @@ static OpenTelemetry.Trace.SamplingResult.operator !=(OpenTelemetry.Trace.Sampli
 static OpenTelemetry.Trace.SamplingResult.operator ==(OpenTelemetry.Trace.SamplingResult decision1, OpenTelemetry.Trace.SamplingResult decision2) -> bool
 static OpenTelemetry.Trace.TracerProviderExtensions.AddProcessor(this OpenTelemetry.Trace.TracerProvider provider, OpenTelemetry.BaseProcessor<System.Diagnostics.Activity> processor) -> OpenTelemetry.Trace.TracerProvider
 static OpenTelemetry.Trace.TracerProviderExtensions.Shutdown(this OpenTelemetry.Trace.TracerProvider provider, int timeoutMilliseconds = -1) -> bool
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddProcessor(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, OpenTelemetry.BaseProcessor<System.Diagnostics.Activity> processor) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.Build(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder) -> OpenTelemetry.Trace.TracerProvider
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.SetResource(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, OpenTelemetry.Resources.Resource resource) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.SetSampler(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, OpenTelemetry.Trace.Sampler sampler) -> OpenTelemetry.Trace.TracerProviderBuilder
 virtual OpenTelemetry.BaseExporter<T>.Dispose(bool disposing) -> void
 virtual OpenTelemetry.BaseExporter<T>.OnShutdown(int timeoutMilliseconds) -> bool
 virtual OpenTelemetry.BaseProcessor<T>.Dispose(bool disposing) -> void

--- a/src/OpenTelemetry/Sdk.cs
+++ b/src/OpenTelemetry/Sdk.cs
@@ -68,7 +68,7 @@ namespace OpenTelemetry
         /// <returns>TracerProviderBuilder instance, which should be used to build TracerProvider.</returns>
         public static TracerProviderBuilder CreateTracerProviderBuilder()
         {
-            return new TracerProviderBuilder();
+            return new TracerProviderBuilderSdk();
         }
     }
 }

--- a/src/OpenTelemetry/Trace/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderBuilderExtensions.cs
@@ -1,0 +1,110 @@
+// <copyright file="TracerProviderBuilderExtensions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using OpenTelemetry.Resources;
+
+namespace OpenTelemetry.Trace
+{
+    public static class TracerProviderBuilderExtensions
+    {
+        /// <summary>
+        /// Sets sampler.
+        /// </summary>
+        /// <param name="tracerProviderBuilder">TracerProviderBuilder instance.</param>
+        /// <param name="sampler">Sampler instance.</param>
+        /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
+        public static TracerProviderBuilder SetSampler(this TracerProviderBuilder tracerProviderBuilder, Sampler sampler)
+        {
+            if (tracerProviderBuilder is TracerProviderBuilderSdk tracerProviderBuilderSdk)
+            {
+                tracerProviderBuilderSdk.SetSampler(sampler);
+            }
+
+            return tracerProviderBuilder;
+        }
+
+        /// <summary>
+        /// Sets the <see cref="Resource"/> describing the app associated with all traces. Overwrites currently set resource.
+        /// </summary>
+        /// <param name="tracerProviderBuilder">TracerProviderBuilder instance.</param>
+        /// <param name="resource">Resource to be associate with all traces.</param>
+        /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
+        public static TracerProviderBuilder SetResource(this TracerProviderBuilder tracerProviderBuilder, Resource resource)
+        {
+            if (tracerProviderBuilder is TracerProviderBuilderSdk tracerProviderBuilderSdk)
+            {
+                tracerProviderBuilderSdk.SetResource(resource);
+            }
+
+            return tracerProviderBuilder;
+        }
+
+        /// <summary>
+        /// Adds processor to the provider.
+        /// </summary>
+        /// <param name="tracerProviderBuilder">TracerProviderBuilder instance.</param>
+        /// <param name="processor">Activity processor to add.</param>
+        /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
+        public static TracerProviderBuilder AddProcessor(this TracerProviderBuilder tracerProviderBuilder, BaseProcessor<Activity> processor)
+        {
+            if (tracerProviderBuilder is TracerProviderBuilderSdk tracerProviderBuilderSdk)
+            {
+                tracerProviderBuilderSdk.AddProcessor(processor);
+            }
+
+            return tracerProviderBuilder;
+        }
+
+        public static TracerProvider Build(this TracerProviderBuilder tracerProviderBuilder)
+        {
+            if (tracerProviderBuilder is TracerProviderBuilderSdk tracerProviderBuilderSdk)
+            {
+                return tracerProviderBuilderSdk.Build();
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Adds a DiagnosticSource based instrumentation.
+        /// This is required for libraries which is already instrumented with
+        /// DiagnosticSource and Activity, without using ActivitySource.
+        /// </summary>
+        /// <typeparam name="TInstrumentation">Type of instrumentation class.</typeparam>
+        /// <param name="tracerProviderBuilder">TracerProviderBuilder instance.</param>
+        /// <param name="instrumentationFactory">Function that builds instrumentation.</param>
+        /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
+        internal static TracerProviderBuilder AddDiagnosticSourceInstrumentation<TInstrumentation>(
+            this TracerProviderBuilder tracerProviderBuilder,
+            Func<ActivitySourceAdapter, TInstrumentation> instrumentationFactory)
+            where TInstrumentation : class
+        {
+            if (instrumentationFactory == null)
+            {
+                throw new ArgumentNullException(nameof(instrumentationFactory));
+            }
+
+            if (tracerProviderBuilder is TracerProviderBuilderSdk tracerProviderBuilderSdk)
+            {
+                tracerProviderBuilderSdk.AddDiagnosticSourceInstrumentation(instrumentationFactory);
+            }
+
+            return tracerProviderBuilder;
+        }
+    }
+}

--- a/src/OpenTelemetry/Trace/TracerProviderBuilderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderBuilderSdk.cs
@@ -1,4 +1,4 @@
-// <copyright file="TracerProviderBuilder.cs" company="OpenTelemetry Authors">
+// <copyright file="TracerProviderBuilderSdk.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,7 @@ namespace OpenTelemetry.Trace
     /// <summary>
     /// Build TracerProvider with Resource, Sampler, Processors and Instrumentation.
     /// </summary>
-    public class TracerProviderBuilder
+    internal class TracerProviderBuilderSdk : TracerProviderBuilder
     {
         private readonly List<DiagnosticSourceInstrumentationFactory> diagnosticSourceInstrumentationFactories = new List<DiagnosticSourceInstrumentationFactory>();
         private readonly List<InstrumentationFactory> instrumentationFactories = new List<InstrumentationFactory>();
@@ -33,39 +33,31 @@ namespace OpenTelemetry.Trace
         private Resource resource = Resource.Empty.GetResourceWithDefaultAttributes();
         private Sampler sampler = new ParentBasedSampler(new AlwaysOnSampler());
 
-        internal TracerProviderBuilder()
+        internal TracerProviderBuilderSdk()
         {
         }
 
         /// <summary>
-        /// Sets sampler.
+        /// Adds an instrumentation to the provider.
         /// </summary>
-        /// <param name="sampler">Sampler instance.</param>
+        /// <typeparam name="TInstrumentation">Type of instrumentation class.</typeparam>
+        /// <param name="instrumentationFactory">Function that builds instrumentation.</param>
         /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
-        public TracerProviderBuilder SetSampler(Sampler sampler)
+        public override TracerProviderBuilder AddInstrumentation<TInstrumentation>(
+            Func<TInstrumentation> instrumentationFactory)
+            where TInstrumentation : class
         {
-            if (sampler == null)
+            if (instrumentationFactory == null)
             {
-                throw new ArgumentNullException(nameof(sampler));
+                throw new ArgumentNullException(nameof(instrumentationFactory));
             }
 
-            this.sampler = sampler;
-            return this;
-        }
+            this.instrumentationFactories.Add(
+                new InstrumentationFactory(
+                    typeof(TInstrumentation).Name,
+                    "semver:" + typeof(TInstrumentation).Assembly.GetName().Version,
+                    instrumentationFactory));
 
-        /// <summary>
-        /// Sets the <see cref="Resource"/> describing the app associated with all traces. Overwrites currently set resource.
-        /// </summary>
-        /// <param name="resource">Resource to be associate with all traces.</param>
-        /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
-        public TracerProviderBuilder SetResource(Resource resource)
-        {
-            if (resource == null)
-            {
-                throw new ArgumentNullException(nameof(resource));
-            }
-
-            this.resource = resource;
             return this;
         }
 
@@ -74,7 +66,7 @@ namespace OpenTelemetry.Trace
         /// </summary>
         /// <param name="names">Activity source names.</param>
         /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
-        public TracerProviderBuilder AddSource(params string[] names)
+        public override TracerProviderBuilder AddSource(params string[] names)
         {
             if (names == null)
             {
@@ -97,11 +89,43 @@ namespace OpenTelemetry.Trace
         }
 
         /// <summary>
+        /// Sets sampler.
+        /// </summary>
+        /// <param name="sampler">Sampler instance.</param>
+        /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
+        internal TracerProviderBuilder SetSampler(Sampler sampler)
+        {
+            if (sampler == null)
+            {
+                throw new ArgumentNullException(nameof(sampler));
+            }
+
+            this.sampler = sampler;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the <see cref="Resource"/> describing the app associated with all traces. Overwrites currently set resource.
+        /// </summary>
+        /// <param name="resource">Resource to be associate with all traces.</param>
+        /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
+        internal TracerProviderBuilder SetResource(Resource resource)
+        {
+            if (resource == null)
+            {
+                throw new ArgumentNullException(nameof(resource));
+            }
+
+            this.resource = resource;
+            return this;
+        }
+
+        /// <summary>
         /// Adds processor to the provider.
         /// </summary>
         /// <param name="processor">Activity processor to add.</param>
         /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
-        public TracerProviderBuilder AddProcessor(BaseProcessor<Activity> processor)
+        internal TracerProviderBuilder AddProcessor(BaseProcessor<Activity> processor)
         {
             if (processor == null)
             {
@@ -113,31 +137,7 @@ namespace OpenTelemetry.Trace
             return this;
         }
 
-        /// <summary>
-        /// Adds an instrumentation to the provider.
-        /// </summary>
-        /// <typeparam name="TInstrumentation">Type of instrumentation class.</typeparam>
-        /// <param name="instrumentationFactory">Function that builds instrumentation.</param>
-        /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
-        public TracerProviderBuilder AddInstrumentation<TInstrumentation>(
-            Func<TInstrumentation> instrumentationFactory)
-            where TInstrumentation : class
-        {
-            if (instrumentationFactory == null)
-            {
-                throw new ArgumentNullException(nameof(instrumentationFactory));
-            }
-
-            this.instrumentationFactories.Add(
-                new InstrumentationFactory(
-                    typeof(TInstrumentation).Name,
-                    "semver:" + typeof(TInstrumentation).Assembly.GetName().Version,
-                    instrumentationFactory));
-
-            return this;
-        }
-
-        public TracerProvider Build()
+        internal TracerProvider Build()
         {
             return new TracerProviderSdk(this.resource, this.sources, this.diagnosticSourceInstrumentationFactories, this.instrumentationFactories, this.sampler, this.processors);
         }

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -39,8 +39,8 @@ namespace OpenTelemetry.Trace
         internal TracerProviderSdk(
             Resource resource,
             IEnumerable<string> sources,
-            IEnumerable<TracerProviderBuilder.DiagnosticSourceInstrumentationFactory> diagnosticSourceInstrumentationFactories,
-            IEnumerable<TracerProviderBuilder.InstrumentationFactory> instrumentationFactories,
+            IEnumerable<TracerProviderBuilderSdk.DiagnosticSourceInstrumentationFactory> diagnosticSourceInstrumentationFactories,
+            IEnumerable<TracerProviderBuilderSdk.InstrumentationFactory> instrumentationFactories,
             Sampler sampler,
             List<BaseProcessor<Activity>> processors)
         {

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.StackExchangeRedis\OpenTelemetry.Instrumentation.StackExchangeRedis.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry\OpenTelemetry.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Move TracerProviderBuilder to API project as an abstract class and declares AddSource and AddInstrumentation abstract methods.
TracerProviderBuilderSdk is in SDK Project, which extends TracerProviderBuilder.

This allows instrumentation library to take a dependency on just the API project. (They needed SDK dependency now, to write extension method on TracerProviderBuilder, but TracerProviderBuilder is now in API itself)

For example, StackExchangeInstrumentation now depends only on API project.

(Other instrumentation still relies on SDK, as its special cased to allow access to ActivitySourceAdapter. This is a TODO for later)