### PR TITLE
Avoid code coverage run on push trigger

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,10 +1,6 @@
 name: Code Coverage
 
 on:
-  push:
-    branches: [ main, metrics ]
-    paths-ignore:
-    - '**.md'
   pull_request:
     branches: [ main, metrics ]
     paths-ignore:


### PR DESCRIPTION
I think we're not enforcing code coverage today? It is a bit misleading to see the latest push failed the CI:

![image](https://user-images.githubusercontent.com/17327289/109074320-77b90a00-76ac-11eb-9c15-548bfe0f1a31.png)

