### PR TITLE
Add changelog for rc4

### DIFF
--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-rc4
+
+Released 2021-Feb-09
+
 ## 1.0.0-rc3
 
 Released 2021-Feb-04

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-rc4
+
+Released 2021-Feb-09
+
 ## 1.0.0-rc3
 
 Released 2021-Feb-04

--- a/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-rc4
+
+Released 2021-Feb-09
+
 ## 1.0.0-rc3
 
 Released 2021-Feb-04

--- a/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-rc4
+
+Released 2021-Feb-09
+
 ## 1.0.0-rc3
 
 Released 2021-Feb-04

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-rc4
+
+Released 2021-Feb-09
+
 * Add back support for secure gRPC connections over https.
   ([#1804](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1804))
 

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-rc4
+
+Released 2021-Feb-09
+
 ## 1.0.0-rc3
 
 Released 2021-Feb-04

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0-rc4
+
+Released 2021-Feb-09
+
 ## 1.0.0-rc3
 
 Released 2021-Feb-04


### PR DESCRIPTION
rc4 release is same bits as rc3, except for OTLP Exporter.

This release also helps validate the release process and versioning. (its manual now)