### PR TITLE
Adds to REDIS instrumentation message value as tag

### DIFF
--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/Message.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/Message.cs
@@ -1,0 +1,30 @@
+// <copyright file="Message.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Implementation
+{
+    internal sealed class Message
+    {
+        private readonly string messageValue;
+
+        public Message(string value)
+        {
+            this.messageValue = value;
+        }
+
+        public override string ToString() => this.messageValue;
+    }
+}

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/ProfiledCommandStub.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/ProfiledCommandStub.cs
@@ -1,0 +1,74 @@
+// <copyright file="ProfiledCommandStub.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Net;
+using StackExchange.Redis;
+using StackExchange.Redis.Profiling;
+
+namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Implementation
+{
+    internal sealed class ProfiledCommandStub : IProfiledCommand
+    {
+        internal Message Message;
+
+        public ProfiledCommandStub(
+            int db,
+            string command,
+            string message)
+        {
+            this.Db = db;
+            this.Command = command;
+            this.Message = new Message(message);
+        }
+
+        /// <inheritdoc/>
+        public EndPoint EndPoint => null;
+
+        /// <inheritdoc/>
+        public int Db { get; }
+
+        /// <inheritdoc/>
+        public string Command { get; }
+
+        /// <inheritdoc/>
+        public CommandFlags Flags => CommandFlags.None;
+
+        /// <inheritdoc/>
+        public DateTime CommandCreated => DateTime.UtcNow;
+
+        /// <inheritdoc/>
+        public TimeSpan CreationToEnqueued => TimeSpan.Zero;
+
+        /// <inheritdoc/>
+        public TimeSpan EnqueuedToSending => TimeSpan.Zero;
+
+        /// <inheritdoc/>
+        public TimeSpan SentToResponse => TimeSpan.Zero;
+
+        /// <inheritdoc/>
+        public TimeSpan ResponseToCompletion => TimeSpan.Zero;
+
+        /// <inheritdoc/>
+        public TimeSpan ElapsedTime => TimeSpan.Zero;
+
+        /// <inheritdoc/>
+        public IProfiledCommand RetransmissionOf => null;
+
+        /// <inheritdoc/>
+        public RetransmissionReasonType? RetransmissionReason => null;
+    }
+}

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToActivityConverterTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToActivityConverterTests.cs
@@ -160,6 +160,22 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Implementation
             Assert.Equal(dnsEndPoint.Port, result.GetTagValue(SemanticConventions.AttributeNetPeerPort));
         }
 
+        [Fact]
+        public void ProfilerCommandToActivity_UsesMessageForDbOperation()
+        {
+            const int db = 0;
+            const string command = "GET";
+            const string message = "[0]: GET key";
+
+            var activity = new Activity("redis-profiler");
+            var profiledCommand = new ProfiledCommandStub(db, command, message);
+
+            var result = RedisProfilerEntryToActivityConverter.ProfilerCommandToActivity(activity, profiledCommand);
+
+            Assert.NotNull(result.GetTagValue(SemanticConventions.AttributeDbOperation));
+            Assert.Equal(message, result.GetTagValue(SemanticConventions.AttributeDbOperation));
+        }
+
 #if !NET461
         [Fact]
         public void ProfilerCommandToActivity_UsesOtherEndPointAsEndPoint()


### PR DESCRIPTION
## Changes

Current implementation detects database number and command (like `GET`, `EXISTS` and other) but does not present information about key(s). This implementation of the `RedisProfilerEntryToActivityConverter` analyzes command and tries extract `Message` value (like `[0]:GET key1`) using reflection . In case extract message operation completed successfully the value will be placed to tag with name `SemanticConventions.AttributeDbOperation`.