### PR TITLE
Document zipkin exporters support for DI based config

### DIFF
--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * When using OpenTelemetry.Extensions.Hosting you can now bind
-  `JaegerExporterOptions` to `IConfiguration` using the `Configure` extension
+  `ZipkinExporterOptions` to `IConfiguration` using the `Configure` extension
   (ex:
   `services.Configure<ZipkinExporterOptions>(this.Configuration.GetSection("Zipkin"));`).
   ([#1889](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1889))

--- a/src/OpenTelemetry.Exporter.Zipkin/README.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/README.md
@@ -13,9 +13,12 @@
 dotnet add package OpenTelemetry.Exporter.Zipkin
 ```
 
-## Configuration
+## Enable/Add Zipkin as a tracing exporter
 
-You can enable the the `ZipkinExporter` with the `AddZipkinExporter()`.
+You can enable the the `ZipkinExporter` with the `AddZipkinExporter()` extension
+method on `TracerProviderBuilder`.
+
+## Configuration
 
 You can configure the `ZipkinExporter` through
 `ZipkinExporterOptions` properties:
@@ -37,6 +40,15 @@ You can configure the `ZipkinExporter` through
 See
 [`TestZipkinExporter.cs`](../../examples/Console/TestZipkinExporter.cs)
 for example use.
+
+## Configuration using Dependency Injection
+
+This exporter allows easy configuration of `ZipkinExporterOptions` from
+dependency injection container, when used in conjunction with
+[`OpenTelemetry.Extensions.Hosting`](../OpenTelemetry.Extensions.Hosting/README.md).
+
+See the [Startup](../../examples/AspNetCore/Startup.cs) class of the ASP.NET
+Core application for example use.
 
 ## References
 


### PR DESCRIPTION
Want to get some feedback if this is a good improvement. If yes, we can expand same approach to all other exporters/instrumentations which support DI based configs.
If not, need to see if there is better way of documented this capability.

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
