### PR TITLE
StackExchange Redis: Provide 'db.system' on Span creation

### DIFF
--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Activities are now created with the `db.system` attribute set for usage
+  during sampling. ([#](https://github.com/open-telemetry/opentelemetry-dotnet/pull/))
+
 ## 1.0.0-rc3
 
 Released 2021-Mar-19

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Activities are now created with the `db.system` attribute set for usage
-  during sampling. ([#](https://github.com/open-telemetry/opentelemetry-dotnet/pull/))
+  during sampling. ([#1984](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1984))
 
 ## 1.0.0-rc3
 

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
@@ -35,6 +35,7 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Implementation
                 name,
                 ActivityKind.Client,
                 parentActivity?.Context ?? default,
+                StackExchangeRedisCallsInstrumentation.CreationTags,
                 startTime: command.CommandCreated);
 
             if (activity == null)
@@ -59,7 +60,6 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Implementation
 
                 activity.SetStatus(Status.Unset);
 
-                activity.SetTag(SemanticConventions.AttributeDbSystem, "redis");
                 activity.SetTag(StackExchangeRedisCallsInstrumentation.RedisFlagsKeyName, command.Flags.ToString());
 
                 if (command.Command != null)

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisCallsInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisCallsInstrumentation.cs
@@ -16,9 +16,11 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using OpenTelemetry.Instrumentation.StackExchangeRedis.Implementation;
+using OpenTelemetry.Trace;
 using StackExchange.Redis;
 using StackExchange.Redis.Profiling;
 
@@ -35,6 +37,10 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis
         internal const string ActivityName = ActivitySourceName + ".Execute";
         internal static readonly Version Version = typeof(StackExchangeRedisCallsInstrumentation).Assembly.GetName().Version;
         internal static readonly ActivitySource ActivitySource = new ActivitySource(ActivitySourceName, Version.ToString());
+        internal static readonly IEnumerable<KeyValuePair<string, object>> CreationTags = new[]
+        {
+            new KeyValuePair<string, object>(SemanticConventions.AttributeDbSystem, "redis"),
+        };
 
         internal readonly ConcurrentDictionary<(ActivityTraceId TraceId, ActivitySpanId SpanId), (Activity Activity, ProfilingSession Session)> Cache
             = new ConcurrentDictionary<(ActivityTraceId, ActivitySpanId), (Activity, ProfilingSession)>();

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\SkipUnlessEnvVarFoundTheoryAttribute.cs" Link="Implementation\SkipUnlessEnvVarFoundTheoryAttribute.cs" />
+    <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestSampler.cs" Link="TestSampler.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #1971 for Redis -- The issue was fixed for SQL instrumentation library by @johnduhart  in #1979 , and this PR is largely based on his work.

## Changes

Since we always attach the tag KeyVal ("db.system", "redis"), statically instantiating it is worth the small cost, and allows samplers to check for this tag when deciding to sample or not