### PR TITLE
Update the instructions to add ConsoleExporter package in Getting-Started examples

### DIFF
--- a/docs/logs/getting-started/README.md
+++ b/docs/logs/getting-started/README.md
@@ -42,7 +42,7 @@ Install the
 package (Use the latest version):
 
 ```sh
-dotnet add package OpenTelemetry.Exporter.Console -v 1.0.0-rc1.1
+dotnet add package OpenTelemetry.Exporter.Console
 ```
 
 Update the `Program.cs` file with the code from [Program.cs](./Program.cs):

--- a/docs/trace/getting-started/README.md
+++ b/docs/trace/getting-started/README.md
@@ -22,7 +22,7 @@ Install the
 package:
 
 ```sh
-dotnet add package OpenTelemetry.Exporter.Console -v 1.0.0-rc1.1
+dotnet add package OpenTelemetry.Exporter.Console
 ```
 
 Update the `Program.cs` file with the code from [Program.cs](./Program.cs):


### PR DESCRIPTION
## Changes
- Updated the instructions to add ConsoleExporter package to get rid of the package version. This would fail now but will work when 1.0.0 or any non pre-release version is in nuget
