### PR TITLE
[WIP] OTLP log exporter

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -1,0 +1,22 @@
+OpenTelemetry.Exporter.OtlpExporterOptions
+OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
+OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.get -> System.Uri
+OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
+OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.Headers.get -> string
+OpenTelemetry.Exporter.OtlpExporterOptions.Headers.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.OtlpExporterOptions() -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.TimeoutMilliseconds.get -> int
+OpenTelemetry.Exporter.OtlpExporterOptions.TimeoutMilliseconds.set -> void
+OpenTelemetry.Exporter.OtlpTraceExporter
+OpenTelemetry.Exporter.OtlpTraceExporter.OtlpTraceExporter(OpenTelemetry.Exporter.OtlpExporterOptions options) -> void
+OpenTelemetry.Trace.OtlpTraceExporterHelperExtensions
+override OpenTelemetry.Exporter.OtlpTraceExporter.Export(in OpenTelemetry.Batch<System.Diagnostics.Activity> activityBatch) -> OpenTelemetry.ExportResult
+override OpenTelemetry.Exporter.OtlpTraceExporter.OnShutdown(int timeoutMilliseconds) -> bool
+static OpenTelemetry.Trace.OtlpTraceExporterHelperExtensions.AddOtlpExporter(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Exporter.OtlpExporterOptions> configure = null) -> OpenTelemetry.Trace.TracerProviderBuilder
+OpenTelemetry.Exporter.OtlpLogExporter
+OpenTelemetry.Exporter.OtlpLogExporter.OtlpLogExporter(OpenTelemetry.Exporter.OtlpExporterOptions options) -> void
+override OpenTelemetry.Exporter.OtlpLogExporter.Export(in OpenTelemetry.Batch<OpenTelemetry.Logs.LogRecord> logRecordBatch) -> OpenTelemetry.ExportResult
+override OpenTelemetry.Exporter.OtlpLogExporter.OnShutdown(int timeoutMilliseconds) -> bool

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,4 @@
+OpenTelemetry.Exporter.OtlpLogExporter
+OpenTelemetry.Exporter.OtlpLogExporter.OtlpLogExporter(OpenTelemetry.Exporter.OtlpExporterOptions options) -> void
+override OpenTelemetry.Exporter.OtlpLogExporter.Export(in OpenTelemetry.Batch<OpenTelemetry.Logs.LogRecord> logRecordBatch) -> OpenTelemetry.ExportResult
+override OpenTelemetry.Exporter.OtlpLogExporter.OnShutdown(int timeoutMilliseconds) -> bool

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,0 +1,4 @@
+OpenTelemetry.Exporter.OtlpLogExporter
+OpenTelemetry.Exporter.OtlpLogExporter.OtlpLogExporter(OpenTelemetry.Exporter.OtlpExporterOptions options) -> void
+override OpenTelemetry.Exporter.OtlpLogExporter.Export(in OpenTelemetry.Batch<OpenTelemetry.Logs.LogRecord> logRecordBatch) -> OpenTelemetry.ExportResult
+override OpenTelemetry.Exporter.OtlpLogExporter.OnShutdown(int timeoutMilliseconds) -> bool

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
@@ -1,0 +1,172 @@
+// <copyright file="LogRecordExtensions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET461 || NETSTANDARD2_0 || NETSTANDARD2_1
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using Google.Protobuf;
+using Google.Protobuf.Collections;
+using OpenTelemetry.Logs;
+using OtlpCollector = Opentelemetry.Proto.Collector.Logs.V1;
+using OtlpCommon = Opentelemetry.Proto.Common.V1;
+using OtlpLogs = Opentelemetry.Proto.Logs.V1;
+using OtlpResource = Opentelemetry.Proto.Resource.V1;
+
+namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
+{
+    internal static class LogRecordExtensions
+    {
+        private static readonly ConcurrentBag<OtlpLogs.InstrumentationLibraryLogs> LogListPool = new ConcurrentBag<OtlpLogs.InstrumentationLibraryLogs>();
+        private static readonly Action<RepeatedField<OtlpLogs.LogRecord>, int> RepeatedFieldOfLogSetCountAction = CreateRepeatedFieldOfLogSetCountAction();
+
+        internal static void AddBatch(
+            this OtlpCollector.ExportLogsServiceRequest request,
+            OtlpResource.Resource processResource,
+            in Batch<LogRecord> logRecordBatch)
+        {
+            Dictionary<string, OtlpLogs.InstrumentationLibraryLogs> logRecordsByLibrary = new Dictionary<string, OtlpLogs.InstrumentationLibraryLogs>();
+            OtlpLogs.ResourceLogs resourceLogs = new OtlpLogs.ResourceLogs
+            {
+                Resource = processResource,
+            };
+            request.ResourceLogs.Add(resourceLogs);
+
+            foreach (var item in logRecordBatch)
+            {
+                var logRecord = item.ToOtlpLog();
+                if (logRecord == null)
+                {
+                    OpenTelemetryProtocolExporterEventSource.Log.CouldNotTranslateLogRecord(
+                        nameof(LogRecordExtensions),
+                        nameof(AddBatch));
+                    continue;
+                }
+
+                // TODO: Record source/version correctly
+                var logRecordSourceName = "OpenTelemetry Logs";
+                if (!logRecordsByLibrary.TryGetValue(logRecordSourceName, out var logRecords))
+                {
+                    logRecords = GetLogListFromPool(logRecordSourceName, "1.2.3");
+
+                    logRecordsByLibrary.Add(logRecordSourceName, logRecords);
+                    resourceLogs.InstrumentationLibraryLogs.Add(logRecords);
+                }
+
+                logRecords.Logs.Add(logRecord);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void Return(this OtlpCollector.ExportLogsServiceRequest request)
+        {
+            var resourceLogs = request.ResourceLogs.FirstOrDefault();
+            if (resourceLogs == null)
+            {
+                return;
+            }
+
+            foreach (var libraryLogs in resourceLogs.InstrumentationLibraryLogs)
+            {
+                RepeatedFieldOfLogSetCountAction(libraryLogs.Logs, 0);
+                LogListPool.Add(libraryLogs);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static OtlpLogs.InstrumentationLibraryLogs GetLogListFromPool(string name, string version)
+        {
+            if (!LogListPool.TryTake(out var logs))
+            {
+                logs = new OtlpLogs.InstrumentationLibraryLogs
+                {
+                    InstrumentationLibrary = new OtlpCommon.InstrumentationLibrary
+                    {
+                        Name = name, // Name is enforced to not be null, but it can be empty.
+                        Version = version ?? string.Empty, // NRE throw by proto
+                    },
+                };
+            }
+            else
+            {
+                logs.InstrumentationLibrary.Name = name;
+                logs.InstrumentationLibrary.Version = version ?? string.Empty;
+            }
+
+            return logs;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static OtlpLogs.LogRecord ToOtlpLog(this LogRecord logRecord)
+        {
+            byte[] traceIdBytes = new byte[16];
+            byte[] spanIdBytes = new byte[8];
+
+            logRecord.TraceId.CopyTo(traceIdBytes);
+            logRecord.SpanId.CopyTo(spanIdBytes);
+
+            var otlpLogRecord = new OtlpLogs.LogRecord
+            {
+                TimeUnixNano = (ulong)logRecord.Timestamp.ToUnixTimeNanoseconds(),
+                Name = logRecord.CategoryName,
+                Body = new OtlpCommon.AnyValue { StringValue = logRecord.State.ToString() },
+                SeverityText = logRecord.LogLevel.ToString(),
+                TraceId = UnsafeByteOperations.UnsafeWrap(traceIdBytes),
+                SpanId = UnsafeByteOperations.UnsafeWrap(spanIdBytes),
+
+                // TODO: Handle remaining fields
+                // Flags
+                // SeverityNumber
+                // Attributes
+                // DroppedAttributesCount
+            };
+
+            return otlpLogRecord;
+        }
+
+        private static Action<RepeatedField<OtlpLogs.LogRecord>, int> CreateRepeatedFieldOfLogSetCountAction()
+        {
+            FieldInfo repeatedFieldOfLogCountField = typeof(RepeatedField<OtlpLogs.LogRecord>).GetField("count", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            DynamicMethod dynamicMethod = new DynamicMethod(
+                "CreateSetCountAction",
+                null,
+                new[] { typeof(RepeatedField<OtlpLogs.LogRecord>), typeof(int) },
+                typeof(LogRecordExtensions).Module,
+                skipVisibility: true);
+
+            var generator = dynamicMethod.GetILGenerator();
+
+            generator.Emit(OpCodes.Ldarg_0);
+            generator.Emit(OpCodes.Ldarg_1);
+            generator.Emit(OpCodes.Stfld, repeatedFieldOfLogCountField);
+            generator.Emit(OpCodes.Ret);
+
+            return (Action<RepeatedField<OtlpLogs.LogRecord>, int>)dynamicMethod.CreateDelegate(typeof(Action<RepeatedField<OtlpLogs.LogRecord>, int>));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static OtlpCommon.KeyValue CreateOtlpKeyValue(string key, OtlpCommon.AnyValue value)
+        {
+            return new OtlpCommon.KeyValue { Key = key, Value = value };
+        }
+    }
+}
+#endif

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogsService.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogsService.cs
@@ -1,0 +1,50 @@
+// <copyright file="LogsService.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Threading;
+using Grpc.Core;
+
+namespace Opentelemetry.Proto.Collector.Logs.V1
+{
+    /// <summary>
+    /// LogService extensions.
+    /// </summary>
+    internal static partial class LogsService
+    {
+        /// <summary>Interface for LogService.</summary>
+        public interface ILogsServiceClient
+        {
+            /// <summary>
+            /// For performance reasons, it is recommended to keep this RPC
+            /// alive for the entire life of the application.
+            /// </summary>
+            /// <param name="request">The request to send to the server.</param>
+            /// <param name="headers">The initial metadata to send with the call. This parameter is optional.</param>
+            /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
+            /// <param name="cancellationToken">An optional token for canceling the call.</param>
+            /// <returns>The response received from the server.</returns>
+            ExportLogsServiceResponse Export(ExportLogsServiceRequest request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default);
+        }
+
+        /// <summary>
+        /// LogsServiceClient extensions.
+        /// </summary>
+        public partial class LogsServiceClient : ILogsServiceClient
+        {
+        }
+    }
+}

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OpenTelemetryProtocolExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OpenTelemetryProtocolExporterEventSource.cs
@@ -75,5 +75,11 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
         {
             this.WriteEvent(4, ex);
         }
+
+        [Event(5, Message = "Could not translate LogRecord from class '{0}' and method '{1}', log will not be recorded.", Level = EventLevel.Informational)]
+        public void CouldNotTranslateLogRecord(string className, string methodName)
+        {
+            this.WriteEvent(5, className, methodName);
+        }
     }
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;net46;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;net46;net461;netstandard2.0</TargetFrameworks>
 
     <!--
         There is an integration test for the OTLP exporter that runs a test targeting netcoreapp2.1, netcoreapp3.1 and net5.0.

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporter.cs
@@ -1,0 +1,209 @@
+// <copyright file="OtlpLogExporter.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET461 || NETSTANDARD2_0 || NETSTANDARD2_1
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Grpc.Core;
+#if NETSTANDARD2_1
+using Grpc.Net.Client;
+#endif
+using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Resources;
+using OtlpCollector = Opentelemetry.Proto.Collector.Logs.V1;
+using OtlpCommon = Opentelemetry.Proto.Common.V1;
+using OtlpResource = Opentelemetry.Proto.Resource.V1;
+
+namespace OpenTelemetry.Exporter
+{
+    /// <summary>
+    /// Exporter consuming <see cref="LogRecord"/> and exporting the data using
+    /// the OpenTelemetry protocol (OTLP).
+    /// </summary>
+    public class OtlpLogExporter : BaseExporter<LogRecord>
+    {
+        private readonly OtlpExporterOptions options;
+#if NETSTANDARD2_1
+        private readonly GrpcChannel channel;
+#else
+        private readonly Channel channel;
+#endif
+        private readonly OtlpCollector.LogsService.ILogsServiceClient logsClient;
+        private readonly Metadata headers;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OtlpLogExporter"/> class.
+        /// </summary>
+        /// <param name="options">Configuration options for the exporter.</param>
+        public OtlpLogExporter(OtlpExporterOptions options)
+            : this(options, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OtlpLogExporter"/> class.
+        /// </summary>
+        /// <param name="options">Configuration options for the exporter.</param>
+        /// <param name="traceServiceClient"><see cref="OtlpCollector.LogsService.LogsServiceClient"/>.</param>
+        internal OtlpLogExporter(OtlpExporterOptions options, OtlpCollector.LogsService.ILogsServiceClient traceServiceClient = null)
+        {
+            this.options = options ?? throw new ArgumentNullException(nameof(options));
+            this.headers = GetMetadataFromHeaders(options.Headers);
+            if (this.options.TimeoutMilliseconds <= 0)
+            {
+                throw new ArgumentException("Timeout value provided is not a positive number.", nameof(this.options.TimeoutMilliseconds));
+            }
+
+            if (traceServiceClient != null)
+            {
+                this.logsClient = traceServiceClient;
+            }
+            else
+            {
+                if (options.Endpoint.Scheme != Uri.UriSchemeHttp && options.Endpoint.Scheme != Uri.UriSchemeHttps)
+                {
+                    throw new NotSupportedException($"Endpoint URI scheme ({options.Endpoint.Scheme}) is not supported. Currently only \"http\" and \"https\" are supported.");
+                }
+
+#if NETSTANDARD2_1
+                this.channel = GrpcChannel.ForAddress(options.Endpoint);
+#else
+                ChannelCredentials channelCredentials;
+                if (options.Endpoint.Scheme == Uri.UriSchemeHttps)
+                {
+                    channelCredentials = new SslCredentials();
+                }
+                else
+                {
+                    channelCredentials = ChannelCredentials.Insecure;
+                }
+
+                this.channel = new Channel(options.Endpoint.Authority, channelCredentials);
+#endif
+
+                this.logsClient = new OtlpCollector.LogsService.LogsServiceClient(this.channel);
+            }
+        }
+
+        internal OtlpResource.Resource ProcessResource { get; private set; }
+
+        /// <inheritdoc/>
+        public override ExportResult Export(in Batch<LogRecord> logRecordBatch)
+        {
+            if (this.ProcessResource == null)
+            {
+                this.SetResource(this.ParentProvider.GetResource());
+            }
+
+            // Prevents the exporter's gRPC and HTTP operations from being instrumented.
+            using var scope = SuppressInstrumentationScope.Begin();
+
+            OtlpCollector.ExportLogsServiceRequest request = new OtlpCollector.ExportLogsServiceRequest();
+
+            request.AddBatch(this.ProcessResource, logRecordBatch);
+            var deadline = DateTime.UtcNow.AddMilliseconds(this.options.TimeoutMilliseconds);
+
+            try
+            {
+                this.logsClient.Export(request, headers: this.headers, deadline: deadline);
+            }
+            catch (RpcException ex)
+            {
+                OpenTelemetryProtocolExporterEventSource.Log.FailedToReachCollector(ex);
+
+                return ExportResult.Failure;
+            }
+            catch (Exception ex)
+            {
+                OpenTelemetryProtocolExporterEventSource.Log.ExportMethodException(ex);
+
+                return ExportResult.Failure;
+            }
+            finally
+            {
+                request.Return();
+            }
+
+            return ExportResult.Success;
+        }
+
+        internal void SetResource(Resource resource)
+        {
+            OtlpResource.Resource processResource = new OtlpResource.Resource();
+
+            foreach (KeyValuePair<string, object> attribute in resource.Attributes)
+            {
+                var oltpAttribute = attribute.ToOtlpAttribute();
+                if (oltpAttribute != null)
+                {
+                    processResource.Attributes.Add(oltpAttribute);
+                }
+            }
+
+            if (!processResource.Attributes.Any(kvp => kvp.Key == ResourceSemanticConventions.AttributeServiceName))
+            {
+                var serviceName = (string)this.ParentProvider.GetDefaultResource().Attributes.Where(
+                    kvp => kvp.Key == ResourceSemanticConventions.AttributeServiceName).FirstOrDefault().Value;
+                processResource.Attributes.Add(new OtlpCommon.KeyValue
+                {
+                    Key = ResourceSemanticConventions.AttributeServiceName,
+                    Value = new OtlpCommon.AnyValue { StringValue = serviceName },
+                });
+            }
+
+            this.ProcessResource = processResource;
+        }
+
+        /// <inheritdoc/>
+        protected override bool OnShutdown(int timeoutMilliseconds)
+        {
+            if (this.channel == null)
+            {
+                return true;
+            }
+
+            return Task.WaitAny(new Task[] { this.channel.ShutdownAsync(), Task.Delay(timeoutMilliseconds) }) == 0;
+        }
+
+        private static Metadata GetMetadataFromHeaders(string headers)
+        {
+            var metadata = new Metadata();
+            if (!string.IsNullOrEmpty(headers))
+            {
+                Array.ForEach(
+                    headers.Split(','),
+                    (pair) =>
+                    {
+                        var keyValueData = pair.Split('=');
+                        if (keyValueData.Length != 2)
+                        {
+                            throw new ArgumentException("Headers provided in an invalid format.");
+                        }
+
+                        var key = keyValueData[0].Trim();
+                        var value = keyValueData[1].Trim();
+                        metadata.Add(key, value);
+                    });
+            }
+
+            return metadata;
+        }
+    }
+}
+#endif


### PR DESCRIPTION
This is a first cut at an OTLP log exporter. It was relatively simple to do a proof-of-concept for this. Much of the code is nearly the same as the trace exporter. As such, there's definitely an opportunity to abstract out common functionality between traces and logs (likely benefitting metrics as well). I'll work on this.

Code duplication aside, I wanted to put this PR out there beginning a discussion of how we might ship this functionality. Currently, I have the implementation in the `OpenTelemetry.Exporter.OpenTelemetryProtocol` project. However, this cannot ship as a regular release until logs are deemed stable.

There's a couple options:

* Leave the code in this project and ship a prerelease version of the package.
* Move the code to a separate project - e.g., `OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs` - and ship this as a prerelease.