### PR TITLE
Fix bug of recording events of all severity levels in .NET Frameworks in SelfDiagnostics

### DIFF
--- a/src/OpenTelemetry/Internal/SelfDiagnosticsConfigRefresher.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnosticsConfigRefresher.cs
@@ -36,7 +36,7 @@ namespace OpenTelemetry.Internal
     {
         private const int ConfigurationUpdatePeriodMilliSeconds = 10000;
 
-        private static readonly byte[] MessageOnNewFile = Encoding.UTF8.GetBytes("Successfully opened file.");
+        private static readonly byte[] MessageOnNewFile = Encoding.UTF8.GetBytes("Successfully opened file.\n");
 
         private readonly CancellationTokenSource cancellationTokenSource;
         private readonly Task worker;

--- a/src/OpenTelemetry/Internal/SelfDiagnosticsEventListener.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnosticsEventListener.cs
@@ -123,7 +123,7 @@ namespace OpenTelemetry.Internal
                 var buffer = this.writeBuffer.Value;
                 if (buffer == null)
                 {
-                    buffer = new byte[BUFFERSIZE];  // TODO: handle OOM
+                    buffer = new byte[BUFFERSIZE];
                     this.writeBuffer.Value = buffer;
                 }
 
@@ -166,7 +166,8 @@ namespace OpenTelemetry.Internal
             }
             catch (Exception)
             {
-                // One concurrent condition: memory mapped file is disposed in other thread after TryGetLogStream() finishes.
+                // Fail to allocate memory for buffer, or
+                // A concurrent condition: memory mapped file is disposed in other thread after TryGetLogStream() finishes.
                 // In this case, silently fail.
             }
         }

--- a/src/OpenTelemetry/Internal/SelfDiagnosticsEventListener.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnosticsEventListener.cs
@@ -34,6 +34,7 @@ namespace OpenTelemetry.Internal
         // Buffer size of the log line. A UTF-16 encoded character in C# can take up to 4 bytes if encoded in UTF-8.
         private const int BUFFERSIZE = 4 * 5120;
         private const string EventSourceNamePrefix = "OpenTelemetry-";
+        private readonly object lockObj = new object();
         private readonly EventLevel logLevel;
         private readonly SelfDiagnosticsConfigRefresher configRefresher;
         private readonly ThreadLocal<byte[]> writeBuffer = new ThreadLocal<byte[]>(() => null);
@@ -45,7 +46,7 @@ namespace OpenTelemetry.Internal
             this.configRefresher = configRefresher ?? throw new ArgumentNullException(nameof(configRefresher));
 
             List<EventSource> eventSources;
-            lock (this.eventSourcesBeforeConstructor)
+            lock (this.lockObj)
             {
                 eventSources = this.eventSourcesBeforeConstructor;
                 this.eventSourcesBeforeConstructor = null;
@@ -180,7 +181,7 @@ namespace OpenTelemetry.Internal
                 // Thus we should save the event source and enable them later, when code runs in constructor.
                 if (this.eventSourcesBeforeConstructor != null)
                 {
-                    lock (this.eventSourcesBeforeConstructor)
+                    lock (this.lockObj)
                     {
                         if (this.eventSourcesBeforeConstructor != null)
                         {

--- a/src/OpenTelemetry/Internal/SelfDiagnosticsEventListener.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnosticsEventListener.cs
@@ -208,7 +208,6 @@ namespace OpenTelemetry.Internal
         /// <param name="eventData">Data of the EventSource event.</param>
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
-            // TODO: retrieve the file stream object from configRefresher and write to it
             this.WriteEvent(eventData.Message, eventData.Payload);
         }
     }

--- a/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsEventListenerTest.cs
+++ b/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsEventListenerTest.cs
@@ -43,27 +43,6 @@ namespace OpenTelemetry.Internal.Tests
 
         [Fact]
         [Trait("Platform", "Any")]
-        public void SelfDiagnosticsEventListener_WriteEvent()
-        {
-            var configRefresherMock = new Mock<SelfDiagnosticsConfigRefresher>();
-            var memoryMappedFile = MemoryMappedFile.CreateFromFile(LOGFILEPATH, FileMode.Create, null, 1024);
-            Stream stream = memoryMappedFile.CreateViewStream();
-            string eventMessage = "Event Message";
-            int timestampPrefixLength = "2020-08-14T20:33:24.4788109Z:".Length;
-            byte[] bytes = Encoding.UTF8.GetBytes(eventMessage);
-            int availableByteCount = 100;
-            configRefresherMock.Setup(configRefresher => configRefresher.TryGetLogStream(timestampPrefixLength + bytes.Length + 1, out stream, out availableByteCount))
-                .Returns(true);
-            var listener = new SelfDiagnosticsEventListener(EventLevel.Error, configRefresherMock.Object);
-            listener.WriteEvent(eventMessage, null);
-            configRefresherMock.Verify(refresher => refresher.TryGetLogStream(timestampPrefixLength + bytes.Length + 1, out stream, out availableByteCount));
-            stream.Dispose();
-            memoryMappedFile.Dispose();
-            AssertFileOutput(LOGFILEPATH, eventMessage);
-        }
-
-        [Fact]
-        [Trait("Platform", "Any")]
         public void SelfDiagnosticsEventListener_EventSourceSetup_LowerSeverity()
         {
             var configRefresherMock = new Mock<SelfDiagnosticsConfigRefresher>();
@@ -86,6 +65,82 @@ namespace OpenTelemetry.Internal.Tests
             // Emitting an Error event. Or any EventSource event with higher than or equal to to Error severity.
             OpenTelemetrySdkEventSource.Log.TracerProviderException("TestEvent", "Exception Details");
             configRefresherMock.Verify(refresher => refresher.TryGetLogStream(It.IsAny<int>(), out It.Ref<Stream>.IsAny, out It.Ref<int>.IsAny));
+        }
+
+        [Fact]
+        [Trait("Platform", "Any")]
+        public void SelfDiagnosticsEventListener_WriteEvent()
+        {
+            // Arrange
+            var configRefresherMock = new Mock<SelfDiagnosticsConfigRefresher>();
+            var memoryMappedFile = MemoryMappedFile.CreateFromFile(LOGFILEPATH, FileMode.Create, null, 1024);
+            Stream stream = memoryMappedFile.CreateViewStream();
+            string eventMessage = "Event Message";
+            int timestampPrefixLength = "2020-08-14T20:33:24.4788109Z:".Length;
+            byte[] bytes = Encoding.UTF8.GetBytes(eventMessage);
+            int availableByteCount = 100;
+            configRefresherMock.Setup(configRefresher => configRefresher.TryGetLogStream(timestampPrefixLength + bytes.Length + 1, out stream, out availableByteCount))
+                .Returns(true);
+            var listener = new SelfDiagnosticsEventListener(EventLevel.Error, configRefresherMock.Object);
+
+            // Act: call WriteEvent method directly
+            listener.WriteEvent(eventMessage, null);
+
+            // Assert
+            configRefresherMock.Verify(refresher => refresher.TryGetLogStream(timestampPrefixLength + bytes.Length + 1, out stream, out availableByteCount));
+            stream.Dispose();
+            memoryMappedFile.Dispose();
+            AssertFileOutput(LOGFILEPATH, eventMessage);
+        }
+
+        [Fact]
+        [Trait("Platform", "Any")]
+        public void SelfDiagnosticsEventListener_EmitEvent_OmitAsConfigured()
+        {
+            // Arrange
+            var configRefresherMock = new Mock<SelfDiagnosticsConfigRefresher>();
+            var memoryMappedFile = MemoryMappedFile.CreateFromFile(LOGFILEPATH, FileMode.Create, null, 1024);
+            Stream stream = memoryMappedFile.CreateViewStream();
+            configRefresherMock.Setup(configRefresher => configRefresher.TryGetLogStream(It.IsAny<int>(), out stream, out It.Ref<int>.IsAny))
+                .Returns(true);
+            var listener = new SelfDiagnosticsEventListener(EventLevel.Error, configRefresherMock.Object);
+
+            // Act: emit an event with severity lower than configured
+            OpenTelemetrySdkEventSource.Log.ActivityStarted("ActivityStart", "123");
+
+            // Assert
+            configRefresherMock.Verify(refresher => refresher.TryGetLogStream(It.IsAny<int>(), out stream, out It.Ref<int>.IsAny), Times.Never());
+            stream.Dispose();
+            memoryMappedFile.Dispose();
+
+            using FileStream file = File.Open(LOGFILEPATH, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            var buffer = new byte[256];
+            file.Read(buffer, 0, buffer.Length);
+            Assert.Equal('\0', (char)buffer[0]);
+        }
+
+        [Fact]
+        [Trait("Platform", "Any")]
+        public void SelfDiagnosticsEventListener_EmitEvent_CaptureAsConfigured()
+        {
+            // Arrange
+            var configRefresherMock = new Mock<SelfDiagnosticsConfigRefresher>();
+            var memoryMappedFile = MemoryMappedFile.CreateFromFile(LOGFILEPATH, FileMode.Create, null, 1024);
+            Stream stream = memoryMappedFile.CreateViewStream();
+            configRefresherMock.Setup(configRefresher => configRefresher.TryGetLogStream(It.IsAny<int>(), out stream, out It.Ref<int>.IsAny))
+                .Returns(true);
+            var listener = new SelfDiagnosticsEventListener(EventLevel.Verbose, configRefresherMock.Object);
+
+            // Act: emit an event with severity equal to configured
+            OpenTelemetrySdkEventSource.Log.ActivityStarted("ActivityStart", "123");
+
+            // Assert
+            configRefresherMock.Verify(refresher => refresher.TryGetLogStream(It.IsAny<int>(), out stream, out It.Ref<int>.IsAny));
+            stream.Dispose();
+            memoryMappedFile.Dispose();
+
+            var expectedLog = "Activity started. OperationName = '{0}', Id = '{1}'.{ActivityStart}";
+            AssertFileOutput(LOGFILEPATH, expectedLog);
         }
 
         [Fact]
@@ -196,11 +251,16 @@ namespace OpenTelemetry.Internal.Tests
             using FileStream file = File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
             var buffer = new byte[256];
             file.Read(buffer, 0, buffer.Length);
-            string logMessage = Encoding.UTF8.GetString(buffer);
+            string logLine = Encoding.UTF8.GetString(buffer);
+            string logMessage = ParseLogMessage(logLine);
+            Assert.StartsWith(eventMessage, logMessage);
+        }
+
+        private static string ParseLogMessage(string logLine)
+        {
             int timestampPrefixLength = "2020-08-14T20:33:24.4788109Z:".Length;
-            string parsedEventMessage = logMessage.Substring(timestampPrefixLength);
-            Assert.StartsWith(eventMessage, parsedEventMessage);
-            Assert.Matches(@"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}Z:", logMessage.Substring(0, timestampPrefixLength));
+            Assert.Matches(@"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}Z:", logLine.Substring(0, timestampPrefixLength));
+            return logLine.Substring(timestampPrefixLength);
         }
 
         private static void AssertBufferOutput(byte[] expected, byte[] buffer, int startPos, int endPos)

--- a/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsEventListenerTest.cs
+++ b/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsEventListenerTest.cs
@@ -129,17 +129,17 @@ namespace OpenTelemetry.Internal.Tests
             Stream stream = memoryMappedFile.CreateViewStream();
             configRefresherMock.Setup(configRefresher => configRefresher.TryGetLogStream(It.IsAny<int>(), out stream, out It.Ref<int>.IsAny))
                 .Returns(true);
-            var listener = new SelfDiagnosticsEventListener(EventLevel.Verbose, configRefresherMock.Object);
+            var listener = new SelfDiagnosticsEventListener(EventLevel.Error, configRefresherMock.Object);
 
             // Act: emit an event with severity equal to configured
-            OpenTelemetrySdkEventSource.Log.ActivityStarted("ActivityStart", "123");
+            OpenTelemetrySdkEventSource.Log.TracerProviderException("TestEvent", "Exception Details");
 
             // Assert
             configRefresherMock.Verify(refresher => refresher.TryGetLogStream(It.IsAny<int>(), out stream, out It.Ref<int>.IsAny));
             stream.Dispose();
             memoryMappedFile.Dispose();
 
-            var expectedLog = "Activity started. OperationName = '{0}', Id = '{1}'.{ActivityStart}";
+            var expectedLog = "Unknown error in TracerProvider '{0}': '{1}'.{TestEvent}{Exception Details}";
             AssertFileOutput(LOGFILEPATH, expectedLog);
         }
 


### PR DESCRIPTION
Fixes Bug#1 in #1689.

**Bug explanation**

In .NET Frameworks, `OpenTelemetrySdkEventSource` class is initialized before `SelfDiagnosticsEventListener` class. (In .NET Core, it's in the opposite order.)

In this case, `SelfDiagnosticsEventListener`'s constructor gets called after its base class (`EventListener`) [constructor](https://referencesource.microsoft.com/#mscorlib/system/diagnostics/eventing/eventsource.cs,4227), which eventually invokes `SelfDiagnosticsEventListener.OnEventSourceCreated` because it overrides `EventListener.OnEventSourceCreated`. The event sources in `OnEventSourceCreated` will always be enabled with `LogAlways`, the default value of [EventLevel enum](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.tracing.eventlevel?view=net-5.0).

So `SelfDiagnosticsEventListener.OnEventSourceCreated` doesn't have access to parameters passed to constructor, such as the `LogLevel` configuration. Essentially there is no way to pass any values to `SelfDiagnosticsEventListener.OnEventSourceCreated`. All `EventSource` events of any severity levels will always be captured by `SelfDiagnosticsEventListener`.

## Changes

To honor the configuration, I'm storing the event sources in `OnEventSourceCreated` in an array and enable them in constructor where the configuration values are available.