### PR TITLE
Filter() docs: Clarify 'collect telemetry' vs 'instrumentation'

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationOptions.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Instrumentation.AspNet
     public class AspNetInstrumentationOptions
     {
         /// <summary>
-        /// Gets or sets a Filter function to filter instrumentation for requests on a per request basis.
+        /// Gets or sets a Filter function to collect telemetry about requests on a per request basis.
         /// The Filter gets the HttpContext, and should return a boolean.
         /// If Filter returns true, the request is collected.
         /// If Filter returns false or throw exception, the request is filtered out.

--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationOptions.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Instrumentation.AspNet
     public class AspNetInstrumentationOptions
     {
         /// <summary>
-        /// Gets or sets a Filter function to collect telemetry about requests on a per request basis.
+        /// Gets or sets a Filter function that determines whether or not to collect telemetry about requests on a per request basis.
         /// The Filter gets the HttpContext, and should return a boolean.
         /// If Filter returns true, the request is collected.
         /// If Filter returns false or throw exception, the request is filtered out.

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationOptions.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore
     public class AspNetCoreInstrumentationOptions
     {
         /// <summary>
-        /// Gets or sets a Filter function to filter instrumentation for requests on a per request basis.
+        /// Gets or sets a Filter function that determines whether or not to collect telemetry about requests on a per request basis.
         /// The Filter gets the HttpContext, and should return a boolean.
         /// If Filter returns true, the request is collected.
         /// If Filter returns false or throw exception, the request is filtered out.

--- a/src/OpenTelemetry.Instrumentation.Http/HttpClientInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/HttpClientInstrumentationOptions.cs
@@ -34,7 +34,7 @@ namespace OpenTelemetry.Instrumentation.Http
         public bool SetHttpFlavor { get; set; }
 
         /// <summary>
-        /// Gets or sets a Filter function to filter instrumentation for requests on a per request basis.
+        /// Gets or sets a Filter function that determines whether or not to collect telemetry about requests on a per request basis.
         /// The Filter gets the HttpRequestMessage, and should return a boolean.
         /// If Filter returns true, the request is collected.
         /// If Filter returns false or throw exception, the request is filtered out.

--- a/src/OpenTelemetry.Instrumentation.Http/HttpWebRequestInstrumentationOptions.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/HttpWebRequestInstrumentationOptions.netfx.cs
@@ -34,7 +34,7 @@ namespace OpenTelemetry.Instrumentation.Http
         public bool SetHttpFlavor { get; set; }
 
         /// <summary>
-        /// Gets or sets a Filter function to filter instrumentation for requests on a per request basis.
+        /// Gets or sets a Filter function that determines whether or not to collect telemetry about requests on a per request basis.
         /// The Filter gets the HttpWebRequest, and should return a boolean.
         /// If Filter returns true, the request is collected.
         /// If Filter returns false or throw exception, the request is filtered out.


### PR DESCRIPTION
## Changes

Clarify `Filter()` identifies requests that are desired for collecting telemetry (vs instrumentation)
reference: https://github.com/open-telemetry/opentelemetry-dotnet/issues/1186

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #1186
* [ ] Changes in public API reviewed
