### PR TITLE
Enable integration tests for .NET 5.0

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [netcoreapp2.1,netcoreapp3.1]
+        version: [netcoreapp2.1,netcoreapp3.1,net5.0]
     steps:
       - uses: actions/checkout@v2
       - name: Run redis docker-compose.integration
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [netcoreapp2.1,netcoreapp3.1]
+        version: [netcoreapp2.1,netcoreapp3.1,net5.0]
     steps:
       - uses: actions/checkout@v2
       - name: Run sql docker-compose.integration
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [netcoreapp2.1,netcoreapp3.1]
+        version: [netcoreapp2.1,netcoreapp3.1,net5.0]
     steps:
       - uses: actions/checkout@v2
       - name: Run W3C Trace Context docker-compose.integration

--- a/build/docker-compose.net5.0.yml
+++ b/build/docker-compose.net5.0.yml
@@ -1,0 +1,8 @@
+﻿version: '3.7'
+
+services:
+  tests:
+    build:
+      args:
+        PUBLISH_FRAMEWORK: net5.0
+        SDK_VERSION: 5.0

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/dockerfile
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/dockerfile
@@ -2,17 +2,17 @@
 # This should be run from the root of the repo:
 # docker build --file test/OpenTelemetry.Instrumentation.SqlClient.Tests/dockerfile .
 
-ARG SDK_VERSION=3.1
-FROM mcr.microsoft.com/dotnet/core/sdk:${SDK_VERSION} AS build
+ARG SDK_VERSION=5.0
+FROM mcr.microsoft.com/dotnet/sdk:${SDK_VERSION} AS build
 ARG PUBLISH_CONFIGURATION=Release
-ARG PUBLISH_FRAMEWORK=netcoreapp3.1
+ARG PUBLISH_FRAMEWORK=net5.0
 WORKDIR /repo
 COPY . ./
 RUN ls -la /repo
 WORKDIR "/repo/test/OpenTelemetry.Instrumentation.SqlClient.Tests"
 RUN dotnet publish "OpenTelemetry.Instrumentation.SqlClient.Tests.csproj" -c "${PUBLISH_CONFIGURATION}" -f "${PUBLISH_FRAMEWORK}" -o /drop -p:IntegrationBuild=true -p:TARGET_FRAMEWORK=${PUBLISH_FRAMEWORK}
 
-FROM mcr.microsoft.com/dotnet/core/sdk:${SDK_VERSION} AS final
+FROM mcr.microsoft.com/dotnet/sdk:${SDK_VERSION} AS final
 ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.7.3/wait /wait
 RUN chmod +x /wait
 WORKDIR /test

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/dockerfile
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/dockerfile
@@ -2,16 +2,16 @@
 # This should be run from the root of the repo:
 # docker build --file test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/dockerfile .
 
-ARG SDK_VERSION=3.1
-FROM mcr.microsoft.com/dotnet/core/sdk:${SDK_VERSION} AS build
+ARG SDK_VERSION=5.0
+FROM mcr.microsoft.com/dotnet/sdk:${SDK_VERSION} AS build
 ARG PUBLISH_CONFIGURATION=Release
-ARG PUBLISH_FRAMEWORK=netcoreapp3.1
+ARG PUBLISH_FRAMEWORK=net5.0
 WORKDIR /repo
 COPY . ./
 WORKDIR "/repo/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests"
 RUN dotnet publish "OpenTelemetry.Instrumentation.StackExchangeRedis.Tests.csproj" -c "${PUBLISH_CONFIGURATION}" -f "${PUBLISH_FRAMEWORK}" -o /drop -p:IntegrationBuild=true -p:TARGET_FRAMEWORK=${PUBLISH_FRAMEWORK}
 
-FROM mcr.microsoft.com/dotnet/core/sdk:${SDK_VERSION} AS final
+FROM mcr.microsoft.com/dotnet/sdk:${SDK_VERSION} AS final
 WORKDIR /test
 COPY --from=build /drop .
 ENTRYPOINT ["dotnet", "vstest", "OpenTelemetry.Instrumentation.StackExchangeRedis.Tests.dll"]

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/Dockerfile
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/Dockerfile
@@ -2,22 +2,22 @@
 # This should be run from the root of the repo:
 # docker build --file test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/Dockerfile .
 
-ARG SDK_VERSION=3.1
+ARG SDK_VERSION=5.0
 FROM ubuntu AS w3c
 #Install git
 WORKDIR /w3c
 RUN apt-get update && apt-get install -y git
 RUN git clone https://github.com/w3c/trace-context.git
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 ARG PUBLISH_CONFIGURATION=Release
-ARG PUBLISH_FRAMEWORK=netcoreapp3.1
+ARG PUBLISH_FRAMEWORK=net5.0
 WORKDIR /repo
 COPY . ./
 WORKDIR "/repo/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests"
 RUN dotnet publish "OpenTelemetry.Instrumentation.W3cTraceContext.Tests.csproj" -c "${PUBLISH_CONFIGURATION}" -f "${PUBLISH_FRAMEWORK}" -o /drop -p:IntegrationBuild=true -p:TARGET_FRAMEWORK=${PUBLISH_FRAMEWORK}
 
-FROM mcr.microsoft.com/dotnet/core/sdk:${SDK_VERSION} AS final
+FROM mcr.microsoft.com/dotnet/sdk:${SDK_VERSION} AS final
 WORKDIR /test
 COPY --from=build /drop .
 COPY --from=w3c /w3c .


### PR DESCRIPTION
Fixes #1686.

## Changes

Add integration tests for .NET 5.0.
