### PR TITLE
Correct definition of ActivitySource name.

### DIFF
--- a/src/OpenTelemetry.Api/README.md
+++ b/src/OpenTelemetry.Api/README.md
@@ -148,12 +148,12 @@ here as well.
     ```
 
 2. Create an `ActivitySource`, providing the name and version of the
-   library/application being instrumented. `ActivitySource` instance is
+   library/application doing the instrumentation. `ActivitySource` instance is
    typically created once and is reused throughout the application/library.
 
     ```csharp
     static ActivitySource activitySource = new ActivitySource(
-        "companyname.product.library",
+        "companyname.product.instrumentationlibrary",
         "semver1.0.0");
     ```
 


### PR DESCRIPTION
## Changes

Spec says at https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#get-a-tracer

> This name must identify the instrumentation library (e.g. io.opentelemetry.contrib.mongodb) and not the instrumented library.

But the README in .NET suggested exactly the opposite.

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed


----

This is just the first place I encountered this bug, there may be other places that need fixing. I'm just opening this PR to bring up the issue.
