### PR TITLE
Small Zipkin Perf Improvement

### DIFF
--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinEndpoint.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinEndpoint.cs
@@ -117,22 +117,22 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
 
             if (this.ServiceName != null)
             {
-                writer.WriteString("serviceName", this.ServiceName);
+                writer.WriteString(ZipkinSpanJsonHelper.ServiceNamePropertyName, this.ServiceName);
             }
 
             if (this.Ipv4 != null)
             {
-                writer.WriteString("ipv4", this.Ipv4);
+                writer.WriteString(ZipkinSpanJsonHelper.Ipv4PropertyName, this.Ipv4);
             }
 
             if (this.Ipv6 != null)
             {
-                writer.WriteString("ipv6", this.Ipv6);
+                writer.WriteString(ZipkinSpanJsonHelper.Ipv6PropertyName, this.Ipv6);
             }
 
             if (this.Port.HasValue)
             {
-                writer.WriteNumber("port", this.Port.Value);
+                writer.WriteNumber(ZipkinSpanJsonHelper.PortPropertyName, this.Port.Value);
             }
 
             writer.WriteEndObject();

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinSpan.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinSpan.cs
@@ -227,69 +227,69 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
         {
             writer.WriteStartObject();
 
-            writer.WriteString("traceId", this.TraceId);
+            writer.WriteString(ZipkinSpanJsonHelper.TraceIdPropertyName, this.TraceId);
 
             if (this.Name != null)
             {
-                writer.WriteString("name", this.Name);
+                writer.WriteString(ZipkinSpanJsonHelper.NamePropertyName, this.Name);
             }
 
             if (this.ParentId != null)
             {
-                writer.WriteString("parentId", this.ParentId);
+                writer.WriteString(ZipkinSpanJsonHelper.ParentIdPropertyName, this.ParentId);
             }
 
-            writer.WriteString("id", this.Id);
+            writer.WriteString(ZipkinSpanJsonHelper.IdPropertyName, this.Id);
 
             if (this.Kind != null)
             {
-                writer.WriteString("kind", this.Kind);
+                writer.WriteString(ZipkinSpanJsonHelper.KindPropertyName, this.Kind);
             }
 
             if (this.Timestamp.HasValue)
             {
-                writer.WriteNumber("timestamp", this.Timestamp.Value);
+                writer.WriteNumber(ZipkinSpanJsonHelper.TimestampPropertyName, this.Timestamp.Value);
             }
 
             if (this.Duration.HasValue)
             {
-                writer.WriteNumber("duration", this.Duration.Value);
+                writer.WriteNumber(ZipkinSpanJsonHelper.DurationPropertyName, this.Duration.Value);
             }
 
             if (this.Debug.HasValue)
             {
-                writer.WriteBoolean("debug", this.Debug.Value);
+                writer.WriteBoolean(ZipkinSpanJsonHelper.DebugPropertyName, this.Debug.Value);
             }
 
             if (this.Shared.HasValue)
             {
-                writer.WriteBoolean("shared", this.Shared.Value);
+                writer.WriteBoolean(ZipkinSpanJsonHelper.SharedPropertyName, this.Shared.Value);
             }
 
             if (this.LocalEndpoint != null)
             {
-                writer.WritePropertyName("localEndpoint");
+                writer.WritePropertyName(ZipkinSpanJsonHelper.LocalEndpointPropertyName);
                 this.LocalEndpoint.Write(writer);
             }
 
             if (this.RemoteEndpoint != null)
             {
-                writer.WritePropertyName("remoteEndpoint");
+                writer.WritePropertyName(ZipkinSpanJsonHelper.RemoteEndpointPropertyName);
                 this.RemoteEndpoint.Write(writer);
             }
 
             if (!this.Annotations.IsEmpty)
             {
-                writer.WritePropertyName("annotations");
+                writer.WritePropertyName(ZipkinSpanJsonHelper.AnnotationsPropertyName);
                 writer.WriteStartArray();
 
                 foreach (var annotation in this.Annotations)
                 {
                     writer.WriteStartObject();
 
-                    writer.WriteNumber("timestamp", annotation.Timestamp);
+                    writer.WriteNumber(ZipkinSpanJsonHelper.TimestampPropertyName, annotation.Timestamp);
 
-                    writer.WriteString("value", annotation.Value);
+                    writer.WriteString(ZipkinSpanJsonHelper.ValuePropertyName, annotation.Value);
 
                     writer.WriteEndObject();
                 }
@@ -299,7 +299,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
 
             if (!this.Tags.IsEmpty || this.LocalEndpoint.Tags != null)
             {
-                writer.WritePropertyName("tags");
+                writer.WritePropertyName(ZipkinSpanJsonHelper.TagsPropertyName);
                 writer.WriteStartObject();
 
                 // this will be used when we convert int, double, int[], double[] to string

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinSpanJsonHelper.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinSpanJsonHelper.cs
@@ -1,0 +1,61 @@
+// <copyright file="ZipkinSpanJsonHelper.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if !NET452
+using System.Text.Json;
+
+namespace OpenTelemetry.Exporter.Zipkin.Implementation
+{
+    internal static class ZipkinSpanJsonHelper
+    {
+        public static readonly JsonEncodedText TraceIdPropertyName = JsonEncodedText.Encode("traceId");
+
+        public static readonly JsonEncodedText NamePropertyName = JsonEncodedText.Encode("name");
+
+        public static readonly JsonEncodedText ParentIdPropertyName = JsonEncodedText.Encode("parentId");
+
+        public static readonly JsonEncodedText IdPropertyName = JsonEncodedText.Encode("id");
+
+        public static readonly JsonEncodedText KindPropertyName = JsonEncodedText.Encode("kind");
+
+        public static readonly JsonEncodedText TimestampPropertyName = JsonEncodedText.Encode("timestamp");
+
+        public static readonly JsonEncodedText DurationPropertyName = JsonEncodedText.Encode("duration");
+
+        public static readonly JsonEncodedText DebugPropertyName = JsonEncodedText.Encode("debug");
+
+        public static readonly JsonEncodedText SharedPropertyName = JsonEncodedText.Encode("shared");
+
+        public static readonly JsonEncodedText LocalEndpointPropertyName = JsonEncodedText.Encode("localEndpoint");
+
+        public static readonly JsonEncodedText RemoteEndpointPropertyName = JsonEncodedText.Encode("remoteEndpoint");
+
+        public static readonly JsonEncodedText AnnotationsPropertyName = JsonEncodedText.Encode("annotations");
+
+        public static readonly JsonEncodedText ValuePropertyName = JsonEncodedText.Encode("value");
+
+        public static readonly JsonEncodedText TagsPropertyName = JsonEncodedText.Encode("tags");
+
+        public static readonly JsonEncodedText ServiceNamePropertyName = JsonEncodedText.Encode("serviceName");
+
+        public static readonly JsonEncodedText Ipv4PropertyName = JsonEncodedText.Encode("ipv4");
+
+        public static readonly JsonEncodedText Ipv6PropertyName = JsonEncodedText.Encode("ipv6");
+
+        public static readonly JsonEncodedText PortPropertyName = JsonEncodedText.Encode("port");
+    }
+}
+#endif


### PR DESCRIPTION
Reuses the encoded property names to save some processing time when converting spans to Json in Zipkin.

## Before
|                  Method | NumberOfBatches | NumberOfSpans |        Mean |      Error |     StdDev | Completed Work Items | Lock Contentions |      Gen 0 |     Gen 1 | Gen 2 | Allocated |
|------------------------ |---------------- |-------------- |------------:|-----------:|-----------:|---------------------:|-----------------:|-----------:|----------:|------:|----------:|
| ZipkinExporter_Batching |               1 |         10000 |    64.51 ms |   1.083 ms |   1.158 ms |               4.2500 |                - |   125.0000 |         - |     - |   1.71 MB |
| ZipkinExporter_Batching |              10 |         10000 |   600.62 ms |  10.988 ms |  10.278 ms |              24.0000 |                - |  2000.0000 |         - |     - |  16.95 MB |
| ZipkinExporter_Batching |             100 |         10000 | 6,360.48 ms | 124.514 ms | 224.524 ms |             205.0000 |                - | 21000.0000 | 2000.0000 |     - |  169.3 MB |

## After
|                  Method | NumberOfBatches | NumberOfSpans |        Mean |     Error |    StdDev | Completed Work Items | Lock Contentions |      Gen 0 |     Gen 1 | Gen 2 | Allocated |
|------------------------ |---------------- |-------------- |------------:|----------:|----------:|---------------------:|-----------------:|-----------:|----------:|------:|----------:|
| ZipkinExporter_Batching |               1 |         10000 |    56.29 ms |  0.752 ms |  0.703 ms |               4.2000 |                - |   200.0000 |         - |     - |   1.71 MB |
| ZipkinExporter_Batching |              10 |         10000 |   540.61 ms |  9.663 ms |  9.039 ms |              24.0000 |                - |  2000.0000 |         - |     - |  16.95 MB |
| ZipkinExporter_Batching |             100 |         10000 | 5,393.68 ms | 76.291 ms | 63.706 ms |             204.0000 |                - | 21000.0000 | 1000.0000 |     - |  169.3 MB |