### PR TITLE
Fix parsing logic for headers in OtlpExporter

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporter.cs
@@ -188,6 +188,8 @@ namespace OpenTelemetry.Exporter
                     headers.Split(','),
                     (pair) =>
                     {
+                        // Specify the maximum number of substrings to return to 2
+                        // This treats everything that follows the first `=` in the string as the value to be added for the metadata key
                         var keyValueData = pair.Split(new char[] { '=' }, 2);
                         if (keyValueData.Length != 2)
                         {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporter.cs
@@ -188,7 +188,7 @@ namespace OpenTelemetry.Exporter
                     headers.Split(','),
                     (pair) =>
                     {
-                        var keyValueData = pair.Split('=');
+                        var keyValueData = pair.Split(new char[] { '=' }, 2);
                         if (keyValueData.Length != 2)
                         {
                             throw new ArgumentException("Headers provided in an invalid format.");

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterTest.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterTest.cs
@@ -330,6 +330,9 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
         [InlineData("key=value", new string[] { "key" }, new string[] { "value" })]
         [InlineData("key1=value1,key2=value2", new string[] { "key1", "key2" }, new string[] { "value1", "value2" })]
         [InlineData("key1 = value1, key2=value2 ", new string[] { "key1", "key2" }, new string[] { "value1", "value2" })]
+        [InlineData("key==value", new string[] { "key" }, new string[] { "=value" })]
+        [InlineData("access-token=abc=/123,timeout=1234", new string[] { "access-token", "timeout" }, new string[] { "abc=/123", "1234" })]
+        [InlineData("key1=value1;key2=value2", new string[] { "key1" }, new string[] { "value1;key2=value2" })] // semicolon is not treated as a delimeter (https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#specifying-headers-via-environment-variables)
         public void GetMetadataFromHeadersWorksCorrectFormat(string headers, string[] keys, string[] values)
         {
             var otlpExporter = new OtlpTraceExporter(new OtlpExporterOptions());
@@ -348,8 +351,6 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
         [Theory]
         [InlineData("headers")]
         [InlineData("key,value")]
-        [InlineData("key==value")]
-        [InlineData("key1=value1;key2=value2")] // semicolon separated values are not supported (https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#specifying-headers-via-environment-variables)
         public void GetMetadataFromHeadersThrowsExceptionOnOnvalidFormat(string headers)
         {
             var otlpExporter = new OtlpTraceExporter(new OtlpExporterOptions());

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterTest.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterTest.cs
@@ -18,8 +18,10 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using Google.Protobuf.Collections;
+using Grpc.Core;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Resources;
 #if NET452
@@ -28,10 +30,12 @@ using OpenTelemetry.Internal;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
 using Xunit;
+using Xunit.Sdk;
 using GrpcCore = Grpc.Core;
 using OtlpCollector = Opentelemetry.Proto.Collector.Trace.V1;
 using OtlpCommon = Opentelemetry.Proto.Common.V1;
 using OtlpTrace = Opentelemetry.Proto.Trace.V1;
+using Status = OpenTelemetry.Trace.Status;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
 {
@@ -320,6 +324,51 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
 
             Assert.True(startCalled);
             Assert.True(endCalled);
+        }
+
+        [Theory]
+        [InlineData("key=value", new string[] { "key" }, new string[] { "value" })]
+        [InlineData("key1=value1,key2=value2", new string[] { "key1", "key2" }, new string[] { "value1", "value2" })]
+        [InlineData("key1 = value1, key2=value2 ", new string[] { "key1", "key2" }, new string[] { "value1", "value2" })]
+        public void GetMetadataFromHeadersWorksCorrectFormat(string headers, string[] keys, string[] values)
+        {
+            var otlpExporter = new OtlpTraceExporter(new OtlpExporterOptions());
+            var metadata = typeof(OtlpTraceExporter)
+                    .GetMethod("GetMetadataFromHeaders", BindingFlags.NonPublic | BindingFlags.Static)
+                    .Invoke(otlpExporter, new object[] { headers }) as Metadata;
+
+            Assert.Equal(keys.Length, metadata.Count);
+
+            for (int i = 0; i < keys.Length; i++)
+            {
+                Assert.Contains(metadata, entry => entry.Key == keys[i] && entry.Value == values[i]);
+            }
+        }
+
+        [Theory]
+        [InlineData("headers")]
+        [InlineData("key,value")]
+        [InlineData("key==value")]
+        [InlineData("key1=value1;key2=value2")] // semicolon separated values are not supported (https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#specifying-headers-via-environment-variables)
+        public void GetMetadataFromHeadersThrowsExceptionOnOnvalidFormat(string headers)
+        {
+            var otlpExporter = new OtlpTraceExporter(new OtlpExporterOptions());
+            try
+            {
+                var metadata = typeof(OtlpTraceExporter)
+                            .GetMethod("GetMetadataFromHeaders", BindingFlags.NonPublic | BindingFlags.Static)
+                            .Invoke(otlpExporter, new object[] { headers }) as Metadata;
+            }
+            catch (Exception ex)
+            {
+                // The exception thrown here is System.Reflection.TargetInvocationException. The exception thrown by the method GetMetadataFromHeaders
+                // is captured in the inner exception
+                Assert.IsType<ArgumentException>(ex.InnerException);
+                Assert.Equal("Headers provided in an invalid format.", ex.InnerException.Message);
+                return;
+            }
+
+            throw new XunitException("GetMetadataFromHeaders did not throw an exception for invalid input headers");
         }
 
         private static void AssertOtlpAttributes(


### PR DESCRIPTION
Fixes #1902 

## Changes
- Fixed the parsing logic to pick the first '=' as the delimiter and parse everything that follows the first `=` in the string as the value for the header field
  For eg. Parse `key==value` to add the following to metadata:
  `metadata.Add("key", "==value");`
- Added unit tests for GetMetadataFromHeaders method for OtlpExporter.cs

https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#specifying-headers-via-environment-variables