### PR TITLE
Minor annoyance in the Visual studio output view

### DIFF
--- a/src/OpenTelemetry/Internal/SelfDiagnosticsConfigParser.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnosticsConfigParser.cs
@@ -54,6 +54,11 @@ namespace OpenTelemetry.Internal
             logLevel = EventLevel.LogAlways;
             try
             {
+                if (!File.Exists(ConfigFileName))
+                {
+                    return false;
+                }
+
                 using FileStream file = File.Open(ConfigFileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
                 var buffer = this.configBuffer;
                 if (buffer == null)


### PR DESCRIPTION
Fixes #.

No need to try to open the selfdiagnostic file if it does not exist, so first do a file.exist check

Please provide a brief description of the changes here.
When running an aspnet core app in Visual Studio the output pane has many entries of FileNotFoundException. This made me wonder where the exception came from, and could potentially hide important exceptions in the clutter of this

Not a major change, and didn't feel it matches the bug issue template either
For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Design discussion issue #
* [x] Changes in public API reviewed
