### PR TITLE
Fix metric timestamps now UTC aware (#1485)

### DIFF
--- a/src/OpenTelemetry/Metrics/Aggregators/DoubleCounterSumAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregators/DoubleCounterSumAggregator.cs
@@ -42,9 +42,9 @@ namespace OpenTelemetry.Metrics.Aggregators
         {
             return new DoubleSumData
             {
-                StartTimestamp = new DateTime(this.GetLastStartTimestamp().Ticks),
+                StartTimestamp = new DateTime(this.GetLastStartTimestamp().Ticks, DateTimeKind.Utc),
                 Sum = this.checkPoint,
-                Timestamp = new DateTime(this.GetLastEndTimestamp().Ticks),
+                Timestamp = new DateTime(this.GetLastEndTimestamp().Ticks, DateTimeKind.Utc),
             };
         }
 

--- a/src/OpenTelemetry/Metrics/Aggregators/DoubleLastValueAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregators/DoubleLastValueAggregator.cs
@@ -41,9 +41,9 @@ namespace OpenTelemetry.Metrics.Aggregators
         {
             return new DoubleSumData
             {
-                StartTimestamp = new DateTime(this.GetLastStartTimestamp().Ticks),
+                StartTimestamp = new DateTime(this.GetLastStartTimestamp().Ticks, DateTimeKind.Utc),
                 Sum = this.checkpoint,
-                Timestamp = new DateTime(this.GetLastEndTimestamp().Ticks),
+                Timestamp = new DateTime(this.GetLastEndTimestamp().Ticks, DateTimeKind.Utc),
             };
         }
 

--- a/src/OpenTelemetry/Metrics/Aggregators/DoubleMeasureMinMaxSumCountAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregators/DoubleMeasureMinMaxSumCountAggregator.cs
@@ -49,11 +49,11 @@ namespace OpenTelemetry.Metrics.Aggregators
             return new DoubleSummaryData
             {
                 Count = this.checkPoint.Count,
-                StartTimestamp = new DateTime(this.GetLastStartTimestamp().Ticks),
+                StartTimestamp = new DateTime(this.GetLastStartTimestamp().Ticks, DateTimeKind.Utc),
                 Sum = this.checkPoint.Sum,
                 Min = this.checkPoint.Min,
                 Max = this.checkPoint.Max,
-                Timestamp = new DateTime(this.GetLastEndTimestamp().Ticks),
+                Timestamp = new DateTime(this.GetLastEndTimestamp().Ticks, DateTimeKind.Utc),
             };
         }
 

--- a/src/OpenTelemetry/Metrics/Aggregators/Int64CounterSumAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregators/Int64CounterSumAggregator.cs
@@ -42,9 +42,9 @@ namespace OpenTelemetry.Metrics.Aggregators
         {
             return new Int64SumData
             {
-                StartTimestamp = new DateTime(this.GetLastStartTimestamp().Ticks),
+                StartTimestamp = new DateTime(this.GetLastStartTimestamp().Ticks, DateTimeKind.Utc),
                 Sum = this.checkPoint,
-                Timestamp = new DateTime(this.GetLastEndTimestamp().Ticks),
+                Timestamp = new DateTime(this.GetLastEndTimestamp().Ticks, DateTimeKind.Utc),
             };
         }
 

--- a/src/OpenTelemetry/Metrics/Aggregators/Int64LastValueAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregators/Int64LastValueAggregator.cs
@@ -41,9 +41,9 @@ namespace OpenTelemetry.Metrics.Aggregators
         {
             return new Int64SumData
             {
-                StartTimestamp = new DateTime(this.GetLastStartTimestamp().Ticks),
+                StartTimestamp = new DateTime(this.GetLastStartTimestamp().Ticks, DateTimeKind.Utc),
                 Sum = this.checkpoint,
-                Timestamp = new DateTime(this.GetLastEndTimestamp().Ticks),
+                Timestamp = new DateTime(this.GetLastEndTimestamp().Ticks, DateTimeKind.Utc),
             };
         }
 

--- a/src/OpenTelemetry/Metrics/Aggregators/Int64MeasureMinMaxSumCountAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregators/Int64MeasureMinMaxSumCountAggregator.cs
@@ -49,11 +49,11 @@ namespace OpenTelemetry.Metrics.Aggregators
             return new Int64SummaryData
             {
                 Count = this.checkPoint.Count,
-                StartTimestamp = new DateTime(this.GetLastStartTimestamp().Ticks),
+                StartTimestamp = new DateTime(this.GetLastStartTimestamp().Ticks, DateTimeKind.Utc),
                 Sum = this.checkPoint.Sum,
                 Min = this.checkPoint.Min,
                 Max = this.checkPoint.Max,
-                Timestamp = new DateTime(this.GetLastEndTimestamp().Ticks),
+                Timestamp = new DateTime(this.GetLastEndTimestamp().Ticks, DateTimeKind.Utc),
             };
         }
 

--- a/test/OpenTelemetry.Tests/Metrics/Aggregators/AggregatorTest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/Aggregators/AggregatorTest.cs
@@ -43,6 +43,9 @@ namespace OpenTelemetry.Metrics.Tests
                     metricData.Timestamp.Add(TimeSpan.FromTicks(1)),
                     otherMetricData.StartTimestamp) == 0);
             Assert.True(DateTime.Compare(otherMetricData.StartTimestamp, otherMetricData.Timestamp) < 0);
+
+            Assert.Equal(DateTimeKind.Utc, metricData.Timestamp.Kind);
+            Assert.Equal(DateTimeKind.Utc, otherMetricData.Timestamp.Kind);
         }
     }
 }


### PR DESCRIPTION
Fixes #1485.

## Changes

When DateTime objects are being created from ticks, they need to be made aware they represent UTC time. Of that argument isn't specified, they end up with `DateTime.Kind == DateTimeKind.Unspecified` in which case `DateTime.ToUniversalTime` does not yield the expected result.

The bug was introduced in #1375 where creation of DateTime objects became based on ticks, instead of DateTime.Now.

I've tested locally and it fixes the problem for me, as described in #1485.

I've adapted a unit test to check for `DateTime.Kind == DateTimeKind.Utc`. Please let me know if this is enough or if there are more places to check for this.