### PR TITLE
Set Filter description to describe what the filter allows instead of …

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
@@ -61,7 +61,8 @@ This instrumentation can be configured to change the default behavior by using
 
 This instrumentation by default collects all the incoming http requests. It
 allows filtering of requests by using `Filter` function in
-`AspNetCoreInstrumentationOptions`. This defines the condition for allowable requests. The Filter receives the `HttpContext` of the incoming
+`AspNetCoreInstrumentationOptions`. This defines the condition for allowable
+requests. The Filter receives the `HttpContext` of the incoming
 request, and does not instrument the request if the Filter returns false or throws
 exception.
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
@@ -63,8 +63,8 @@ This instrumentation by default collects all the incoming http requests. It
 allows filtering of requests by using `Filter` function in
 `AspNetCoreInstrumentationOptions`. This defines the condition for allowable
 requests. The Filter receives the `HttpContext` of the incoming
-request, and does not collect telemetry about the request if the Filter returns false or throws
-exception.
+request, and does not collect telemetry about the request if the Filter
+returns false or throws exception.
 
 The following code snippet shows how to use `Filter` to filter out all POST
 requests.

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
@@ -76,7 +76,7 @@ services.AddOpenTelemetryTracing(
             opt => opt.Filter =
                 (httpContext) =>
                 {
-                    // only instrument HTTP GET requests
+                    // only collect telemetry about HTTP GET requests
                     return httpContext.Request.Method.Equals("GET");
                 })
         .AddJaegerExporter()

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
@@ -61,9 +61,8 @@ This instrumentation can be configured to change the default behavior by using
 
 This instrumentation by default collects all the incoming http requests. It
 allows filtering of requests by using `Filter` function in
-`AspNetCoreInstrumentationOptions`. This can be used to filter out any requests
-based on some condition. The Filter receives the `HttpContext` of the incoming
-request, and filters out the request if the Filter returns false or throws
+`AspNetCoreInstrumentationOptions`. This defines the condition for allowable requests. The Filter receives the `HttpContext` of the incoming
+request, and does not instrument the request if the Filter returns false or throws
 exception.
 
 The following code snippet shows how to use `Filter` to filter out all POST
@@ -76,8 +75,8 @@ services.AddOpenTelemetryTracing(
             opt => opt.Filter =
                 (httpContext) =>
                 {
-                    // filter out all HTTP POST requests.
-                    return !httpContext.Request.Method.Equals("POST");
+                    // only instrument HTTP GET requests
+                    return httpContext.Request.Method.Equals("GET");
                 })
         .AddJaegerExporter()
         );

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
@@ -63,7 +63,7 @@ This instrumentation by default collects all the incoming http requests. It
 allows filtering of requests by using `Filter` function in
 `AspNetCoreInstrumentationOptions`. This defines the condition for allowable
 requests. The Filter receives the `HttpContext` of the incoming
-request, and does not instrument the request if the Filter returns false or throws
+request, and does not collect telemetry about the request if the Filter returns false or throws
 exception.
 
 The following code snippet shows how to use `Filter` to filter out all POST


### PR DESCRIPTION

## Changes

Reword the description and example for Filter to describe it's purpose which is to define what is _allowed_ instead of what is removed.
Issue driving the change: https://github.com/open-telemetry/opentelemetry-dotnet/issues/1186

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #1186 
* [ ] Changes in public API reviewed
