### PR TITLE
Fix resource attribute telemetry.sdk.version

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -39,6 +39,7 @@
 * Metrics removed as it is not part 1.0.0 release. See issue
   [#1501](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1655)
   for details on Metric release plans.
+* Fix Resource attribute telemetry.sdk.version to have correct file version.
 
 ## 1.0.0-rc1.1
 

--- a/src/OpenTelemetry/Resources/ResourceBuilderExtensions.cs
+++ b/src/OpenTelemetry/Resources/ResourceBuilderExtensions.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace OpenTelemetry.Resources
 {
@@ -24,13 +25,13 @@ namespace OpenTelemetry.Resources
     /// </summary>
     public static class ResourceBuilderExtensions
     {
-        private static readonly Version Version = typeof(Resource).Assembly.GetName().Version;
+        private static readonly string FileVersion = FileVersionInfo.GetVersionInfo(typeof(Resource).Assembly.Location).FileVersion;
 
         private static Resource TelemetryResource { get; } = new Resource(new Dictionary<string, object>
         {
             [ResourceSemanticConventions.AttributeTelemetrySdkName] = "opentelemetry",
             [ResourceSemanticConventions.AttributeTelemetrySdkLanguage] = "dotnet",
-            [ResourceSemanticConventions.AttributeTelemetrySdkVersion] = Version.ToString(),
+            [ResourceSemanticConventions.AttributeTelemetrySdkVersion] = FileVersion,
         });
 
         /// <summary>


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-dotnet/pull/1697/files fixed assembly version to be in line with .NET recommendation. As it produces same assembly version for every release (until major version change), it cannot be used as Resource "telemetry.sdk.version". This PR uses assembly file version as replacement .
eg: 1.0.0.82

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
