### PR TITLE
AspNetCore instrumentation options to be configurable from DI

### DIFF
--- a/examples/AspNetCore/Startup.cs
+++ b/examples/AspNetCore/Startup.cs
@@ -98,17 +98,9 @@ namespace Examples.AspNetCore
                         .AddConsoleExporter());
 
                     // For options which can be bound from IConfiguration.
-                    // If uncommenting this, make sure to have a section
-                    // named "AspNetCore" in appsettings.json
-                    // services.Configure<AspNetCoreInstrumentationOptions>(this.Configuration.GetSection("AspNetCore"));
+                    services.Configure<AspNetCoreInstrumentationOptions>(this.Configuration.GetSection("AspNetCoreInstrumentation"));
 
-                    // For options which can be configure via code only.
-                    services.Configure<AspNetCoreInstrumentationOptions>(options =>
-                    {
-                        options.RecordException = true;
-                    });
-
-                    // Keep configuring..
+                    // For options which can be configured from code only.
                     services.Configure<AspNetCoreInstrumentationOptions>(options =>
                     {
                         options.Filter = (req) =>

--- a/examples/AspNetCore/Startup.cs
+++ b/examples/AspNetCore/Startup.cs
@@ -24,6 +24,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
 using OpenTelemetry.Exporter;
+using OpenTelemetry.Instrumentation.AspNetCore;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
@@ -95,6 +96,27 @@ namespace Examples.AspNetCore
                         .AddAspNetCoreInstrumentation()
                         .AddHttpClientInstrumentation()
                         .AddConsoleExporter());
+
+                    // For options which can be bound from IConfiguration.
+                    // If uncommenting this, make sure to have a section
+                    // named "AspNetCore" in appsettings.json
+                    // services.Configure<AspNetCoreInstrumentationOptions>(this.Configuration.GetSection("AspNetCore"));
+
+                    // For options which can be configure via code only.
+                    services.Configure<AspNetCoreInstrumentationOptions>(options =>
+                    {
+                        options.RecordException = true;
+                    });
+
+                    // Keep configuring..
+                    services.Configure<AspNetCoreInstrumentationOptions>(options =>
+                    {
+                        options.Filter = (req) =>
+                        {
+                            return req.Request.Host != null;
+                        };
+                    });
+
                     break;
             }
         }

--- a/examples/AspNetCore/appsettings.json
+++ b/examples/AspNetCore/appsettings.json
@@ -20,5 +20,8 @@
   "Otlp": {
     "ServiceName": "otlp-test",
     "Endpoint": "http://localhost:4317"
+  },
+  "AspNetCoreInstrumentation": {
+    "RecordException": "true"
   }
 }

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* When using OpenTelemetry.Extensions.Hosting you can now bind
+  `AspNetCoreInstrumentationOptions` from DI.
+  ([#1997](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1997))
+
 ## 1.0.0-rc3
 
 Released 2021-Mar-19

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.GrpcNetClient\GrpcTagHelper.cs" Link="Includes\GrpcTagHelper.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.GrpcNetClient\StatusCanonicalCode.cs" Link="Includes\StatusCanonicalCode.cs" />
+    <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\ServiceProviderExtensions.cs" Link="Includes\ServiceProviderExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
@@ -57,6 +57,29 @@ This instrumentation can be configured to change the default behavior by using
 `AspNetCoreInstrumentationOptions`, which allows adding [`Filter`](#filter),
 [`Enrich`](#enrich) as explained below.
 
+// TODO: This section could be refined.
+When used with [`OpenTelemetry.Extensions.Hosting`](../OpenTelemetry.Extensions.Hosting/README.md),
+all configurations to `AspNetCoreInstrumentationOptions` can be done in the `ConfigureServices`
+method of you applications `Startup` class as shown below.
+
+```csharp
+// Configure
+services.Configure<AspNetCoreInstrumentationOptions>(options =>
+        {
+            options.Filter = (req) =>
+            {
+                // only collect telemetry about HTTP GET requests
+                return httpContext.Request.Method.Equals("GET");
+            };
+        });
+
+services.AddOpenTelemetryTracing(
+        (builder) => builder
+            .AddAspNetCoreInstrumentation()
+            .AddJaegerExporter()
+            );
+```
+
 ### Filter
 
 This instrumentation by default collects all the incoming http requests. It

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/TracerProviderBuilderExtensions.cs
@@ -40,14 +40,27 @@ namespace OpenTelemetry.Trace
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            var aspnetCoreOptions = new AspNetCoreInstrumentationOptions();
-            configureAspNetCoreInstrumentationOptions?.Invoke(aspnetCoreOptions);
-            builder.AddInstrumentation(() => new AspNetCoreInstrumentation(aspnetCoreOptions));
+            if (builder is IDeferredTracerProviderBuilder deferredTracerProviderBuilder)
+            {
+                return deferredTracerProviderBuilder.Configure((sp, builder) =>
+                {
+                    var options = sp.GetOptions<AspNetCoreInstrumentationOptions>();
+                    sp.ApplyConfigAction<AspNetCoreInstrumentationOptions>(options);
+                    AddAspNetCoreInstrumentation(builder, options, configureAspNetCoreInstrumentationOptions);
+                });
+            }
+
+            return AddAspNetCoreInstrumentation(builder, new AspNetCoreInstrumentationOptions(), configureAspNetCoreInstrumentationOptions);
+        }
+
+        private static TracerProviderBuilder AddAspNetCoreInstrumentation(TracerProviderBuilder builder, AspNetCoreInstrumentationOptions options, Action<AspNetCoreInstrumentationOptions> configure = null)
+        {
+            configure?.Invoke(options);
+            var instrumentation = new AspNetCoreInstrumentation(options);
             builder.AddSource(HttpInListener.ActivitySourceName);
             builder.AddLegacySource(HttpInListener.ActivityOperationName); // for the activities created by AspNetCore
             builder.AddLegacySource(HttpInListener.ActivityNameByHttpInListener); // for the sibling activities created by the instrumentation library
-
-            return builder;
+            return builder.AddInstrumentation(() => instrumentation);
         }
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/TracerProviderBuilderExtensions.cs
@@ -44,9 +44,7 @@ namespace OpenTelemetry.Trace
             {
                 return deferredTracerProviderBuilder.Configure((sp, builder) =>
                 {
-                    var options = sp.GetOptions<AspNetCoreInstrumentationOptions>();
-                    sp.ApplyConfigAction<AspNetCoreInstrumentationOptions>(options);
-                    AddAspNetCoreInstrumentation(builder, options, configureAspNetCoreInstrumentationOptions);
+                    AddAspNetCoreInstrumentation(builder, sp.GetOptions<AspNetCoreInstrumentationOptions>(), configureAspNetCoreInstrumentationOptions);
                 });
             }
 

--- a/src/OpenTelemetry/Internal/ServiceProviderExtensions.cs
+++ b/src/OpenTelemetry/Internal/ServiceProviderExtensions.cs
@@ -14,7 +14,8 @@
 // limitations under the License.
 // </copyright>
 
-#if NET461 || NETSTANDARD2_0
+#if NET461 || NETSTANDARD2_0 || NETSTANDARD2_1
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 #endif
 
@@ -34,13 +35,28 @@ namespace System
         public static T GetOptions<T>(this IServiceProvider serviceProvider)
             where T : class, new()
         {
-#if NET461 || NETSTANDARD2_0
+#if NET461 || NETSTANDARD2_0 || NETSTANDARD2_1
             IOptions<T> options = (IOptions<T>)serviceProvider.GetService(typeof(IOptions<T>));
 
             // Note: options could be null if user never invoked services.AddOptions().
             return options?.Value ?? new T();
 #else
             return new T();
+#endif
+        }
+
+        /// <summary>
+        /// Apply Config actions from the supplied <see cref="IServiceProvider"/> to the instance of T.
+        /// </summary>
+        /// <typeparam name="T">Options type.</typeparam>
+        /// <param name="serviceProvider"><see cref="IServiceProvider"/>.</param>
+        /// <param name="toConfigure">Instance to configure.</param>
+        public static void ApplyConfigAction<T>(this IServiceProvider serviceProvider, T toConfigure)
+            where T : class, new()
+        {
+#if NET461 || NETSTANDARD2_0 || NETSTANDARD2_1
+            var configAction = serviceProvider.GetRequiredService<IConfigureOptions<T>>();
+            configAction?.Configure(toConfigure);
 #endif
         }
     }

--- a/src/OpenTelemetry/Internal/ServiceProviderExtensions.cs
+++ b/src/OpenTelemetry/Internal/ServiceProviderExtensions.cs
@@ -44,20 +44,5 @@ namespace System
             return new T();
 #endif
         }
-
-        /// <summary>
-        /// Apply Config actions from the supplied <see cref="IServiceProvider"/> to the instance of T.
-        /// </summary>
-        /// <typeparam name="T">Options type.</typeparam>
-        /// <param name="serviceProvider"><see cref="IServiceProvider"/>.</param>
-        /// <param name="toConfigure">Instance to configure.</param>
-        public static void ApplyConfigAction<T>(this IServiceProvider serviceProvider, T toConfigure)
-            where T : class, new()
-        {
-#if NET461 || NETSTANDARD2_0 || NETSTANDARD2_1
-            var configAction = serviceProvider.GetRequiredService<IConfigureOptions<T>>();
-            configAction?.Configure(toConfigure);
-#endif
-        }
     }
 }


### PR DESCRIPTION
Ability to bind AspNetCoreOptions from DI - similar to https://github.com/open-telemetry/opentelemetry-dotnet/pull/1942/files
Building on this: https://github.com/open-telemetry/opentelemetry-dotnet/pull/1889

Usage example:
```            
// For options which can be bound from IConfiguration.
services.Configure<AspNetCoreInstrumentationOptions>(this.Configuration.GetSection("AspNetCoreInstrumentation"));

// For options which can be configured from code only.
services.Configure<AspNetCoreInstrumentationOptions>(options =>
{
    options.Filter = (req) =>
    {
        return req.Request.Host != null;
    };
});
```
Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
