### PR TITLE
Fix spelling of event messages: 'thrw' -> 'threw'

### DIFF
--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcInstrumentationEventSource.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcInstrumentationEventSource.cs
@@ -43,7 +43,7 @@ namespace OpenTelemetry.Instrumentation.GrpcNetClient.Implementation
             }
         }
 
-        [Event(2, Message = "Enrichment thrw exception. Exception {0}.", Level = EventLevel.Error)]
+        [Event(2, Message = "Enrichment threw exception. Exception {0}.", Level = EventLevel.Error)]
         public void EnrichmentException(string exception)
         {
             this.WriteEvent(2, exception);

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientInstrumentationEventSource.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientInstrumentationEventSource.cs
@@ -43,7 +43,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Implementation
             this.WriteEvent(1, handlerName, eventName, ex);
         }
 
-        [Event(2, Message = "Current Activity is NULL the '{0}' callback. Span will not be recorded.", Level = EventLevel.Warning)]
+        [Event(2, Message = "Current Activity is NULL in the '{0}' callback. Span will not be recorded.", Level = EventLevel.Warning)]
         public void NullActivity(string eventName)
         {
             this.WriteEvent(2, eventName);
@@ -70,7 +70,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Implementation
             }
         }
 
-        [Event(5, Message = "Enrichment thrw exception. Exception {0}.", Level = EventLevel.Error)]
+        [Event(5, Message = "Enrichment threw exception. Exception {0}.", Level = EventLevel.Error)]
         public void EnrichmentException(string exception)
         {
             this.WriteEvent(5, exception);

--- a/src/OpenTelemetry/DiagnosticSourceInstrumentation/InstrumentationEventSource.cs
+++ b/src/OpenTelemetry/DiagnosticSourceInstrumentation/InstrumentationEventSource.cs
@@ -28,7 +28,7 @@ namespace OpenTelemetry.Instrumentation
     {
         public static InstrumentationEventSource Log = new InstrumentationEventSource();
 
-        [Event(1, Message = "Current Activity is NULL the '{0}' callback. Activity will not be recorded.", Level = EventLevel.Warning)]
+        [Event(1, Message = "Current Activity is NULL in the '{0}' callback. Activity will not be recorded.", Level = EventLevel.Warning)]
         public void NullActivity(string eventName)
         {
             this.WriteEvent(1, eventName);


### PR DESCRIPTION
## Changes

Fixes incorrect spelling of 'threw'.

Fixes spelling of `NullActivity` messages.