### PR TITLE
Make ZipkinExporter and JaegerExporter internal

### DIFF
--- a/src/OpenTelemetry.Exporter.Jaeger/.publicApi/net46/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Jaeger/.publicApi/net46/PublicAPI.Unshipped.txt
@@ -1,4 +1,3 @@
-OpenTelemetry.Exporter.Jaeger.JaegerExporter
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentHost.get -> string
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentHost.set -> void
@@ -12,5 +11,4 @@ OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ProcessTags.set -> void
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ServiceName.get -> string
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ServiceName.set -> void
 OpenTelemetry.Trace.JaegerExporterHelperExtensions
-override OpenTelemetry.Exporter.Jaeger.JaegerExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> activityBatch) -> OpenTelemetry.ExportResult
 static OpenTelemetry.Trace.JaegerExporterHelperExtensions.AddJaegerExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Exporter.Jaeger/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Jaeger/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,3 @@
-OpenTelemetry.Exporter.Jaeger.JaegerExporter
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentHost.get -> string
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentHost.set -> void
@@ -12,5 +11,4 @@ OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ProcessTags.set -> void
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ServiceName.get -> string
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ServiceName.set -> void
 OpenTelemetry.Trace.JaegerExporterHelperExtensions
-override OpenTelemetry.Exporter.Jaeger.JaegerExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> activityBatch) -> OpenTelemetry.ExportResult
 static OpenTelemetry.Trace.JaegerExporterHelperExtensions.AddJaegerExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Exporter.Jaeger/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Jaeger/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,4 +1,3 @@
-OpenTelemetry.Exporter.Jaeger.JaegerExporter
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentHost.get -> string
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentHost.set -> void
@@ -12,5 +11,4 @@ OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ProcessTags.set -> void
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ServiceName.get -> string
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ServiceName.set -> void
 OpenTelemetry.Trace.JaegerExporterHelperExtensions
-override OpenTelemetry.Exporter.Jaeger.JaegerExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> activityBatch) -> OpenTelemetry.ExportResult
 static OpenTelemetry.Trace.JaegerExporterHelperExtensions.AddJaegerExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Jaeger tags used for InstrumentationLibrary changed from library.name,
   library.version to otel.library.name, otel.library.version respectively.
   ([#1513](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1513))
+* The `JaegerExporter` class has been made internal.
+  ([#1540](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1540))
 
 ## 0.8.0-beta.1
 

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
@@ -26,7 +26,7 @@ using Process = OpenTelemetry.Exporter.Jaeger.Implementation.Process;
 
 namespace OpenTelemetry.Exporter.Jaeger
 {
-    public class JaegerExporter : BaseExporter<Activity>
+    internal class JaegerExporter : BaseExporter<Activity>
     {
         private readonly int maxPayloadSizeInBytes;
         private readonly TProtocolFactory protocolFactory;

--- a/src/OpenTelemetry.Exporter.Zipkin/.publicApi/net452/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Zipkin/.publicApi/net452/PublicAPI.Unshipped.txt
@@ -1,4 +1,3 @@
-OpenTelemetry.Exporter.Zipkin.ZipkinExporter
 OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions
 OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
 OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.BatchExportProcessorOptions.set -> void
@@ -12,5 +11,4 @@ OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.UseShortTraceIds.get -> bool
 OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.UseShortTraceIds.set -> void
 OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.ZipkinExporterOptions() -> void
 OpenTelemetry.Trace.ZipkinExporterHelperExtensions
-override OpenTelemetry.Exporter.Zipkin.ZipkinExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) -> OpenTelemetry.ExportResult
 static OpenTelemetry.Trace.ZipkinExporterHelperExtensions.AddZipkinExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Exporter.Zipkin/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Zipkin/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -1,4 +1,3 @@
-OpenTelemetry.Exporter.Zipkin.ZipkinExporter
 OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions
 OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
 OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.BatchExportProcessorOptions.set -> void
@@ -14,5 +13,4 @@ OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.UseShortTraceIds.get -> bool
 OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.UseShortTraceIds.set -> void
 OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.ZipkinExporterOptions() -> void
 OpenTelemetry.Trace.ZipkinExporterHelperExtensions
-override OpenTelemetry.Exporter.Zipkin.ZipkinExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) -> OpenTelemetry.ExportResult
 static OpenTelemetry.Trace.ZipkinExporterHelperExtensions.AddZipkinExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Exporter.Zipkin/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Zipkin/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,3 @@
-OpenTelemetry.Exporter.Zipkin.ZipkinExporter
 OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions
 OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
 OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.BatchExportProcessorOptions.set -> void
@@ -14,5 +13,4 @@ OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.UseShortTraceIds.get -> bool
 OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.UseShortTraceIds.set -> void
 OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.ZipkinExporterOptions() -> void
 OpenTelemetry.Trace.ZipkinExporterHelperExtensions
-override OpenTelemetry.Exporter.Zipkin.ZipkinExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) -> OpenTelemetry.ExportResult
 static OpenTelemetry.Trace.ZipkinExporterHelperExtensions.AddZipkinExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -8,6 +8,8 @@
   library.version to otel.library.name, otel.library.version respectively.
 * Sending `service.namespace` as Zipkin tag.
   ([#1521](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1521))
+* The `ZipkinExporter` class has been made internal.
+  ([#1540](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1540))
 
 ## 0.8.0-beta.1
 

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporter.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporter.cs
@@ -37,7 +37,7 @@ namespace OpenTelemetry.Exporter.Zipkin
     /// <summary>
     /// Zipkin exporter.
     /// </summary>
-    public class ZipkinExporter : BaseExporter<Activity>
+    internal class ZipkinExporter : BaseExporter<Activity>
     {
         private readonly ZipkinExporterOptions options;
 #if !NET452


### PR DESCRIPTION
In #1528 I made the OtlpExporter internal. This does the same for the Zipkin and Jaeger exporters.

The thought is that adding and configuring these exporters is to be done through their respective `TracerProviderBuilder` extension methods. I also believe there is a plan to apply the pattern started with Zipkin in #1504 to both Jaeger and Otlp for configuring Simple vs. Batch export.