### PR TITLE
Update the release process to cover the opentelemetry.io docs

### DIFF
--- a/build/RELEASING.md
+++ b/build/RELEASING.md
@@ -121,3 +121,7 @@ and contents of combinedchangelog from Step2.
 
 TODO: Add tagging for Metrics release.
 TODO: Separate version for instrumention/hosting/OTshim package.
+
+16.Update the OpenTelemetry.io document
+[here](https://github.com/open-telemetry/opentelemetry.io/tree/main/content/en/docs/net)
+by sending a Pull Request.


### PR DESCRIPTION
Related to #1944.

## Changes

Updated the release process document, mentioned that OpenTelemetry.io docs should be updated to reflect the release changes.
