### PR TITLE
ConsoleExporter: Write array tags to debug output when using ConsoleExporterOutputTargets.Debug

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporter.cs
@@ -64,12 +64,12 @@ namespace OpenTelemetry.Exporter
                                 continue;
                             }
 
-                            Console.Write($"    {tag.Key}: [");
+                            this.Write($"    {tag.Key}: [");
 
                             for (int i = 0; i < array.Length; i++)
                             {
-                                Console.Write(i != 0 ? ", " : string.Empty);
-                                Console.Write($"{array.GetValue(i)}");
+                                this.Write(i != 0 ? ", " : string.Empty);
+                                this.Write($"{array.GetValue(i)}");
                             }
 
                             this.WriteLine($"]");
@@ -149,6 +149,19 @@ namespace OpenTelemetry.Exporter
             if (this.options.Targets.HasFlag(ConsoleExporterOutputTargets.Debug))
             {
                 Debug.WriteLine(message);
+            }
+        }
+
+        private void Write(string message)
+        {
+            if (this.options.Targets.HasFlag(ConsoleExporterOutputTargets.Console))
+            {
+                Console.Write(message);
+            }
+
+            if (this.options.Targets.HasFlag(ConsoleExporterOutputTargets.Debug))
+            {
+                Debug.Write(message);
             }
         }
     }


### PR DESCRIPTION
Fixes [#1617](https://github.com/open-telemetry/opentelemetry-dotnet/issues/1617). 

## Changes

- Adding a new private method `Write` to output the tags with an array value either to console or debug listener based on the `ConsoleExporterOutputTargets` option value.
