### PR TITLE
Changed default port for OTLP Exporter from 55680 to 4317

### DIFF
--- a/examples/AspNetCore/appsettings.json
+++ b/examples/AspNetCore/appsettings.json
@@ -19,6 +19,6 @@
   },
   "Otlp": {
     "ServiceName": "otlp-test",
-    "Endpoint": "localhost:55680"
+    "Endpoint": "localhost:4317"
   }
 }

--- a/examples/Console/Program.cs
+++ b/examples/Console/Program.cs
@@ -32,7 +32,7 @@ namespace Examples.Console
         /// dotnet run -p Examples.Console.csproj zipkin -u http://localhost:9411/api/v2/spans
         /// dotnet run -p Examples.Console.csproj jaeger -h localhost -p 6831
         /// dotnet run -p Examples.Console.csproj prometheus -i 15 -p 9184 -d 2
-        /// dotnet run -p Examples.Console.csproj otlp -e "localhost:55680"
+        /// dotnet run -p Examples.Console.csproj otlp -e "localhost:4317"
         /// dotnet run -p Examples.Console.csproj zpages
         ///
         /// The above must be run from the project root folder
@@ -119,7 +119,7 @@ namespace Examples.Console
     [Verb("otlp", HelpText = "Specify the options required to test OpenTelemetry Protocol (OTLP)")]
     internal class OtlpOptions
     {
-        [Option('e', "endpoint", HelpText = "Target to which the exporter is going to send traces or metrics", Default = "http://localhost:55680")]
+        [Option('e', "endpoint", HelpText = "Target to which the exporter is going to send traces or metrics", Default = "http://localhost:4317")]
         public string Endpoint { get; set; }
     }
 

--- a/examples/Console/TestOtlpExporter.cs
+++ b/examples/Console/TestOtlpExporter.cs
@@ -33,10 +33,10 @@ namespace Examples.Console
              * launch the OpenTelemetry Collector with an OTLP receiver, by running:
              *
              *  - On Unix based systems use:
-             *     docker run --rm -it -p 55680:55680 -v $(pwd):/cfg otel/opentelemetry-collector:0.14.0 --config=/cfg/otlp-collector-example/config.yaml
+             *     docker run --rm -it -p 4317:4317 -v $(pwd):/cfg otel/opentelemetry-collector:0.19.0 --config=/cfg/otlp-collector-example/config.yaml
              *
              *  - On Windows use:
-             *     docker run --rm -it -p 55680:55680 -v "%cd%":/cfg otel/opentelemetry-collector:0.14.0 --config=/cfg/otlp-collector-example/config.yaml
+             *     docker run --rm -it -p 4317:4317 -v "%cd%":/cfg otel/opentelemetry-collector:0.19.0 --config=/cfg/otlp-collector-example/config.yaml
              *
              * Open another terminal window at the examples/Console/ directory and
              * launch the OTLP example by running:

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Moved `OtlpTraceExporter` and `OtlpExporterOptions` classes to
   `OpenTelemetry.Exporter` namespace.
   ([#1770](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1770))
+* Changed default port for OTLP Exporter from 55680 to 4317
 
 ## 1.0.0-rc2
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -34,13 +34,13 @@ namespace OpenTelemetry.Exporter
         /// Gets or sets the target to which the exporter is going to send traces or metrics.
         /// The valid syntax is described at https://github.com/grpc/grpc/blob/master/doc/naming.md.
         /// </summary>
-        public Uri Endpoint { get; set; } = new Uri("http://localhost:55680");
+        public Uri Endpoint { get; set; } = new Uri("http://localhost:4317");
 #else
         /// <summary>
         /// Gets or sets the target to which the exporter is going to send traces or metrics.
         /// The valid syntax is described at https://github.com/grpc/grpc/blob/master/doc/naming.md.
         /// </summary>
-        public string Endpoint { get; set; } = "localhost:55680";
+        public string Endpoint { get; set; } = "localhost:4317";
 #endif
 
 #if NETSTANDARD2_1

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
@@ -30,7 +30,6 @@ namespace OpenTelemetry.Trace
         /// <param name="builder"><see cref="TracerProviderBuilder"/> builder to use.</param>
         /// <param name="configure">Exporter configuration options.</param>
         /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The objects should not be disposed.")]
         public static TracerProviderBuilder AddOtlpExporter(this TracerProviderBuilder builder, Action<OtlpExporterOptions> configure = null)
         {
             if (builder == null)

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/docker-compose.yml
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - ./test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests:/cfg
     command: --config=/cfg/config.yaml
     ports:
-      - "55680:55680"
+      - "4317:4317"
 
   tests:
     build:
@@ -19,6 +19,6 @@ services:
       dockerfile: ./test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Dockerfile
     command: --TestCaseFilter:CategoryName=CollectorIntegrationTests
     environment:
-      - OTEL_EXPORTER_OTLP_ENDPOINT=otel-collector:55680
+      - OTEL_EXPORTER_OTLP_ENDPOINT=otel-collector:4317
     depends_on:
       - otel-collector


### PR DESCRIPTION
4317 is the default as per spec. (See https://github.com/open-telemetry/opentelemetry-specification/pull/1221)

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
