### PR TITLE
Use application base directory to locate self diagnostic config file

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -25,7 +25,6 @@ please check the latest changes
   [self diagnostic configuration file](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry/README.md#troubleshooting).
   ([#1865](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1865))
 
-
 ## 1.0.1
 
 Released 2021-Feb-10

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -20,6 +20,12 @@ please check the latest changes
 * Added new constructor with optional parameters to allow customization of
   `ParentBasedSampler` behavior. ([#1727](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1727))
 
+* The application base directory is now tested after the current directory when
+  searching for the
+  [self diagnostic configuration file](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry/README.md#troubleshooting).
+  ([#1865](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1865))
+
+
 ## 1.0.1
 
 Released 2021-Feb-10

--- a/src/OpenTelemetry/Internal/SelfDiagnosticsConfigParser.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnosticsConfigParser.cs
@@ -54,12 +54,19 @@ namespace OpenTelemetry.Internal
             logLevel = EventLevel.LogAlways;
             try
             {
-                if (!File.Exists(ConfigFileName))
+#if NET452
+                var configFilePath = AppDomain.CurrentDomain.BaseDirectory;
+#else
+                var configFilePath = AppContext.BaseDirectory;
+#endif
+                configFilePath = Path.Combine(configFilePath, ConfigFileName);
+
+                if (!File.Exists(configFilePath))
                 {
                     return false;
                 }
 
-                using FileStream file = File.Open(ConfigFileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+                using FileStream file = File.Open(configFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
                 var buffer = this.configBuffer;
                 if (buffer == null)
                 {

--- a/src/OpenTelemetry/Internal/SelfDiagnosticsConfigParser.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnosticsConfigParser.cs
@@ -64,7 +64,8 @@ namespace OpenTelemetry.Internal
 #else
                     configFilePath = Path.Combine(AppContext.BaseDirectory, ConfigFileName);
 #endif
-                    // second check using application base directory
+
+                    // Second check using application base directory
                     if (!File.Exists(configFilePath))
                     {
                         return false;

--- a/src/OpenTelemetry/Internal/SelfDiagnosticsConfigParser.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnosticsConfigParser.cs
@@ -54,16 +54,21 @@ namespace OpenTelemetry.Internal
             logLevel = EventLevel.LogAlways;
             try
             {
-#if NET452
-                var configFilePath = AppDomain.CurrentDomain.BaseDirectory;
-#else
-                var configFilePath = AppContext.BaseDirectory;
-#endif
-                configFilePath = Path.Combine(configFilePath, ConfigFileName);
+                var configFilePath = ConfigFileName;
 
+                // First check using current working directory
                 if (!File.Exists(configFilePath))
                 {
-                    return false;
+#if NET452
+                    configFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ConfigFileName);
+#else
+                    configFilePath = Path.Combine(AppContext.BaseDirectory, ConfigFileName);
+#endif
+                    // second check using application base directory
+                    if (!File.Exists(configFilePath))
+                    {
+                        return false;
+                    }
                 }
 
                 using FileStream file = File.Open(configFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);


### PR DESCRIPTION
Fixes #1714. Invalidate #1717

## Changes

This change updates the way the self diagnostic config file is located. Instead of using environment current directory, it uses the application base directory.

This fixes self diagnostic config file lookup in ASP.NET applications and makes the app compatible with all kinds of hosting.

This PR should also update documentation (readme).