### PR TITLE
Disable public api analyzer for metrics

### DIFF
--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -6,9 +6,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="$(MicrosoftCodeAnalysisAnalyzersPkgVer)" Condition=" $(OS) == 'Windows_NT'">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Disabling Public API check from Metrics branch. Once the API is relatively stable, we'll reenable this check.