### PR TITLE
Revert "Remove net46 target from OpenTracing shim"

### DIFF
--- a/src/OpenTelemetry.Shims.OpenTracing/.publicApi/net46/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Shims.OpenTracing/.publicApi/net46/PublicAPI.Unshipped.txt
@@ -1,0 +1,7 @@
+OpenTelemetry.Shims.OpenTracing.TracerShim
+OpenTelemetry.Shims.OpenTracing.TracerShim.ActiveSpan.get -> OpenTracing.ISpan
+OpenTelemetry.Shims.OpenTracing.TracerShim.BuildSpan(string operationName) -> OpenTracing.ISpanBuilder
+OpenTelemetry.Shims.OpenTracing.TracerShim.Extract<TCarrier>(OpenTracing.Propagation.IFormat<TCarrier> format, TCarrier carrier) -> OpenTracing.ISpanContext
+OpenTelemetry.Shims.OpenTracing.TracerShim.Inject<TCarrier>(OpenTracing.ISpanContext spanContext, OpenTracing.Propagation.IFormat<TCarrier> format, TCarrier carrier) -> void
+OpenTelemetry.Shims.OpenTracing.TracerShim.ScopeManager.get -> OpenTracing.IScopeManager
+OpenTelemetry.Shims.OpenTracing.TracerShim.TracerShim(OpenTelemetry.Trace.Tracer tracer, OpenTelemetry.Context.Propagation.TextMapPropagator textFormat) -> void

--- a/src/OpenTelemetry.Shims.OpenTracing/OpenTelemetry.Shims.OpenTracing.csproj
+++ b/src/OpenTelemetry.Shims.OpenTracing/OpenTelemetry.Shims.OpenTracing.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;net46;netstandard2.0</TargetFrameworks>
     <Description>OpenTracing shim for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);distributed-tracing;OpenTracing</PackageTags>
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-dotnet#1624

@alanwest We may want to keep the net46 target, for the following reason:
If a user has Net472 app, and uses this shim, he'd be given net452 version, which would likely take the net452 of the OpenTelemetry SDK/API, denying the user any perf benefits of net46

Reopening to discuss this.