### PR TITLE
Sanitize `http.url` attribute

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Sanitize `http.url` attribute. ([#1961](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1961))
+
 ## 1.0.0-rc3
 
 Released 2021-Mar-19

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -273,7 +273,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
         {
             if (string.IsNullOrEmpty(uri.UserInfo))
             {
-                return uri.OriginalString;
+                return uri.ToString();
             }
 
             return string.Concat(uri.Scheme, Uri.SchemeDelimiter, uri.Authority, uri.PathAndQuery, uri.Fragment);

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -145,7 +145,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
                 activity.SetTag(SemanticConventions.AttributeHttpMethod, request.HttpMethod);
                 activity.SetTag(SpanAttributeConstants.HttpPathKey, path);
                 activity.SetTag(SemanticConventions.AttributeHttpUserAgent, request.UserAgent);
-                activity.SetTag(SemanticConventions.AttributeHttpUrl, request.Url.ToString());
+                activity.SetTag(SemanticConventions.AttributeHttpUrl, GetUriTagValueFromRequestUri(request.Url));
 
                 try
                 {
@@ -262,6 +262,21 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
                     Activity.Current = activity;
                 }
             }
+        }
+
+        /// <summary>
+        /// Gets the OpenTelemetry standard uri tag value for a span based on its request <see cref="Uri"/>.
+        /// </summary>
+        /// <param name="uri"><see cref="Uri"/>.</param>
+        /// <returns>Span uri value.</returns>
+        private static string GetUriTagValueFromRequestUri(Uri uri)
+        {
+            if (string.IsNullOrEmpty(uri.UserInfo))
+            {
+                return uri.OriginalString;
+            }
+
+            return string.Concat(uri.Scheme, Uri.SchemeDelimiter, uri.Authority, uri.PathAndQuery, uri.Fragment);
         }
     }
 }

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Sanitize `http.url` attribute. ([#1961](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1961))
+
 ## 1.0.0-rc3
 
 Released 2021-Mar-19

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -130,8 +130,7 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
 
                 activity.SetTag(SemanticConventions.AttributeHttpMethod, HttpTagHelper.GetNameForHttpMethod(request.Method));
                 activity.SetTag(SemanticConventions.AttributeHttpHost, HttpTagHelper.GetHostTagValueFromRequestUri(request.RequestUri));
-                activity.SetTag(SemanticConventions.AttributeHttpUrl, request.RequestUri.OriginalString);
-
+                activity.SetTag(SemanticConventions.AttributeHttpUrl, HttpTagHelper.GetUriTagValueFromRequestUri(request.RequestUri));
                 if (this.options.SetHttpFlavor)
                 {
                     activity.SetTag(SemanticConventions.AttributeHttpFlavor, HttpTagHelper.GetFlavorTagValueFromProtocolVersion(request.Version));

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpTagHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpTagHelper.cs
@@ -99,7 +99,14 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
         /// </summary>
         /// <param name="uri"><see cref="Uri"/>.</param>
         /// <returns>Span uri value.</returns>
-        public static string GetUriTagValueFromRequestUri(Uri uri) => string.Concat(uri.Scheme, Uri.SchemeDelimiter, uri.Authority, uri.PathAndQuery, uri.Fragment);
+        public static string GetUriTagValueFromRequestUri(Uri uri)
+        {
+            if (string.IsNullOrEmpty(uri.UserInfo))
+            {
+                return uri.OriginalString;
+            }
+            return string.Concat(uri.Scheme, Uri.SchemeDelimiter, uri.Authority, uri.PathAndQuery, uri.Fragment);
+        }
 
         private static string ConvertMethodToOperationName(string method) => $"HTTP {method}";
 

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpTagHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpTagHelper.cs
@@ -105,6 +105,7 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
             {
                 return uri.OriginalString;
             }
+
             return string.Concat(uri.Scheme, Uri.SchemeDelimiter, uri.Authority, uri.PathAndQuery, uri.Fragment);
         }
 

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpTagHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpTagHelper.cs
@@ -94,6 +94,13 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
             return hostTagValue;
         }
 
+        /// <summary>
+        /// Gets the OpenTelemetry standard uri tag value for a span based on its request <see cref="Uri"/>.
+        /// </summary>
+        /// <param name="uri"><see cref="Uri"/>.</param>
+        /// <returns>Span uri value.</returns>
+        public static string GetUriTagValueFromRequestUri(Uri uri) => string.Concat(uri.Scheme, Uri.SchemeDelimiter, uri.Authority, uri.PathAndQuery, uri.Fragment);
+
         private static string ConvertMethodToOperationName(string method) => $"HTTP {method}";
 
         private static string ConvertHttpMethodToOperationName(HttpMethod method) => $"HTTP {method}";

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
@@ -98,7 +98,7 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
             {
                 activity.SetTag(SemanticConventions.AttributeHttpMethod, request.Method);
                 activity.SetTag(SemanticConventions.AttributeHttpHost, HttpTagHelper.GetHostTagValueFromRequestUri(request.RequestUri));
-                activity.SetTag(SemanticConventions.AttributeHttpUrl, request.RequestUri.OriginalString);
+                activity.SetTag(SemanticConventions.AttributeHttpUrl, HttpTagHelper.GetUriTagValueFromRequestUri(request.RequestUri));
                 if (Options.SetHttpFlavor)
                 {
                     activity.SetTag(SemanticConventions.AttributeHttpFlavor, HttpTagHelper.GetFlavorTagValueFromProtocolVersion(request.ProtocolVersion));

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -49,7 +49,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
         [InlineData("http://localhost/", "http://localhost/", 0, null, "TraceContext")]
         [InlineData("http://localhost/", "http://localhost/", 0, null, "TraceContext", true)]
         [InlineData("https://localhost/", "https://localhost/", 0, null, "TraceContext")]
-        [InlineData("http://localhost/", "https://user:pass@localhost/", 0, null, "TraceContext")] // Test URL sanitization
+        [InlineData("https://localhost/", "https://user:pass@localhost/", 0, null, "TraceContext")] // Test URL sanitization
         [InlineData("http://localhost:443/", "http://localhost:443/", 0, null, "TraceContext")] // Test http over 443
         [InlineData("https://localhost:80/", "https://localhost:80/", 0, null, "TraceContext")] // Test https over 80
         [InlineData("http://localhost:80/Index", "http://localhost:80/Index", 1, "{controller}/{action}/{id}", "TraceContext")]

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -48,10 +48,10 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
         [Theory]
         [InlineData("http://localhost/", "http://localhost/", 0, null, "TraceContext")]
         [InlineData("http://localhost/", "http://localhost/", 0, null, "TraceContext", true)]
-        [InlineData("http://localhost/", "https://localhost/", 0, null, "TraceContext")]
+        [InlineData("https://localhost/", "https://localhost/", 0, null, "TraceContext")]
         [InlineData("http://localhost/", "https://user:pass@localhost/", 0, null, "TraceContext")] // Test URL sanitization
         [InlineData("http://localhost:443/", "http://localhost:443/", 0, null, "TraceContext")] // Test http over 443
-        [InlineData("http://localhost:80/", "https://localhost:80/", 0, null, "TraceContext")] // Test https over 80
+        [InlineData("https://localhost:80/", "https://localhost:80/", 0, null, "TraceContext")] // Test https over 80
         [InlineData("http://localhost:80/Index", "http://localhost:80/Index", 1, "{controller}/{action}/{id}", "TraceContext")]
         [InlineData("https://localhost:443/about_attr_route/10", "https://localhost:443/about_attr_route/10", 2, "about_attr_route/{customerId}", "TraceContext")]
         [InlineData("http://localhost:1880/api/weatherforecast", "http://localhost:1880/api/weatherforecast", 3, "api/{controller}/{id}", "TraceContext")]
@@ -304,10 +304,10 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
                 Assert.True(string.IsNullOrEmpty(span.GetStatus().Description));
             }
 
-            var actualUrl = span.GetTagValue(SemanticConventions.AttributeHttpUrl);
-            Assert.Equal(expectedUrl, actualUrl);
-
             var expectedUri = new Uri(expectedUrl);
+            var actualUrl = span.GetTagValue(SemanticConventions.AttributeHttpUrl);
+
+            Assert.Equal(expectedUri.ToString(), actualUrl);
 
             // Url strips 80 or 443 if the scheme matches.
             if ((expectedUri.Port == 80 && expectedUri.Scheme == "http") || (expectedUri.Port == 443 && expectedUri.Scheme == "https"))

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -46,21 +46,23 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
         }
 
         [Theory]
-        [InlineData("http://localhost/", 0, null, "TraceContext")]
-        [InlineData("http://localhost/", 0, null, "TraceContext", true)]
-        [InlineData("https://localhost/", 0, null, "TraceContext")]
-        [InlineData("http://localhost:443/", 0, null, "TraceContext")] // Test http over 443
-        [InlineData("https://localhost:80/", 0, null, "TraceContext")] // Test https over 80
-        [InlineData("http://localhost:80/Index", 1, "{controller}/{action}/{id}", "TraceContext")]
-        [InlineData("https://localhost:443/about_attr_route/10", 2, "about_attr_route/{customerId}", "TraceContext")]
-        [InlineData("http://localhost:1880/api/weatherforecast", 3, "api/{controller}/{id}", "TraceContext")]
-        [InlineData("https://localhost:1843/subroute/10", 4, "subroute/{customerId}", "TraceContext")]
-        [InlineData("http://localhost/api/value", 0, null, "TraceContext", false, "/api/value")] // Request will be filtered
-        [InlineData("http://localhost/api/value", 0, null, "TraceContext", false, "{ThrowException}")] // Filter user code will throw an exception
-        [InlineData("http://localhost/api/value/2", 0, null, "CustomContextMatchParent")]
-        [InlineData("http://localhost/api/value/2", 0, null, "CustomContextNonmatchParent")]
-        [InlineData("http://localhost/api/value/2", 0, null, "CustomContextNonmatchParent", false, null, true)]
+        [InlineData("http://localhost/", "http://localhost/", 0, null, "TraceContext")]
+        [InlineData("http://localhost/", "http://localhost/", 0, null, "TraceContext", true)]
+        [InlineData("http://localhost/", "https://localhost/", 0, null, "TraceContext")]
+        [InlineData("http://localhost/", "https://user:pass@localhost/", 0, null, "TraceContext")] // Test URL sanitization
+        [InlineData("http://localhost:443/", "http://localhost:443/", 0, null, "TraceContext")] // Test http over 443
+        [InlineData("http://localhost:80/","https://localhost:80/", 0, null, "TraceContext")] // Test https over 80
+        [InlineData("http://localhost:80/Index", "http://localhost:80/Index", 1, "{controller}/{action}/{id}", "TraceContext")]
+        [InlineData("https://localhost:443/about_attr_route/10", "https://localhost:443/about_attr_route/10", 2, "about_attr_route/{customerId}", "TraceContext")]
+        [InlineData("http://localhost:1880/api/weatherforecast", "http://localhost:1880/api/weatherforecast", 3, "api/{controller}/{id}", "TraceContext")]
+        [InlineData("https://localhost:1843/subroute/10", "https://localhost:1843/subroute/10", 4, "subroute/{customerId}", "TraceContext")]
+        [InlineData("http://localhost/api/value", "http://localhost/api/value", 0, null, "TraceContext", false, "/api/value")] // Request will be filtered
+        [InlineData("http://localhost/api/value", "http://localhost/api/value", 0, null, "TraceContext", false, "{ThrowException}")] // Filter user code will throw an exception
+        [InlineData("http://localhost/api/value/2", "http://localhost/api/value/2", 0, null, "CustomContextMatchParent")]
+        [InlineData("http://localhost/api/value/2", "http://localhost/api/value/2", 0, null, "CustomContextNonmatchParent")]
+        [InlineData("http://localhost/api/value/2", "http://localhost/api/value/2", 0, null, "CustomContextNonmatchParent", false, null, true)]
         public void AspNetRequestsAreCollectedSuccessfully(
+            string expectedUrl,
             string url,
             int routeType,
             string routeTemplate,
@@ -302,11 +304,10 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
                 Assert.True(string.IsNullOrEmpty(span.GetStatus().Description));
             }
 
-            var expectedUri = new Uri(url);
             var actualUrl = span.GetTagValue(SemanticConventions.AttributeHttpUrl);
+            Assert.Equal(expectedUrl, actualUrl);
 
-            Assert.Equal(expectedUri.ToString(), actualUrl);
-
+            var expectedUri = new Uri(expectedUrl);
             // Url strips 80 or 443 if the scheme matches.
             if ((expectedUri.Port == 80 && expectedUri.Scheme == "http") || (expectedUri.Port == 443 && expectedUri.Scheme == "https"))
             {

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -51,7 +51,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
         [InlineData("http://localhost/", "https://localhost/", 0, null, "TraceContext")]
         [InlineData("http://localhost/", "https://user:pass@localhost/", 0, null, "TraceContext")] // Test URL sanitization
         [InlineData("http://localhost:443/", "http://localhost:443/", 0, null, "TraceContext")] // Test http over 443
-        [InlineData("http://localhost:80/","https://localhost:80/", 0, null, "TraceContext")] // Test https over 80
+        [InlineData("http://localhost:80/", "https://localhost:80/", 0, null, "TraceContext")] // Test https over 80
         [InlineData("http://localhost:80/Index", "http://localhost:80/Index", 1, "{controller}/{action}/{id}", "TraceContext")]
         [InlineData("https://localhost:443/about_attr_route/10", "https://localhost:443/about_attr_route/10", 2, "about_attr_route/{customerId}", "TraceContext")]
         [InlineData("http://localhost:1880/api/weatherforecast", "http://localhost:1880/api/weatherforecast", 3, "api/{controller}/{id}", "TraceContext")]

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -308,6 +308,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
             Assert.Equal(expectedUrl, actualUrl);
 
             var expectedUri = new Uri(expectedUrl);
+
             // Url strips 80 or 443 if the scheme matches.
             if ((expectedUri.Port == 80 && expectedUri.Scheme == "http") || (expectedUri.Port == 443 && expectedUri.Scheme == "https"))
             {

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -52,6 +52,8 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
         [InlineData("https://localhost/", "https://user:pass@localhost/", 0, null, "TraceContext")] // Test URL sanitization
         [InlineData("http://localhost:443/", "http://localhost:443/", 0, null, "TraceContext")] // Test http over 443
         [InlineData("https://localhost:80/", "https://localhost:80/", 0, null, "TraceContext")] // Test https over 80
+        [InlineData("https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", 0, null, "TraceContext")] // Test complex URL
+        [InlineData("https://localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", "https://user:password@localhost:80/Home/Index.htm?q1=v1&q2=v2#FragmentName", 0, null, "TraceContext")] // Test complex URL sanitization
         [InlineData("http://localhost:80/Index", "http://localhost:80/Index", 1, "{controller}/{action}/{id}", "TraceContext")]
         [InlineData("https://localhost:443/about_attr_route/10", "https://localhost:443/about_attr_route/10", 2, "about_attr_route/{customerId}", "TraceContext")]
         [InlineData("http://localhost:1880/api/weatherforecast", "http://localhost:1880/api/weatherforecast", 3, "api/{controller}/{id}", "TraceContext")]

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.netfx.cs
@@ -88,27 +88,6 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
             ValidateHttpWebRequestActivity(activity);
             Assert.Equal(tc.SpanName, activity.DisplayName);
 
-            Assert.Equal(ActivityKind.Client, activity.Kind);
-            Assert.Equal(
-                    tc.SpanStatus,
-                    activity.GetTagValue(SpanAttributeConstants.StatusCodeKey) as string);
-
-            if (tc.SpanStatusHasDescription.HasValue)
-            {
-                var desc = activity.GetTagValue(SpanAttributeConstants.StatusDescriptionKey) as string;
-                Assert.Equal(tc.SpanStatusHasDescription.Value, !string.IsNullOrEmpty(desc));
-            }
-
-            var normalizedAttributes = activity.TagObjects.Where(kv => !kv.Key.StartsWith("otel.")).ToImmutableSortedDictionary(x => x.Key, x => x.Value.ToString());
-            var normalizedAttributesTestCase = tc.SpanAttributes.ToDictionary(x => x.Key, x => HttpTestData.NormalizeValues(x.Value, host, port));
-
-            Assert.Equal(normalizedAttributesTestCase.Count, normalizedAttributes.Count);
-
-            foreach (var kv in normalizedAttributesTestCase)
-            {
-                Assert.Contains(activity.TagObjects, i => i.Key == kv.Key && i.Value.ToString().Equals(kv.Value, StringComparison.InvariantCultureIgnoreCase));
-            }
-
             tc.SpanAttributes = tc.SpanAttributes.ToDictionary(
                 x => x.Key,
                 x =>

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/http-out-test-cases.json
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/http-out-test-cases.json
@@ -43,6 +43,21 @@
     }
   },
   {
+    "name": "http.url must not contain username nor password",
+    "method": "GET",
+    "url": "http://username:password@{host}:{port}/path/to/resource/",
+    "responseCode": 200,
+    "spanName": "HTTP GET",
+    "spanStatus": "UNSET",
+    "responseExpected": true,
+    "spanAttributes": {
+      "http.method": "GET",
+      "http.host": "{host}:{port}",
+      "http.status_code": "200",
+      "http.url": "http://{host}:{port}/path/to/resource/"
+    }
+  },
+  {
     "name": "Call that cannot resolve DNS will be reported as error span",
     "method": "GET",
     "url": "https://sdlfaldfjalkdfjlkajdflkajlsdjf.sdlkjafsdjfalfadslkf.com/",

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/http-out-test-cases.json
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/http-out-test-cases.json
@@ -43,9 +43,9 @@
     }
   },
   {
-    "name": "http.url must not contain username nor password",
+    "name": "URL with fragment",
     "method": "GET",
-    "url": "http://username:password@{host}:{port}/path/to/resource/",
+    "url": "http://{host}:{port}/path/to/resource#fragment",
     "responseCode": 200,
     "spanName": "HTTP GET",
     "spanStatus": "UNSET",
@@ -54,7 +54,22 @@
       "http.method": "GET",
       "http.host": "{host}:{port}",
       "http.status_code": "200",
-      "http.url": "http://{host}:{port}/path/to/resource/"
+      "http.url": "http://{host}:{port}/path/to/resource#fragment"
+    }
+  },
+  {
+    "name": "http.url must not contain username nor password",
+    "method": "GET",
+    "url": "http://username:password@{host}:{port}/path/to/resource#fragment",
+    "responseCode": 200,
+    "spanName": "HTTP GET",
+    "spanStatus": "UNSET",
+    "responseExpected": true,
+    "spanAttributes": {
+      "http.method": "GET",
+      "http.host": "{host}:{port}",
+      "http.status_code": "200",
+      "http.url": "http://{host}:{port}/path/to/resource#fragment"
     }
   },
   {


### PR DESCRIPTION
Fixes #1884.

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Design discussion issue https://github.com/open-telemetry/opentelemetry-specification/pull/1502
* [x] Changes in public API reviewed

## Constraints 

- For requests without username/password data the `http.url` value would remain the same. For ASP.NET instrumentation it is `uri.ToString()` for HTTP instrumentation it is `uri.OriginalString`. We can consider unifying it but rather in separate PR.
- The public API is untouched. In theory, we could expose the method which sanitizes an URL in a separate PR.
