### PR TITLE
Add SetErrorStatusOnException option to TracerProviderSdk

### DIFF
--- a/OpenTelemetry.sln
+++ b/OpenTelemetry.sln
@@ -197,6 +197,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.Shared", "src
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestApp.AspNetCore.5.0", "test\TestApp.AspNetCore.5.0\TestApp.AspNetCore.5.0.csproj", "{972396A8-E35B-499C-9BA1-765E9B8822E1}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "exception-handling", "docs\trace\exception-handling\exception-handling.csproj", "{08D29501-F0A3-468F-B18D-BD1821A72383}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -387,6 +389,10 @@ Global
 		{972396A8-E35B-499C-9BA1-765E9B8822E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{972396A8-E35B-499C-9BA1-765E9B8822E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{972396A8-E35B-499C-9BA1-765E9B8822E1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{08D29501-F0A3-468F-B18D-BD1821A72383}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{08D29501-F0A3-468F-B18D-BD1821A72383}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{08D29501-F0A3-468F-B18D-BD1821A72383}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{08D29501-F0A3-468F-B18D-BD1821A72383}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -416,6 +422,7 @@ Global
 		{B3F03725-23A0-4582-9526-F6A7E38F35CC} = {3862190B-E2C5-418E-AFDC-DB281FB5C705}
 		{13C10C9A-07E8-43EB-91F5-C2B116FBE0FC} = {3862190B-E2C5-418E-AFDC-DB281FB5C705}
 		{972396A8-E35B-499C-9BA1-765E9B8822E1} = {77C7929A-2EED-4AA6-8705-B5C443C8AA0F}
+		{08D29501-F0A3-468F-B18D-BD1821A72383} = {5B7FB835-3FFF-4BC2-99C5-A5B5FAE3C818}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {55639B5C-0770-4A22-AB56-859604650521}

--- a/docs/Directory.Build.props
+++ b/docs/Directory.Build.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <!-- https://dotnet.microsoft.com/download/dotnet-core -->
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <!-- https://dotnet.microsoft.com/download/dotnet-framework -->
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net461;net462;net47;net471;net472;net48</TargetFrameworks>
   </PropertyGroup>

--- a/docs/trace/exception-handling/Program.cs
+++ b/docs/trace/exception-handling/Program.cs
@@ -32,8 +32,8 @@ public class Program
             {
                 options.SetErrorStatusOnException = true;
             })
-            .SetSampler(new AlwaysOnSampler())
             .AddSource("MyCompany.MyProduct.MyLibrary")
+            .SetSampler(new AlwaysOnSampler())
             .AddConsoleExporter()
             .Build();
 
@@ -68,8 +68,7 @@ public class Program
 
         while (activity != null)
         {
-            activity.SetTag("exception.type", $"UnhandledException<{ex.GetType().Name}>");
-            activity.SetTag("exception.message", ex.Message);
+            activity.RecordException(ex);
             activity.Dispose();
             activity = activity.Parent;
         }

--- a/docs/trace/exception-handling/Program.cs
+++ b/docs/trace/exception-handling/Program.cs
@@ -30,7 +30,7 @@ public class Program
 
         using var tracerProvider = Sdk.CreateTracerProviderBuilder(options =>
             {
-                options.SetErrorStatusOnUnhandledException = true;
+                options.SetErrorStatusOnException = true;
             })
             .SetSampler(new AlwaysOnSampler())
             .AddSource("MyCompany.MyProduct.MyLibrary")

--- a/docs/trace/exception-handling/Program.cs
+++ b/docs/trace/exception-handling/Program.cs
@@ -1,0 +1,58 @@
+// <copyright file="Program.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+
+public class Program
+{
+    private static readonly ActivitySource MyActivitySource = new ActivitySource(
+        "MyCompany.MyProduct.MyLibrary");
+
+    public static void Main()
+    {
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder(options =>
+            {
+                options.SetErrorStatusOnUnhandledException = true;
+            })
+            .SetSampler(new AlwaysOnSampler())
+            .AddSource("MyCompany.MyProduct.MyLibrary")
+            .AddConsoleExporter()
+            .Build();
+
+        try
+        {
+            Func();
+        }
+        catch (Exception)
+        {
+            // swallow the exception
+        }
+    }
+
+    public static void Func()
+    {
+        using (MyActivitySource.StartActivity("Foo"))
+        {
+            using (MyActivitySource.StartActivity("Bar"))
+            {
+                throw new Exception("Oops!");
+            }
+        }
+    }
+}

--- a/docs/trace/exception-handling/Program.cs
+++ b/docs/trace/exception-handling/Program.cs
@@ -62,10 +62,14 @@ public class Program
 
     private static void UnhandledExceptionHandler(object source, UnhandledExceptionEventArgs args)
     {
+        var ex = (Exception)args.ExceptionObject;
+
         var activity = Activity.Current;
 
         while (activity != null)
         {
+            activity.SetTag("exception.type", $"UnhandledException<{ex.GetType().Name}>");
+            activity.SetTag("exception.message", ex.Message);
             activity.Dispose();
             activity = activity.Parent;
         }

--- a/docs/trace/exception-handling/README.md
+++ b/docs/trace/exception-handling/README.md
@@ -86,3 +86,5 @@ static void UnhandledExceptionHandler(object source, UnhandledExceptionEventArgs
 }
 ```
 <!-- markdownlint-enable MD013 -->
+
+A complete example can be found [here](./Program.cs).

--- a/docs/trace/exception-handling/README.md
+++ b/docs/trace/exception-handling/README.md
@@ -1,3 +1,85 @@
-# Handling Exceptions
+# Exception Handling
 
-TBD
+## First Chance Exception
+
+The term `First Chance Exception` is used to describe exceptions that are
+handled by the application, whether in the user code or the framework.
+
+While using `Activity` API, the common pattern would be:
+
+```csharp
+using (var activity = MyActivitySource.StartActivity("Foo"))
+{
+    try
+    {
+        Func();
+    }
+    catch (SomeException ex)
+    {
+        activity?.SetStatus(Status.Error);
+        DoSomething();
+    }
+    catch (Exception)
+    {
+        activity?.SetStatus(Status.Error);
+        throw;
+    }
+}
+```
+
+The above approach could become hard to manage if there are deeply nested
+`Activity` objects, or there are activities created in a 3rd party library.
+
+The following configuration will automatically detect first chance exception and automatically set the activity status to `Error`:
+
+```csharp
+Sdk.CreateTracerProviderBuilder(options => {
+    options.SetErrorStatusOnUnhandledException = true;
+});
+```
+
+A complete example can be found [here](./Program.cs).
+
+Note: this feature is platform dependant as it relies on
+[System.Runtime.InteropServices.Marshal.GetExceptionPointers](https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.marshal.getexceptionpointers).
+
+## Second Chance Exception
+
+The term `Second Chance Exception` is used to describe exceptions that are not
+handled by the application.
+
+When a second chance exception happened, the behavior will depend on the
+presence of a debugger:
+
+* If there is no debugger, the exception will normally crash the process or
+  terminate the thread.
+* If a debugger is attached, the debugger will be notified that an "unhandled
+  exception" happened.
+* In case a postmortem debugger is configured, the postmortem debugger will be
+  activited and normally it will collect a crash dump.
+
+Handling _unhandled exception_ is a very dangerous thing since the handler
+itself could introduce exception, which would result in an unrecoverable
+situation similar to [triple fault](https://en.wikipedia.org/wiki/Triple_fault).
+
+In a non-production environment, it might be useful to automatically capture the
+unhandled exceptions, travel through the unfinished activities and export them
+for troubleshooting. Here goes one possible way of doing this:
+
+```csharp
+static void Main()
+{
+    AppDomain.CurrentDomain.UnhandledException += UnhandledExceptionHandler;
+}
+
+static void UnhandledExceptionHandler(object source, UnhandledExceptionEventArgs args)
+{
+    var activity = Activity.Current;
+
+    while (activity != null)
+    {
+        activity.Dispose();
+        activity = activity.Parent;
+    }
+}
+```

--- a/docs/trace/exception-handling/README.md
+++ b/docs/trace/exception-handling/README.md
@@ -1,0 +1,3 @@
+# Handling Exceptions
+
+TBD

--- a/docs/trace/exception-handling/README.md
+++ b/docs/trace/exception-handling/README.md
@@ -35,7 +35,7 @@ automatically set the activity status to `Error`:
 
 ```csharp
 Sdk.CreateTracerProviderBuilder(options => {
-    options.SetErrorStatusOnUnhandledException = true;
+    options.SetErrorStatusOnException = true;
 });
 ```
 

--- a/docs/trace/exception-handling/README.md
+++ b/docs/trace/exception-handling/README.md
@@ -3,7 +3,7 @@
 ## First Chance Exception
 
 The term `First Chance Exception` is used to describe exceptions that are
-handled by the application, whether in the user code or the framework.
+handled by the application - whether in the user code or the framework.
 
 While using `Activity` API, the common pattern would be:
 
@@ -30,7 +30,8 @@ using (var activity = MyActivitySource.StartActivity("Foo"))
 The above approach could become hard to manage if there are deeply nested
 `Activity` objects, or there are activities created in a 3rd party library.
 
-The following configuration will automatically detect first chance exception and automatically set the activity status to `Error`:
+The following configuration will automatically detect first chance exception and
+automatically set the activity status to `Error`:
 
 ```csharp
 Sdk.CreateTracerProviderBuilder(options => {

--- a/docs/trace/exception-handling/README.md
+++ b/docs/trace/exception-handling/README.md
@@ -59,32 +59,13 @@ presence of a debugger:
 * In case a postmortem debugger is configured, the postmortem debugger will be
   activited and normally it will collect a crash dump.
 
-Handling _unhandled exception_ is a very dangerous thing since the handler
+It might be useful to automatically capture the unhandled exceptions, travel
+through the unfinished activities and export them for troubleshooting. One
+possible way of doing this by using
+[AppDomain.UnhandledException](https://docs.microsoft.com/dotnet/api/system.appdomain.unhandledexception)
+can be found [here](./Program.cs).
+
+Note: _handling unhandled exception is a very dangerous thing since the handler
 itself could introduce exception, which would result in an unrecoverable
-situation similar to [triple fault](https://en.wikipedia.org/wiki/Triple_fault).
-
-In a non-production environment, it might be useful to automatically capture the
-unhandled exceptions, travel through the unfinished activities and export them
-for troubleshooting. Here goes one possible way of doing this:
-
-<!-- markdownlint-disable MD013 -->
-```csharp
-static void Main()
-{
-    AppDomain.CurrentDomain.UnhandledException += UnhandledExceptionHandler;
-}
-
-static void UnhandledExceptionHandler(object source, UnhandledExceptionEventArgs args)
-{
-    var activity = Activity.Current;
-
-    while (activity != null)
-    {
-        activity.Dispose();
-        activity = activity.Parent;
-    }
-}
-```
-<!-- markdownlint-enable MD013 -->
-
-A complete example can be found [here](./Program.cs).
+situation similar to [triple
+fault](https://en.wikipedia.org/wiki/Triple_fault)_.

--- a/docs/trace/exception-handling/README.md
+++ b/docs/trace/exception-handling/README.md
@@ -65,7 +65,6 @@ possible way of doing this by using
 [AppDomain.UnhandledException](https://docs.microsoft.com/dotnet/api/system.appdomain.unhandledexception)
 can be found [here](./Program.cs).
 
-Note: _handling unhandled exception is a very dangerous thing since the handler
-itself could introduce exception, which would result in an unrecoverable
-situation similar to [triple
-fault](https://en.wikipedia.org/wiki/Triple_fault)_.
+**WARNING:** Use `AppDomain.UnhandledException` with caution. A throw in the
+handler puts the process into an unrecoverable state (a [triple
+fault](https://en.wikipedia.org/wiki/Triple_fault)).

--- a/docs/trace/exception-handling/README.md
+++ b/docs/trace/exception-handling/README.md
@@ -67,6 +67,7 @@ In a non-production environment, it might be useful to automatically capture the
 unhandled exceptions, travel through the unfinished activities and export them
 for troubleshooting. Here goes one possible way of doing this:
 
+<!-- markdownlint-disable MD013 -->
 ```csharp
 static void Main()
 {
@@ -84,3 +85,4 @@ static void UnhandledExceptionHandler(object source, UnhandledExceptionEventArgs
     }
 }
 ```
+<!-- markdownlint-enable MD013 -->

--- a/docs/trace/exception-handling/README.md
+++ b/docs/trace/exception-handling/README.md
@@ -1,9 +1,9 @@
 # Exception Handling
 
-## First Chance Exception
+## User-handled Exception
 
-The term `First Chance Exception` is used to describe exceptions that are
-handled by the application - whether in the user code or the framework.
+The term `User-handled Exception` is used to describe exceptions that are
+handled by the application.
 
 While using `Activity` API, the common pattern would be:
 
@@ -30,8 +30,8 @@ using (var activity = MyActivitySource.StartActivity("Foo"))
 The above approach could become hard to manage if there are deeply nested
 `Activity` objects, or there are activities created in a 3rd party library.
 
-The following configuration will automatically detect first chance exception and
-automatically set the activity status to `Error`:
+The following configuration will automatically detect exception and set the
+activity status to `Error`:
 
 ```csharp
 Sdk.CreateTracerProviderBuilder(options => {
@@ -44,18 +44,16 @@ A complete example can be found [here](./Program.cs).
 Note: this feature is platform dependent as it relies on
 [System.Runtime.InteropServices.Marshal.GetExceptionPointers](https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.marshal.getexceptionpointers).
 
-## Second Chance Exception
+## Unhandled Exception
 
-The term `Second Chance Exception` is used to describe exceptions that are not
-handled by the application.
-
-When a second chance exception happened, the behavior will depend on the
-presence of a debugger:
+The term `Unhandled Exception` is used to describe exceptions that are not
+handled by the application. When an unhandled exception happened, the behavior
+will depend on the presence of a debugger:
 
 * If there is no debugger, the exception will normally crash the process or
   terminate the thread.
-* If a debugger is attached, the debugger will be notified that an "unhandled
-  exception" happened.
+* If a debugger is attached, the debugger will be notified that an unhandled
+  exception happened.
 * In case a postmortem debugger is configured, the postmortem debugger will be
   activited and normally it will collect a crash dump.
 
@@ -66,5 +64,4 @@ possible way of doing this by using
 can be found [here](./Program.cs).
 
 **WARNING:** Use `AppDomain.UnhandledException` with caution. A throw in the
-handler puts the process into an unrecoverable state (a [triple
-fault](https://en.wikipedia.org/wiki/Triple_fault)).
+handler puts the process into an unrecoverable state.

--- a/docs/trace/exception-handling/README.md
+++ b/docs/trace/exception-handling/README.md
@@ -41,7 +41,7 @@ Sdk.CreateTracerProviderBuilder(options => {
 
 A complete example can be found [here](./Program.cs).
 
-Note: this feature is platform dependant as it relies on
+Note: this feature is platform dependent as it relies on
 [System.Runtime.InteropServices.Marshal.GetExceptionPointers](https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.marshal.getexceptionpointers).
 
 ## Second Chance Exception

--- a/docs/trace/exception-handling/exception-handling.csproj
+++ b/docs/trace/exception-handling/exception-handling.csproj
@@ -1,0 +1,8 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <!---
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="$(OpenTelemetryExporterConsolePkgVer)" />
+    -->
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Console\OpenTelemetry.Exporter.Console.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/OpenTelemetry/.publicApi/net452/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net452/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
 OpenTelemetry.Trace.ParentBasedSampler.ParentBasedSampler(OpenTelemetry.Trace.Sampler rootSampler, OpenTelemetry.Trace.Sampler remoteParentSampled = null, OpenTelemetry.Trace.Sampler remoteParentNotSampled = null, OpenTelemetry.Trace.Sampler localParentSampled = null, OpenTelemetry.Trace.Sampler localParentNotSampled = null) -> void
 OpenTelemetry.Trace.TracerProviderOptions
-OpenTelemetry.Trace.TracerProviderOptions.SetErrorStatusOnUnhandledException.get -> bool
-OpenTelemetry.Trace.TracerProviderOptions.SetErrorStatusOnUnhandledException.set -> void
+OpenTelemetry.Trace.TracerProviderOptions.SetErrorStatusOnException.get -> bool
+OpenTelemetry.Trace.TracerProviderOptions.SetErrorStatusOnException.set -> void
 OpenTelemetry.Trace.TracerProviderOptions.TracerProviderOptions() -> void
 static OpenTelemetry.Sdk.CreateTracerProviderBuilder(System.Action<OpenTelemetry.Trace.TracerProviderOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddLegacyActivity(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, string operationName) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry/.publicApi/net452/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net452/PublicAPI.Unshipped.txt
@@ -1,3 +1,8 @@
 OpenTelemetry.Trace.ParentBasedSampler.ParentBasedSampler(OpenTelemetry.Trace.Sampler rootSampler, OpenTelemetry.Trace.Sampler remoteParentSampled = null, OpenTelemetry.Trace.Sampler remoteParentNotSampled = null, OpenTelemetry.Trace.Sampler localParentSampled = null, OpenTelemetry.Trace.Sampler localParentNotSampled = null) -> void
+OpenTelemetry.Trace.TracerProviderOptions
+OpenTelemetry.Trace.TracerProviderOptions.SetErrorStatusOnUnhandledException.get -> bool
+OpenTelemetry.Trace.TracerProviderOptions.SetErrorStatusOnUnhandledException.set -> void
+OpenTelemetry.Trace.TracerProviderOptions.TracerProviderOptions() -> void
+static OpenTelemetry.Sdk.CreateTracerProviderBuilder(System.Action<OpenTelemetry.Trace.TracerProviderOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddLegacyActivity(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, string operationName) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Trace.TracerProviderExtensions.ForceFlush(this OpenTelemetry.Trace.TracerProvider provider, int timeoutMilliseconds = -1) -> bool

--- a/src/OpenTelemetry/.publicApi/net46/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net46/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
 OpenTelemetry.Trace.ParentBasedSampler.ParentBasedSampler(OpenTelemetry.Trace.Sampler rootSampler, OpenTelemetry.Trace.Sampler remoteParentSampled = null, OpenTelemetry.Trace.Sampler remoteParentNotSampled = null, OpenTelemetry.Trace.Sampler localParentSampled = null, OpenTelemetry.Trace.Sampler localParentNotSampled = null) -> void
 OpenTelemetry.Trace.TracerProviderOptions
-OpenTelemetry.Trace.TracerProviderOptions.SetErrorStatusOnUnhandledException.get -> bool
-OpenTelemetry.Trace.TracerProviderOptions.SetErrorStatusOnUnhandledException.set -> void
+OpenTelemetry.Trace.TracerProviderOptions.SetErrorStatusOnException.get -> bool
+OpenTelemetry.Trace.TracerProviderOptions.SetErrorStatusOnException.set -> void
 OpenTelemetry.Trace.TracerProviderOptions.TracerProviderOptions() -> void
 static OpenTelemetry.Sdk.CreateTracerProviderBuilder(System.Action<OpenTelemetry.Trace.TracerProviderOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddLegacyActivity(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, string operationName) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry/.publicApi/net46/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net46/PublicAPI.Unshipped.txt
@@ -1,3 +1,8 @@
 OpenTelemetry.Trace.ParentBasedSampler.ParentBasedSampler(OpenTelemetry.Trace.Sampler rootSampler, OpenTelemetry.Trace.Sampler remoteParentSampled = null, OpenTelemetry.Trace.Sampler remoteParentNotSampled = null, OpenTelemetry.Trace.Sampler localParentSampled = null, OpenTelemetry.Trace.Sampler localParentNotSampled = null) -> void
+OpenTelemetry.Trace.TracerProviderOptions
+OpenTelemetry.Trace.TracerProviderOptions.SetErrorStatusOnUnhandledException.get -> bool
+OpenTelemetry.Trace.TracerProviderOptions.SetErrorStatusOnUnhandledException.set -> void
+OpenTelemetry.Trace.TracerProviderOptions.TracerProviderOptions() -> void
+static OpenTelemetry.Sdk.CreateTracerProviderBuilder(System.Action<OpenTelemetry.Trace.TracerProviderOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddLegacyActivity(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, string operationName) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Trace.TracerProviderExtensions.ForceFlush(this OpenTelemetry.Trace.TracerProvider provider, int timeoutMilliseconds = -1) -> bool

--- a/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
 OpenTelemetry.Trace.ParentBasedSampler.ParentBasedSampler(OpenTelemetry.Trace.Sampler rootSampler, OpenTelemetry.Trace.Sampler remoteParentSampled = null, OpenTelemetry.Trace.Sampler remoteParentNotSampled = null, OpenTelemetry.Trace.Sampler localParentSampled = null, OpenTelemetry.Trace.Sampler localParentNotSampled = null) -> void
 OpenTelemetry.Trace.TracerProviderOptions
-OpenTelemetry.Trace.TracerProviderOptions.SetErrorStatusOnUnhandledException.get -> bool
-OpenTelemetry.Trace.TracerProviderOptions.SetErrorStatusOnUnhandledException.set -> void
+OpenTelemetry.Trace.TracerProviderOptions.SetErrorStatusOnException.get -> bool
+OpenTelemetry.Trace.TracerProviderOptions.SetErrorStatusOnException.set -> void
 OpenTelemetry.Trace.TracerProviderOptions.TracerProviderOptions() -> void
 static OpenTelemetry.Sdk.CreateTracerProviderBuilder(System.Action<OpenTelemetry.Trace.TracerProviderOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddLegacyActivity(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, string operationName) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -1,3 +1,8 @@
 OpenTelemetry.Trace.ParentBasedSampler.ParentBasedSampler(OpenTelemetry.Trace.Sampler rootSampler, OpenTelemetry.Trace.Sampler remoteParentSampled = null, OpenTelemetry.Trace.Sampler remoteParentNotSampled = null, OpenTelemetry.Trace.Sampler localParentSampled = null, OpenTelemetry.Trace.Sampler localParentNotSampled = null) -> void
+OpenTelemetry.Trace.TracerProviderOptions
+OpenTelemetry.Trace.TracerProviderOptions.SetErrorStatusOnUnhandledException.get -> bool
+OpenTelemetry.Trace.TracerProviderOptions.SetErrorStatusOnUnhandledException.set -> void
+OpenTelemetry.Trace.TracerProviderOptions.TracerProviderOptions() -> void
+static OpenTelemetry.Sdk.CreateTracerProviderBuilder(System.Action<OpenTelemetry.Trace.TracerProviderOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddLegacyActivity(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, string operationName) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Trace.TracerProviderExtensions.ForceFlush(this OpenTelemetry.Trace.TracerProvider provider, int timeoutMilliseconds = -1) -> bool

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
 OpenTelemetry.Trace.ParentBasedSampler.ParentBasedSampler(OpenTelemetry.Trace.Sampler rootSampler, OpenTelemetry.Trace.Sampler remoteParentSampled = null, OpenTelemetry.Trace.Sampler remoteParentNotSampled = null, OpenTelemetry.Trace.Sampler localParentSampled = null, OpenTelemetry.Trace.Sampler localParentNotSampled = null) -> void
 OpenTelemetry.Trace.TracerProviderOptions
-OpenTelemetry.Trace.TracerProviderOptions.SetErrorStatusOnUnhandledException.get -> bool
-OpenTelemetry.Trace.TracerProviderOptions.SetErrorStatusOnUnhandledException.set -> void
+OpenTelemetry.Trace.TracerProviderOptions.SetErrorStatusOnException.get -> bool
+OpenTelemetry.Trace.TracerProviderOptions.SetErrorStatusOnException.set -> void
 OpenTelemetry.Trace.TracerProviderOptions.TracerProviderOptions() -> void
 static OpenTelemetry.Sdk.CreateTracerProviderBuilder(System.Action<OpenTelemetry.Trace.TracerProviderOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddLegacyActivity(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, string operationName) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,8 @@
 OpenTelemetry.Trace.ParentBasedSampler.ParentBasedSampler(OpenTelemetry.Trace.Sampler rootSampler, OpenTelemetry.Trace.Sampler remoteParentSampled = null, OpenTelemetry.Trace.Sampler remoteParentNotSampled = null, OpenTelemetry.Trace.Sampler localParentSampled = null, OpenTelemetry.Trace.Sampler localParentNotSampled = null) -> void
+OpenTelemetry.Trace.TracerProviderOptions
+OpenTelemetry.Trace.TracerProviderOptions.SetErrorStatusOnUnhandledException.get -> bool
+OpenTelemetry.Trace.TracerProviderOptions.SetErrorStatusOnUnhandledException.set -> void
+OpenTelemetry.Trace.TracerProviderOptions.TracerProviderOptions() -> void
+static OpenTelemetry.Sdk.CreateTracerProviderBuilder(System.Action<OpenTelemetry.Trace.TracerProviderOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddLegacyActivity(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, string operationName) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Trace.TracerProviderExtensions.ForceFlush(this OpenTelemetry.Trace.TracerProvider provider, int timeoutMilliseconds = -1) -> bool

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -9,7 +9,7 @@ please check the latest changes
 
 ## Unreleased
 
-* Added `TracerProviderOptions` and `SetErrorStatusOnUnhandledException`.
+* Added `TracerProviderOptions` and `SetErrorStatusOnException`.
   ([#1858](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1858))
 * Added `ForceFlush` to `TracerProvider`.
   ([#1837](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1837))

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -9,7 +9,11 @@ please check the latest changes
 
 ## Unreleased
 
-* Added `ForceFlush` to `TracerProvider`. ([#1837](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1837))
+* Added `TracerProviderOptions` and `SetErrorStatusOnUnhandledException`.
+  ([#1858](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1858))
+
+* Added `ForceFlush` to `TracerProvider`.
+  ([#1837](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1837))
 
 * Added a TracerProvierBuilder extension method called
   `AddLegacyActivityOperationName` which is used by instrumentation libraries

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -11,16 +11,13 @@ please check the latest changes
 
 * Added `TracerProviderOptions` and `SetErrorStatusOnUnhandledException`.
   ([#1858](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1858))
-
 * Added `ForceFlush` to `TracerProvider`.
   ([#1837](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1837))
-
 * Added a TracerProvierBuilder extension method called
   `AddLegacyActivityOperationName` which is used by instrumentation libraries
   that use DiagnosticSource to get activities processed without
   ActivitySourceAdapter.
-  [#1836](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1836)
-
+  ([#1836](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1836))
 * Added new constructor with optional parameters to allow customization of
   `ParentBasedSampler` behavior. ([#1727](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1727))
 

--- a/src/OpenTelemetry/Sdk.cs
+++ b/src/OpenTelemetry/Sdk.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using System.Diagnostics;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Internal;
@@ -54,13 +55,24 @@ namespace OpenTelemetry
         }
 
         /// <summary>
-        /// Creates TracerProviderBuilder which should be used to build
-        /// TracerProvider.
+        /// Creates TracerProviderBuilder which should be used to build TracerProvider.
         /// </summary>
         /// <returns>TracerProviderBuilder instance, which should be used to build TracerProvider.</returns>
         public static TracerProviderBuilder CreateTracerProviderBuilder()
         {
-            return new TracerProviderBuilderSdk();
+            return CreateTracerProviderBuilder(null);
+        }
+
+        /// <summary>
+        /// Creates TracerProviderBuilder which should be used to build TracerProvider.
+        /// </summary>
+        /// <param name="configure">TracerProvider configuration options.</param>
+        /// <returns>TracerProviderBuilder instance, which should be used to build TracerProvider.</returns>
+        public static TracerProviderBuilder CreateTracerProviderBuilder(Action<TracerProviderOptions> configure = null)
+        {
+            var options = new TracerProviderOptions();
+            configure?.Invoke(options);
+            return new TracerProviderBuilderSdk(options);
         }
     }
 }

--- a/src/OpenTelemetry/Trace/ExceptionProcessor.cs
+++ b/src/OpenTelemetry/Trace/ExceptionProcessor.cs
@@ -39,7 +39,7 @@ namespace OpenTelemetry.Trace
             }
             catch (Exception ex)
             {
-                throw new NotSupportedException("System.Runtime.InteropServices.Marshal.GetExceptionPointers is not supported.", ex);
+                throw new NotSupportedException("Automatic exception detection is not supported on this platform.", ex);
             }
         }
 

--- a/src/OpenTelemetry/Trace/ExceptionProcessor.cs
+++ b/src/OpenTelemetry/Trace/ExceptionProcessor.cs
@@ -1,0 +1,53 @@
+// <copyright file="ExceptionProcessor.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace OpenTelemetry.Trace
+{
+    internal class ExceptionProcessor : BaseProcessor<Activity>
+    {
+        private readonly Func<IntPtr> fnGetExceptionPointers;
+
+        public ExceptionProcessor()
+        {
+            try
+            {
+                var flags = BindingFlags.Static | BindingFlags.Public;
+                var method = typeof(Marshal).GetMethod("GetExceptionPointers", flags, null, new Type[] { }, null);
+                var lambda = Expression.Lambda<Func<IntPtr>>(Expression.Call(method));
+                this.fnGetExceptionPointers = lambda.Compile();
+            }
+            catch (Exception ex)
+            {
+                throw new NotSupportedException("System.Runtime.InteropServices.Marshal.GetExceptionPointers is not supported.", ex);
+            }
+        }
+
+        /// <inheritdoc />
+        public override void OnEnd(Activity activity)
+        {
+            if (this.fnGetExceptionPointers() != IntPtr.Zero)
+            {
+                activity.SetStatus(Status.Error);
+            }
+        }
+    }
+}

--- a/src/OpenTelemetry/Trace/ExceptionProcessor.cs
+++ b/src/OpenTelemetry/Trace/ExceptionProcessor.cs
@@ -39,7 +39,7 @@ namespace OpenTelemetry.Trace
             }
             catch (Exception ex)
             {
-                throw new NotSupportedException("Automatic exception detection is not supported on this platform.", ex);
+                throw new NotSupportedException("System.Runtime.InteropServices.Marshal.GetExceptionPointers is not supported.", ex);
             }
         }
 

--- a/src/OpenTelemetry/Trace/TracerProviderBuilderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderBuilderSdk.cs
@@ -39,7 +39,7 @@ namespace OpenTelemetry.Trace
         {
             this.options = options ?? new TracerProviderOptions();
 
-            if (options.SetErrorStatusOnUnhandledException)
+            if (options.SetErrorStatusOnException)
             {
                 this.AddProcessor(new ExceptionProcessor());
             }

--- a/src/OpenTelemetry/Trace/TracerProviderBuilderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderBuilderSdk.cs
@@ -41,7 +41,14 @@ namespace OpenTelemetry.Trace
 
             if (options.SetErrorStatusOnException)
             {
-                this.AddProcessor(new ExceptionProcessor());
+                try
+                {
+                    this.AddProcessor(new ExceptionProcessor());
+                }
+                catch (Exception ex)
+                {
+                    throw new NotSupportedException($"{nameof(options.SetErrorStatusOnException)} is not supported on this platform.", ex);
+                }
             }
         }
 

--- a/src/OpenTelemetry/Trace/TracerProviderBuilderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderBuilderSdk.cs
@@ -28,14 +28,21 @@ namespace OpenTelemetry.Trace
     {
         private readonly List<InstrumentationFactory> instrumentationFactories = new List<InstrumentationFactory>();
 
+        private readonly TracerProviderOptions options;
         private readonly List<BaseProcessor<Activity>> processors = new List<BaseProcessor<Activity>>();
         private readonly List<string> sources = new List<string>();
         private readonly Dictionary<string, bool> legacyActivityOperationNames = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
         private ResourceBuilder resourceBuilder = ResourceBuilder.CreateDefault();
         private Sampler sampler = new ParentBasedSampler(new AlwaysOnSampler());
 
-        internal TracerProviderBuilderSdk()
+        internal TracerProviderBuilderSdk(TracerProviderOptions options)
         {
+            this.options = options ?? new TracerProviderOptions();
+
+            if (options.SetErrorStatusOnUnhandledException)
+            {
+                this.AddProcessor(new ExceptionProcessor());
+            }
         }
 
         /// <summary>

--- a/src/OpenTelemetry/Trace/TracerProviderOptions.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderOptions.cs
@@ -22,6 +22,6 @@ namespace OpenTelemetry.Trace
         /// Gets or sets a value indicating whether the status of <see cref="System.Diagnostics.Activity"/>
         /// should be set to <c>Status.Error</c> when it ended abnormally due to an unhandled exception.
         /// </summary>
-        public bool SetErrorStatusOnUnhandledException { get; set; } = false;
+        public bool SetErrorStatusOnException { get; set; } = false;
     }
 }

--- a/src/OpenTelemetry/Trace/TracerProviderOptions.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderOptions.cs
@@ -1,0 +1,27 @@
+// <copyright file="TracerProviderOptions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Trace
+{
+    public class TracerProviderOptions
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether the status of <see cref="System.Diagnostics.Activity"/>
+        /// should be set to <c>Status.Error</c> when it ended abnormally due to an unhandled exception.
+        /// </summary>
+        public bool SetErrorStatusOnUnhandledException { get; set; } = false;
+    }
+}

--- a/test/OpenTelemetry.Tests/Trace/ExceptionProcessorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ExceptionProcessorTest.cs
@@ -1,0 +1,79 @@
+// <copyright file="ExceptionProcessorTest.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using OpenTelemetry.Tests;
+using Xunit;
+
+namespace OpenTelemetry.Trace.Tests
+{
+    public class ExceptionProcessorTest
+    {
+        private const string ActivitySourceName = "ExceptionProcessorTest";
+
+        [Fact]
+        public void ActivityStatusSetToErrorWhenExceptionProcessorEnabled()
+        {
+            using var activitySource = new ActivitySource(ActivitySourceName);
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                .AddSource(ActivitySourceName)
+                .SetSampler(new AlwaysOnSampler())
+                .AddProcessor(new ExceptionProcessor())
+                .Build();
+
+            var activity = activitySource.StartActivity("Activity");
+
+            try
+            {
+                using (activity)
+                {
+                    throw new Exception("Oops!");
+                }
+            }
+            catch (Exception)
+            {
+            }
+
+            Assert.Equal(StatusCode.Error, activity.GetStatus().StatusCode);
+        }
+
+        [Fact]
+        public void ActivityStatusNotSetWhenExceptionProcessorNotEnabled()
+        {
+            using var activitySource = new ActivitySource(ActivitySourceName);
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                .AddSource(ActivitySourceName)
+                .SetSampler(new AlwaysOnSampler())
+                .Build();
+
+            var activity = activitySource.StartActivity("Activity");
+
+            try
+            {
+                using (activity)
+                {
+                    throw new Exception("Oops!");
+                }
+            }
+            catch (Exception)
+            {
+            }
+
+            Assert.Equal(StatusCode.Unset, activity.GetStatus().StatusCode);
+        }
+    }
+}

--- a/test/OpenTelemetry.Tests/Trace/ExceptionProcessorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ExceptionProcessorTest.cs
@@ -56,15 +56,24 @@ namespace OpenTelemetry.Trace.Tests
                 using (activity3 = activitySource.StartActivity("Activity3"))
                 {
                 }
-
-                activity5 = activitySource.StartActivity("Activity5");
             }
             finally
             {
                 using (activity4 = activitySource.StartActivity("Activity4"))
                 {
                 }
+            }
 
+            try
+            {
+                throw new Exception("Oops!");
+            }
+            catch (Exception)
+            {
+                activity5 = activitySource.StartActivity("Activity5");
+            }
+            finally
+            {
                 activity5.Dispose();
             }
 
@@ -77,7 +86,10 @@ namespace OpenTelemetry.Trace.Tests
             Assert.Equal(StatusCode.Unset, activity4.GetStatus().StatusCode);
             Assert.Null(activity4.GetTagValue("otel.exception_pointers"));
             Assert.Equal(StatusCode.Unset, activity5.GetStatus().StatusCode);
+#if !NETFRAMEWORK
+            // In this rare case, the following Activity tag will not get cleaned up due to perf consideration.
             Assert.NotNull(activity5.GetTagValue("otel.exception_pointers"));
+#endif
         }
 
         [Fact]

--- a/test/OpenTelemetry.Tests/Trace/ExceptionProcessorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ExceptionProcessorTest.cs
@@ -39,6 +39,7 @@ namespace OpenTelemetry.Trace.Tests
             Activity activity2 = null;
             Activity activity3 = null;
             Activity activity4 = null;
+            Activity activity5 = null;
 
             try
             {
@@ -55,18 +56,28 @@ namespace OpenTelemetry.Trace.Tests
                 using (activity3 = activitySource.StartActivity("Activity3"))
                 {
                 }
+
+                activity5 = activitySource.StartActivity("Activity5");
             }
             finally
             {
                 using (activity4 = activitySource.StartActivity("Activity4"))
                 {
                 }
+
+                activity5.Dispose();
             }
 
             Assert.Equal(StatusCode.Error, activity1.GetStatus().StatusCode);
+            Assert.Null(activity1.GetTagValue("otel.exception_pointers"));
             Assert.Equal(StatusCode.Error, activity2.GetStatus().StatusCode);
+            Assert.Null(activity2.GetTagValue("otel.exception_pointers"));
             Assert.Equal(StatusCode.Unset, activity3.GetStatus().StatusCode);
+            Assert.Null(activity3.GetTagValue("otel.exception_pointers"));
             Assert.Equal(StatusCode.Unset, activity4.GetStatus().StatusCode);
+            Assert.Null(activity4.GetTagValue("otel.exception_pointers"));
+            Assert.Equal(StatusCode.Unset, activity5.GetStatus().StatusCode);
+            Assert.NotNull(activity5.GetTagValue("otel.exception_pointers"));
         }
 
         [Fact]

--- a/test/OpenTelemetry.Tests/Trace/ExceptionProcessorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ExceptionProcessorTest.cs
@@ -35,20 +35,38 @@ namespace OpenTelemetry.Trace.Tests
                 .AddProcessor(new ExceptionProcessor())
                 .Build();
 
-            var activity = activitySource.StartActivity("Activity");
+            Activity activity1 = null;
+            Activity activity2 = null;
+            Activity activity3 = null;
+            Activity activity4 = null;
 
             try
             {
-                using (activity)
+                using (activity1 = activitySource.StartActivity("Activity1"))
                 {
-                    throw new Exception("Oops!");
+                    using (activity2 = activitySource.StartActivity("Activity2"))
+                    {
+                        throw new Exception("Oops!");
+                    }
                 }
             }
             catch (Exception)
             {
+                using (activity3 = activitySource.StartActivity("Activity3"))
+                {
+                }
+            }
+            finally
+            {
+                using (activity4 = activitySource.StartActivity("Activity4"))
+                {
+                }
             }
 
-            Assert.Equal(StatusCode.Error, activity.GetStatus().StatusCode);
+            Assert.Equal(StatusCode.Error, activity1.GetStatus().StatusCode);
+            Assert.Equal(StatusCode.Error, activity2.GetStatus().StatusCode);
+            Assert.Equal(StatusCode.Unset, activity3.GetStatus().StatusCode);
+            Assert.Equal(StatusCode.Unset, activity4.GetStatus().StatusCode);
         }
 
         [Fact]
@@ -60,11 +78,11 @@ namespace OpenTelemetry.Trace.Tests
                 .SetSampler(new AlwaysOnSampler())
                 .Build();
 
-            var activity = activitySource.StartActivity("Activity");
+            Activity activity = null;
 
             try
             {
-                using (activity)
+                using (activity = activitySource.StartActivity("Activity"))
                 {
                     throw new Exception("Oops!");
                 }

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderOptionsTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderOptionsTest.cs
@@ -26,12 +26,12 @@ namespace OpenTelemetry.Trace.Tests
         private const string ActivitySourceName = "TracerProviderOptionsTest";
 
         [Fact]
-        public void SetErrorStatusOnUnhandledExceptionEnabled()
+        public void SetErrorStatusOnExceptionEnabled()
         {
             using var activitySource = new ActivitySource(ActivitySourceName);
             using var tracerProvider = Sdk.CreateTracerProviderBuilder(options =>
                 {
-                    options.SetErrorStatusOnUnhandledException = true;
+                    options.SetErrorStatusOnException = true;
                 })
                 .AddSource(ActivitySourceName)
                 .SetSampler(new AlwaysOnSampler())
@@ -54,7 +54,7 @@ namespace OpenTelemetry.Trace.Tests
         }
 
         [Fact]
-        public void SetErrorStatusOnUnhandledExceptionDefault()
+        public void SetErrorStatusOnExceptionDefault()
         {
             using var activitySource = new ActivitySource(ActivitySourceName);
             using var tracerProvider = Sdk.CreateTracerProviderBuilder(options => { })

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderOptionsTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderOptionsTest.cs
@@ -1,0 +1,81 @@
+// <copyright file="TracerProviderOptionsTest.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using OpenTelemetry.Tests;
+using Xunit;
+
+namespace OpenTelemetry.Trace.Tests
+{
+    public class TracerProviderOptionsTest
+    {
+        private const string ActivitySourceName = "TracerProviderOptionsTest";
+
+        [Fact]
+        public void SetErrorStatusOnUnhandledExceptionEnabled()
+        {
+            using var activitySource = new ActivitySource(ActivitySourceName);
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder(options =>
+                {
+                    options.SetErrorStatusOnUnhandledException = true;
+                })
+                .AddSource(ActivitySourceName)
+                .SetSampler(new AlwaysOnSampler())
+                .Build();
+
+            var activity = activitySource.StartActivity("Activity");
+
+            try
+            {
+                using (activity)
+                {
+                    throw new Exception("Oops!");
+                }
+            }
+            catch (Exception)
+            {
+            }
+
+            Assert.Equal(StatusCode.Error, activity.GetStatus().StatusCode);
+        }
+
+        [Fact]
+        public void SetErrorStatusOnUnhandledExceptionDefault()
+        {
+            using var activitySource = new ActivitySource(ActivitySourceName);
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder(options => { })
+                .AddSource(ActivitySourceName)
+                .SetSampler(new AlwaysOnSampler())
+                .Build();
+
+            var activity = activitySource.StartActivity("Activity");
+
+            try
+            {
+                using (activity)
+                {
+                    throw new Exception("Oops!");
+                }
+            }
+            catch (Exception)
+            {
+            }
+
+            Assert.Equal(StatusCode.Unset, activity.GetStatus().StatusCode);
+        }
+    }
+}


### PR DESCRIPTION
Related to #1853.

## Changes

* Added `TracerProviderOptions` to allow configurations while creating the tracer provider. Inspired by @CodeBlanch per offline discussion.
* Introduced `ExceptionProcessor` based on the idea from #1853.
  * I made this a processor, later we can add more features to it (by supporting more options/flags) - e.g. extract the SEH content and call activity.SetTag.
  * An alternative way is to put the logic inside TraceProviderSdk but I think it will be too bulky (and people who don't use this will pay for an extra if-condition check).

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Design discussion issue #1853
* [x] Changes in public API reviewed
