### PR TITLE
Allow users to override instrumentation tags and status

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -115,15 +115,6 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
 
             if (activity.IsAllDataRequested)
             {
-                try
-                {
-                    this.options.Enrich?.Invoke(activity, "OnStartActivity", request);
-                }
-                catch (Exception ex)
-                {
-                    AspNetInstrumentationEventSource.Log.EnrichmentException(ex);
-                }
-
                 if (request.Url.Port == 80 || request.Url.Port == 443)
                 {
                     activity.SetTag(SemanticConventions.AttributeHttpHost, request.Url.Host);
@@ -137,6 +128,15 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
                 activity.SetTag(SpanAttributeConstants.HttpPathKey, path);
                 activity.SetTag(SemanticConventions.AttributeHttpUserAgent, request.UserAgent);
                 activity.SetTag(SemanticConventions.AttributeHttpUrl, request.Url.ToString());
+
+                try
+                {
+                    this.options.Enrich?.Invoke(activity, "OnStartActivity", request);
+                }
+                catch (Exception ex)
+                {
+                    AspNetInstrumentationEventSource.Log.EnrichmentException(ex);
+                }
             }
         }
 
@@ -176,15 +176,6 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
 
                 var response = context.Response;
 
-                try
-                {
-                    this.options.Enrich?.Invoke(activityToEnrich, "OnStopActivity", response);
-                }
-                catch (Exception ex)
-                {
-                    AspNetInstrumentationEventSource.Log.EnrichmentException(ex);
-                }
-
                 activityToEnrich.SetTag(SemanticConventions.AttributeHttpStatusCode, response.StatusCode);
 
                 Status status = SpanHelper.ResolveSpanStatusForHttpStatusCode(response.StatusCode);
@@ -216,6 +207,15 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
                     // Override the name that was previously set to the path part of URL.
                     activityToEnrich.DisplayName = template;
                     activityToEnrich.SetTag(SemanticConventions.AttributeHttpRoute, template);
+                }
+
+                try
+                {
+                    this.options.Enrich?.Invoke(activityToEnrich, "OnStopActivity", response);
+                }
+                catch (Exception ex)
+                {
+                    AspNetInstrumentationEventSource.Log.EnrichmentException(ex);
                 }
             }
 

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -47,6 +47,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
 
         [Theory]
         [InlineData("http://localhost/", 0, null, "TraceContext")]
+        [InlineData("http://localhost/", 0, null, "TraceContext", true)]
         [InlineData("https://localhost/", 0, null, "TraceContext")]
         [InlineData("http://localhost:443/", 0, null, "TraceContext")] // Test http over 443
         [InlineData("https://localhost:80/", 0, null, "TraceContext")] // Test https over 80
@@ -54,16 +55,17 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
         [InlineData("https://localhost:443/about_attr_route/10", 2, "about_attr_route/{customerId}", "TraceContext")]
         [InlineData("http://localhost:1880/api/weatherforecast", 3, "api/{controller}/{id}", "TraceContext")]
         [InlineData("https://localhost:1843/subroute/10", 4, "subroute/{customerId}", "TraceContext")]
-        [InlineData("http://localhost/api/value", 0, null, "TraceContext", "/api/value")] // Request will be filtered
-        [InlineData("http://localhost/api/value", 0, null, "TraceContext", "{ThrowException}")] // Filter user code will throw an exception
+        [InlineData("http://localhost/api/value", 0, null, "TraceContext", false, "/api/value")] // Request will be filtered
+        [InlineData("http://localhost/api/value", 0, null, "TraceContext", false, "{ThrowException}")] // Filter user code will throw an exception
         [InlineData("http://localhost/api/value/2", 0, null, "CustomContextMatchParent")]
         [InlineData("http://localhost/api/value/2", 0, null, "CustomContextNonmatchParent")]
-        [InlineData("http://localhost/api/value/2", 0, null, "CustomContextNonmatchParent", null, true)]
+        [InlineData("http://localhost/api/value/2", 0, null, "CustomContextNonmatchParent", false, null, true)]
         public void AspNetRequestsAreCollectedSuccessfully(
             string url,
             int routeType,
             string routeTemplate,
             string carrierFormat,
+            bool setStatusToErrorInEnrich = false,
             string filter = null,
             bool restoreCurrentActivity = false)
         {
@@ -162,7 +164,14 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
                         return httpContext.Request.Path != filter;
                     };
 
-                    options.Enrich = ActivityEnrichment;
+                    if (setStatusToErrorInEnrich)
+                    {
+                        options.Enrich = GetEnrichmentAction(Status.Error);
+                    }
+                    else
+                    {
+                        options.Enrich = GetEnrichmentAction(default);
+                    }
                 })
             .AddProcessor(activityProcessor.Object).Build())
             {
@@ -219,11 +228,25 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
             Assert.True(span.Duration != TimeSpan.Zero);
 
             Assert.Equal(200, span.GetTagValue(SemanticConventions.AttributeHttpStatusCode));
-            Assert.Equal(Status.Unset, span.GetStatus());
 
-            // Instrumentation is not expected to set status description
-            // as the reason can be inferred from SemanticConventions.AttributeHttpStatusCode
-            Assert.True(string.IsNullOrEmpty(span.GetStatus().Description));
+            if (setStatusToErrorInEnrich)
+            {
+                // This validates that users can override the
+                // status in Enrich.
+                Assert.Equal(Status.Error, span.GetStatus());
+
+                // Instrumentation is not expected to set status description
+                // as the reason can be inferred from SemanticConventions.AttributeHttpStatusCode
+                Assert.True(string.IsNullOrEmpty(span.GetStatus().Description));
+            }
+            else
+            {
+                Assert.Equal(Status.Unset, span.GetStatus());
+
+                // Instrumentation is not expected to set status description
+                // as the reason can be inferred from SemanticConventions.AttributeHttpStatusCode
+                Assert.True(string.IsNullOrEmpty(span.GetStatus().Description));
+            }
 
             var expectedUri = new Uri(url);
             var actualUrl = span.GetTagValue(SemanticConventions.AttributeHttpUrl);
@@ -259,21 +282,33 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
             Assert.Equal(HttpContext.Current.Request.UserAgent, span.GetTagValue(SemanticConventions.AttributeHttpUserAgent) as string);
         }
 
-        private static void ActivityEnrichment(Activity activity, string method, object obj)
+        private static Action<Activity, string, object> GetEnrichmentAction(Status statusToBeSet)
         {
-            switch (method)
+            Action<Activity, string, object> enrichAction;
+
+            enrichAction = (activity, method, obj) =>
             {
-                case "OnStartActivity":
-                    Assert.True(obj is HttpRequest);
-                    break;
+                switch (method)
+                {
+                    case "OnStartActivity":
+                        Assert.True(obj is HttpRequest);
+                        break;
 
-                case "OnStopActivity":
-                    Assert.True(obj is HttpResponse);
-                    break;
+                    case "OnStopActivity":
+                        Assert.True(obj is HttpResponse);
+                        if (statusToBeSet != default)
+                        {
+                            activity.SetStatus(statusToBeSet);
+                        }
 
-                default:
-                    break;
-            }
+                        break;
+
+                    default:
+                        break;
+                }
+            };
+
+            return enrichAction;
         }
 
         private class FakeAspNetDiagnosticSource : IDisposable


### PR DESCRIPTION
Fix AspNet instrumentation to call Enrich after setting status and all the tags by the instrumentation. This ensures that any tags/status set by the user in Enrich wins.
Enrich is a "special" case in some instrumentations. The general guideline on overriding anything is by adding ActivityProcessor. As ActivityProcessor is called *after* instrumentation has done its enrichments, we don't have this issue with ActivityProcessor, hence the fix is only required in Enrich.

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
