### PR TITLE
Add ForceFlush to TracerProvider

### DIFF
--- a/src/OpenTelemetry/.publicApi/net452/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net452/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+static OpenTelemetry.Trace.TracerProviderExtensions.ForceFlush(this OpenTelemetry.Trace.TracerProvider provider, int timeoutMilliseconds = -1) -> bool

--- a/src/OpenTelemetry/.publicApi/net46/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net46/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+static OpenTelemetry.Trace.TracerProviderExtensions.ForceFlush(this OpenTelemetry.Trace.TracerProvider provider, int timeoutMilliseconds = -1) -> bool

--- a/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+static OpenTelemetry.Trace.TracerProviderExtensions.ForceFlush(this OpenTelemetry.Trace.TracerProvider provider, int timeoutMilliseconds = -1) -> bool

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+static OpenTelemetry.Trace.TracerProviderExtensions.ForceFlush(this OpenTelemetry.Trace.TracerProvider provider, int timeoutMilliseconds = -1) -> bool

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -9,6 +9,8 @@ please check the latest changes
 
 ## Unreleased
 
+* Added `ForceFlush` method `TracerProviderExtensions`. ([#1837](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1837))
+
 ## 1.0.1
 
 Released 2021-Feb-10

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -9,7 +9,7 @@ please check the latest changes
 
 ## Unreleased
 
-* Added `ForceFlush` method `TracerProviderExtensions`. ([#1837](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1837))
+* Added `ForceFlush` to `TracerProvider`. ([#1837](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1837))
 
 ## 1.0.1
 

--- a/src/OpenTelemetry/Trace/TracerProviderExtensions.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderExtensions.cs
@@ -59,8 +59,7 @@ namespace OpenTelemetry.Trace
         /// Thrown when the <c>timeoutMilliseconds</c> is smaller than -1.
         /// </exception>
         /// <remarks>
-        /// This function guarantees thread-safety. Only the first call will
-        /// win, subsequent calls will be no-op.
+        /// This function guarantees thread-safety.
         /// </remarks>
         public static bool ForceFlush(this TracerProvider provider, int timeoutMilliseconds = Timeout.Infinite)
         {

--- a/src/OpenTelemetry/Trace/TracerProviderExtensions.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderExtensions.cs
@@ -44,8 +44,8 @@ namespace OpenTelemetry.Trace
         }
 
         /// <summary>
-        /// Attempts to force flush the TracerProviderSdk, blocks the current thread until
-        /// force flush completed or timed out.
+        /// Flushes the all the processors at TracerProviderSdk, blocks the current thread until flush
+        /// completed, shutdown signaled or timed out.
         /// </summary>
         /// <param name="provider">TracerProviderSdk instance on which ForceFlush will be called.</param>
         /// <param name="timeoutMilliseconds">

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -207,6 +207,11 @@ namespace OpenTelemetry.Trace
             return this;
         }
 
+        internal bool OnForceFlush(int timeoutMilliseconds)
+        {
+            return this.processor?.ForceFlush(timeoutMilliseconds) ?? true;
+        }
+
         /// <summary>
         /// Called by <c>Shutdown</c>. This function should block the current
         /// thread until shutdown completed or timed out.

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
@@ -407,10 +407,6 @@ namespace OpenTelemetry.Trace.Tests
                         .AddProcessor(testActivityProcessor)
                         .Build();
 
-            Activity activity = new Activity("test");
-            activity.Start();
-            activity.Stop();
-
             var isFlushed = tracerProvider.ForceFlush();
 
             Assert.True(isFlushed);

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
@@ -398,6 +398,25 @@ namespace OpenTelemetry.Trace.Tests
             Assert.Single(versionAttribute);
         }
 
+        [Fact]
+        public void TracerProviderSdkFlushesProcessorForcibly()
+        {
+            using TestActivityProcessor testActivityProcessor = new TestActivityProcessor();
+
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                        .AddProcessor(testActivityProcessor)
+                        .Build();
+
+            Activity activity = new Activity("test");
+            activity.Start();
+            activity.Stop();
+
+            var isFlushed = tracerProvider.ForceFlush();
+
+            Assert.True(isFlushed);
+            Assert.True(testActivityProcessor.ForceFlushCalled);
+        }
+
         public void Dispose()
         {
             GC.SuppressFinalize(this);


### PR DESCRIPTION
I'm using OpenTelemetry for AWS lambda functions. And I'm using dotnet opentelemetry library to achieve that. After each call, lambda goes to sleep and freezes background threads. Therefore I need to send activities to the exporter forcibly if I want to use the batch processor instead of the simple one.

Thankfully, `BaseProcessor` already contains a `ForceFlush` method that works perfectly in this case.

I've made a proof of concept
```
public static void ForceFlush(this TracerProvider tracerProvider)
{
	var tracerProviderSdkType = typeof(BaseProcessor<>).Assembly.GetType("OpenTelemetry.Trace.TracerProviderSdk");
	var tracerProviderSdk = tracerProvider.Cast(tracerProviderSdkType);
	var processorObj = tracerProviderSdk.GetFieldValue("processor");
	var processor = (BaseProcessor<Activity>) processorObj;
	processor.ForceFlush();
}
```
and it works as I expected. The only problem — access modifiers. This PR allows the user to trigger `TracerProvider.ForceFlush` without reflection. As I can see [java solution has the same feature](https://github.com/open-telemetry/opentelemetry-java/blob/6bb9894b2fa4a7f881542756025a8eceeb8084dd/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/SdkTracerProvider.java#L116).

Related to: https://github.com/open-telemetry/opentelemetry-java/pull/1068