### PR TITLE
Status & error flag updates to match spec

### DIFF
--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -15,6 +15,9 @@
   [#1501](https://github.com/open-telemetry/opentelemetry-dotnet/issues/1501)
   for more information.
   ([#1611](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1611))
+* `Status.WithDescription` will now ignore the provided description if the
+  `Status.StatusCode` is anything other than `ERROR`.
+  ([#1655](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1655))
 
 ## 1.0.0-rc1.1
 

--- a/src/OpenTelemetry.Api/Trace/Status.cs
+++ b/src/OpenTelemetry.Api/Trace/Status.cs
@@ -69,11 +69,18 @@ namespace OpenTelemetry.Trace
         /// <summary>
         /// Returns a new instance of a status with the description populated.
         /// </summary>
+        /// <remarks>
+        /// Note: Status Description is only valid for <see
+        /// cref="StatusCode.Error"/> Status and will be ignored for all other
+        /// <see cref="Trace.StatusCode"/> values. See the <a
+        /// href="https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#set-status">Status
+        /// API</a> for details.
+        /// </remarks>
         /// <param name="description">Description of the status.</param>
         /// <returns>New instance of the status class with the description populated.</returns>
         public Status WithDescription(string description)
         {
-            if (this.Description == description)
+            if (this.StatusCode != StatusCode.Error || this.Description == description)
             {
                 return this;
             }

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerActivityExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerActivityExtensions.cs
@@ -25,6 +25,8 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
 {
     internal static class JaegerActivityExtensions
     {
+        internal const string JaegerErrorFlagTagName = "error";
+
         private const int DaysPerYear = 365;
 
         // Number of days in 4 years
@@ -263,7 +265,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
                     if (statusCode == StatusCode.Error)
                     {
                         // Error flag: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk_exporters/jaeger.md#error-flag
-                        PooledList<JaegerTag>.Add(ref state.Tags, new JaegerTag("error", JaegerTagType.BOOL, vBool: true));
+                        PooledList<JaegerTag>.Add(ref state.Tags, new JaegerTag(JaegerErrorFlagTagName, JaegerTagType.BOOL, vBool: true));
                     }
                     else if (!statusCode.HasValue || statusCode == StatusCode.Unset)
                     {
@@ -273,6 +275,11 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
 
                     // Normalize status since it is user-driven.
                     jaegerTag = new JaegerTag(key, JaegerTagType.STRING, vStr: StatusHelper.GetTagValueForStatusCode(statusCode.Value));
+                }
+                else if (key == JaegerErrorFlagTagName)
+                {
+                    // Ignore `error` tag if it exists, it will be added based on StatusCode + StatusDescription.
+                    return;
                 }
             }
             else if (jaegerTag.VLong.HasValue)

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -5,9 +5,12 @@
 * Changed `ZipkinExporter` class and constructor from internal to public.
   ([#1612](https://github.com/open-telemetry/opentelemetry-dotnet/issues/1612))
 
-* Zipkin will now set the `error` tag when `otel.status_code` is set to `ERROR`.
-  ([#1579](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1579) &
-  [#1620](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1620))
+* Zipkin will now set the `error` tag to the `Status.Description` value or an
+  empty string when `Status.StatusCode` (`otel.status_code` tag) is set to
+  `ERROR`.
+  ([#1579](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1579),
+  [#1620](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1620), &
+  [#1655](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1655))
 
 * Zipkin will no longer send the `otel.status_code` tag if the value is `UNSET`.
   ([#1609](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1609) &

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerActivityConversionTest.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerActivityConversionTest.cs
@@ -466,11 +466,11 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
 
             if (expectedStatusCode == StatusCode.Error)
             {
-                Assert.Contains(jaegerSpan.Tags, t => t.Key == "error" && t.VType == JaegerTagType.BOOL && (t.VBool ?? false));
+                Assert.Contains(jaegerSpan.Tags, t => t.Key == JaegerActivityExtensions.JaegerErrorFlagTagName && t.VType == JaegerTagType.BOOL && (t.VBool ?? false));
             }
             else
             {
-                Assert.DoesNotContain(jaegerSpan.Tags, t => t.Key == "error");
+                Assert.DoesNotContain(jaegerSpan.Tags, t => t.Key == JaegerActivityExtensions.JaegerErrorFlagTagName);
             }
         }
 

--- a/test/OpenTelemetry.Tests/Trace/ActivityExtensionsTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ActivityExtensionsTest.cs
@@ -78,6 +78,23 @@ namespace OpenTelemetry.Trace.Tests
         }
 
         [Fact]
+        public void SetStatusWithIgnoredDescription()
+        {
+            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+                .AddSource(ActivitySourceName)
+                .Build();
+
+            using var source = new ActivitySource(ActivitySourceName);
+            using var activity = source.StartActivity(ActivityName);
+            activity.SetStatus(Status.Ok.WithDescription("This should be ignored."));
+            activity?.Stop();
+
+            var status = activity.GetStatus();
+            Assert.Equal(StatusCode.Ok, status.StatusCode);
+            Assert.Null(status.Description);
+        }
+
+        [Fact]
         public void SetCancelledStatus()
         {
             using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()


### PR DESCRIPTION
## Changes

Updated Status & Zipkin/Jaeger exporter error flag handling based on final merged [PR into spec](https://github.com/open-telemetry/opentelemetry-specification/pull/1257).

## TODOs:

* [X] `CHANGELOG.md` updated for non-trivial changes
