### PR TITLE
Adding TracerProviderSdkOptions and use factories for all options

### DIFF
--- a/src/OpenTelemetry/.publicApi/net452/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net452/PublicAPI.Unshipped.txt
@@ -1,4 +1,30 @@
 OpenTelemetry.Trace.ParentBasedSampler.ParentBasedSampler(OpenTelemetry.Trace.Sampler rootSampler, OpenTelemetry.Trace.Sampler remoteParentSampled = null, OpenTelemetry.Trace.Sampler remoteParentNotSampled = null, OpenTelemetry.Trace.Sampler localParentSampled = null, OpenTelemetry.Trace.Sampler localParentNotSampled = null) -> void
+OpenTelemetry.Trace.TracerProviderBuilderSdk
+OpenTelemetry.Trace.TracerProviderBuilderSdk.TracerProviderBuilderSdk() -> void
+OpenTelemetry.Trace.TracerProviderSdkOptions
+OpenTelemetry.Trace.TracerProviderSdkOptions.InstrumentationFactories.get -> System.Collections.Generic.ICollection<OpenTelemetry.Trace.TracerProviderSdkOptions.InstrumentationFactory>
+OpenTelemetry.Trace.TracerProviderSdkOptions.InstrumentationFactory
+OpenTelemetry.Trace.TracerProviderSdkOptions.InstrumentationFactory.InstrumentationFactory() -> void
+OpenTelemetry.Trace.TracerProviderSdkOptions.InstrumentationFactory.InstrumentationFactory(string name, string version, System.Func<object> factory) -> void
+OpenTelemetry.Trace.TracerProviderSdkOptions.LegacyActivityOperationNames.get -> System.Collections.Generic.IDictionary<string, bool>
+OpenTelemetry.Trace.TracerProviderSdkOptions.ProcessorFactories.get -> System.Collections.Generic.ICollection<System.Func<OpenTelemetry.BaseProcessor<System.Diagnostics.Activity>>>
+OpenTelemetry.Trace.TracerProviderSdkOptions.ResourceFactory.get -> System.Func<OpenTelemetry.Resources.Resource>
+OpenTelemetry.Trace.TracerProviderSdkOptions.ResourceFactory.set -> void
+OpenTelemetry.Trace.TracerProviderSdkOptions.SamplerFactory.get -> System.Func<OpenTelemetry.Trace.Sampler>
+OpenTelemetry.Trace.TracerProviderSdkOptions.SamplerFactory.set -> void
+OpenTelemetry.Trace.TracerProviderSdkOptions.SetErrorStatusOnException.get -> bool
+OpenTelemetry.Trace.TracerProviderSdkOptions.SetErrorStatusOnException.set -> void
+OpenTelemetry.Trace.TracerProviderSdkOptions.Sources.get -> System.Collections.Generic.ICollection<string>
+OpenTelemetry.Trace.TracerProviderSdkOptions.TracerProviderSdkOptions() -> void
+override OpenTelemetry.Trace.TracerProviderBuilderSdk.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation> instrumentationFactory) -> OpenTelemetry.Trace.TracerProviderBuilder
+override OpenTelemetry.Trace.TracerProviderBuilderSdk.AddSource(params string[] names) -> OpenTelemetry.Trace.TracerProviderBuilder
+readonly OpenTelemetry.Trace.TracerProviderBuilderSdk.options -> OpenTelemetry.Trace.TracerProviderSdkOptions
+readonly OpenTelemetry.Trace.TracerProviderSdkOptions.InstrumentationFactory.Factory -> System.Func<object>
+readonly OpenTelemetry.Trace.TracerProviderSdkOptions.InstrumentationFactory.Name -> string
+readonly OpenTelemetry.Trace.TracerProviderSdkOptions.InstrumentationFactory.Version -> string
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddLegacySource(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, string operationName) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddProcessor(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, System.Func<OpenTelemetry.BaseProcessor<System.Diagnostics.Activity>> processorFactory) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.SetErrorStatusOnException(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, bool enabled = true) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.SetResourceBuilder(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, System.Func<OpenTelemetry.Resources.Resource> resourceFactory) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.SetSampler(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, System.Func<OpenTelemetry.Trace.Sampler> samplerFactory) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Trace.TracerProviderExtensions.ForceFlush(this OpenTelemetry.Trace.TracerProvider provider, int timeoutMilliseconds = -1) -> bool

--- a/src/OpenTelemetry/Trace/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderBuilderExtensions.cs
@@ -49,7 +49,23 @@ namespace OpenTelemetry.Trace
         {
             if (tracerProviderBuilder is TracerProviderBuilderSdk tracerProviderBuilderSdk)
             {
-                tracerProviderBuilderSdk.SetSampler(sampler);
+                tracerProviderBuilderSdk.SetSampler(() => sampler);
+            }
+
+            return tracerProviderBuilder;
+        }
+
+        /// <summary>
+        /// Sets sampler.
+        /// </summary>
+        /// <param name="tracerProviderBuilder">TracerProviderBuilder instance.</param>
+        /// <param name="samplerFactory">Sampler instance.</param>
+        /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
+        public static TracerProviderBuilder SetSampler(this TracerProviderBuilder tracerProviderBuilder, Func<Sampler> samplerFactory)
+        {
+            if (tracerProviderBuilder is TracerProviderBuilderSdk tracerProviderBuilderSdk)
+            {
+                tracerProviderBuilderSdk.SetSampler(samplerFactory);
             }
 
             return tracerProviderBuilder;
@@ -66,7 +82,24 @@ namespace OpenTelemetry.Trace
         {
             if (tracerProviderBuilder is TracerProviderBuilderSdk tracerProviderBuilderSdk)
             {
-                tracerProviderBuilderSdk.SetResourceBuilder(resourceBuilder);
+                tracerProviderBuilderSdk.SetResource(() => resourceBuilder.Build());
+            }
+
+            return tracerProviderBuilder;
+        }
+
+        /// <summary>
+        /// Sets the <see cref="ResourceBuilder"/> from which the Resource associated with
+        /// this provider is built from. Overwrites currently set ResourceBuilder.
+        /// </summary>
+        /// <param name="tracerProviderBuilder">TracerProviderBuilder instance.</param>
+        /// <param name="resourceFactory"><see cref="ResourceBuilder"/> from which Resource will be built.</param>
+        /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
+        public static TracerProviderBuilder SetResourceBuilder(this TracerProviderBuilder tracerProviderBuilder, Func<Resource> resourceFactory)
+        {
+            if (tracerProviderBuilder is TracerProviderBuilderSdk tracerProviderBuilderSdk)
+            {
+                tracerProviderBuilderSdk.SetResource(resourceFactory);
             }
 
             return tracerProviderBuilder;
@@ -76,13 +109,29 @@ namespace OpenTelemetry.Trace
         /// Adds processor to the provider.
         /// </summary>
         /// <param name="tracerProviderBuilder">TracerProviderBuilder instance.</param>
-        /// <param name="processor">Activity processor to add.</param>
+        /// <param name="processor"><see cref="BaseProcessor{Activity}"/> to add.</param>
         /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
         public static TracerProviderBuilder AddProcessor(this TracerProviderBuilder tracerProviderBuilder, BaseProcessor<Activity> processor)
         {
             if (tracerProviderBuilder is TracerProviderBuilderSdk tracerProviderBuilderSdk)
             {
-                tracerProviderBuilderSdk.AddProcessor(processor);
+                tracerProviderBuilderSdk.AddProcessor(() => processor);
+            }
+
+            return tracerProviderBuilder;
+        }
+
+        /// <summary>
+        /// Adds processor to the provider.
+        /// </summary>
+        /// <param name="tracerProviderBuilder">TracerProviderBuilder instance.</param>
+        /// <param name="processorFactory">Function that builds a <see cref="BaseProcessor{Activity}"/> instance to add.</param>
+        /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
+        public static TracerProviderBuilder AddProcessor(this TracerProviderBuilder tracerProviderBuilder, Func<BaseProcessor<Activity>> processorFactory)
+        {
+            if (tracerProviderBuilder is TracerProviderBuilderSdk tracerProviderBuilderSdk)
+            {
+                tracerProviderBuilderSdk.AddProcessor(processorFactory);
             }
 
             return tracerProviderBuilder;

--- a/src/OpenTelemetry/Trace/TracerProviderSdkOptions.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdkOptions.cs
@@ -1,0 +1,54 @@
+// <copyright file="TracerProviderOptions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using OpenTelemetry.Resources;
+
+namespace OpenTelemetry.Trace
+{
+    public class TracerProviderSdkOptions
+    {
+        public Func<Resource> ResourceFactory { get; set; }
+
+        public ICollection<string> Sources { get; } = new List<string>();
+
+        public ICollection<InstrumentationFactory> InstrumentationFactories { get; } = new List<InstrumentationFactory>();
+
+        public Func<Sampler> SamplerFactory { get; set; }
+
+        public ICollection<Func<BaseProcessor<Activity>>> ProcessorFactories { get; } = new List<Func<BaseProcessor<Activity>>>();
+
+        public IDictionary<string, bool> LegacyActivityOperationNames { get; } = new Dictionary<string, bool>();
+
+        public bool SetErrorStatusOnException { get; set; } = false;
+
+        public readonly struct InstrumentationFactory
+        {
+            public readonly string Name;
+            public readonly string Version;
+            public readonly Func<object> Factory;
+
+            public InstrumentationFactory(string name, string version, Func<object> factory)
+            {
+                this.Name = name;
+                this.Version = version;
+                this.Factory = factory;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Changes

This PR is creating `TracerProviderSdkOptions` class and making it so that the builder is not forced to new up any instances of processors or instrumentations during the configuration phase. This PR is trying to work towards a solution to be able to add DI features (#894) to the builder and allow instances to be created from a DI container, but without taking any DI dependencies in the core project. It's also trying to create a separation between the builder phase and the runtime phase by not forcing instances of classed to be created during the builder phase.

I am hoping to get feedback and see if this is something that the team is interested in pursuing or not.

* [ ] Changes in public API reviewed
