### PR TITLE
Make OpenTracing shim classes internal?

### DIFF
--- a/src/OpenTelemetry.Shims.OpenTracing/.publicApi/net452/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Shims.OpenTracing/.publicApi/net452/PublicAPI.Unshipped.txt
@@ -1,57 +1,7 @@
-OpenTelemetry.Shims.OpenTracing.ScopeManagerShim
-OpenTelemetry.Shims.OpenTracing.ScopeManagerShim.Activate(OpenTracing.ISpan span, bool finishSpanOnDispose) -> OpenTracing.IScope
-OpenTelemetry.Shims.OpenTracing.ScopeManagerShim.Active.get -> OpenTracing.IScope
-OpenTelemetry.Shims.OpenTracing.ScopeManagerShim.ScopeManagerShim(OpenTelemetry.Trace.Tracer tracer) -> void
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.AddReference(string referenceType, OpenTracing.ISpanContext referencedContext) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.AsChildOf(OpenTracing.ISpan parent) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.AsChildOf(OpenTracing.ISpanContext parent) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.IgnoreActiveSpan() -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.SpanBuilderShim(OpenTelemetry.Trace.Tracer tracer, string spanName, System.Collections.Generic.IList<string> rootOperationNamesForActivityBasedAutoInstrumentations = null) -> void
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.Start() -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.StartActive() -> OpenTracing.IScope
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.StartActive(bool finishSpanOnDispose) -> OpenTracing.IScope
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithStartTimestamp(System.DateTimeOffset timestamp) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithTag(OpenTracing.Tag.BooleanTag tag, bool value) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithTag(OpenTracing.Tag.IntOrStringTag tag, string value) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithTag(OpenTracing.Tag.IntTag tag, int value) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithTag(OpenTracing.Tag.StringTag tag, string value) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithTag(string key, bool value) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithTag(string key, double value) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithTag(string key, int value) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithTag(string key, string value) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanContextShim
-OpenTelemetry.Shims.OpenTracing.SpanContextShim.GetBaggageItems() -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>
-OpenTelemetry.Shims.OpenTracing.SpanContextShim.SpanContext.get -> OpenTelemetry.Trace.SpanContext
-OpenTelemetry.Shims.OpenTracing.SpanContextShim.SpanContextShim(in OpenTelemetry.Trace.SpanContext spanContext) -> void
-OpenTelemetry.Shims.OpenTracing.SpanContextShim.SpanId.get -> string
-OpenTelemetry.Shims.OpenTracing.SpanContextShim.TraceId.get -> string
-OpenTelemetry.Shims.OpenTracing.SpanShim
-OpenTelemetry.Shims.OpenTracing.SpanShim.Context.get -> OpenTracing.ISpanContext
-OpenTelemetry.Shims.OpenTracing.SpanShim.Finish() -> void
-OpenTelemetry.Shims.OpenTracing.SpanShim.Finish(System.DateTimeOffset finishTimestamp) -> void
-OpenTelemetry.Shims.OpenTracing.SpanShim.GetBaggageItem(string key) -> string
-OpenTelemetry.Shims.OpenTracing.SpanShim.Log(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>> fields) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.Log(System.DateTimeOffset timestamp, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>> fields) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.Log(System.DateTimeOffset timestamp, string event) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.Log(string event) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetBaggageItem(string key, string value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetOperationName(string operationName) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetTag(OpenTracing.Tag.BooleanTag tag, bool value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetTag(OpenTracing.Tag.IntOrStringTag tag, string value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetTag(OpenTracing.Tag.IntTag tag, int value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetTag(OpenTracing.Tag.StringTag tag, string value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetTag(string key, bool value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetTag(string key, double value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetTag(string key, int value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetTag(string key, string value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.Span.get -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SpanShim(OpenTelemetry.Trace.TelemetrySpan span) -> void
 OpenTelemetry.Shims.OpenTracing.TracerShim
 OpenTelemetry.Shims.OpenTracing.TracerShim.ActiveSpan.get -> OpenTracing.ISpan
 OpenTelemetry.Shims.OpenTracing.TracerShim.BuildSpan(string operationName) -> OpenTracing.ISpanBuilder
 OpenTelemetry.Shims.OpenTracing.TracerShim.Extract<TCarrier>(OpenTracing.Propagation.IFormat<TCarrier> format, TCarrier carrier) -> OpenTracing.ISpanContext
 OpenTelemetry.Shims.OpenTracing.TracerShim.Inject<TCarrier>(OpenTracing.ISpanContext spanContext, OpenTracing.Propagation.IFormat<TCarrier> format, TCarrier carrier) -> void
 OpenTelemetry.Shims.OpenTracing.TracerShim.ScopeManager.get -> OpenTracing.IScopeManager
-const OpenTelemetry.Shims.OpenTracing.SpanShim.DefaultEventName = "log" -> string
 OpenTelemetry.Shims.OpenTracing.TracerShim.TracerShim(OpenTelemetry.Trace.Tracer tracer, OpenTelemetry.Context.Propagation.TextMapPropagator textFormat) -> void

--- a/src/OpenTelemetry.Shims.OpenTracing/.publicApi/net46/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Shims.OpenTracing/.publicApi/net46/PublicAPI.Unshipped.txt
@@ -1,52 +1,3 @@
-OpenTelemetry.Shims.OpenTracing.ScopeManagerShim
-OpenTelemetry.Shims.OpenTracing.ScopeManagerShim.Activate(OpenTracing.ISpan span, bool finishSpanOnDispose) -> OpenTracing.IScope
-OpenTelemetry.Shims.OpenTracing.ScopeManagerShim.Active.get -> OpenTracing.IScope
-OpenTelemetry.Shims.OpenTracing.ScopeManagerShim.ScopeManagerShim(OpenTelemetry.Trace.Tracer tracer) -> void
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.AddReference(string referenceType, OpenTracing.ISpanContext referencedContext) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.AsChildOf(OpenTracing.ISpan parent) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.AsChildOf(OpenTracing.ISpanContext parent) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.IgnoreActiveSpan() -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.SpanBuilderShim(OpenTelemetry.Trace.Tracer tracer, string spanName, System.Collections.Generic.IList<string> rootOperationNamesForActivityBasedAutoInstrumentations = null) -> void
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.Start() -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.StartActive() -> OpenTracing.IScope
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.StartActive(bool finishSpanOnDispose) -> OpenTracing.IScope
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithStartTimestamp(System.DateTimeOffset timestamp) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithTag(OpenTracing.Tag.BooleanTag tag, bool value) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithTag(OpenTracing.Tag.IntOrStringTag tag, string value) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithTag(OpenTracing.Tag.IntTag tag, int value) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithTag(OpenTracing.Tag.StringTag tag, string value) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithTag(string key, bool value) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithTag(string key, double value) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithTag(string key, int value) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithTag(string key, string value) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanContextShim
-OpenTelemetry.Shims.OpenTracing.SpanContextShim.GetBaggageItems() -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>
-OpenTelemetry.Shims.OpenTracing.SpanContextShim.SpanContext.get -> OpenTelemetry.Trace.SpanContext
-OpenTelemetry.Shims.OpenTracing.SpanContextShim.SpanContextShim(in OpenTelemetry.Trace.SpanContext spanContext) -> void
-OpenTelemetry.Shims.OpenTracing.SpanContextShim.SpanId.get -> string
-OpenTelemetry.Shims.OpenTracing.SpanContextShim.TraceId.get -> string
-OpenTelemetry.Shims.OpenTracing.SpanShim
-OpenTelemetry.Shims.OpenTracing.SpanShim.Context.get -> OpenTracing.ISpanContext
-OpenTelemetry.Shims.OpenTracing.SpanShim.Finish() -> void
-OpenTelemetry.Shims.OpenTracing.SpanShim.Finish(System.DateTimeOffset finishTimestamp) -> void
-OpenTelemetry.Shims.OpenTracing.SpanShim.GetBaggageItem(string key) -> string
-OpenTelemetry.Shims.OpenTracing.SpanShim.Log(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>> fields) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.Log(System.DateTimeOffset timestamp, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>> fields) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.Log(System.DateTimeOffset timestamp, string event) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.Log(string event) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetBaggageItem(string key, string value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetOperationName(string operationName) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetTag(OpenTracing.Tag.BooleanTag tag, bool value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetTag(OpenTracing.Tag.IntOrStringTag tag, string value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetTag(OpenTracing.Tag.IntTag tag, int value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetTag(OpenTracing.Tag.StringTag tag, string value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetTag(string key, bool value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetTag(string key, double value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetTag(string key, int value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetTag(string key, string value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.Span.get -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SpanShim(OpenTelemetry.Trace.TelemetrySpan span) -> void
 OpenTelemetry.Shims.OpenTracing.TracerShim
 OpenTelemetry.Shims.OpenTracing.TracerShim.ActiveSpan.get -> OpenTracing.ISpan
 OpenTelemetry.Shims.OpenTracing.TracerShim.BuildSpan(string operationName) -> OpenTracing.ISpanBuilder
@@ -54,4 +5,3 @@ OpenTelemetry.Shims.OpenTracing.TracerShim.Extract<TCarrier>(OpenTracing.Propaga
 OpenTelemetry.Shims.OpenTracing.TracerShim.Inject<TCarrier>(OpenTracing.ISpanContext spanContext, OpenTracing.Propagation.IFormat<TCarrier> format, TCarrier carrier) -> void
 OpenTelemetry.Shims.OpenTracing.TracerShim.ScopeManager.get -> OpenTracing.IScopeManager
 OpenTelemetry.Shims.OpenTracing.TracerShim.TracerShim(OpenTelemetry.Trace.Tracer tracer, OpenTelemetry.Context.Propagation.TextMapPropagator textFormat) -> void
-const OpenTelemetry.Shims.OpenTracing.SpanShim.DefaultEventName = "log" -> string

--- a/src/OpenTelemetry.Shims.OpenTracing/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Shims.OpenTracing/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,52 +1,3 @@
-OpenTelemetry.Shims.OpenTracing.ScopeManagerShim
-OpenTelemetry.Shims.OpenTracing.ScopeManagerShim.Activate(OpenTracing.ISpan span, bool finishSpanOnDispose) -> OpenTracing.IScope
-OpenTelemetry.Shims.OpenTracing.ScopeManagerShim.Active.get -> OpenTracing.IScope
-OpenTelemetry.Shims.OpenTracing.ScopeManagerShim.ScopeManagerShim(OpenTelemetry.Trace.Tracer tracer) -> void
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.AddReference(string referenceType, OpenTracing.ISpanContext referencedContext) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.AsChildOf(OpenTracing.ISpan parent) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.AsChildOf(OpenTracing.ISpanContext parent) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.IgnoreActiveSpan() -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.SpanBuilderShim(OpenTelemetry.Trace.Tracer tracer, string spanName, System.Collections.Generic.IList<string> rootOperationNamesForActivityBasedAutoInstrumentations = null) -> void
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.Start() -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.StartActive() -> OpenTracing.IScope
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.StartActive(bool finishSpanOnDispose) -> OpenTracing.IScope
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithStartTimestamp(System.DateTimeOffset timestamp) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithTag(OpenTracing.Tag.BooleanTag tag, bool value) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithTag(OpenTracing.Tag.IntOrStringTag tag, string value) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithTag(OpenTracing.Tag.IntTag tag, int value) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithTag(OpenTracing.Tag.StringTag tag, string value) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithTag(string key, bool value) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithTag(string key, double value) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithTag(string key, int value) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanBuilderShim.WithTag(string key, string value) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.SpanContextShim
-OpenTelemetry.Shims.OpenTracing.SpanContextShim.GetBaggageItems() -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>
-OpenTelemetry.Shims.OpenTracing.SpanContextShim.SpanContext.get -> OpenTelemetry.Trace.SpanContext
-OpenTelemetry.Shims.OpenTracing.SpanContextShim.SpanContextShim(in OpenTelemetry.Trace.SpanContext spanContext) -> void
-OpenTelemetry.Shims.OpenTracing.SpanContextShim.SpanId.get -> string
-OpenTelemetry.Shims.OpenTracing.SpanContextShim.TraceId.get -> string
-OpenTelemetry.Shims.OpenTracing.SpanShim
-OpenTelemetry.Shims.OpenTracing.SpanShim.Context.get -> OpenTracing.ISpanContext
-OpenTelemetry.Shims.OpenTracing.SpanShim.Finish() -> void
-OpenTelemetry.Shims.OpenTracing.SpanShim.Finish(System.DateTimeOffset finishTimestamp) -> void
-OpenTelemetry.Shims.OpenTracing.SpanShim.GetBaggageItem(string key) -> string
-OpenTelemetry.Shims.OpenTracing.SpanShim.Log(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>> fields) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.Log(System.DateTimeOffset timestamp, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>> fields) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.Log(System.DateTimeOffset timestamp, string event) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.Log(string event) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetBaggageItem(string key, string value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetOperationName(string operationName) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetTag(OpenTracing.Tag.BooleanTag tag, bool value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetTag(OpenTracing.Tag.IntOrStringTag tag, string value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetTag(OpenTracing.Tag.IntTag tag, int value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetTag(OpenTracing.Tag.StringTag tag, string value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetTag(string key, bool value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetTag(string key, double value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetTag(string key, int value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SetTag(string key, string value) -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.Span.get -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Shims.OpenTracing.SpanShim.SpanShim(OpenTelemetry.Trace.TelemetrySpan span) -> void
 OpenTelemetry.Shims.OpenTracing.TracerShim
 OpenTelemetry.Shims.OpenTracing.TracerShim.ActiveSpan.get -> OpenTracing.ISpan
 OpenTelemetry.Shims.OpenTracing.TracerShim.BuildSpan(string operationName) -> OpenTracing.ISpanBuilder
@@ -54,4 +5,3 @@ OpenTelemetry.Shims.OpenTracing.TracerShim.Extract<TCarrier>(OpenTracing.Propaga
 OpenTelemetry.Shims.OpenTracing.TracerShim.Inject<TCarrier>(OpenTracing.ISpanContext spanContext, OpenTracing.Propagation.IFormat<TCarrier> format, TCarrier carrier) -> void
 OpenTelemetry.Shims.OpenTracing.TracerShim.ScopeManager.get -> OpenTracing.IScopeManager
 OpenTelemetry.Shims.OpenTracing.TracerShim.TracerShim(OpenTelemetry.Trace.Tracer tracer, OpenTelemetry.Context.Propagation.TextMapPropagator textFormat) -> void
-const OpenTelemetry.Shims.OpenTracing.SpanShim.DefaultEventName = "log" -> string

--- a/src/OpenTelemetry.Shims.OpenTracing/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/AssemblyInfo.cs
@@ -1,0 +1,23 @@
+// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Runtime.CompilerServices;
+
+#if SIGNED
+[assembly: InternalsVisibleTo("OpenTelemetry.Shims.OpenTracing.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010051c1562a090fb0c9f391012a32198b5e5d9a60e9b80fa2d7b434c9e5ccb7259bd606e66f9660676afc6692b8cdc6793d190904551d2103b7b22fa636dcbb8208839785ba402ea08fc00c8f1500ccef28bbf599aa64ffb1e1d5dc1bf3420a3777badfe697856e9d52070a50c3ea5821c80bef17ca3acffa28f89dd413f096f898")]
+#else
+[assembly: InternalsVisibleTo("OpenTelemetry.Shims.OpenTracing.Tests")]
+#endif

--- a/src/OpenTelemetry.Shims.OpenTracing/CHANGELOG.md
+++ b/src/OpenTelemetry.Shims.OpenTracing/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Made the following shim classes internal: `ScopeManagerShim`,
+  `SpanBuilderShim`, `SpanContextShim`, `SpanShim`.
+  ([#1619](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1619))
+
 ## 1.0.0-rc1.1
 
 Released 2020-Nov-17

--- a/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
@@ -22,7 +22,7 @@ using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Shims.OpenTracing
 {
-    public sealed class ScopeManagerShim : IScopeManager
+    internal sealed class ScopeManagerShim : IScopeManager
     {
         private static readonly ConditionalWeakTable<TelemetrySpan, global::OpenTracing.IScope> SpanScopeTable = new ConditionalWeakTable<TelemetrySpan, global::OpenTracing.IScope>();
 

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
@@ -27,7 +27,7 @@ namespace OpenTelemetry.Shims.OpenTracing
     /// </summary>
     /// <remarks>Instances of this class are not thread-safe.</remarks>
     /// <seealso cref="ISpanBuilder" />
-    public sealed class SpanBuilderShim : ISpanBuilder
+    internal sealed class SpanBuilderShim : ISpanBuilder
     {
         /// <summary>
         /// The tracer.

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanContextShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanContextShim.cs
@@ -20,7 +20,7 @@ using global::OpenTracing;
 
 namespace OpenTelemetry.Shims.OpenTracing
 {
-    public sealed class SpanContextShim : ISpanContext
+    internal sealed class SpanContextShim : ISpanContext
     {
         public SpanContextShim(in Trace.SpanContext spanContext)
         {

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanShim.cs
@@ -22,7 +22,7 @@ using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Shims.OpenTracing
 {
-    public sealed class SpanShim : global::OpenTracing.ISpan
+    internal sealed class SpanShim : global::OpenTracing.ISpan
     {
         /// <summary>
         /// The default event name if not specified.


### PR DESCRIPTION
I have started reviewing the OpenTracing shim. As a first pass, I've looked over the API surface area and questioning whether we should reduce it.

The shim is comprised of the following classes
* `TracerShim` implementing `OpenTracing.ITracer`
* `ScopeManagerShim` implementing `OpenTracing.IScopeManager`
* `SpanBuilderShim` implementing `OpenTracing.ISpanBuilder`
* `SpanContextShim` implementing `OpenTracing.ISpanContext`
* `SpanShim` implementing `OpenTracing.ISpan`

The `TracerShim` is the primary API and has been left as public. This PR proposes making the rest of the shim classes internal. Most of the methods of these classes simply provide the OpenTracing implementation with two notable exceptions.

1. The `SpanShim` previously exposed a `Span` property that gave access to the underlying `OpenTelemetry.Trace.TelemetrySpan`.
2. The `SpanContextShim` previously exposed a `SpanContext` property that gave access to the underlying `OpenTelemetry.Trace.SpanContext`.

I could see an argument for leaving the `SpanShim` accessible as this would allow a user (with some casting) to access the functionality unique to OpenTelemetry from the exposed `TelemetrySpan` property. For example, `RecordException`, `AddEvent`, `SetStatus`, etc.

Any opinions for leaving the `SpanShim` exposed to support this use case?