### PR TITLE
Question: Change namespace of extension methods?

### DIFF
--- a/examples/AspNetCore/Startup.cs
+++ b/examples/AspNetCore/Startup.cs
@@ -23,6 +23,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
+using OpenTelemetry;
 using OpenTelemetry.Trace;
 
 namespace Examples.AspNetCore

--- a/examples/GrpcService/Startup.cs
+++ b/examples/GrpcService/Startup.cs
@@ -21,6 +21,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using OpenTelemetry;
 using OpenTelemetry.Trace;
 
 namespace Examples.GrpcService

--- a/examples/MicroserviceExample/WebApi/Startup.cs
+++ b/examples/MicroserviceExample/WebApi/Startup.cs
@@ -20,6 +20,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using OpenTelemetry;
 using OpenTelemetry.Trace;
 using Utils.Messaging;
 

--- a/examples/MicroserviceExample/WorkerService/Program.cs
+++ b/examples/MicroserviceExample/WorkerService/Program.cs
@@ -17,6 +17,7 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using OpenTelemetry;
 using OpenTelemetry.Trace;
 using Utils.Messaging;
 

--- a/src/OpenTelemetry.Exporter.Jaeger/.publicApi/net46/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Jaeger/.publicApi/net46/PublicAPI.Unshipped.txt
@@ -11,6 +11,6 @@ OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ProcessTags.get -> System.Co
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ProcessTags.set -> void
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ServiceName.get -> string
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ServiceName.set -> void
-OpenTelemetry.Trace.JaegerExporterHelperExtensions
+OpenTelemetry.JaegerExporterHelperExtensions
 override OpenTelemetry.Exporter.Jaeger.JaegerExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> activityBatch) -> OpenTelemetry.ExportResult
-static OpenTelemetry.Trace.JaegerExporterHelperExtensions.AddJaegerExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.JaegerExporterHelperExtensions.AddJaegerExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Exporter.Jaeger/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Jaeger/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -11,6 +11,6 @@ OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ProcessTags.get -> System.Co
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ProcessTags.set -> void
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ServiceName.get -> string
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ServiceName.set -> void
-OpenTelemetry.Trace.JaegerExporterHelperExtensions
+OpenTelemetry.JaegerExporterHelperExtensions
 override OpenTelemetry.Exporter.Jaeger.JaegerExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> activityBatch) -> OpenTelemetry.ExportResult
-static OpenTelemetry.Trace.JaegerExporterHelperExtensions.AddJaegerExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.JaegerExporterHelperExtensions.AddJaegerExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Exporter.Jaeger/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Jaeger/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
@@ -11,6 +11,6 @@ OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ProcessTags.get -> System.Co
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ProcessTags.set -> void
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ServiceName.get -> string
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ServiceName.set -> void
-OpenTelemetry.Trace.JaegerExporterHelperExtensions
+OpenTelemetry.JaegerExporterHelperExtensions
 override OpenTelemetry.Exporter.Jaeger.JaegerExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> activityBatch) -> OpenTelemetry.ExportResult
-static OpenTelemetry.Trace.JaegerExporterHelperExtensions.AddJaegerExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.JaegerExporterHelperExtensions.AddJaegerExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterHelperExtensions.cs
@@ -17,8 +17,9 @@
 using System;
 using System.Diagnostics;
 using OpenTelemetry.Exporter.Jaeger;
+using OpenTelemetry.Trace;
 
-namespace OpenTelemetry.Trace
+namespace OpenTelemetry
 {
     /// <summary>
     /// Extension methods to simplify registering a Jaeger exporter.

--- a/src/OpenTelemetry.Exporter.Zipkin/.publicApi/net452/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Zipkin/.publicApi/net452/PublicAPI.Unshipped.txt
@@ -11,6 +11,6 @@ OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.ServiceName.set -> void
 OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.UseShortTraceIds.get -> bool
 OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.UseShortTraceIds.set -> void
 OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.ZipkinExporterOptions() -> void
-OpenTelemetry.Trace.ZipkinExporterHelperExtensions
+OpenTelemetry.ZipkinExporterHelperExtensions
 override OpenTelemetry.Exporter.Zipkin.ZipkinExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) -> OpenTelemetry.ExportResult
-static OpenTelemetry.Trace.ZipkinExporterHelperExtensions.AddZipkinExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.ZipkinExporterHelperExtensions.AddZipkinExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Exporter.Zipkin/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Zipkin/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -13,6 +13,6 @@ OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.ServiceName.set -> void
 OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.UseShortTraceIds.get -> bool
 OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.UseShortTraceIds.set -> void
 OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.ZipkinExporterOptions() -> void
-OpenTelemetry.Trace.ZipkinExporterHelperExtensions
+OpenTelemetry.ZipkinExporterHelperExtensions
 override OpenTelemetry.Exporter.Zipkin.ZipkinExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) -> OpenTelemetry.ExportResult
-static OpenTelemetry.Trace.ZipkinExporterHelperExtensions.AddZipkinExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.ZipkinExporterHelperExtensions.AddZipkinExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Exporter.Zipkin/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Zipkin/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -13,6 +13,6 @@ OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.ServiceName.set -> void
 OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.UseShortTraceIds.get -> bool
 OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.UseShortTraceIds.set -> void
 OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.ZipkinExporterOptions() -> void
-OpenTelemetry.Trace.ZipkinExporterHelperExtensions
+OpenTelemetry.ZipkinExporterHelperExtensions
 override OpenTelemetry.Exporter.Zipkin.ZipkinExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) -> OpenTelemetry.ExportResult
-static OpenTelemetry.Trace.ZipkinExporterHelperExtensions.AddZipkinExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.ZipkinExporterHelperExtensions.AddZipkinExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporterHelperExtensions.cs
@@ -16,9 +16,10 @@
 
 using System;
 using System.Diagnostics;
+using OpenTelemetry.Trace;
 using OpenTelemetry.Exporter.Zipkin;
 
-namespace OpenTelemetry.Trace
+namespace OpenTelemetry
 {
     /// <summary>
     /// Extension methods to simplify registering of Zipkin exporter.


### PR DESCRIPTION
I'm putting this out here to pose a question regarding the namespaces we've chosen for some of our extension methods. We may very well not want to adopt any of the changes I've made here.

#### Background

We have many extension methods off of `TracerBuilderProvider`. Extension methods are great, but often can be a little tricky for a newcomer to a library since in some contexts they'll need to make sure they add the appropriate `using` statements.

For example, in the context of an ASP.NET Core app one might write the following:

```csharp
using Microsoft.Extensions.Hosting;

...

services.AddOpenTelemetryTracing((builder) => // no additional using here since this is an extension on a non-otel type and is in the Microsoft.Extensions.Hosting namespace
    builder
        .AddSource("my-source") // no additional using needed here since AddSource is not an extension on TracerProviderBuilder
        .AddAspNetCoreInstrumentation() // this requires using OpenTelemetry.Trace
        .AddZipkinExporter() // also requires OpenTelemetry.Trace
);


// In the future we will probably have the following

services.AddOpenTelemetryMetrics((builder) =>
    builder
        .AddAspNetCoreInstrumentation() // this requires using OpenTelemetry.Metrics
        .AddPrometheus() // also requires OpenTelemetry.Metrics
);

...
```

This example code requires the user to know to add both `using OpenTelemetry.Trace` and `using OpenTelemetry.Metrics` to expose the necessary extension methods.

#### Question

Does it make sense to keep extension methods for OpenTelemetry types (i.e., `TracerProviderBuilder`, `MeterProviderBuilder`, etc) in a single namespace like `OpenTelemetry` or `OpenTelemetry.Extensions`? Adding a using statement would still be required, but the benefit would be that a single using statement would make all extension methods available.

The change here is in the context of the Zipkin and Jaeger exporters, but as shown, this question applies to our extension methods defined in instrumentation projects as well. Also, note that this would be a small breaking change.