### PR TITLE
Write one line when opening a new Self Diagnostics log file

### DIFF
--- a/src/OpenTelemetry/Internal/SelfDiagnosticsConfigRefresher.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnosticsConfigRefresher.cs
@@ -206,7 +206,7 @@ namespace OpenTelemetry.Internal
                 this.memoryMappedFile = MemoryMappedFile.CreateFromFile(filePath, FileMode.Create, null, newFileSize);
                 this.logDirectory = newLogDirectory;
                 this.logFileSize = newFileSize;
-                this.logFilePosition = 0;
+                this.logFilePosition = MessageOnNewFile.Length;
                 using var stream = this.memoryMappedFile.CreateViewStream();
                 stream.Write(MessageOnNewFile, 0, MessageOnNewFile.Length);
             }

--- a/src/OpenTelemetry/Internal/SelfDiagnosticsConfigRefresher.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnosticsConfigRefresher.cs
@@ -19,6 +19,7 @@ using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.IO;
 using System.IO.MemoryMappedFiles;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -34,6 +35,8 @@ namespace OpenTelemetry.Internal
     internal class SelfDiagnosticsConfigRefresher : IDisposable
     {
         private const int ConfigurationUpdatePeriodMilliSeconds = 10000;
+
+        private static readonly byte[] MessageOnNewFile = Encoding.UTF8.GetBytes("Successfully opened file.");
 
         private readonly CancellationTokenSource cancellationTokenSource;
         private readonly Task worker;
@@ -204,6 +207,8 @@ namespace OpenTelemetry.Internal
                 this.logDirectory = newLogDirectory;
                 this.logFileSize = newFileSize;
                 this.logFilePosition = 0;
+                using var stream = this.memoryMappedFile.CreateViewStream();
+                stream.Write(MessageOnNewFile, 0, MessageOnNewFile.Length);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Fixes #1589.

## Changes

Write one line when self-diagnostic module detects config and opens a new Self Diagnostics log file.

Another approach was to emit an EventSource event and go through the EventListener handler. However, the event of `Informational` level might be skipped if the LogLevel is set to `Warning`, `Error` or `Critical`.