### PR TITLE
Add RecordException support for HttpClient (.NETCore)

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Http/.publicApi/net452/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.Http/.publicApi/net452/PublicAPI.Unshipped.txt
@@ -4,6 +4,8 @@ OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions.Enrich.set -
 OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions.Filter.get -> System.Func<System.Net.Http.HttpRequestMessage, bool>
 OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions.Filter.set -> void
 OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions.HttpClientInstrumentationOptions() -> void
+OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions.RecordException.get -> bool
+OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions.RecordException.set -> void
 OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions.SetHttpFlavor.get -> bool
 OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions.SetHttpFlavor.set -> void
 OpenTelemetry.Instrumentation.Http.HttpWebRequestInstrumentationOptions

--- a/src/OpenTelemetry.Instrumentation.Http/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.Http/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -4,6 +4,8 @@ OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions.Enrich.set -
 OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions.Filter.get -> System.Func<System.Net.Http.HttpRequestMessage, bool>
 OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions.Filter.set -> void
 OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions.HttpClientInstrumentationOptions() -> void
+OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions.RecordException.get -> bool
+OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions.RecordException.set -> void
 OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions.SetHttpFlavor.get -> bool
 OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions.SetHttpFlavor.set -> void
 OpenTelemetry.Instrumentation.Http.HttpWebRequestInstrumentationOptions

--- a/src/OpenTelemetry.Instrumentation.Http/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.Http/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -4,6 +4,8 @@ OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions.Enrich.set -
 OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions.Filter.get -> System.Func<System.Net.Http.HttpRequestMessage, bool>
 OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions.Filter.set -> void
 OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions.HttpClientInstrumentationOptions() -> void
+OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions.RecordException.get -> bool
+OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions.RecordException.set -> void
 OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions.SetHttpFlavor.get -> bool
 OpenTelemetry.Instrumentation.Http.HttpClientInstrumentationOptions.SetHttpFlavor.set -> void
 OpenTelemetry.Trace.TracerProviderBuilderExtensions

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 * Sanitize `http.url` attribute. ([#1961](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1961))
+* Added `RecordException` to HttpClientInstrumentationOptions which allows
+  Exception to be reported as ActivityEvent.
 
 ## 1.0.0-rc3
 

--- a/src/OpenTelemetry.Instrumentation.Http/HttpClientInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/HttpClientInstrumentationOptions.cs
@@ -52,6 +52,14 @@ namespace OpenTelemetry.Instrumentation.Http
         /// </remarks>
         public Action<Activity, string, object> Enrich { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether exception will be recorded as ActivityEvent or not.
+        /// </summary>
+        /// <remarks>
+        /// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/exceptions.md.
+        /// </remarks>
+        public bool RecordException { get; set; }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal bool EventFilter(string activityName, object arg1)
         {

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -171,7 +171,7 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
                     {
                         if (currentStatusCode == StatusCode.Unset)
                         {
-                            // Faults are handled in OnException and should already have a span.Status of Unknown w/ Description.
+                            // Faults are handled in OnException and should already have a span.Status of Error w/ Description.
                             activity.SetStatus(Status.Error);
                         }
                     }
@@ -206,6 +206,11 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
                 {
                     HttpInstrumentationEventSource.Log.NullPayload(nameof(HttpHandlerDiagnosticListener), nameof(this.OnException));
                     return;
+                }
+
+                if (this.options.RecordException)
+                {
+                    activity.RecordException(exc);
                 }
 
                 if (exc is HttpRequestException)

--- a/src/OpenTelemetry.Instrumentation.Http/README.md
+++ b/src/OpenTelemetry.Instrumentation.Http/README.md
@@ -177,6 +177,10 @@ is the general extensibility point to add additional properties to any
 activity. The `Enrich` option is specific to this instrumentation, and is
 provided to get access to raw request, response, and exception objects.
 
+### RecordException
+
+// TODO:
+
 ## References
 
 * [OpenTelemetry Project](https://opentelemetry.io/)

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.netcore31.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.netcore31.cs
@@ -60,6 +60,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
                                {
                                    opt.SetHttpFlavor = tc.SetHttpFlavor;
                                    opt.Enrich = ActivityEnrichment;
+                                   opt.RecordException = tc.RecordException.HasValue ? tc.RecordException.Value : false;
                                })
                                .AddProcessor(processor.Object)
                                .Build())
@@ -115,6 +116,11 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
             foreach (var kv in normalizedAttributesTestCase)
             {
                 Assert.Contains(activity.TagObjects, i => i.Key == kv.Key && i.Value.ToString().Equals(kv.Value, StringComparison.InvariantCultureIgnoreCase));
+            }
+
+            if (tc.RecordException.HasValue && tc.RecordException.Value)
+            {
+                Assert.Single(activity.Events.Where(evt => evt.Name.Equals("exception")));
             }
         }
 

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpTestData.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpTestData.cs
@@ -67,6 +67,8 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
 
             public bool ResponseExpected { get; set; }
 
+            public bool? RecordException { get; set; }
+
             public string SpanStatus { get; set; }
 
             public bool? SpanStatusHasDescription { get; set; }

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/http-out-test-cases.json
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/http-out-test-cases.json
@@ -79,7 +79,23 @@
     "spanName": "HTTP GET",
     "spanStatus": "ERROR",
     "spanStatusHasDescription": true,
-    "responseExpected" : false,
+    "responseExpected": false,
+    "recordException": false,
+    "spanAttributes": {
+      "http.method": "GET",
+      "http.host": "sdlfaldfjalkdfjlkajdflkajlsdjf.sdlkjafsdjfalfadslkf.com",
+      "http.url": "https://sdlfaldfjalkdfjlkajdflkajlsdjf.sdlkjafsdjfalfadslkf.com/"
+    }
+  },
+  {
+    "name": "Call that cannot resolve DNS will be reported as error span. And Records exception",
+    "method": "GET",
+    "url": "https://sdlfaldfjalkdfjlkajdflkajlsdjf.sdlkjafsdjfalfadslkf.com/",
+    "spanName": "HTTP GET",
+    "spanStatus": "ERROR",
+    "spanStatusHasDescription": true,
+    "responseExpected": false,
+    "recordException": true,
     "spanAttributes": {
       "http.method": "GET",
       "http.host": "sdlfaldfjalkdfjlkajdflkajlsdjf.sdlkjafsdjfalfadslkf.com",


### PR DESCRIPTION
Only for .NET Core in this PR.
Coming next is same for .NET FW.

Expecting some conflicts with https://github.com/open-telemetry/opentelemetry-dotnet/pull/1982, will do ordered merge.

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
