### PR TITLE
Azure Function example

### DIFF
--- a/OpenTelemetry.sln
+++ b/OpenTelemetry.sln
@@ -205,6 +205,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.Shared", "src
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestApp.AspNetCore.5.0", "test\TestApp.AspNetCore.5.0\TestApp.AspNetCore.5.0.csproj", "{972396A8-E35B-499C-9BA1-765E9B8822E1}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Examples.AzureFunction", "examples\AzureFunction\Examples.AzureFunction.csproj", "{F6ECFA83-C306-4228-9770-7CACA4A5D166}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -403,6 +405,10 @@ Global
 		{972396A8-E35B-499C-9BA1-765E9B8822E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{972396A8-E35B-499C-9BA1-765E9B8822E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{972396A8-E35B-499C-9BA1-765E9B8822E1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F6ECFA83-C306-4228-9770-7CACA4A5D166}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F6ECFA83-C306-4228-9770-7CACA4A5D166}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F6ECFA83-C306-4228-9770-7CACA4A5D166}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F6ECFA83-C306-4228-9770-7CACA4A5D166}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -433,6 +439,7 @@ Global
 		{B3F03725-23A0-4582-9526-F6A7E38F35CC} = {3862190B-E2C5-418E-AFDC-DB281FB5C705}
 		{13C10C9A-07E8-43EB-91F5-C2B116FBE0FC} = {3862190B-E2C5-418E-AFDC-DB281FB5C705}
 		{972396A8-E35B-499C-9BA1-765E9B8822E1} = {77C7929A-2EED-4AA6-8705-B5C443C8AA0F}
+		{F6ECFA83-C306-4228-9770-7CACA4A5D166} = {E359BB2B-9AEC-497D-B321-7DF2450C3B8E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {55639B5C-0770-4A22-AB56-859604650521}

--- a/examples/AzureFunction/Examples.AzureFunction.csproj
+++ b/examples/AzureFunction/Examples.AzureFunction.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Console\OpenTelemetry.Exporter.Console.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Extensions.Hosting\OpenTelemetry.Extensions.Hosting.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.Http\OpenTelemetry.Instrumentation.Http.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/examples/AzureFunction/MyFunction.cs
+++ b/examples/AzureFunction/MyFunction.cs
@@ -1,0 +1,48 @@
+// <copyright file="MyFunction.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+
+namespace Examples.AzureFunction
+{
+    public class MyFunction
+    {
+        private static ActivitySource activitySource = new ActivitySource("MyFunction");
+
+        [FunctionName("MyFunction")]
+        public async Task<IActionResult> Run(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = null)] HttpRequest req,
+            ExecutionContext context)
+        {
+            using var activity = activitySource.StartActivity("MyFunction", ActivityKind.Server);
+            activity?.SetTag("faas.trigger", "http");
+
+            // TODO: Consider adding other relevant tags to the activity demonstrating the FAAS semantic conventions:
+            // https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/faas.md
+
+            // TODO: Figure out why this HttpClient invocation does not generate an activity.
+            using var client = new HttpClient();
+            var response = await client.GetStringAsync("https://opentelemetry.io/");
+            return new OkObjectResult(response);
+        }
+    }
+}

--- a/examples/AzureFunction/Startup.cs
+++ b/examples/AzureFunction/Startup.cs
@@ -1,0 +1,53 @@
+// <copyright file="Startup.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+[assembly: FunctionsStartup(typeof(Examples.AzureFunction.Startup))]
+
+namespace Examples.AzureFunction
+{
+    public class Startup : FunctionsStartup
+    {
+        private static TracerProvider tracerProvider;
+
+        public override void Configure(IFunctionsHostBuilder builder)
+        {
+            // TODO: It does not appear that the OpenTelemetry.Extensions.Hosting package is compatible with Azure Functions.
+            // Using it causes the following error:
+            //     [Invalid] ServiceType: Microsoft.Extensions.Hosting.IHostedService, Lifetime: Singleton, ImplementationType: OpenTelemetry.Extensions.Hosting.Implementation.TelemetryHostedService, OpenTelemetry.Extensions.Hosting, Version = 0.2.0.909, Culture = neutral, PublicKeyToken = 7bd6737fe5b67e3c.
+            // builder.Services.AddOpenTelemetryTracing(builder =>
+            // {
+            //     builder
+            //         .AddSource("MyFunction")
+            //         .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("MyFunction"))
+            //         .AddHttpClientInstrumentation()
+            //         .AddConsoleExporter();
+            // });
+
+            tracerProvider = Sdk.CreateTracerProviderBuilder()
+                .AddSource("MyFunction")
+                .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("MyFunction"))
+                .AddHttpClientInstrumentation()
+                .AddConsoleExporter()
+                .Build();
+        }
+    }
+}

--- a/examples/AzureFunction/host.json
+++ b/examples/AzureFunction/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "fileLoggingMode": "always",
+    "logLevel": {
+      "Default": "Debug"
+    },
+    "applicationInsights": {
+      "samplingExcludedTypes": "Request",
+      "samplingSettings": {
+        "isEnabled": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
In working with my colleague @kolanos today, we were playing around with instrumenting an Azure Function with OpenTelemetry. I thought it may be useful to have a simple example in the repository.

However, we ran into a couple issues we've yet to resolve, so keeping as a draft PR for now...

1. OpenTelemetry.Extensions.Hosting does not seem to work with Azure Functions.
2. HttpClient instrumentation has been enabled, however the HttpClient invocation the function makes does not cause the instrumentation to be invoked.