### PR TITLE
OpenTelemetry.Instrumentation.StackExchangeRedis memory leak on _cache

### DIFF
--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisCallsInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisCallsInstrumentation.cs
@@ -140,6 +140,7 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis
 
                 ProfilingSession session = entry.Value.Session;
                 RedisProfilerEntryToActivityConverter.DrainSession(parent, session.FinishProfiling());
+                this.cache.TryRemove((entry.Key.TraceId, entry.Key.SpanId), out _);
             }
         }
     }


### PR DESCRIPTION
Fixes [#1943](https://github.com/open-telemetry/opentelemetry-dotnet/issues/1943).

## Changes

In the Flush method of the Redis instrumentation cache, the profiling session is being drained but the entry of the cache isn't removed from the cache. I am proposing the following change so it does not keep the references.  

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
