### PR TITLE
[After 1.0 release] Remove code that prints Baggage information in ConsoleExporter

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Removed code that prints Baggage information
+  ([#1825](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1825))
+
 ## 1.0.0-rc4
 
 Released 2021-Feb-09

--- a/src/OpenTelemetry.Exporter.Console/ConsoleActivityExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleActivityExporter.cs
@@ -72,15 +72,6 @@ namespace OpenTelemetry.Exporter
                     }
                 }
 
-                if (activity.Baggage.Any())
-                {
-                    this.WriteLine("Activity.Baggage:");
-                    foreach (var baggage in activity.Baggage)
-                    {
-                        this.WriteLine($"    {baggage.Key}: {baggage.Value}");
-                    }
-                }
-
                 var resource = this.ParentProvider.GetResource();
                 if (resource != Resource.Empty)
                 {


### PR DESCRIPTION
Fixes #1824

## Changes
- Removed code that prints Baggage information

This will be merged **only after 1.0.0 release**.

* [x] `CHANGELOG.md` updated for non-trivial changes
