### PR TITLE
Show release version on badges (instead of prerelease)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/dotnet-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C01N3BC2W7Q)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet/branch/main/graphs/badge.svg?)](https://codecov.io/gh/open-telemetry/opentelemetry-dotnet/)
-[![Release](https://img.shields.io/github/v/release/open-telemetry/opentelemetry-dotnet?include_prereleases&style=)](https://github.com/open-telemetry/opentelemetry-dotnet/releases/)
-[![Nuget](https://img.shields.io/nuget/vpre/OpenTelemetry.svg)](https://www.nuget.org/profiles/OpenTelemetry)
+[![Release](https://img.shields.io/github/v/release/open-telemetry/opentelemetry-dotnet)](https://github.com/open-telemetry/opentelemetry-dotnet/releases/)
+[![Nuget](https://img.shields.io/nuget/v/OpenTelemetry.svg)](https://www.nuget.org/profiles/OpenTelemetry)
 [![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.svg)](https://www.nuget.org/profiles/OpenTelemetry)
 
 The .NET [OpenTelemetry](https://opentelemetry.io/) client.


### PR DESCRIPTION
Trying to see if this makes sense, try https://github.com/open-telemetry/opentelemetry-dotnet/tree/reyang/badge to see the new look.

The current homepage shows something like this, which might cause new comers to think the project is still under RC, also the download suggests the pre-release and I guess most users would use stable?

![image](https://user-images.githubusercontent.com/17327289/116962969-610ad280-ac5c-11eb-9967-3191781d9f22.png)

An alternative way is to provide both the stable nuget and pre-release nuget.