### PR TITLE
Added instructions to setup Jaegar locally using Docker

### DIFF
--- a/examples/Console/TestJaegerExporter.cs
+++ b/examples/Console/TestJaegerExporter.cs
@@ -23,6 +23,22 @@ namespace Examples.Console
     {
         internal static object Run(string host, int port)
         {
+            // Prerequisite for running this example.
+            // Setup Jaegar inside local docker using following command (Source: https://www.jaegertracing.io/docs/1.21/getting-started/#all-in-one):
+            /*
+            $ docker run -d --name jaeger \
+            -e COLLECTOR_ZIPKIN_HTTP_PORT=9411 \
+            -p 5775:5775/udp \
+            -p 6831:6831/udp \
+            -p 6832:6832/udp \
+            -p 5778:5778 \
+            -p 16686:16686 \
+            -p 14268:14268 \
+            -p 14250:14250 \
+            -p 9411:9411 \
+            jaegertracing/all-in-one:1.21
+            */
+
             // To run this example, run the following command from
             // the reporoot\examples\Console\.
             // (eg: C:\repos\opentelemetry-dotnet\examples\Console\)


### PR DESCRIPTION
## Changes
- Added instructions to run Jaegar locally using Docker to the TestJaegarExporter sample code
