### PR TITLE
Add a temp project with Metric API (which will come eventually from runtime)

### DIFF
--- a/OpenTelemetry.sln
+++ b/OpenTelemetry.sln
@@ -207,6 +207,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "exception-reporting", "docs
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "customizing-the-sdk", "docs\trace\customizing-the-sdk\customizing-the-sdk.csproj", "{64E3D8BB-93AB-4571-93F7-ED8D64DFFD06}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Diagnostics.Metrics.Temp", "src\System.Diagnostics.Metrics.Temp\System.Diagnostics.Metrics.Temp.csproj", "{4481390E-52F5-46A6-8510-3B1433ABAFE6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -405,6 +407,10 @@ Global
 		{64E3D8BB-93AB-4571-93F7-ED8D64DFFD06}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{64E3D8BB-93AB-4571-93F7-ED8D64DFFD06}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{64E3D8BB-93AB-4571-93F7-ED8D64DFFD06}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4481390E-52F5-46A6-8510-3B1433ABAFE6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4481390E-52F5-46A6-8510-3B1433ABAFE6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4481390E-52F5-46A6-8510-3B1433ABAFE6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4481390E-52F5-46A6-8510-3B1433ABAFE6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/OpenTelemetry.Api/Metrics/MeterProviderBuilder.cs
+++ b/src/OpenTelemetry.Api/Metrics/MeterProviderBuilder.cs
@@ -1,0 +1,39 @@
+// <copyright file="MeterProviderBuilder.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+using System;
+
+namespace OpenTelemetry.Metrics
+{
+    /// <summary>
+    /// MeterProviderBuilder base class.
+    /// </summary>
+    public abstract class MeterProviderBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MeterProviderBuilder"/> class.
+        /// </summary>
+        protected MeterProviderBuilder()
+        {
+        }
+
+        /// <summary>
+        /// Adds given meter source names to the list of subscribed sources.
+        /// </summary>
+        /// <param name="names">Meter source names.</param>
+        /// <returns>Returns <see cref="MeterProviderBuilder"/> for chaining.</returns>
+        public abstract MeterProviderBuilder AddSource(params string[] names);
+    }
+}

--- a/src/OpenTelemetry/Metrics/MeterProviderBuilderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderBuilderSdk.cs
@@ -1,0 +1,30 @@
+// <copyright file="MeterProviderBuilderSdk.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Metrics
+{
+    public class MeterProviderBuilderSdk : MeterProviderBuilder
+    {
+        protected MeterProviderBuilderSdk()
+        {
+        }
+
+        public override MeterProviderBuilder AddSource(params string[] names)
+        {
+            return this;
+        }
+    }
+}

--- a/src/OpenTelemetry/OpenTelemetry.csproj
+++ b/src/OpenTelemetry/OpenTelemetry.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Api\OpenTelemetry.Api.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\System.Diagnostics.Metrics.Temp\System.Diagnostics.Metrics.Temp.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Diagnostics.Metrics.Temp/Counter.cs
+++ b/src/System.Diagnostics.Metrics.Temp/Counter.cs
@@ -1,0 +1,42 @@
+// <copyright file="ActivityExtensions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#nullable enable
+
+namespace System.Diagnostics.Metrics
+{
+    public class Counter<T> : MeterInstrument<T>
+        where T : unmanaged
+    {
+        internal Counter(Meter meter, string name, string? description, string? unit) :
+            base(meter, name, description, unit)
+        {
+            Publish();
+        }
+
+        public void Add(T measurement) => RecordMeasurement(measurement);
+        public void Add(T measurement,
+            (string LabelName, object LabelValue) label1) => RecordMeasurement(measurement, label1);
+        public void Add(T measurement,
+            (string LabelName, object LabelValue) label1,
+            (string LabelName, object LabelValue) label2) => RecordMeasurement(measurement, label1, label2);
+        public void Add(T measurement,
+            (string LabelName, object LabelValue) label1,
+            (string LabelName, object LabelValue) label2,
+            (string LabelName, object LabelValue) label3) => RecordMeasurement(measurement, label1, label2, label3);
+        public void Add(T measurement, params (string LabelName, object LabelValue)[] labels) => RecordMeasurement(measurement, labels);
+    }
+}

--- a/src/System.Diagnostics.Metrics.Temp/CounterFunc.cs
+++ b/src/System.Diagnostics.Metrics.Temp/CounterFunc.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 
 namespace System.Diagnostics.Metrics
 {
-
     public class CounterFunc<T> : ObservableMeterInstrument<T> where T: unmanaged
     {
         // This is either a Func<T> or an Func<IEnumerable<Measurement<T>>>

--- a/src/System.Diagnostics.Metrics.Temp/CounterFunc.cs
+++ b/src/System.Diagnostics.Metrics.Temp/CounterFunc.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace System.Diagnostics.Metrics
 {
-    public class CounterFunc<T> : ObservableMeterInstrument<T> where T: unmanaged
+    public class CounterFunc<T> : ObservableMeterInstrument<T> where T : unmanaged
     {
         // This is either a Func<T> or an Func<IEnumerable<Measurement<T>>>
         object _observeValueFunc;

--- a/src/System.Diagnostics.Metrics.Temp/CounterFunc.cs
+++ b/src/System.Diagnostics.Metrics.Temp/CounterFunc.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace System.Diagnostics.Metrics
+{
+
+    public class CounterFunc<T> : ObservableMeterInstrument<T> where T: unmanaged
+    {
+        // This is either a Func<T> or an Func<IEnumerable<Measurement<T>>>
+        object _observeValueFunc;
+
+        public CounterFunc(Meter meter, string name, Func<T> observeValue, string? description, string? unit) :
+            base(meter, name, description, unit)
+        {
+            _observeValueFunc = observeValue;
+            Publish();
+        }
+
+        public CounterFunc(Meter meter, string name, Func<IEnumerable<Measurement<T>>> observeValues, string? description, string? unit) :
+            base(meter, name, description, unit)
+        {
+            _observeValueFunc = observeValues;
+            Publish();
+        }
+
+        protected override IEnumerable<Measurement<T>> Observe()
+        {
+            if (_observeValueFunc is Func<T>)
+            {
+                T value = ((Func<T>)_observeValueFunc)();
+                return new Measurement<T>[] { new Measurement<T>(value) };
+            }
+            else
+            {
+                return ((Func<IEnumerable<Measurement<T>>>)_observeValueFunc)();
+            }
+        }
+    }
+}

--- a/src/System.Diagnostics.Metrics.Temp/Distribution.cs
+++ b/src/System.Diagnostics.Metrics.Temp/Distribution.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace System.Diagnostics.Metrics
 {
-    public class Distribution<T> : MeterInstrument<T> where T: unmanaged
+    public class Distribution<T> : MeterInstrument<T> where T : unmanaged
     {
         internal Distribution(Meter meter, string name, string? description, string? unit)
             : base(meter, name, description, unit)

--- a/src/System.Diagnostics.Metrics.Temp/Distribution.cs
+++ b/src/System.Diagnostics.Metrics.Temp/Distribution.cs
@@ -4,14 +4,12 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-#nullable enable
-
 namespace System.Diagnostics.Metrics
 {
     public class Distribution<T> : MeterInstrument<T> where T: unmanaged
     {
-        internal Distribution(Meter meter, string name, string? description, string? unit) :
-            base(meter, name, description, unit)
+        internal Distribution(Meter meter, string name, string? description, string? unit)
+            : base(meter, name, description, unit)
         {
             Publish();
         }

--- a/src/System.Diagnostics.Metrics.Temp/Distribution.cs
+++ b/src/System.Diagnostics.Metrics.Temp/Distribution.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace System.Diagnostics.Metrics
+{
+    public class Distribution<T> : MeterInstrument<T> where T: unmanaged
+    {
+        internal Distribution(Meter meter, string name, string? description, string? unit) :
+            base(meter, name, description, unit)
+        {
+            Publish();
+        }
+
+        public void Record(T measurement) => RecordMeasurement(measurement);
+        public void Record(T measurement,
+            (string LabelName, object LabelValue) label1) => RecordMeasurement(measurement, label1);
+        public void Record(T measurement,
+            (string LabelName, object LabelValue) label1,
+            (string LabelName, object LabelValue) label2) => RecordMeasurement(measurement, label1, label2);
+        public void Record(T measurement,
+            (string LabelName, object LabelValue) label1,
+            (string LabelName, object LabelValue) label2,
+            (string LabelName, object LabelValue) label3) => RecordMeasurement(measurement, label1, label2, label3);
+        public void Record(T measurement, params (string LabelName, object LabelValue)[] labels) => RecordMeasurement(measurement, labels);
+    }
+}

--- a/src/System.Diagnostics.Metrics.Temp/Gauge.cs
+++ b/src/System.Diagnostics.Metrics.Temp/Gauge.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace System.Diagnostics.Metrics
+{
+    public class Gauge<T> : MeterInstrument<T> where T: unmanaged
+    {
+        internal Gauge(Meter meter, string name, string? description, string? unit) :
+            base(meter, name, description, unit)
+        {
+            Publish();
+        }
+
+        public void Set(T val)
+        {
+            RecordMeasurement(val);
+        }
+
+        public void Set(T val, params (string LabelName, object LabelValue)[] labels)
+        {
+            RecordMeasurement(val, labels);
+        }
+    }
+}

--- a/src/System.Diagnostics.Metrics.Temp/Gauge.cs
+++ b/src/System.Diagnostics.Metrics.Temp/Gauge.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace System.Diagnostics.Metrics
 {
-    public class Gauge<T> : MeterInstrument<T> where T: unmanaged
+    public class Gauge<T> : MeterInstrument<T> where T : unmanaged
     {
         internal Gauge(Meter meter, string name, string? description, string? unit) :
             base(meter, name, description, unit)

--- a/src/System.Diagnostics.Metrics.Temp/Meter.cs
+++ b/src/System.Diagnostics.Metrics.Temp/Meter.cs
@@ -24,27 +24,27 @@ namespace System.Diagnostics.Metrics
             }
         }
 
-        public Counter<T> CreateCounter<T>(string name, string? description = null, string? unit = null) where T:unmanaged
+        public Counter<T> CreateCounter<T>(string name, string? description = null, string? unit = null) where T :unmanaged
         {
             return new Counter<T>(this, name, description, unit);
         }
 
-        public CounterFunc<T> CreateCounterFunc<T>(string name, Func<T> observeValue, string? description = null, string? unit = null) where T: unmanaged
+        public CounterFunc<T> CreateCounterFunc<T>(string name, Func<T> observeValue, string? description = null, string? unit = null) where T : unmanaged
         {
             return new CounterFunc<T>(this, name, observeValue, description, unit);
         }
 
-        public CounterFunc<T> CreateCounterFunc<T>(string name, Func<IEnumerable<Measurement<T>>> observeValues, string? description = null, string? unit = null) where T: unmanaged
+        public CounterFunc<T> CreateCounterFunc<T>(string name, Func<IEnumerable<Measurement<T>>> observeValues, string? description = null, string? unit = null) where T : unmanaged
         {
             return new CounterFunc<T>(this, name, observeValues, description, unit);
         }
 
-        public Gauge<T> CreateGauge<T>(string name, string? description = null, string? unit = null) where T: unmanaged
+        public Gauge<T> CreateGauge<T>(string name, string? description = null, string? unit = null) where T : unmanaged
         {
             return new Gauge<T>(this, name, description, unit);
         }
 
-        public Distribution<T> CreateDistribution<T>(string name, string? description = null, string? unit = null) where T: unmanaged
+        public Distribution<T> CreateDistribution<T>(string name, string? description = null, string? unit = null) where T : unmanaged
         {
             return new Distribution<T>(this, name, description, unit);
         }

--- a/src/System.Diagnostics.Metrics.Temp/Meter.cs
+++ b/src/System.Diagnostics.Metrics.Temp/Meter.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace System.Diagnostics.Metrics
+{
+    public class Meter : IDisposable
+    {
+        List<MeterInstrument>? _instruments = new List<MeterInstrument>();
+
+        public Meter(string name) : this(name, "") { }
+
+        public Meter(string name, string version)
+        {
+            Name = name;
+            Version = version;
+            lock (MeterInstrumentCollection.Lock)
+            {
+                MeterInstrumentCollection.Instance.AddMeter(this);
+            }
+        }
+
+        public Counter<T> CreateCounter<T>(string name, string? description = null, string? unit = null) where T:unmanaged
+        {
+            return new Counter<T>(this, name, description, unit);
+        }
+
+        public CounterFunc<T> CreateCounterFunc<T>(string name, Func<T> observeValue, string? description = null, string? unit = null) where T: unmanaged
+        {
+            return new CounterFunc<T>(this, name, observeValue, description, unit);
+        }
+
+        public CounterFunc<T> CreateCounterFunc<T>(string name, Func<IEnumerable<Measurement<T>>> observeValues, string? description = null, string? unit = null) where T: unmanaged
+        {
+            return new CounterFunc<T>(this, name, observeValues, description, unit);
+        }
+
+        public Gauge<T> CreateGauge<T>(string name, string? description = null, string? unit = null) where T: unmanaged
+        {
+            return new Gauge<T>(this, name, description, unit);
+        }
+
+        public Distribution<T> CreateDistribution<T>(string name, string? description = null, string? unit = null) where T: unmanaged
+        {
+            return new Distribution<T>(this, name, description, unit);
+        }
+
+        public string Name { get; }
+        public string Version { get; }
+
+
+        internal void PublishInstrument(MeterInstrument instrument)
+        {
+            lock (MeterInstrumentCollection.Lock)
+            {
+                if (_instruments != null) // if not disposed
+                {
+                    _instruments.Add(instrument);
+                    MeterInstrumentCollection.Instance.PublishInstrument(instrument);
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (MeterInstrumentCollection.Lock)
+            {
+                MeterInstrumentCollection.Instance.RemoveMeter(this);
+                _instruments = null;
+            }
+        }
+
+        internal IEnumerable<MeterInstrument> Instruments =>
+            #if NET452
+                (IEnumerable<MeterInstrument>?)_instruments ?? new MeterInstrument[0];
+            #else
+                (IEnumerable<MeterInstrument>?)_instruments ?? Array.Empty<MeterInstrument>();
+            #endif
+    }
+}

--- a/src/System.Diagnostics.Metrics.Temp/Meter.cs
+++ b/src/System.Diagnostics.Metrics.Temp/Meter.cs
@@ -24,7 +24,7 @@ namespace System.Diagnostics.Metrics
             }
         }
 
-        public Counter<T> CreateCounter<T>(string name, string? description = null, string? unit = null) where T :unmanaged
+        public Counter<T> CreateCounter<T>(string name, string? description = null, string? unit = null) where T : unmanaged
         {
             return new Counter<T>(this, name, description, unit);
         }
@@ -75,10 +75,10 @@ namespace System.Diagnostics.Metrics
         }
 
         internal IEnumerable<MeterInstrument> Instruments =>
-            #if NET452
+#if NET452
                 (IEnumerable<MeterInstrument>?)_instruments ?? new MeterInstrument[0];
-            #else
+#else
                 (IEnumerable<MeterInstrument>?)_instruments ?? Array.Empty<MeterInstrument>();
-            #endif
+#endif
     }
 }

--- a/src/System.Diagnostics.Metrics.Temp/MeterInstrument.cs
+++ b/src/System.Diagnostics.Metrics.Temp/MeterInstrument.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace System.Diagnostics.Metrics
+{
+    public abstract class MeterInstrument
+    {
+        protected MeterInstrument(Meter meter, string name, string? description, string? unit)
+        {
+            Meter = meter;
+            Name = name;
+            Description = description;
+            Unit = unit;
+        }
+
+        internal struct ListenerSubscription
+        {
+            public MeterInstrumentListener Listener;
+            public object? Cookie;
+        }
+
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct ThreeLabels
+        {
+            public (string LabelName, object LabelValue) Label1;
+            public (string LabelName, object LabelValue) Label2;
+            public (string LabelName, object LabelValue) Label3;
+        }
+
+#if NET452
+        internal ListenerSubscription[] _subscriptions = new ListenerSubscription[0];
+#else
+        internal ListenerSubscription[] _subscriptions = Array.Empty<ListenerSubscription>();
+#endif
+
+        public Meter Meter { get; }
+        public string Name { get; }
+        public string? Description { get; }
+        public string? Unit { get; }
+        public bool Enabled => _subscriptions.Length > 0 || IsObservable;
+
+        /// <summary>
+        /// Adds the instrument to the list maintained on Meter which in turn
+        /// makes it visible to listeners.
+        /// </summary>
+        protected void Publish()
+        {
+            Meter.PublishInstrument(this);
+        }
+
+        public virtual bool IsObservable => false;
+
+        internal virtual void Observe(MeterInstrumentListener listener, object? cookie)
+        {
+            // Observe should only be called on Observable metrics
+            // The call needs to be here because ObservableMeterInstrument<T> would require
+            // the caller to know the generic T and they don't know it.
+            // Alternative impls:
+            // 1. Create a non-generic ObservableMeterInstrument
+            // that is a base class of ObservableMeterInstrument<T> and put this method there
+            // 2. Make a hard-coded list of every supported T and then directly invoke
+            // ObservableMeterInstrument<T>.Observe(listener, cookie)
+            Debug.Assert(false);
+            throw new InvalidOperationException();
+        }
+
+        /// <summary>
+        /// Adds a new subscription or updates the old subscription to use the new cookie.
+        /// Returns true when adding a new subscription, returns false if a subscription already exists
+        /// regardless of previous cookie
+        /// </summary>
+        internal bool AddOrUpdateSubscription(MeterInstrumentListener listener, object? listenerCookie, out object? previousCookie)
+        {
+            // only push metrics should have subscriptions
+            Debug.Assert(!IsObservable);
+            // this should only be called under the metric collection lock
+            Debug.Assert(Monitor.IsEntered(MeterInstrumentCollection.Lock));
+
+            ListenerSubscription[] subs;
+            for (int i = 0; i < _subscriptions.Length; i++)
+            {
+                if(_subscriptions[i].Listener == listener)
+                {
+                    previousCookie = _subscriptions[i].Cookie;
+                    if(_subscriptions[i].Cookie != listenerCookie)
+                    {
+                        // because the array is read lock-free we always allocate a new
+                        // one when making any change. If we wanted to get really detailed
+                        // about what consistency guarantees we were making maybe we could
+                        // avoid the alloc but subscription isn't a perf critical path so
+                        // lets keep it simple.
+                        subs = new ListenerSubscription[_subscriptions.Length];
+                        Array.Copy(_subscriptions, subs, _subscriptions.Length);
+                        subs[i].Cookie = listenerCookie;
+                        _subscriptions = subs;
+                    }
+                    return false;
+                }
+            }
+
+            subs = new ListenerSubscription[_subscriptions.Length + 1];
+            Array.Copy(_subscriptions, subs, _subscriptions.Length);
+            subs[_subscriptions.Length].Listener = listener;
+            subs[_subscriptions.Length].Cookie = listenerCookie;
+            _subscriptions = subs;
+            previousCookie = null;
+            return true;
+        }
+
+        /// <summary>
+        /// Returns true if the listener was previously subscribed
+        /// </summary>
+        /// <param name="listener"></param>
+        /// <param name="cookie"></param>
+        /// <returns></returns>
+        internal bool RemoveSubscription(MeterInstrumentListener listener, out object? cookie)
+        {
+            // only push metrics should have subscriptions
+            Debug.Assert(!IsObservable);
+
+            // this should only be called under metric collection lock
+            Debug.Assert(Monitor.IsEntered(MeterInstrumentCollection.Lock));
+
+            for (int i = 0; i < _subscriptions.Length; i++)
+            {
+                if (_subscriptions[i].Listener == listener)
+                {
+                    cookie = _subscriptions[i].Cookie;
+                    ListenerSubscription[] subs = new ListenerSubscription[_subscriptions.Length - 1];
+                    Array.Copy(_subscriptions, subs, i);
+                    Array.Copy(_subscriptions, i + 1, subs, i, _subscriptions.Length - i - 1);
+                    _subscriptions = subs;
+                    return true;
+                }
+            }
+            cookie = null;
+            return false;
+        }
+    }
+
+    public abstract class MeterInstrument<T> : MeterInstrument where T : unmanaged
+    {
+        protected MeterInstrument(Meter meter, string name, string? description, string? unit) : base(meter, name, description, unit) { }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void RecordMeasurement(T val) =>
+#if NET452
+                RecordMeasurement(val, new (string LabelName, object LabelValue)[0]);
+#else
+                RecordMeasurement(val, Array.Empty<(string LabelName, object LabelValue)>());
+            #endif
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void RecordMeasurement(T val, (string LabelName, object LabelValue) label1)
+        {
+            #if NET5_0
+                ReadOnlySpan<(string LabelName, object LabelValue)> labels = MemoryMarshal.CreateReadOnlySpan(ref label1, 1);
+#else
+                var oneLabels = new (string LabelName, object labelValue)[1];
+                oneLabels[0] = label1;
+                var labels = new ReadOnlySpan<(string LabelName, object LabelValue)>(oneLabels);
+#endif
+            RecordMeasurement(val, labels);
+        }
+
+        #if NET5_0
+        [SkipLocalsInit]
+        #endif
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void RecordMeasurement(T val,
+            (string LabelName, object LabelValue) label1,
+            (string LabelName, object LabelValue) label2)
+        {
+#if NET5_0
+            ThreeLabels threeLabels = new ThreeLabels();
+            threeLabels.Label1 = label1;
+            threeLabels.Label2 = label2;
+            ReadOnlySpan<(string LabelName, object LabelValue)> labels = MemoryMarshal.CreateReadOnlySpan(ref threeLabels.Label1, 2);
+#else
+            var twoLabels = new (string LabelName, object labelValue)[2];
+            twoLabels[0] = label1;
+            twoLabels[1] = label2;
+            var labels = new ReadOnlySpan<(string LabelName, object LabelValue)>(twoLabels);
+#endif
+            RecordMeasurement(val, labels);
+        }
+
+        #if NET5_0
+        [SkipLocalsInit]
+        #endif
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void RecordMeasurement(T val,
+            (string LabelName, object LabelValue) label1,
+            (string LabelName, object LabelValue) label2,
+            (string LabelName, object LabelValue) label3)
+        {
+            #if NET5_0
+                ThreeLabels threeLabels = new ThreeLabels();
+                threeLabels.Label1 = label1;
+                threeLabels.Label2 = label2;
+                threeLabels.Label3 = label3;
+                ReadOnlySpan<(string LabelName, object LabelValue)> labels = MemoryMarshal.CreateReadOnlySpan(ref threeLabels.Label1, 3);
+#else
+                var threeLabels = new (string LabelName, object labelValue)[3];
+                threeLabels[0] = label1;
+                threeLabels[1] = label2;
+                threeLabels[2] = label3;
+                var labels = new ReadOnlySpan<(string LabelName, object LabelValue)>(threeLabels);
+#endif
+            RecordMeasurement(val, labels);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void RecordMeasurement(T val, ReadOnlySpan<(string LabelName, object LabelValue)> labels)
+        {
+            // this captures a snapshot, _subscriptions array could be replaced while
+            // we are invoking callbacks
+            ListenerSubscription[] subscriptions = _subscriptions;
+            for (int i = 0; i < subscriptions.Length; i++)
+            {
+                subscriptions[i].Listener.OnMeasurement(this, val, labels, subscriptions[i].Cookie);
+            }
+        }
+
+    }
+}

--- a/src/System.Diagnostics.Metrics.Temp/MeterInstrument.cs
+++ b/src/System.Diagnostics.Metrics.Temp/MeterInstrument.cs
@@ -159,22 +159,23 @@ namespace System.Diagnostics.Metrics
 #else
                 RecordMeasurement(val, Array.Empty<(string LabelName, object LabelValue)>());
 #endif
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void RecordMeasurement(T val, (string LabelName, object LabelValue) label1)
         {
 #if NET5_0
-                ReadOnlySpan<(string LabelName, object LabelValue)> labels = MemoryMarshal.CreateReadOnlySpan(ref label1, 1);
+            ReadOnlySpan<(string LabelName, object LabelValue)> labels = MemoryMarshal.CreateReadOnlySpan(ref label1, 1);
 #else
-                var oneLabels = new (string LabelName, object labelValue)[1];
-                oneLabels[0] = label1;
-                var labels = new ReadOnlySpan<(string LabelName, object LabelValue)>(oneLabels);
+            var oneLabels = new (string LabelName, object labelValue)[1];
+            oneLabels[0] = label1;
+            var labels = new ReadOnlySpan<(string LabelName, object LabelValue)>(oneLabels);
 #endif
             RecordMeasurement(val, labels);
         }
 
 #if NET5_0
         [SkipLocalsInit]
-        #endif
+#endif
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void RecordMeasurement(T val,
             (string LabelName, object LabelValue) label1,
@@ -204,17 +205,17 @@ namespace System.Diagnostics.Metrics
             (string LabelName, object LabelValue) label3)
         {
 #if NET5_0
-                ThreeLabels threeLabels = new ThreeLabels();
-                threeLabels.Label1 = label1;
-                threeLabels.Label2 = label2;
-                threeLabels.Label3 = label3;
-                ReadOnlySpan<(string LabelName, object LabelValue)> labels = MemoryMarshal.CreateReadOnlySpan(ref threeLabels.Label1, 3);
+            ThreeLabels threeLabels = new ThreeLabels();
+            threeLabels.Label1 = label1;
+            threeLabels.Label2 = label2;
+            threeLabels.Label3 = label3;
+            ReadOnlySpan<(string LabelName, object LabelValue)> labels = MemoryMarshal.CreateReadOnlySpan(ref threeLabels.Label1, 3);
 #else
-                var threeLabels = new (string LabelName, object labelValue)[3];
-                threeLabels[0] = label1;
-                threeLabels[1] = label2;
-                threeLabels[2] = label3;
-                var labels = new ReadOnlySpan<(string LabelName, object LabelValue)>(threeLabels);
+            var threeLabels = new (string LabelName, object labelValue)[3];
+            threeLabels[0] = label1;
+            threeLabels[1] = label2;
+            threeLabels[2] = label3;
+            var labels = new ReadOnlySpan<(string LabelName, object LabelValue)>(threeLabels);
 #endif
             RecordMeasurement(val, labels);
         }

--- a/src/System.Diagnostics.Metrics.Temp/MeterInstrument.cs
+++ b/src/System.Diagnostics.Metrics.Temp/MeterInstrument.cs
@@ -89,10 +89,10 @@ namespace System.Diagnostics.Metrics
             ListenerSubscription[] subs;
             for (int i = 0; i < _subscriptions.Length; i++)
             {
-                if(_subscriptions[i].Listener == listener)
+                if (_subscriptions[i].Listener == listener)
                 {
                     previousCookie = _subscriptions[i].Cookie;
-                    if(_subscriptions[i].Cookie != listenerCookie)
+                    if (_subscriptions[i].Cookie != listenerCookie)
                     {
                         // because the array is read lock-free we always allocate a new
                         // one when making any change. If we wanted to get really detailed
@@ -163,7 +163,7 @@ namespace System.Diagnostics.Metrics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void RecordMeasurement(T val, (string LabelName, object LabelValue) label1)
         {
-            #if NET5_0
+#if NET5_0
                 ReadOnlySpan<(string LabelName, object LabelValue)> labels = MemoryMarshal.CreateReadOnlySpan(ref label1, 1);
 #else
                 var oneLabels = new (string LabelName, object labelValue)[1];
@@ -173,7 +173,7 @@ namespace System.Diagnostics.Metrics
             RecordMeasurement(val, labels);
         }
 
-        #if NET5_0
+#if NET5_0
         [SkipLocalsInit]
         #endif
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -195,16 +195,16 @@ namespace System.Diagnostics.Metrics
             RecordMeasurement(val, labels);
         }
 
-        #if NET5_0
+#if NET5_0
         [SkipLocalsInit]
-        #endif
+#endif
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void RecordMeasurement(T val,
             (string LabelName, object LabelValue) label1,
             (string LabelName, object LabelValue) label2,
             (string LabelName, object LabelValue) label3)
         {
-            #if NET5_0
+#if NET5_0
                 ThreeLabels threeLabels = new ThreeLabels();
                 threeLabels.Label1 = label1;
                 threeLabels.Label2 = label2;

--- a/src/System.Diagnostics.Metrics.Temp/MeterInstrument.cs
+++ b/src/System.Diagnostics.Metrics.Temp/MeterInstrument.cs
@@ -158,8 +158,7 @@ namespace System.Diagnostics.Metrics
                 RecordMeasurement(val, new (string LabelName, object LabelValue)[0]);
 #else
                 RecordMeasurement(val, Array.Empty<(string LabelName, object LabelValue)>());
-            #endif
-
+#endif
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void RecordMeasurement(T val, (string LabelName, object LabelValue) label1)
         {

--- a/src/System.Diagnostics.Metrics.Temp/MeterInstrumentCollection.cs
+++ b/src/System.Diagnostics.Metrics.Temp/MeterInstrumentCollection.cs
@@ -96,7 +96,7 @@ namespace System.Diagnostics.Metrics
 
         public void VisitInstruments(Action<MeterInstrument> visitor)
         {
-            lock(Lock)
+            lock (Lock)
             {
                 foreach (Meter meter in _meters)
                 {

--- a/src/System.Diagnostics.Metrics.Temp/MeterInstrumentCollection.cs
+++ b/src/System.Diagnostics.Metrics.Temp/MeterInstrumentCollection.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.NetworkInformation;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Diagnostics.Metrics
+{
+    internal class MeterInstrumentCollection
+    {
+        public static MeterInstrumentCollection Instance = new MeterInstrumentCollection();
+
+        // Even if we had multiple exposed instances of this collection in the future
+        // this lock also synchronizes access to per-metric subscription lists so it
+        // needs to remain global (or metric subscription lists need to be changed)
+        static internal object Lock = new object();
+
+        List<Meter> _meters = new List<Meter>();
+        List<MeterInstrumentListener> _instrumentPublishedListeners = new List<MeterInstrumentListener>();
+        List<MeterInstrumentListener> _instrumentDisposedListeners = new List<MeterInstrumentListener>();
+
+        public void AddMeter(Meter meter)
+        {
+            lock (Lock)
+            {
+                _meters.Add(meter);
+                foreach (MeterInstrumentListener listener in _instrumentPublishedListeners)
+                {
+                    foreach (MeterInstrument instrument in meter.Instruments)
+                    {
+                        NotifyListenerInstrumentPublished(listener, instrument);
+                    }
+                }
+            }
+        }
+
+        public void RemoveMeter(Meter meter)
+        {
+            lock (Lock)
+            {
+                _meters.Remove(meter);
+                foreach (MeterInstrumentListener listener in _instrumentDisposedListeners.ToArray())
+                {
+                    foreach (MeterInstrument instrument in meter.Instruments)
+                    {
+                        NotifyInstrumentDisposed(listener, instrument);
+                    }
+                }
+            }
+        }
+
+        public void PublishInstrument(MeterInstrument instrument)
+        {
+            Debug.Assert(Monitor.IsEntered(Lock));
+            foreach (MeterInstrumentListener listener in _instrumentPublishedListeners)
+            {
+                NotifyListenerInstrumentPublished(listener, instrument);
+            }
+        }
+
+        public void AddInstrumentPublishedListener(MeterInstrumentListener listener)
+        {
+            lock (Lock)
+            {
+                _instrumentPublishedListeners.Add(listener);
+                VisitInstruments(i => NotifyListenerInstrumentPublished(listener, i));
+            }
+        }
+
+        public void RemoveInstrumentedPublishedListener(MeterInstrumentListener listener)
+        {
+            lock (Lock)
+            {
+                _instrumentPublishedListeners.Remove(listener);
+            }
+        }
+
+        public void AddInstrumentDisposedListener(MeterInstrumentListener listener)
+        {
+            lock (Lock)
+            {
+                _instrumentDisposedListeners.Add(listener);
+            }
+        }
+
+        public void RemoveInstrumentDisposedListener(MeterInstrumentListener listener)
+        {
+            lock (Lock)
+            {
+                _instrumentDisposedListeners.Remove(listener);
+            }
+        }
+
+        public void VisitInstruments(Action<MeterInstrument> visitor)
+        {
+            lock(Lock)
+            {
+                foreach (Meter meter in _meters)
+                {
+                    foreach (MeterInstrument instrument in meter.Instruments)
+                    {
+                        visitor(instrument);
+                    }
+                }
+            }
+        }
+
+        void NotifyListenerInstrumentPublished(MeterInstrumentListener listener, MeterInstrument instrument)
+        {
+            listener.OnMeterInstrumentPublished(instrument);
+        }
+
+        void NotifyInstrumentDisposed(MeterInstrumentListener listener, MeterInstrument instrument)
+        {
+            listener.OnMeterInstrumentDisposed(instrument);
+        }
+    }
+}

--- a/src/System.Diagnostics.Metrics.Temp/MeterInstrumentListener.cs
+++ b/src/System.Diagnostics.Metrics.Temp/MeterInstrumentListener.cs
@@ -1,0 +1,302 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#nullable enable
+
+namespace System.Diagnostics.Metrics
+{
+    public delegate void MeasurementCallback<T>(MeterInstrument instrument, T measurement, ReadOnlySpan<(string LabelName, object LabelValue)> labels, object? cookie);
+
+    public class MeterInstrumentListener : IDisposable
+    {
+        Dictionary<MeterInstrument, object?> _subscribedObservableMeters = new Dictionary<MeterInstrument, object?>();
+        int _countSubscribedInstruments;
+        MeasurementCallback<object?> _recordObjectFunc;
+        MeasurementCallback<double> _recordDoubleFunc;
+        MeasurementCallback<float> _recordFloatFunc;
+        MeasurementCallback<long> _recordLongFunc;
+        MeasurementCallback<int> _recordIntFunc;
+        MeasurementCallback<short> _recordShortFunc;
+        MeasurementCallback<byte> _recordByteFunc;
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor.
+                               // SetMeasurementEventCallback will set these values
+        public MeterInstrumentListener()
+#pragma warning restore CS8618
+        {
+            SetMeasurementEventCallback<object>(null);
+            SetMeasurementEventCallback<double>(null);
+            SetMeasurementEventCallback<float>(null);
+            SetMeasurementEventCallback<long>(null);
+            SetMeasurementEventCallback<int>(null);
+            SetMeasurementEventCallback<short>(null);
+            SetMeasurementEventCallback<byte>(null);
+        }
+
+        public void EnablePublishingEvents()
+        {
+            MeterInstrumentCollection.Instance.AddInstrumentPublishedListener(this);
+        }
+
+        public void DisablePublishingEvents()
+        {
+            MeterInstrumentCollection.Instance.RemoveInstrumentedPublishedListener(this);
+        }
+
+
+        public void EnableMeasurementEvents(MeterInstrument instrument, object? cookie = null)
+        {
+            bool isNewlySubscribed = false;
+            object? previousCookie;
+            lock (MeterInstrumentCollection.Lock)
+            {
+                if (!instrument.IsObservable)
+                {
+                    isNewlySubscribed = SubscribeInstrument(instrument, cookie, out previousCookie);
+                }
+                else
+                {
+                    isNewlySubscribed = SubscribeObservableInstrument(instrument, cookie, out previousCookie);
+                }
+                if (isNewlySubscribed)
+                {
+                    _countSubscribedInstruments++;
+                    if (_countSubscribedInstruments == 1)
+                    {
+                        MeterInstrumentCollection.Instance.AddInstrumentDisposedListener(this);
+                    }
+                }
+            }
+            if(!isNewlySubscribed)
+            {
+                InstrumentMeasurementsComplete?.Invoke(instrument, previousCookie);
+            }
+        }
+
+        public void DisableMeasurementEvents(MeterInstrument instrument)
+        {
+            object? cookie;
+            bool wasSubscribed;
+            lock (MeterInstrumentCollection.Lock)
+            {
+                if (!instrument.IsObservable)
+                {
+                    wasSubscribed = UnsubscribeInstrument(instrument, out cookie);
+                }
+                else
+                {
+                    wasSubscribed = UnsubscribeObservableInstrument(instrument, out cookie);
+                }
+                if (wasSubscribed)
+                {
+                    _countSubscribedInstruments--;
+                    if (_countSubscribedInstruments == 0)
+                    {
+                        MeterInstrumentCollection.Instance.RemoveInstrumentDisposedListener(this);
+                    }
+                }
+            }
+
+            if(wasSubscribed)
+            {
+                InstrumentMeasurementsComplete?.Invoke(instrument, cookie);
+            }
+        }
+
+
+
+        public Action<MeterInstrument, MeterInstrumentListener>? MeterInstrumentPublished { get; set; }
+        public Action<MeterInstrument, object?>? InstrumentMeasurementsComplete { get; set; }
+
+        public void SetMeasurementEventCallback<T>(MeasurementCallback<T>? measurementFunc)
+        {
+            // measurementFunc might be null so we can't type test with 'is'
+            if(typeof(T) == typeof(object))
+            {
+                if (measurementFunc is MeasurementCallback<object?> objFunc)
+                {
+                    _recordObjectFunc = objFunc;
+                }
+                else
+                {
+                    _recordObjectFunc = (i, m, l, c) => { };
+                }
+            }
+            else if(typeof(T) == typeof(double))
+            {
+                if (measurementFunc is MeasurementCallback<double> doubleFunc)
+                {
+                    _recordDoubleFunc = doubleFunc;
+                }
+                else
+                {
+                    _recordDoubleFunc = (instrument, measurement, labels, cookie) =>
+                        _recordObjectFunc(instrument, measurement, labels, cookie);
+                }
+            }
+            else if (typeof(T) == typeof(float))
+            {
+                if (measurementFunc is MeasurementCallback<float> floatFunc)
+                {
+                    _recordFloatFunc = floatFunc;
+                }
+                else
+                {
+                    _recordFloatFunc = (instrument, measurement, labels, cookie) =>
+                        _recordObjectFunc(instrument, measurement, labels, cookie);
+                }
+            }
+            else if (typeof(T) == typeof(long))
+            {
+                if (measurementFunc is MeasurementCallback<long> longFunc)
+                {
+                    _recordLongFunc = longFunc;
+                }
+                else
+                {
+                    _recordLongFunc = (instrument, measurement, labels, cookie) =>
+                        _recordObjectFunc(instrument, measurement, labels, cookie);
+                }
+            }
+            else if (typeof(T) == typeof(int))
+            {
+                if (measurementFunc is MeasurementCallback<int> intFunc)
+                {
+                    _recordIntFunc = intFunc;
+                }
+                else
+                {
+                    _recordIntFunc = (instrument, measurement, labels, cookie) =>
+                        _recordObjectFunc(instrument, measurement, labels, cookie);
+                }
+            }
+            else if (typeof(T) == typeof(short))
+            {
+                if (measurementFunc is MeasurementCallback<short> shortFunc)
+                {
+                    _recordShortFunc = shortFunc;
+                }
+                else
+                {
+                    _recordShortFunc = (instrument, measurement, labels, cookie) =>
+                        _recordObjectFunc(instrument, measurement, labels, cookie);
+                }
+            }
+            else if (typeof(T) == typeof(byte))
+            {
+                if (measurementFunc is MeasurementCallback<byte> byteFunc)
+                {
+                    _recordByteFunc = byteFunc;
+                }
+                else
+                {
+                    _recordByteFunc = (instrument, measurement, labels, cookie) =>
+                        _recordObjectFunc(instrument, measurement, labels, cookie);
+                }
+            }
+        }
+
+        public void RecordObservableInstruments()
+        {
+            // This ensures that meters can't be published/unpublished while we are trying to traverse the
+            // list. The Observe callback could still be concurrent with Dispose().
+            Dictionary<MeterInstrument, object?> subscriptionCopy;
+            lock (_subscribedObservableMeters)
+            {
+                subscriptionCopy = new Dictionary<MeterInstrument, object?>(_subscribedObservableMeters);
+            }
+            foreach (KeyValuePair<MeterInstrument, object?> kv in subscriptionCopy)
+            {
+                MeterInstrument instrument = kv.Key;
+                object? cookie = kv.Value;
+                instrument.Observe(this, cookie);
+            }
+        }
+
+        public void Dispose()
+        {
+            MeterInstrumentCollection.Instance.RemoveInstrumentedPublishedListener(this);
+            MeterInstrumentCollection.Instance.VisitInstruments(i => OnMeterInstrumentDisposed(i));
+        }
+
+        private bool SubscribeObservableInstrument(MeterInstrument instrument, object? listenerCookie, out object? previousCookie)
+        {
+            lock (_subscribedObservableMeters)
+            {
+                bool ret = !_subscribedObservableMeters.TryGetValue(instrument, out previousCookie);
+                _subscribedObservableMeters[instrument] = listenerCookie;
+                return ret;
+            }
+        }
+
+        private bool UnsubscribeObservableInstrument(MeterInstrument instrument, out object? cookie)
+        {
+            lock (_subscribedObservableMeters)
+            {
+                if (_subscribedObservableMeters.TryGetValue(instrument, out cookie))
+                {
+                    return _subscribedObservableMeters.Remove(instrument);
+                }
+                return false;
+            }
+        }
+
+        private bool SubscribeInstrument(MeterInstrument instrument, object? cookie, out object? previousCookie)
+        {
+            return instrument.AddOrUpdateSubscription(this, cookie, out previousCookie);
+        }
+
+        private bool UnsubscribeInstrument(MeterInstrument instrument, out object? cookie)
+        {
+            return instrument.RemoveSubscription(this, out cookie);
+        }
+
+        internal void OnMeterInstrumentPublished(MeterInstrument instrument)
+        {
+            MeterInstrumentPublished?.Invoke(instrument, this);
+        }
+
+        internal void OnMeterInstrumentDisposed(MeterInstrument instrument)
+        {
+            DisableMeasurementEvents(instrument);
+        }
+
+        internal void OnMeasurement<T>(MeterInstrument instrument, T val, ReadOnlySpan<ValueTuple<string, object>> labels, object? cookie)
+            where T : unmanaged
+        {
+            // All these type check conditionals can be resolved statically by the JIT once it knows the T type.
+            // The body of the loop reduces to just one branch and all the rest are eliminated
+            if (val is double dVal)
+            {
+                _recordDoubleFunc(instrument, dVal, labels, cookie);
+            }
+            else if (val is float fVal)
+            {
+                _recordFloatFunc(instrument, fVal, labels, cookie);
+            }
+            else if (val is long lVal)
+            {
+                _recordLongFunc(instrument, lVal, labels, cookie);
+            }
+            else if (val is int iVal)
+            {
+                _recordIntFunc(instrument, iVal, labels, cookie);
+            }
+            else if (val is short sVal)
+            {
+                _recordShortFunc(instrument, sVal, labels, cookie);
+            }
+            else if (val is byte bVal)
+            {
+                _recordByteFunc(instrument, bVal, labels, cookie);
+            }
+            else
+            {
+                _recordObjectFunc(instrument, val, labels, cookie);
+            }
+        }
+    }
+}

--- a/src/System.Diagnostics.Metrics.Temp/MeterInstrumentListener.cs
+++ b/src/System.Diagnostics.Metrics.Temp/MeterInstrumentListener.cs
@@ -70,7 +70,7 @@ namespace System.Diagnostics.Metrics
                     }
                 }
             }
-            if(!isNewlySubscribed)
+            if (!isNewlySubscribed)
             {
                 InstrumentMeasurementsComplete?.Invoke(instrument, previousCookie);
             }
@@ -100,7 +100,7 @@ namespace System.Diagnostics.Metrics
                 }
             }
 
-            if(wasSubscribed)
+            if (wasSubscribed)
             {
                 InstrumentMeasurementsComplete?.Invoke(instrument, cookie);
             }
@@ -114,7 +114,7 @@ namespace System.Diagnostics.Metrics
         public void SetMeasurementEventCallback<T>(MeasurementCallback<T>? measurementFunc)
         {
             // measurementFunc might be null so we can't type test with 'is'
-            if(typeof(T) == typeof(object))
+            if (typeof(T) == typeof(object))
             {
                 if (measurementFunc is MeasurementCallback<object?> objFunc)
                 {
@@ -125,7 +125,7 @@ namespace System.Diagnostics.Metrics
                     _recordObjectFunc = (i, m, l, c) => { };
                 }
             }
-            else if(typeof(T) == typeof(double))
+            else if (typeof(T) == typeof(double))
             {
                 if (measurementFunc is MeasurementCallback<double> doubleFunc)
                 {

--- a/src/System.Diagnostics.Metrics.Temp/MeterInstrumentListener.cs
+++ b/src/System.Diagnostics.Metrics.Temp/MeterInstrumentListener.cs
@@ -22,8 +22,7 @@ namespace System.Diagnostics.Metrics
         MeasurementCallback<short> _recordShortFunc;
         MeasurementCallback<byte> _recordByteFunc;
 
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor.
-                               // SetMeasurementEventCallback will set these values
+#pragma warning disable CS8618
         public MeterInstrumentListener()
 #pragma warning restore CS8618
         {

--- a/src/System.Diagnostics.Metrics.Temp/ObservableMeterInstrument.cs
+++ b/src/System.Diagnostics.Metrics.Temp/ObservableMeterInstrument.cs
@@ -17,7 +17,7 @@ namespace System.Diagnostics.Metrics
 
         internal override void Observe(MeterInstrumentListener listener, object? cookie)
         {
-            foreach(Measurement<T> m in Observe())
+            foreach (Measurement<T> m in Observe())
             {
                 listener.OnMeasurement(this, m.Value, m.Labels.ToArray(), cookie);
             }

--- a/src/System.Diagnostics.Metrics.Temp/ObservableMeterInstrument.cs
+++ b/src/System.Diagnostics.Metrics.Temp/ObservableMeterInstrument.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace System.Diagnostics.Metrics
+{
+    public abstract class ObservableMeterInstrument<T> : MeterInstrument where T : unmanaged
+    {
+        protected ObservableMeterInstrument(Meter meter, string name, string? description, string? unit) : base(meter, name, description, unit) { }
+
+        protected abstract IEnumerable<Measurement<T>> Observe();
+        public override bool IsObservable => true;
+
+        internal override void Observe(MeterInstrumentListener listener, object? cookie)
+        {
+            foreach(Measurement<T> m in Observe())
+            {
+                listener.OnMeasurement(this, m.Value, m.Labels.ToArray(), cookie);
+            }
+        }
+    }
+
+    public struct Measurement<T> where T : unmanaged
+    {
+        public Measurement(T value, IEnumerable<(string, object)> labels)
+        {
+            Labels = labels;
+            Value = value;
+        }
+
+        public Measurement(T value, params (string, object)[] labels)
+        {
+            Labels = labels;
+            Value = value;
+        }
+
+        public IEnumerable<(string, object)> Labels { get; }
+        public T Value { get; }
+    }
+}

--- a/src/System.Diagnostics.Metrics.Temp/README.md
+++ b/src/System.Diagnostics.Metrics.Temp/README.md
@@ -1,5 +1,4 @@
-﻿# OpenTelemetry Temporary project to host Metric API
+# OpenTelemetry .NET API
 
-Temporarily hosting the code for Metrics API.
-This will be removed when we start getting
-the package from .NET runtime.
+Temporary project until .NET starts providing
+nuget packages with Metric API.

--- a/src/System.Diagnostics.Metrics.Temp/README.md
+++ b/src/System.Diagnostics.Metrics.Temp/README.md
@@ -1,0 +1,3 @@
+﻿Temporarily hosting the code for Metrics API.
+This will be removed when we start getting
+the package from .NET runtime.

--- a/src/System.Diagnostics.Metrics.Temp/README.md
+++ b/src/System.Diagnostics.Metrics.Temp/README.md
@@ -1,4 +1,4 @@
-﻿# Temporary project for Metric API
+﻿# OpenTelemetry Temporary project to host Metric API
 
 Temporarily hosting the code for Metrics API.
 This will be removed when we start getting

--- a/src/System.Diagnostics.Metrics.Temp/README.md
+++ b/src/System.Diagnostics.Metrics.Temp/README.md
@@ -1,4 +1,5 @@
 ﻿# Temporary project for Metric API
+
 Temporarily hosting the code for Metrics API.
 This will be removed when we start getting
 the package from .NET runtime.

--- a/src/System.Diagnostics.Metrics.Temp/README.md
+++ b/src/System.Diagnostics.Metrics.Temp/README.md
@@ -1,3 +1,4 @@
-﻿Temporarily hosting the code for Metrics API.
+﻿# Temporary project for Metric API
+Temporarily hosting the code for Metrics API.
 This will be removed when we start getting
 the package from .NET runtime.

--- a/src/System.Diagnostics.Metrics.Temp/System.Diagnostics.Metrics.Temp.csproj
+++ b/src/System.Diagnostics.Metrics.Temp/System.Diagnostics.Metrics.Temp.csproj
@@ -4,6 +4,7 @@
     <Description>Temporary .NET Metrics API</Description>
     <RootNamespace>OpenTelemetry</RootNamespace>
     <NoWarn>$(NoWarn),CS0618, CS1591</NoWarn>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Diagnostics.Metrics.Temp/System.Diagnostics.Metrics.Temp.csproj
+++ b/src/System.Diagnostics.Metrics.Temp/System.Diagnostics.Metrics.Temp.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <Description>Temporary .NET Metrics API</Description>
+    <RootNamespace>OpenTelemetry</RootNamespace>
+    <NoWarn>$(NoWarn),CS0618, CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
+</Project>

--- a/src/System.Diagnostics.Metrics.Temp/System.Diagnostics.Metrics.Temp.csproj
+++ b/src/System.Diagnostics.Metrics.Temp/System.Diagnostics.Metrics.Temp.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>OpenTelemetry</RootNamespace>
     <NoWarn>$(NoWarn),CS0618, CS1591</NoWarn>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added a temp project to host metric API which is expected to come from .NET runtime.
Starting this to get started with a Otel Metric SDK implementation.