### PR TITLE
Relax System.* package upper bounds.

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -40,7 +40,7 @@
     <OpenTracingPkgVer>[0.12.1,0.13)</OpenTracingPkgVer>
     <StackExchangeRedisPkgVer>[2.1.58,3.0)</StackExchangeRedisPkgVer>
     <StyleCopAnalyzersPkgVer>[1.1.118,2.0)</StyleCopAnalyzersPkgVer>
-    <SystemCollectionsImmutablePkgVer>1.4.0)</SystemCollectionsImmutablePkgVer>
+    <SystemCollectionsImmutablePkgVer>1.4.0</SystemCollectionsImmutablePkgVer>
     <SystemDiagnosticSourcePkgVer>5.0.1</SystemDiagnosticSourcePkgVer>
     <SystemReflectionEmitLightweightPkgVer>4.7.0</SystemReflectionEmitLightweightPkgVer>
     <SystemTextJsonPkgVer>4.7.0</SystemTextJsonPkgVer>

--- a/build/Common.props
+++ b/build/Common.props
@@ -40,11 +40,11 @@
     <OpenTracingPkgVer>[0.12.1,0.13)</OpenTracingPkgVer>
     <StackExchangeRedisPkgVer>[2.1.58,3.0)</StackExchangeRedisPkgVer>
     <StyleCopAnalyzersPkgVer>[1.1.118,2.0)</StyleCopAnalyzersPkgVer>
-    <SystemCollectionsImmutablePkgVer>[1.4.0,6.0)</SystemCollectionsImmutablePkgVer>
-    <SystemDiagnosticSourcePkgVer>5.0.0</SystemDiagnosticSourcePkgVer>
-    <SystemReflectionEmitLightweightPkgVer>[4.7.0,6.0)</SystemReflectionEmitLightweightPkgVer>
-    <SystemTextJsonPkgVer>[4.7.0,6.0)</SystemTextJsonPkgVer>
-    <SystemThreadingTasksExtensionsPkgVer>[4.5.3,6.0)</SystemThreadingTasksExtensionsPkgVer>
+    <SystemCollectionsImmutablePkgVer>1.4.0)</SystemCollectionsImmutablePkgVer>
+    <SystemDiagnosticSourcePkgVer>5.0.1</SystemDiagnosticSourcePkgVer>
+    <SystemReflectionEmitLightweightPkgVer>4.7.0</SystemReflectionEmitLightweightPkgVer>
+    <SystemTextJsonPkgVer>4.7.0</SystemTextJsonPkgVer>
+    <SystemThreadingTasksExtensionsPkgVer>4.5.3</SystemThreadingTasksExtensionsPkgVer>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Relax System.* packages version requirement to remove upper bound.
+  Require System.Diagnostics.DiagnosticSource package 5.0.1.
+
 ## 1.0.0-rc2
 
 Released 2021-Jan-29

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Relax System.* packages version requirement to remove upper bound.
-  Require System.Diagnostics.DiagnosticSource package 5.0.1.
+* Require System.Diagnostics.DiagnosticSource package 5.0.1.
 
 ## 1.0.0-rc2
 


### PR DESCRIPTION
Remove upper bound restriction for System.* packages as these are expected to not introduce breaking changes.

Also require 5.0.1 of DS package, as per this discussion: https://github.com/open-telemetry/opentelemetry-dotnet/pull/1745#discussion_r567023082 


## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
