### PR TITLE
Remove netcoreapp2.1 from logging examples

### DIFF
--- a/docs/Directory.Build.props
+++ b/docs/Directory.Build.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <!-- https://dotnet.microsoft.com/download/dotnet-core -->
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <!-- https://dotnet.microsoft.com/download/dotnet-framework -->
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net461;net462;net47;net471;net472;net48</TargetFrameworks>
   </PropertyGroup>

--- a/docs/logs/extending-the-sdk/Program.cs
+++ b/docs/logs/extending-the-sdk/Program.cs
@@ -15,9 +15,6 @@
 // </copyright>
 
 using System.Collections.Generic;
-#if NETCOREAPP2_1
-using Microsoft.Extensions.DependencyInjection;
-#endif
 using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 using OpenTelemetry.Logs;
@@ -26,11 +23,7 @@ public class Program
 {
     public static void Main()
     {
-#if NETCOREAPP2_1
-        var serviceCollection = new ServiceCollection().AddLogging(builder =>
-#else
         using var loggerFactory = LoggerFactory.Create(builder =>
-#endif
             builder.AddOpenTelemetry(options =>
             {
                 options.IncludeScopes = true;
@@ -40,12 +33,7 @@ public class Program
                        .AddMyExporter();
             }));
 
-#if NETCOREAPP2_1
-        using var serviceProvider = serviceCollection.BuildServiceProvider();
-        var logger = serviceProvider.GetRequiredService<ILogger<Program>>();
-#else
         var logger = loggerFactory.CreateLogger<Program>();
-#endif
 
         // unstructured log
         logger.LogInformation("Hello, World!");

--- a/docs/logs/extending-the-sdk/extending-the-sdk.csproj
+++ b/docs/logs/extending-the-sdk/extending-the-sdk.csproj
@@ -3,12 +3,7 @@
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry\OpenTelemetry.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingPkgVer)" />
   </ItemGroup>
 </Project>

--- a/docs/logs/getting-started/Program.cs
+++ b/docs/logs/getting-started/Program.cs
@@ -14,9 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-#if NETCOREAPP2_1
-using Microsoft.Extensions.DependencyInjection;
-#endif
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
 
@@ -24,23 +21,13 @@ public class Program
 {
     public static void Main()
     {
-#if NETCOREAPP2_1
-        var serviceCollection = new ServiceCollection().AddLogging(builder =>
-#else
         using var loggerFactory = LoggerFactory.Create(builder =>
-#endif
         {
             builder.AddOpenTelemetry(options => options
                 .AddConsoleExporter());
         });
 
-#if NETCOREAPP2_1
-        using var serviceProvider = serviceCollection.BuildServiceProvider();
-        var logger = serviceProvider.GetRequiredService<ILogger<Program>>();
-#else
         var logger = loggerFactory.CreateLogger<Program>();
-#endif
-
         logger.LogInformation("Hello from {name} {price}.", "tomato", 2.99);
     }
 }

--- a/docs/logs/getting-started/README.md
+++ b/docs/logs/getting-started/README.md
@@ -17,21 +17,7 @@ You should see the following output:
 Hello World!
 ```
 
-Let's install the packages to get started with logging. If your ConsoleApp
-targets `netcoreapp2.1` install the version `2.1.1` of
-`Microsoft.Extensions.Logging` and `Microsoft.Extensions.DependencyInjection`
-packages:
-
-  ```sh
-  dotnet add package Microsoft.Extensions.Logging -v 2.1.1
-  ```
-
-  ```sh
-  dotnet add package Microsoft.Extensions.DependencyInjection -v 2.1.1
-  ```
-
-If your ConsoleApp targets a framework other than `netcoreapp2.1`, install the
-latest Microsoft.Extensions.Logging package:
+Install the latest `Microsoft.Extensions.Logging` package:
 
   ```sh
   dotnet add package Microsoft.Extensions.Logging
@@ -39,7 +25,7 @@ latest Microsoft.Extensions.Logging package:
 
 Install the
 [OpenTelemetry.Exporter.Console](../../../src/OpenTelemetry.Exporter.Console/README.md)
-package (Use the latest version):
+package:
 
 ```sh
 dotnet add package OpenTelemetry.Exporter.Console

--- a/docs/logs/getting-started/getting-started.csproj
+++ b/docs/logs/getting-started/getting-started.csproj
@@ -3,12 +3,7 @@
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Console\OpenTelemetry.Exporter.Console.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.1'">
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingPkgVer)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
.Net Core 2.1 is reaching eol in ~4 months.
No product change in this PR.
Only docs are updated for logs - as this makes the docs much simpler :) 

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
