### PR TITLE
Use a ubuntu based image for integration tests

### DIFF
--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/dockerfile
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/dockerfile
@@ -3,7 +3,7 @@
 # docker build --file test/OpenTelemetry.Instrumentation.SqlClient.Tests/dockerfile .
 
 ARG SDK_VERSION=5.0
-FROM mcr.microsoft.com/dotnet/sdk:${SDK_VERSION} AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS build
 ARG PUBLISH_CONFIGURATION=Release
 ARG PUBLISH_FRAMEWORK=net5.0
 WORKDIR /repo

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/dockerfile
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/dockerfile
@@ -2,8 +2,8 @@
 # This should be run from the root of the repo:
 # docker build --file test/OpenTelemetry.Instrumentation.SqlClient.Tests/dockerfile .
 
-ARG SDK_VERSION=5.0-focal
-FROM mcr.microsoft.com/dotnet/sdk:${SDK_VERSION} AS build
+ARG SDK_VERSION=5.0
+FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS build
 ARG PUBLISH_CONFIGURATION=Release
 ARG PUBLISH_FRAMEWORK=net5.0
 WORKDIR /repo

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/dockerfile
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/dockerfile
@@ -2,8 +2,8 @@
 # This should be run from the root of the repo:
 # docker build --file test/OpenTelemetry.Instrumentation.SqlClient.Tests/dockerfile .
 
-ARG SDK_VERSION=5.0
-FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS build
+ARG SDK_VERSION=5.0-focal
+FROM mcr.microsoft.com/dotnet/sdk:${SDK_VERSION} AS build
 ARG PUBLISH_CONFIGURATION=Release
 ARG PUBLISH_FRAMEWORK=net5.0
 WORKDIR /repo

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/dockerfile
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/dockerfile
@@ -2,8 +2,8 @@
 # This should be run from the root of the repo:
 # docker build --file test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/dockerfile .
 
-ARG SDK_VERSION=5.0
-FROM mcr.microsoft.com/dotnet/sdk:${SDK_VERSION} AS build
+ARG SDK_VERSION=5.0-focal
+FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS build
 ARG PUBLISH_CONFIGURATION=Release
 ARG PUBLISH_FRAMEWORK=net5.0
 WORKDIR /repo

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/dockerfile
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/dockerfile
@@ -2,8 +2,8 @@
 # This should be run from the root of the repo:
 # docker build --file test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/dockerfile .
 
-ARG SDK_VERSION=5.0-focal
-FROM mcr.microsoft.com/dotnet/sdk:${SDK_VERSION} AS build
+ARG SDK_VERSION=5.0
+FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS build
 ARG PUBLISH_CONFIGURATION=Release
 ARG PUBLISH_FRAMEWORK=net5.0
 WORKDIR /repo

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/dockerfile
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/dockerfile
@@ -3,7 +3,7 @@
 # docker build --file test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/dockerfile .
 
 ARG SDK_VERSION=5.0-focal
-FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS build
+FROM mcr.microsoft.com/dotnet/sdk:${SDK_VERSION} AS build
 ARG PUBLISH_CONFIGURATION=Release
 ARG PUBLISH_FRAMEWORK=net5.0
 WORKDIR /repo

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/dockerfile
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/dockerfile
@@ -3,7 +3,7 @@
 # docker build --file test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/dockerfile .
 
 ARG SDK_VERSION=5.0-focal
-FROM mcr.microsoft.com/dotnet/sdk:${SDK_VERSION} AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS build
 ARG PUBLISH_CONFIGURATION=Release
 ARG PUBLISH_FRAMEWORK=net5.0
 WORKDIR /repo
@@ -11,7 +11,7 @@ COPY . ./
 WORKDIR "/repo/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests"
 RUN dotnet publish "OpenTelemetry.Instrumentation.StackExchangeRedis.Tests.csproj" -c "${PUBLISH_CONFIGURATION}" -f "${PUBLISH_FRAMEWORK}" -o /drop -p:IntegrationBuild=true -p:TARGET_FRAMEWORK=${PUBLISH_FRAMEWORK}
 
-FROM mcr.microsoft.com/dotnet/sdk:${SDK_VERSION} AS final
+FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS final
 WORKDIR /test
 COPY --from=build /drop .
 ENTRYPOINT ["dotnet", "vstest", "OpenTelemetry.Instrumentation.StackExchangeRedis.Tests.dll"]

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/dockerfile
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/dockerfile
@@ -3,7 +3,7 @@
 # docker build --file test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/dockerfile .
 
 ARG SDK_VERSION=5.0-focal
-FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS build
+FROM mcr.microsoft.com/dotnet/sdk:${SDK_VERSION} AS build
 ARG PUBLISH_CONFIGURATION=Release
 ARG PUBLISH_FRAMEWORK=net5.0
 WORKDIR /repo
@@ -11,7 +11,7 @@ COPY . ./
 WORKDIR "/repo/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests"
 RUN dotnet publish "OpenTelemetry.Instrumentation.StackExchangeRedis.Tests.csproj" -c "${PUBLISH_CONFIGURATION}" -f "${PUBLISH_FRAMEWORK}" -o /drop -p:IntegrationBuild=true -p:TARGET_FRAMEWORK=${PUBLISH_FRAMEWORK}
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS final
+FROM mcr.microsoft.com/dotnet/sdk:${SDK_VERSION} AS final
 WORKDIR /test
 COPY --from=build /drop .
 ENTRYPOINT ["dotnet", "vstest", "OpenTelemetry.Instrumentation.StackExchangeRedis.Tests.dll"]

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/Dockerfile
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/Dockerfile
@@ -2,14 +2,14 @@
 # This should be run from the root of the repo:
 # docker build --file test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/Dockerfile .
 
-ARG SDK_VERSION=5.0
+ARG SDK_VERSION=5.0-focal
 FROM ubuntu AS w3c
 #Install git
 WORKDIR /w3c
 RUN apt-get update && apt-get install -y git
 RUN git clone https://github.com/w3c/trace-context.git
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:${SDK_VERSION} AS build
 ARG PUBLISH_CONFIGURATION=Release
 ARG PUBLISH_FRAMEWORK=net5.0
 WORKDIR /repo

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/Dockerfile
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/Dockerfile
@@ -2,14 +2,14 @@
 # This should be run from the root of the repo:
 # docker build --file test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/Dockerfile .
 
-ARG SDK_VERSION=5.0-focal
+ARG SDK_VERSION=5.0
 FROM ubuntu AS w3c
 #Install git
 WORKDIR /w3c
 RUN apt-get update && apt-get install -y git
 RUN git clone https://github.com/w3c/trace-context.git
 
-FROM mcr.microsoft.com/dotnet/sdk:${SDK_VERSION} AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS build
 ARG PUBLISH_CONFIGURATION=Release
 ARG PUBLISH_FRAMEWORK=net5.0
 WORKDIR /repo


### PR DESCRIPTION
Attempt to use a different image (Ubuntu vs debian), as dotnet restore is failing from inside the docker for .net 5.0 projects.

Not sure yet, why this repo is affected (https://devblogs.microsoft.com/nuget/microsoft-author-signing-certificate-update/#who-will-be-impacted), but this is done to unblock PRs as every CI is failing on integration tests now.

Update:
This workaround is now the official one recommended by nuget: https://status.nuget.org/