### PR TITLE
Do not maintain DOS/Windows style line endings in md files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,9 +11,6 @@ insert_final_newline = true
 indent_size = 4 
 trim_trailing_whitespace = true 
 charset = utf-8 
-# maintain DOS/Windows style line endings in md files
-[*.md]
-end_of_line = crlf
 ############################### 
 # .NET Coding Conventions     # 
 ############################### 


### PR DESCRIPTION
It seems that the CI requires `.md` files to have LF line endings as seen here: https://github.com/open-telemetry/opentelemetry-dotnet/runs/1567694088.

However, the editorconfig seemed to explicitly enforce CRLF line endings, so merely saving a file in an editor with native editorconfig support changes all of the line endings.

Do we want LF or CRLF?

Looks like the answer is LF based on #1250