### PR TITLE
Enable self diagnostics module

### DIFF
--- a/src/OpenTelemetry/README.md
+++ b/src/OpenTelemetry/README.md
@@ -134,9 +134,9 @@ log file would be generated. Otherwise, it will create or overwrite the log
 file as described above.
 
 Note that the `FileSize` has to be between 1 MiB and 128 MiB (inclusive), or it
-will be rounded to the closest upper or lower limit.  When the `LogDirectory` or
+will be rounded to the closest upper or lower limit. When the `LogDirectory` or
 `FileSize` is found to be changed, the SDK will create or overwrite a file with
-new logs according to the new configuration.  The configuration file has to be
+new logs according to the new configuration. The configuration file has to be
 no more than 4 KiB. In case the file is larger than 4 KiB, only the first 4 KiB
 of content will be read.
 

--- a/src/OpenTelemetry/README.md
+++ b/src/OpenTelemetry/README.md
@@ -100,11 +100,16 @@ content:
 }
 ```
 
-`LogDirectory` is the directory of the output file. It can be an absolute path
-or a relative path to the current directory. `FileSize` is a positive integer,
+#### Configuration Parameters
+
+1. `LogDirectory` is the directory of the output file. It can be an absolute
+path or a relative path to the current directory.
+
+2. `FileSize` is a positive integer,
 which specifies the log file size in
 [KiB](https://en.wikipedia.org/wiki/Kibibyte).
-`LogLevel` is the lowest level of the events to be captured.
+
+3. `LogLevel` is the lowest level of the events to be captured.
 It has to be one of the
 [values](https://docs.microsoft.com/dotnet/api/system.diagnostics.tracing.eventlevel#fields)
 of the [`EventLevel`
@@ -115,13 +120,18 @@ higher severity levels. For example, `Warning` includes the `Error` and
 [here](https://docs.microsoft.com/dotnet/api/system.diagnostics.tracing.eventlevel)
 for more.)
 
+#### Remarks
+
+A `FileSize`-KiB log file named as `ExecutableName.ProcessId.log` (e.g.
+`foobar.exe.12345.log`) will be generated at the specific directory
+`LogDirectory`.
+
 The SDK will attempt to open the configuration file in non-exclusive read-only
-mode, read the file and parse it as the configuration file every 3 seconds. If
+mode, read the file and parse it as the configuration file every 10 seconds. If
 the SDK fails to parse the `LogDirectory`, `FileSize` or `LogLevel` fields as
 the specified format, the configuration file will be treated as invalid and no
-log file would be generated. Otherwise, it will create or overwrite a
-`FileSize`-KiB file at the specific directory `LogDirectory` with the log file
-named as `ExecutableName.ProcessId.log` (e.g. `foobar.exe.12345.log`).
+log file would be generated. Otherwise, it will create or overwrite the log
+file as described above.
 
 Note that the `FileSize` has to be between 1 MiB and 128 MiB (inclusive), or it
 will be rounded to the closest upper or lower limit.  When the `LogDirectory` or

--- a/src/OpenTelemetry/Sdk.cs
+++ b/src/OpenTelemetry/Sdk.cs
@@ -16,6 +16,7 @@
 
 using System.Diagnostics;
 using OpenTelemetry.Context.Propagation;
+using OpenTelemetry.Internal;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 
@@ -36,6 +37,7 @@ namespace OpenTelemetry
 
             Activity.DefaultIdFormat = ActivityIdFormat.W3C;
             Activity.ForceDefaultIdFormat = true;
+            SelfDiagnostics.EnsureInitialized();
         }
 
         /// <summary>


### PR DESCRIPTION
Enable the self diagnostics module as described in #1258

## Changes

Initialize self diagnostics module in `Sdk.cs`.

Update README for config update period #1523 

Rephrase remarks in the README to emphasize _what/where the output file is_ over _how the file is generated_ to be easier to read and more user-friendly.