### PR TITLE
ActivitySourceAdapter sampling is internal-only

### DIFF
--- a/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
+++ b/src/OpenTelemetry/Trace/ActivitySourceAdapter.cs
@@ -15,8 +15,11 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq.Expressions;
+using System.Reflection;
+using System.Reflection.Emit;
 using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Trace
@@ -40,8 +43,9 @@ namespace OpenTelemetry.Trace
     {
         private static readonly Action<Activity, ActivityKind> SetKindProperty = CreateActivityKindSetter();
         private static readonly Action<Activity, ActivitySource> SetActivitySourceProperty = CreateActivitySourceSetter();
+        private static readonly Func<ActivitySource, Activity, ActivityContext, SampleResult> CallSamplersFunc = CreateCallSamplersFunc();
         private readonly Sampler sampler;
-        private readonly Action<Activity> getRequestedDataAction;
+        private readonly Action<ActivitySource, Activity> getRequestedDataAction;
         private BaseProcessor<Activity> activityProcessor;
 
         internal ActivitySourceAdapter(Sampler sampler, BaseProcessor<Activity> activityProcessor)
@@ -80,7 +84,7 @@ namespace OpenTelemetry.Trace
 
             SetActivitySourceProperty(activity, source);
             SetKindProperty(activity, kind);
-            this.getRequestedDataAction(activity);
+            this.getRequestedDataAction(source, activity);
             if (activity.IsAllDataRequested)
             {
                 this.activityProcessor?.OnStart(activity);
@@ -122,18 +126,213 @@ namespace OpenTelemetry.Trace
             return Expression.Lambda<Action<Activity, ActivityKind>>(body, instance, propertyValue).Compile();
         }
 
-        private void RunGetRequestedDataAlwaysOnSampler(Activity activity)
+        /*
+            Build a dynamic method for invoking the sample method on all listeners.
+
+            Based on this: https://github.com/dotnet/runtime/blob/f2148079d4476073bb5e79277b557807ed0c9984/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivitySource.cs#L194-L216
+
+            SampleResult Sample(ActivitySource activitySource, Activity activity, ActivityContext activityContext)
+            {
+                SynchronizedList<ActivityListener>? listeners = _listeners;
+                if (listeners == null || listeners.Count == 0)
+                {
+                    return new SampleResult(ActivitySamplingResult.None, null);
+                }
+
+                ActivitySamplingResult samplingResult = default;
+
+                ActivityCreationOptions<ActivityContext> aco = new ActivityCreationOptions<ActivityContext>(activitySource, activity.DisplayName, activityContext, activity.Kind, activity.TagObjects, activity.Links);
+
+                listeners.EnumWithFunc((ActivityListener listener, ref ActivityCreationOptions<ActivityContext> data, ref ActivitySamplingResult result, ref ActivityCreationOptions<ActivityContext> unused) => {
+                    SampleActivity<ActivityContext>? sample = listener.Sample;
+                    if (sample != null)
+                    {
+                        ActivitySamplingResult dr = sample(ref data);
+                        if (dr > result)
+                        {
+                            result = dr;
+                        }
+                    }
+                }, ref aco, ref samplingResult, ref aco);
+
+                return new SampleResult(samplingResult, aco._samplerTags);
+            }
+        */
+        private static Func<ActivitySource, Activity, ActivityContext, SampleResult> CreateCallSamplersFunc()
+        {
+            Type activitySourceType = typeof(ActivitySource);
+            Type activityType = typeof(Activity);
+
+            var dynamicMethod = new DynamicMethod(
+                nameof(ActivitySourceAdapter),
+                typeof(SampleResult),
+                new[] { activitySourceType, typeof(Activity), typeof(ActivityContext) },
+                typeof(ActivitySourceAdapter).Module,
+                skipVisibility: true);
+
+            FieldInfo listenersField = activitySourceType.GetField("_listeners", BindingFlags.Instance | BindingFlags.NonPublic);
+            if (listenersField == null)
+            {
+                throw new InvalidOperationException("_listeners field could not be found on ActivitySource.");
+            }
+
+            Type functionType = null;
+            MethodInfo enumWithFuncClosureMethod = null;
+            FieldInfo compilerTypeField = null;
+            FieldInfo enumWithFuncClosureDelegate = null;
+
+            foreach (Type nestedType in activitySourceType.GetNestedTypes(BindingFlags.Instance | BindingFlags.NonPublic))
+            {
+                if (nestedType.Name.StartsWith("Function"))
+                {
+                    functionType = nestedType;
+                    continue;
+                }
+
+                if (nestedType.Name != "<>c")
+                {
+                    continue;
+                }
+
+                foreach (MethodInfo compilerMethod in nestedType.GetMethods(BindingFlags.Instance | BindingFlags.NonPublic))
+                {
+                    if (!compilerMethod.Name.StartsWith("<StartActivity>"))
+                    {
+                        continue;
+                    }
+
+                    ParameterInfo[] parameters = compilerMethod.GetParameters();
+                    if (parameters.Length == 4 && parameters[3].Name == "unused")
+                    {
+                        enumWithFuncClosureMethod = compilerMethod;
+                        break;
+                    }
+                }
+
+                foreach (FieldInfo compilerField in nestedType.GetFields(BindingFlags.Static | BindingFlags.Public))
+                {
+                    if (compilerField.FieldType.Name == "<>c")
+                    {
+                        compilerTypeField = compilerField;
+                        continue;
+                    }
+
+                    if (compilerField.FieldType.Name.StartsWith("Function"))
+                    {
+                        Type[] genericArguments = compilerField.FieldType.GetGenericArguments();
+                        if (genericArguments.Length == 2 && genericArguments[0] == typeof(ActivityListener) && genericArguments[1] == typeof(ActivityContext))
+                        {
+                            enumWithFuncClosureDelegate = compilerField;
+                            continue;
+                        }
+                    }
+                }
+            }
+
+            if (functionType == null)
+            {
+                throw new InvalidOperationException("Function type could not be found on ActivitySource.");
+            }
+
+            if (enumWithFuncClosureMethod == null || compilerTypeField == null || enumWithFuncClosureDelegate == null)
+            {
+                throw new InvalidOperationException("StartActivity closure could not be found on ActivitySource.");
+            }
+
+            var generator = dynamicMethod.GetILGenerator();
+
+            Label returnNullLabel = generator.DefineLabel();
+            Label performLogicLabel = generator.DefineLabel();
+            Label delegateExistsLabel = generator.DefineLabel();
+
+            generator.DeclareLocal(listenersField.FieldType); // listeners
+            generator.DeclareLocal(typeof(ActivityCreationOptions<ActivityContext>)); // aco
+            generator.DeclareLocal(typeof(ActivitySamplingResult)); // samplingResult
+
+            // SynchronizedList<ActivityListener>? listeners = _listeners;
+            generator.Emit(OpCodes.Ldarg_0);
+            generator.Emit(OpCodes.Ldfld, listenersField);
+            generator.Emit(OpCodes.Stloc_0);
+
+            // if (listeners == null || listeners.Count == 0) return ActivitySamplingResult.None
+            generator.Emit(OpCodes.Ldloc_0);
+            generator.Emit(OpCodes.Brfalse_S, returnNullLabel);
+            generator.Emit(OpCodes.Ldloc_0);
+            generator.Emit(OpCodes.Callvirt, listenersField.FieldType.GetProperty("Count").GetMethod);
+            generator.Emit(OpCodes.Brtrue_S, performLogicLabel);
+
+            generator.MarkLabel(returnNullLabel);
+            generator.Emit(OpCodes.Ldc_I4_0); // ActivitySamplingResult.None
+            generator.Emit(OpCodes.Ldnull); // null
+            generator.Emit(OpCodes.Newobj, typeof(SampleResult).GetConstructor(new Type[] { typeof(ActivitySamplingResult), typeof(ActivityTagsCollection) }));
+            generator.Emit(OpCodes.Ret);
+
+            generator.MarkLabel(performLogicLabel);
+
+            generator.Emit(OpCodes.Ldloca_S, 1); // &aco
+            generator.Emit(OpCodes.Ldarg_0); // activitySource
+
+            generator.Emit(OpCodes.Ldarg_1); // activity
+            generator.Emit(OpCodes.Callvirt, activityType.GetProperty("DisplayName").GetMethod); // activity.DisplayName
+
+            generator.Emit(OpCodes.Ldarg_2); // activityContext
+
+            generator.Emit(OpCodes.Ldarg_1); // activity
+            generator.Emit(OpCodes.Callvirt, activityType.GetProperty("Kind").GetMethod); // activity.Kind
+
+            generator.Emit(OpCodes.Ldarg_1); // activity
+            generator.Emit(OpCodes.Callvirt, activityType.GetProperty("TagObjects").GetMethod); // activity.TagObjects
+
+            generator.Emit(OpCodes.Ldarg_1); // activity
+            generator.Emit(OpCodes.Callvirt, activityType.GetProperty("Links").GetMethod); // activity.Links
+
+            // aco = new ActivityCreationOptions<ActivityContext>(activitySource, activity.Name, activityContext, activity.Kind, activity.TagObjects, activity.Links)
+            generator.Emit(OpCodes.Call, typeof(ActivityCreationOptions<ActivityContext>).GetConstructor(
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                null,
+                new Type[] { activitySourceType, typeof(string), typeof(ActivityContext), typeof(ActivityKind), typeof(IEnumerable<KeyValuePair<string, object>>), typeof(IEnumerable<ActivityLink>) },
+                null));
+
+            generator.Emit(OpCodes.Ldloc_0); // listeners
+
+            generator.Emit(OpCodes.Ldsfld, enumWithFuncClosureDelegate); // loading the delegate for the closure
+            generator.Emit(OpCodes.Dup);
+            generator.Emit(OpCodes.Brtrue_S, delegateExistsLabel);
+            generator.Emit(OpCodes.Pop);
+            generator.Emit(OpCodes.Ldsfld, compilerTypeField);
+            generator.Emit(OpCodes.Ldftn, enumWithFuncClosureMethod);
+            generator.Emit(OpCodes.Newobj, functionType.MakeGenericType(typeof(ActivityListener), typeof(ActivityContext)).GetConstructors()[0]);
+            generator.Emit(OpCodes.Dup);
+            generator.Emit(OpCodes.Stsfld, enumWithFuncClosureDelegate);
+
+            generator.MarkLabel(delegateExistsLabel);
+
+            generator.Emit(OpCodes.Ldloca_S, 1); // &aco
+            generator.Emit(OpCodes.Ldloca_S, 2); // &samplingResult
+            generator.Emit(OpCodes.Ldloca_S, 1); // &aco
+            generator.Emit(OpCodes.Callvirt, listenersField.FieldType.GetMethod("EnumWithFunc").MakeGenericMethod(typeof(ActivityContext))); // listeners.EnumWithFunc
+
+            generator.Emit(OpCodes.Ldloc_2); // samplingResult
+            generator.Emit(OpCodes.Ldloca_S, 1); // &aco
+            generator.Emit(OpCodes.Ldfld, typeof(ActivityCreationOptions<ActivityContext>).GetField("_samplerTags", BindingFlags.Instance | BindingFlags.NonPublic)); // aco._samplerTags
+            generator.Emit(OpCodes.Newobj, typeof(SampleResult).GetConstructor(new Type[] { typeof(ActivitySamplingResult), typeof(ActivityTagsCollection) }));
+            generator.Emit(OpCodes.Ret);
+
+            return (Func<ActivitySource, Activity, ActivityContext, SampleResult>)dynamicMethod.CreateDelegate(typeof(Func<ActivitySource, Activity, ActivityContext, SampleResult>));
+        }
+
+        private void RunGetRequestedDataAlwaysOnSampler(ActivitySource activitySource, Activity activity)
         {
             activity.IsAllDataRequested = true;
             activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
         }
 
-        private void RunGetRequestedDataAlwaysOffSampler(Activity activity)
+        private void RunGetRequestedDataAlwaysOffSampler(ActivitySource activitySource, Activity activity)
         {
             activity.IsAllDataRequested = false;
         }
 
-        private void RunGetRequestedDataOtherSampler(Activity activity)
+        private void RunGetRequestedDataOtherSampler(ActivitySource activitySource, Activity activity)
         {
             ActivityContext parentContext;
 
@@ -157,37 +356,44 @@ namespace OpenTelemetry.Trace
                     isRemote: true);
             }
 
-            var samplingParameters = new SamplingParameters(
-                parentContext,
-                activity.TraceId,
-                activity.DisplayName,
-                activity.Kind,
-                activity.TagObjects,
-                activity.Links);
+            SampleResult samplingResult = CallSamplersFunc(activitySource, activity, parentContext);
 
-            var samplingResult = this.sampler.ShouldSample(samplingParameters);
-
-            switch (samplingResult.Decision)
+            switch (samplingResult.ActivitySamplingResult)
             {
-                case SamplingDecision.Drop:
+                case ActivitySamplingResult.PropagationData:
                     activity.IsAllDataRequested = false;
                     break;
-                case SamplingDecision.RecordOnly:
+                case ActivitySamplingResult.AllData:
                     activity.IsAllDataRequested = true;
                     break;
-                case SamplingDecision.RecordAndSample:
+                case ActivitySamplingResult.AllDataAndRecorded:
                     activity.IsAllDataRequested = true;
                     activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
                     break;
             }
 
-            if (samplingResult.Decision != SamplingDecision.Drop)
+            if (samplingResult.ActivityTagsCollection != null
+                && samplingResult.ActivitySamplingResult != ActivitySamplingResult.None
+                && samplingResult.ActivitySamplingResult != ActivitySamplingResult.None)
             {
-                foreach (var att in samplingResult.Attributes)
+                foreach (var att in samplingResult.ActivityTagsCollection)
                 {
                     activity.SetTag(att.Key, att.Value);
                 }
             }
+        }
+
+        private readonly struct SampleResult
+        {
+            public SampleResult(ActivitySamplingResult activitySamplingResult, ActivityTagsCollection samplingTags)
+            {
+                this.ActivitySamplingResult = activitySamplingResult;
+                this.ActivityTagsCollection = samplingTags;
+            }
+
+            public ActivitySamplingResult ActivitySamplingResult { get; }
+
+            public ActivityTagsCollection ActivityTagsCollection { get; }
         }
     }
 }


### PR DESCRIPTION
The .NET API allows anyone to register an `ActivityListener` like this:

```csharp
            using var activityListener = new ActivityListener
            {
                ShouldListenTo = source => source.Name == myActivitySourceName,
                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
            };

            ActivitySource.AddActivityListener(activityListener);
```

The `Sample` call will apply to any `Activity` sent through where `ShouldListenTo` resolves to `true`. In the case of multiple listeners, the highest level of sampling returned wins. This means users can participate in OpenTelemetry sampling if they so desire.

`ActivitySourceAdapter` however only runs the OpenTelemetry sampling.

## Changes

`ActivitySourceAdapter` will now sample using all the registered listeners.

## Example

This test case is a good example of what this fix accomplishes:

https://github.com/open-telemetry/opentelemetry-dotnet/blob/e962c8da0d2d1c53c7b2f8180d52828b6541522e/test/OpenTelemetry.Tests/Trace/ActivitySourceAdapterTest.cs#L270-L290

External ActivityListener impacting the OpenTelemetry sampling decision.

## TODOs

* [ ] `CHANGELOG.md` updated for non-trivial changes

