### PR TITLE
Remove grpc class options from OTLPExporter. Make Endpoint Uri for all frameworks

### DIFF
--- a/examples/AspNetCore/appsettings.json
+++ b/examples/AspNetCore/appsettings.json
@@ -19,6 +19,6 @@
   },
   "Otlp": {
     "ServiceName": "otlp-test",
-    "Endpoint": "localhost:4317"
+    "Endpoint": "http://localhost:4317"
   }
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net452/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net452/PublicAPI.Unshipped.txt
@@ -3,11 +3,7 @@ OpenTelemetry.Exporter.OtlpTraceExporter.OtlpTraceExporter(OpenTelemetry.Exporte
 OpenTelemetry.Exporter.OtlpExporterOptions
 OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
 OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.ChannelOptions.get -> System.Collections.Generic.IEnumerable<Grpc.Core.ChannelOption>
-OpenTelemetry.Exporter.OtlpExporterOptions.ChannelOptions.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.Credentials.get -> Grpc.Core.ChannelCredentials
-OpenTelemetry.Exporter.OtlpExporterOptions.Credentials.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.get -> string
+OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.get -> System.Uri
 OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
 OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.set -> void

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net46/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net46/PublicAPI.Unshipped.txt
@@ -3,11 +3,7 @@ OpenTelemetry.Exporter.OtlpTraceExporter.OtlpTraceExporter(OpenTelemetry.Exporte
 OpenTelemetry.Exporter.OtlpExporterOptions
 OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
 OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.ChannelOptions.get -> System.Collections.Generic.IEnumerable<Grpc.Core.ChannelOption>
-OpenTelemetry.Exporter.OtlpExporterOptions.ChannelOptions.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.Credentials.get -> Grpc.Core.ChannelCredentials
-OpenTelemetry.Exporter.OtlpExporterOptions.Credentials.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.get -> string
+OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.get -> System.Uri
 OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
 OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.set -> void

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -3,11 +3,7 @@ OpenTelemetry.Exporter.OtlpTraceExporter.OtlpTraceExporter(OpenTelemetry.Exporte
 OpenTelemetry.Exporter.OtlpExporterOptions
 OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
 OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.ChannelOptions.get -> System.Collections.Generic.IEnumerable<Grpc.Core.ChannelOption>
-OpenTelemetry.Exporter.OtlpExporterOptions.ChannelOptions.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.Credentials.get -> Grpc.Core.ChannelCredentials
-OpenTelemetry.Exporter.OtlpExporterOptions.Credentials.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.get -> string
+OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.get -> System.Uri
 OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
 OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.set -> void

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
@@ -3,8 +3,6 @@ OpenTelemetry.Exporter.OtlpTraceExporter.OtlpTraceExporter(OpenTelemetry.Exporte
 OpenTelemetry.Exporter.OtlpExporterOptions
 OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
 OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.GrpcChannelOptions.get -> Grpc.Net.Client.GrpcChannelOptions
-OpenTelemetry.Exporter.OtlpExporterOptions.GrpcChannelOptions.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.get -> System.Uri
 OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -12,6 +12,10 @@
   TimeoutMilliseconds for computing the `deadline` to be used by gRPC client for
   `Export`
   ([#1781](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1781))
+* Removes Grpc specific options from OTLPExporterOptions, which removes support
+  for secure connections. See [1778](https://github.com/open-telemetry/opentelemetry-dotnet/issues/1778)
+  for details.
+* Endpoint is made Uri for all target frameworks.
 
 ## 1.0.0-rc2
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -25,7 +25,10 @@ namespace OpenTelemetry.Exporter
     public class OtlpExporterOptions
     {
         /// <summary>
-        /// Gets or sets the target to which the exporter is going to send traces or metrics.
+        /// Gets or sets the target to which the exporter is going to send traces.
+        /// Must be a valid Uri with scheme (http) and host, and
+        /// may contain a port and path. Secure connection(https) is not
+        /// supported.
         /// </summary>
         public Uri Endpoint { get; set; } = new Uri("http://localhost:4317");
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -15,12 +15,7 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using Grpc.Core;
-#if NETSTANDARD2_1
-using Grpc.Net.Client;
-#endif
 
 namespace OpenTelemetry.Exporter
 {
@@ -29,37 +24,10 @@ namespace OpenTelemetry.Exporter
     /// </summary>
     public class OtlpExporterOptions
     {
-#if NETSTANDARD2_1
         /// <summary>
         /// Gets or sets the target to which the exporter is going to send traces or metrics.
-        /// The valid syntax is described at https://github.com/grpc/grpc/blob/master/doc/naming.md.
         /// </summary>
         public Uri Endpoint { get; set; } = new Uri("http://localhost:4317");
-#else
-        /// <summary>
-        /// Gets or sets the target to which the exporter is going to send traces or metrics.
-        /// The valid syntax is described at https://github.com/grpc/grpc/blob/master/doc/naming.md.
-        /// </summary>
-        public string Endpoint { get; set; } = "localhost:4317";
-#endif
-
-#if NETSTANDARD2_1
-        /// <summary>
-        /// Gets or sets the gRPC channel options.
-        /// </summary>
-        public GrpcChannelOptions GrpcChannelOptions { get; set; }
-#else
-        /// <summary>
-        /// Gets or sets the client-side channel credentials. Used for creation of a secure channel.
-        /// The default is "insecure". See detais at https://grpc.io/docs/guides/auth/#credential-types.
-        /// </summary>
-        public ChannelCredentials Credentials { get; set; } = ChannelCredentials.Insecure;
-
-        /// <summary>
-        /// Gets or sets the gRPC channel options.
-        /// </summary>
-        public IEnumerable<ChannelOption> ChannelOptions { get; set; }
-#endif
 
         /// <summary>
         /// Gets or sets optional headers for the connection. Refer to the <a href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#specifying-headers-via-environment-variables">

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporter.cs
@@ -77,7 +77,7 @@ namespace OpenTelemetry.Exporter
             {
                 if (options.Endpoint.Scheme == Uri.UriSchemeHttps)
                 {
-                    throw new ArgumentException("Https Endpoint is not supported.");
+                    throw new NotSupportedException("Https Endpoint is not supported.");
                 }
 
 #if NETSTANDARD2_1

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporter.cs
@@ -45,7 +45,6 @@ namespace OpenTelemetry.Exporter
 #endif
         private readonly OtlpCollector.TraceService.ITraceServiceClient traceClient;
         private readonly Metadata headers;
-        private DateTime deadline;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OtlpTraceExporter"/> class.
@@ -76,12 +75,15 @@ namespace OpenTelemetry.Exporter
             }
             else
             {
+                if (options.Endpoint.Scheme == Uri.UriSchemeHttps)
+                {
+                    throw new ArgumentException("Https Endpoint is not supported.");
+                }
+
 #if NETSTANDARD2_1
-                this.channel = options.GrpcChannelOptions == default
-                    ? GrpcChannel.ForAddress(options.Endpoint)
-                    : GrpcChannel.ForAddress(options.Endpoint, options.GrpcChannelOptions);
+                this.channel = GrpcChannel.ForAddress(options.Endpoint);
 #else
-                this.channel = new Channel(options.Endpoint, options.Credentials, options.ChannelOptions);
+                this.channel = new Channel(options.Endpoint.Authority, ChannelCredentials.Insecure);
 #endif
                 this.traceClient = new OtlpCollector.TraceService.TraceServiceClient(this.channel);
             }
@@ -103,11 +105,11 @@ namespace OpenTelemetry.Exporter
             OtlpCollector.ExportTraceServiceRequest request = new OtlpCollector.ExportTraceServiceRequest();
 
             request.AddBatch(this.ProcessResource, activityBatch);
-            this.deadline = DateTime.UtcNow.AddMilliseconds(this.options.TimeoutMilliseconds);
+            var deadline = DateTime.UtcNow.AddMilliseconds(this.options.TimeoutMilliseconds);
 
             try
             {
-                this.traceClient.Export(request, headers: this.headers, deadline: this.deadline);
+                this.traceClient.Export(request, headers: this.headers, deadline: deadline);
             }
             catch (RpcException ex)
             {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
@@ -21,9 +21,11 @@ dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
 You can configure the `OtlpExporter` through `OtlpExporterOptions` properties:
 
 * `Endpoint`: Target to which the exporter is going to send traces or metrics.
-* `Credentials`: Client-side channel credentials.
+The endpoint must be a valid Uri with scheme (http) and host, and
+MAY contain a port and path. In 1.0, secure connection(https) is *NOT*
+supported.
 * `Headers`: Optional headers for the connection.
-* `ChannelOptions`: gRPC channel options.
+* `TimeoutMilliseconds` : Max waiting time for the backend to process a batch.
 * `ExportProcessorType`: Whether the exporter should use
   [Batch or Simple exporting processor](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#built-in-span-processors)
   .

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTests.cs
@@ -40,11 +40,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
 
             var exporterOptions = new OtlpExporterOptions
             {
-#if NETCOREAPP3_1 || NET5_0
                 Endpoint = new System.Uri($"http://{CollectorEndpoint}"),
-#else
-                Endpoint = CollectorEndpoint,
-#endif
             };
 
             var otlpExporter = new OtlpTraceExporter(exporterOptions);


### PR DESCRIPTION
Option 2 from https://github.com/open-telemetry/opentelemetry-dotnet/issues/1778#issuecomment-773605888

This PR makes Endpoint as Uri for both framework targets.
It removes from OTLPOptions anything tied to Grpc classes. This means users no longer have the ability to use OTLPExporter with TLS.
If https Endpoint is specified, throws at ctor() saying Https is unsupported.

In 1.1, proper support can be added for TLS without requiring breaking changes.


