### PR TITLE
Exporter spec updates.

### DIFF
--- a/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
@@ -8,6 +8,13 @@
 * Jaeger will now set the `error` tag when `otel.status_code` is set to `Error`.
   ([#1579](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1579))
 
+* Jaeger will no longer send the `otel.status_code` tag if the value is `Unset`.
+  ([#1609](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1609))
+
+* Span Event.Name will now be populated as the `event` field on Jaeger Logs
+  instead of `message`.
+  ([#1609](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1609))
+
 ## 1.0.0-rc1.1
 
 Released 2020-Nov-17

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -5,6 +5,13 @@
 * Zipkin will now set the `error` tag when `otel.status_code` is set to `Error`.
   ([#1579](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1579))
 
+* Zipkin will no longer send the `otel.status_code` tag if the value is `Unset`.
+  ([#1609](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1609))
+
+* Zipkin bool tag values will now be sent as `true`/`false` instead of
+  `True`/`False`.
+  ([#1609](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1609))
+
 ## 1.0.0-rc1.1
 
 Released 2020-Nov-17

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinActivityConversionExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinActivityConversionExtensions.cs
@@ -175,9 +175,17 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
                 {
                     PeerServiceResolver.InspectTag(ref this, key, strVal);
 
-                    if (key == SpanAttributeConstants.StatusCodeKey && strVal == "Error")
+                    if (key == SpanAttributeConstants.StatusCodeKey)
                     {
-                        PooledList<KeyValuePair<string, object>>.Add(ref this.Tags, new KeyValuePair<string, object>("error", "true"));
+                        if (strVal == "Error")
+                        {
+                            PooledList<KeyValuePair<string, object>>.Add(ref this.Tags, new KeyValuePair<string, object>("error", "true"));
+                        }
+                        else if (strVal == "Unset")
+                        {
+                            // Unset Status is not sent: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk_exporters/zipkin.md#status
+                            return true;
+                        }
                     }
                 }
                 else if (activityTag.Value is int intVal && activityTag.Key == SemanticConventions.AttributeNetPeerPort)

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerActivityConversionTest.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerActivityConversionTest.cs
@@ -116,7 +116,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
             Assert.Equal("string_array", eventField.Key);
             Assert.Equal("b", eventField.VStr);
             eventField = eventFields[3];
-            Assert.Equal("message", eventField.Key);
+            Assert.Equal("event", eventField.Key);
             Assert.Equal("Event1", eventField.VStr);
 
             Assert.Equal(activity.Events.First().Timestamp.ToEpochMicroseconds(), jaegerLog.Timestamp);
@@ -128,7 +128,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
             Assert.Equal("key", eventField.Key);
             Assert.Equal("value", eventField.VStr);
             eventField = eventFields[1];
-            Assert.Equal("message", eventField.Key);
+            Assert.Equal("event", eventField.Key);
             Assert.Equal("Event2", eventField.VStr);
         }
 
@@ -175,7 +175,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
             Assert.Equal("key", eventField.Key);
             Assert.Equal("value", eventField.VStr);
             eventField = eventFields[3];
-            Assert.Equal("message", eventField.Key);
+            Assert.Equal("event", eventField.Key);
             Assert.Equal("Event1", eventField.VStr);
 
             Assert.Equal(activity.Events.First().Timestamp.ToEpochMicroseconds(), jaegerLog.Timestamp);
@@ -187,7 +187,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
             Assert.Equal("key", eventField.Key);
             Assert.Equal("value", eventField.VStr);
             eventField = eventFields[1];
-            Assert.Equal("message", eventField.Key);
+            Assert.Equal("event", eventField.Key);
             Assert.Equal("Event2", eventField.VStr);
         }
 
@@ -340,7 +340,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
             Assert.Equal("key", eventField.Key);
             Assert.Equal("value", eventField.VStr);
             eventField = eventFields[3];
-            Assert.Equal("message", eventField.Key);
+            Assert.Equal("event", eventField.Key);
             Assert.Equal("Event1", eventField.VStr);
             Assert.Equal(activity.Events.First().Timestamp.ToEpochMicroseconds(), jaegerLog.Timestamp);
 
@@ -351,7 +351,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
             Assert.Equal("key", eventField.Key);
             Assert.Equal("value", eventField.VStr);
             eventField = eventFields[1];
-            Assert.Equal("message", eventField.Key);
+            Assert.Equal("event", eventField.Key);
             Assert.Equal("Event2", eventField.VStr);
         }
 
@@ -456,6 +456,18 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
             var jaegerSpan = activity.ToJaegerSpan();
 
             // Assert
+
+            if (statusCode == StatusCode.Unset)
+            {
+                Assert.DoesNotContain(jaegerSpan.Tags, t => t.Key == SpanAttributeConstants.StatusCodeKey);
+            }
+            else
+            {
+                Assert.Equal(
+                    StatusHelper.GetStringNameForStatusCode(statusCode),
+                    jaegerSpan.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.StatusCodeKey).VStr);
+            }
+
             if (hasErrorFlag)
             {
                 Assert.Contains(jaegerSpan.Tags, t => t.Key == "error" && t.VType == JaegerTagType.BOOL && (t.VBool ?? false));

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
@@ -193,7 +193,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Tests
             var traceId = useShortTraceIds ? TraceId.Substring(TraceId.Length - 16, 16) : TraceId;
 
             Assert.Equal(
-                $@"[{{""traceId"":""{traceId}"",""name"":""Name"",{parentId}""id"":""{ZipkinActivityConversionExtensions.EncodeSpanId(context.SpanId)}"",""kind"":""CLIENT"",""timestamp"":{timestamp},""duration"":60000000,""localEndpoint"":{{""serviceName"":""{serviceName}""{ipInformation}}},""remoteEndpoint"":{{""serviceName"":""http://localhost:44312/""}},""annotations"":[{{""timestamp"":{eventTimestamp},""value"":""Event1""}},{{""timestamp"":{eventTimestamp},""value"":""Event2""}}],""tags"":{{{resoureTags}""stringKey"":""value"",""longKey"":""1"",""longKey2"":""1"",""doubleKey"":""1"",""doubleKey2"":""1"",""longArrayKey"":""1,2"",""boolKey"":""True"",""http.host"":""http://localhost:44312/"",""otel.library.name"":""CreateTestActivity"",""peer.service"":""http://localhost:44312/""}}}}]",
+                $@"[{{""traceId"":""{traceId}"",""name"":""Name"",{parentId}""id"":""{ZipkinActivityConversionExtensions.EncodeSpanId(context.SpanId)}"",""kind"":""CLIENT"",""timestamp"":{timestamp},""duration"":60000000,""localEndpoint"":{{""serviceName"":""{serviceName}""{ipInformation}}},""remoteEndpoint"":{{""serviceName"":""http://localhost:44312/""}},""annotations"":[{{""timestamp"":{eventTimestamp},""value"":""Event1""}},{{""timestamp"":{eventTimestamp},""value"":""Event2""}}],""tags"":{{{resoureTags}""stringKey"":""value"",""longKey"":""1"",""longKey2"":""1"",""doubleKey"":""1"",""doubleKey2"":""1"",""longArrayKey"":""1,2"",""boolKey"":""true"",""boolArrayKey"":""true,false"",""http.host"":""http://localhost:44312/"",""otel.library.name"":""CreateTestActivity"",""peer.service"":""http://localhost:44312/""}}}}]",
                 Responses[requestId]);
         }
 
@@ -223,6 +223,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Tests
                 { "doubleKey2", 1F },
                 { "longArrayKey", new long[] { 1, 2 } },
                 { "boolKey", true },
+                { "boolArrayKey", new bool[] { true, false } },
                 { "http.host", "http://localhost:44312/" }, // simulating instrumentation tag adding http.host
             };
             if (additionalAttributes != null)


### PR DESCRIPTION
## Changes

I noticed updating the exporter compliance matrix in the spec that Jaeger & Zipkin were missing a couple things that the spec has outlined:

* Zipkin bool tags should be `true`/`false` not `True`/`False` ([spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk_exporters/zipkin.md#attribute)).
* `Unset` Status should not be sent ([spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk_exporters/zipkin.md#status)).
* Jaeger Event.Name should be sent as `event` tag, if it isn't already present ([spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk_exporters/jaeger.md#events)).

## TODOs:

* [X] `CHANGELOG.md` updated for non-trivial changes