### PR TITLE
Legacy activity support for SuppressInstrumentation

### DIFF
--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -75,8 +75,17 @@ namespace OpenTelemetry.Trace
                         // We have a legacy activity in hand now
                         if (legacyActivityOperationNames.ContainsKey(activity.OperationName))
                         {
-                            // Legacy activity matches the user configured list. Call sampler for the legacy activity
-                            this.getRequestedDataAction(activity);
+                            // Legacy activity matches the user configured list.
+                            // Call sampler for the legacy activity
+                            // unless suppressed.
+                            if (!Sdk.SuppressInstrumentation)
+                            {
+                                this.getRequestedDataAction(activity);
+                            }
+                            else
+                            {
+                                activity.IsAllDataRequested = false;
+                            }
                         }
                         else
                         {

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
@@ -216,6 +216,42 @@ namespace OpenTelemetry.Trace.Tests
         }
 
         [Fact]
+        public void TracerSdkSetsActivityDataRequestedToFalseWhenSuppressInstrumentationIsTrueForLegacyActivity()
+        {
+            using TestActivityProcessor testActivityProcessor = new TestActivityProcessor();
+
+            bool startCalled = false;
+            bool endCalled = false;
+
+            testActivityProcessor.StartAction =
+                (a) =>
+                {
+                    startCalled = true;
+                };
+
+            testActivityProcessor.EndAction =
+                (a) =>
+                {
+                    endCalled = true;
+                };
+
+            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+                        .AddLegacyActivity("random")
+                        .AddProcessor(testActivityProcessor)
+                        .SetSampler(new AlwaysOnSampler())
+                        .Build();
+
+            using (SuppressInstrumentationScope.Begin(true))
+            {
+                using var activity = new Activity("random").Start();
+                Assert.False(activity.IsAllDataRequested);
+            }
+
+            Assert.False(startCalled);
+            Assert.False(endCalled);
+        }
+
+        [Fact]
         public void ProcessorDoesNotReceiveNotRecordDecisionSpan()
         {
             var testSampler = new TestSampler();

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
@@ -236,7 +236,7 @@ namespace OpenTelemetry.Trace.Tests
                 };
 
             using var openTelemetry = Sdk.CreateTracerProviderBuilder()
-                        .AddLegacyActivity("random")
+                        .AddLegacySource("random")
                         .AddProcessor(testActivityProcessor)
                         .SetSampler(new AlwaysOnSampler())
                         .Build();


### PR DESCRIPTION
This makes the behavior close to ActivitySource activities - in that case Activity is not created at all, but the closest we can have in legacy activity is to set `IsAllDataRequested` as false

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
