### PR TITLE
Remove net46 target from OpenTracing shim

### DIFF
--- a/src/OpenTelemetry.Shims.OpenTracing/.publicApi/net46/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Shims.OpenTracing/.publicApi/net46/PublicAPI.Unshipped.txt
@@ -1,7 +1,0 @@
-OpenTelemetry.Shims.OpenTracing.TracerShim
-OpenTelemetry.Shims.OpenTracing.TracerShim.ActiveSpan.get -> OpenTracing.ISpan
-OpenTelemetry.Shims.OpenTracing.TracerShim.BuildSpan(string operationName) -> OpenTracing.ISpanBuilder
-OpenTelemetry.Shims.OpenTracing.TracerShim.Extract<TCarrier>(OpenTracing.Propagation.IFormat<TCarrier> format, TCarrier carrier) -> OpenTracing.ISpanContext
-OpenTelemetry.Shims.OpenTracing.TracerShim.Inject<TCarrier>(OpenTracing.ISpanContext spanContext, OpenTracing.Propagation.IFormat<TCarrier> format, TCarrier carrier) -> void
-OpenTelemetry.Shims.OpenTracing.TracerShim.ScopeManager.get -> OpenTracing.IScopeManager
-OpenTelemetry.Shims.OpenTracing.TracerShim.TracerShim(OpenTelemetry.Trace.Tracer tracer, OpenTelemetry.Context.Propagation.TextMapPropagator textFormat) -> void

--- a/src/OpenTelemetry.Shims.OpenTracing/OpenTelemetry.Shims.OpenTracing.csproj
+++ b/src/OpenTelemetry.Shims.OpenTracing/OpenTelemetry.Shims.OpenTracing.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;net46;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <Description>OpenTracing shim for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);distributed-tracing;OpenTracing</PackageTags>
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
I suspect the shim previously used AsyncLocal (introduced in net46) for something. There is nothing in this project anymore that requires a net46 build.
