### PR TITLE
AssemblyVersion to only use MajorVersion as per dotnet guidelines

### DIFF
--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -23,7 +23,6 @@
     <PropertyGroup>
       <RevisionNumber>0</RevisionNumber>
       <RevisionNumber Condition="$(MinVerVersion.Split(`.`).Length) == 4">$(MinVerVersion.Split(`.`)[3])</RevisionNumber>
-      <AssemblyVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(RevisionNumber)</AssemblyVersion>
       <Version>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(RevisionNumber)</Version>
       <FileVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).$(RevisionNumber)</FileVersion>
     </PropertyGroup>


### PR DESCRIPTION
Fixes #1695 

Also see: https://github.com/open-telemetry/opentelemetry-dotnet/issues/1696

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
