### PR TITLE
Add unit test for grpc client instrumentation respecting suppress

### DIFF
--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.server.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.server.cs
@@ -33,6 +33,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
     {
         private const string OperationNameHttpRequestIn = "Microsoft.AspNetCore.Hosting.HttpRequestIn";
         private const string OperationNameGrpcOut = "Grpc.Net.Client.GrpcOut";
+        private const string OperationNameHttpOut = "System.Net.Http.HttpRequestOut";
 
         private readonly GrpcServer<GreeterService> server;
 


### PR DESCRIPTION
Related to #1906 

## Changes
- Added a unit test `GrpcClientInstrumentationRespectsSdkSuppressInstrumentation` to check if `Sdk.SuppressInstrumentation` is respected
- Updated existing unit test for `SuppressDownstreamInstrumentation` which is provided as an option when adding grpc client instrumentation
