### PR TITLE
IsAllDataRequested true after ending

### DIFF
--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -99,7 +99,11 @@ namespace OpenTelemetry.Trace
 
                     // Spec says IsRecording must be false once span ends.
                     // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#isrecording
-                    activity.IsAllDataRequested = false;
+                    // However, Activity has slightly different semantic
+                    // than Span and we don't have strong reason to do this
+                    // now, as Activity anyway allows read/write always.
+                    // Intentionally commenting the following line.
+                    // activity.IsAllDataRequested = false;
 
                     if (SuppressInstrumentationScope.DecrementIfTriggered() == 0)
                     {

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -97,9 +97,9 @@ namespace OpenTelemetry.Trace
                         return;
                     }
 
-                    // Spec says IsRecording must be true once span ends.
+                    // Spec says IsRecording must be false once span ends.
                     // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#isrecording
-                    activity.IsAllDataRequested = true;
+                    activity.IsAllDataRequested = false;
 
                     if (SuppressInstrumentationScope.DecrementIfTriggered() == 0)
                     {

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -97,6 +97,10 @@ namespace OpenTelemetry.Trace
                         return;
                     }
 
+                    // Spec says IsRecording must be true once span ends.
+                    // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#isrecording
+                    activity.IsAllDataRequested = true;
+
                     if (SuppressInstrumentationScope.DecrementIfTriggered() == 0)
                     {
                         this.processor?.OnEnd(activity);


### PR DESCRIPTION
Opening this to get feedback on this spec requirement.
Given the fact that .NET's Activity doesn't become read-only after ending, this is not really having an impact.
