### PR TITLE
Add propagation to filtered out events from HttpClient

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -6,6 +6,12 @@
   description/reason phrase for outgoing http spans.
   ([#1579](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1579))
 
+* Moved the DiagnosticListener filtering logic from HttpClientInstrumentation
+  ctor to OnStartActivity method of HttpHandlerDiagnosticListener.cs; Updated
+  the logic of OnStartActivity to inject propagation data into Headers for
+  filtered out events as well.
+  ([#1707](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1707))
+
 ## 1.0.0-rc1.1
 
 Released 2020-Nov-17

--- a/src/OpenTelemetry.Instrumentation.Http/HttpClientInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/HttpClientInstrumentation.cs
@@ -33,7 +33,7 @@ namespace OpenTelemetry.Instrumentation.Http
         /// <param name="options">Configuration options for HTTP client instrumentation.</param>
         public HttpClientInstrumentation(ActivitySourceAdapter activitySourceAdapter, HttpClientInstrumentationOptions options)
         {
-            this.diagnosticSourceSubscriber = new DiagnosticSourceSubscriber(new HttpHandlerDiagnosticListener(options, activitySourceAdapter), (activityName, arg1, arg2) => options?.EventFilter(activityName, arg1) ?? true);
+            this.diagnosticSourceSubscriber = new DiagnosticSourceSubscriber(new HttpHandlerDiagnosticListener(options, activitySourceAdapter), null);
             this.diagnosticSourceSubscriber.Subscribe();
         }
 

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpInstrumentationEventSource.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpInstrumentationEventSource.cs
@@ -93,5 +93,11 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
         {
             this.WriteEvent(5, exception);
         }
+
+        [Event(2, Message = "Request is filtered out.", Level = EventLevel.Verbose)]
+        public void RequestIsFilteredOut(string eventName)
+        {
+            this.WriteEvent(2, eventName);
+        }
     }
 }

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpInstrumentationEventSource.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpInstrumentationEventSource.cs
@@ -94,10 +94,10 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
             this.WriteEvent(5, exception);
         }
 
-        [Event(2, Message = "Request is filtered out.", Level = EventLevel.Verbose)]
+        [Event(6, Message = "Request is filtered out.", Level = EventLevel.Verbose)]
         public void RequestIsFilteredOut(string eventName)
         {
-            this.WriteEvent(2, eventName);
+            this.WriteEvent(6, eventName);
         }
     }
 }


### PR DESCRIPTION
Fixes #1561 Item#2

## Changes
-  Moved the filtering logic to HttpHandlerDiagnosticListener.cs  OnStartActivity method from HttpClientInstrumentation.cs
-  Updated logic of OnStartActivity to inject propagation data into Headers for filtered out events as well
