### PR TITLE
Make all test cases in W3C trace-context test suite pass

### DIFF
--- a/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
@@ -309,11 +309,19 @@ namespace OpenTelemetry.Context.Propagation
 
         private static byte HexCharToByte(char c)
         {
-            if (((c >= '0') && (c <= '9'))
-                || ((c >= 'a') && (c <= 'f'))
-                || ((c >= 'A') && (c <= 'F')))
+            if ((c >= '0') && (c <= '9'))
             {
-                return Convert.ToByte(c);
+                return (byte)(c - '0');
+            }
+
+            if ((c >= 'a') && (c <= 'f'))
+            {
+                return (byte)(c - 'a' + 10);
+            }
+
+            if ((c >= 'A') && (c <= 'F'))
+            {
+                return (byte)(c - 'A' + 10);
             }
 
             throw new ArgumentOutOfRangeException(nameof(c), c, $"Invalid character: {c}.");

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
@@ -39,7 +39,6 @@ namespace OpenTelemetry.Context.Propagation
         private static readonly int VersionAndTraceIdAndSpanIdLength = "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-".Length;
         private static readonly int OptionsLength = "00".Length;
         private static readonly int TraceparentLengthV0 = "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-00".Length;
-        private static readonly char[] OptionalWhiteSpaceCharacters = new char[] { ' ', '\t' };
 
         // The following length limits are from Trace Context v1 https://www.w3.org/TR/trace-context-1/#key
         private static readonly int TraceStateKeyMaxLength = 256;

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
@@ -352,6 +352,12 @@ namespace OpenTelemetry.Context.Propagation
             for (int i = 1; i < key.Length; ++i)
             {
                 char ch = key[i];
+                if (ch == '@')
+                {
+                    tenentLength = i;
+                    break;
+                }
+
                 if (!(IsLowerAlphaDigit(ch)
                     || ch == '_'
                     || ch == '-'
@@ -359,12 +365,6 @@ namespace OpenTelemetry.Context.Propagation
                     || ch == '/'))
                 {
                     return false;
-                }
-
-                if (ch == '@')
-                {
-                    tenentLength = i;
-                    break;
                 }
             }
 
@@ -388,7 +388,11 @@ namespace OpenTelemetry.Context.Propagation
             for (int i = tenentLength + 1; i < key.Length; ++i)
             {
                 char ch = key[i];
-                if (!(ch >= 'a' && ch <= 'z'))
+                if (!(IsLowerAlphaDigit(ch)
+                    || ch == '_'
+                    || ch == '-'
+                    || ch == '*'
+                    || ch == '/'))
                 {
                     return false;
                 }

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using OpenTelemetry.Internal;
 
@@ -342,8 +343,7 @@ namespace OpenTelemetry.Context.Propagation
             // There is an inconsistency in the expression above and the description in note.
             // Here is following the description in note:
             // Identifiers MUST begin with a lowercase letter or a digit.
-            char first = key[0];
-            if (!((first >= '0' && first <= '9') || (first >= 'a' && first <= 'z')))
+            if (!IsLowerAlphaDigit(key[0]))
             {
                 return false;
             }
@@ -352,8 +352,7 @@ namespace OpenTelemetry.Context.Propagation
             for (int i = 1; i < key.Length; ++i)
             {
                 char ch = key[i];
-                if (!((ch >= '0' && ch <= '9')
-                    || (ch >= 'a' && ch <= 'z')
+                if (!(IsLowerAlphaDigit(ch)
                     || ch == '_'
                     || ch == '-'
                     || ch == '*'
@@ -420,6 +419,12 @@ namespace OpenTelemetry.Context.Propagation
 
             char last = value[value.Length - 1];
             return last >= 0x21 && last <= 0x7E && last != 0x2C && last != 0x3D;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsLowerAlphaDigit(char c)
+        {
+            return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z');
         }
     }
 }

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
@@ -288,6 +288,7 @@ namespace OpenTelemetry.Context.Propagation
                         return false;
                     }
 
+                    // ValidateKey() call above has ensured the key does not contain upper case letters.
                     if (keySet.Contains(key))
                     {
                         // test_tracestate_duplicated_keys
@@ -335,16 +336,19 @@ namespace OpenTelemetry.Context.Propagation
             // This implementation follows Trace Context v1 which has W3C Recommendation.
             // It will be slightly differently from the next version of specification in GitHub repository.
             // https://www.w3.org/TR/trace-context-1/#key
-            // key = lcalpha 0*255( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )
-            // lcalpha = % x61 - 7A; a - z
+
+            // There are two format for the key. The length rule applies to both.
             if (key.Length <= 0 || key.Length > TraceStateKeyMaxLength)
             {
                 return false;
             }
 
-            // There is an inconsistency in the expression above and the description in note.
+            // The first format:
+            // key = lcalpha 0*255( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )
+            // lcalpha = % x61 - 7A; a - z
+            // (There is an inconsistency in the expression above and the description in note.
             // Here is following the description in note:
-            // Identifiers MUST begin with a lowercase letter or a digit.
+            // "Identifiers MUST begin with a lowercase letter or a digit.")
             if (!IsLowerAlphaDigit(key[0]))
             {
                 return false;
@@ -372,9 +376,11 @@ namespace OpenTelemetry.Context.Propagation
 
             if (tenantLength == -1)
             {
+                // There is no "@" sign. The key follow the first format.
                 return true;
             }
 
+            // The second format:
             // key = (lcalpha / DIGIT) 0 * 240(lcalpha / DIGIT / "_" / "-" / "*" / "/") "@" lcalpha 0 * 13(lcalpha / DIGIT / "_" / "-" / "*" / "/")
             if (tenantLength == 0 || tenantLength > TraceStateKeyTenantMaxLength)
             {

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
@@ -334,8 +334,8 @@ namespace OpenTelemetry.Context.Propagation
         private static bool ValidateKey(string key)
         {
             // This implementation follows Trace Context v1 which has W3C Recommendation.
-            // It will be slightly differently from the next version of specification in GitHub repository.
             // https://www.w3.org/TR/trace-context-1/#key
+            // It will be slightly differently from the next version of specification in GitHub repository.
 
             // There are two format for the key. The length rule applies to both.
             if (key.Length <= 0 || key.Length > TraceStateKeyMaxLength)

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
@@ -39,6 +39,7 @@ namespace OpenTelemetry.Context.Propagation
         private static readonly int VersionAndTraceIdAndSpanIdLength = "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-".Length;
         private static readonly int OptionsLength = "00".Length;
         private static readonly int TraceparentLengthV0 = "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-00".Length;
+        private static readonly char[] OptionalWhiteSpaceCharacters = new char[] { ' ', '\t' };
 
         // The following length limits are from Trace Context v1 https://www.w3.org/TR/trace-context-1/#key
         private static readonly int TraceStateKeyMaxLength = 256;
@@ -264,7 +265,7 @@ namespace OpenTelemetry.Context.Propagation
                     }
 
                     // Spaces and horizontal tabs surrounding list-members are ignored.
-                    var listMember = listMembers[i].Trim(new char[] { ' ', '\t' });
+                    var listMember = listMembers[i].Trim(OptionalWhiteSpaceCharacters);
                     int keyLength = listMember.IndexOf('=');
                     if (keyLength == listMember.Length || keyLength == -1)
                     {
@@ -289,13 +290,11 @@ namespace OpenTelemetry.Context.Propagation
                     }
 
                     // ValidateKey() call above has ensured the key does not contain upper case letters.
-                    if (keySet.Contains(key))
+                    if (!keySet.Add(key))
                     {
                         // test_tracestate_duplicated_keys
                         return false;
                     }
-
-                    keySet.Add(key);
 
                     if (result.Length > 0)
                     {
@@ -321,11 +320,6 @@ namespace OpenTelemetry.Context.Propagation
             if ((c >= 'a') && (c <= 'f'))
             {
                 return (byte)(c - 'a' + 10);
-            }
-
-            if ((c >= 'A') && (c <= 'F'))
-            {
-                return (byte)(c - 'A' + 10);
             }
 
             throw new ArgumentOutOfRangeException(nameof(c), c, $"Invalid character: {c}.");

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
@@ -39,8 +39,10 @@ namespace OpenTelemetry.Context.Propagation
         private static readonly int VersionAndTraceIdAndSpanIdLength = "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-".Length;
         private static readonly int OptionsLength = "00".Length;
         private static readonly int TraceparentLengthV0 = "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-00".Length;
+
+        // The following length limits are from Trace Context v1 https://www.w3.org/TR/trace-context-1/#key
         private static readonly int TraceStateKeyMaxLength = 256;
-        private static readonly int TraceStateKeyTenentMaxLength = 241;
+        private static readonly int TraceStateKeyTenantMaxLength = 241;
         private static readonly int TraceStateKeyVendorMaxLength = 14;
         private static readonly int TraceStateValueMaxLength = 256;
 
@@ -348,13 +350,13 @@ namespace OpenTelemetry.Context.Propagation
                 return false;
             }
 
-            int tenentLength = -1;
+            int tenantLength = -1;
             for (int i = 1; i < key.Length; ++i)
             {
                 char ch = key[i];
                 if (ch == '@')
                 {
-                    tenentLength = i;
+                    tenantLength = i;
                     break;
                 }
 
@@ -368,24 +370,24 @@ namespace OpenTelemetry.Context.Propagation
                 }
             }
 
-            if (tenentLength == -1)
+            if (tenantLength == -1)
             {
                 return true;
             }
 
             // key = (lcalpha / DIGIT) 0 * 240(lcalpha / DIGIT / "_" / "-" / "*" / "/") "@" lcalpha 0 * 13(lcalpha / DIGIT / "_" / "-" / "*" / "/")
-            if (tenentLength == 0 || tenentLength > TraceStateKeyTenentMaxLength)
+            if (tenantLength == 0 || tenantLength > TraceStateKeyTenantMaxLength)
             {
                 return false;
             }
 
-            int vendorLength = key.Length - tenentLength - 1;
+            int vendorLength = key.Length - tenantLength - 1;
             if (vendorLength == 0 || vendorLength > TraceStateKeyVendorMaxLength)
             {
                 return false;
             }
 
-            for (int i = tenentLength + 1; i < key.Length; ++i)
+            for (int i = tenantLength + 1; i < key.Length; ++i)
             {
                 char ch = key[i];
                 if (!(IsLowerAlphaDigit(ch)

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/W3CTraceContextTests.cs
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/W3CTraceContextTests.cs
@@ -52,9 +52,9 @@ namespace OpenTelemetry.Instrumentation.W3cTraceContext.Tests
                 // Assert
                 // Assert on the last line
                 // TODO: fix W3C Trace Context test suite
-                // ASP NET Core 2.1: FAILED (failures=3, errors=2)
-                // ASP NET Core 3.1: FAILED (failures=5, errors=2)
-                // ASP NET Core 5.0: FAILED (failures=5, errors=2)
+                // ASP NET Core 2.1: FAILED (failures=3)
+                // ASP NET Core 3.1: FAILED (failures=5)
+                // ASP NET Core 5.0: FAILED (failures=5)
                 string lastLine = ParseLastLine(result);
                 this.output.WriteLine("result:" + result);
                 Assert.StartsWith("FAILED", lastLine);

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/W3CTraceContextTests.cs
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/W3CTraceContextTests.cs
@@ -52,8 +52,9 @@ namespace OpenTelemetry.Instrumentation.W3cTraceContext.Tests
                 // Assert
                 // Assert on the last line
                 // TODO: fix W3C Trace Context test suite
-                // ASP NET Core 2.1: FAILED (failures=4, errors=7)
-                // ASP NET Core 3.1: FAILED (failures=6, errors=7)
+                // ASP NET Core 2.1: FAILED (failures=3, errors=2)
+                // ASP NET Core 3.1: FAILED (failures=5, errors=2)
+                // ASP NET Core 5.0: FAILED (failures=5, errors=2)
                 string lastLine = ParseLastLine(result);
                 this.output.WriteLine("result:" + result);
                 Assert.StartsWith("FAILED", lastLine);

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/W3CTraceContextTests.cs
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/W3CTraceContextTests.cs
@@ -52,9 +52,9 @@ namespace OpenTelemetry.Instrumentation.W3cTraceContext.Tests
                 // Assert
                 // Assert on the last line
                 // TODO: fix W3C Trace Context test suite
-                // ASP NET Core 2.1: FAILED (failures=3)
-                // ASP NET Core 3.1: FAILED (failures=5)
-                // ASP NET Core 5.0: FAILED (failures=5)
+                // ASP NET Core 2.1: FAILED (failures=1)
+                // ASP NET Core 3.1: FAILED (failures=3)
+                // ASP NET Core 5.0: FAILED (failures=3)
                 string lastLine = ParseLastLine(result);
                 this.output.WriteLine("result:" + result);
                 Assert.StartsWith("FAILED", lastLine);

--- a/test/OpenTelemetry.Tests/Trace/Propagation/TraceContextPropagatorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/TraceContextPropagatorTest.cs
@@ -207,6 +207,16 @@ namespace OpenTelemetry.Context.Propagation.Tests
         }
 
         [Fact]
+        public void Key_IllegalVendorFormat()
+        {
+            // test_tracestate_key_illegal_vendor_format
+            Assert.Empty(CallTraceContextPropagator("foo@=1,bar=2"));
+            Assert.Empty(CallTraceContextPropagator("@foo=1,bar=2"));
+            Assert.Empty(CallTraceContextPropagator("foo@@bar=1,bar=2"));
+            Assert.Empty(CallTraceContextPropagator("foo@bar@baz=1,bar=2"));
+        }
+
+        [Fact]
         public void MemberCountLimit()
         {
             // test_tracestate_member_count_limit
@@ -232,6 +242,19 @@ namespace OpenTelemetry.Context.Propagation.Tests
                 "bar31=31,bar32=32,bar33=33",
             });
             Assert.Empty(output2);
+        }
+
+        [Fact]
+        public void Key_KeyLengthLimit()
+        {
+            // test_tracestate_key_length_limit
+            string input1 = new string('z', 256) + "=1";
+            Assert.Equal(input1, CallTraceContextPropagator(input1));
+            Assert.Empty(CallTraceContextPropagator(new string('z', 257) + "=1"));
+            string input2 = new string('t', 241) + "@" + new string('v', 14) + "=1";
+            Assert.Equal(input2, CallTraceContextPropagator(input2));
+            Assert.Empty(CallTraceContextPropagator(new string('t', 242) + "@v=1"));
+            Assert.Empty(CallTraceContextPropagator("t@" + new string('v', 15) + "=1"));
         }
 
         [Fact]

--- a/test/OpenTelemetry.Tests/Trace/Propagation/TraceContextPropagatorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/TraceContextPropagatorTest.cs
@@ -265,6 +265,45 @@ namespace OpenTelemetry.Context.Propagation.Tests
             Assert.Empty(CallTraceContextPropagator("foo=,bar=3"));
         }
 
+        [Fact]
+        public void Traceparent_Version()
+        {
+            // test_traceparent_version_0x00
+            Assert.NotEqual(
+                "12345678901234567890123456789012",
+                CallTraceContextPropagatorWithTraceParent("00-12345678901234567890123456789012-1234567890123456-01."));
+            Assert.NotEqual(
+                "12345678901234567890123456789012",
+                CallTraceContextPropagatorWithTraceParent("00-12345678901234567890123456789012-1234567890123456-01-what-the-future-will-be-like"));
+
+            // test_traceparent_version_0xcc
+            Assert.Equal(
+                "12345678901234567890123456789012",
+                CallTraceContextPropagatorWithTraceParent("cc-12345678901234567890123456789012-1234567890123456-01"));
+            Assert.Equal(
+                "12345678901234567890123456789012",
+                CallTraceContextPropagatorWithTraceParent("cc-12345678901234567890123456789012-1234567890123456-01-what-the-future-will-be-like"));
+            Assert.NotEqual(
+                "12345678901234567890123456789012",
+                CallTraceContextPropagatorWithTraceParent("cc-12345678901234567890123456789012-1234567890123456-01.what-the-future-will-be-like"));
+
+            // test_traceparent_version_0xff
+            Assert.NotEqual(
+                "12345678901234567890123456789012",
+                CallTraceContextPropagatorWithTraceParent("ff-12345678901234567890123456789012-1234567890123456-01"));
+        }
+
+        private static string CallTraceContextPropagatorWithTraceParent(string traceparent)
+        {
+            var headers = new Dictionary<string, string>
+            {
+                { TraceParent, traceparent },
+            };
+            var f = new TraceContextPropagator();
+            var ctx = f.Extract(default, headers, Getter);
+            return ctx.ActivityContext.TraceId.ToString();
+        }
+
         private static string CallTraceContextPropagator(string tracestate)
         {
             var headers = new Dictionary<string, string>


### PR DESCRIPTION
Fixed errors and failures (marked as "Fixed in this PR" below) in W3C Trace Context tests of #1219. (Tracking individual test case would be easier after merging PR #1243, which parses the test run result and identifies individual test case status.)

## Note on key format

There is an inconsistency in [Trace Context v1](https://www.w3.org/TR/trace-context-1/#key) between the expressions and the description in the note below.

Expressions:

```
key = lcalpha 0*255( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )
key = ( lcalpha / DIGIT ) 0*240( lcalpha / DIGIT / "_" / "-"/ "*" / "/" ) "@" lcalpha 0*13( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )
lcalpha    = %x61-7A ; a-z
```

Note:

```
Note: Identifiers MUST begin with a lowercase letter or a digit, and can only contain lowercase letters (a-z), digits (0-9), underscores (_), dashes (-), asterisks (*), and forward slashes (/).
```

I think the first expression has a bug and the key should start with `( lcalpha / DIGIT )` instead of `lcalpha` to be consistent with the note of Trace Context v1 and the next version of specification being developed in [w3c/trace-context repository](https://github.com/w3c/trace-context/blob/master/spec/20-http_request_header_format.md#key).

The same note has been added in code as inline comment (Ctrl+F for "inconsistency").

## Note on vendor format

[Trace Context v1](https://www.w3.org/TR/trace-context-1/) which has W3C Recommendation status differs from the next version of specification being developed in [w3c/trace-context repository](https://github.com/w3c/trace-context/blob/master/spec/20-http_request_header_format.md#list) regarding the "tenant@vendor" rules, which are covered by the following two test cases in the [python test code](https://github.com/w3c/trace-context/blob/master/test/test.py).

Here I implemented the rules in accordance with Trace Context v1 as following to pass the python test case.

`test_tracestate_key_illegal_vendor_format`: The trace state is in such format `tenant@vendor`. Neither tenant and vendor can be empty. There can be at most one `@`. Otherwise remove all other list-members even if they are valid (in other words, remove all trace states).
`test_tracestate_key_length_limit`: The key can be up to 256 characters. Vendor up to 14. Tenant up to 241. Otherwise remove all trace states.

## Explanation on version number

Regarding the failing two cases on version number and generating new trace_id (`test_traceparent_version_0x00` and `test_traceparent_version_0xff`), the feature was working until a bug was introduced in [this change](https://github.com/open-telemetry/opentelemetry-dotnet/pull/923/files#diff-670edb2ea7fa1212aab16a9f732dad8b1e2f15801a3eac1bd0824385355d7d97L262).


## Summary of the failures in Netcoreapp 2.1

Errors:
- [x] `test_tracestate_duplicated_keys`: Fixed in this PR.
- [x] `test_tracestate_key_illegal_characters`: Fixed in this PR.
- [x] `test_tracestate_key_illegal_vendor_format`: Fixed in this PR.
- [x] `test_tracestate_key_length_limit`: Fixed in this PR.
- [x] `test_tracestate_member_count_limit`: Fixed in this PR.
- [x] `test_tracestate_multiple_headers_different_keys`: Fixed in this PR.
- [x] `test_tracestate_value_illegal_characters`: Fixed in this PR.

Failures:
- [x] `test_traceparent_trace_flags_illegal_characters`: See issue #1219.
- [x] `test_traceparent_version_0x00`: Fixed in this PR.
- [x] `test_traceparent_version_0xff`: Fixed in this PR.
- [x] `test_tracestate_empty_header`: Fixed in this PR.

## Summary of the failures in Netcoreapp 3.1

Errors:
- [x] `test_tracestate_duplicated_keys`: Fixed in this PR.
- [x] `test_tracestate_key_illegal_characters`: Fixed in this PR.
- [x] `test_tracestate_key_illegal_vendor_format`: Fixed in this PR.
- [x] `test_tracestate_key_length_limit`: Fixed in this PR.
- [x] `test_tracestate_member_count_limit`: Fixed in this PR.
- [x] `test_tracestate_multiple_headers_different_keys`: Fixed in this PR.
- [x] `test_tracestate_value_illegal_characters`: Fixed in this PR.

Failures:
- [x] `test_traceparent_parent_id_all_zero`: See issue #1219.
- [x] `test_traceparent_parent_id_illegal_characters`: See issue #1219.
- [x] `test_traceparent_trace_flags_illegal_characters`: See issue #1219.
- [x] `test_traceparent_version_0x00`: Fixed in this PR.
- [x] `test_traceparent_version_0xff`: Fixed in this PR.
- [x] `test_tracestate_empty_header`: Fixed in this PR.

## Summary of the failures in Netcoreapp 5.0

Errors:
- [x] test_tracestate_key_illegal_vendor_format: Fixed in this PR.
- [x] test_tracestate_key_length_limit: Fixed in this PR.

Failures:
- [x] test_traceparent_parent_id_all_zero: See issue #1219.
- [x] test_traceparent_parent_id_illegal_characters: See issue #1219.
- [x] test_traceparent_trace_flags_illegal_characters: See issue #1219.
- [x] test_traceparent_version_0x00: Fixed in this PR.
- [x] test_traceparent_version_0xff: Fixed in this PR.
