### PR TITLE
string[], float[], and short[] support in Zipkin

### DIFF
--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinSpan.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinSpan.cs
@@ -342,6 +342,9 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
                 long[] arrayValue => string.Join(",", arrayValue),
                 double[] arrayValue => string.Join(",", arrayValue),
                 bool[] arrayValue => string.Join(",", arrayValue.Select(GetBoolString)),
+                string[] arrayValue => string.Join(",", arrayValue),
+                float[] arrayValue => string.Join(",", arrayValue),
+                short[] arrayValue => string.Join(",", arrayValue),
                 _ => obj.ToString(),
             };
         }


### PR DESCRIPTION
Zipkin previously only displayed certain arrays correctly, as shown in this picture:
![image](https://user-images.githubusercontent.com/29290481/114374514-92e6b880-9b38-11eb-9e8e-899a9ca2de09.png)
We have support for exporting string[], float[]. and short[] so these should also be displayed as comma-separated values.

I thought this change might be too trivial to update a changelog for, but please reply if you think that'd be good to show.