### PR TITLE
SqlClient: parse optional Protocol part of the connection string Data Source

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentationOptions.cs
@@ -36,7 +36,9 @@ namespace OpenTelemetry.Instrumentation.SqlClient
          *  serverName[ ]\\[ ]instanceName[ ],[ ]port
          * [ ] can be any number of white-space, SQL allows it for some reason.
          */
-        private static readonly Regex DataSourceRegex = new Regex("^(.*?)\\s*(?:[\\\\,]|$)\\s*(.*?)\\s*(?:,|$)\\s*(.*)$", RegexOptions.Compiled);
+        private static readonly Regex DataSourceRegex = new Regex("^(.*\\s*:\\s*\\\\{0,2})?(.*?)\\s*(?:[\\\\,]|$)\\s*(.*?)\\s*(?:,|$)\\s*(.*)$", RegexOptions.Compiled);
+
+        private static readonly Regex NamedPipeRegex = new Regex("pipe\\\\MSSQL\\$(.*?)\\\\", RegexOptions.Compiled);
         private static readonly ConcurrentDictionary<string, SqlConnectionDetails> ConnectionDetailCache = new ConcurrentDictionary<string, SqlConnectionDetails>(StringComparer.OrdinalIgnoreCase);
 
         // .NET Framework implementation uses SqlEventSource from which we can't reliably distinguish
@@ -121,8 +123,10 @@ namespace OpenTelemetry.Instrumentation.SqlClient
         {
             Match match = DataSourceRegex.Match(dataSource);
 
-            string serverHostName = match.Groups[1].Value;
+            string serverHostName = match.Groups[2].Value;
             string serverIpAddress = null;
+
+            string instanceName;
 
             var uriHostNameType = Uri.CheckHostName(serverHostName);
             if (uriHostNameType == UriHostNameType.IPv4 || uriHostNameType == UriHostNameType.IPv6)
@@ -131,25 +135,56 @@ namespace OpenTelemetry.Instrumentation.SqlClient
                 serverHostName = null;
             }
 
-            string instanceName;
-            string port;
-            if (match.Groups[3].Length > 0)
+            string maybeProtocol = match.Groups[1].Value;
+            bool isNamedPipe = maybeProtocol.Length > 0 &&
+                               maybeProtocol.StartsWith("np", StringComparison.OrdinalIgnoreCase);
+
+            if (isNamedPipe)
             {
-                instanceName = match.Groups[2].Value;
-                port = match.Groups[3].Value;
+                string pipeName = match.Groups[3].Value;
+                if (pipeName.Length > 0)
+                {
+                    var namedInstancePipeMatch = NamedPipeRegex.Match(pipeName);
+                    if (namedInstancePipeMatch.Success)
+                    {
+                        instanceName = namedInstancePipeMatch.Groups[1].Value;
+                        return new SqlConnectionDetails
+                        {
+                            ServerHostName = serverHostName,
+                            ServerIpAddress = serverIpAddress,
+                            InstanceName = instanceName,
+                            Port = null,
+                        };
+                    }
+                }
+
+                return new SqlConnectionDetails
+                {
+                    ServerHostName = serverHostName,
+                    ServerIpAddress = serverIpAddress,
+                    InstanceName = null,
+                    Port = null,
+                };
+            }
+
+            string port;
+            if (match.Groups[4].Length > 0)
+            {
+                instanceName = match.Groups[3].Value;
+                port = match.Groups[4].Value;
                 if (port == "1433")
                 {
                     port = null;
                 }
             }
-            else if (int.TryParse(match.Groups[2].Value, out int parsedPort))
+            else if (int.TryParse(match.Groups[3].Value, out int parsedPort))
             {
-                port = parsedPort == 1433 ? null : match.Groups[2].Value;
+                port = parsedPort == 1433 ? null : match.Groups[3].Value;
                 instanceName = null;
             }
             else
             {
-                instanceName = match.Groups[2].Value;
+                instanceName = match.Groups[3].Value;
 
                 if (string.IsNullOrEmpty(instanceName))
                 {

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientInstrumentationOptionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientInstrumentationOptionsTests.cs
@@ -43,6 +43,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests
         [InlineData("127.0.0.1, 1818", null, "127.0.0.1", null, "1818")]
         [InlineData("127.0.0.1  \\  instanceName", null, "127.0.0.1", "instanceName", null)]
         [InlineData("127.0.0.1\\instanceName, 1818", null, "127.0.0.1", "instanceName", "1818")]
+        [InlineData("tcp:127.0.0.1\\instanceName, 1818", null, "127.0.0.1", "instanceName", "1818")]
         [InlineData("tcp:localhost", "localhost", null, null, null)]
         [InlineData("tcp : localhost", "localhost", null, null, null)]
         [InlineData("np : localhost", "localhost", null, null, null)]

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientInstrumentationOptionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientInstrumentationOptionsTests.cs
@@ -43,6 +43,13 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests
         [InlineData("127.0.0.1, 1818", null, "127.0.0.1", null, "1818")]
         [InlineData("127.0.0.1  \\  instanceName", null, "127.0.0.1", "instanceName", null)]
         [InlineData("127.0.0.1\\instanceName, 1818", null, "127.0.0.1", "instanceName", "1818")]
+        [InlineData("tcp:localhost", "localhost", null, null, null)]
+        [InlineData("tcp : localhost", "localhost", null, null, null)]
+        [InlineData("np : localhost", "localhost", null, null, null)]
+        [InlineData("lpc:localhost", "localhost", null, null, null)]
+        [InlineData("np:\\\\localhost\\pipe\\sql\\query", "localhost", null, null, null)]
+        [InlineData("np : \\\\localhost\\pipe\\sql\\query", "localhost", null, null, null)]
+        [InlineData("np:\\\\localhost\\pipe\\MSSQL$instanceName\\sql\\query", "localhost", null, "instanceName", null)]
         public void ParseDataSourceTests(
             string dataSource,
             string expectedServerHostName,


### PR DESCRIPTION
Fixes #1605.

## Changes

Added support for correct parsing of "uncommon" Data Source formats which start with a "protocol" prefix:
* tcp:hostname\instanceName,port
* lpc:hostname
* np:hostname
* np:\\\\hostname\pipe\MSSQL$instanceName\sql\query

See the "Data Source" section [here](https://docs.microsoft.com/dotnet/api/system.data.sqlclient.sqlconnection.connectionstring?view=dotnet-plat-ext-5.0&viewFallbackFrom=net-5.0) for some details on possible formats.