### PR TITLE
[WIP] Support custom scope provider

### DIFF
--- a/docs/logs/extending-the-sdk/MyScopeProvider.cs
+++ b/docs/logs/extending-the-sdk/MyScopeProvider.cs
@@ -1,0 +1,30 @@
+// <copyright file="MyScopeProvider.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+
+internal class MyScopeProvider : LoggerExternalScopeProvider, IExternalScopeProvider
+{
+    public new void ForEachScope<TState>(Action<object, TState> callback, TState state)
+    {
+        callback("[global]", state);
+        base.ForEachScope(callback, state);
+    }
+}

--- a/docs/logs/extending-the-sdk/Program.cs
+++ b/docs/logs/extending-the-sdk/Program.cs
@@ -31,14 +31,12 @@ public class Program
 #else
         using var loggerFactory = LoggerFactory.Create(builder =>
 #endif
-            builder.AddOpenTelemetry(options =>
-            {
-                options.IncludeScopes = true;
-                options.AddProcessor(new MyProcessor("ProcessorA"))
-                       .AddProcessor(new MyProcessor("ProcessorB"))
-                       .AddProcessor(new SimpleLogRecordExportProcessor(new MyExporter("ExporterX")))
-                       .AddMyExporter();
-            }));
+            builder.AddOpenTelemetry(options => options
+                .SetScopeProvider(new MyScopeProvider())
+                .AddProcessor(new MyProcessor("ProcessorA"))
+                .AddProcessor(new MyProcessor("ProcessorB"))
+                .AddProcessor(new SimpleLogRecordExportProcessor(new MyExporter("ExporterX")))
+                .AddMyExporter()));
 
 #if NETCOREAPP2_1
         using var serviceProvider = serviceCollection.BuildServiceProvider();

--- a/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -5,6 +5,8 @@ OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeMessage.get -> bool
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeMessage.set -> void
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.get -> bool
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.set -> void
+OpenTelemetry.Logs.OpenTelemetryLoggerOptions.SetScopeProvider() -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions
+OpenTelemetry.Logs.OpenTelemetryLoggerOptions.SetScopeProvider(Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions
 OpenTelemetry.Trace.ParentBasedSampler.ParentBasedSampler(OpenTelemetry.Trace.Sampler rootSampler, OpenTelemetry.Trace.Sampler remoteParentSampled = null, OpenTelemetry.Trace.Sampler remoteParentNotSampled = null, OpenTelemetry.Trace.Sampler localParentSampled = null, OpenTelemetry.Trace.Sampler localParentNotSampled = null) -> void
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddLegacySource(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, string operationName) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.SetErrorStatusOnException(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, bool enabled = true) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -3,8 +3,6 @@ OpenTelemetry.Logs.LogRecord.Message.get -> string
 OpenTelemetry.Logs.LogRecord.StateValues.get -> System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, object>>
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeMessage.get -> bool
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeMessage.set -> void
-OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeScopes.get -> bool
-OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeScopes.set -> void
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.get -> bool
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.set -> void
 OpenTelemetry.Trace.ParentBasedSampler.ParentBasedSampler(OpenTelemetry.Trace.Sampler rootSampler, OpenTelemetry.Trace.Sampler remoteParentSampled = null, OpenTelemetry.Trace.Sampler remoteParentNotSampled = null, OpenTelemetry.Trace.Sampler localParentSampled = null, OpenTelemetry.Trace.Sampler localParentNotSampled = null) -> void

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -5,6 +5,8 @@ OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeMessage.get -> bool
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeMessage.set -> void
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.get -> bool
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.set -> void
+OpenTelemetry.Logs.OpenTelemetryLoggerOptions.SetScopeProvider() -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions
+OpenTelemetry.Logs.OpenTelemetryLoggerOptions.SetScopeProvider(Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions
 OpenTelemetry.Trace.ParentBasedSampler.ParentBasedSampler(OpenTelemetry.Trace.Sampler rootSampler, OpenTelemetry.Trace.Sampler remoteParentSampled = null, OpenTelemetry.Trace.Sampler remoteParentNotSampled = null, OpenTelemetry.Trace.Sampler localParentSampled = null, OpenTelemetry.Trace.Sampler localParentNotSampled = null) -> void
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddLegacySource(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, string operationName) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.SetErrorStatusOnException(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, bool enabled = true) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -3,8 +3,6 @@ OpenTelemetry.Logs.LogRecord.Message.get -> string
 OpenTelemetry.Logs.LogRecord.StateValues.get -> System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, object>>
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeMessage.get -> bool
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeMessage.set -> void
-OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeScopes.get -> bool
-OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeScopes.set -> void
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.get -> bool
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.set -> void
 OpenTelemetry.Trace.ParentBasedSampler.ParentBasedSampler(OpenTelemetry.Trace.Sampler rootSampler, OpenTelemetry.Trace.Sampler remoteParentSampled = null, OpenTelemetry.Trace.Sampler remoteParentNotSampled = null, OpenTelemetry.Trace.Sampler localParentSampled = null, OpenTelemetry.Trace.Sampler localParentNotSampled = null) -> void

--- a/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
@@ -49,7 +49,7 @@ namespace OpenTelemetry.Logs
                 var options = this.provider.Options;
 
                 var record = new LogRecord(
-                    options.IncludeScopes ? this.ScopeProvider : null,
+                    this.ScopeProvider,
                     DateTime.UtcNow,
                     this.categoryName,
                     logLevel,

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggerOptions.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggerOptions.cs
@@ -17,17 +17,13 @@
 #if NET461 || NETSTANDARD2_0
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
 
 namespace OpenTelemetry.Logs
 {
     public class OpenTelemetryLoggerOptions
     {
         internal readonly List<BaseProcessor<LogRecord>> Processors = new List<BaseProcessor<LogRecord>>();
-
-        /// <summary>
-        /// Gets or sets a value indicating whether or not log scopes should be included on generated <see cref="LogRecord"/>s. Default value: False.
-        /// </summary>
-        public bool IncludeScopes { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether or not log message should be included on generated <see cref="LogRecord"/>s. Default value: False.
@@ -38,6 +34,8 @@ namespace OpenTelemetry.Logs
         /// Gets or sets a value indicating whether or not log state should be parsed into <see cref="LogRecord.StateValues"/> on generated <see cref="LogRecord"/>s. Default value: False.
         /// </summary>
         public bool ParseStateValues { get; set; }
+
+        internal IExternalScopeProvider ScopeProvider { get; set; }
 
         /// <summary>
         /// Adds processor to the options.
@@ -54,6 +52,26 @@ namespace OpenTelemetry.Logs
             this.Processors.Add(processor);
 
             return this;
+        }
+
+        /// <summary>
+        /// Sets the scope provider to the options.
+        /// </summary>
+        /// <param name="scopeProvider">The scope provider to be used.</param>
+        /// <returns>Returns <see cref="OpenTelemetryLoggerOptions"/> for chaining.</returns>
+        public OpenTelemetryLoggerOptions SetScopeProvider(IExternalScopeProvider scopeProvider)
+        {
+            this.ScopeProvider = scopeProvider;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the <see cref="Microsoft.Extensions.Logging.LoggerExternalScopeProvider"/> scope provider to the options.
+        /// </summary>
+        /// <returns>Returns <see cref="OpenTelemetryLoggerOptions"/> for chaining.</returns>
+        public OpenTelemetryLoggerOptions SetScopeProvider()
+        {
+            return this.SetScopeProvider(new LoggerExternalScopeProvider());
         }
     }
 }

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggerProvider.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggerProvider.cs
@@ -23,7 +23,7 @@ using Microsoft.Extensions.Options;
 namespace OpenTelemetry.Logs
 {
     [ProviderAlias("OpenTelemetry")]
-    public class OpenTelemetryLoggerProvider : ILoggerProvider, ISupportExternalScope
+    public class OpenTelemetryLoggerProvider : ILoggerProvider
     {
         internal readonly OpenTelemetryLoggerOptions Options;
         internal BaseProcessor<LogRecord> Processor;
@@ -47,25 +47,11 @@ namespace OpenTelemetry.Logs
         {
             this.Options = options ?? throw new ArgumentNullException(nameof(options));
 
+            this.scopeProvider = options.ScopeProvider;
+
             foreach (var processor in options.Processors)
             {
                 this.AddProcessor(processor);
-            }
-        }
-
-        void ISupportExternalScope.SetScopeProvider(IExternalScopeProvider scopeProvider)
-        {
-            this.scopeProvider = scopeProvider;
-
-            lock (this.loggers)
-            {
-                foreach (DictionaryEntry entry in this.loggers)
-                {
-                    if (entry.Value is OpenTelemetryLogger logger)
-                    {
-                        logger.ScopeProvider = scopeProvider;
-                    }
-                }
             }
         }
 


### PR DESCRIPTION
## Changes

Please provide a brief description of the changes here.

* Added `SetScopeProvider` to the log provider builder. There are three ways of using it:
  1. `SetScopeProvider(provider)` sets the user-specified scope provider
  2. `SetScopeProvider(null)` clears the scope provider
  3. `SetScopeProvider()` sets the built-in scope provider 

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
