### PR TITLE
Update the data type of OtlpExporter option Endpoint to string

### DIFF
--- a/examples/AspNetCore/Startup.cs
+++ b/examples/AspNetCore/Startup.cs
@@ -90,7 +90,7 @@ namespace Examples.AspNetCore
                         .AddHttpClientInstrumentation()
                         .AddOtlpExporter(otlpOptions =>
                         {
-                            otlpOptions.Endpoint = new Uri(this.Configuration.GetValue<string>("Otlp:Endpoint"));
+                            otlpOptions.Endpoint = this.Configuration.GetValue<string>("Otlp:Endpoint");
                         }));
                     break;
                 default:

--- a/examples/AspNetCore/appsettings.json
+++ b/examples/AspNetCore/appsettings.json
@@ -7,7 +7,7 @@
     }
   },
   "AllowedHosts": "*",
-  "UseExporter": "console",
+  "UseExporter": "otlp",
   "Jaeger": {
     "ServiceName": "jaeger-test",
     "Host": "localhost",
@@ -19,6 +19,6 @@
   },
   "Otlp": {
     "ServiceName": "otlp-test",
-    "Endpoint": "localhost:4317"
+    "Endpoint": "http://localhost:4317"
   }
 }

--- a/examples/AspNetCore/appsettings.json
+++ b/examples/AspNetCore/appsettings.json
@@ -7,7 +7,7 @@
     }
   },
   "AllowedHosts": "*",
-  "UseExporter": "otlp",
+  "UseExporter": "console",
   "Jaeger": {
     "ServiceName": "jaeger-test",
     "Host": "localhost",

--- a/examples/Console/TestOtlpExporter.cs
+++ b/examples/Console/TestOtlpExporter.cs
@@ -64,7 +64,7 @@ namespace Examples.Console
             using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                     .AddSource("Samples.SampleClient", "Samples.SampleServer")
                     .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("otlp-test"))
-                    .AddOtlpExporter(opt => opt.Endpoint = new Uri(endpoint))
+                    .AddOtlpExporter(opt => opt.Endpoint = endpoint)
                     .Build();
 
             // The above line is required only in Applications

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
@@ -5,7 +5,7 @@ OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.get -> Op
 OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.GrpcChannelOptions.get -> Grpc.Net.Client.GrpcChannelOptions
 OpenTelemetry.Exporter.OtlpExporterOptions.GrpcChannelOptions.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.get -> System.Uri
+OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.get -> string
 OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
 OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.set -> void

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -8,10 +8,12 @@
 * Changed default port for OTLP Exporter from 55680 to 4317
 * Default ServiceName, if not found in Resource, is obtained from SDK using
   GetDefaultResource().
-* Modified the data type of Headers option to string; Added a new option called
-  TimeoutMilliseconds for computing the `deadline` to be used by gRPC client for
-  `Export`
+* Modified the data type of `Headers` option to string; Added a new option
+  called `TimeoutMilliseconds` for computing the `deadline` to be used by gRPC
+  client for `Export`
   ([#1781](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1781))
+* Modified the data type of `Endpoint` option to string for netstandard2.1
+  ([#1786](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1786))
 
 ## 1.0.0-rc2
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -32,9 +32,9 @@ namespace OpenTelemetry.Exporter
 #if NETSTANDARD2_1
         /// <summary>
         /// Gets or sets the target to which the exporter is going to send traces or metrics.
-        /// The valid syntax is described at https://github.com/grpc/grpc/blob/master/doc/naming.md.
+        /// The valid syntax is described at https://github.com/grpc/grpc/blob/master/doc/naming.md. The endpoint value should starts with http or https.
         /// </summary>
-        public Uri Endpoint { get; set; } = new Uri("http://localhost:4317");
+        public string Endpoint { get; set; } = "http://localhost:4317";
 #else
         /// <summary>
         /// Gets or sets the target to which the exporter is going to send traces or metrics.

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -32,13 +32,14 @@ namespace OpenTelemetry.Exporter
 #if NETSTANDARD2_1
         /// <summary>
         /// Gets or sets the target to which the exporter is going to send traces or metrics.
-        /// The valid syntax is described at https://github.com/grpc/grpc/blob/master/doc/naming.md. The endpoint value should start with http or https.
+        /// The endpoint value should have http or https as the scheme. The default value is "http://localhost:4317".
         /// </summary>
         public string Endpoint { get; set; } = "http://localhost:4317";
 #else
         /// <summary>
         /// Gets or sets the target to which the exporter is going to send traces or metrics.
-        /// The valid syntax is described at https://github.com/grpc/grpc/blob/master/doc/naming.md.
+        /// The valid syntax is described at https://github.com/grpc/grpc/blob/master/doc/naming.md. The endpoint value should not start with http or https.
+        /// The default value is "localhost:4317".
         /// </summary>
         public string Endpoint { get; set; } = "localhost:4317";
 #endif

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -32,7 +32,7 @@ namespace OpenTelemetry.Exporter
 #if NETSTANDARD2_1
         /// <summary>
         /// Gets or sets the target to which the exporter is going to send traces or metrics.
-        /// The valid syntax is described at https://github.com/grpc/grpc/blob/master/doc/naming.md. The endpoint value should starts with http or https.
+        /// The valid syntax is described at https://github.com/grpc/grpc/blob/master/doc/naming.md. The endpoint value should start with http or https.
         /// </summary>
         public string Endpoint { get; set; } = "http://localhost:4317";
 #else

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTests.cs
@@ -40,11 +40,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
 
             var exporterOptions = new OtlpExporterOptions
             {
-#if NETCOREAPP3_1 || NET5_0
-                Endpoint = new System.Uri($"http://{CollectorEndpoint}"),
-#else
                 Endpoint = CollectorEndpoint,
-#endif
             };
 
             var otlpExporter = new OtlpTraceExporter(exporterOptions);

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTests.cs
@@ -40,7 +40,11 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
 
             var exporterOptions = new OtlpExporterOptions
             {
+#if NETCOREAPP3_1 || NET5_0
+                Endpoint = $"http://{CollectorEndpoint}",
+#else
                 Endpoint = CollectorEndpoint,
+#endif
             };
 
             var otlpExporter = new OtlpTraceExporter(exporterOptions);


### PR DESCRIPTION
Partially Fixes #1778 

## Changes
- Updated the data type of the configuration option Endpoint to string for netstandard 2.1

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Changes in public API reviewed
