### PR TITLE
Jaeger exporter options

### DIFF
--- a/src/OpenTelemetry.Exporter.Jaeger/.publicApi/net46/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Jaeger/.publicApi/net46/PublicAPI.Unshipped.txt
@@ -3,6 +3,10 @@ OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentHost.get -> string
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentHost.set -> void
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentPort.get -> int
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentPort.set -> void
+OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
+OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.BatchExportProcessorOptions.set -> void
+OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
+OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ExportProcessorType.set -> void
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.JaegerExporterOptions() -> void
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.MaxPayloadSizeInBytes.get -> int?
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.MaxPayloadSizeInBytes.set -> void

--- a/src/OpenTelemetry.Exporter.Jaeger/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Jaeger/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -3,6 +3,10 @@ OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentHost.get -> string
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentHost.set -> void
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentPort.get -> int
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentPort.set -> void
+OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
+OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.BatchExportProcessorOptions.set -> void
+OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
+OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ExportProcessorType.set -> void
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.JaegerExporterOptions() -> void
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.MaxPayloadSizeInBytes.get -> int?
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.MaxPayloadSizeInBytes.set -> void

--- a/src/OpenTelemetry.Exporter.Jaeger/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Jaeger/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
@@ -3,6 +3,10 @@ OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentHost.get -> string
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentHost.set -> void
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentPort.get -> int
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentPort.set -> void
+OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
+OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.BatchExportProcessorOptions.set -> void
+OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
+OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ExportProcessorType.set -> void
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.JaegerExporterOptions() -> void
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.MaxPayloadSizeInBytes.get -> int?
 OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.MaxPayloadSizeInBytes.set -> void

--- a/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+
 * In `JaegerExporterOptions`: Exporter options now include a switch for
   Batch vs Simple exporter, and settings for batch exporting properties.
 

--- a/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+* In `JaegerExporterOptions`: Exporter options now include a switch for
+  Batch vs Simple exporter, and settings for batch exporting properties.
 
 * Jaeger will now set the `error` tag when `otel.status_code` is set to `Error`.
   ([#1579](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1579))

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterHelperExtensions.cs
@@ -43,8 +43,19 @@ namespace OpenTelemetry.Trace
             configure?.Invoke(exporterOptions);
             var jaegerExporter = new JaegerExporter(exporterOptions);
 
-            // TODO: Pick Simple vs Batching based on JaegerExporterOptions
-            return builder.AddProcessor(new BatchExportProcessor<Activity>(jaegerExporter));
+            if (exporterOptions.ExportProcessorType == ExportProcessorType.Simple)
+            {
+                return builder.AddProcessor(new SimpleExportProcessor<Activity>(jaegerExporter));
+            }
+            else
+            {
+                return builder.AddProcessor(new BatchExportProcessor<Activity>(
+                    jaegerExporter,
+                    exporterOptions.BatchExportProcessorOptions.MaxQueueSize,
+                    exporterOptions.BatchExportProcessorOptions.ScheduledDelayMilliseconds,
+                    exporterOptions.BatchExportProcessorOptions.ExporterTimeoutMilliseconds,
+                    exporterOptions.BatchExportProcessorOptions.MaxExportBatchSize));
+            }
         }
     }
 }

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptions.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace OpenTelemetry.Exporter.Jaeger
 {
@@ -41,5 +42,15 @@ namespace OpenTelemetry.Exporter.Jaeger
         /// Gets or sets the tags that should be sent with telemetry.
         /// </summary>
         public IEnumerable<KeyValuePair<string, object>> ProcessTags { get; set; }
+
+        /// <summary>
+        /// Gets or sets the export processor type to be used with Jaeger Exporter.
+        /// </summary>
+        public ExportProcessorType ExportProcessorType { get; set; } = ExportProcessorType.Batch;
+
+        /// <summary>
+        /// Gets or sets the BatchExportProcessor options. Ignored unless ExportProcessorType is BatchExporter.
+        /// </summary>
+        public BatchExportProcessorOptions<Activity> BatchExportProcessorOptions { get; set; } = new BatchExportProcessorOptions<Activity>();
     }
 }


### PR DESCRIPTION
Fixes #1495 .

Follows very closely from @utpilla 's work on #1504 

## Changes

Allow users to choose between a Batch or Simple processor when exporting to Jaeger. Also options included for the batch export.

Passes dotnet test locally.
Changelog and API references updated.
* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
