### PR TITLE
Extensions.Hosting Config improvements.

### DIFF
--- a/src/OpenTelemetry.Extensions.Hosting/Trace/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Trace/TracerProviderBuilderExtensions.cs
@@ -42,40 +42,6 @@ namespace OpenTelemetry.Trace
         }
 
         /// <summary>
-        /// Adds a processor to the provider.
-        /// </summary>
-        /// <typeparam name="T">Processor type.</typeparam>
-        /// <param name="tracerProviderBuilder"><see cref="TracerProviderBuilder"/>.</param>
-        /// <returns>The supplied <see cref="TracerProviderBuilder"/> for chaining.</returns>
-        public static TracerProviderBuilder AddProcessor<T>(this TracerProviderBuilder tracerProviderBuilder)
-            where T : BaseProcessor<Activity>
-        {
-            if (tracerProviderBuilder is TracerProviderBuilderHosting tracerProviderBuilderHosting)
-            {
-                tracerProviderBuilderHosting.AddProcessor<T>();
-            }
-
-            return tracerProviderBuilder;
-        }
-
-        /// <summary>
-        /// Sets the sampler on the provider.
-        /// </summary>
-        /// <typeparam name="T">Sampler type.</typeparam>
-        /// <param name="tracerProviderBuilder"><see cref="TracerProviderBuilder"/>.</param>
-        /// <returns>The supplied <see cref="TracerProviderBuilder"/> for chaining.</returns>
-        public static TracerProviderBuilder SetSampler<T>(this TracerProviderBuilder tracerProviderBuilder)
-            where T : Sampler
-        {
-            if (tracerProviderBuilder is TracerProviderBuilderHosting tracerProviderBuilderHosting)
-            {
-                tracerProviderBuilderHosting.SetSampler<T>();
-            }
-
-            return tracerProviderBuilder;
-        }
-
-        /// <summary>
         /// Register a callback action to configure the <see cref="TracerProviderBuilder"/> during initialization.
         /// </summary>
         /// <param name="tracerProviderBuilder"><see cref="TracerProviderBuilder"/>.</param>

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetry.Extensions.Hosting.Tests.csproj
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetry.Extensions.Hosting.Tests.csproj
@@ -9,6 +9,7 @@
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Extensions.Hosting\OpenTelemetry.Extensions.Hosting.csproj" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\EventSourceTestHelper.cs" Link="EventSourceTestHelper.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestEventListener.cs" Link="TestEventListener.cs" />
+    <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestActivityProcessor.cs" Link="TestActivityProcessor.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Similar to https://github.com/open-telemetry/opentelemetry-dotnet/pull/1998
Another idea to address https://github.com/open-telemetry/opentelemetry-dotnet/issues/1394

Current way of setting a Sampler with DI:
```
var builder = new HostBuilder().ConfigureServices(services =>
            {
                services.AddOpenTelemetryTracing(builder => builder.SetSampler<ParentBasedSampler>());
                // The below sampler gets picked up. But it requires that AddOpenTelemetryTracingcall
               // already announces that it wants ParentBasedSampler
              // This requires the AddOpenTelemetryTracing() call to have the whole
             // knowledge of what to be configured.
            // This is described in https://github.com/open-telemetry/opentelemetry-dotnet/issues/1394
                services.AddSingleton<ParentBasedSampler>(new ParentBasedSampler(new AlwaysOffSampler()));
            });
```

With this PR:
```
var builder = new HostBuilder().ConfigureServices(services =>
            {
                services.AddOpenTelemetryTracing();

                // tracerproviderbuilder can be configured anywhere in DI. it doesn't require AddOpenTelemetryTracing
               // knowing ahead that a ParentBasedSampler is coming.
                services.AddSingleton<Sampler>(new ParentBasedSampler(new AlwaysOffSampler()));
            });
```