### PR TITLE
Exporter spec fixup 2

### DIFF
--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -5,9 +5,10 @@
 * In order to align with the
   [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#set-status)
   the `Status` (otel.status_code) tag (added on `Activity` using the `SetStatus`
-  extension) will now be set as the `Unset`, `Error`, or `Ok` string
+  extension) will now be set as the `UNSET`, `OK`, or `ERROR` string
   representation instead of the `0`, `1`, or `2` integer representation.
-  ([#1579](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1579))
+  ([#1579](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1579) &
+  [#1620](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1620))
 * Metrics API/SDK support is in an experimental state and is not recommended for
   production use. All metric APIs have been marked with the `Obsolete`
   attribute. See

--- a/src/OpenTelemetry.Api/Internal/ActivityHelperExtensions.cs
+++ b/src/OpenTelemetry.Api/Internal/ActivityHelperExtensions.cs
@@ -188,7 +188,7 @@ namespace OpenTelemetry.Trace
                 switch (item.Key)
                 {
                     case SpanAttributeConstants.StatusCodeKey:
-                        this.StatusCode = StatusHelper.GetStatusCodeForStringName(item.Value as string);
+                        this.StatusCode = StatusHelper.GetStatusCodeForTagValue(item.Value as string);
                         break;
                     case SpanAttributeConstants.StatusDescriptionKey:
                         this.StatusDescription = item.Value as string;

--- a/src/OpenTelemetry.Api/Internal/StatusHelper.cs
+++ b/src/OpenTelemetry.Api/Internal/StatusHelper.cs
@@ -56,7 +56,7 @@ namespace OpenTelemetry.Internal
                 string _ when UnsetStatusCodeTagValue.Equals(statusCodeTagValue, StringComparison.OrdinalIgnoreCase) => StatusCode.Unset,
                 string _ when ErrorStatusCodeTagValue.Equals(statusCodeTagValue, StringComparison.OrdinalIgnoreCase) => StatusCode.Error,
                 string _ when OkStatusCodeTagValue.Equals(statusCodeTagValue, StringComparison.OrdinalIgnoreCase) => StatusCode.Ok,
-                _ => null,
+                _ => (StatusCode?)null,
             };
         }
     }

--- a/src/OpenTelemetry.Api/Internal/StatusHelper.cs
+++ b/src/OpenTelemetry.Api/Internal/StatusHelper.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using System.Runtime.CompilerServices;
 using OpenTelemetry.Trace;
 
@@ -21,8 +22,12 @@ namespace OpenTelemetry.Internal
 {
     internal static class StatusHelper
     {
+        public const string UnsetStatusCodeTagValue = "UNSET";
+        public const string OkStatusCodeTagValue = "OK";
+        public const string ErrorStatusCodeTagValue = "ERROR";
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string GetStringNameForStatusCode(StatusCode statusCode)
+        public static string GetTagValueForStatusCode(StatusCode statusCode)
         {
             return statusCode switch
             {
@@ -31,27 +36,27 @@ namespace OpenTelemetry.Internal
                  * first because assumption is most spans will be
                  * Unset, then Error. Ok is not set by the SDK.
                  */
-                StatusCode.Unset => "Unset",
-                StatusCode.Error => "Error",
-                StatusCode.Ok => "Ok",
+                StatusCode.Unset => UnsetStatusCodeTagValue,
+                StatusCode.Error => ErrorStatusCodeTagValue,
+                StatusCode.Ok => OkStatusCodeTagValue,
                 _ => null,
             };
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static StatusCode? GetStatusCodeForStringName(string statusCodeName)
+        public static StatusCode? GetStatusCodeForTagValue(string statusCodeTagValue)
         {
-            return statusCodeName switch
+            return statusCodeTagValue switch
             {
                 /*
                  * Note: Order here does matter for perf. Unset is
                  * first because assumption is most spans will be
                  * Unset, then Error. Ok is not set by the SDK.
                  */
-                "Unset" => StatusCode.Unset,
-                "Error" => StatusCode.Error,
-                "Ok" => StatusCode.Ok,
-                _ => (StatusCode?)null,
+                string _ when UnsetStatusCodeTagValue.Equals(statusCodeTagValue, StringComparison.OrdinalIgnoreCase) => StatusCode.Unset,
+                string _ when ErrorStatusCodeTagValue.Equals(statusCodeTagValue, StringComparison.OrdinalIgnoreCase) => StatusCode.Error,
+                string _ when OkStatusCodeTagValue.Equals(statusCodeTagValue, StringComparison.OrdinalIgnoreCase) => StatusCode.Ok,
+                _ => null,
             };
         }
     }

--- a/src/OpenTelemetry.Api/README.md
+++ b/src/OpenTelemetry.Api/README.md
@@ -358,11 +358,11 @@ to be associated with `Activity`. There is no `Status` class in .NET, and hence
 Example:
 
 ```csharp
-activity?.SetTag("otel.status_code", "Error");
+activity?.SetTag("otel.status_code", "ERROR");
 activity?.SetTag("otel.status_description", "error status description");
 ```
 
-Values for the StatusCode tag must be one of the strings "Unset", "Ok", or "Error",
+Values for the StatusCode tag must be one of the strings "UNSET", "OK", or "ERROR",
 which correspond respectively to the enums `Unset`, `Ok`, and `Error` from
 [`StatusCode`](./Trace/StatusCode.cs).
 

--- a/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
@@ -45,7 +45,7 @@ namespace OpenTelemetry.Trace
         {
             Debug.Assert(activity != null, "Activity should not be null");
 
-            activity.SetTag(SpanAttributeConstants.StatusCodeKey, StatusHelper.GetStringNameForStatusCode(status.StatusCode));
+            activity.SetTag(SpanAttributeConstants.StatusCodeKey, StatusHelper.GetTagValueForStatusCode(status.StatusCode));
             activity.SetTag(SpanAttributeConstants.StatusDescriptionKey, status.Description);
         }
 

--- a/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
@@ -5,11 +5,13 @@
 * In `JaegerExporterOptions`: Exporter options now include a switch for
   Batch vs Simple exporter, and settings for batch exporting properties.
 
-* Jaeger will now set the `error` tag when `otel.status_code` is set to `Error`.
-  ([#1579](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1579))
+* Jaeger will now set the `error` tag when `otel.status_code` is set to `ERROR`.
+  ([#1579](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1579) &
+  [#1620](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1620))
 
-* Jaeger will no longer send the `otel.status_code` tag if the value is `Unset`.
-  ([#1609](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1609))
+* Jaeger will no longer send the `otel.status_code` tag if the value is `UNSET`.
+  ([#1609](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1609) &
+  [#1620](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1620))
 
 * Span Event.Name will now be populated as the `event` field on Jaeger Logs
   instead of `message`.

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
@@ -239,7 +239,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static OtlpTrace.Status ToOtlpStatus(ref TagEnumerationState otlpTags)
         {
-            var status = StatusHelper.GetStatusCodeForStringName(otlpTags.StatusCode);
+            var status = StatusHelper.GetStatusCodeForTagValue(otlpTags.StatusCode);
 
             if (!status.HasValue)
             {

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## Unreleased
 
-* Zipkin will now set the `error` tag when `otel.status_code` is set to `Error`.
-  ([#1579](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1579))
+* Zipkin will now set the `error` tag when `otel.status_code` is set to `ERROR`.
+  ([#1579](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1579) &
+  [#1620](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1620))
 
-* Zipkin will no longer send the `otel.status_code` tag if the value is `Unset`.
-  ([#1609](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1609))
+* Zipkin will no longer send the `otel.status_code` tag if the value is `UNSET`.
+  ([#1609](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1609) &
+  [#1620](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1620))
 
 * Zipkin bool tag values will now be sent as `true`/`false` instead of
   `True`/`False`.

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
@@ -137,8 +137,18 @@ namespace OpenTelemetry.Exporter.Zipkin.Tests
         [InlineData(false, false, false)]
         [InlineData(false, true, false)]
         [InlineData(false, false, true)]
-        public void IntegrationTest(bool useShortTraceIds, bool useTestResource, bool isRootSpan)
+        [InlineData(false, false, false, StatusCode.Ok)]
+        [InlineData(false, false, false, StatusCode.Error)]
+        public void IntegrationTest(bool useShortTraceIds, bool useTestResource, bool isRootSpan, StatusCode statusCode = StatusCode.Unset)
         {
+            var status = statusCode switch
+            {
+                StatusCode.Unset => Status.Unset,
+                StatusCode.Ok => Status.Ok,
+                StatusCode.Error => Status.Error,
+                _ => throw new InvalidOperationException(),
+            };
+
             Guid requestId = Guid.NewGuid();
 
             ZipkinExporter exporter = new ZipkinExporter(
@@ -150,7 +160,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Tests
 
             var serviceName = ZipkinExporterOptions.DefaultServiceName;
             var resoureTags = string.Empty;
-            var activity = CreateTestActivity(isRootSpan: isRootSpan);
+            var activity = CreateTestActivity(isRootSpan: isRootSpan, status: status);
             if (useTestResource)
             {
                 serviceName = "MyService";
@@ -192,8 +202,15 @@ namespace OpenTelemetry.Exporter.Zipkin.Tests
 
             var traceId = useShortTraceIds ? TraceId.Substring(TraceId.Length - 16, 16) : TraceId;
 
+            var statusTag = statusCode switch
+            {
+                StatusCode.Ok => $@"""{SpanAttributeConstants.StatusCodeKey}"":""OK"",",
+                StatusCode.Error => $@"""error"":"""",""{SpanAttributeConstants.StatusCodeKey}"":""ERROR"",",
+                _ => string.Empty,
+            };
+
             Assert.Equal(
-                $@"[{{""traceId"":""{traceId}"",""name"":""Name"",{parentId}""id"":""{ZipkinActivityConversionExtensions.EncodeSpanId(context.SpanId)}"",""kind"":""CLIENT"",""timestamp"":{timestamp},""duration"":60000000,""localEndpoint"":{{""serviceName"":""{serviceName}""{ipInformation}}},""remoteEndpoint"":{{""serviceName"":""http://localhost:44312/""}},""annotations"":[{{""timestamp"":{eventTimestamp},""value"":""Event1""}},{{""timestamp"":{eventTimestamp},""value"":""Event2""}}],""tags"":{{{resoureTags}""stringKey"":""value"",""longKey"":""1"",""longKey2"":""1"",""doubleKey"":""1"",""doubleKey2"":""1"",""longArrayKey"":""1,2"",""boolKey"":""true"",""boolArrayKey"":""true,false"",""http.host"":""http://localhost:44312/"",""otel.library.name"":""CreateTestActivity"",""peer.service"":""http://localhost:44312/""}}}}]",
+                $@"[{{""traceId"":""{traceId}"",""name"":""Name"",{parentId}""id"":""{ZipkinActivityConversionExtensions.EncodeSpanId(context.SpanId)}"",""kind"":""CLIENT"",""timestamp"":{timestamp},""duration"":60000000,""localEndpoint"":{{""serviceName"":""{serviceName}""{ipInformation}}},""remoteEndpoint"":{{""serviceName"":""http://localhost:44312/""}},""annotations"":[{{""timestamp"":{eventTimestamp},""value"":""Event1""}},{{""timestamp"":{eventTimestamp},""value"":""Event2""}}],""tags"":{{{resoureTags}""stringKey"":""value"",""longKey"":""1"",""longKey2"":""1"",""doubleKey"":""1"",""doubleKey2"":""1"",""longArrayKey"":""1,2"",""boolKey"":""true"",""boolArrayKey"":""true,false"",""http.host"":""http://localhost:44312/"",{statusTag}""otel.library.name"":""CreateTestActivity"",""peer.service"":""http://localhost:44312/""}}}}]",
                 Responses[requestId]);
         }
 

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.netcore31.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.netcore31.cs
@@ -96,17 +96,10 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
             Assert.Equal(ActivityKind.Client, activity.Kind);
             Assert.Equal(tc.SpanName, activity.DisplayName);
 
-            var d = new Dictionary<string, string>()
-            {
-                { "Ok", "OK" },
-                { "Error", "ERROR" },
-                { "Unset", "UNSET" },
-            };
-
             // Assert.Equal(tc.SpanStatus, d[span.Status.CanonicalCode]);
             Assert.Equal(
                     tc.SpanStatus,
-                    d[activity.GetTagValue(SpanAttributeConstants.StatusCodeKey) as string]);
+                    activity.GetTagValue(SpanAttributeConstants.StatusCodeKey) as string);
 
             if (tc.SpanStatusHasDescription.HasValue)
             {

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.netfx.cs
@@ -88,13 +88,6 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
             ValidateHttpWebRequestActivity(activity);
             Assert.Equal(tc.SpanName, activity.DisplayName);
 
-            var d = new Dictionary<string, string>()
-            {
-                { "Ok", "OK" },
-                { "Error", "ERROR" },
-                { "Unset", "UNSET" },
-            };
-
             tc.SpanAttributes = tc.SpanAttributes.ToDictionary(
                 x => x.Key,
                 x =>
@@ -115,7 +108,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
                 {
                     if (tag.Key == SpanAttributeConstants.StatusCodeKey)
                     {
-                        Assert.Equal(tc.SpanStatus, d[tagValue]);
+                        Assert.Equal(tc.SpanStatus, tagValue);
                         continue;
                     }
 


### PR DESCRIPTION
## Changes

* Zipkin error tag (added in #1571) value is now an empty string.
* Status enum values (discussed in #1609) are now UPPERCASE to be in line with the exporter spec. Parsing made case insensitive so we'll be somewhat forgiving of people setting `otel.status_code` directly via Activity API.

Should match up to https://github.com/open-telemetry/opentelemetry-specification/pull/1257 when merged.

## TODOs

* [X] `CHANGELOG.md` updated for non-trivial changes
