### PR TITLE
Remove suppress inc and dec from diagnosticsourcelisteners 

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -9,6 +9,9 @@ please check the latest changes
 
 ## Unreleased
 
+* Removed SuppressScope Increment/Decrement from DiagnosticSourceListeners.
+  ([1893](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1893))
+
 * Added `TracerProviderBuilder.SetErrorStatusOnException` which automatically
   sets the activity status to `Error` when exception happened.
   ([#1858](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1858)

--- a/src/OpenTelemetry/DiagnosticSourceInstrumentation/DiagnosticSourceListener.cs
+++ b/src/OpenTelemetry/DiagnosticSourceInstrumentation/DiagnosticSourceListener.cs
@@ -53,17 +53,11 @@ namespace OpenTelemetry.Instrumentation
             {
                 if (value.Key.EndsWith("Start", StringComparison.Ordinal))
                 {
-                    if (SuppressInstrumentationScope.IncrementIfTriggered() == 0)
-                    {
-                        this.handler.OnStartActivity(Activity.Current, value.Value);
-                    }
+                    this.handler.OnStartActivity(Activity.Current, value.Value);
                 }
                 else if (value.Key.EndsWith("Stop", StringComparison.Ordinal))
                 {
-                    if (SuppressInstrumentationScope.DecrementIfTriggered() == 0)
-                    {
-                        this.handler.OnStopActivity(Activity.Current, value.Value);
-                    }
+                    this.handler.OnStopActivity(Activity.Current, value.Value);
                 }
                 else if (value.Key.EndsWith("Exception", StringComparison.Ordinal))
                 {

--- a/test/OpenTelemetry.Tests/Instrumentation/DiagnosticSourceListenerTest.cs
+++ b/test/OpenTelemetry.Tests/Instrumentation/DiagnosticSourceListenerTest.cs
@@ -33,28 +33,5 @@ namespace OpenTelemetry.Instrumentation.Tests
             this.testDiagnosticSourceSubscriber = new DiagnosticSourceSubscriber(this.testListenerHandler, null);
             this.testDiagnosticSourceSubscriber.Subscribe();
         }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void ListenerHandlerIsNotInvokedWhenSuppressInstrumentationTrue(bool suppressInstrumentation)
-        {
-            using var scope = SuppressInstrumentationScope.Begin(suppressInstrumentation);
-
-            var activity = new Activity("Main");
-            this.diagnosticSource.StartActivity(activity, null);
-            this.diagnosticSource.StopActivity(activity, null);
-
-            if (suppressInstrumentation)
-            {
-                Assert.Equal(0, this.testListenerHandler.OnStartInvokedCount);
-                Assert.Equal(0, this.testListenerHandler.OnStopInvokedCount);
-            }
-            else
-            {
-                Assert.Equal(1, this.testListenerHandler.OnStartInvokedCount);
-                Assert.Equal(1, this.testListenerHandler.OnStopInvokedCount);
-            }
-        }
     }
 }


### PR DESCRIPTION
as TracerProviderSdk is the sole place controlling start and stop of activities and feeding to processor pipeline.
(This is cause TracerProviderSdk now natively listens to legacy activities start/stop after https://github.com/open-telemetry/opentelemetry-dotnet/pull/1836)

Fixes #.

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
