### PR TITLE
Doc for customizing tracing sdk

### DIFF
--- a/OpenTelemetry.sln
+++ b/OpenTelemetry.sln
@@ -199,6 +199,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestApp.AspNetCore.5.0", "t
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "exception-reporting", "docs\trace\exception-reporting\exception-reporting.csproj", "{08D29501-F0A3-468F-B18D-BD1821A72383}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "customizing-the-sdk", "docs\trace\customizing-the-sdk\customizing-the-sdk.csproj", "{64E3D8BB-93AB-4571-93F7-ED8D64DFFD06}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -393,6 +395,10 @@ Global
 		{08D29501-F0A3-468F-B18D-BD1821A72383}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{08D29501-F0A3-468F-B18D-BD1821A72383}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{08D29501-F0A3-468F-B18D-BD1821A72383}.Release|Any CPU.Build.0 = Release|Any CPU
+		{64E3D8BB-93AB-4571-93F7-ED8D64DFFD06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{64E3D8BB-93AB-4571-93F7-ED8D64DFFD06}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{64E3D8BB-93AB-4571-93F7-ED8D64DFFD06}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{64E3D8BB-93AB-4571-93F7-ED8D64DFFD06}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -423,6 +429,7 @@ Global
 		{13C10C9A-07E8-43EB-91F5-C2B116FBE0FC} = {3862190B-E2C5-418E-AFDC-DB281FB5C705}
 		{972396A8-E35B-499C-9BA1-765E9B8822E1} = {77C7929A-2EED-4AA6-8705-B5C443C8AA0F}
 		{08D29501-F0A3-468F-B18D-BD1821A72383} = {5B7FB835-3FFF-4BC2-99C5-A5B5FAE3C818}
+		{64E3D8BB-93AB-4571-93F7-ED8D64DFFD06} = {5B7FB835-3FFF-4BC2-99C5-A5B5FAE3C818}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {55639B5C-0770-4A22-AB56-859604650521}

--- a/docs/trace/customizing-the-sdk/Program.cs
+++ b/docs/trace/customizing-the-sdk/Program.cs
@@ -1,0 +1,22 @@
+// <copyright file="Program.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+    }
+}

--- a/docs/trace/customizing-the-sdk/README.md
+++ b/docs/trace/customizing-the-sdk/README.md
@@ -1,0 +1,16 @@
+# Customizing OpenTelemetry .NET SDK
+
+Talks about customizing the SDK.
+
+## TracerProvider
+
+Contents from https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry#tracing-configuration
+
+
+## Context Propagation
+
+Contents from https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry#propagators
+Links to built-in instrumentations doing Context Propagation.
+
+
+

--- a/docs/trace/customizing-the-sdk/README.md
+++ b/docs/trace/customizing-the-sdk/README.md
@@ -4,13 +4,9 @@ Talks about customizing the SDK.
 
 ## TracerProvider
 
-Contents from https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry#tracing-configuration
-
+// TODO: OpenTelemetry Sdk contents about Tracer configuration.
 
 ## Context Propagation
 
-Contents from https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry#propagators
-Links to built-in instrumentations doing Context Propagation.
-
-
-
+// TODO: OpenTelemetry Sdk contents about Context.
+// TODO: Links to built-in instrumentations doing Propagation.

--- a/docs/trace/customizing-the-sdk/customizing-the-sdk.csproj
+++ b/docs/trace/customizing-the-sdk/customizing-the-sdk.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <!--
+    <PackageReference Include="OpenTelemetry" Version="$(OpenTelemetryPkgVer)" />
+    -->
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry\OpenTelemetry.csproj" />
+  </ItemGroup>
+</Project>

--- a/docs/trace/getting-started/README.md
+++ b/docs/trace/getting-started/README.md
@@ -77,5 +77,7 @@ to learn more.
 
 ## Learn more
 
+* If you want to customize the Sdk, refer to [customizing
+  the SDK](../customizing-the-sdk/README.md).
 * If you want to build a custom exporter/processor/sampler, refer to [extending
   the SDK](../extending-the-sdk/README.md).


### PR DESCRIPTION
To get an initial feedback if this/this direction is useful:
The goal is to add customizing the sdk section to docs. The individual readme.md files for each component (esp. SDK) can be modified to be a reference doc and the contents under /docs can be the step by step tutorial.