### PR TITLE
Propose Victor Lu as triager

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ Maintainers
 *Find more about the maintainer role in [community
 repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer).*
 
+Triager
+([@open-telemetry/dotnet-triagers](https://github.com/orgs/open-telemetry/teams/dotnet-triagers)):
+
+* [Victor Lu](https://github.com/victlu), Microsoft
+
+*Find more about the triager role in [community
+repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#triager).*
+
 ### Thanks to all the people who have contributed
 
 [![contributors](https://contributors-img.web.app/image?repo=open-telemetry/opentelemetry-dotnet)](https://github.com/open-telemetry/opentelemetry-dotnet/graphs/contributors)


### PR DESCRIPTION
As discussed in 4/13/2021 SIG meeting, proposing to add Victor Lu to Triager role to help with issues management.
Victor has been active participant in SIG meetings for 2+ months and have expressed interest in helping more with managing issues/backlogs.