### PR TITLE
Resource merge precedence

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -22,6 +22,10 @@
 * Added check in `ActivitySourceAdapter` class for root activity if traceid is
   overridden by calling `SetParentId`
   ([#1355](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1355))
+* Resource Attributes now accept int, short, and float as values, converting
+  them to supported data types (long for int/short, double for float). For
+  invalid attributes we now throw an exception instead of logging an error.
+  ([#1720](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1720))
 
 ## 1.0.0-rc1.1
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -26,9 +26,9 @@
   them to supported data types (long for int/short, double for float). For
   invalid attributes we now throw an exception instead of logging an error.
   ([#1720](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1720))
-* Merging "this" resource with another previously kept "this" resource's
-  attributes in the event of a conflict. We've rectified to follow a recent
-  change to the spec, where we now prioritize the incoming resource's tags.
+* Merging "this" resource with an "other" resource now prioritizes the "other"
+  resource's attributes in a conflict. We've rectified to follow a recent
+  change to the spec. We previously prioritized "this" resource's tags.
   ([#1728](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1728))
 
 ## 1.0.0-rc1.1

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -26,6 +26,10 @@
   them to supported data types (long for int/short, double for float). For
   invalid attributes we now throw an exception instead of logging an error.
   ([#1720](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1720))
+* Merging "this" resource with another previously kept "this" resource's
+  attributes in the event of a conflict. We've rectified to follow a recent
+  change to the spec, where we now prioritize the incoming resource's tags.
+  ([#1728](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1728))
 
 ## 1.0.0-rc1.1
 

--- a/src/OpenTelemetry/Resources/Resource.cs
+++ b/src/OpenTelemetry/Resources/Resource.cs
@@ -58,9 +58,9 @@ namespace OpenTelemetry.Resources
 
         /// <summary>
         /// Returns a new, merged <see cref="Resource"/> by merging the old <see cref="Resource"/> with the
-        /// <code>other</code> <see cref="Resource"/>. In case of a collision the other <see cref="Resource"/> takes precedence.
+        /// <c>other</c> <see cref="Resource"/>. In case of a collision the other <see cref="Resource"/> takes precedence.
         /// </summary>
-        /// <param name="other">The <see cref="Resource"/> that will be merged with. <code>this</code>.</param>
+        /// <param name="other">The <see cref="Resource"/> that will be merged with <c>this</c>.</param>
         /// <returns><see cref="Resource"/>.</returns>
         public Resource Merge(Resource other)
         {

--- a/src/OpenTelemetry/Resources/Resource.cs
+++ b/src/OpenTelemetry/Resources/Resource.cs
@@ -57,7 +57,7 @@ namespace OpenTelemetry.Resources
         public IEnumerable<KeyValuePair<string, object>> Attributes { get; }
 
         /// <summary>
-        /// Returns a new, merged <see cref="Resource"/> by merging the old <see cref="Resource"/> with the.
+        /// Returns a new, merged <see cref="Resource"/> by merging the old <see cref="Resource"/> with the
         /// <code>other</code> <see cref="Resource"/>. In case of a collision the other <see cref="Resource"/> takes precedence.
         /// </summary>
         /// <param name="other">The <see cref="Resource"/> that will be merged with. <code>this</code>.</param>

--- a/src/OpenTelemetry/Resources/Resource.cs
+++ b/src/OpenTelemetry/Resources/Resource.cs
@@ -57,8 +57,8 @@ namespace OpenTelemetry.Resources
         public IEnumerable<KeyValuePair<string, object>> Attributes { get; }
 
         /// <summary>
-        /// Returns a new, merged <see cref="Resource"/> by merging the current <see cref="Resource"/> with the.
-        /// <code>other</code> <see cref="Resource"/>. In case of a collision the current <see cref="Resource"/> takes precedence.
+        /// Returns a new, merged <see cref="Resource"/> by merging the old <see cref="Resource"/> with the.
+        /// <code>other</code> <see cref="Resource"/>. In case of a collision the other <see cref="Resource"/> takes precedence.
         /// </summary>
         /// <param name="other">The <see cref="Resource"/> that will be merged with. <code>this</code>.</param>
         /// <returns><see cref="Resource"/>.</returns>
@@ -66,22 +66,22 @@ namespace OpenTelemetry.Resources
         {
             var newAttributes = new Dictionary<string, object>();
 
-            foreach (var attribute in this.Attributes)
-            {
-                if (!newAttributes.TryGetValue(attribute.Key, out var value) || (value is string strValue && string.IsNullOrEmpty(strValue)))
-                {
-                    newAttributes[attribute.Key] = attribute.Value;
-                }
-            }
-
             if (other != null)
             {
                 foreach (var attribute in other.Attributes)
                 {
-                    if (!newAttributes.TryGetValue(attribute.Key, out var value) || (value is string strValue && string.IsNullOrEmpty(strValue)))
+                    if (!newAttributes.TryGetValue(attribute.Key, out var value))
                     {
                         newAttributes[attribute.Key] = attribute.Value;
                     }
+                }
+            }
+
+            foreach (var attribute in this.Attributes)
+            {
+                if (!newAttributes.TryGetValue(attribute.Key, out var value))
+                {
+                    newAttributes[attribute.Key] = attribute.Value;
                 }
             }
 

--- a/test/OpenTelemetry.Tests/Resources/ResourceTest.cs
+++ b/test/OpenTelemetry.Tests/Resources/ResourceTest.cs
@@ -46,15 +46,8 @@ namespace OpenTelemetry.Resources.Tests
             // Arrange
             var attributes = new Dictionary<string, object> { { "NullValue", null } };
 
-            // Act
-            var resource = new Resource(attributes);
-
-            // Assert
-            Assert.Single(resource.Attributes);
-
-            var attribute = resource.Attributes.Single();
-            Assert.Equal("NullValue", attribute.Key);
-            Assert.Empty((string)attribute.Value);
+            // Act and Assert
+            Assert.Throws<ArgumentException>(() => new Resource(attributes));
         }
 
         [Fact]
@@ -139,15 +132,25 @@ namespace OpenTelemetry.Resources.Tests
                 { "long", 1L },
                 { "bool", true },
                 { "double", 0.1d },
+
+                // int and float supported by conversion to long and double
+                { "int", 1 },
+                { "short", (short)1 },
+                { "float", 0.1f },
             };
 
             var resource = new Resource(attributes);
 
-            Assert.Equal(4, resource.Attributes.Count());
+            Assert.Equal(7, resource.Attributes.Count());
             Assert.Contains(new KeyValuePair<string, object>("string", "stringValue"), resource.Attributes);
             Assert.Contains(new KeyValuePair<string, object>("long", 1L), resource.Attributes);
             Assert.Contains(new KeyValuePair<string, object>("bool", true), resource.Attributes);
             Assert.Contains(new KeyValuePair<string, object>("double", 0.1d), resource.Attributes);
+            Assert.Contains(new KeyValuePair<string, object>("int", 1L), resource.Attributes);
+            Assert.Contains(new KeyValuePair<string, object>("short", 1L), resource.Attributes);
+
+            double convertedFloat = Convert.ToDouble(0.1f, System.Globalization.CultureInfo.InvariantCulture);
+            Assert.Contains(new KeyValuePair<string, object>("float", convertedFloat), resource.Attributes);
         }
 
         [Fact]
@@ -158,16 +161,9 @@ namespace OpenTelemetry.Resources.Tests
                 { "dynamic", new { } },
                 { "array", new int[1] },
                 { "complex", this },
-                { "float", 0.1f },
             };
 
-            var resource = new Resource(attributes);
-
-            Assert.Equal(4, resource.Attributes.Count());
-            Assert.Contains(new KeyValuePair<string, object>("dynamic", string.Empty), resource.Attributes);
-            Assert.Contains(new KeyValuePair<string, object>("array", string.Empty), resource.Attributes);
-            Assert.Contains(new KeyValuePair<string, object>("complex", string.Empty), resource.Attributes);
-            Assert.Contains(new KeyValuePair<string, object>("float", string.Empty), resource.Attributes);
+            Assert.Throws<ArgumentException>(() => new Resource(attributes));
         }
 
         [Fact]

--- a/test/OpenTelemetry.Tests/Resources/ResourceTest.cs
+++ b/test/OpenTelemetry.Tests/Resources/ResourceTest.cs
@@ -315,19 +315,19 @@ namespace OpenTelemetry.Resources.Tests
         }
 
         [Fact]
-        public void MergeResource_SecondaryCanOverridePrimaryEmptyAttributeValue()
+        public void MergeResource_UpdatingResourceOverridesCurrentResource()
         {
             // Arrange
-            var primaryAttributes = new Dictionary<string, object> { { "value", string.Empty } };
-            var secondaryAttributes = new Dictionary<string, object> { { "value", "not empty" } };
-            var primaryResource = new Resource(primaryAttributes);
-            var secondaryResource = new Resource(secondaryAttributes);
+            var currentAttributes = new Dictionary<string, object> { { "value", "currentValue" } };
+            var updatingAttributes = new Dictionary<string, object> { { "value", "updatedValue" } };
+            var currentResource = new Resource(currentAttributes);
+            var updatingResource = new Resource(updatingAttributes);
 
-            var newResource = primaryResource.Merge(secondaryResource);
+            var newResource = currentResource.Merge(updatingResource);
 
             // Assert
             Assert.Single(newResource.Attributes);
-            Assert.Contains(new KeyValuePair<string, object>("value", "not empty"), newResource.Attributes);
+            Assert.Contains(new KeyValuePair<string, object>("value", "updatedValue"), newResource.Attributes);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #1712 

## Changes

When merging an "other" resource to "this" resource, we previously kept the values from "this" resource in conflicts. Due to recent changes in the OTel specification, this has been reversed to always use the incoming resource's attributes.


For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
