### PR TITLE
POC - ignore SetStatus is the status is already set to Ok

### DIFF
--- a/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
@@ -45,6 +45,14 @@ namespace OpenTelemetry.Trace
         {
             Debug.Assert(activity != null, "Activity should not be null");
 
+            if (activity.GetStatus().StatusCode == StatusCode.Ok)
+            {
+                // If the status is Ok, subsequent calls will be ignored.
+                // This will travel through the list which hurts the performance.
+                // The perf issue will be solved once .NET added native support for Activity.SetStatus.
+                return;
+            }
+
             activity.SetTag(SpanAttributeConstants.StatusCodeKey, StatusHelper.GetTagValueForStatusCode(status.StatusCode));
             activity.SetTag(SpanAttributeConstants.StatusDescriptionKey, status.Description);
         }


### PR DESCRIPTION
This is a POC for the [option2 of this spec discussion](https://github.com/open-telemetry/opentelemetry-specification/issues/1584#issuecomment-831929954).

Update: this PR now depends on the specification PR to be merged and released - https://github.com/open-telemetry/opentelemetry-specification/pull/1685.

## Changes

* If the status is set to Ok, freeze the status and not allow future updates (including both the status code and description).

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
