### PR TITLE
Rename Baggage Header name to baggage

### DIFF
--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -9,6 +9,10 @@ please check the latest changes
 
 ## Unreleased
 
+* `BaggagePropagator` now uses `baggage` as the header name instead of `Baggage`
+  to `Extract` from and `Inject` to `carrier`
+  ([#2003](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2003))
+
 ## 1.1.0-beta1
 
 Released 2021-Mar-19

--- a/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
@@ -28,7 +28,7 @@ namespace OpenTelemetry.Context.Propagation
     /// </summary>
     public class BaggagePropagator : TextMapPropagator
     {
-        internal const string BaggageHeaderName = "Baggage";
+        internal const string BaggageHeaderName = "baggage";
 
         private const int MaxBaggageLength = 8192;
         private const int MaxBaggageItems = 180;

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.netcore31.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.netcore31.cs
@@ -392,7 +392,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
 
             Assert.True(request.Headers.TryGetValues("traceparent", out var traceparents));
             Assert.True(request.Headers.TryGetValues("tracestate", out var tracestates));
-            Assert.True(request.Headers.TryGetValues("Baggage", out var baggages));
+            Assert.True(request.Headers.TryGetValues("baggage", out var baggages));
             Assert.Single(traceparents);
             Assert.Single(tracestates);
             Assert.Single(baggages);

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestActivitySourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestActivitySourceTests.netfx.cs
@@ -816,7 +816,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
 
         private static void ValidateBaggage(HttpWebRequest request)
         {
-            string[] baggage = request.Headers["Baggage"].Split(',');
+            string[] baggage = request.Headers["baggage"].Split(',');
 
             Assert.Equal(3, baggage.Length);
             Assert.Contains("key=value", baggage);


### PR DESCRIPTION
Fixes #1967 

## Changes
- Renamed BaggageHeader name to `baggage` (lowercase). `BaggagePropagator.Extract` and `BaggagePropagator.Inject` will now look for and add `baggage` to the `carrier` respectively
-  Updated `HttpInstrumentationTests` to look for `baggage` in `Headers` instead of `Baggage`. Although these look ups are case insensitive, I updated them to be consistent with the BaggageHeader Name.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
