### PR TITLE
Create an activity even when SamplingDecision is Drop

### DIFF
--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -112,7 +112,7 @@ namespace OpenTelemetry.Trace
             else if (sampler is AlwaysOffSampler)
             {
                 listener.Sample = (ref ActivityCreationOptions<ActivityContext> options) =>
-                    !Sdk.SuppressInstrumentation ? PropagateOrIgnoreData(options.Parent.TraceId) : ActivitySamplingResult.None;
+                    !Sdk.SuppressInstrumentation ? ActivitySamplingResult.PropagationData : ActivitySamplingResult.None;
             }
             else
             {
@@ -287,23 +287,9 @@ namespace OpenTelemetry.Trace
                 {
                     options.SamplingTags.Add(att.Key, att.Value);
                 }
-
-                return activitySamplingResult;
             }
 
-            return PropagateOrIgnoreData(options.Parent.TraceId);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static ActivitySamplingResult PropagateOrIgnoreData(ActivityTraceId traceId)
-        {
-            var isRootSpan = traceId == default;
-
-            // If it is the root span select PropagationData so the trace ID is preserved
-            // even if no activity of the trace is recorded (sampled per OpenTelemetry parlance).
-            return isRootSpan
-                ? ActivitySamplingResult.PropagationData
-                : ActivitySamplingResult.None;
+            return activitySamplingResult;
         }
     }
 }

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
@@ -162,8 +162,6 @@ namespace OpenTelemetry.Trace.Tests
 
             using (var activity = activitySource.StartActivity("root"))
             {
-                // Even if sampling returns false, for root activities,
-                // activity is still created with PropagationOnly.
                 Assert.NotNull(activity);
                 Assert.True(activity.IsAllDataRequested);
                 Assert.False(activity.Recorded);
@@ -176,7 +174,7 @@ namespace OpenTelemetry.Trace.Tests
 
             using (var activity = activitySource.StartActivity("root"))
             {
-                // Even if sampling returns false, for root activities,
+                // Even if sampling returns false,
                 // activity is still created with PropagationOnly.
                 Assert.NotNull(activity);
                 Assert.False(activity.IsAllDataRequested);
@@ -184,9 +182,11 @@ namespace OpenTelemetry.Trace.Tests
 
                 using (var innerActivity = activitySource.StartActivity("inner"))
                 {
-                    // This is not a root activity.
-                    // If sampling returns false, no activity is created at all.
-                    Assert.Null(innerActivity);
+                    // If sampling returns false, activity is created with PropagationOnly regardless
+                    // of whether the activity is root or not.
+                    Assert.NotNull(activity);
+                    Assert.False(activity.IsAllDataRequested);
+                    Assert.False(activity.Recorded);
                 }
             }
         }


### PR DESCRIPTION
Fixes #1709.

## Changes

-  Return ActivitySamplingResult.Propagation when SamplingDecision is Drop and the activity is not root
-  This is to comply with the spec requirement of always creating a span regardless of the Sampling Decision