### PR TITLE
Filter() description and code snippet clarity and consistency

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/README.md
@@ -76,29 +76,28 @@ This instrumentation can be configured to change the default behavior by using
 ### Filter
 
 This instrumentation by default collects all the incoming http requests. It allows
-filtering of requests by using `Filter` function in `AspNetInstrumentationOptions`.
-This can be used to filter out any requests based on some condition. The Filter
-receives the `HttpContext` of the incoming request, and filters out the request
-if the Filter returns false or throws exception.
+filtering of requests by using the `Filter` function in `AspNetInstrumentationOptions`.
+This defines the condition for allowable requests. The Filter
+receives the `HttpContext` of the incoming request, and does not collect telemetry
+ about the request if the Filter returns false or throws exception.
 
-The following shows an example of `Filter` being used to filter out all POST requests.
+The following code snippet shows how to use `Filter` to only allow GET
+requests.
 
 ```csharp
 this.tracerProvider = Sdk.CreateTracerProviderBuilder()
     .AddAspNetInstrumentation(
-        (options) =>
-        {
-            options.Filter = (httpContext) =>
+        (options) => options.Filter =
+            (httpContext) =>
             {
-                // filter out all HTTP POST requests.
-                return !httpContext.Request.HttpMethod.Equals("POST");
-            };
-        })
+                // only collect telemetry about HTTP GET requests
+                return httpContext.Request.HttpMethod.Equals("GET");
+            })
     .Build();
 ```
 
 It is important to note that this `Filter` option is specific to this
-instrumentation. OpenTelemetry has a concept of
+instrumentation. OpenTelemetry has a concept of a
 [Sampler](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#sampling),
 and the `Filter` option does the filtering *before* the Sampler is invoked.
 
@@ -116,7 +115,7 @@ The following code snippet shows how to add additional tags using `Enrich`.
 
 ```csharp
 this.tracerProvider = Sdk.CreateTracerProviderBuilder()
-    .AddAspNetInstrumentation(opt => opt.Enrich
+    .AddAspNetInstrumentation((options) => options.Enrich
         = (activity, eventName, rawObject) =>
     {
         if (eventName.Equals("OnStartActivity"))

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
@@ -45,9 +45,9 @@ public void ConfigureServices(IServiceCollection services)
 {
     services.AddOpenTelemetryTracing(
         (builder) => builder
-                .AddAspNetCoreInstrumentation()
-                .AddJaegerExporter()
-                );
+            .AddAspNetCoreInstrumentation()
+            .AddJaegerExporter()
+            );
 }
 ```
 
@@ -104,7 +104,7 @@ The following code snippet shows how to add additional tags using `Enrich`.
 services.AddOpenTelemetryTracing((builder) =>
 {
     builder
-    .AddAspNetCoreInstrumentation(opt => opt.Enrich
+    .AddAspNetCoreInstrumentation((options) => options.Enrich
         = (activity, eventName, rawObject) =>
     {
         if (eventName.Equals("OnStartActivity"))

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
@@ -60,31 +60,31 @@ This instrumentation can be configured to change the default behavior by using
 ### Filter
 
 This instrumentation by default collects all the incoming http requests. It
-allows filtering of requests by using `Filter` function in
+allows filtering of requests by using the `Filter` function in
 `AspNetCoreInstrumentationOptions`. This defines the condition for allowable
 requests. The Filter receives the `HttpContext` of the incoming
 request, and does not collect telemetry about the request if the Filter
 returns false or throws exception.
 
-The following code snippet shows how to use `Filter` to filter out all POST
+The following code snippet shows how to use `Filter` to only allow GET
 requests.
 
 ```csharp
 services.AddOpenTelemetryTracing(
-        (builder) => builder
-        .AddAspNetCoreInstrumentation(
-            opt => opt.Filter =
-                (httpContext) =>
-                {
-                    // only collect telemetry about HTTP GET requests
-                    return httpContext.Request.Method.Equals("GET");
-                })
-        .AddJaegerExporter()
-        );
+    (builder) => builder
+    .AddAspNetCoreInstrumentation(
+        (options) => options.Filter =
+            (httpContext) =>
+            {
+                // only collect telemetry about HTTP GET requests
+                return httpContext.Request.Method.Equals("GET");
+            })
+    .AddJaegerExporter()
+    );
 ```
 
 It is important to note that this `Filter` option is specific to this
-instrumentation. OpenTelemetry has a concept of
+instrumentation. OpenTelemetry has a concept of a
 [Sampler](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#sampling),
 and the `Filter` option does the filtering *before* the Sampler is invoked.
 

--- a/src/OpenTelemetry.Instrumentation.Http/README.md
+++ b/src/OpenTelemetry.Instrumentation.Http/README.md
@@ -72,7 +72,7 @@ The following example shows how to use `SetHttpFlavor`.
 ```csharp
 using Sdk.CreateTracerProviderBuilder()
     .AddHttpClientInstrumentation(
-        options => options.SetHttpFlavor = true)
+        (options) => options.SetHttpFlavor = true)
     .AddConsoleExporter()
     .Build();
 ```
@@ -81,22 +81,23 @@ using Sdk.CreateTracerProviderBuilder()
 
 This instrumentation by default collects all the outgoing HTTP requests. It
 allows filtering of requests by using the `Filter` function option.
-This can be used to filter out any requests based on some condition. The Filter
+This defines the condition for allowable requests. The Filter
 receives the request object - `HttpRequestMessage` for .NET Core and
-`HttpWebRequest` for .NET Framework - of the outgoing request and filters out
-the request if the Filter returns false or throws an exception.
+`HttpWebRequest` for .NET Framework - of the outgoing request and does not
+collect telemetry about the request if the Filter returns false or throws
+exception.
 
-The following shows an example of `Filter` being used to filter out all POST
+The following code snippet shows how to use `Filter` to only allow GET
 requests.
 
 ```csharp
 using Sdk.CreateTracerProviderBuilder()
     .AddHttpClientInstrumentation(
-        options => options.Filter =
-            httpRequestMessage =>
+        (options) => options.Filter =
+            (httpRequestMessage) =>
             {
-                // filter out all HTTP POST requests.
-                return httpRequestMessage.Method != HttpMethod.Post;
+                // only collect telemetry about HTTP GET requests
+                return httpRequestMessage.Method.Equals(HttpMethod.Get);
             })
     .AddConsoleExporter()
     .Build();
@@ -143,7 +144,7 @@ The following code snippet shows how to add additional tags using `Enrich`.
 services.AddOpenTelemetryTracing((builder) =>
 {
     builder
-    .AddHttpClientInstrumentation(opt => opt.Enrich
+    .AddHttpClientInstrumentation((options) => options.Enrich
         = (activity, eventName, rawObject) =>
     {
         if (eventName.Equals("OnStartActivity"))


### PR DESCRIPTION
## Changes

Reword the description and code snippets for `Filter()` in OpenTelemetry.Instrumentation.* READMEs.

Grammar and code syntax updated to be consistent between AspNet, AspNetCore, and Http.
Where components were inconsistent, the following decisions were made. These can easily be changed if desired.
* Lambda parameter syntax. Using of `()` for single params eg. `(x) => {}`
* AspNetInstrumentationOptions parameter name `options` instead of `opt`
* Single statement lambdas do not use `{}` eg. `(x) => x.foo()` instead of `(x) => { x.foo(); }`
* README code referenced as "code snippet" instead of "example"
* Tab spacing for code snippets.


Issue driving change: https://github.com/open-telemetry/opentelemetry-dotnet/issues/1186
Previous related PRs: https://github.com/open-telemetry/opentelemetry-dotnet/pull/1615

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #1186 
* [ ] Changes in public API reviewed
