### PR TITLE
Updating ReadMEs for Jaeger, Zipkin, OTLP exporters

### DIFF
--- a/src/OpenTelemetry.Exporter.Jaeger/README.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/README.md
@@ -36,7 +36,7 @@ properties:
   sent to the agent. (default `65000`).
 * `ProcessTags`: Which tags should be sent with telemetry.
 * `ExportProcessorType`: Whether the exporter should use
-  [Batch or Simple base exporter](https://github.com/open-telemetry/opentelemetry-dotnet/tree/master/src/OpenTelemetry#introduction)
+  [Batch or Simple base exporter](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#built-in-span-processors)
   .
 * `BatchExportProcessorOptions`: Configuration options for the batch exporter.
   Only used if ExportProcessorType is set to Batch.

--- a/src/OpenTelemetry.Exporter.Jaeger/README.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/README.md
@@ -25,15 +25,21 @@ dotnet add package OpenTelemetry.Exporter.Jaeger
 
 ## Configuration
 
-You can configure the `JaegerExporter` by following the directions below:
+You can configure the `JaegerExporter` through `JaegerExporterOptions`
+properties:
 
-* `ServiceName`: The name of your application or service.
 * `AgentHost`: Usually `localhost` since an agent should usually be running on
   the same machine as your application or service.
 * `AgentPort`: The compact thrift protocol port of the Jaeger Agent (default
   `6831`).
-* `MaxPacketSize`: The maximum size of each UDP packet that gets sent to the
-  agent. (default `65000`).
+* `MaxPayloadSizeInBytes`: The maximum size of each UDP packet that gets 
+  sent to the agent. (default `65000`).
+* `ProcessTags`: Which tags should be sent with telemetry.
+* `ExportProcessorType`: Whether the exporter should use
+  [Batch or Simple base exporter](https://github.com/open-telemetry/opentelemetry-dotnet/tree/master/src/OpenTelemetry#introduction)
+  .
+* `BatchExportProcessorOptions`: Configuration options for the batch exporter.
+  Only used if ExportProcessorType is set to Batch.
 
 See the
 [`TestJaegerExporter.cs`](../../examples/Console/TestJaegerExporter.cs)

--- a/src/OpenTelemetry.Exporter.Jaeger/README.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/README.md
@@ -32,7 +32,7 @@ properties:
   the same machine as your application or service.
 * `AgentPort`: The compact thrift protocol port of the Jaeger Agent (default
   `6831`).
-* `MaxPayloadSizeInBytes`: The maximum size of each UDP packet that gets 
+* `MaxPayloadSizeInBytes`: The maximum size of each UDP packet that gets
   sent to the agent. (default `65000`).
 * `ProcessTags`: Which tags should be sent with telemetry.
 * `ExportProcessorType`: Whether the exporter should use

--- a/src/OpenTelemetry.Exporter.Jaeger/README.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/README.md
@@ -36,7 +36,7 @@ properties:
   sent to the agent. (default `65000`).
 * `ProcessTags`: Which tags should be sent with telemetry.
 * `ExportProcessorType`: Whether the exporter should use
-  [Batch or Simple base exporter](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#built-in-span-processors)
+  [Batch or Simple exporting processor](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#built-in-span-processors)
   .
 * `BatchExportProcessorOptions`: Configuration options for the batch exporter.
   Only used if ExportProcessorType is set to Batch.

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
@@ -18,13 +18,17 @@ dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
 
 ## Configuration
 
-You can configure the `OtlpExporter` by following the directions below:
+You can configure the `OtlpExporter` through `OtlpExporterOptions` properties:
 
-* `ServiceName`: Name of the service reporting telemetry.
 * `Endpoint`: Target to which the exporter is going to send traces or metrics.
 * `Credentials`: Client-side channel credentials.
 * `Headers`: Optional headers for the connection.
 * `ChannelOptions`: gRPC channel options.
+* `ExportProcessorType`: Whether the exporter should use
+  [Batch or Simple base exporter](https://github.com/open-telemetry/opentelemetry-dotnet/tree/master/src/OpenTelemetry#introduction)
+  .
+* `BatchExportProcessorOptions`: Configuration options for the batch exporter.
+  Only used if ExportProcessorType is set to Batch.
 
 See the
 [`TestOtlpExporter.cs`](../../examples/Console/TestOtlpExporter.cs)

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
@@ -25,7 +25,7 @@ You can configure the `OtlpExporter` through `OtlpExporterOptions` properties:
 * `Headers`: Optional headers for the connection.
 * `ChannelOptions`: gRPC channel options.
 * `ExportProcessorType`: Whether the exporter should use
-  [Batch or Simple base exporter](https://github.com/open-telemetry/opentelemetry-dotnet/tree/master/src/OpenTelemetry#introduction)
+  [Batch or Simple base exporter](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#built-in-span-processors)
   .
 * `BatchExportProcessorOptions`: Configuration options for the batch exporter.
   Only used if ExportProcessorType is set to Batch.

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
@@ -25,7 +25,7 @@ You can configure the `OtlpExporter` through `OtlpExporterOptions` properties:
 * `Headers`: Optional headers for the connection.
 * `ChannelOptions`: gRPC channel options.
 * `ExportProcessorType`: Whether the exporter should use
-  [Batch or Simple base exporter](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#built-in-span-processors)
+  [Batch or Simple exporting processor](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#built-in-span-processors)
   .
 * `BatchExportProcessorOptions`: Configuration options for the batch exporter.
   Only used if ExportProcessorType is set to Batch.

--- a/src/OpenTelemetry.Exporter.Zipkin/README.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/README.md
@@ -15,7 +15,7 @@ dotnet add package OpenTelemetry.Exporter.Zipkin
 
 ## Configuration
 
-You can configure the `ZipkinExporter` through 
+You can configure the `ZipkinExporter` through
 `ZipkinExporterOptions` properties:
 
 * `ServiceName`: Name of the service reporting telemetry. If the `Resource`

--- a/src/OpenTelemetry.Exporter.Zipkin/README.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/README.md
@@ -27,7 +27,7 @@ You can configure the `ZipkinExporter` through
 * `MaxPayloadSizeInBytes`: Maximum payload size - for .NET versions
    **other** than 4.5.2 (default 4096).
 * `ExportProcessorType`: Whether the exporter should use
-  [Batch or Simple base exporter](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#built-in-span-processors)
+  [Batch or Simple exporting processor](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#built-in-span-processors)
   .
 * `BatchExportProcessorOptions`: Configuration options for the batch exporter.
   Only used if ExportProcessorType is set to Batch.

--- a/src/OpenTelemetry.Exporter.Zipkin/README.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/README.md
@@ -27,7 +27,7 @@ You can configure the `ZipkinExporter` through
 * `MaxPayloadSizeInBytes`: Maximum payload size - for .NET versions
    **other** than 4.5.2 (default 4096).
 * `ExportProcessorType`: Whether the exporter should use
-  [Batch or Simple base exporter](https://github.com/open-telemetry/opentelemetry-dotnet/tree/master/src/OpenTelemetry#introduction)
+  [Batch or Simple base exporter](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#built-in-span-processors)
   .
 * `BatchExportProcessorOptions`: Configuration options for the batch exporter.
   Only used if ExportProcessorType is set to Batch.

--- a/src/OpenTelemetry.Exporter.Zipkin/README.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/README.md
@@ -15,8 +15,8 @@ dotnet add package OpenTelemetry.Exporter.Zipkin
 
 ## Configuration
 
-You can configure the `ZipkinExporter` with the following options
-in `ZipkinExporterOptions`:
+You can configure the `ZipkinExporter` through 
+`ZipkinExporterOptions` properties:
 
 * `ServiceName`: Name of the service reporting telemetry. If the `Resource`
    associated with the telemetry has "service.name" defined, then it'll be
@@ -26,6 +26,11 @@ in `ZipkinExporterOptions`:
    sending to Zipkin (default false).
 * `MaxPayloadSizeInBytes`: Maximum payload size - for .NET versions
    **other** than 4.5.2 (default 4096).
+* `ExportProcessorType`: Whether the exporter should use
+  [Batch or Simple base exporter](https://github.com/open-telemetry/opentelemetry-dotnet/tree/master/src/OpenTelemetry#introduction)
+  .
+* `BatchExportProcessorOptions`: Configuration options for the batch exporter.
+  Only used if ExportProcessorType is set to Batch.
 
 See
 [`TestZipkinExporter.cs`](../../examples/Console/TestZipkinExporter.cs)


### PR DESCRIPTION
One thought: Does the ReadMe look too cluttered this way? We are listing every option available in configuring the exporter. The descriptions are brief, but it is still a bullet point of 5-ish entries each. @reyang  @cijothomas  @eddynaka please advise.

## Changes

#1584  #1587 #1504  all added the batch exporter and exporter type properties. We include these in the ReadMEs.

#1557 and #1572 removed the ServiceName option from Otlp and Jaeger Exporters. We removed these from ReadMes.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
