### PR TITLE
Resource attributes fix

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -22,6 +22,10 @@
 * Added check in `ActivitySourceAdapter` class for root activity if traceid is
   overridden by calling `SetParentId`
   ([#1355](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1355))
+* Resource Attributes now accept int, short, and float as values, converting
+  them to supported data types (long for int/short, double for float). For
+  invalid attributes we now throw an exception instead of logging an error.
+  ([#1720](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1720))
 
 ## 1.0.0-rc1.1
 

--- a/test/OpenTelemetry.Tests/Resources/ResourceTest.cs
+++ b/test/OpenTelemetry.Tests/Resources/ResourceTest.cs
@@ -46,15 +46,8 @@ namespace OpenTelemetry.Resources.Tests
             // Arrange
             var attributes = new Dictionary<string, object> { { "NullValue", null } };
 
-            // Act
-            var resource = new Resource(attributes);
-
-            // Assert
-            Assert.Single(resource.Attributes);
-
-            var attribute = resource.Attributes.Single();
-            Assert.Equal("NullValue", attribute.Key);
-            Assert.Empty((string)attribute.Value);
+            // Act and Assert
+            Assert.Throws<ArgumentException>(() => new Resource(attributes));
         }
 
         [Fact]
@@ -139,15 +132,25 @@ namespace OpenTelemetry.Resources.Tests
                 { "long", 1L },
                 { "bool", true },
                 { "double", 0.1d },
+
+                // int and float supported by conversion to long and double
+                { "int", 1 },
+                { "short", (short)1 },
+                { "float", 0.1f },
             };
 
             var resource = new Resource(attributes);
 
-            Assert.Equal(4, resource.Attributes.Count());
+            Assert.Equal(7, resource.Attributes.Count());
             Assert.Contains(new KeyValuePair<string, object>("string", "stringValue"), resource.Attributes);
             Assert.Contains(new KeyValuePair<string, object>("long", 1L), resource.Attributes);
             Assert.Contains(new KeyValuePair<string, object>("bool", true), resource.Attributes);
             Assert.Contains(new KeyValuePair<string, object>("double", 0.1d), resource.Attributes);
+            Assert.Contains(new KeyValuePair<string, object>("int", 1L), resource.Attributes);
+            Assert.Contains(new KeyValuePair<string, object>("short", 1L), resource.Attributes);
+
+            double convertedFloat = Convert.ToDouble(0.1f, System.Globalization.CultureInfo.InvariantCulture);
+            Assert.Contains(new KeyValuePair<string, object>("float", convertedFloat), resource.Attributes);
         }
 
         [Fact]
@@ -158,16 +161,9 @@ namespace OpenTelemetry.Resources.Tests
                 { "dynamic", new { } },
                 { "array", new int[1] },
                 { "complex", this },
-                { "float", 0.1f },
             };
 
-            var resource = new Resource(attributes);
-
-            Assert.Equal(4, resource.Attributes.Count());
-            Assert.Contains(new KeyValuePair<string, object>("dynamic", string.Empty), resource.Attributes);
-            Assert.Contains(new KeyValuePair<string, object>("array", string.Empty), resource.Attributes);
-            Assert.Contains(new KeyValuePair<string, object>("complex", string.Empty), resource.Attributes);
-            Assert.Contains(new KeyValuePair<string, object>("float", string.Empty), resource.Attributes);
+            Assert.Throws<ArgumentException>(() => new Resource(attributes));
         }
 
         [Fact]


### PR DESCRIPTION
I messed up with Git commands on PR #1647 and accidentally added a whole host of various changes that I could not undo. The work has been recovered here but for discussion, please refer to the conversation in that request.

**This is my first time working on a change that would require a rework of a unit test. Please let me know if I have done that incorrectly.**

Fixes #1606 .

## Changes

Resource Attributes fixed to allow the values of key-value pairs to be of any object type, matching the behavior of Activity's SetTag method.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
