### PR TITLE
Logs: Support parsing State & Scopes and capture of formatted Message

### DIFF
--- a/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -1,3 +1,12 @@
+OpenTelemetry.Logs.LogRecord.ForEachScope<TState>(System.Action<object, TState> callback, TState state) -> void
+OpenTelemetry.Logs.LogRecord.Message.get -> string
+OpenTelemetry.Logs.LogRecord.StateValues.get -> System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, object>>
+OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeMessage.get -> bool
+OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeMessage.set -> void
+OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeScopes.get -> bool
+OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeScopes.set -> void
+OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.get -> bool
+OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.set -> void
 OpenTelemetry.Trace.ParentBasedSampler.ParentBasedSampler(OpenTelemetry.Trace.Sampler rootSampler, OpenTelemetry.Trace.Sampler remoteParentSampled = null, OpenTelemetry.Trace.Sampler remoteParentNotSampled = null, OpenTelemetry.Trace.Sampler localParentSampled = null, OpenTelemetry.Trace.Sampler localParentNotSampled = null) -> void
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddLegacyActivity(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, string operationName) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Trace.TracerProviderExtensions.ForceFlush(this OpenTelemetry.Trace.TracerProvider provider, int timeoutMilliseconds = -1) -> bool

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,12 @@
+OpenTelemetry.Logs.LogRecord.ForEachScope<TState>(System.Action<object, TState> callback, TState state) -> void
+OpenTelemetry.Logs.LogRecord.Message.get -> string
+OpenTelemetry.Logs.LogRecord.StateValues.get -> System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, object>>
+OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeMessage.get -> bool
+OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeMessage.set -> void
+OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeScopes.get -> bool
+OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeScopes.set -> void
+OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.get -> bool
+OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.set -> void
 OpenTelemetry.Trace.ParentBasedSampler.ParentBasedSampler(OpenTelemetry.Trace.Sampler rootSampler, OpenTelemetry.Trace.Sampler remoteParentSampled = null, OpenTelemetry.Trace.Sampler remoteParentNotSampled = null, OpenTelemetry.Trace.Sampler localParentSampled = null, OpenTelemetry.Trace.Sampler localParentNotSampled = null) -> void
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddLegacyActivity(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, string operationName) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Trace.TracerProviderExtensions.ForceFlush(this OpenTelemetry.Trace.TracerProvider provider, int timeoutMilliseconds = -1) -> bool

--- a/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
@@ -16,8 +16,9 @@
 
 #if NET461 || NETSTANDARD2_0
 using System;
+using System.Collections.Generic;
+using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using Microsoft.Extensions.Logging;
 
 namespace OpenTelemetry.Logs
@@ -37,19 +38,29 @@ namespace OpenTelemetry.Logs
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
-            if (!this.IsEnabled(logLevel))
+            if (!this.IsEnabled(logLevel) || Sdk.SuppressInstrumentation)
             {
                 return;
             }
 
-            if (Sdk.SuppressInstrumentation)
+            var processor = this.provider.Processor;
+            if (processor != null)
             {
-                return;
+                var options = this.provider.Options;
+
+                var record = new LogRecord(
+                    options.IncludeScopes ? this.ScopeProvider : null,
+                    DateTime.UtcNow,
+                    this.categoryName,
+                    logLevel,
+                    eventId,
+                    options.IncludeMessage ? formatter(state, exception) : null,
+                    options.ParseStateValues ? null : (object)state,
+                    exception,
+                    options.ParseStateValues ? this.ParseState(state) : null);
+
+                processor.OnEnd(record);
             }
-
-            var record = new LogRecord(DateTime.UtcNow, this.categoryName, logLevel, eventId, state, exception);
-
-            this.provider.Processor?.OnEnd(record);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -59,6 +70,126 @@ namespace OpenTelemetry.Logs
         }
 
         public IDisposable BeginScope<TState>(TState state) => this.ScopeProvider?.Push(state) ?? null;
+
+        private IReadOnlyList<KeyValuePair<string, object>> ParseState<TState>(TState state)
+        {
+            if (state is IReadOnlyList<KeyValuePair<string, object>>)
+            {
+                return StateValueListParser<TState>.ParseStateFunc(state);
+            }
+            else if (state is IEnumerable<KeyValuePair<string, object>> stateValues)
+            {
+                return new List<KeyValuePair<string, object>>(stateValues);
+            }
+            else
+            {
+                return new List<KeyValuePair<string, object>>
+                {
+                    new KeyValuePair<string, object>(string.Empty, state),
+                };
+            }
+        }
+
+        private static class StateValueListParser<TState>
+        {
+            static StateValueListParser()
+            {
+                /* The code below is building a dynamic method to do this...
+
+                     int count = state.Count;
+
+                     List<KeyValuePair<string, object>> stateValues = new List<KeyValuePair<string, object>>(count);
+
+                     for (int i = 0; i < count; i++)
+                     {
+                         stateValues.Add(state[i]);
+                     }
+
+                     return stateValues;
+
+                  ...so we don't box structs or allocate an enumerator. */
+
+                var stateType = typeof(TState);
+                var listType = typeof(List<KeyValuePair<string, object>>);
+                var readOnlyListType = typeof(IReadOnlyList<KeyValuePair<string, object>>);
+
+                var dynamicMethod = new DynamicMethod(
+                    nameof(StateValueListParser<TState>),
+                    readOnlyListType,
+                    new[] { stateType },
+                    typeof(StateValueListParser<TState>).Module,
+                    skipVisibility: true);
+
+                var generator = dynamicMethod.GetILGenerator();
+
+                var testLabel = generator.DefineLabel();
+                var writeItemLabel = generator.DefineLabel();
+
+                generator.DeclareLocal(typeof(int)); // count
+                generator.DeclareLocal(listType); // list
+                generator.DeclareLocal(typeof(int)); // i
+
+                if (stateType.IsValueType)
+                {
+                    generator.Emit(OpCodes.Ldarga_S, 0); // state
+                    generator.Emit(OpCodes.Call, stateType.GetProperty("Count").GetMethod);
+                }
+                else
+                {
+                    generator.Emit(OpCodes.Ldarg_0); // state
+                    generator.Emit(OpCodes.Callvirt, typeof(IReadOnlyCollection<KeyValuePair<string, object>>).GetProperty("Count").GetMethod);
+                }
+
+                generator.Emit(OpCodes.Stloc_0); // count = state.Count
+                generator.Emit(OpCodes.Ldloc_0);
+                generator.Emit(OpCodes.Newobj, listType.GetConstructor(new Type[] { typeof(int) }));
+                generator.Emit(OpCodes.Stloc_1); // list = new List(count)
+
+                generator.Emit(OpCodes.Ldc_I4_0);
+                generator.Emit(OpCodes.Stloc_2); // i = 0
+
+                generator.Emit(OpCodes.Br_S, testLabel);
+                generator.MarkLabel(writeItemLabel);
+                generator.Emit(OpCodes.Ldloc_1); // list
+                if (stateType.IsValueType)
+                {
+                    generator.Emit(OpCodes.Ldarga_S, 0); // state
+                }
+                else
+                {
+                    generator.Emit(OpCodes.Ldarg_0); // state
+                }
+
+                generator.Emit(OpCodes.Ldloc_2); // i
+                if (stateType.IsValueType)
+                {
+                    generator.Emit(OpCodes.Call, stateType.GetProperty("Item").GetMethod);
+                }
+                else
+                {
+                    generator.Emit(OpCodes.Callvirt, readOnlyListType.GetProperty("Item").GetMethod);
+                }
+
+                generator.Emit(OpCodes.Callvirt, listType.GetMethod("Add", new Type[] { typeof(KeyValuePair<string, object>) })); // list.Add(state[i])
+
+                generator.Emit(OpCodes.Ldloc_2); // i
+                generator.Emit(OpCodes.Ldc_I4_1);
+                generator.Emit(OpCodes.Add); // i++
+                generator.Emit(OpCodes.Stloc_2);
+
+                generator.MarkLabel(testLabel);
+                generator.Emit(OpCodes.Ldloc_2); // i
+                generator.Emit(OpCodes.Ldloc_0); // count
+                generator.Emit(OpCodes.Blt_S, writeItemLabel);
+
+                generator.Emit(OpCodes.Ldloc_1); // list
+                generator.Emit(OpCodes.Ret);
+
+                ParseStateFunc = (Func<TState, IReadOnlyList<KeyValuePair<string, object>>>)dynamicMethod.CreateDelegate(typeof(Func<TState, IReadOnlyList<KeyValuePair<string, object>>>));
+            }
+
+            public static Func<TState, IReadOnlyList<KeyValuePair<string, object>>> ParseStateFunc { get; }
+        }
     }
 }
 #endif

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggerOptions.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggerOptions.cs
@@ -17,13 +17,27 @@
 #if NET461 || NETSTANDARD2_0
 using System;
 using System.Collections.Generic;
-using Microsoft.Extensions.Logging;
 
 namespace OpenTelemetry.Logs
 {
     public class OpenTelemetryLoggerOptions
     {
         internal readonly List<BaseProcessor<LogRecord>> Processors = new List<BaseProcessor<LogRecord>>();
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not log scopes should be included on generated <see cref="LogRecord"/>s. Default value: False.
+        /// </summary>
+        public bool IncludeScopes { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not log message should be included on generated <see cref="LogRecord"/>s. Default value: False.
+        /// </summary>
+        public bool IncludeMessage { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not log state should be parsed into <see cref="LogRecord.StateValues"/> on generated <see cref="LogRecord"/>s. Default value: False.
+        /// </summary>
+        public bool ParseStateValues { get; set; }
 
         /// <summary>
         /// Adds processor to the options.


### PR DESCRIPTION
Fixes #1834

## Changes

[Originally part of #1833 but @cijothomas requested that it be split up.]

* Exposes scope, message, & parsed state features on `LogRecord`
* Default behavior is exactly as it is in 1.0 (no message, no scopes, not parsing state)
* When turned on state parsing uses some IL magic to not box structs or allocate enumerators. It will allocate a list to store the parsed KVPs. We do have pooled list capability but they have to be returned to the pool and the API is not very nice. Since these have to go to userland an allocation seemed unavoidable. I do pass the size/capacity to the list ctor in order to reduce the growth penalty.

## Public API

```csharp
public class OpenTelemetryLoggerOptions
{
        // Turns on parsing scopes onto tags. Default: False
        public bool IncludeScopes { get; set; }

        // Turns on calling the formatter. Default: False
        public bool IncludeMessage { get; set; }

        // Turns on parsing state onto tags. Default: False
        public bool ParseStateValues { get; set; }
}

public class LogRecord
{
// Existing-----------------------------------------------------------------------------------//
        // Will now be set to null if ParseStateValues is turned on. To avoid boxing.
        public object State { get; }

// New--------------------------------------------------------------------------------------//
        // Set to the result of the formatter if IncludeMessage is turned on.
        public string Message { get; }

        // Set to the parsing results if ParseStateValues is turned on.
        public IReadOnlyList<KeyValuePair<string, object>> StateValues { get; }

        // Invoke a callback for each registered scope. Does a no-op if IncludeScopes is turned off.
        public void ForEachScope<TState>(Action<object, TState> callback, TState state)
}
```

## TODOs

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
