### PR TITLE
Add RecordException to HttpClientInstrumentation in .NET FX

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Http/.publicApi/net452/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.Http/.publicApi/net452/PublicAPI.Unshipped.txt
@@ -14,6 +14,8 @@ OpenTelemetry.Instrumentation.Http.HttpWebRequestInstrumentationOptions.Enrich.s
 OpenTelemetry.Instrumentation.Http.HttpWebRequestInstrumentationOptions.Filter.get -> System.Func<System.Net.HttpWebRequest, bool>
 OpenTelemetry.Instrumentation.Http.HttpWebRequestInstrumentationOptions.Filter.set -> void
 OpenTelemetry.Instrumentation.Http.HttpWebRequestInstrumentationOptions.HttpWebRequestInstrumentationOptions() -> void
+OpenTelemetry.Instrumentation.Http.HttpWebRequestInstrumentationOptions.RecordException.get -> bool
+OpenTelemetry.Instrumentation.Http.HttpWebRequestInstrumentationOptions.RecordException.set -> void
 OpenTelemetry.Instrumentation.Http.HttpWebRequestInstrumentationOptions.SetHttpFlavor.get -> bool
 OpenTelemetry.Instrumentation.Http.HttpWebRequestInstrumentationOptions.SetHttpFlavor.set -> void
 OpenTelemetry.Trace.TracerProviderBuilderExtensions

--- a/src/OpenTelemetry.Instrumentation.Http/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.Http/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -14,6 +14,8 @@ OpenTelemetry.Instrumentation.Http.HttpWebRequestInstrumentationOptions.Enrich.s
 OpenTelemetry.Instrumentation.Http.HttpWebRequestInstrumentationOptions.Filter.get -> System.Func<System.Net.HttpWebRequest, bool>
 OpenTelemetry.Instrumentation.Http.HttpWebRequestInstrumentationOptions.Filter.set -> void
 OpenTelemetry.Instrumentation.Http.HttpWebRequestInstrumentationOptions.HttpWebRequestInstrumentationOptions() -> void
+OpenTelemetry.Instrumentation.Http.HttpWebRequestInstrumentationOptions.RecordException.get -> bool
+OpenTelemetry.Instrumentation.Http.HttpWebRequestInstrumentationOptions.RecordException.set -> void
 OpenTelemetry.Instrumentation.Http.HttpWebRequestInstrumentationOptions.SetHttpFlavor.get -> bool
 OpenTelemetry.Instrumentation.Http.HttpWebRequestInstrumentationOptions.SetHttpFlavor.set -> void
 OpenTelemetry.Trace.TracerProviderBuilderExtensions

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## Unreleased
 
 * Sanitize `http.url` attribute. ([#1961](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1961))
-* Added `RecordException` to HttpClientInstrumentationOptions which allows
-  Exception to be reported as ActivityEvent.
+* Added `RecordException` to HttpClientInstrumentationOptions and
+  HttpWebRequestInstrumentationOptions which allows Exception to be
+  reported as ActivityEvent.
 
 ## 1.0.0-rc3
 

--- a/src/OpenTelemetry.Instrumentation.Http/HttpWebRequestInstrumentationOptions.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/HttpWebRequestInstrumentationOptions.netfx.cs
@@ -52,6 +52,14 @@ namespace OpenTelemetry.Instrumentation.Http
         /// </remarks>
         public Action<Activity, string, object> Enrich { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether exception will be recorded as ActivityEvent or not.
+        /// </summary>
+        /// <remarks>
+        /// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/exceptions.md.
+        /// </remarks>
+        public bool RecordException { get; set; }
+
         internal bool EventFilter(HttpWebRequest request)
         {
             try

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
@@ -180,6 +180,10 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
             }
 
             activity.SetStatus(status);
+            if (Options.RecordException)
+            {
+                activity.RecordException(exception);
+            }
 
             try
             {

--- a/src/OpenTelemetry.Instrumentation.Http/README.md
+++ b/src/OpenTelemetry.Instrumentation.Http/README.md
@@ -179,7 +179,10 @@ provided to get access to raw request, response, and exception objects.
 
 ### RecordException
 
-// TODO:
+This instrumentation automatically sets Activity Status to Error if the
+Http StatusCode is >= 400.
+Additionally, `RecordException` feature may be turned on, to store the exception
+to the Activity itself as ActivityEvent.
 
 ## References
 

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.netfx.cs
@@ -52,6 +52,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
                 {
                     options.SetHttpFlavor = tc.SetHttpFlavor;
                     options.Enrich = ActivityEnrichment;
+                    options.RecordException = tc.RecordException.HasValue ? tc.RecordException.Value : false;
                 })
                 .Build();
 
@@ -126,6 +127,11 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
                 }
 
                 Assert.Equal(value, tagValue);
+            }
+
+            if (tc.RecordException.HasValue && tc.RecordException.Value)
+            {
+                Assert.Single(activity.Events.Where(evt => evt.Name.Equals("exception")));
             }
         }
 


### PR DESCRIPTION
Continuing from https://github.com/open-telemetry/opentelemetry-dotnet/pull/1987

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
