### PR TITLE
reference Extensions.Hosting package implicitly in Instrumentation.AspNetCore

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry\OpenTelemetry.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Extensions.Hosting\OpenTelemetry.Extensions.Hosting.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="$(MicrosoftAspNetCoreHttpAbstractionsPkgVer)" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="$(MicrosoftAspNetCoreHttpFeaturesPkgVer)" />
   </ItemGroup>


### PR DESCRIPTION
## Changes

When using `OpenTelemetry.Instrumentation.AspNetCore` we almost always need to reference `OpenTelemetry.Extensions.Hosting` package in order to register OpenTelemetry services in the DI container using `AddOpenTelemetryTracing()`, so I've referenced `OpenTelemetry.Extensions.Hosting` in `OpenTelemetry.Instrumentation.AspNetCore` and now there's no need to install/reference `OpenTelemetry.Extensions.Hosting` explicitly when using AspNetCore instrumentation package.