### PR TITLE
GrpcAspNetCoreInstrumentationAddsCorrectAttributes test stabilize attempt

### DIFF
--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.server.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.server.cs
@@ -75,6 +75,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
             var client = new Greeter.GreeterClient(channel);
             client.SayHello(new HelloRequest());
 
+            tracerProvider.ForceFlush();
             WaitForProcessorInvocations(processor, 2);
 
             Assert.InRange(processor.Invocations.Count, 2, 6); // begin and end was called

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.server.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.server.cs
@@ -75,7 +75,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
             var client = new Greeter.GreeterClient(channel);
             client.SayHello(new HelloRequest());
 
-            tracerProvider.ForceFlush();
+            this.server.Dispose();
             WaitForProcessorInvocations(processor, 2);
 
             Assert.InRange(processor.Invocations.Count, 2, 6); // begin and end was called


### PR DESCRIPTION
`GrpcAspNetCoreInstrumentationAddsCorrectAttributes` has been unstable recently. Was able to get couple of failures locally as well. Try a force server dispose to see if this helps in anyway.