### PR TITLE
Add ability for MinVer to version 1.0.0 for core projects

### DIFF
--- a/src/OpenTelemetry.Api/OpenTelemetry.Api.csproj
+++ b/src/OpenTelemetry.Api/OpenTelemetry.Api.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>OpenTelemetry</RootNamespace>
 
     <NoWarn>$(NoWarn),CS0618</NoWarn>
+    <MinVerTagPrefix>core-</MinVerTagPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Exporter.Console/OpenTelemetry.Exporter.Console.csproj
+++ b/src/OpenTelemetry.Exporter.Console/OpenTelemetry.Exporter.Console.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net452;net461;netstandard2.0</TargetFrameworks>
     <Description>Console exporter for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);Console;distributed-tracing</PackageTags>
+    <MinVerTagPrefix>core-</MinVerTagPrefix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenTelemetry.Exporter.InMemory/OpenTelemetry.Exporter.InMemory.csproj
+++ b/src/OpenTelemetry.Exporter.InMemory/OpenTelemetry.Exporter.InMemory.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net452;net46;net461;netstandard2.0</TargetFrameworks>
     <Description>In-memory exporter for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags)</PackageTags>
+    <MinVerTagPrefix>core-</MinVerTagPrefix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenTelemetry.Exporter.Jaeger/OpenTelemetry.Exporter.Jaeger.csproj
+++ b/src/OpenTelemetry.Exporter.Jaeger/OpenTelemetry.Exporter.Jaeger.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net46;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>Jaeger exporter for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);Jaeger;distributed-tracing</PackageTags>
+    <MinVerTagPrefix>core-</MinVerTagPrefix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj
@@ -23,6 +23,7 @@
 
     <Description>OpenTelemetry protocol exporter for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);OTLP</PackageTags>
+    <MinVerTagPrefix>core-</MinVerTagPrefix>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">

--- a/src/OpenTelemetry.Exporter.Zipkin/OpenTelemetry.Exporter.Zipkin.csproj
+++ b/src/OpenTelemetry.Exporter.Zipkin/OpenTelemetry.Exporter.Zipkin.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>net452;net461;netstandard2.0</TargetFrameworks>
     <Description>Zipkin exporter for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);Zipkin;distributed-tracing</PackageTags>
+    <MinVerTagPrefix>core-</MinVerTagPrefix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry/OpenTelemetry.csproj
+++ b/src/OpenTelemetry/OpenTelemetry.csproj
@@ -6,6 +6,7 @@
     TODO: Disable this exception, and actually do document all public API.
     -->
     <NoWarn>$(NoWarn),1591,CS0618</NoWarn>
+    <MinVerTagPrefix>core-</MinVerTagPrefix>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR is adding a MinVerTagPreix of "core-" to all the core projects. "Core" projects refers to the one which has an official spec https://github.com/open-telemetry/opentelemetry-specification currently marked "Stable". These projects are intended to be released as 1.0.0 soon.

Rest of the projects (instrumentation, extensions, opentracing shim etc) will remain in RC state, until their respective spec is marked stable and/or the project itself stabilizes.

(though it is releasing separately initially, the medium term we'd expect to release everything together with same version. and in long term, the instrumentations may even move out of this repo to elsewhere, likely current contrib repo or new dedicated per instrumentation repos.)
