### PR TITLE
Fix namespace for exporters

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/.publicApi/net452/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Console/.publicApi/net452/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
-OpenTelemetry.Exporter.Console.ConsoleActivityExporter
-OpenTelemetry.Exporter.Console.ConsoleActivityExporter.ConsoleActivityExporter(OpenTelemetry.Exporter.ConsoleExporterOptions options) -> void
+OpenTelemetry.Exporter.ConsoleActivityExporter
+OpenTelemetry.Exporter.ConsoleActivityExporter.ConsoleActivityExporter(OpenTelemetry.Exporter.ConsoleExporterOptions options) -> void
 OpenTelemetry.Exporter.ConsoleExporter<T>
 OpenTelemetry.Exporter.ConsoleExporter<T>.ConsoleExporter(OpenTelemetry.Exporter.ConsoleExporterOptions options) -> void
 OpenTelemetry.Exporter.ConsoleExporter<T>.WriteLine(string message) -> void
@@ -11,5 +11,5 @@ OpenTelemetry.Exporter.ConsoleExporterOutputTargets
 OpenTelemetry.Exporter.ConsoleExporterOutputTargets.Console = 1 -> OpenTelemetry.Exporter.ConsoleExporterOutputTargets
 OpenTelemetry.Exporter.ConsoleExporterOutputTargets.Debug = 2 -> OpenTelemetry.Exporter.ConsoleExporterOutputTargets
 OpenTelemetry.Trace.ConsoleExporterHelperExtensions
-override OpenTelemetry.Exporter.Console.ConsoleActivityExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) -> OpenTelemetry.ExportResult
+override OpenTelemetry.Exporter.ConsoleActivityExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) -> OpenTelemetry.ExportResult
 static OpenTelemetry.Trace.ConsoleExporterHelperExtensions.AddConsoleExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.ConsoleExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Exporter.Console/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Console/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
-OpenTelemetry.Exporter.Console.ConsoleActivityExporter
-OpenTelemetry.Exporter.Console.ConsoleActivityExporter.ConsoleActivityExporter(OpenTelemetry.Exporter.ConsoleExporterOptions options) -> void
-OpenTelemetry.Exporter.Console.ConsoleLogRecordExporter
-OpenTelemetry.Exporter.Console.ConsoleLogRecordExporter.ConsoleLogRecordExporter(OpenTelemetry.Exporter.ConsoleExporterOptions options) -> void
+OpenTelemetry.Exporter.ConsoleActivityExporter
+OpenTelemetry.Exporter.ConsoleActivityExporter.ConsoleActivityExporter(OpenTelemetry.Exporter.ConsoleExporterOptions options) -> void
+OpenTelemetry.Exporter.ConsoleLogRecordExporter
+OpenTelemetry.Exporter.ConsoleLogRecordExporter.ConsoleLogRecordExporter(OpenTelemetry.Exporter.ConsoleExporterOptions options) -> void
 OpenTelemetry.Exporter.ConsoleExporter<T>
 OpenTelemetry.Exporter.ConsoleExporter<T>.ConsoleExporter(OpenTelemetry.Exporter.ConsoleExporterOptions options) -> void
 OpenTelemetry.Exporter.ConsoleExporter<T>.WriteLine(string message) -> void
@@ -14,7 +14,7 @@ OpenTelemetry.Exporter.ConsoleExporterOutputTargets.Console = 1 -> OpenTelemetry
 OpenTelemetry.Exporter.ConsoleExporterOutputTargets.Debug = 2 -> OpenTelemetry.Exporter.ConsoleExporterOutputTargets
 OpenTelemetry.Trace.ConsoleExporterHelperExtensions
 OpenTelemetry.Logs.ConsoleExporterLoggingExtensions
-override OpenTelemetry.Exporter.Console.ConsoleActivityExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) -> OpenTelemetry.ExportResult
-override OpenTelemetry.Exporter.Console.ConsoleLogRecordExporter.Export(in OpenTelemetry.Batch<OpenTelemetry.Logs.LogRecord> batch) -> OpenTelemetry.ExportResult
+override OpenTelemetry.Exporter.ConsoleActivityExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) -> OpenTelemetry.ExportResult
+override OpenTelemetry.Exporter.ConsoleLogRecordExporter.Export(in OpenTelemetry.Batch<OpenTelemetry.Logs.LogRecord> batch) -> OpenTelemetry.ExportResult
 static OpenTelemetry.Trace.ConsoleExporterHelperExtensions.AddConsoleExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.ConsoleExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Logs.ConsoleExporterLoggingExtensions.AddConsoleExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions loggerOptions, System.Action<OpenTelemetry.Exporter.ConsoleExporterOptions> configure = null) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions

--- a/src/OpenTelemetry.Exporter.Console/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Console/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
-OpenTelemetry.Exporter.Console.ConsoleActivityExporter
-OpenTelemetry.Exporter.Console.ConsoleActivityExporter.ConsoleActivityExporter(OpenTelemetry.Exporter.ConsoleExporterOptions options) -> void
-OpenTelemetry.Exporter.Console.ConsoleLogRecordExporter
-OpenTelemetry.Exporter.Console.ConsoleLogRecordExporter.ConsoleLogRecordExporter(OpenTelemetry.Exporter.ConsoleExporterOptions options) -> void
+OpenTelemetry.Exporter.ConsoleActivityExporter
+OpenTelemetry.Exporter.ConsoleActivityExporter.ConsoleActivityExporter(OpenTelemetry.Exporter.ConsoleExporterOptions options) -> void
+OpenTelemetry.Exporter.ConsoleLogRecordExporter
+OpenTelemetry.Exporter.ConsoleLogRecordExporter.ConsoleLogRecordExporter(OpenTelemetry.Exporter.ConsoleExporterOptions options) -> void
 OpenTelemetry.Exporter.ConsoleExporter<T>
 OpenTelemetry.Exporter.ConsoleExporter<T>.ConsoleExporter(OpenTelemetry.Exporter.ConsoleExporterOptions options) -> void
 OpenTelemetry.Exporter.ConsoleExporter<T>.WriteLine(string message) -> void
@@ -14,7 +14,7 @@ OpenTelemetry.Exporter.ConsoleExporterOutputTargets.Console = 1 -> OpenTelemetry
 OpenTelemetry.Exporter.ConsoleExporterOutputTargets.Debug = 2 -> OpenTelemetry.Exporter.ConsoleExporterOutputTargets
 OpenTelemetry.Trace.ConsoleExporterHelperExtensions
 OpenTelemetry.Logs.ConsoleExporterLoggingExtensions
-override OpenTelemetry.Exporter.Console.ConsoleActivityExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) -> OpenTelemetry.ExportResult
-override OpenTelemetry.Exporter.Console.ConsoleLogRecordExporter.Export(in OpenTelemetry.Batch<OpenTelemetry.Logs.LogRecord> batch) -> OpenTelemetry.ExportResult
+override OpenTelemetry.Exporter.ConsoleActivityExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) -> OpenTelemetry.ExportResult
+override OpenTelemetry.Exporter.ConsoleLogRecordExporter.Export(in OpenTelemetry.Batch<OpenTelemetry.Logs.LogRecord> batch) -> OpenTelemetry.ExportResult
 static OpenTelemetry.Trace.ConsoleExporterHelperExtensions.AddConsoleExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.ConsoleExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Logs.ConsoleExporterLoggingExtensions.AddConsoleExporter(this OpenTelemetry.Logs.OpenTelemetryLoggerOptions loggerOptions, System.Action<OpenTelemetry.Exporter.ConsoleExporterOptions> configure = null) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Moved `ConsoleActivityExporter` and `ConsoleLogRecordExporter` classes to
+  `OpenTelemetry.Exporter` namespace.
+  ([#1770](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1770))
+
 ## 1.0.0-rc2
 
 Released 2021-Jan-29

--- a/src/OpenTelemetry.Exporter.Console/ConsoleActivityExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleActivityExporter.cs
@@ -19,7 +19,7 @@ using System.Diagnostics;
 using System.Linq;
 using OpenTelemetry.Resources;
 
-namespace OpenTelemetry.Exporter.Console
+namespace OpenTelemetry.Exporter
 {
     public class ConsoleActivityExporter : ConsoleExporter<Activity>
     {

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterHelperExtensions.cs
@@ -15,9 +15,7 @@
 // </copyright>
 
 using System;
-using System.Diagnostics;
 using OpenTelemetry.Exporter;
-using OpenTelemetry.Exporter.Console;
 
 namespace OpenTelemetry.Trace
 {

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterLoggingExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterLoggingExtensions.cs
@@ -17,7 +17,6 @@
 #if NET461 || NETSTANDARD2_0
 using System;
 using OpenTelemetry.Exporter;
-using OpenTelemetry.Exporter.Console;
 
 namespace OpenTelemetry.Logs
 {

--- a/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
@@ -18,7 +18,7 @@
 using System;
 using OpenTelemetry.Logs;
 
-namespace OpenTelemetry.Exporter.Console
+namespace OpenTelemetry.Exporter
 {
     public class ConsoleLogRecordExporter : ConsoleExporter<LogRecord>
     {

--- a/src/OpenTelemetry.Exporter.Jaeger/.publicApi/net46/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Jaeger/.publicApi/net46/PublicAPI.Unshipped.txt
@@ -1,20 +1,20 @@
-OpenTelemetry.Exporter.Jaeger.JaegerExporter
-OpenTelemetry.Exporter.Jaeger.JaegerExporter.JaegerExporter(OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions options) -> void
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentHost.get -> string
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentHost.set -> void
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentPort.get -> int
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentPort.set -> void
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.BatchExportProcessorOptions.set -> void
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ExportProcessorType.set -> void
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.JaegerExporterOptions() -> void
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.MaxPayloadSizeInBytes.get -> int?
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.MaxPayloadSizeInBytes.set -> void
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ProcessTags.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ProcessTags.set -> void
+OpenTelemetry.Exporter.JaegerExporter
+OpenTelemetry.Exporter.JaegerExporter.JaegerExporter(OpenTelemetry.Exporter.JaegerExporterOptions options) -> void
+OpenTelemetry.Exporter.JaegerExporterOptions
+OpenTelemetry.Exporter.JaegerExporterOptions.AgentHost.get -> string
+OpenTelemetry.Exporter.JaegerExporterOptions.AgentHost.set -> void
+OpenTelemetry.Exporter.JaegerExporterOptions.AgentPort.get -> int
+OpenTelemetry.Exporter.JaegerExporterOptions.AgentPort.set -> void
+OpenTelemetry.Exporter.JaegerExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
+OpenTelemetry.Exporter.JaegerExporterOptions.BatchExportProcessorOptions.set -> void
+OpenTelemetry.Exporter.JaegerExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
+OpenTelemetry.Exporter.JaegerExporterOptions.ExportProcessorType.set -> void
+OpenTelemetry.Exporter.JaegerExporterOptions.JaegerExporterOptions() -> void
+OpenTelemetry.Exporter.JaegerExporterOptions.MaxPayloadSizeInBytes.get -> int?
+OpenTelemetry.Exporter.JaegerExporterOptions.MaxPayloadSizeInBytes.set -> void
+OpenTelemetry.Exporter.JaegerExporterOptions.ProcessTags.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>
+OpenTelemetry.Exporter.JaegerExporterOptions.ProcessTags.set -> void
 OpenTelemetry.Trace.JaegerExporterHelperExtensions
-override OpenTelemetry.Exporter.Jaeger.JaegerExporter.Dispose(bool disposing) -> void
-override OpenTelemetry.Exporter.Jaeger.JaegerExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> activityBatch) -> OpenTelemetry.ExportResult
-static OpenTelemetry.Trace.JaegerExporterHelperExtensions.AddJaegerExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
+override OpenTelemetry.Exporter.JaegerExporter.Dispose(bool disposing) -> void
+override OpenTelemetry.Exporter.JaegerExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> activityBatch) -> OpenTelemetry.ExportResult
+static OpenTelemetry.Trace.JaegerExporterHelperExtensions.AddJaegerExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.JaegerExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Exporter.Jaeger/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Jaeger/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,20 +1,20 @@
-OpenTelemetry.Exporter.Jaeger.JaegerExporter
-OpenTelemetry.Exporter.Jaeger.JaegerExporter.JaegerExporter(OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions options) -> void
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentHost.get -> string
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentHost.set -> void
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentPort.get -> int
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentPort.set -> void
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.BatchExportProcessorOptions.set -> void
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ExportProcessorType.set -> void
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.JaegerExporterOptions() -> void
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.MaxPayloadSizeInBytes.get -> int?
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.MaxPayloadSizeInBytes.set -> void
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ProcessTags.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ProcessTags.set -> void
+OpenTelemetry.Exporter.JaegerExporter
+OpenTelemetry.Exporter.JaegerExporter.JaegerExporter(OpenTelemetry.Exporter.JaegerExporterOptions options) -> void
+OpenTelemetry.Exporter.JaegerExporterOptions
+OpenTelemetry.Exporter.JaegerExporterOptions.AgentHost.get -> string
+OpenTelemetry.Exporter.JaegerExporterOptions.AgentHost.set -> void
+OpenTelemetry.Exporter.JaegerExporterOptions.AgentPort.get -> int
+OpenTelemetry.Exporter.JaegerExporterOptions.AgentPort.set -> void
+OpenTelemetry.Exporter.JaegerExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
+OpenTelemetry.Exporter.JaegerExporterOptions.BatchExportProcessorOptions.set -> void
+OpenTelemetry.Exporter.JaegerExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
+OpenTelemetry.Exporter.JaegerExporterOptions.ExportProcessorType.set -> void
+OpenTelemetry.Exporter.JaegerExporterOptions.JaegerExporterOptions() -> void
+OpenTelemetry.Exporter.JaegerExporterOptions.MaxPayloadSizeInBytes.get -> int?
+OpenTelemetry.Exporter.JaegerExporterOptions.MaxPayloadSizeInBytes.set -> void
+OpenTelemetry.Exporter.JaegerExporterOptions.ProcessTags.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>
+OpenTelemetry.Exporter.JaegerExporterOptions.ProcessTags.set -> void
 OpenTelemetry.Trace.JaegerExporterHelperExtensions
-override OpenTelemetry.Exporter.Jaeger.JaegerExporter.Dispose(bool disposing) -> void
-override OpenTelemetry.Exporter.Jaeger.JaegerExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> activityBatch) -> OpenTelemetry.ExportResult
-static OpenTelemetry.Trace.JaegerExporterHelperExtensions.AddJaegerExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
+override OpenTelemetry.Exporter.JaegerExporter.Dispose(bool disposing) -> void
+override OpenTelemetry.Exporter.JaegerExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> activityBatch) -> OpenTelemetry.ExportResult
+static OpenTelemetry.Trace.JaegerExporterHelperExtensions.AddJaegerExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.JaegerExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Exporter.Jaeger/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Jaeger/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,20 +1,20 @@
-OpenTelemetry.Exporter.Jaeger.JaegerExporter
-OpenTelemetry.Exporter.Jaeger.JaegerExporter.JaegerExporter(OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions options) -> void
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentHost.get -> string
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentHost.set -> void
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentPort.get -> int
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.AgentPort.set -> void
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.BatchExportProcessorOptions.set -> void
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ExportProcessorType.set -> void
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.JaegerExporterOptions() -> void
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.MaxPayloadSizeInBytes.get -> int?
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.MaxPayloadSizeInBytes.set -> void
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ProcessTags.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>
-OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions.ProcessTags.set -> void
+OpenTelemetry.Exporter.JaegerExporter
+OpenTelemetry.Exporter.JaegerExporter.JaegerExporter(OpenTelemetry.Exporter.JaegerExporterOptions options) -> void
+OpenTelemetry.Exporter.JaegerExporterOptions
+OpenTelemetry.Exporter.JaegerExporterOptions.AgentHost.get -> string
+OpenTelemetry.Exporter.JaegerExporterOptions.AgentHost.set -> void
+OpenTelemetry.Exporter.JaegerExporterOptions.AgentPort.get -> int
+OpenTelemetry.Exporter.JaegerExporterOptions.AgentPort.set -> void
+OpenTelemetry.Exporter.JaegerExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
+OpenTelemetry.Exporter.JaegerExporterOptions.BatchExportProcessorOptions.set -> void
+OpenTelemetry.Exporter.JaegerExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
+OpenTelemetry.Exporter.JaegerExporterOptions.ExportProcessorType.set -> void
+OpenTelemetry.Exporter.JaegerExporterOptions.JaegerExporterOptions() -> void
+OpenTelemetry.Exporter.JaegerExporterOptions.MaxPayloadSizeInBytes.get -> int?
+OpenTelemetry.Exporter.JaegerExporterOptions.MaxPayloadSizeInBytes.set -> void
+OpenTelemetry.Exporter.JaegerExporterOptions.ProcessTags.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>
+OpenTelemetry.Exporter.JaegerExporterOptions.ProcessTags.set -> void
 OpenTelemetry.Trace.JaegerExporterHelperExtensions
-override OpenTelemetry.Exporter.Jaeger.JaegerExporter.Dispose(bool disposing) -> void
-override OpenTelemetry.Exporter.Jaeger.JaegerExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> activityBatch) -> OpenTelemetry.ExportResult
-static OpenTelemetry.Trace.JaegerExporterHelperExtensions.AddJaegerExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Jaeger.JaegerExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
+override OpenTelemetry.Exporter.JaegerExporter.Dispose(bool disposing) -> void
+override OpenTelemetry.Exporter.JaegerExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> activityBatch) -> OpenTelemetry.ExportResult
+static OpenTelemetry.Trace.JaegerExporterHelperExtensions.AddJaegerExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.JaegerExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Moved `JaegerExporter` and `JaegerExporterOptions` classes to
+  `OpenTelemetry.Exporter` namespace.
+  ([#1770](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1770))
+
 ## 1.0.0-rc2
 
 Released 2021-Jan-29

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
@@ -24,7 +24,7 @@ using Thrift.Protocol;
 using Thrift.Transport;
 using Process = OpenTelemetry.Exporter.Jaeger.Implementation.Process;
 
-namespace OpenTelemetry.Exporter.Jaeger
+namespace OpenTelemetry.Exporter
 {
     public class JaegerExporter : BaseExporter<Activity>
     {

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterHelperExtensions.cs
@@ -15,8 +15,7 @@
 // </copyright>
 
 using System;
-using System.Diagnostics;
-using OpenTelemetry.Exporter.Jaeger;
+using OpenTelemetry.Exporter;
 
 namespace OpenTelemetry.Trace
 {

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptions.cs
@@ -17,7 +17,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 
-namespace OpenTelemetry.Exporter.Jaeger
+namespace OpenTelemetry.Exporter
 {
     public class JaegerExporterOptions
     {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net452/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net452/PublicAPI.Unshipped.txt
@@ -1,20 +1,20 @@
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpTraceExporter
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpTraceExporter.OtlpTraceExporter(OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions options) -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.BatchExportProcessorOptions.set -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.ChannelOptions.get -> System.Collections.Generic.IEnumerable<Grpc.Core.ChannelOption>
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.ChannelOptions.set -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.Credentials.get -> Grpc.Core.ChannelCredentials
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.Credentials.set -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.Endpoint.get -> string
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.Endpoint.set -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.ExportProcessorType.set -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.Headers.get -> Grpc.Core.Metadata
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.Headers.set -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.OtlpExporterOptions() -> void
+OpenTelemetry.Exporter.OtlpTraceExporter
+OpenTelemetry.Exporter.OtlpTraceExporter.OtlpTraceExporter(OpenTelemetry.Exporter.OtlpExporterOptions options) -> void
+OpenTelemetry.Exporter.OtlpExporterOptions
+OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
+OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.ChannelOptions.get -> System.Collections.Generic.IEnumerable<Grpc.Core.ChannelOption>
+OpenTelemetry.Exporter.OtlpExporterOptions.ChannelOptions.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.Credentials.get -> Grpc.Core.ChannelCredentials
+OpenTelemetry.Exporter.OtlpExporterOptions.Credentials.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.get -> string
+OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
+OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.Headers.get -> Grpc.Core.Metadata
+OpenTelemetry.Exporter.OtlpExporterOptions.Headers.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.OtlpExporterOptions() -> void
 OpenTelemetry.Trace.OtlpTraceExporterHelperExtensions
-override OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpTraceExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> activityBatch) -> OpenTelemetry.ExportResult
-override OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpTraceExporter.OnShutdown(int timeoutMilliseconds) -> bool
-static OpenTelemetry.Trace.OtlpTraceExporterHelperExtensions.AddOtlpExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
+override OpenTelemetry.Exporter.OtlpTraceExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> activityBatch) -> OpenTelemetry.ExportResult
+override OpenTelemetry.Exporter.OtlpTraceExporter.OnShutdown(int timeoutMilliseconds) -> bool
+static OpenTelemetry.Trace.OtlpTraceExporterHelperExtensions.AddOtlpExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.OtlpExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net46/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net46/PublicAPI.Unshipped.txt
@@ -1,20 +1,20 @@
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpTraceExporter
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpTraceExporter.OtlpTraceExporter(OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions options) -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.BatchExportProcessorOptions.set -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.ChannelOptions.get -> System.Collections.Generic.IEnumerable<Grpc.Core.ChannelOption>
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.ChannelOptions.set -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.Credentials.get -> Grpc.Core.ChannelCredentials
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.Credentials.set -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.Endpoint.get -> string
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.Endpoint.set -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.ExportProcessorType.set -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.Headers.get -> Grpc.Core.Metadata
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.Headers.set -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.OtlpExporterOptions() -> void
+OpenTelemetry.Exporter.OtlpTraceExporter
+OpenTelemetry.Exporter.OtlpTraceExporter.OtlpTraceExporter(OpenTelemetry.Exporter.OtlpExporterOptions options) -> void
+OpenTelemetry.Exporter.OtlpExporterOptions
+OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
+OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.ChannelOptions.get -> System.Collections.Generic.IEnumerable<Grpc.Core.ChannelOption>
+OpenTelemetry.Exporter.OtlpExporterOptions.ChannelOptions.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.Credentials.get -> Grpc.Core.ChannelCredentials
+OpenTelemetry.Exporter.OtlpExporterOptions.Credentials.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.get -> string
+OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
+OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.Headers.get -> Grpc.Core.Metadata
+OpenTelemetry.Exporter.OtlpExporterOptions.Headers.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.OtlpExporterOptions() -> void
 OpenTelemetry.Trace.OtlpTraceExporterHelperExtensions
-override OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpTraceExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> activityBatch) -> OpenTelemetry.ExportResult
-override OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpTraceExporter.OnShutdown(int timeoutMilliseconds) -> bool
-static OpenTelemetry.Trace.OtlpTraceExporterHelperExtensions.AddOtlpExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
+override OpenTelemetry.Exporter.OtlpTraceExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> activityBatch) -> OpenTelemetry.ExportResult
+override OpenTelemetry.Exporter.OtlpTraceExporter.OnShutdown(int timeoutMilliseconds) -> bool
+static OpenTelemetry.Trace.OtlpTraceExporterHelperExtensions.AddOtlpExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.OtlpExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,20 +1,20 @@
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpTraceExporter
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpTraceExporter.OtlpTraceExporter(OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions options) -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.BatchExportProcessorOptions.set -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.ChannelOptions.get -> System.Collections.Generic.IEnumerable<Grpc.Core.ChannelOption>
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.ChannelOptions.set -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.Credentials.get -> Grpc.Core.ChannelCredentials
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.Credentials.set -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.Endpoint.get -> string
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.Endpoint.set -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.ExportProcessorType.set -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.Headers.get -> Grpc.Core.Metadata
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.Headers.set -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.OtlpExporterOptions() -> void
+OpenTelemetry.Exporter.OtlpTraceExporter
+OpenTelemetry.Exporter.OtlpTraceExporter.OtlpTraceExporter(OpenTelemetry.Exporter.OtlpExporterOptions options) -> void
+OpenTelemetry.Exporter.OtlpExporterOptions
+OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
+OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.ChannelOptions.get -> System.Collections.Generic.IEnumerable<Grpc.Core.ChannelOption>
+OpenTelemetry.Exporter.OtlpExporterOptions.ChannelOptions.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.Credentials.get -> Grpc.Core.ChannelCredentials
+OpenTelemetry.Exporter.OtlpExporterOptions.Credentials.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.get -> string
+OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
+OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.Headers.get -> Grpc.Core.Metadata
+OpenTelemetry.Exporter.OtlpExporterOptions.Headers.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.OtlpExporterOptions() -> void
 OpenTelemetry.Trace.OtlpTraceExporterHelperExtensions
-override OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpTraceExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> activityBatch) -> OpenTelemetry.ExportResult
-override OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpTraceExporter.OnShutdown(int timeoutMilliseconds) -> bool
-static OpenTelemetry.Trace.OtlpTraceExporterHelperExtensions.AddOtlpExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
+override OpenTelemetry.Exporter.OtlpTraceExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> activityBatch) -> OpenTelemetry.ExportResult
+override OpenTelemetry.Exporter.OtlpTraceExporter.OnShutdown(int timeoutMilliseconds) -> bool
+static OpenTelemetry.Trace.OtlpTraceExporterHelperExtensions.AddOtlpExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.OtlpExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,18 +1,18 @@
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpTraceExporter
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpTraceExporter.OtlpTraceExporter(OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions options) -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.BatchExportProcessorOptions.set -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.GrpcChannelOptions.get -> Grpc.Net.Client.GrpcChannelOptions
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.GrpcChannelOptions.set -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.Endpoint.get -> System.Uri
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.Endpoint.set -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.ExportProcessorType.set -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.Headers.get -> Grpc.Core.Metadata
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.Headers.set -> void
-OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions.OtlpExporterOptions() -> void
+OpenTelemetry.Exporter.OtlpTraceExporter
+OpenTelemetry.Exporter.OtlpTraceExporter.OtlpTraceExporter(OpenTelemetry.Exporter.OtlpExporterOptions options) -> void
+OpenTelemetry.Exporter.OtlpExporterOptions
+OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
+OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.GrpcChannelOptions.get -> Grpc.Net.Client.GrpcChannelOptions
+OpenTelemetry.Exporter.OtlpExporterOptions.GrpcChannelOptions.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.get -> System.Uri
+OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
+OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.Headers.get -> Grpc.Core.Metadata
+OpenTelemetry.Exporter.OtlpExporterOptions.Headers.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.OtlpExporterOptions() -> void
 OpenTelemetry.Trace.OtlpTraceExporterHelperExtensions
-override OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpTraceExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> activityBatch) -> OpenTelemetry.ExportResult
-override OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpTraceExporter.OnShutdown(int timeoutMilliseconds) -> bool
-static OpenTelemetry.Trace.OtlpTraceExporterHelperExtensions.AddOtlpExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.OpenTelemetryProtocol.OtlpExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
+override OpenTelemetry.Exporter.OtlpTraceExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> activityBatch) -> OpenTelemetry.ExportResult
+override OpenTelemetry.Exporter.OtlpTraceExporter.OnShutdown(int timeoutMilliseconds) -> bool
+static OpenTelemetry.Trace.OtlpTraceExporterHelperExtensions.AddOtlpExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.OtlpExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Moved `OtlpTraceExporter` and `OtlpExporterOptions` classes to
+  `OpenTelemetry.Exporter` namespace.
+  ([#1770](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1770))
+
 ## 1.0.0-rc2
 
 Released 2021-Jan-29
@@ -9,13 +13,13 @@ Released 2021-Jan-29
 * Changed `OltpTraceExporter` class and constructor from internal to public.
   ([#1612](https://github.com/open-telemetry/opentelemetry-dotnet/issues/1612))
 
-* In `OtlpExporterOptions.cs`: Exporter options now include a switch for
-  Batch vs Simple exporter, and settings for batch exporting properties.
+* In `OtlpExporterOptions.cs`: Exporter options now include a switch for Batch
+  vs Simple exporter, and settings for batch exporting properties.
 
-* Introduce a `netstandard2.1` build enabling the exporter to use the
-  [gRPC for .NET](https://github.com/grpc/grpc-dotnet) library instead of the
-  [gRPC for C#](https://github.com/grpc/grpc/tree/master/src/csharp) library
-  for .NET Core 3.0+ applications. This required some breaking changes to the
+* Introduce a `netstandard2.1` build enabling the exporter to use the [gRPC for
+  .NET](https://github.com/grpc/grpc-dotnet) library instead of the [gRPC for
+  C#](https://github.com/grpc/grpc/tree/master/src/csharp) library for .NET Core
+  3.0+ applications. This required some breaking changes to the
   `OtlpExporterOptions`.
   ([#1662](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1662))
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -22,7 +22,7 @@ using Grpc.Core;
 using Grpc.Net.Client;
 #endif
 
-namespace OpenTelemetry.Exporter.OpenTelemetryProtocol
+namespace OpenTelemetry.Exporter
 {
     /// <summary>
     /// Configuration options for the OpenTelemetry Protocol (OTLP) exporter.

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporter.cs
@@ -29,7 +29,7 @@ using OtlpCollector = Opentelemetry.Proto.Collector.Trace.V1;
 using OtlpCommon = Opentelemetry.Proto.Common.V1;
 using OtlpResource = Opentelemetry.Proto.Resource.V1;
 
-namespace OpenTelemetry.Exporter.OpenTelemetryProtocol
+namespace OpenTelemetry.Exporter
 {
     /// <summary>
     /// Exporter consuming <see cref="Activity"/> and exporting the data using

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
@@ -15,8 +15,7 @@
 // </copyright>
 
 using System;
-using System.Diagnostics;
-using OpenTelemetry.Exporter.OpenTelemetryProtocol;
+using OpenTelemetry.Exporter;
 
 namespace OpenTelemetry.Trace
 {

--- a/src/OpenTelemetry.Exporter.Zipkin/.publicApi/net452/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Zipkin/.publicApi/net452/PublicAPI.Unshipped.txt
@@ -1,17 +1,17 @@
-OpenTelemetry.Exporter.Zipkin.ZipkinExporter
-OpenTelemetry.Exporter.Zipkin.ZipkinExporter.ZipkinExporter(OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions options, System.Net.Http.HttpClient client = null) -> void
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.BatchExportProcessorOptions.set -> void
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.Endpoint.get -> System.Uri
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.Endpoint.set -> void
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.ExportProcessorType.set -> void
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.ServiceName.get -> string
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.ServiceName.set -> void
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.UseShortTraceIds.get -> bool
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.UseShortTraceIds.set -> void
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.ZipkinExporterOptions() -> void
+OpenTelemetry.Exporter.ZipkinExporter
+OpenTelemetry.Exporter.ZipkinExporter.ZipkinExporter(OpenTelemetry.Exporter.ZipkinExporterOptions options, System.Net.Http.HttpClient client = null) -> void
+OpenTelemetry.Exporter.ZipkinExporterOptions
+OpenTelemetry.Exporter.ZipkinExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
+OpenTelemetry.Exporter.ZipkinExporterOptions.BatchExportProcessorOptions.set -> void
+OpenTelemetry.Exporter.ZipkinExporterOptions.Endpoint.get -> System.Uri
+OpenTelemetry.Exporter.ZipkinExporterOptions.Endpoint.set -> void
+OpenTelemetry.Exporter.ZipkinExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
+OpenTelemetry.Exporter.ZipkinExporterOptions.ExportProcessorType.set -> void
+OpenTelemetry.Exporter.ZipkinExporterOptions.ServiceName.get -> string
+OpenTelemetry.Exporter.ZipkinExporterOptions.ServiceName.set -> void
+OpenTelemetry.Exporter.ZipkinExporterOptions.UseShortTraceIds.get -> bool
+OpenTelemetry.Exporter.ZipkinExporterOptions.UseShortTraceIds.set -> void
+OpenTelemetry.Exporter.ZipkinExporterOptions.ZipkinExporterOptions() -> void
 OpenTelemetry.Trace.ZipkinExporterHelperExtensions
-override OpenTelemetry.Exporter.Zipkin.ZipkinExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) -> OpenTelemetry.ExportResult
-static OpenTelemetry.Trace.ZipkinExporterHelperExtensions.AddZipkinExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
+override OpenTelemetry.Exporter.ZipkinExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) -> OpenTelemetry.ExportResult
+static OpenTelemetry.Trace.ZipkinExporterHelperExtensions.AddZipkinExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.ZipkinExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Exporter.Zipkin/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Zipkin/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -1,19 +1,19 @@
-OpenTelemetry.Exporter.Zipkin.ZipkinExporter
-OpenTelemetry.Exporter.Zipkin.ZipkinExporter.ZipkinExporter(OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions options, System.Net.Http.HttpClient client = null) -> void
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.BatchExportProcessorOptions.set -> void
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.Endpoint.get -> System.Uri
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.Endpoint.set -> void
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.ExportProcessorType.set -> void
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.MaxPayloadSizeInBytes.get -> int?
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.MaxPayloadSizeInBytes.set -> void
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.ServiceName.get -> string
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.ServiceName.set -> void
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.UseShortTraceIds.get -> bool
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.UseShortTraceIds.set -> void
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.ZipkinExporterOptions() -> void
+OpenTelemetry.Exporter.ZipkinExporter
+OpenTelemetry.Exporter.ZipkinExporter.ZipkinExporter(OpenTelemetry.Exporter.ZipkinExporterOptions options, System.Net.Http.HttpClient client = null) -> void
+OpenTelemetry.Exporter.ZipkinExporterOptions
+OpenTelemetry.Exporter.ZipkinExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
+OpenTelemetry.Exporter.ZipkinExporterOptions.BatchExportProcessorOptions.set -> void
+OpenTelemetry.Exporter.ZipkinExporterOptions.Endpoint.get -> System.Uri
+OpenTelemetry.Exporter.ZipkinExporterOptions.Endpoint.set -> void
+OpenTelemetry.Exporter.ZipkinExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
+OpenTelemetry.Exporter.ZipkinExporterOptions.ExportProcessorType.set -> void
+OpenTelemetry.Exporter.ZipkinExporterOptions.MaxPayloadSizeInBytes.get -> int?
+OpenTelemetry.Exporter.ZipkinExporterOptions.MaxPayloadSizeInBytes.set -> void
+OpenTelemetry.Exporter.ZipkinExporterOptions.ServiceName.get -> string
+OpenTelemetry.Exporter.ZipkinExporterOptions.ServiceName.set -> void
+OpenTelemetry.Exporter.ZipkinExporterOptions.UseShortTraceIds.get -> bool
+OpenTelemetry.Exporter.ZipkinExporterOptions.UseShortTraceIds.set -> void
+OpenTelemetry.Exporter.ZipkinExporterOptions.ZipkinExporterOptions() -> void
 OpenTelemetry.Trace.ZipkinExporterHelperExtensions
-override OpenTelemetry.Exporter.Zipkin.ZipkinExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) -> OpenTelemetry.ExportResult
-static OpenTelemetry.Trace.ZipkinExporterHelperExtensions.AddZipkinExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
+override OpenTelemetry.Exporter.ZipkinExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) -> OpenTelemetry.ExportResult
+static OpenTelemetry.Trace.ZipkinExporterHelperExtensions.AddZipkinExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.ZipkinExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Exporter.Zipkin/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Zipkin/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,19 +1,19 @@
-OpenTelemetry.Exporter.Zipkin.ZipkinExporter
-OpenTelemetry.Exporter.Zipkin.ZipkinExporter.ZipkinExporter(OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions options, System.Net.Http.HttpClient client = null) -> void
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.BatchExportProcessorOptions.set -> void
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.Endpoint.get -> System.Uri
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.Endpoint.set -> void
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.ExportProcessorType.set -> void
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.MaxPayloadSizeInBytes.get -> int?
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.MaxPayloadSizeInBytes.set -> void
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.ServiceName.get -> string
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.ServiceName.set -> void
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.UseShortTraceIds.get -> bool
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.UseShortTraceIds.set -> void
-OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions.ZipkinExporterOptions() -> void
+OpenTelemetry.Exporter.ZipkinExporter
+OpenTelemetry.Exporter.ZipkinExporter.ZipkinExporter(OpenTelemetry.Exporter.ZipkinExporterOptions options, System.Net.Http.HttpClient client = null) -> void
+OpenTelemetry.Exporter.ZipkinExporterOptions
+OpenTelemetry.Exporter.ZipkinExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
+OpenTelemetry.Exporter.ZipkinExporterOptions.BatchExportProcessorOptions.set -> void
+OpenTelemetry.Exporter.ZipkinExporterOptions.Endpoint.get -> System.Uri
+OpenTelemetry.Exporter.ZipkinExporterOptions.Endpoint.set -> void
+OpenTelemetry.Exporter.ZipkinExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
+OpenTelemetry.Exporter.ZipkinExporterOptions.ExportProcessorType.set -> void
+OpenTelemetry.Exporter.ZipkinExporterOptions.MaxPayloadSizeInBytes.get -> int?
+OpenTelemetry.Exporter.ZipkinExporterOptions.MaxPayloadSizeInBytes.set -> void
+OpenTelemetry.Exporter.ZipkinExporterOptions.ServiceName.get -> string
+OpenTelemetry.Exporter.ZipkinExporterOptions.ServiceName.set -> void
+OpenTelemetry.Exporter.ZipkinExporterOptions.UseShortTraceIds.get -> bool
+OpenTelemetry.Exporter.ZipkinExporterOptions.UseShortTraceIds.set -> void
+OpenTelemetry.Exporter.ZipkinExporterOptions.ZipkinExporterOptions() -> void
 OpenTelemetry.Trace.ZipkinExporterHelperExtensions
-override OpenTelemetry.Exporter.Zipkin.ZipkinExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) -> OpenTelemetry.ExportResult
-static OpenTelemetry.Trace.ZipkinExporterHelperExtensions.AddZipkinExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.Zipkin.ZipkinExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
+override OpenTelemetry.Exporter.ZipkinExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> batch) -> OpenTelemetry.ExportResult
+static OpenTelemetry.Trace.ZipkinExporterHelperExtensions.AddZipkinExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.ZipkinExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Moved `ZipkinExporter` and `ZipkinExporterOptions` classes to
+  `OpenTelemetry.Exporter` namespace.
+  ([#1770](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1770))
+
 ## 1.0.0-rc2
 
 Released 2021-Jan-29

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporter.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporter.cs
@@ -32,7 +32,7 @@ using System.Threading.Tasks;
 using OpenTelemetry.Exporter.Zipkin.Implementation;
 using OpenTelemetry.Resources;
 
-namespace OpenTelemetry.Exporter.Zipkin
+namespace OpenTelemetry.Exporter
 {
     /// <summary>
     /// Zipkin exporter.

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporterHelperExtensions.cs
@@ -15,8 +15,7 @@
 // </copyright>
 
 using System;
-using System.Diagnostics;
-using OpenTelemetry.Exporter.Zipkin;
+using OpenTelemetry.Exporter;
 
 namespace OpenTelemetry.Trace
 {

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporterOptions.cs
@@ -17,7 +17,7 @@
 using System;
 using System.Diagnostics;
 
-namespace OpenTelemetry.Exporter.Zipkin
+namespace OpenTelemetry.Exporter
 {
     /// <summary>
     /// Zipkin trace exporter options.

--- a/test/Benchmarks/Exporter/JaegerExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/JaegerExporterBenchmarks.cs
@@ -18,7 +18,7 @@ using System.Diagnostics;
 using BenchmarkDotNet.Attributes;
 using Benchmarks.Helper;
 using OpenTelemetry;
-using OpenTelemetry.Exporter.Jaeger;
+using OpenTelemetry.Exporter;
 using OpenTelemetry.Internal;
 using Thrift.Transport;
 

--- a/test/Benchmarks/Exporter/OtlpExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/OtlpExporterBenchmarks.cs
@@ -21,7 +21,7 @@ using BenchmarkDotNet.Attributes;
 using Benchmarks.Helper;
 using Grpc.Core;
 using OpenTelemetry;
-using OpenTelemetry.Exporter.OpenTelemetryProtocol;
+using OpenTelemetry.Exporter;
 using OpenTelemetry.Internal;
 using OtlpCollector = Opentelemetry.Proto.Collector.Trace.V1;
 

--- a/test/Benchmarks/Exporter/ZipkinExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/ZipkinExporterBenchmarks.cs
@@ -20,7 +20,7 @@ using System.IO;
 using BenchmarkDotNet.Attributes;
 using Benchmarks.Helper;
 using OpenTelemetry;
-using OpenTelemetry.Exporter.Zipkin;
+using OpenTelemetry.Exporter;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Tests;
 

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterTests.cs
@@ -17,7 +17,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using OpenTelemetry.Exporter.Jaeger.Implementation;
 using OpenTelemetry.Exporter.Jaeger.Tests.Implementation;
 using OpenTelemetry.Resources;


### PR DESCRIPTION
This PR makes the namespace used by exporters consistent.

All the exporter and the respective options classes will now be under OpenTelemetry.Exporter namespace.

Continuation of #1332
Related: #1766 

## Changes
- Updated the namespace of exporters and exporter options to OpenTelemetry.Exporter
