### PR TITLE
Fix exception in ResourceBuilderExtensions when running in AWS Lambda

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -58,7 +58,7 @@ Released 2021-Mar-19
 
 * `ResourceBuilderExtensions` type constructor will no longer throw when
   OpenTelemetry is used in AWS Lambda. ([#1908](https://github.com/open-telemetry/opentelemetry-dotnet/issues/1908))
- 
+
 ## 1.0.1
 
 Released 2021-Feb-10

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -56,8 +56,10 @@ Released 2021-Mar-19
 * Added `SetResourceBuilder` support to `OpenTelemetryLoggerOptions`.
   ([#1913](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1913))
 
-* `ResourceBuilderExtensions` type constructor will no longer throw when
-  OpenTelemetry is used in AWS Lambda. ([#1908](https://github.com/open-telemetry/opentelemetry-dotnet/issues/1908))
+* Use `AssemblyFileVersionAttribute` instead of `FileVersionInfo.GetVersionInfo`
+  to get the SDK version attribute to ensure that it works when the assembly
+  is not loaded directly from a file on disk
+  ([#1908](https://github.com/open-telemetry/opentelemetry-dotnet/issues/1908))
 
 ## 1.0.1
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -56,6 +56,9 @@ Released 2021-Mar-19
 * Added `SetResourceBuilder` support to `OpenTelemetryLoggerOptions`.
   ([#1913](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1913))
 
+* `ResourceBuilderExtensions` type constructor will no longer throw when
+  OpenTelemetry is used in AWS Lambda. ([#1908](https://github.com/open-telemetry/opentelemetry-dotnet/issues/1908))
+ 
 ## 1.0.1
 
 Released 2021-Feb-10

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -9,6 +9,11 @@ please check the latest changes
 
 ## Unreleased
 
+* Use `AssemblyFileVersionAttribute` instead of `FileVersionInfo.GetVersionInfo`
+  to get the SDK version attribute to ensure that it works when the assembly
+  is not loaded directly from a file on disk
+  ([#1908](https://github.com/open-telemetry/opentelemetry-dotnet/issues/1908))
+
 ## 1.1.0-beta1
 
 Released 2021-Mar-19
@@ -55,11 +60,6 @@ Released 2021-Mar-19
 
 * Added `SetResourceBuilder` support to `OpenTelemetryLoggerOptions`.
   ([#1913](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1913))
-
-* Use `AssemblyFileVersionAttribute` instead of `FileVersionInfo.GetVersionInfo`
-  to get the SDK version attribute to ensure that it works when the assembly
-  is not loaded directly from a file on disk
-  ([#1908](https://github.com/open-telemetry/opentelemetry-dotnet/issues/1908))
 
 ## 1.0.1
 

--- a/src/OpenTelemetry/Resources/ResourceBuilderExtensions.cs
+++ b/src/OpenTelemetry/Resources/ResourceBuilderExtensions.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Reflection;
 
 namespace OpenTelemetry.Resources
 {
@@ -126,7 +127,7 @@ namespace OpenTelemetry.Resources
         {
             try
             {
-                return FileVersionInfo.GetVersionInfo(typeof(Resource).Assembly.Location).FileVersion;
+                return typeof(Resource).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version ?? string.Empty;
             }
             catch (Exception)
             {

--- a/src/OpenTelemetry/Resources/ResourceBuilderExtensions.cs
+++ b/src/OpenTelemetry/Resources/ResourceBuilderExtensions.cs
@@ -25,13 +25,11 @@ namespace OpenTelemetry.Resources
     /// </summary>
     public static class ResourceBuilderExtensions
     {
-        private static readonly string FileVersion = FileVersionInfo.GetVersionInfo(typeof(Resource).Assembly.Location).FileVersion;
-
         private static Resource TelemetryResource { get; } = new Resource(new Dictionary<string, object>
         {
             [ResourceSemanticConventions.AttributeTelemetrySdkName] = "opentelemetry",
             [ResourceSemanticConventions.AttributeTelemetrySdkLanguage] = "dotnet",
-            [ResourceSemanticConventions.AttributeTelemetrySdkVersion] = FileVersion,
+            [ResourceSemanticConventions.AttributeTelemetrySdkVersion] = GetFileVersion(),
         });
 
         /// <summary>
@@ -122,6 +120,18 @@ namespace OpenTelemetry.Resources
         public static ResourceBuilder AddEnvironmentVariableDetector(this ResourceBuilder resourceBuilder)
         {
             return resourceBuilder.AddDetector(new OtelEnvResourceDetector());
+        }
+
+        private static string GetFileVersion()
+        {
+            try
+            {
+                return FileVersionInfo.GetVersionInfo(typeof(Resource).Assembly.Location).FileVersion;
+            }
+            catch (Exception)
+            {
+                return string.Empty;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #1908.

## Changes

Loaded assembly file version from `AssemblyFileVersionAttribute` rather than using `FileVersionInfo.GetVersionInfo` as this works with assemblies which weren't loaded directly from a file on disk. Added defensive catch block.

* [x] `CHANGELOG.md` updated for non-trivial changes
