### PR TITLE
Update to API ReadMes

### DIFF
--- a/src/OpenTelemetry.Api/README.md
+++ b/src/OpenTelemetry.Api/README.md
@@ -358,7 +358,7 @@ to be associated with `Activity`. There is no `Status` class in .NET, and hence
 Example:
 
 ```csharp
-activity?.SetTag("otel.status_code", StatusCode.Error);
+activity?.SetTag("otel.status_code", "Error");
 activity?.SetTag("otel.status_description", "error status description");
 ```
 

--- a/src/OpenTelemetry.Api/README.md
+++ b/src/OpenTelemetry.Api/README.md
@@ -349,7 +349,7 @@ corresponding overloads of `ActivityEvent`.
 OpenTelemetry defines a concept called
 [Status](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#set-status)
 to be associated with `Activity`. There is no `Status` class in .NET, and hence
-`Status` is set to an `Activity` using the following special tags
+`Status` is set to an `Activity` using the following special tags:
 
 `otel.status_code` is the `Tag` name used to store the `StatusCode`, and
 `otel.status_description` is the `Tag` name used to store the optional
@@ -358,12 +358,12 @@ to be associated with `Activity`. There is no `Status` class in .NET, and hence
 Example:
 
 ```csharp
-activity?.SetTag("otel.status_code", 2);
+activity?.SetTag("otel.status_code", StatusCode.Error);
 activity?.SetTag("otel.status_description", "error status description");
 ```
 
-StatusCodes can be 0, 1, 2 which corresponds to `Unset`, `Ok` and `Error`
-respectively from [StatusCode.cs](./Trace/StatusCode.cs)
+[`StatusCode`](./Trace/StatusCode.cs) is an enum with options for `Unset`,
+`Ok` and `Error`.
 
 If using OpenTelemetry API
 [shim](#instrumenting-using-opentelemetryapi-shim), then you

--- a/src/OpenTelemetry.Api/README.md
+++ b/src/OpenTelemetry.Api/README.md
@@ -362,8 +362,9 @@ activity?.SetTag("otel.status_code", "Error");
 activity?.SetTag("otel.status_description", "error status description");
 ```
 
-[`StatusCode`](./Trace/StatusCode.cs) is an enum with options for `Unset`,
-`Ok` and `Error`.
+Values for the StatusCode tag have to be the strings "Unset", "Ok", or "Error",
+which correspond respectively to the enums `Unset`, `Ok`, and `Error` from
+[`StatusCode`](./Trace/StatusCode.cs).
 
 If using OpenTelemetry API
 [shim](#instrumenting-using-opentelemetryapi-shim), then you

--- a/src/OpenTelemetry.Api/README.md
+++ b/src/OpenTelemetry.Api/README.md
@@ -362,7 +362,7 @@ activity?.SetTag("otel.status_code", "Error");
 activity?.SetTag("otel.status_description", "error status description");
 ```
 
-Values for the StatusCode tag have to be the strings "Unset", "Ok", or "Error",
+Values for the StatusCode tag must be one of the strings "Unset", "Ok", or "Error",
 which correspond respectively to the enums `Unset`, `Ok`, and `Error` from
 [`StatusCode`](./Trace/StatusCode.cs).
 


### PR DESCRIPTION
Fixes #1588 in response to changes in #1579 .

## Changes

README changes only. StatusCode was previously just ints representing statuses, we now use an enum that more explicitly details "Unset", "Ok", "Error". Other changes in the relevant PR we are responding to (#1579) include Http Span changes and specific changes to how Jaeger and Zipkin process these statuses, but I felt they were **not** intended to be included here.