### PR TITLE
Remove supress check from DSListeners as TracerProviderSdk handles this already

### DIFF
--- a/src/OpenTelemetry/DiagnosticSourceInstrumentation/DiagnosticSourceListener.cs
+++ b/src/OpenTelemetry/DiagnosticSourceInstrumentation/DiagnosticSourceListener.cs
@@ -41,11 +41,6 @@ namespace OpenTelemetry.Instrumentation
         {
             if (!this.handler.SupportsNullActivity && Activity.Current == null)
             {
-                if (!Sdk.SuppressInstrumentation)
-                {
-                    InstrumentationEventSource.Log.NullActivity(value.Key);
-                }
-
                 return;
             }
 
@@ -61,17 +56,11 @@ namespace OpenTelemetry.Instrumentation
                 }
                 else if (value.Key.EndsWith("Exception", StringComparison.Ordinal))
                 {
-                    if (!Sdk.SuppressInstrumentation)
-                    {
-                        this.handler.OnException(Activity.Current, value.Value);
-                    }
+                    this.handler.OnException(Activity.Current, value.Value);
                 }
                 else
                 {
-                    if (!Sdk.SuppressInstrumentation)
-                    {
-                        this.handler.OnCustom(value.Key, Activity.Current, value.Value);
-                    }
+                    this.handler.OnCustom(value.Key, Activity.Current, value.Value);
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
This would allow us to make Instrumentations depend only on the API. and not on SDK.
(SDK dependency is still needed if a particular instrumentation need to leverage Suppress feature. This may change in future once a spec is written for this scenario and API starts exposing it.)