### PR TITLE
Fix "using" syntax in README code snippets

### DIFF
--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/README.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/README.md
@@ -49,7 +49,7 @@ public class Program
 {
     public static void Main(string[] args)
     {
-        using Sdk.CreateTracerProviderBuilder()
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
             .AddGrpcClientInstrumentation()
             .AddHttpClientInstrumentaiton()
             .AddConsoleExporter()
@@ -80,7 +80,7 @@ context when `SuppressDownstreamInstrumentation` is enabled.
 The following example shows how to use `SuppressDownstreamInstrumentation`.
 
 ```csharp
-using Sdk.CreateTracerProviderBuilder()
+using var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .AddGrpcClientInstrumentation(
         opt => opt.SuppressDownstreamInstrumentation = true)
     .AddHttpClientInstrumentation()

--- a/src/OpenTelemetry.Instrumentation.Http/README.md
+++ b/src/OpenTelemetry.Instrumentation.Http/README.md
@@ -39,7 +39,7 @@ public class Program
 {
     public static void Main(string[] args)
     {
-        using Sdk.CreateTracerProviderBuilder()
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
             .AddHttpClientInstrumentation()
             .AddConsoleExporter()
             .Build();
@@ -70,7 +70,7 @@ the `http.flavor` attribute.
 The following example shows how to use `SetHttpFlavor`.
 
 ```csharp
-using Sdk.CreateTracerProviderBuilder()
+using var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .AddHttpClientInstrumentation(
         (options) => options.SetHttpFlavor = true)
     .AddConsoleExporter()
@@ -91,7 +91,7 @@ The following code snippet shows how to use `Filter` to only allow GET
 requests.
 
 ```csharp
-using Sdk.CreateTracerProviderBuilder()
+using var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .AddHttpClientInstrumentation(
         (options) => options.Filter =
             (httpRequestMessage) =>

--- a/src/OpenTelemetry.Instrumentation.SqlClient/README.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/README.md
@@ -40,7 +40,7 @@ public class Program
 {
     public static void Main(string[] args)
     {
-        using Sdk.CreateTracerProviderBuilder()
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
             .AddSqlClientInstrumentation()
             .AddConsoleExporter()
             .Build();
@@ -70,7 +70,7 @@ command name. This behavior can be disabled by setting the
 The following example shows how to use `SetStoredProcedureCommandName`.
 
 ```csharp
-using Sdk.CreateTracerProviderBuilder()
+using var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .AddSqlClientInstrumentation(
         options => options.SetStoredProcedureCommandName = false)
     .AddConsoleExporter()
@@ -86,7 +86,7 @@ set the `db.statement` attribute. This behavior can be enabled by setting
 The following example shows how to use `SetTextCommandContent`.
 
 ```csharp
-using Sdk.CreateTracerProviderBuilder()
+using var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .AddSqlClientInstrumentation(
         options => options.SetTextCommandContent = true)
     .AddConsoleExporter()
@@ -133,7 +133,7 @@ the `db.mssql.instance_name` attribute, and the port will be sent as the
 The following example shows how to use `EnableConnectionLevelAttributes`.
 
 ```csharp
-using Sdk.CreateTracerProviderBuilder()
+using var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .AddSqlClientInstrumentation(
         options => options.EnableConnectionLevelAttributes = true)
     .AddConsoleExporter()

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/README.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/README.md
@@ -41,7 +41,7 @@ public class Program
         // Connect to the server.
         using var connection = ConnectionMultiplexer.Connect("localhost:6379");
 
-        using Sdk.CreateTracerProviderBuilder()
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
             .AddRedisInstrumentation(connection)
             .AddConsoleExporter()
             .Build();
@@ -71,7 +71,7 @@ interval. The `FlushInterval` option can be used to adjust this internval.
 The following example shows how to use `FlushInterval`.
 
 ```csharp
-using Sdk.CreateTracerProviderBuilder()
+using var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .AddRedisInstrumentation(
         connection,
         options => options.FlushInterval = TimeSpan.FromSeconds(5))


### PR DESCRIPTION
## Changes

A few code snippets in various README.md files had code that wouldn't compile: `using Sdk.CreateTracerProviderBuilder()` instead of `using var something = ...`