### PR TITLE
Use Trace.WriteLine instead of Debug.WriteLine for the Debug option

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -10,6 +10,10 @@
   `ConsoleExporter` to get rid of type specific check in the class
   ([#1593](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1593))
 
+* Replaced Debug.WriteLine with Trace.WriteLine to display the logs to the Debug
+  window with Release configuration
+  ([#1719](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1719))
+
 ## 1.0.0-rc1.1
 
 Released 2020-Nov-17

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporter.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System.Diagnostics;
-
 namespace OpenTelemetry.Exporter
 {
     public abstract class ConsoleExporter<T> : BaseExporter<T>
@@ -37,7 +35,7 @@ namespace OpenTelemetry.Exporter
 
             if (this.options.Targets.HasFlag(ConsoleExporterOutputTargets.Debug))
             {
-                Debug.WriteLine(message);
+                System.Diagnostics.Trace.WriteLine(message);
             }
         }
     }


### PR DESCRIPTION
Fixes #1718 

## Changes
- Replaced Debug.WriteLine with Trace.WriteLine in ConsoleExporter.cs