### PR TITLE
Use fully-qualified type in RecordException

### DIFF
--- a/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
@@ -83,7 +83,7 @@ namespace OpenTelemetry.Trace
 
             var tagsCollection = new ActivityTagsCollection
             {
-                { SemanticConventions.AttributeExceptionType, ex.GetType().Name },
+                { SemanticConventions.AttributeExceptionType, ex.GetType().FullName },
                 { SemanticConventions.AttributeExceptionStacktrace, ex.ToInvariantString() },
             };
 

--- a/test/OpenTelemetry.Tests/Trace/ActivityExtensionsTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ActivityExtensionsTest.cs
@@ -132,7 +132,7 @@ namespace OpenTelemetry.Trace.Tests
 
             var @event = activity.Events.FirstOrDefault(e => e.Name == SemanticConventions.AttributeExceptionEventName);
             Assert.Equal(message, @event.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeExceptionMessage).Value);
-            Assert.Equal(exception.GetType().Name, @event.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeExceptionType).Value);
+            Assert.Equal("System.ArgumentNullException", @event.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeExceptionType).Value);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #1600.

Use fully-qualified exception type name in the `RecordActivity` extension method since the [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/exceptions.md) recommends it.
