### PR TITLE
Rolling back OTLP null array change for non-strings

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -9,9 +9,10 @@ please check the latest changes
 
 ## Unreleased
 
-* Null values in primitive arrays are preserved through otlp.
+* Null values in string arrays are preserved according to
   [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/common.md).
-  ([#1919](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1919))
+  ([#1919](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1919)) and
+  ([#1945](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1945)).
 
 * When using OpenTelemetry.Extensions.Hosting you can now bind
   `OtlpExporterOptions` to `IConfiguration` using the `Configure` extension (ex:

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
@@ -466,27 +466,6 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
                         }
 
                         break;
-                    case bool?[] boolArray:
-                        foreach (var item in boolArray)
-                        {
-                            PooledList<OtlpCommon.KeyValue>.Add(ref this.Tags, CreateOtlpKeyValue(key, item == null ? null : new OtlpCommon.AnyValue { BoolValue = item.Value }));
-                        }
-
-                        break;
-                    case double?[] doubleArray:
-                        foreach (var item in doubleArray)
-                        {
-                            PooledList<OtlpCommon.KeyValue>.Add(ref this.Tags, CreateOtlpKeyValue(key, item == null ? null : new OtlpCommon.AnyValue { DoubleValue = item.Value }));
-                        }
-
-                        break;
-                    case long?[] longArray:
-                        foreach (var item in longArray)
-                        {
-                            PooledList<OtlpCommon.KeyValue>.Add(ref this.Tags, CreateOtlpKeyValue(key, item == null ? null : new OtlpCommon.AnyValue { IntValue = item.Value }));
-                        }
-
-                        break;
                     default:
                         PooledList<OtlpCommon.KeyValue>.Add(ref this.Tags, CreateOtlpKeyValue(key, new OtlpCommon.AnyValue { StringValue = activityTag.Value.ToString() }));
                         break;

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterTest.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterTest.cs
@@ -273,23 +273,15 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
         }
 
         [Fact]
-        public void ToOtlpSpanActivitiesWithNullArraysTest()
+        public void ToOtlpSpanActivitiesWithNullArrayTest()
         {
             using var activitySource = new ActivitySource(nameof(this.ToOtlpSpanTest));
 
             using var rootActivity = activitySource.StartActivity("root", ActivityKind.Client);
+            Assert.NotNull(rootActivity);
 
             var stringArr = new string[] { "test", string.Empty, null };
             rootActivity.SetTag("stringArray", stringArr);
-
-            var boolArr = new bool?[] { true, false, null };
-            rootActivity.SetTag("boolArray", boolArr);
-
-            var doubleArr = new double?[] { 1.0, 0.0, null };
-            rootActivity.SetTag("doubleArray", doubleArr);
-
-            var longArr = new long?[] { 1, 0, null };
-            rootActivity.SetTag("longArray", longArr);
 
             var otlpSpan = rootActivity.ToOtlpSpan();
 
@@ -302,30 +294,6 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
             Assert.Equal("test", stringArray[0].Value.StringValue);
             Assert.Equal(string.Empty, stringArray[1].Value.StringValue);
             Assert.Null(stringArray[2].Value);
-
-            var boolArray = otlpSpan.Attributes.Where(kvp => kvp.Key == "boolArray").ToList();
-
-            Assert.NotNull(boolArray);
-            Assert.Equal(3, boolArray.Count());
-            Assert.True(boolArray[0].Value.BoolValue);
-            Assert.False(boolArray[1].Value.BoolValue);
-            Assert.Null(boolArray[2].Value);
-
-            var doubleArray = otlpSpan.Attributes.Where(kvp => kvp.Key == "doubleArray").ToList();
-
-            Assert.NotNull(doubleArray);
-            Assert.Equal(3, doubleArray.Count());
-            Assert.Equal(1.0, doubleArray[0].Value.DoubleValue);
-            Assert.Equal(0.0, doubleArray[1].Value.DoubleValue);
-            Assert.Null(doubleArray[2].Value);
-
-            var longArray = otlpSpan.Attributes.Where(kvp => kvp.Key == "longArray").ToList();
-
-            Assert.NotNull(longArray);
-            Assert.Equal(3, longArray.Count());
-            Assert.Equal(1, longArray[0].Value.IntValue);
-            Assert.Equal(0, longArray[1].Value.IntValue);
-            Assert.Null(longArray[2].Value);
         }
 
         [Fact]


### PR DESCRIPTION
Addressing @Oberon00 's [comments here](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1919#issuecomment-809163623). A previous interpretation of the spec I made in PR #1919  was incorrect. We allowed long?[], bool?[], and double?[] when we shouldn't have according to [OTel common spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/common.md#attributes).

String arrays should still preserve null values since we don't have compile-time checks.

* [x] `CHANGELOG.md` updated for non-trivial changes
