### PR TITLE
Fixing status description behavior

### DIFF
--- a/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
@@ -15,9 +15,7 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using OpenTelemetry.Internal;
 
@@ -43,10 +41,7 @@ namespace OpenTelemetry.Trace
             Debug.Assert(activity != null, "Activity should not be null");
 
             activity.SetTag(SpanAttributeConstants.StatusCodeKey, (int)status.StatusCode);
-            if (!string.IsNullOrEmpty(status.Description))
-            {
-                activity.SetTag(SpanAttributeConstants.StatusDescriptionKey, status.Description);
-            }
+            activity.SetTag(SpanAttributeConstants.StatusDescriptionKey, status.Description);
         }
 
         /// <summary>

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -178,9 +178,9 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
 
                 activityToEnrich.SetTag(SemanticConventions.AttributeHttpStatusCode, response.StatusCode);
 
-                Status status = SpanHelper.ResolveSpanStatusForHttpStatusCode(response.StatusCode);
                 if (activityToEnrich.GetStatus().StatusCode == StatusCode.Unset)
                 {
+                    Status status = SpanHelper.ResolveSpanStatusForHttpStatusCode(response.StatusCode);
                     activityToEnrich.SetStatus(status);
                 }
 

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -179,7 +179,10 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
                 activityToEnrich.SetTag(SemanticConventions.AttributeHttpStatusCode, response.StatusCode);
 
                 Status status = SpanHelper.ResolveSpanStatusForHttpStatusCode(response.StatusCode);
-                activityToEnrich.SetStatus(status);
+                if (activityToEnrich.GetStatus().StatusCode == StatusCode.Unset)
+                {
+                    activityToEnrich.SetStatus(status);
+                }
 
                 var routeData = context.Request.RequestContext.RouteData;
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -169,10 +169,16 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
                 }
                 else
                 {
-                    SetStatusFromHttpStatusCode(activity, response.StatusCode);
+                    if (activity.GetStatus().StatusCode == StatusCode.Unset)
+                    {
+                        SetStatusFromHttpStatusCode(activity, response.StatusCode);
+                    }
                 }
 #else
-                SetStatusFromHttpStatusCode(activity, response.StatusCode);
+                if (activity.GetStatus().StatusCode == StatusCode.Unset)
+                {
+                    SetStatusFromHttpStatusCode(activity, response.StatusCode);
+                }
 #endif
 
                 try

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
@@ -134,7 +134,10 @@ namespace OpenTelemetry.Instrumentation.GrpcNetClient.Implementation
                 bool validConversion = GrpcTagHelper.TryGetGrpcStatusCodeFromActivity(activity, out int status);
                 if (validConversion)
                 {
-                    activity.SetStatus(GrpcTagHelper.ResolveSpanStatusForGrpcStatusCode(status));
+                    if (activity.GetStatus().StatusCode == StatusCode.Unset)
+                    {
+                        activity.SetStatus(GrpcTagHelper.ResolveSpanStatusForGrpcStatusCode(status));
+                    }
 
                     // setting rpc.grpc.status_code
                     activity.SetTag(SemanticConventions.AttributeRpcGrpcStatusCode, status);

--- a/test/OpenTelemetry.Tests/Trace/ActivityExtensionsTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ActivityExtensionsTest.cs
@@ -60,6 +60,24 @@ namespace OpenTelemetry.Trace.Tests
         }
 
         [Fact]
+        public void SetStatusWithDescriptionTwice()
+        {
+            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+                .AddSource(ActivitySourceName)
+                .Build();
+
+            using var source = new ActivitySource(ActivitySourceName);
+            using var activity = source.StartActivity(ActivityName);
+            activity.SetStatus(Status.Error.WithDescription("Not Found"));
+            activity.SetStatus(Status.Ok);
+            activity?.Stop();
+
+            var status = activity.GetStatus();
+            Assert.Equal(StatusCode.Ok, status.StatusCode);
+            Assert.Null(status.Description);
+        }
+
+        [Fact]
         public void SetCancelledStatus()
         {
             using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()


### PR DESCRIPTION
Fixes #.

## Old Behavior

activity.SetStatus(ok.WithDescription("it is ok"))
activity.SetStatus(error)

if we check the status, we would see
Status = error
Description = "it is ok"

## New Behavior

activity.SetStatus(ok.WithDescription("it is ok"))
activity.SetStatus(error)

if we check the status, we would see
Status = error
Description = null

## Changes
Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
