### PR TITLE
Update changelog for 1.0.1 release

### DIFF
--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.1
+
+Released 2021-Feb-10
+
 ## 1.0.0-rc4
 
 Released 2021-Feb-09

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.1
+
+Released 2021-Feb-10
+
 ## 1.0.0-rc4
 
 Released 2021-Feb-09

--- a/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.1
+
+Released 2021-Feb-10
+
 ## 1.0.0-rc4
 
 Released 2021-Feb-09

--- a/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.1
+
+Released 2021-Feb-10
+
 ## 1.0.0-rc4
 
 Released 2021-Feb-09

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.1
+
+Released 2021-Feb-10
+
 ## 1.0.0-rc4
 
 Released 2021-Feb-09

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.1
+
+Released 2021-Feb-10
+
 ## 1.0.0-rc4
 
 Released 2021-Feb-09

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.1
+
+Released 2021-Feb-10
+
 ## 1.0.0-rc4
 
 Released 2021-Feb-09


### PR DESCRIPTION
As discussed during the [Feb. 9, 2021 OTel.NET SIG meeting](https://docs.google.com/document/d/1yjjD6aBcLxlRazYrawukDgrhZMObwHARJbB9glWdHj8/edit#), it was agreed to do the 1.0 release once [Spec 1.0 PR](https://github.com/open-telemetry/opentelemetry-specification/pull/1372) is merged. 

[Spec 1.0 PR](https://github.com/open-telemetry/opentelemetry-specification/pull/1372) is merged, and spec has released [1.0.0](https://github.com/open-telemetry/opentelemetry-specification/releases/tag/v1.0.0)

Proceeding with 1.0 release.
(The actual version will be 1.0.1, as someone had a 1.0.0 package already in nuget with the name OpenTelemetry, *before* the prefix was reserved)

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes