### PR TITLE
Creating OpenTelemetrySdk Class to Replace the Sdk Class with a Better Name and Marking Sdk as Obsolete

### DIFF
--- a/docs/trace/customizing-the-sdk/Program.cs
+++ b/docs/trace/customizing-the-sdk/Program.cs
@@ -34,7 +34,7 @@ public class Program
 
     public static void Main()
     {
-        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+        using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
 
             // The following adds subscription to activities from Activity Source
             // named "MyCompany.MyProduct.MyLibrary" only.

--- a/docs/trace/customizing-the-sdk/Program.cs
+++ b/docs/trace/customizing-the-sdk/Program.cs
@@ -34,7 +34,7 @@ public class Program
 
     public static void Main()
     {
-        using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
 
             // The following adds subscription to activities from Activity Source
             // named "MyCompany.MyProduct.MyLibrary" only.

--- a/docs/trace/exception-reporting/Program.cs
+++ b/docs/trace/exception-reporting/Program.cs
@@ -26,7 +26,7 @@ public class Program
 
     public static void Main()
     {
-        using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
             .AddSource("MyCompany.MyProduct.MyLibrary")
             .SetSampler(new AlwaysOnSampler())
             .SetErrorStatusOnException()

--- a/docs/trace/exception-reporting/Program.cs
+++ b/docs/trace/exception-reporting/Program.cs
@@ -26,7 +26,7 @@ public class Program
 
     public static void Main()
     {
-        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+        using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
             .AddSource("MyCompany.MyProduct.MyLibrary")
             .SetSampler(new AlwaysOnSampler())
             .SetErrorStatusOnException()

--- a/docs/trace/extending-the-sdk/Program.cs
+++ b/docs/trace/extending-the-sdk/Program.cs
@@ -24,7 +24,7 @@ public class Program
 
     public static void Main()
     {
-        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+        using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
             .SetSampler(new MySampler())
             .AddSource("OTel.Demo")
             .AddProcessor(new MyProcessor("ProcessorA"))

--- a/docs/trace/extending-the-sdk/Program.cs
+++ b/docs/trace/extending-the-sdk/Program.cs
@@ -24,7 +24,7 @@ public class Program
 
     public static void Main()
     {
-        using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
             .SetSampler(new MySampler())
             .AddSource("OTel.Demo")
             .AddProcessor(new MyProcessor("ProcessorA"))

--- a/docs/trace/getting-started/Program.cs
+++ b/docs/trace/getting-started/Program.cs
@@ -25,7 +25,7 @@ public class Program
 
     public static void Main()
     {
-        using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
             .SetSampler(new AlwaysOnSampler())
             .AddSource("MyCompany.MyProduct.MyLibrary")
             .AddConsoleExporter()

--- a/docs/trace/getting-started/Program.cs
+++ b/docs/trace/getting-started/Program.cs
@@ -25,7 +25,7 @@ public class Program
 
     public static void Main()
     {
-        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+        using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
             .SetSampler(new AlwaysOnSampler())
             .AddSource("MyCompany.MyProduct.MyLibrary")
             .AddConsoleExporter()

--- a/examples/AspNet/Global.asax.cs
+++ b/examples/AspNet/Global.asax.cs
@@ -34,7 +34,7 @@ namespace Examples.AspNet
 
         protected void Application_Start()
         {
-            var builder = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            var builder = Sdk.CreateTracerProviderBuilder()
                  .AddAspNetInstrumentation()
                  .AddHttpClientInstrumentation();
 

--- a/examples/AspNet/Global.asax.cs
+++ b/examples/AspNet/Global.asax.cs
@@ -34,7 +34,7 @@ namespace Examples.AspNet
 
         protected void Application_Start()
         {
-            var builder = Sdk.CreateTracerProviderBuilder()
+            var builder = OpenTelemetrySdk.CreateTracerProviderBuilder()
                  .AddAspNetInstrumentation()
                  .AddHttpClientInstrumentation();
 

--- a/examples/Console/TestConsoleExporter.cs
+++ b/examples/Console/TestConsoleExporter.cs
@@ -38,7 +38,7 @@ namespace Examples.Console
         {
             // Enable OpenTelemetry for the sources "Samples.SampleServer" and "Samples.SampleClient"
             // and use Console exporter.
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                     .AddSource("Samples.SampleClient", "Samples.SampleServer")
                     .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("console-test"))
                     .AddProcessor(new MyProcessor()) // This must be added before ConsoleExporter

--- a/examples/Console/TestConsoleExporter.cs
+++ b/examples/Console/TestConsoleExporter.cs
@@ -38,7 +38,7 @@ namespace Examples.Console
         {
             // Enable OpenTelemetry for the sources "Samples.SampleServer" and "Samples.SampleClient"
             // and use Console exporter.
-            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                     .AddSource("Samples.SampleClient", "Samples.SampleServer")
                     .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("console-test"))
                     .AddProcessor(new MyProcessor()) // This must be added before ConsoleExporter

--- a/examples/Console/TestGrpcNetClient.cs
+++ b/examples/Console/TestGrpcNetClient.cs
@@ -41,7 +41,7 @@ namespace Examples.Console
             //
             // dotnet run grpc
 
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddGrpcClientInstrumentation()
                 .AddSource("grpc-net-client-test")
                 .AddConsoleExporter()

--- a/examples/Console/TestGrpcNetClient.cs
+++ b/examples/Console/TestGrpcNetClient.cs
@@ -41,7 +41,7 @@ namespace Examples.Console
             //
             // dotnet run grpc
 
-            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                 .AddGrpcClientInstrumentation()
                 .AddSource("grpc-net-client-test")
                 .AddConsoleExporter()

--- a/examples/Console/TestHttpClient.cs
+++ b/examples/Console/TestHttpClient.cs
@@ -32,7 +32,7 @@ namespace Examples.Console
         {
             System.Console.WriteLine("Hello World!");
 
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddHttpClientInstrumentation()
                 .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("http-service-example"))
                 .AddSource("http-client-test")

--- a/examples/Console/TestHttpClient.cs
+++ b/examples/Console/TestHttpClient.cs
@@ -32,7 +32,7 @@ namespace Examples.Console
         {
             System.Console.WriteLine("Hello World!");
 
-            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                 .AddHttpClientInstrumentation()
                 .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("http-service-example"))
                 .AddSource("http-client-test")

--- a/examples/Console/TestInMemoryExporter.cs
+++ b/examples/Console/TestInMemoryExporter.cs
@@ -50,7 +50,7 @@ namespace Examples.Console
         {
             // Enable OpenTelemetry for the sources "Samples.SampleServer" and "Samples.SampleClient"
             // and use InMemory exporter.
-            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                     .AddSource("Samples.SampleClient", "Samples.SampleServer")
                     .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("inmemory-test"))
                     .AddInMemoryExporter(exportedItems)

--- a/examples/Console/TestInMemoryExporter.cs
+++ b/examples/Console/TestInMemoryExporter.cs
@@ -50,7 +50,7 @@ namespace Examples.Console
         {
             // Enable OpenTelemetry for the sources "Samples.SampleServer" and "Samples.SampleClient"
             // and use InMemory exporter.
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                     .AddSource("Samples.SampleClient", "Samples.SampleServer")
                     .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("inmemory-test"))
                     .AddInMemoryExporter(exportedItems)

--- a/examples/Console/TestJaegerExporter.cs
+++ b/examples/Console/TestJaegerExporter.cs
@@ -55,7 +55,7 @@ namespace Examples.Console
         {
             // Enable OpenTelemetry for the sources "Samples.SampleServer" and "Samples.SampleClient"
             // and use the Jaeger exporter.
-            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                     .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("jaeger-test"))
                     .AddSource("Samples.SampleClient", "Samples.SampleServer")
                     .AddJaegerExporter(o =>

--- a/examples/Console/TestJaegerExporter.cs
+++ b/examples/Console/TestJaegerExporter.cs
@@ -55,7 +55,7 @@ namespace Examples.Console
         {
             // Enable OpenTelemetry for the sources "Samples.SampleServer" and "Samples.SampleClient"
             // and use the Jaeger exporter.
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                     .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("jaeger-test"))
                     .AddSource("Samples.SampleClient", "Samples.SampleServer")
                     .AddJaegerExporter(o =>

--- a/examples/Console/TestOTelShimWithConsoleExporter.cs
+++ b/examples/Console/TestOTelShimWithConsoleExporter.cs
@@ -26,7 +26,7 @@ namespace Examples.Console
         {
             // Enable OpenTelemetry for the source "MyCompany.MyProduct.MyWebServer"
             // and use a single pipeline with a custom MyProcessor, and Console exporter.
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                     .AddSource("MyCompany.MyProduct.MyWebServer")
                     .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("MyServiceName"))
                     .AddConsoleExporter()

--- a/examples/Console/TestOTelShimWithConsoleExporter.cs
+++ b/examples/Console/TestOTelShimWithConsoleExporter.cs
@@ -26,7 +26,7 @@ namespace Examples.Console
         {
             // Enable OpenTelemetry for the source "MyCompany.MyProduct.MyWebServer"
             // and use a single pipeline with a custom MyProcessor, and Console exporter.
-            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                     .AddSource("MyCompany.MyProduct.MyWebServer")
                     .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("MyServiceName"))
                     .AddConsoleExporter()

--- a/examples/Console/TestOpenTracingShim.cs
+++ b/examples/Console/TestOpenTracingShim.cs
@@ -29,7 +29,7 @@ namespace Examples.Console
         {
             // Enable OpenTelemetry for the source "MyCompany.MyProduct.MyWebServer"
             // and use Console exporter.
-            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                     .AddSource("MyCompany.MyProduct.MyWebServer")
                     .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("MyServiceName"))
                     .AddConsoleExporter()

--- a/examples/Console/TestOpenTracingShim.cs
+++ b/examples/Console/TestOpenTracingShim.cs
@@ -29,7 +29,7 @@ namespace Examples.Console
         {
             // Enable OpenTelemetry for the source "MyCompany.MyProduct.MyWebServer"
             // and use Console exporter.
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                     .AddSource("MyCompany.MyProduct.MyWebServer")
                     .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("MyServiceName"))
                     .AddConsoleExporter()

--- a/examples/Console/TestOtlpExporter.cs
+++ b/examples/Console/TestOtlpExporter.cs
@@ -61,7 +61,7 @@ namespace Examples.Console
 
             // Enable OpenTelemetry for the sources "Samples.SampleServer" and "Samples.SampleClient"
             // and use OTLP exporter.
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                     .AddSource("Samples.SampleClient", "Samples.SampleServer")
                     .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("otlp-test"))
                     .AddOtlpExporter(opt => opt.Endpoint = new Uri(endpoint))

--- a/examples/Console/TestOtlpExporter.cs
+++ b/examples/Console/TestOtlpExporter.cs
@@ -61,7 +61,7 @@ namespace Examples.Console
 
             // Enable OpenTelemetry for the sources "Samples.SampleServer" and "Samples.SampleClient"
             // and use OTLP exporter.
-            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                     .AddSource("Samples.SampleClient", "Samples.SampleServer")
                     .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("otlp-test"))
                     .AddOtlpExporter(opt => opt.Endpoint = new Uri(endpoint))

--- a/examples/Console/TestRedis.cs
+++ b/examples/Console/TestRedis.cs
@@ -42,7 +42,7 @@ namespace Examples.Console
             var connection = ConnectionMultiplexer.Connect("localhost");
 
             // Configure exporter to export traces to Zipkin
-            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                     .AddZipkinExporter(o =>
                     {
                         o.Endpoint = new Uri(zipkinUri);

--- a/examples/Console/TestRedis.cs
+++ b/examples/Console/TestRedis.cs
@@ -42,7 +42,7 @@ namespace Examples.Console
             var connection = ConnectionMultiplexer.Connect("localhost");
 
             // Configure exporter to export traces to Zipkin
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                     .AddZipkinExporter(o =>
                     {
                         o.Endpoint = new Uri(zipkinUri);

--- a/examples/Console/TestZPagesExporter.cs
+++ b/examples/Console/TestZPagesExporter.cs
@@ -33,7 +33,7 @@ namespace Examples.Console
             // Start the server
             httpServer.Start();
 
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                     .AddSource("zpages-test")
                     .AddZPagesExporter(o =>
                     {

--- a/examples/Console/TestZPagesExporter.cs
+++ b/examples/Console/TestZPagesExporter.cs
@@ -33,7 +33,7 @@ namespace Examples.Console
             // Start the server
             httpServer.Start();
 
-            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                     .AddSource("zpages-test")
                     .AddZPagesExporter(o =>
                     {

--- a/examples/Console/TestZipkinExporter.cs
+++ b/examples/Console/TestZipkinExporter.cs
@@ -37,7 +37,7 @@ namespace Examples.Console
 
             // Enable OpenTelemetry for the sources "Samples.SampleServer" and "Samples.SampleClient"
             // and use the Zipkin exporter.
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                     .AddSource("Samples.SampleClient", "Samples.SampleServer")
                     .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("zipkin-test"))
                     .AddZipkinExporter(o =>

--- a/examples/Console/TestZipkinExporter.cs
+++ b/examples/Console/TestZipkinExporter.cs
@@ -37,7 +37,7 @@ namespace Examples.Console
 
             // Enable OpenTelemetry for the sources "Samples.SampleServer" and "Samples.SampleClient"
             // and use the Zipkin exporter.
-            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                     .AddSource("Samples.SampleClient", "Samples.SampleServer")
                     .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("zipkin-test"))
                     .AddZipkinExporter(o =>

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -57,7 +57,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
             // By this time, samplers have already run and
             // activity.IsAllDataRequested populated accordingly.
 
-            if (OpenTelemetrySdk.SuppressInstrumentation)
+            if (Sdk.SuppressInstrumentation)
             {
                 return;
             }

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -57,7 +57,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
             // By this time, samplers have already run and
             // activity.IsAllDataRequested populated accordingly.
 
-            if (Sdk.SuppressInstrumentation)
+            if (OpenTelemetrySdk.SuppressInstrumentation)
             {
                 return;
             }

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -66,7 +66,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
             // By this time, samplers have already run and
             // activity.IsAllDataRequested populated accordingly.
 
-            if (Sdk.SuppressInstrumentation)
+            if (OpenTelemetrySdk.SuppressInstrumentation)
             {
                 return;
             }

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -66,7 +66,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
             // By this time, samplers have already run and
             // activity.IsAllDataRequested populated accordingly.
 
-            if (OpenTelemetrySdk.SuppressInstrumentation)
+            if (Sdk.SuppressInstrumentation)
             {
                 return;
             }

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
@@ -53,7 +53,7 @@ namespace OpenTelemetry.Instrumentation.GrpcNetClient.Implementation
             // By this time, samplers have already run and
             // activity.IsAllDataRequested populated accordingly.
 
-            if (Sdk.SuppressInstrumentation)
+            if (OpenTelemetrySdk.SuppressInstrumentation)
             {
                 return;
             }

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
@@ -53,7 +53,7 @@ namespace OpenTelemetry.Instrumentation.GrpcNetClient.Implementation
             // By this time, samplers have already run and
             // activity.IsAllDataRequested populated accordingly.
 
-            if (OpenTelemetrySdk.SuppressInstrumentation)
+            if (Sdk.SuppressInstrumentation)
             {
                 return;
             }

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -77,7 +77,7 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
             // By this time, samplers have already run and
             // activity.IsAllDataRequested populated accordingly.
 
-            if (Sdk.SuppressInstrumentation)
+            if (OpenTelemetrySdk.SuppressInstrumentation)
             {
                 return;
             }

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -77,7 +77,7 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
             // By this time, samplers have already run and
             // activity.IsAllDataRequested populated accordingly.
 
-            if (OpenTelemetrySdk.SuppressInstrumentation)
+            if (Sdk.SuppressInstrumentation)
             {
                 return;
             }

--- a/src/OpenTelemetry/.publicApi/net452/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry/.publicApi/net452/PublicAPI.Shipped.txt
@@ -55,7 +55,7 @@ OpenTelemetry.Resources.ResourceBuilder
 OpenTelemetry.Resources.ResourceBuilder.Build() -> OpenTelemetry.Resources.Resource
 OpenTelemetry.Resources.ResourceBuilder.Clear() -> OpenTelemetry.Resources.ResourceBuilder
 OpenTelemetry.Resources.ResourceBuilderExtensions
-OpenTelemetry.Sdk
+OpenTelemetry.OpenTelemetrySdk
 OpenTelemetry.SimpleActivityExportProcessor
 OpenTelemetry.SimpleActivityExportProcessor.SimpleActivityExportProcessor(OpenTelemetry.BaseExporter<System.Diagnostics.Activity> exporter) -> void
 OpenTelemetry.SimpleExportProcessor<T>
@@ -128,9 +128,9 @@ static OpenTelemetry.Resources.ResourceBuilderExtensions.AddAttributes(this Open
 static OpenTelemetry.Resources.ResourceBuilderExtensions.AddEnvironmentVariableDetector(this OpenTelemetry.Resources.ResourceBuilder resourceBuilder) -> OpenTelemetry.Resources.ResourceBuilder
 static OpenTelemetry.Resources.ResourceBuilderExtensions.AddService(this OpenTelemetry.Resources.ResourceBuilder resourceBuilder, string serviceName, string serviceNamespace = null, string serviceVersion = null, bool autoGenerateServiceInstanceId = true, string serviceInstanceId = null) -> OpenTelemetry.Resources.ResourceBuilder
 static OpenTelemetry.Resources.ResourceBuilderExtensions.AddTelemetrySdk(this OpenTelemetry.Resources.ResourceBuilder resourceBuilder) -> OpenTelemetry.Resources.ResourceBuilder
-static OpenTelemetry.Sdk.CreateTracerProviderBuilder() -> OpenTelemetry.Trace.TracerProviderBuilder
-static OpenTelemetry.Sdk.SetDefaultTextMapPropagator(OpenTelemetry.Context.Propagation.TextMapPropagator textMapPropagator) -> void
-static OpenTelemetry.Sdk.SuppressInstrumentation.get -> bool
+static OpenTelemetry.OpenTelemetrySdk.CreateTracerProviderBuilder() -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.OpenTelemetrySdk.SetDefaultTextMapPropagator(OpenTelemetry.Context.Propagation.TextMapPropagator textMapPropagator) -> void
+static OpenTelemetry.OpenTelemetrySdk.SuppressInstrumentation.get -> bool
 static OpenTelemetry.SuppressInstrumentationScope.Begin(bool value = true) -> System.IDisposable
 static OpenTelemetry.SuppressInstrumentationScope.Enter() -> int
 static OpenTelemetry.Trace.SamplingResult.operator !=(OpenTelemetry.Trace.SamplingResult decision1, OpenTelemetry.Trace.SamplingResult decision2) -> bool

--- a/src/OpenTelemetry/.publicApi/net452/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry/.publicApi/net452/PublicAPI.Shipped.txt
@@ -55,7 +55,7 @@ OpenTelemetry.Resources.ResourceBuilder
 OpenTelemetry.Resources.ResourceBuilder.Build() -> OpenTelemetry.Resources.Resource
 OpenTelemetry.Resources.ResourceBuilder.Clear() -> OpenTelemetry.Resources.ResourceBuilder
 OpenTelemetry.Resources.ResourceBuilderExtensions
-OpenTelemetry.OpenTelemetrySdk
+OpenTelemetry.Sdk
 OpenTelemetry.SimpleActivityExportProcessor
 OpenTelemetry.SimpleActivityExportProcessor.SimpleActivityExportProcessor(OpenTelemetry.BaseExporter<System.Diagnostics.Activity> exporter) -> void
 OpenTelemetry.SimpleExportProcessor<T>
@@ -128,9 +128,9 @@ static OpenTelemetry.Resources.ResourceBuilderExtensions.AddAttributes(this Open
 static OpenTelemetry.Resources.ResourceBuilderExtensions.AddEnvironmentVariableDetector(this OpenTelemetry.Resources.ResourceBuilder resourceBuilder) -> OpenTelemetry.Resources.ResourceBuilder
 static OpenTelemetry.Resources.ResourceBuilderExtensions.AddService(this OpenTelemetry.Resources.ResourceBuilder resourceBuilder, string serviceName, string serviceNamespace = null, string serviceVersion = null, bool autoGenerateServiceInstanceId = true, string serviceInstanceId = null) -> OpenTelemetry.Resources.ResourceBuilder
 static OpenTelemetry.Resources.ResourceBuilderExtensions.AddTelemetrySdk(this OpenTelemetry.Resources.ResourceBuilder resourceBuilder) -> OpenTelemetry.Resources.ResourceBuilder
-static OpenTelemetry.OpenTelemetrySdk.CreateTracerProviderBuilder() -> OpenTelemetry.Trace.TracerProviderBuilder
-static OpenTelemetry.OpenTelemetrySdk.SetDefaultTextMapPropagator(OpenTelemetry.Context.Propagation.TextMapPropagator textMapPropagator) -> void
-static OpenTelemetry.OpenTelemetrySdk.SuppressInstrumentation.get -> bool
+static OpenTelemetry.Sdk.CreateTracerProviderBuilder() -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Sdk.SetDefaultTextMapPropagator(OpenTelemetry.Context.Propagation.TextMapPropagator textMapPropagator) -> void
+static OpenTelemetry.Sdk.SuppressInstrumentation.get -> bool
 static OpenTelemetry.SuppressInstrumentationScope.Begin(bool value = true) -> System.IDisposable
 static OpenTelemetry.SuppressInstrumentationScope.Enter() -> int
 static OpenTelemetry.Trace.SamplingResult.operator !=(OpenTelemetry.Trace.SamplingResult decision1, OpenTelemetry.Trace.SamplingResult decision2) -> bool

--- a/src/OpenTelemetry/.publicApi/net452/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net452/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+OpenTelemetry.OpenTelemetrySdk
 OpenTelemetry.Trace.IDeferredTracerProviderBuilder
 OpenTelemetry.Trace.IDeferredTracerProviderBuilder.Configure(System.Action<System.IServiceProvider, OpenTelemetry.Trace.TracerProviderBuilder> configure) -> OpenTelemetry.Trace.TracerProviderBuilder
 OpenTelemetry.Trace.ParentBasedSampler.ParentBasedSampler(OpenTelemetry.Trace.Sampler rootSampler, OpenTelemetry.Trace.Sampler remoteParentSampled = null, OpenTelemetry.Trace.Sampler remoteParentNotSampled = null, OpenTelemetry.Trace.Sampler localParentSampled = null, OpenTelemetry.Trace.Sampler localParentNotSampled = null) -> void
@@ -8,5 +9,8 @@ OpenTelemetry.Trace.TracerProviderBuilderBase.TracerProviderBuilderBase() -> voi
 override OpenTelemetry.Trace.TracerProviderBuilderBase.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation> instrumentationFactory) -> OpenTelemetry.Trace.TracerProviderBuilder
 override OpenTelemetry.Trace.TracerProviderBuilderBase.AddLegacySource(string operationName) -> OpenTelemetry.Trace.TracerProviderBuilder
 override OpenTelemetry.Trace.TracerProviderBuilderBase.AddSource(params string[] names) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.OpenTelemetrySdk.CreateTracerProviderBuilder() -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.OpenTelemetrySdk.SetDefaultTextMapPropagator(OpenTelemetry.Context.Propagation.TextMapPropagator textMapPropagator) -> void
+static OpenTelemetry.OpenTelemetrySdk.SuppressInstrumentation.get -> bool
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.SetErrorStatusOnException(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, bool enabled = true) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Trace.TracerProviderExtensions.ForceFlush(this OpenTelemetry.Trace.TracerProvider provider, int timeoutMilliseconds = -1) -> bool

--- a/src/OpenTelemetry/.publicApi/net46/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry/.publicApi/net46/PublicAPI.Shipped.txt
@@ -55,7 +55,7 @@ OpenTelemetry.Resources.ResourceBuilder
 OpenTelemetry.Resources.ResourceBuilder.Build() -> OpenTelemetry.Resources.Resource
 OpenTelemetry.Resources.ResourceBuilder.Clear() -> OpenTelemetry.Resources.ResourceBuilder
 OpenTelemetry.Resources.ResourceBuilderExtensions
-OpenTelemetry.Sdk
+OpenTelemetry.OpenTelemetrySdk
 OpenTelemetry.SimpleActivityExportProcessor
 OpenTelemetry.SimpleActivityExportProcessor.SimpleActivityExportProcessor(OpenTelemetry.BaseExporter<System.Diagnostics.Activity> exporter) -> void
 OpenTelemetry.SimpleExportProcessor<T>
@@ -128,9 +128,9 @@ static OpenTelemetry.Resources.ResourceBuilderExtensions.AddAttributes(this Open
 static OpenTelemetry.Resources.ResourceBuilderExtensions.AddEnvironmentVariableDetector(this OpenTelemetry.Resources.ResourceBuilder resourceBuilder) -> OpenTelemetry.Resources.ResourceBuilder
 static OpenTelemetry.Resources.ResourceBuilderExtensions.AddService(this OpenTelemetry.Resources.ResourceBuilder resourceBuilder, string serviceName, string serviceNamespace = null, string serviceVersion = null, bool autoGenerateServiceInstanceId = true, string serviceInstanceId = null) -> OpenTelemetry.Resources.ResourceBuilder
 static OpenTelemetry.Resources.ResourceBuilderExtensions.AddTelemetrySdk(this OpenTelemetry.Resources.ResourceBuilder resourceBuilder) -> OpenTelemetry.Resources.ResourceBuilder
-static OpenTelemetry.Sdk.CreateTracerProviderBuilder() -> OpenTelemetry.Trace.TracerProviderBuilder
-static OpenTelemetry.Sdk.SetDefaultTextMapPropagator(OpenTelemetry.Context.Propagation.TextMapPropagator textMapPropagator) -> void
-static OpenTelemetry.Sdk.SuppressInstrumentation.get -> bool
+static OpenTelemetry.OpenTelemetrySdk.CreateTracerProviderBuilder() -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.OpenTelemetrySdk.SetDefaultTextMapPropagator(OpenTelemetry.Context.Propagation.TextMapPropagator textMapPropagator) -> void
+static OpenTelemetry.OpenTelemetrySdk.SuppressInstrumentation.get -> bool
 static OpenTelemetry.SuppressInstrumentationScope.Begin(bool value = true) -> System.IDisposable
 static OpenTelemetry.SuppressInstrumentationScope.Enter() -> int
 static OpenTelemetry.Trace.SamplingResult.operator !=(OpenTelemetry.Trace.SamplingResult decision1, OpenTelemetry.Trace.SamplingResult decision2) -> bool

--- a/src/OpenTelemetry/.publicApi/net46/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry/.publicApi/net46/PublicAPI.Shipped.txt
@@ -55,7 +55,7 @@ OpenTelemetry.Resources.ResourceBuilder
 OpenTelemetry.Resources.ResourceBuilder.Build() -> OpenTelemetry.Resources.Resource
 OpenTelemetry.Resources.ResourceBuilder.Clear() -> OpenTelemetry.Resources.ResourceBuilder
 OpenTelemetry.Resources.ResourceBuilderExtensions
-OpenTelemetry.OpenTelemetrySdk
+OpenTelemetry.Sdk
 OpenTelemetry.SimpleActivityExportProcessor
 OpenTelemetry.SimpleActivityExportProcessor.SimpleActivityExportProcessor(OpenTelemetry.BaseExporter<System.Diagnostics.Activity> exporter) -> void
 OpenTelemetry.SimpleExportProcessor<T>
@@ -128,9 +128,9 @@ static OpenTelemetry.Resources.ResourceBuilderExtensions.AddAttributes(this Open
 static OpenTelemetry.Resources.ResourceBuilderExtensions.AddEnvironmentVariableDetector(this OpenTelemetry.Resources.ResourceBuilder resourceBuilder) -> OpenTelemetry.Resources.ResourceBuilder
 static OpenTelemetry.Resources.ResourceBuilderExtensions.AddService(this OpenTelemetry.Resources.ResourceBuilder resourceBuilder, string serviceName, string serviceNamespace = null, string serviceVersion = null, bool autoGenerateServiceInstanceId = true, string serviceInstanceId = null) -> OpenTelemetry.Resources.ResourceBuilder
 static OpenTelemetry.Resources.ResourceBuilderExtensions.AddTelemetrySdk(this OpenTelemetry.Resources.ResourceBuilder resourceBuilder) -> OpenTelemetry.Resources.ResourceBuilder
-static OpenTelemetry.OpenTelemetrySdk.CreateTracerProviderBuilder() -> OpenTelemetry.Trace.TracerProviderBuilder
-static OpenTelemetry.OpenTelemetrySdk.SetDefaultTextMapPropagator(OpenTelemetry.Context.Propagation.TextMapPropagator textMapPropagator) -> void
-static OpenTelemetry.OpenTelemetrySdk.SuppressInstrumentation.get -> bool
+static OpenTelemetry.Sdk.CreateTracerProviderBuilder() -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Sdk.SetDefaultTextMapPropagator(OpenTelemetry.Context.Propagation.TextMapPropagator textMapPropagator) -> void
+static OpenTelemetry.Sdk.SuppressInstrumentation.get -> bool
 static OpenTelemetry.SuppressInstrumentationScope.Begin(bool value = true) -> System.IDisposable
 static OpenTelemetry.SuppressInstrumentationScope.Enter() -> int
 static OpenTelemetry.Trace.SamplingResult.operator !=(OpenTelemetry.Trace.SamplingResult decision1, OpenTelemetry.Trace.SamplingResult decision2) -> bool

--- a/src/OpenTelemetry/.publicApi/net46/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net46/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+OpenTelemetry.OpenTelemetrySdk
 OpenTelemetry.Trace.IDeferredTracerProviderBuilder
 OpenTelemetry.Trace.IDeferredTracerProviderBuilder.Configure(System.Action<System.IServiceProvider, OpenTelemetry.Trace.TracerProviderBuilder> configure) -> OpenTelemetry.Trace.TracerProviderBuilder
 OpenTelemetry.Trace.ParentBasedSampler.ParentBasedSampler(OpenTelemetry.Trace.Sampler rootSampler, OpenTelemetry.Trace.Sampler remoteParentSampled = null, OpenTelemetry.Trace.Sampler remoteParentNotSampled = null, OpenTelemetry.Trace.Sampler localParentSampled = null, OpenTelemetry.Trace.Sampler localParentNotSampled = null) -> void
@@ -8,5 +9,8 @@ OpenTelemetry.Trace.TracerProviderBuilderBase.TracerProviderBuilderBase() -> voi
 override OpenTelemetry.Trace.TracerProviderBuilderBase.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation> instrumentationFactory) -> OpenTelemetry.Trace.TracerProviderBuilder
 override OpenTelemetry.Trace.TracerProviderBuilderBase.AddLegacySource(string operationName) -> OpenTelemetry.Trace.TracerProviderBuilder
 override OpenTelemetry.Trace.TracerProviderBuilderBase.AddSource(params string[] names) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.OpenTelemetrySdk.CreateTracerProviderBuilder() -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.OpenTelemetrySdk.SetDefaultTextMapPropagator(OpenTelemetry.Context.Propagation.TextMapPropagator textMapPropagator) -> void
+static OpenTelemetry.OpenTelemetrySdk.SuppressInstrumentation.get -> bool
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.SetErrorStatusOnException(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, bool enabled = true) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Trace.TracerProviderExtensions.ForceFlush(this OpenTelemetry.Trace.TracerProvider provider, int timeoutMilliseconds = -1) -> bool

--- a/src/OpenTelemetry/.publicApi/net461/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry/.publicApi/net461/PublicAPI.Shipped.txt
@@ -75,7 +75,7 @@ OpenTelemetry.Resources.ResourceBuilder
 OpenTelemetry.Resources.ResourceBuilder.Build() -> OpenTelemetry.Resources.Resource
 OpenTelemetry.Resources.ResourceBuilder.Clear() -> OpenTelemetry.Resources.ResourceBuilder
 OpenTelemetry.Resources.ResourceBuilderExtensions
-OpenTelemetry.OpenTelemetrySdk
+OpenTelemetry.Sdk
 OpenTelemetry.SimpleActivityExportProcessor
 OpenTelemetry.SimpleActivityExportProcessor.SimpleActivityExportProcessor(OpenTelemetry.BaseExporter<System.Diagnostics.Activity> exporter) -> void
 OpenTelemetry.SimpleExportProcessor<T>
@@ -151,9 +151,9 @@ static OpenTelemetry.Resources.ResourceBuilderExtensions.AddAttributes(this Open
 static OpenTelemetry.Resources.ResourceBuilderExtensions.AddEnvironmentVariableDetector(this OpenTelemetry.Resources.ResourceBuilder resourceBuilder) -> OpenTelemetry.Resources.ResourceBuilder
 static OpenTelemetry.Resources.ResourceBuilderExtensions.AddService(this OpenTelemetry.Resources.ResourceBuilder resourceBuilder, string serviceName, string serviceNamespace = null, string serviceVersion = null, bool autoGenerateServiceInstanceId = true, string serviceInstanceId = null) -> OpenTelemetry.Resources.ResourceBuilder
 static OpenTelemetry.Resources.ResourceBuilderExtensions.AddTelemetrySdk(this OpenTelemetry.Resources.ResourceBuilder resourceBuilder) -> OpenTelemetry.Resources.ResourceBuilder
-static OpenTelemetry.OpenTelemetrySdk.CreateTracerProviderBuilder() -> OpenTelemetry.Trace.TracerProviderBuilder
-static OpenTelemetry.OpenTelemetrySdk.SetDefaultTextMapPropagator(OpenTelemetry.Context.Propagation.TextMapPropagator textMapPropagator) -> void
-static OpenTelemetry.OpenTelemetrySdk.SuppressInstrumentation.get -> bool
+static OpenTelemetry.Sdk.CreateTracerProviderBuilder() -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Sdk.SetDefaultTextMapPropagator(OpenTelemetry.Context.Propagation.TextMapPropagator textMapPropagator) -> void
+static OpenTelemetry.Sdk.SuppressInstrumentation.get -> bool
 static OpenTelemetry.SuppressInstrumentationScope.Begin(bool value = true) -> System.IDisposable
 static OpenTelemetry.SuppressInstrumentationScope.Enter() -> int
 static OpenTelemetry.Trace.SamplingResult.operator !=(OpenTelemetry.Trace.SamplingResult decision1, OpenTelemetry.Trace.SamplingResult decision2) -> bool

--- a/src/OpenTelemetry/.publicApi/net461/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry/.publicApi/net461/PublicAPI.Shipped.txt
@@ -75,7 +75,7 @@ OpenTelemetry.Resources.ResourceBuilder
 OpenTelemetry.Resources.ResourceBuilder.Build() -> OpenTelemetry.Resources.Resource
 OpenTelemetry.Resources.ResourceBuilder.Clear() -> OpenTelemetry.Resources.ResourceBuilder
 OpenTelemetry.Resources.ResourceBuilderExtensions
-OpenTelemetry.Sdk
+OpenTelemetry.OpenTelemetrySdk
 OpenTelemetry.SimpleActivityExportProcessor
 OpenTelemetry.SimpleActivityExportProcessor.SimpleActivityExportProcessor(OpenTelemetry.BaseExporter<System.Diagnostics.Activity> exporter) -> void
 OpenTelemetry.SimpleExportProcessor<T>
@@ -151,9 +151,9 @@ static OpenTelemetry.Resources.ResourceBuilderExtensions.AddAttributes(this Open
 static OpenTelemetry.Resources.ResourceBuilderExtensions.AddEnvironmentVariableDetector(this OpenTelemetry.Resources.ResourceBuilder resourceBuilder) -> OpenTelemetry.Resources.ResourceBuilder
 static OpenTelemetry.Resources.ResourceBuilderExtensions.AddService(this OpenTelemetry.Resources.ResourceBuilder resourceBuilder, string serviceName, string serviceNamespace = null, string serviceVersion = null, bool autoGenerateServiceInstanceId = true, string serviceInstanceId = null) -> OpenTelemetry.Resources.ResourceBuilder
 static OpenTelemetry.Resources.ResourceBuilderExtensions.AddTelemetrySdk(this OpenTelemetry.Resources.ResourceBuilder resourceBuilder) -> OpenTelemetry.Resources.ResourceBuilder
-static OpenTelemetry.Sdk.CreateTracerProviderBuilder() -> OpenTelemetry.Trace.TracerProviderBuilder
-static OpenTelemetry.Sdk.SetDefaultTextMapPropagator(OpenTelemetry.Context.Propagation.TextMapPropagator textMapPropagator) -> void
-static OpenTelemetry.Sdk.SuppressInstrumentation.get -> bool
+static OpenTelemetry.OpenTelemetrySdk.CreateTracerProviderBuilder() -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.OpenTelemetrySdk.SetDefaultTextMapPropagator(OpenTelemetry.Context.Propagation.TextMapPropagator textMapPropagator) -> void
+static OpenTelemetry.OpenTelemetrySdk.SuppressInstrumentation.get -> bool
 static OpenTelemetry.SuppressInstrumentationScope.Begin(bool value = true) -> System.IDisposable
 static OpenTelemetry.SuppressInstrumentationScope.Enter() -> int
 static OpenTelemetry.Trace.SamplingResult.operator !=(OpenTelemetry.Trace.SamplingResult decision1, OpenTelemetry.Trace.SamplingResult decision2) -> bool

--- a/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -19,6 +19,7 @@ OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeScopes.set -> void
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.get -> bool
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.set -> void
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.SetResourceBuilder(OpenTelemetry.Resources.ResourceBuilder resourceBuilder) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions
+OpenTelemetry.OpenTelemetrySdk
 OpenTelemetry.Trace.IDeferredTracerProviderBuilder
 OpenTelemetry.Trace.IDeferredTracerProviderBuilder.Configure(System.Action<System.IServiceProvider, OpenTelemetry.Trace.TracerProviderBuilder> configure) -> OpenTelemetry.Trace.TracerProviderBuilder
 OpenTelemetry.Trace.IDeferredTracerProviderBuilder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection
@@ -32,5 +33,8 @@ override OpenTelemetry.Trace.TracerProviderBuilderBase.AddInstrumentation<TInstr
 override OpenTelemetry.Trace.TracerProviderBuilderBase.AddLegacySource(string operationName) -> OpenTelemetry.Trace.TracerProviderBuilder
 override OpenTelemetry.Trace.TracerProviderBuilderBase.AddSource(params string[] names) -> OpenTelemetry.Trace.TracerProviderBuilder
 override OpenTelemetry.Logs.OpenTelemetryLoggerProvider.Dispose(bool disposing) -> void
+static OpenTelemetry.OpenTelemetrySdk.CreateTracerProviderBuilder() -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.OpenTelemetrySdk.SetDefaultTextMapPropagator(OpenTelemetry.Context.Propagation.TextMapPropagator textMapPropagator) -> void
+static OpenTelemetry.OpenTelemetrySdk.SuppressInstrumentation.get -> bool
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.SetErrorStatusOnException(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, bool enabled = true) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Trace.TracerProviderExtensions.ForceFlush(this OpenTelemetry.Trace.TracerProvider provider, int timeoutMilliseconds = -1) -> bool

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Shipped.txt
@@ -75,7 +75,7 @@ OpenTelemetry.Resources.ResourceBuilder
 OpenTelemetry.Resources.ResourceBuilder.Build() -> OpenTelemetry.Resources.Resource
 OpenTelemetry.Resources.ResourceBuilder.Clear() -> OpenTelemetry.Resources.ResourceBuilder
 OpenTelemetry.Resources.ResourceBuilderExtensions
-OpenTelemetry.OpenTelemetrySdk
+OpenTelemetry.Sdk
 OpenTelemetry.SimpleActivityExportProcessor
 OpenTelemetry.SimpleActivityExportProcessor.SimpleActivityExportProcessor(OpenTelemetry.BaseExporter<System.Diagnostics.Activity> exporter) -> void
 OpenTelemetry.SimpleExportProcessor<T>
@@ -151,9 +151,9 @@ static OpenTelemetry.Resources.ResourceBuilderExtensions.AddAttributes(this Open
 static OpenTelemetry.Resources.ResourceBuilderExtensions.AddEnvironmentVariableDetector(this OpenTelemetry.Resources.ResourceBuilder resourceBuilder) -> OpenTelemetry.Resources.ResourceBuilder
 static OpenTelemetry.Resources.ResourceBuilderExtensions.AddService(this OpenTelemetry.Resources.ResourceBuilder resourceBuilder, string serviceName, string serviceNamespace = null, string serviceVersion = null, bool autoGenerateServiceInstanceId = true, string serviceInstanceId = null) -> OpenTelemetry.Resources.ResourceBuilder
 static OpenTelemetry.Resources.ResourceBuilderExtensions.AddTelemetrySdk(this OpenTelemetry.Resources.ResourceBuilder resourceBuilder) -> OpenTelemetry.Resources.ResourceBuilder
-static OpenTelemetry.OpenTelemetrySdk.CreateTracerProviderBuilder() -> OpenTelemetry.Trace.TracerProviderBuilder
-static OpenTelemetry.OpenTelemetrySdk.SetDefaultTextMapPropagator(OpenTelemetry.Context.Propagation.TextMapPropagator textMapPropagator) -> void
-static OpenTelemetry.OpenTelemetrySdk.SuppressInstrumentation.get -> bool
+static OpenTelemetry.Sdk.CreateTracerProviderBuilder() -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Sdk.SetDefaultTextMapPropagator(OpenTelemetry.Context.Propagation.TextMapPropagator textMapPropagator) -> void
+static OpenTelemetry.Sdk.SuppressInstrumentation.get -> bool
 static OpenTelemetry.SuppressInstrumentationScope.Begin(bool value = true) -> System.IDisposable
 static OpenTelemetry.SuppressInstrumentationScope.Enter() -> int
 static OpenTelemetry.Trace.SamplingResult.operator !=(OpenTelemetry.Trace.SamplingResult decision1, OpenTelemetry.Trace.SamplingResult decision2) -> bool

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Shipped.txt
@@ -75,7 +75,7 @@ OpenTelemetry.Resources.ResourceBuilder
 OpenTelemetry.Resources.ResourceBuilder.Build() -> OpenTelemetry.Resources.Resource
 OpenTelemetry.Resources.ResourceBuilder.Clear() -> OpenTelemetry.Resources.ResourceBuilder
 OpenTelemetry.Resources.ResourceBuilderExtensions
-OpenTelemetry.Sdk
+OpenTelemetry.OpenTelemetrySdk
 OpenTelemetry.SimpleActivityExportProcessor
 OpenTelemetry.SimpleActivityExportProcessor.SimpleActivityExportProcessor(OpenTelemetry.BaseExporter<System.Diagnostics.Activity> exporter) -> void
 OpenTelemetry.SimpleExportProcessor<T>
@@ -151,9 +151,9 @@ static OpenTelemetry.Resources.ResourceBuilderExtensions.AddAttributes(this Open
 static OpenTelemetry.Resources.ResourceBuilderExtensions.AddEnvironmentVariableDetector(this OpenTelemetry.Resources.ResourceBuilder resourceBuilder) -> OpenTelemetry.Resources.ResourceBuilder
 static OpenTelemetry.Resources.ResourceBuilderExtensions.AddService(this OpenTelemetry.Resources.ResourceBuilder resourceBuilder, string serviceName, string serviceNamespace = null, string serviceVersion = null, bool autoGenerateServiceInstanceId = true, string serviceInstanceId = null) -> OpenTelemetry.Resources.ResourceBuilder
 static OpenTelemetry.Resources.ResourceBuilderExtensions.AddTelemetrySdk(this OpenTelemetry.Resources.ResourceBuilder resourceBuilder) -> OpenTelemetry.Resources.ResourceBuilder
-static OpenTelemetry.Sdk.CreateTracerProviderBuilder() -> OpenTelemetry.Trace.TracerProviderBuilder
-static OpenTelemetry.Sdk.SetDefaultTextMapPropagator(OpenTelemetry.Context.Propagation.TextMapPropagator textMapPropagator) -> void
-static OpenTelemetry.Sdk.SuppressInstrumentation.get -> bool
+static OpenTelemetry.OpenTelemetrySdk.CreateTracerProviderBuilder() -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.OpenTelemetrySdk.SetDefaultTextMapPropagator(OpenTelemetry.Context.Propagation.TextMapPropagator textMapPropagator) -> void
+static OpenTelemetry.OpenTelemetrySdk.SuppressInstrumentation.get -> bool
 static OpenTelemetry.SuppressInstrumentationScope.Begin(bool value = true) -> System.IDisposable
 static OpenTelemetry.SuppressInstrumentationScope.Enter() -> int
 static OpenTelemetry.Trace.SamplingResult.operator !=(OpenTelemetry.Trace.SamplingResult decision1, OpenTelemetry.Trace.SamplingResult decision2) -> bool

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -19,6 +19,7 @@ OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeScopes.set -> void
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.get -> bool
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.set -> void
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.SetResourceBuilder(OpenTelemetry.Resources.ResourceBuilder resourceBuilder) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions
+OpenTelemetry.OpenTelemetrySdk
 OpenTelemetry.Trace.IDeferredTracerProviderBuilder
 OpenTelemetry.Trace.IDeferredTracerProviderBuilder.Configure(System.Action<System.IServiceProvider, OpenTelemetry.Trace.TracerProviderBuilder> configure) -> OpenTelemetry.Trace.TracerProviderBuilder
 OpenTelemetry.Trace.IDeferredTracerProviderBuilder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection
@@ -32,5 +33,8 @@ override OpenTelemetry.Trace.TracerProviderBuilderBase.AddInstrumentation<TInstr
 override OpenTelemetry.Trace.TracerProviderBuilderBase.AddLegacySource(string operationName) -> OpenTelemetry.Trace.TracerProviderBuilder
 override OpenTelemetry.Trace.TracerProviderBuilderBase.AddSource(params string[] names) -> OpenTelemetry.Trace.TracerProviderBuilder
 override OpenTelemetry.Logs.OpenTelemetryLoggerProvider.Dispose(bool disposing) -> void
+static OpenTelemetry.OpenTelemetrySdk.CreateTracerProviderBuilder() -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.OpenTelemetrySdk.SetDefaultTextMapPropagator(OpenTelemetry.Context.Propagation.TextMapPropagator textMapPropagator) -> void
+static OpenTelemetry.OpenTelemetrySdk.SuppressInstrumentation.get -> bool
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.SetErrorStatusOnException(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, bool enabled = true) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Trace.TracerProviderExtensions.ForceFlush(this OpenTelemetry.Trace.TracerProvider provider, int timeoutMilliseconds = -1) -> bool

--- a/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
@@ -38,7 +38,7 @@ namespace OpenTelemetry.Logs
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
             if (!this.IsEnabled(logLevel)
-                || Sdk.SuppressInstrumentation)
+                || OpenTelemetrySdk.SuppressInstrumentation)
             {
                 return;
             }

--- a/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
@@ -38,7 +38,7 @@ namespace OpenTelemetry.Logs
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
             if (!this.IsEnabled(logLevel)
-                || OpenTelemetrySdk.SuppressInstrumentation)
+                || Sdk.SuppressInstrumentation)
             {
                 return;
             }

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggerProvider.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggerProvider.cs
@@ -37,7 +37,7 @@ namespace OpenTelemetry.Logs
         {
             // Accessing Sdk class is just to trigger its static ctor,
             // which sets default Propagators and default Activity Id format
-            _ = OpenTelemetrySdk.SuppressInstrumentation;
+            _ = Sdk.SuppressInstrumentation;
         }
 
         public OpenTelemetryLoggerProvider(IOptionsMonitor<OpenTelemetryLoggerOptions> options)

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggerProvider.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggerProvider.cs
@@ -37,7 +37,7 @@ namespace OpenTelemetry.Logs
         {
             // Accessing Sdk class is just to trigger its static ctor,
             // which sets default Propagators and default Activity Id format
-            _ = Sdk.SuppressInstrumentation;
+            _ = OpenTelemetrySdk.SuppressInstrumentation;
         }
 
         public OpenTelemetryLoggerProvider(IOptionsMonitor<OpenTelemetryLoggerOptions> options)

--- a/src/OpenTelemetry/OpenTelemetrySdk.cs
+++ b/src/OpenTelemetry/OpenTelemetrySdk.cs
@@ -1,4 +1,4 @@
-// <copyright file="Sdk.cs" company="OpenTelemetry Authors">
+// <copyright file="OpenTelemetrySdk.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Diagnostics;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Internal;
@@ -25,9 +24,9 @@ namespace OpenTelemetry
     /// <summary>
     /// OpenTelemetry helper.
     /// </summary>
-    public static class Sdk
+    public static class OpenTelemetrySdk
     {
-        static Sdk()
+        static OpenTelemetrySdk()
         {
             Propagators.DefaultTextMapPropagator = new CompositeTextMapPropagator(new TextMapPropagator[]
             {

--- a/src/OpenTelemetry/OpenTelemetrySdk.cs
+++ b/src/OpenTelemetry/OpenTelemetrySdk.cs
@@ -1,4 +1,4 @@
-// <copyright file="Sdk.cs" company="OpenTelemetry Authors">
+// <copyright file="OpenTelemetrySdk.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Diagnostics;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Internal;
@@ -23,13 +22,11 @@ using OpenTelemetry.Trace;
 namespace OpenTelemetry
 {
     /// <summary>
-    /// This class has been deprecated. Use <see cref="OpenTelemetrySdk"/> instead.
     /// OpenTelemetry helper.
     /// </summary>
-    [Obsolete("This class has been deprecated.  Use the OpenTelemetrySdk instead.")]
-    public static class Sdk
+    public static class OpenTelemetrySdk
     {
-        static Sdk()
+        static OpenTelemetrySdk()
         {
             Propagators.DefaultTextMapPropagator = new CompositeTextMapPropagator(new TextMapPropagator[]
             {

--- a/src/OpenTelemetry/Sdk.cs
+++ b/src/OpenTelemetry/Sdk.cs
@@ -1,4 +1,4 @@
-// <copyright file="OpenTelemetrySdk.cs" company="OpenTelemetry Authors">
+// <copyright file="Sdk.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using System.Diagnostics;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Internal;
@@ -24,9 +25,9 @@ namespace OpenTelemetry
     /// <summary>
     /// OpenTelemetry helper.
     /// </summary>
-    public static class OpenTelemetrySdk
+    public static class Sdk
     {
-        static OpenTelemetrySdk()
+        static Sdk()
         {
             Propagators.DefaultTextMapPropagator = new CompositeTextMapPropagator(new TextMapPropagator[]
             {

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -78,7 +78,7 @@ namespace OpenTelemetry.Trace
                             // Legacy activity matches the user configured list.
                             // Call sampler for the legacy activity
                             // unless suppressed.
-                            if (!Sdk.SuppressInstrumentation)
+                            if (!OpenTelemetrySdk.SuppressInstrumentation)
                             {
                                 this.getRequestedDataAction(activity);
                             }
@@ -143,20 +143,20 @@ namespace OpenTelemetry.Trace
             if (sampler is AlwaysOnSampler)
             {
                 listener.Sample = (ref ActivityCreationOptions<ActivityContext> options) =>
-                    !Sdk.SuppressInstrumentation ? ActivitySamplingResult.AllDataAndRecorded : ActivitySamplingResult.None;
+                    !OpenTelemetrySdk.SuppressInstrumentation ? ActivitySamplingResult.AllDataAndRecorded : ActivitySamplingResult.None;
                 this.getRequestedDataAction = this.RunGetRequestedDataAlwaysOnSampler;
             }
             else if (sampler is AlwaysOffSampler)
             {
                 listener.Sample = (ref ActivityCreationOptions<ActivityContext> options) =>
-                    !Sdk.SuppressInstrumentation ? PropagateOrIgnoreData(options.Parent.TraceId) : ActivitySamplingResult.None;
+                    !OpenTelemetrySdk.SuppressInstrumentation ? PropagateOrIgnoreData(options.Parent.TraceId) : ActivitySamplingResult.None;
                 this.getRequestedDataAction = this.RunGetRequestedDataAlwaysOffSampler;
             }
             else
             {
                 // This delegate informs ActivitySource about sampling decision when the parent context is an ActivityContext.
                 listener.Sample = (ref ActivityCreationOptions<ActivityContext> options) =>
-                    !Sdk.SuppressInstrumentation ? ComputeActivitySamplingResult(options, sampler) : ActivitySamplingResult.None;
+                    !OpenTelemetrySdk.SuppressInstrumentation ? ComputeActivitySamplingResult(options, sampler) : ActivitySamplingResult.None;
                 this.getRequestedDataAction = this.RunGetRequestedDataOtherSampler;
             }
 

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -78,7 +78,7 @@ namespace OpenTelemetry.Trace
                             // Legacy activity matches the user configured list.
                             // Call sampler for the legacy activity
                             // unless suppressed.
-                            if (!OpenTelemetrySdk.SuppressInstrumentation)
+                            if (!Sdk.SuppressInstrumentation)
                             {
                                 this.getRequestedDataAction(activity);
                             }
@@ -143,20 +143,20 @@ namespace OpenTelemetry.Trace
             if (sampler is AlwaysOnSampler)
             {
                 listener.Sample = (ref ActivityCreationOptions<ActivityContext> options) =>
-                    !OpenTelemetrySdk.SuppressInstrumentation ? ActivitySamplingResult.AllDataAndRecorded : ActivitySamplingResult.None;
+                    !Sdk.SuppressInstrumentation ? ActivitySamplingResult.AllDataAndRecorded : ActivitySamplingResult.None;
                 this.getRequestedDataAction = this.RunGetRequestedDataAlwaysOnSampler;
             }
             else if (sampler is AlwaysOffSampler)
             {
                 listener.Sample = (ref ActivityCreationOptions<ActivityContext> options) =>
-                    !OpenTelemetrySdk.SuppressInstrumentation ? PropagateOrIgnoreData(options.Parent.TraceId) : ActivitySamplingResult.None;
+                    !Sdk.SuppressInstrumentation ? PropagateOrIgnoreData(options.Parent.TraceId) : ActivitySamplingResult.None;
                 this.getRequestedDataAction = this.RunGetRequestedDataAlwaysOffSampler;
             }
             else
             {
                 // This delegate informs ActivitySource about sampling decision when the parent context is an ActivityContext.
                 listener.Sample = (ref ActivityCreationOptions<ActivityContext> options) =>
-                    !OpenTelemetrySdk.SuppressInstrumentation ? ComputeActivitySamplingResult(options, sampler) : ActivitySamplingResult.None;
+                    !Sdk.SuppressInstrumentation ? ComputeActivitySamplingResult(options, sampler) : ActivitySamplingResult.None;
                 this.getRequestedDataAction = this.RunGetRequestedDataOtherSampler;
             }
 

--- a/test/Benchmarks/Helper/LocalServer.cs
+++ b/test/Benchmarks/Helper/LocalServer.cs
@@ -38,7 +38,7 @@ namespace Benchmarks.Helper
             {
                 if (enableTracerProvider)
                 {
-                    this.tracerProvider = Sdk.CreateTracerProviderBuilder()
+                    this.tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                         .AddAspNetCoreInstrumentation()
                         .Build();
                 }

--- a/test/Benchmarks/Helper/LocalServer.cs
+++ b/test/Benchmarks/Helper/LocalServer.cs
@@ -38,7 +38,7 @@ namespace Benchmarks.Helper
             {
                 if (enableTracerProvider)
                 {
-                    this.tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+                    this.tracerProvider = Sdk.CreateTracerProviderBuilder()
                         .AddAspNetCoreInstrumentation()
                         .Build();
                 }

--- a/test/Benchmarks/Instrumentation/InstrumentedHttpClientBenchmark.cs
+++ b/test/Benchmarks/Instrumentation/InstrumentedHttpClientBenchmark.cs
@@ -51,7 +51,7 @@ namespace Benchmarks.Instrumentation
                 out var host,
                 out var port);
 
-            this.tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            this.tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddHttpClientInstrumentation()
                 .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(ServiceName))
                 .AddSource(SourceName)

--- a/test/Benchmarks/Instrumentation/InstrumentedHttpClientBenchmark.cs
+++ b/test/Benchmarks/Instrumentation/InstrumentedHttpClientBenchmark.cs
@@ -51,7 +51,7 @@ namespace Benchmarks.Instrumentation
                 out var host,
                 out var port);
 
-            this.tracerProvider = Sdk.CreateTracerProviderBuilder()
+            this.tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddHttpClientInstrumentation()
                 .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(ServiceName))
                 .AddSource(SourceName)

--- a/test/Benchmarks/Trace/OpenTelemetrySdkBenchmarks.cs
+++ b/test/Benchmarks/Trace/OpenTelemetrySdkBenchmarks.cs
@@ -33,17 +33,17 @@ namespace Benchmarks.Trace
         [GlobalSetup]
         public void GlobalSetup()
         {
-            this.tracerProviderAlwaysOnSample = Sdk.CreateTracerProviderBuilder()
+            this.tracerProviderAlwaysOnSample = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource("AlwaysOnSample")
                 .SetSampler(new AlwaysOnSampler())
                 .Build();
 
-            this.tracerProviderAlwaysOffSample = Sdk.CreateTracerProviderBuilder()
+            this.tracerProviderAlwaysOffSample = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource("AlwaysOffSample")
                 .SetSampler(new AlwaysOffSampler())
                 .Build();
 
-            using var traceProviderNoop = Sdk.CreateTracerProviderBuilder().Build();
+            using var traceProviderNoop = OpenTelemetrySdk.CreateTracerProviderBuilder().Build();
 
             this.alwaysSampleTracer = TracerProvider.Default.GetTracer("AlwaysOnSample");
             this.neverSampleTracer = TracerProvider.Default.GetTracer("AlwaysOffSample");

--- a/test/Benchmarks/Trace/OpenTelemetrySdkBenchmarks.cs
+++ b/test/Benchmarks/Trace/OpenTelemetrySdkBenchmarks.cs
@@ -33,17 +33,17 @@ namespace Benchmarks.Trace
         [GlobalSetup]
         public void GlobalSetup()
         {
-            this.tracerProviderAlwaysOnSample = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            this.tracerProviderAlwaysOnSample = Sdk.CreateTracerProviderBuilder()
                 .AddSource("AlwaysOnSample")
                 .SetSampler(new AlwaysOnSampler())
                 .Build();
 
-            this.tracerProviderAlwaysOffSample = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            this.tracerProviderAlwaysOffSample = Sdk.CreateTracerProviderBuilder()
                 .AddSource("AlwaysOffSample")
                 .SetSampler(new AlwaysOffSampler())
                 .Build();
 
-            using var traceProviderNoop = OpenTelemetrySdk.CreateTracerProviderBuilder().Build();
+            using var traceProviderNoop = Sdk.CreateTracerProviderBuilder().Build();
 
             this.alwaysSampleTracer = TracerProvider.Default.GetTracer("AlwaysOnSample");
             this.neverSampleTracer = TracerProvider.Default.GetTracer("AlwaysOffSample");

--- a/test/Benchmarks/Trace/OpenTelemetrySdkBenchmarksActivity.cs
+++ b/test/Benchmarks/Trace/OpenTelemetrySdkBenchmarksActivity.cs
@@ -33,7 +33,7 @@ namespace Benchmarks.Trace
         [GlobalSetup]
         public void GlobalSetup()
         {
-            this.tracerProvider = Sdk.CreateTracerProviderBuilder()
+            this.tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource("BenchMark")
                 .Build();
         }

--- a/test/Benchmarks/Trace/OpenTelemetrySdkBenchmarksActivity.cs
+++ b/test/Benchmarks/Trace/OpenTelemetrySdkBenchmarksActivity.cs
@@ -33,7 +33,7 @@ namespace Benchmarks.Trace
         [GlobalSetup]
         public void GlobalSetup()
         {
-            this.tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            this.tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource("BenchMark")
                 .Build();
         }

--- a/test/Benchmarks/Trace/TraceBenchmarks.cs
+++ b/test/Benchmarks/Trace/TraceBenchmarks.cs
@@ -62,20 +62,20 @@ namespace Benchmarks.Trace
                 Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded,
             });
 
-            OpenTelemetrySdk.CreateTracerProviderBuilder()
+            Sdk.CreateTracerProviderBuilder()
                 .SetSampler(new AlwaysOnSampler())
                 .AddSource(this.sourceWithOneProcessor.Name)
                 .AddProcessor(new DummyActivityProcessor())
                 .Build();
 
-            OpenTelemetrySdk.CreateTracerProviderBuilder()
+            Sdk.CreateTracerProviderBuilder()
                 .SetSampler(new AlwaysOnSampler())
                 .AddSource(this.sourceWithTwoProcessors.Name)
                 .AddProcessor(new DummyActivityProcessor())
                 .AddProcessor(new DummyActivityProcessor())
                 .Build();
 
-            OpenTelemetrySdk.CreateTracerProviderBuilder()
+            Sdk.CreateTracerProviderBuilder()
                 .SetSampler(new AlwaysOnSampler())
                 .AddSource(this.sourceWithThreeProcessors.Name)
                 .AddProcessor(new DummyActivityProcessor())
@@ -83,14 +83,14 @@ namespace Benchmarks.Trace
                 .AddProcessor(new DummyActivityProcessor())
                 .Build();
 
-            OpenTelemetrySdk.CreateTracerProviderBuilder()
+            Sdk.CreateTracerProviderBuilder()
                 .SetSampler(new AlwaysOnSampler())
                 .AddSource(this.sourceWithOneLegacyActivityOperationNameSubscription.Name)
                 .AddLegacySource("TestOperationName")
                 .AddProcessor(new DummyActivityProcessor())
                 .Build();
 
-            OpenTelemetrySdk.CreateTracerProviderBuilder()
+            Sdk.CreateTracerProviderBuilder()
                 .SetSampler(new AlwaysOnSampler())
                 .AddSource(this.sourceWithTwoLegacyActivityOperationNameSubscriptions.Name)
                 .AddLegacySource("TestOperationName1")

--- a/test/Benchmarks/Trace/TraceBenchmarks.cs
+++ b/test/Benchmarks/Trace/TraceBenchmarks.cs
@@ -62,20 +62,20 @@ namespace Benchmarks.Trace
                 Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded,
             });
 
-            Sdk.CreateTracerProviderBuilder()
+            OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .SetSampler(new AlwaysOnSampler())
                 .AddSource(this.sourceWithOneProcessor.Name)
                 .AddProcessor(new DummyActivityProcessor())
                 .Build();
 
-            Sdk.CreateTracerProviderBuilder()
+            OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .SetSampler(new AlwaysOnSampler())
                 .AddSource(this.sourceWithTwoProcessors.Name)
                 .AddProcessor(new DummyActivityProcessor())
                 .AddProcessor(new DummyActivityProcessor())
                 .Build();
 
-            Sdk.CreateTracerProviderBuilder()
+            OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .SetSampler(new AlwaysOnSampler())
                 .AddSource(this.sourceWithThreeProcessors.Name)
                 .AddProcessor(new DummyActivityProcessor())
@@ -83,14 +83,14 @@ namespace Benchmarks.Trace
                 .AddProcessor(new DummyActivityProcessor())
                 .Build();
 
-            Sdk.CreateTracerProviderBuilder()
+            OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .SetSampler(new AlwaysOnSampler())
                 .AddSource(this.sourceWithOneLegacyActivityOperationNameSubscription.Name)
                 .AddLegacySource("TestOperationName")
                 .AddProcessor(new DummyActivityProcessor())
                 .Build();
 
-            Sdk.CreateTracerProviderBuilder()
+            OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .SetSampler(new AlwaysOnSampler())
                 .AddSource(this.sourceWithTwoLegacyActivityOperationNameSubscriptions.Name)
                 .AddLegacySource("TestOperationName1")

--- a/test/Benchmarks/Trace/TraceShimBenchmarks.cs
+++ b/test/Benchmarks/Trace/TraceShimBenchmarks.cs
@@ -33,20 +33,20 @@ namespace Benchmarks.Trace
         {
             Activity.DefaultIdFormat = ActivityIdFormat.W3C;
 
-            OpenTelemetrySdk.CreateTracerProviderBuilder()
+            Sdk.CreateTracerProviderBuilder()
                 .SetSampler(new AlwaysOnSampler())
                 .AddSource("Benchmark.OneProcessor")
                 .AddProcessor(new DummyActivityProcessor())
                 .Build();
 
-            OpenTelemetrySdk.CreateTracerProviderBuilder()
+            Sdk.CreateTracerProviderBuilder()
                 .SetSampler(new AlwaysOnSampler())
                 .AddSource("Benchmark.TwoProcessors")
                 .AddProcessor(new DummyActivityProcessor())
                 .AddProcessor(new DummyActivityProcessor())
                 .Build();
 
-            OpenTelemetrySdk.CreateTracerProviderBuilder()
+            Sdk.CreateTracerProviderBuilder()
                 .SetSampler(new AlwaysOnSampler())
                 .AddSource("Benchmark.ThreeProcessors")
                 .AddProcessor(new DummyActivityProcessor())

--- a/test/Benchmarks/Trace/TraceShimBenchmarks.cs
+++ b/test/Benchmarks/Trace/TraceShimBenchmarks.cs
@@ -33,20 +33,20 @@ namespace Benchmarks.Trace
         {
             Activity.DefaultIdFormat = ActivityIdFormat.W3C;
 
-            Sdk.CreateTracerProviderBuilder()
+            OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .SetSampler(new AlwaysOnSampler())
                 .AddSource("Benchmark.OneProcessor")
                 .AddProcessor(new DummyActivityProcessor())
                 .Build();
 
-            Sdk.CreateTracerProviderBuilder()
+            OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .SetSampler(new AlwaysOnSampler())
                 .AddSource("Benchmark.TwoProcessors")
                 .AddProcessor(new DummyActivityProcessor())
                 .AddProcessor(new DummyActivityProcessor())
                 .Build();
 
-            Sdk.CreateTracerProviderBuilder()
+            OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .SetSampler(new AlwaysOnSampler())
                 .AddSource("Benchmark.ThreeProcessors")
                 .AddProcessor(new DummyActivityProcessor())

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTests.cs
@@ -49,7 +49,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
 
             var activitySourceName = "otlp.collector.test";
 
-            var builder = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            var builder = Sdk.CreateTracerProviderBuilder()
                 .AddSource(activitySourceName)
                 .AddProcessor(exportActivityProcessor);
 

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTests.cs
@@ -49,7 +49,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
 
             var activitySourceName = "otlp.collector.test";
 
-            var builder = Sdk.CreateTracerProviderBuilder()
+            var builder = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource(activitySourceName)
                 .AddProcessor(exportActivityProcessor);
 

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterTest.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterTest.cs
@@ -94,7 +94,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
                 exporter.SetResource(Resources.Resource.Empty);
             }
 
-            var builder = Sdk.CreateTracerProviderBuilder()
+            var builder = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource(sources[0].Name)
                 .AddSource(sources[1].Name);
 
@@ -336,7 +336,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
                     endCalled = true;
                 };
 
-            var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+            var openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                             .AddSource(ActivitySourceName)
                             .AddProcessor(testActivityProcessor)
                             .AddOtlpExporter()

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterTest.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterTest.cs
@@ -94,7 +94,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
                 exporter.SetResource(Resources.Resource.Empty);
             }
 
-            var builder = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            var builder = Sdk.CreateTracerProviderBuilder()
                 .AddSource(sources[0].Name)
                 .AddSource(sources[1].Name);
 
@@ -336,7 +336,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
                     endCalled = true;
                 };
 
-            var openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
                             .AddSource(ActivitySourceName)
                             .AddProcessor(testActivityProcessor)
                             .AddOtlpExporter()

--- a/test/OpenTelemetry.Exporter.ZPages.Tests/ZPagesExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.ZPages.Tests/ZPagesExporterTests.cs
@@ -75,7 +75,7 @@ namespace OpenTelemetry.Exporter.ZPages.Tests
                     endCalled = true;
                 };
 
-            using var openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .AddProcessor(testActivityProcessor)
                 .AddZPagesExporter()

--- a/test/OpenTelemetry.Exporter.ZPages.Tests/ZPagesExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.ZPages.Tests/ZPagesExporterTests.cs
@@ -75,7 +75,7 @@ namespace OpenTelemetry.Exporter.ZPages.Tests
                     endCalled = true;
                 };
 
-            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .AddProcessor(testActivityProcessor)
                 .AddZPagesExporter()

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
@@ -110,7 +110,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Tests
             var zipkinExporter = new ZipkinExporter(exporterOptions);
             var exportActivityProcessor = new BatchActivityExportProcessor(zipkinExporter);
 
-            var openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .AddProcessor(testActivityProcessor)
                 .AddProcessor(exportActivityProcessor)

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
@@ -110,7 +110,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Tests
             var zipkinExporter = new ZipkinExporter(exporterOptions);
             var exportActivityProcessor = new BatchActivityExportProcessor(zipkinExporter);
 
-            var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+            var openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .AddProcessor(testActivityProcessor)
                 .AddProcessor(exportActivityProcessor)

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -148,8 +148,8 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
             }
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            OpenTelemetrySdk.SetDefaultTextMapPropagator(propagator.Object);
-            using (openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            Sdk.SetDefaultTextMapPropagator(propagator.Object);
+            using (openTelemetry = Sdk.CreateTracerProviderBuilder()
                 .AddAspNetInstrumentation(
                 (options) =>
                 {
@@ -369,8 +369,8 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
             var activity = new Activity(HttpInListener.ActivityOperationName);
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            OpenTelemetrySdk.SetDefaultTextMapPropagator(propagator.Object);
-            using (var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            Sdk.SetDefaultTextMapPropagator(propagator.Object);
+            using (var openTelemetry = Sdk.CreateTracerProviderBuilder()
                 .SetSampler(new TestSampler(samplingDecision))
                 .AddAspNetInstrumentation()
                 .AddProcessor(activityProcessor.Object).Build())
@@ -415,8 +415,8 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
 
             bool isFilterCalled = false;
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            OpenTelemetrySdk.SetDefaultTextMapPropagator(propagator.Object);
-            using (var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            Sdk.SetDefaultTextMapPropagator(propagator.Object);
+            using (var openTelemetry = Sdk.CreateTracerProviderBuilder()
                 .AddAspNetInstrumentation(options =>
                 {
                     options.Filter = context =>

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -148,8 +148,8 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
             }
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            Sdk.SetDefaultTextMapPropagator(propagator.Object);
-            using (openTelemetry = Sdk.CreateTracerProviderBuilder()
+            OpenTelemetrySdk.SetDefaultTextMapPropagator(propagator.Object);
+            using (openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddAspNetInstrumentation(
                 (options) =>
                 {
@@ -369,8 +369,8 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
             var activity = new Activity(HttpInListener.ActivityOperationName);
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            Sdk.SetDefaultTextMapPropagator(propagator.Object);
-            using (var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            OpenTelemetrySdk.SetDefaultTextMapPropagator(propagator.Object);
+            using (var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .SetSampler(new TestSampler(samplingDecision))
                 .AddAspNetInstrumentation()
                 .AddProcessor(activityProcessor.Object).Build())
@@ -415,8 +415,8 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
 
             bool isFilterCalled = false;
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            Sdk.SetDefaultTextMapPropagator(propagator.Object);
-            using (var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            OpenTelemetrySdk.SetDefaultTextMapPropagator(propagator.Object);
+            using (var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddAspNetInstrumentation(options =>
                 {
                     options.Filter = context =>

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
@@ -67,7 +67,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
             void ConfigureTestServices(IServiceCollection services)
             {
-                this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+                this.openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                     .AddAspNetCoreInstrumentation()
                     .AddProcessor(activityProcessor.Object)
                     .Build();
@@ -110,7 +110,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
             void ConfigureTestServices(IServiceCollection services)
             {
-                this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+                this.openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                     .AddAspNetCoreInstrumentation(options =>
                     {
                         if (shouldEnrich)
@@ -156,7 +156,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
                 .WithWebHostBuilder(builder =>
                     builder.ConfigureTestServices(services =>
                     {
-                        this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder().AddAspNetCoreInstrumentation()
+                        this.openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder().AddAspNetCoreInstrumentation()
                         .AddProcessor(activityProcessor.Object)
                         .Build();
                     })))
@@ -217,8 +217,8 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
                     .WithWebHostBuilder(builder =>
                         builder.ConfigureTestServices(services =>
                         {
-                            Sdk.SetDefaultTextMapPropagator(propagator.Object);
-                            this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+                            OpenTelemetrySdk.SetDefaultTextMapPropagator(propagator.Object);
+                            this.openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                                 .AddAspNetCoreInstrumentation()
                                 .AddProcessor(activityProcessor.Object)
                                 .Build();
@@ -264,7 +264,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             }
             finally
             {
-                Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+                OpenTelemetrySdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
                 {
                     new TraceContextPropagator(),
                     new BaggagePropagator(),
@@ -279,7 +279,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
 
             void ConfigureTestServices(IServiceCollection services)
             {
-                this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+                this.openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                     .AddAspNetCoreInstrumentation((opt) => opt.Filter = (ctx) => ctx.Request.Path != "/api/values/2")
                     .AddProcessor(activityProcessor.Object)
                     .Build();
@@ -323,7 +323,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
 
             void ConfigureTestServices(IServiceCollection services)
             {
-                this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+                this.openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                     .AddAspNetCoreInstrumentation((opt) => opt.Filter = (ctx) =>
                     {
                         if (ctx.Request.Path == "/api/values/2")
@@ -389,14 +389,14 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
                 var expectedTraceState = "rojo=1,congo=2";
                 var activityContext = new ActivityContext(expectedTraceId, expectedParentSpanId, ActivityTraceFlags.Recorded, expectedTraceState);
                 var expectedBaggage = Baggage.SetBaggage("key1", "value1").SetBaggage("key2", "value2");
-                Sdk.SetDefaultTextMapPropagator(new ExtractOnlyPropagator(activityContext, expectedBaggage));
+                OpenTelemetrySdk.SetDefaultTextMapPropagator(new ExtractOnlyPropagator(activityContext, expectedBaggage));
 
                 // Arrange
                 using (var testFactory = this.factory
                     .WithWebHostBuilder(builder =>
                         builder.ConfigureTestServices(services =>
                         {
-                            this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+                            this.openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                             .SetSampler(new TestSampler(samplingDecision))
                             .AddAspNetCoreInstrumentation()
                             .Build();
@@ -429,7 +429,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             }
             finally
             {
-                Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+                OpenTelemetrySdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
                 {
                     new TraceContextPropagator(),
                     new BaggagePropagator(),
@@ -447,7 +447,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
                 var expectedTraceState = "rojo=1,congo=2";
                 var activityContext = new ActivityContext(expectedTraceId, expectedParentSpanId, ActivityTraceFlags.Recorded, expectedTraceState);
                 var expectedBaggage = Baggage.SetBaggage("key1", "value1").SetBaggage("key2", "value2");
-                Sdk.SetDefaultTextMapPropagator(new ExtractOnlyPropagator(activityContext, expectedBaggage));
+                OpenTelemetrySdk.SetDefaultTextMapPropagator(new ExtractOnlyPropagator(activityContext, expectedBaggage));
 
                 // Arrange
                 bool isFilterCalled = false;
@@ -455,7 +455,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
                     .WithWebHostBuilder(builder =>
                         builder.ConfigureTestServices(services =>
                         {
-                            this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+                            this.openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                             .AddAspNetCoreInstrumentation(options =>
                             {
                                 options.Filter = context =>
@@ -498,7 +498,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             }
             finally
             {
-                Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+                OpenTelemetrySdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
                 {
                     new TraceContextPropagator(),
                     new BaggagePropagator(),
@@ -516,7 +516,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             bool enrichCalled = false;
             void ConfigureTestServices(IServiceCollection services)
             {
-                this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+                this.openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                     .SetSampler(new TestSampler(samplingDecision))
                     .AddAspNetCoreInstrumentation(options =>
                     {

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
@@ -67,7 +67,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
             void ConfigureTestServices(IServiceCollection services)
             {
-                this.openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+                this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
                     .AddAspNetCoreInstrumentation()
                     .AddProcessor(activityProcessor.Object)
                     .Build();
@@ -110,7 +110,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
             void ConfigureTestServices(IServiceCollection services)
             {
-                this.openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+                this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
                     .AddAspNetCoreInstrumentation(options =>
                     {
                         if (shouldEnrich)
@@ -156,7 +156,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
                 .WithWebHostBuilder(builder =>
                     builder.ConfigureTestServices(services =>
                     {
-                        this.openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder().AddAspNetCoreInstrumentation()
+                        this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder().AddAspNetCoreInstrumentation()
                         .AddProcessor(activityProcessor.Object)
                         .Build();
                     })))
@@ -217,8 +217,8 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
                     .WithWebHostBuilder(builder =>
                         builder.ConfigureTestServices(services =>
                         {
-                            OpenTelemetrySdk.SetDefaultTextMapPropagator(propagator.Object);
-                            this.openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+                            Sdk.SetDefaultTextMapPropagator(propagator.Object);
+                            this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
                                 .AddAspNetCoreInstrumentation()
                                 .AddProcessor(activityProcessor.Object)
                                 .Build();
@@ -264,7 +264,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             }
             finally
             {
-                OpenTelemetrySdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+                Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
                 {
                     new TraceContextPropagator(),
                     new BaggagePropagator(),
@@ -279,7 +279,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
 
             void ConfigureTestServices(IServiceCollection services)
             {
-                this.openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+                this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
                     .AddAspNetCoreInstrumentation((opt) => opt.Filter = (ctx) => ctx.Request.Path != "/api/values/2")
                     .AddProcessor(activityProcessor.Object)
                     .Build();
@@ -323,7 +323,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
 
             void ConfigureTestServices(IServiceCollection services)
             {
-                this.openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+                this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
                     .AddAspNetCoreInstrumentation((opt) => opt.Filter = (ctx) =>
                     {
                         if (ctx.Request.Path == "/api/values/2")
@@ -389,14 +389,14 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
                 var expectedTraceState = "rojo=1,congo=2";
                 var activityContext = new ActivityContext(expectedTraceId, expectedParentSpanId, ActivityTraceFlags.Recorded, expectedTraceState);
                 var expectedBaggage = Baggage.SetBaggage("key1", "value1").SetBaggage("key2", "value2");
-                OpenTelemetrySdk.SetDefaultTextMapPropagator(new ExtractOnlyPropagator(activityContext, expectedBaggage));
+                Sdk.SetDefaultTextMapPropagator(new ExtractOnlyPropagator(activityContext, expectedBaggage));
 
                 // Arrange
                 using (var testFactory = this.factory
                     .WithWebHostBuilder(builder =>
                         builder.ConfigureTestServices(services =>
                         {
-                            this.openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+                            this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
                             .SetSampler(new TestSampler(samplingDecision))
                             .AddAspNetCoreInstrumentation()
                             .Build();
@@ -429,7 +429,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             }
             finally
             {
-                OpenTelemetrySdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+                Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
                 {
                     new TraceContextPropagator(),
                     new BaggagePropagator(),
@@ -447,7 +447,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
                 var expectedTraceState = "rojo=1,congo=2";
                 var activityContext = new ActivityContext(expectedTraceId, expectedParentSpanId, ActivityTraceFlags.Recorded, expectedTraceState);
                 var expectedBaggage = Baggage.SetBaggage("key1", "value1").SetBaggage("key2", "value2");
-                OpenTelemetrySdk.SetDefaultTextMapPropagator(new ExtractOnlyPropagator(activityContext, expectedBaggage));
+                Sdk.SetDefaultTextMapPropagator(new ExtractOnlyPropagator(activityContext, expectedBaggage));
 
                 // Arrange
                 bool isFilterCalled = false;
@@ -455,7 +455,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
                     .WithWebHostBuilder(builder =>
                         builder.ConfigureTestServices(services =>
                         {
-                            this.openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+                            this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
                             .AddAspNetCoreInstrumentation(options =>
                             {
                                 options.Filter = context =>
@@ -498,7 +498,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             }
             finally
             {
-                OpenTelemetrySdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+                Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
                 {
                     new TraceContextPropagator(),
                     new BaggagePropagator(),
@@ -516,7 +516,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             bool enrichCalled = false;
             void ConfigureTestServices(IServiceCollection services)
             {
-                this.openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+                this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
                     .SetSampler(new TestSampler(samplingDecision))
                     .AddAspNetCoreInstrumentation(options =>
                     {

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.client.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.client.cs
@@ -52,7 +52,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
                 .SetIdFormat(ActivityIdFormat.W3C)
                 .Start();
 
-            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using (Sdk.CreateTracerProviderBuilder()
                     .SetSampler(new AlwaysOnSampler())
                     .AddGrpcClientInstrumentation(options =>
                     {
@@ -114,7 +114,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
             var parent = new Activity("parent")
                 .Start();
 
-            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using (Sdk.CreateTracerProviderBuilder()
                     .SetSampler(new AlwaysOnSampler())
                     .AddGrpcClientInstrumentation(options =>
                     {
@@ -163,7 +163,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
             var parent = new Activity("parent")
                 .Start();
 
-            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using (Sdk.CreateTracerProviderBuilder()
                     .SetSampler(new AlwaysOnSampler())
                     .AddGrpcClientInstrumentation(o =>
                     {
@@ -231,13 +231,13 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
                         action(message, "customField", "customValue");
                     });
 
-                OpenTelemetrySdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+                Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
                 {
                     new TraceContextPropagator(),
                     propagator.Object,
                 }));
 
-                using (OpenTelemetrySdk.CreateTracerProviderBuilder()
+                using (Sdk.CreateTracerProviderBuilder()
                     .AddSource("test-source")
                     .AddGrpcClientInstrumentation(o =>
                     {
@@ -297,7 +297,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
             }
             finally
             {
-                OpenTelemetrySdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+                Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
                 {
                     new TraceContextPropagator(),
                     new BaggagePropagator(),
@@ -323,11 +323,11 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
                         isPropagatorCalled = true;
                     });
 
-                OpenTelemetrySdk.SetDefaultTextMapPropagator(propagator.Object);
+                Sdk.SetDefaultTextMapPropagator(propagator.Object);
 
                 var headers = new Metadata();
 
-                using (OpenTelemetrySdk.CreateTracerProviderBuilder()
+                using (Sdk.CreateTracerProviderBuilder()
                     .AddSource("test-source")
                     .AddGrpcClientInstrumentation(o =>
                     {
@@ -359,7 +359,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
             }
             finally
             {
-                OpenTelemetrySdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+                Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
                 {
                     new TraceContextPropagator(),
                     new BaggagePropagator(),
@@ -385,13 +385,13 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
                         isPropagatorCalled = true;
                     });
 
-                OpenTelemetrySdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+                Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
                 {
                     new TraceContextPropagator(),
                     propagator.Object,
                 }));
 
-                using (OpenTelemetrySdk.CreateTracerProviderBuilder()
+                using (Sdk.CreateTracerProviderBuilder()
                     .AddSource("test-source")
                     .AddGrpcClientInstrumentation(o =>
                     {
@@ -420,7 +420,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
             }
             finally
             {
-                OpenTelemetrySdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+                Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
                 {
                     new TraceContextPropagator(),
                     new BaggagePropagator(),

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.client.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.client.cs
@@ -52,7 +52,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
                 .SetIdFormat(ActivityIdFormat.W3C)
                 .Start();
 
-            using (Sdk.CreateTracerProviderBuilder()
+            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
                     .SetSampler(new AlwaysOnSampler())
                     .AddGrpcClientInstrumentation(options =>
                     {
@@ -114,7 +114,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
             var parent = new Activity("parent")
                 .Start();
 
-            using (Sdk.CreateTracerProviderBuilder()
+            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
                     .SetSampler(new AlwaysOnSampler())
                     .AddGrpcClientInstrumentation(options =>
                     {
@@ -163,7 +163,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
             var parent = new Activity("parent")
                 .Start();
 
-            using (Sdk.CreateTracerProviderBuilder()
+            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
                     .SetSampler(new AlwaysOnSampler())
                     .AddGrpcClientInstrumentation(o =>
                     {
@@ -231,13 +231,13 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
                         action(message, "customField", "customValue");
                     });
 
-                Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+                OpenTelemetrySdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
                 {
                     new TraceContextPropagator(),
                     propagator.Object,
                 }));
 
-                using (Sdk.CreateTracerProviderBuilder()
+                using (OpenTelemetrySdk.CreateTracerProviderBuilder()
                     .AddSource("test-source")
                     .AddGrpcClientInstrumentation(o =>
                     {
@@ -297,7 +297,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
             }
             finally
             {
-                Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+                OpenTelemetrySdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
                 {
                     new TraceContextPropagator(),
                     new BaggagePropagator(),
@@ -323,11 +323,11 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
                         isPropagatorCalled = true;
                     });
 
-                Sdk.SetDefaultTextMapPropagator(propagator.Object);
+                OpenTelemetrySdk.SetDefaultTextMapPropagator(propagator.Object);
 
                 var headers = new Metadata();
 
-                using (Sdk.CreateTracerProviderBuilder()
+                using (OpenTelemetrySdk.CreateTracerProviderBuilder()
                     .AddSource("test-source")
                     .AddGrpcClientInstrumentation(o =>
                     {
@@ -359,7 +359,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
             }
             finally
             {
-                Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+                OpenTelemetrySdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
                 {
                     new TraceContextPropagator(),
                     new BaggagePropagator(),
@@ -385,13 +385,13 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
                         isPropagatorCalled = true;
                     });
 
-                Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+                OpenTelemetrySdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
                 {
                     new TraceContextPropagator(),
                     propagator.Object,
                 }));
 
-                using (Sdk.CreateTracerProviderBuilder()
+                using (OpenTelemetrySdk.CreateTracerProviderBuilder()
                     .AddSource("test-source")
                     .AddGrpcClientInstrumentation(o =>
                     {
@@ -420,7 +420,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
             }
             finally
             {
-                Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+                OpenTelemetrySdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
                 {
                     new TraceContextPropagator(),
                     new BaggagePropagator(),

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.server.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.server.cs
@@ -53,7 +53,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
         {
             var processor = new Mock<BaseProcessor<Activity>>();
 
-            var tracerProviderBuilder = Sdk.CreateTracerProviderBuilder();
+            var tracerProviderBuilder = OpenTelemetrySdk.CreateTracerProviderBuilder();
 
             if (enableGrpcAspNetCoreSupport.HasValue)
             {
@@ -121,9 +121,9 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
             try
             {
                 // B3Propagator along with the headers passed to the client.SayHello ensure that the instrumentation creates a sibling activity
-                Sdk.SetDefaultTextMapPropagator(new B3Propagator());
+                OpenTelemetrySdk.SetDefaultTextMapPropagator(new B3Propagator());
                 var processor = new Mock<BaseProcessor<Activity>>();
-                var tracerProviderBuilder = Sdk.CreateTracerProviderBuilder();
+                var tracerProviderBuilder = OpenTelemetrySdk.CreateTracerProviderBuilder();
 
                 if (enableGrpcAspNetCoreSupport.HasValue)
                 {
@@ -189,7 +189,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
             finally
             {
                 // Set the SDK to use the default propagator for other unit tests
-                Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+                OpenTelemetrySdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
                 {
                 new TraceContextPropagator(),
                 new BaggagePropagator(),

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.server.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.server.cs
@@ -53,7 +53,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
         {
             var processor = new Mock<BaseProcessor<Activity>>();
 
-            var tracerProviderBuilder = OpenTelemetrySdk.CreateTracerProviderBuilder();
+            var tracerProviderBuilder = Sdk.CreateTracerProviderBuilder();
 
             if (enableGrpcAspNetCoreSupport.HasValue)
             {
@@ -121,9 +121,9 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
             try
             {
                 // B3Propagator along with the headers passed to the client.SayHello ensure that the instrumentation creates a sibling activity
-                OpenTelemetrySdk.SetDefaultTextMapPropagator(new B3Propagator());
+                Sdk.SetDefaultTextMapPropagator(new B3Propagator());
                 var processor = new Mock<BaseProcessor<Activity>>();
-                var tracerProviderBuilder = OpenTelemetrySdk.CreateTracerProviderBuilder();
+                var tracerProviderBuilder = Sdk.CreateTracerProviderBuilder();
 
                 if (enableGrpcAspNetCoreSupport.HasValue)
                 {
@@ -189,7 +189,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
             finally
             {
                 // Set the SDK to use the default propagator for other unit tests
-                OpenTelemetrySdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+                Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
                 {
                 new TraceContextPropagator(),
                 new BaggagePropagator(),

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.netcore31.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.netcore31.cs
@@ -91,7 +91,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
             //             }
             //         });
 
-            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using (Sdk.CreateTracerProviderBuilder()
                         .AddHttpClientInstrumentation(o =>
                         {
                             if (shouldEnrich)
@@ -151,9 +151,9 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
             parent.TraceStateString = "k1=v1,k2=v2";
             parent.ActivityTraceFlags = ActivityTraceFlags.Recorded;
 
-            OpenTelemetrySdk.SetDefaultTextMapPropagator(propagator.Object);
+            Sdk.SetDefaultTextMapPropagator(propagator.Object);
 
-            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using (Sdk.CreateTracerProviderBuilder()
                    .AddHttpClientInstrumentation((opt) =>
                    {
                        if (shouldEnrich)
@@ -184,7 +184,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
 
             Assert.Equal($"00/{activity.Context.TraceId}/{activity.Context.SpanId}/01", traceparents.Single());
             Assert.Equal("k1=v1,k2=v2", tracestates.Single());
-            OpenTelemetrySdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+            Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
             {
                 new TraceContextPropagator(),
                 new BaggagePropagator(),
@@ -218,9 +218,9 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
                 parent.TraceStateString = "k1=v1,k2=v2";
                 parent.ActivityTraceFlags = ActivityTraceFlags.Recorded;
 
-                OpenTelemetrySdk.SetDefaultTextMapPropagator(propagator.Object);
+                Sdk.SetDefaultTextMapPropagator(propagator.Object);
 
-                using (OpenTelemetrySdk.CreateTracerProviderBuilder()
+                using (Sdk.CreateTracerProviderBuilder()
                        .AddHttpClientInstrumentation()
                        .AddProcessor(processor.Object)
                        .Build())
@@ -240,7 +240,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
             }
             finally
             {
-                OpenTelemetrySdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+                Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
                 {
                     new TraceContextPropagator(),
                     new BaggagePropagator(),
@@ -253,7 +253,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         {
             var processor = new Mock<BaseProcessor<Activity>>();
 
-            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using (Sdk.CreateTracerProviderBuilder()
                    .AddHttpClientInstrumentation()
                    .AddProcessor(processor.Object)
                    .Build())
@@ -281,7 +281,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
 
             request.Headers.Add("traceparent", "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01");
 
-            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using (Sdk.CreateTracerProviderBuilder()
                    .AddHttpClientInstrumentation()
                    .AddProcessor(processor.Object)
                    .Build())
@@ -297,7 +297,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         public async void RequestNotCollectedWhenInstrumentationFilterApplied()
         {
             var processor = new Mock<BaseProcessor<Activity>>();
-            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using (Sdk.CreateTracerProviderBuilder()
                                .AddHttpClientInstrumentation(
                         (opt) => opt.Filter = (req) => !req.RequestUri.OriginalString.Contains(this.url))
                                .AddProcessor(processor.Object)
@@ -314,7 +314,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         public async void RequestNotCollectedWhenInstrumentationFilterThrowsException()
         {
             var processor = new Mock<BaseProcessor<Activity>>();
-            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using (Sdk.CreateTracerProviderBuilder()
                                .AddHttpClientInstrumentation(
                         (opt) => opt.Filter = (req) => throw new Exception("From InstrumentationFilter"))
                                .AddProcessor(processor.Object)
@@ -344,7 +344,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
 
             Baggage.SetBaggage("k2", "v2");
 
-            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using (Sdk.CreateTracerProviderBuilder()
                 .AddHttpClientInstrumentation(options => options.Enrich = ActivityEnrichment)
                 .AddProcessor(activityProcessor.Object)
                 .Build())
@@ -372,7 +372,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
             parent.TraceStateString = "k1=v1,k2=v2";
             parent.ActivityTraceFlags = ActivityTraceFlags.Recorded;
             Baggage.Current.SetBaggage("b1", "v1");
-            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using (Sdk.CreateTracerProviderBuilder()
                         .AddHttpClientInstrumentation()
                         .AddProcessor(processor.Object)
                         .Build())

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.netcore31.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.netcore31.cs
@@ -91,7 +91,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
             //             }
             //         });
 
-            using (Sdk.CreateTracerProviderBuilder()
+            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
                         .AddHttpClientInstrumentation(o =>
                         {
                             if (shouldEnrich)
@@ -151,9 +151,9 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
             parent.TraceStateString = "k1=v1,k2=v2";
             parent.ActivityTraceFlags = ActivityTraceFlags.Recorded;
 
-            Sdk.SetDefaultTextMapPropagator(propagator.Object);
+            OpenTelemetrySdk.SetDefaultTextMapPropagator(propagator.Object);
 
-            using (Sdk.CreateTracerProviderBuilder()
+            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
                    .AddHttpClientInstrumentation((opt) =>
                    {
                        if (shouldEnrich)
@@ -184,7 +184,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
 
             Assert.Equal($"00/{activity.Context.TraceId}/{activity.Context.SpanId}/01", traceparents.Single());
             Assert.Equal("k1=v1,k2=v2", tracestates.Single());
-            Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+            OpenTelemetrySdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
             {
                 new TraceContextPropagator(),
                 new BaggagePropagator(),
@@ -218,9 +218,9 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
                 parent.TraceStateString = "k1=v1,k2=v2";
                 parent.ActivityTraceFlags = ActivityTraceFlags.Recorded;
 
-                Sdk.SetDefaultTextMapPropagator(propagator.Object);
+                OpenTelemetrySdk.SetDefaultTextMapPropagator(propagator.Object);
 
-                using (Sdk.CreateTracerProviderBuilder()
+                using (OpenTelemetrySdk.CreateTracerProviderBuilder()
                        .AddHttpClientInstrumentation()
                        .AddProcessor(processor.Object)
                        .Build())
@@ -240,7 +240,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
             }
             finally
             {
-                Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+                OpenTelemetrySdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
                 {
                     new TraceContextPropagator(),
                     new BaggagePropagator(),
@@ -253,7 +253,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         {
             var processor = new Mock<BaseProcessor<Activity>>();
 
-            using (Sdk.CreateTracerProviderBuilder()
+            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
                    .AddHttpClientInstrumentation()
                    .AddProcessor(processor.Object)
                    .Build())
@@ -281,7 +281,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
 
             request.Headers.Add("traceparent", "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01");
 
-            using (Sdk.CreateTracerProviderBuilder()
+            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
                    .AddHttpClientInstrumentation()
                    .AddProcessor(processor.Object)
                    .Build())
@@ -297,7 +297,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         public async void RequestNotCollectedWhenInstrumentationFilterApplied()
         {
             var processor = new Mock<BaseProcessor<Activity>>();
-            using (Sdk.CreateTracerProviderBuilder()
+            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
                                .AddHttpClientInstrumentation(
                         (opt) => opt.Filter = (req) => !req.RequestUri.OriginalString.Contains(this.url))
                                .AddProcessor(processor.Object)
@@ -314,7 +314,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         public async void RequestNotCollectedWhenInstrumentationFilterThrowsException()
         {
             var processor = new Mock<BaseProcessor<Activity>>();
-            using (Sdk.CreateTracerProviderBuilder()
+            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
                                .AddHttpClientInstrumentation(
                         (opt) => opt.Filter = (req) => throw new Exception("From InstrumentationFilter"))
                                .AddProcessor(processor.Object)
@@ -344,7 +344,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
 
             Baggage.SetBaggage("k2", "v2");
 
-            using (Sdk.CreateTracerProviderBuilder()
+            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddHttpClientInstrumentation(options => options.Enrich = ActivityEnrichment)
                 .AddProcessor(activityProcessor.Object)
                 .Build())
@@ -372,7 +372,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
             parent.TraceStateString = "k1=v1,k2=v2";
             parent.ActivityTraceFlags = ActivityTraceFlags.Recorded;
             Baggage.Current.SetBaggage("b1", "v1");
-            using (Sdk.CreateTracerProviderBuilder()
+            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
                         .AddHttpClientInstrumentation()
                         .AddProcessor(processor.Object)
                         .Build())

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.netcore31.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.netcore31.cs
@@ -55,7 +55,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
 
             using (serverLifeTime)
 
-            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using (Sdk.CreateTracerProviderBuilder()
                                .AddHttpClientInstrumentation((opt) =>
                                {
                                    opt.SetHttpFlavor = tc.SetHttpFlavor;
@@ -163,7 +163,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         {
             Counter = 0;
             var processor = new Mock<BaseProcessor<Activity>>();
-            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using (Sdk.CreateTracerProviderBuilder()
                 .SetSampler(sampler)
                 .AddHttpClientInstrumentation(options => options.Enrich = ActivityEnrichmentCounter)
                 .AddProcessor(processor.Object)

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.netcore31.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.netcore31.cs
@@ -55,7 +55,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
 
             using (serverLifeTime)
 
-            using (Sdk.CreateTracerProviderBuilder()
+            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
                                .AddHttpClientInstrumentation((opt) =>
                                {
                                    opt.SetHttpFlavor = tc.SetHttpFlavor;
@@ -163,7 +163,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         {
             Counter = 0;
             var processor = new Mock<BaseProcessor<Activity>>();
-            using (Sdk.CreateTracerProviderBuilder()
+            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .SetSampler(sampler)
                 .AddHttpClientInstrumentation(options => options.Enrich = ActivityEnrichmentCounter)
                 .AddProcessor(processor.Object)

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestActivitySourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestActivitySourceTests.netfx.cs
@@ -50,7 +50,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
 
             // Need to touch something in HttpWebRequestActivitySource/Sdk to do the static injection.
             GC.KeepAlive(HttpWebRequestActivitySource.Options);
-            _ = OpenTelemetrySdk.SuppressInstrumentation;
+            _ = Sdk.SuppressInstrumentation;
         }
 
         public HttpWebRequestActivitySourceTests()

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestActivitySourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestActivitySourceTests.netfx.cs
@@ -50,7 +50,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
 
             // Need to touch something in HttpWebRequestActivitySource/Sdk to do the static injection.
             GC.KeepAlive(HttpWebRequestActivitySource.Options);
-            _ = Sdk.SuppressInstrumentation;
+            _ = OpenTelemetrySdk.SuppressInstrumentation;
         }
 
         public HttpWebRequestActivitySourceTests()

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.Basic.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.Basic.netfx.cs
@@ -61,7 +61,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         public async Task HttpWebRequestInstrumentationInjectsHeadersAsync()
         {
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            using var shutdownSignal = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpClientInstrumentation()
                 .Build();
@@ -107,8 +107,8 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
                     contentFromPropagator = context.ActivityContext;
                 });
 
-            Sdk.SetDefaultTextMapPropagator(propagator.Object);
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            OpenTelemetrySdk.SetDefaultTextMapPropagator(propagator.Object);
+            using var shutdownSignal = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpClientInstrumentation()
                 .Build();
@@ -135,7 +135,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
             Assert.NotEqual(default, contentFromPropagator.SpanId);
 
             parent.Stop();
-            Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+            OpenTelemetrySdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
             {
                 new TraceContextPropagator(),
                 new BaggagePropagator(),
@@ -154,8 +154,8 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
                 });
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            Sdk.SetDefaultTextMapPropagator(propagator.Object);
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            OpenTelemetrySdk.SetDefaultTextMapPropagator(propagator.Object);
+            using var shutdownSignal = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpClientInstrumentation()
                 .Build();
@@ -188,7 +188,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
             Assert.Equal("k1=v1,k2=v2", tracestate);
 
             parent.Stop();
-            Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+            OpenTelemetrySdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
             {
                 new TraceContextPropagator(),
                 new BaggagePropagator(),
@@ -199,7 +199,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         public async Task HttpWebRequestInstrumentationBacksOffIfAlreadyInstrumented()
         {
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            using var shutdownSignal = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpClientInstrumentation()
                 .Build();
@@ -222,7 +222,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         public async Task RequestNotCollectedWhenInstrumentationFilterApplied()
         {
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            using var shutdownSignal = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpClientInstrumentation(
                     c => c.Filter = (req) => !req.RequestUri.OriginalString.Contains(this.url))
@@ -238,7 +238,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         public async Task RequestNotCollectedWhenInstrumentationFilterThrowsException()
         {
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            using var shutdownSignal = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpClientInstrumentation(
                     c => c.Filter = (req) => throw new Exception("From Instrumentation filter"))
@@ -256,7 +256,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         public void AddHttpClientInstrumentationUsesHttpWebRequestInstrumentationOptions()
         {
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var tracerProviderSdk = Sdk.CreateTracerProviderBuilder()
+            using var tracerProviderSdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpClientInstrumentation(options =>
                 {

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.Basic.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.Basic.netfx.cs
@@ -61,7 +61,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         public async Task HttpWebRequestInstrumentationInjectsHeadersAsync()
         {
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpClientInstrumentation()
                 .Build();
@@ -107,8 +107,8 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
                     contentFromPropagator = context.ActivityContext;
                 });
 
-            OpenTelemetrySdk.SetDefaultTextMapPropagator(propagator.Object);
-            using var shutdownSignal = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            Sdk.SetDefaultTextMapPropagator(propagator.Object);
+            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpClientInstrumentation()
                 .Build();
@@ -135,7 +135,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
             Assert.NotEqual(default, contentFromPropagator.SpanId);
 
             parent.Stop();
-            OpenTelemetrySdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+            Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
             {
                 new TraceContextPropagator(),
                 new BaggagePropagator(),
@@ -154,8 +154,8 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
                 });
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            OpenTelemetrySdk.SetDefaultTextMapPropagator(propagator.Object);
-            using var shutdownSignal = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            Sdk.SetDefaultTextMapPropagator(propagator.Object);
+            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpClientInstrumentation()
                 .Build();
@@ -188,7 +188,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
             Assert.Equal("k1=v1,k2=v2", tracestate);
 
             parent.Stop();
-            OpenTelemetrySdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+            Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
             {
                 new TraceContextPropagator(),
                 new BaggagePropagator(),
@@ -199,7 +199,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         public async Task HttpWebRequestInstrumentationBacksOffIfAlreadyInstrumented()
         {
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpClientInstrumentation()
                 .Build();
@@ -222,7 +222,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         public async Task RequestNotCollectedWhenInstrumentationFilterApplied()
         {
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpClientInstrumentation(
                     c => c.Filter = (req) => !req.RequestUri.OriginalString.Contains(this.url))
@@ -238,7 +238,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         public async Task RequestNotCollectedWhenInstrumentationFilterThrowsException()
         {
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpClientInstrumentation(
                     c => c.Filter = (req) => throw new Exception("From Instrumentation filter"))
@@ -256,7 +256,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         public void AddHttpClientInstrumentationUsesHttpWebRequestInstrumentationOptions()
         {
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var tracerProviderSdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var tracerProviderSdk = Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpClientInstrumentation(options =>
                 {

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.netfx.cs
@@ -46,7 +46,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
                 out var port);
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpClientInstrumentation(options =>
                 {

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.netfx.cs
@@ -46,7 +46,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
                 out var port);
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            using var shutdownSignal = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpClientInstrumentation(options =>
                 {

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
@@ -87,7 +87,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests
         {
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
             var sampler = new TestSampler();
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            using var shutdownSignal = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .SetSampler(sampler)
                 .AddSqlClientInstrumentation(options =>
@@ -164,7 +164,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests
             using var sqlCommand = sqlConnection.CreateCommand();
 
             var processor = new Mock<BaseProcessor<Activity>>();
-            using (Sdk.CreateTracerProviderBuilder()
+            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
                     .AddSqlClientInstrumentation(
                         (opt) =>
                         {
@@ -231,7 +231,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests
             using var sqlCommand = sqlConnection.CreateCommand();
 
             var processor = new Mock<BaseProcessor<Activity>>();
-            using (Sdk.CreateTracerProviderBuilder()
+            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSqlClientInstrumentation(options =>
                 {
                     options.RecordException = recordException;
@@ -297,7 +297,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests
             {
                 SamplingAction = _ => new SamplingResult(SamplingDecision.Drop),
             };
-            using (Sdk.CreateTracerProviderBuilder()
+            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSqlClientInstrumentation()
                 .SetSampler(sampler)
                 .Build())

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
@@ -87,7 +87,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests
         {
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
             var sampler = new TestSampler();
-            using var shutdownSignal = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .SetSampler(sampler)
                 .AddSqlClientInstrumentation(options =>
@@ -164,7 +164,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests
             using var sqlCommand = sqlConnection.CreateCommand();
 
             var processor = new Mock<BaseProcessor<Activity>>();
-            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using (Sdk.CreateTracerProviderBuilder()
                     .AddSqlClientInstrumentation(
                         (opt) =>
                         {
@@ -231,7 +231,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests
             using var sqlCommand = sqlConnection.CreateCommand();
 
             var processor = new Mock<BaseProcessor<Activity>>();
-            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using (Sdk.CreateTracerProviderBuilder()
                 .AddSqlClientInstrumentation(options =>
                 {
                     options.RecordException = recordException;
@@ -297,7 +297,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests
             {
                 SamplingAction = _ => new SamplingResult(SamplingDecision.Drop),
             };
-            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using (Sdk.CreateTracerProviderBuilder()
                 .AddSqlClientInstrumentation()
                 .SetSampler(sampler)
                 .Build())

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
@@ -51,7 +51,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests
         public async Task SuccessfulCommandTest(CommandType commandType, string commandText, bool captureText, bool isFailure = false)
         {
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddSqlClientInstrumentation(options =>
                 {
@@ -108,7 +108,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests
             using IFakeBehavingSqlEventSource fakeSqlEventSource = (IFakeBehavingSqlEventSource)Activator.CreateInstance(eventSourceType);
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddSqlClientInstrumentation(options =>
                 {
@@ -149,7 +149,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests
             using IFakeMisbehavingSqlEventSource fakeSqlEventSource = (IFakeMisbehavingSqlEventSource)Activator.CreateInstance(eventSourceType);
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddSqlClientInstrumentation()
                 .Build();
@@ -169,7 +169,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests
             using IFakeMisbehavingSqlEventSource fakeSqlEventSource = (IFakeMisbehavingSqlEventSource)Activator.CreateInstance(eventSourceType);
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddSqlClientInstrumentation()
                 .Build();
@@ -190,7 +190,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests
             using IFakeBehavingSqlEventSource fakeSqlEventSource = (IFakeBehavingSqlEventSource)Activator.CreateInstance(eventSourceType);
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddSqlClientInstrumentation()
                 .Build();

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
@@ -51,7 +51,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests
         public async Task SuccessfulCommandTest(CommandType commandType, string commandText, bool captureText, bool isFailure = false)
         {
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            using var shutdownSignal = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddSqlClientInstrumentation(options =>
                 {
@@ -108,7 +108,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests
             using IFakeBehavingSqlEventSource fakeSqlEventSource = (IFakeBehavingSqlEventSource)Activator.CreateInstance(eventSourceType);
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            using var shutdownSignal = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddSqlClientInstrumentation(options =>
                 {
@@ -149,7 +149,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests
             using IFakeMisbehavingSqlEventSource fakeSqlEventSource = (IFakeMisbehavingSqlEventSource)Activator.CreateInstance(eventSourceType);
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            using var shutdownSignal = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddSqlClientInstrumentation()
                 .Build();
@@ -169,7 +169,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests
             using IFakeMisbehavingSqlEventSource fakeSqlEventSource = (IFakeMisbehavingSqlEventSource)Activator.CreateInstance(eventSourceType);
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            using var shutdownSignal = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddSqlClientInstrumentation()
                 .Build();
@@ -190,7 +190,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests
             using IFakeBehavingSqlEventSource fakeSqlEventSource = (IFakeBehavingSqlEventSource)Activator.CreateInstance(eventSourceType);
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            using var shutdownSignal = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddSqlClientInstrumentation()
                 .Build();

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToActivityConverterTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToActivityConverterTests.cs
@@ -42,7 +42,7 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Implementation
 
             this.connection = ConnectionMultiplexer.Connect(connectionOptions);
 
-            this.sdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            this.sdk = Sdk.CreateTracerProviderBuilder()
                 .AddRedisInstrumentation(this.connection)
                 .Build();
         }

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToActivityConverterTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToActivityConverterTests.cs
@@ -42,7 +42,7 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Implementation
 
             this.connection = ConnectionMultiplexer.Connect(connectionOptions);
 
-            this.sdk = Sdk.CreateTracerProviderBuilder()
+            this.sdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddRedisInstrumentation(this.connection)
                 .Build();
         }

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
@@ -55,7 +55,7 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Tests
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
             var sampler = new TestSampler();
-            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using (Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .SetSampler(sampler)
                 .AddRedisInstrumentation(connection)
@@ -204,7 +204,7 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Tests
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
             Assert.Throws<ArgumentNullException>(() =>
-            OpenTelemetrySdk.CreateTracerProviderBuilder()
+            Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddRedisInstrumentation(null)
                 .Build());

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
@@ -55,7 +55,7 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Tests
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
             var sampler = new TestSampler();
-            using (Sdk.CreateTracerProviderBuilder()
+            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .SetSampler(sampler)
                 .AddRedisInstrumentation(connection)
@@ -204,7 +204,7 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Tests
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
             Assert.Throws<ArgumentNullException>(() =>
-            Sdk.CreateTracerProviderBuilder()
+            OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddRedisInstrumentation(null)
                 .Build());

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/StackExchangeRedisCallsInstrumentationTests.cs
@@ -55,7 +55,7 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Tests
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
             var sampler = new TestSampler();
-            using (Sdk.CreateTracerProviderBuilder()
+            using (OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .SetSampler(sampler)
                 .AddRedisInstrumentation(connection)
@@ -204,7 +204,7 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Tests
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
             Assert.Throws<ArgumentNullException>(() =>
-            Sdk.CreateTracerProviderBuilder()
+                OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddRedisInstrumentation(null)
                 .Build());

--- a/test/OpenTelemetry.Tests/Logs/LogRecordTest.cs
+++ b/test/OpenTelemetry.Tests/Logs/LogRecordTest.cs
@@ -272,7 +272,7 @@ namespace OpenTelemetry.Tests.Logs
             var exportedActivityList = new List<Activity>();
             var activitySourceName = "LogRecordTest";
             var activitySource = new ActivitySource(activitySourceName);
-            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(activitySourceName)
                 .SetSampler(sampler)
                 .AddInMemoryExporter(exportedActivityList)
@@ -297,7 +297,7 @@ namespace OpenTelemetry.Tests.Logs
             var exportedActivityList = new List<Activity>();
             var activitySourceName = "LogRecordTest";
             var activitySource = new ActivitySource(activitySourceName);
-            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(activitySourceName)
                 .SetSampler(sampler)
                 .AddInMemoryExporter(exportedActivityList)

--- a/test/OpenTelemetry.Tests/Logs/LogRecordTest.cs
+++ b/test/OpenTelemetry.Tests/Logs/LogRecordTest.cs
@@ -272,7 +272,7 @@ namespace OpenTelemetry.Tests.Logs
             var exportedActivityList = new List<Activity>();
             var activitySourceName = "LogRecordTest";
             var activitySource = new ActivitySource(activitySourceName);
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource(activitySourceName)
                 .SetSampler(sampler)
                 .AddInMemoryExporter(exportedActivityList)
@@ -297,7 +297,7 @@ namespace OpenTelemetry.Tests.Logs
             var exportedActivityList = new List<Activity>();
             var activitySourceName = "LogRecordTest";
             var activitySource = new ActivitySource(activitySourceName);
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource(activitySourceName)
                 .SetSampler(sampler)
                 .AddInMemoryExporter(exportedActivityList)

--- a/test/OpenTelemetry.Tests/SuppressInstrumentationTest.cs
+++ b/test/OpenTelemetry.Tests/SuppressInstrumentationTest.cs
@@ -24,25 +24,25 @@ namespace OpenTelemetry.Tests
         [Fact]
         public static void UsingSuppressInstrumentation()
         {
-            Assert.False(Sdk.SuppressInstrumentation);
+            Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
 
             using (var scope = SuppressInstrumentationScope.Begin())
             {
-                Assert.True(Sdk.SuppressInstrumentation);
+                Assert.True(OpenTelemetrySdk.SuppressInstrumentation);
 
                 using (var innerScope = SuppressInstrumentationScope.Begin())
                 {
                     innerScope.Dispose();
 
-                    Assert.True(Sdk.SuppressInstrumentation);
+                    Assert.True(OpenTelemetrySdk.SuppressInstrumentation);
 
                     scope.Dispose();
                 }
 
-                Assert.False(Sdk.SuppressInstrumentation);
+                Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
             }
 
-            Assert.False(Sdk.SuppressInstrumentation);
+            Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
         }
 
         [Theory]
@@ -51,66 +51,66 @@ namespace OpenTelemetry.Tests
         [InlineData(true)]
         public void SuppressInstrumentationBeginTest(bool? shouldBegin)
         {
-            Assert.False(Sdk.SuppressInstrumentation);
+            Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
 
             using var scope = shouldBegin.HasValue ? SuppressInstrumentationScope.Begin(shouldBegin.Value) : SuppressInstrumentationScope.Begin();
             if (shouldBegin.HasValue)
             {
-                Assert.Equal(shouldBegin.Value, Sdk.SuppressInstrumentation);
+                Assert.Equal(shouldBegin.Value, OpenTelemetrySdk.SuppressInstrumentation);
             }
             else
             {
-                Assert.True(Sdk.SuppressInstrumentation); // Default behavior is to pass true and suppress the instrumentation
+                Assert.True(OpenTelemetrySdk.SuppressInstrumentation); // Default behavior is to pass true and suppress the instrumentation
             }
         }
 
         [Fact]
         public async void SuppressInstrumentationScopeEnterIsLocalToAsyncFlow()
         {
-            Assert.False(Sdk.SuppressInstrumentation);
+            Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
 
             // SuppressInstrumentationScope.Enter called inside the task is only applicable to this async flow
             await Task.Factory.StartNew(() =>
             {
-                Assert.False(Sdk.SuppressInstrumentation);
+                Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
                 SuppressInstrumentationScope.Enter();
-                Assert.True(Sdk.SuppressInstrumentation);
+                Assert.True(OpenTelemetrySdk.SuppressInstrumentation);
             });
 
-            Assert.False(Sdk.SuppressInstrumentation); // Changes made by SuppressInstrumentationScope.Enter in the task above are not reflected here as it's not part of the same async flow
+            Assert.False(OpenTelemetrySdk.SuppressInstrumentation); // Changes made by SuppressInstrumentationScope.Enter in the task above are not reflected here as it's not part of the same async flow
         }
 
         [Fact]
         public void DecrementIfTriggeredOnlyWorksInReferenceCountingMode()
         {
             // Instrumentation is not suppressed, DecrementIfTriggered is a no op
-            Assert.False(Sdk.SuppressInstrumentation);
+            Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
             SuppressInstrumentationScope.DecrementIfTriggered();
-            Assert.False(Sdk.SuppressInstrumentation);
+            Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
 
             // Instrumentation is suppressed in reference counting mode, DecrementIfTriggered should work
             SuppressInstrumentationScope.Enter();
-            Assert.True(Sdk.SuppressInstrumentation);
+            Assert.True(OpenTelemetrySdk.SuppressInstrumentation);
             SuppressInstrumentationScope.DecrementIfTriggered();
-            Assert.False(Sdk.SuppressInstrumentation); // Instrumentation is not suppressed anymore
+            Assert.False(OpenTelemetrySdk.SuppressInstrumentation); // Instrumentation is not suppressed anymore
         }
 
         [Fact]
         public void IncrementIfTriggeredOnlyWorksInReferenceCountingMode()
         {
             // Instrumentation is not suppressed, IncrementIfTriggered is a no op
-            Assert.False(Sdk.SuppressInstrumentation);
+            Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
             SuppressInstrumentationScope.IncrementIfTriggered();
-            Assert.False(Sdk.SuppressInstrumentation);
+            Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
 
             // Instrumentation is suppressed in reference counting mode, IncrementIfTriggered should work
             SuppressInstrumentationScope.Enter();
             SuppressInstrumentationScope.IncrementIfTriggered();
-            Assert.True(Sdk.SuppressInstrumentation);
+            Assert.True(OpenTelemetrySdk.SuppressInstrumentation);
             SuppressInstrumentationScope.DecrementIfTriggered();
-            Assert.True(Sdk.SuppressInstrumentation); // Instrumentation is still suppressed as IncrementIfTriggered incremented the slot count after Enter, need to decrement the slot count again to enable instrumentation
+            Assert.True(OpenTelemetrySdk.SuppressInstrumentation); // Instrumentation is still suppressed as IncrementIfTriggered incremented the slot count after Enter, need to decrement the slot count again to enable instrumentation
             SuppressInstrumentationScope.DecrementIfTriggered();
-            Assert.False(Sdk.SuppressInstrumentation); // Instrumentation is not suppressed anymore
+            Assert.False(OpenTelemetrySdk.SuppressInstrumentation); // Instrumentation is not suppressed anymore
         }
     }
 }

--- a/test/OpenTelemetry.Tests/SuppressInstrumentationTest.cs
+++ b/test/OpenTelemetry.Tests/SuppressInstrumentationTest.cs
@@ -24,25 +24,25 @@ namespace OpenTelemetry.Tests
         [Fact]
         public static void UsingSuppressInstrumentation()
         {
-            Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
+            Assert.False(Sdk.SuppressInstrumentation);
 
             using (var scope = SuppressInstrumentationScope.Begin())
             {
-                Assert.True(OpenTelemetrySdk.SuppressInstrumentation);
+                Assert.True(Sdk.SuppressInstrumentation);
 
                 using (var innerScope = SuppressInstrumentationScope.Begin())
                 {
                     innerScope.Dispose();
 
-                    Assert.True(OpenTelemetrySdk.SuppressInstrumentation);
+                    Assert.True(Sdk.SuppressInstrumentation);
 
                     scope.Dispose();
                 }
 
-                Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
+                Assert.False(Sdk.SuppressInstrumentation);
             }
 
-            Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
+            Assert.False(Sdk.SuppressInstrumentation);
         }
 
         [Theory]
@@ -51,66 +51,66 @@ namespace OpenTelemetry.Tests
         [InlineData(true)]
         public void SuppressInstrumentationBeginTest(bool? shouldBegin)
         {
-            Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
+            Assert.False(Sdk.SuppressInstrumentation);
 
             using var scope = shouldBegin.HasValue ? SuppressInstrumentationScope.Begin(shouldBegin.Value) : SuppressInstrumentationScope.Begin();
             if (shouldBegin.HasValue)
             {
-                Assert.Equal(shouldBegin.Value, OpenTelemetrySdk.SuppressInstrumentation);
+                Assert.Equal(shouldBegin.Value, Sdk.SuppressInstrumentation);
             }
             else
             {
-                Assert.True(OpenTelemetrySdk.SuppressInstrumentation); // Default behavior is to pass true and suppress the instrumentation
+                Assert.True(Sdk.SuppressInstrumentation); // Default behavior is to pass true and suppress the instrumentation
             }
         }
 
         [Fact]
         public async void SuppressInstrumentationScopeEnterIsLocalToAsyncFlow()
         {
-            Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
+            Assert.False(Sdk.SuppressInstrumentation);
 
             // SuppressInstrumentationScope.Enter called inside the task is only applicable to this async flow
             await Task.Factory.StartNew(() =>
             {
-                Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
+                Assert.False(Sdk.SuppressInstrumentation);
                 SuppressInstrumentationScope.Enter();
-                Assert.True(OpenTelemetrySdk.SuppressInstrumentation);
+                Assert.True(Sdk.SuppressInstrumentation);
             });
 
-            Assert.False(OpenTelemetrySdk.SuppressInstrumentation); // Changes made by SuppressInstrumentationScope.Enter in the task above are not reflected here as it's not part of the same async flow
+            Assert.False(Sdk.SuppressInstrumentation); // Changes made by SuppressInstrumentationScope.Enter in the task above are not reflected here as it's not part of the same async flow
         }
 
         [Fact]
         public void DecrementIfTriggeredOnlyWorksInReferenceCountingMode()
         {
             // Instrumentation is not suppressed, DecrementIfTriggered is a no op
-            Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
+            Assert.False(Sdk.SuppressInstrumentation);
             SuppressInstrumentationScope.DecrementIfTriggered();
-            Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
+            Assert.False(Sdk.SuppressInstrumentation);
 
             // Instrumentation is suppressed in reference counting mode, DecrementIfTriggered should work
             SuppressInstrumentationScope.Enter();
-            Assert.True(OpenTelemetrySdk.SuppressInstrumentation);
+            Assert.True(Sdk.SuppressInstrumentation);
             SuppressInstrumentationScope.DecrementIfTriggered();
-            Assert.False(OpenTelemetrySdk.SuppressInstrumentation); // Instrumentation is not suppressed anymore
+            Assert.False(Sdk.SuppressInstrumentation); // Instrumentation is not suppressed anymore
         }
 
         [Fact]
         public void IncrementIfTriggeredOnlyWorksInReferenceCountingMode()
         {
             // Instrumentation is not suppressed, IncrementIfTriggered is a no op
-            Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
+            Assert.False(Sdk.SuppressInstrumentation);
             SuppressInstrumentationScope.IncrementIfTriggered();
-            Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
+            Assert.False(Sdk.SuppressInstrumentation);
 
             // Instrumentation is suppressed in reference counting mode, IncrementIfTriggered should work
             SuppressInstrumentationScope.Enter();
             SuppressInstrumentationScope.IncrementIfTriggered();
-            Assert.True(OpenTelemetrySdk.SuppressInstrumentation);
+            Assert.True(Sdk.SuppressInstrumentation);
             SuppressInstrumentationScope.DecrementIfTriggered();
-            Assert.True(OpenTelemetrySdk.SuppressInstrumentation); // Instrumentation is still suppressed as IncrementIfTriggered incremented the slot count after Enter, need to decrement the slot count again to enable instrumentation
+            Assert.True(Sdk.SuppressInstrumentation); // Instrumentation is still suppressed as IncrementIfTriggered incremented the slot count after Enter, need to decrement the slot count again to enable instrumentation
             SuppressInstrumentationScope.DecrementIfTriggered();
-            Assert.False(OpenTelemetrySdk.SuppressInstrumentation); // Instrumentation is not suppressed anymore
+            Assert.False(Sdk.SuppressInstrumentation); // Instrumentation is not suppressed anymore
         }
     }
 }

--- a/test/OpenTelemetry.Tests/Trace/ActivityExtensionsTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ActivityExtensionsTest.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void SetStatus()
         {
-            using var openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .Build();
 
@@ -45,7 +45,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void SetStatusWithDescription()
         {
-            using var openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .Build();
 
@@ -62,7 +62,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void SetStatusWithDescriptionTwice()
         {
-            using var openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .Build();
 
@@ -80,7 +80,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void SetStatusWithIgnoredDescription()
         {
-            using var openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .Build();
 
@@ -97,7 +97,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void SetCancelledStatus()
         {
-            using var openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .Build();
 
@@ -112,7 +112,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void GetStatusWithNoStatusInActivity()
         {
-            using var openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .Build();
 
@@ -126,7 +126,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void LastSetStatusWins()
         {
-            using var openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .Build();
 
@@ -260,7 +260,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void EnumerateLinksNonempty()
         {
-            using var openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .Build();
 

--- a/test/OpenTelemetry.Tests/Trace/ActivityExtensionsTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ActivityExtensionsTest.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void SetStatus()
         {
-            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .Build();
 
@@ -45,7 +45,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void SetStatusWithDescription()
         {
-            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .Build();
 
@@ -62,7 +62,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void SetStatusWithDescriptionTwice()
         {
-            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .Build();
 
@@ -80,7 +80,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void SetStatusWithIgnoredDescription()
         {
-            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .Build();
 
@@ -97,7 +97,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void SetCancelledStatus()
         {
-            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .Build();
 
@@ -112,7 +112,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void GetStatusWithNoStatusInActivity()
         {
-            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .Build();
 
@@ -126,7 +126,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void LastSetStatusWins()
         {
-            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .Build();
 
@@ -260,7 +260,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void EnumerateLinksNonempty()
         {
-            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetrySdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .Build();
 

--- a/test/OpenTelemetry.Tests/Trace/ExceptionProcessorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ExceptionProcessorTest.cs
@@ -29,7 +29,7 @@ namespace OpenTelemetry.Trace.Tests
         public void ActivityStatusSetToErrorWhenExceptionProcessorEnabled()
         {
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .SetSampler(new AlwaysOnSampler())
                 .AddProcessor(new ExceptionProcessor())
@@ -96,7 +96,7 @@ namespace OpenTelemetry.Trace.Tests
         public void ActivityStatusNotSetWhenExceptionProcessorNotEnabled()
         {
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .SetSampler(new AlwaysOnSampler())
                 .Build();

--- a/test/OpenTelemetry.Tests/Trace/ExceptionProcessorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ExceptionProcessorTest.cs
@@ -29,7 +29,7 @@ namespace OpenTelemetry.Trace.Tests
         public void ActivityStatusSetToErrorWhenExceptionProcessorEnabled()
         {
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .SetSampler(new AlwaysOnSampler())
                 .AddProcessor(new ExceptionProcessor())
@@ -96,7 +96,7 @@ namespace OpenTelemetry.Trace.Tests
         public void ActivityStatusNotSetWhenExceptionProcessorNotEnabled()
         {
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .SetSampler(new AlwaysOnSampler())
                 .Build();

--- a/test/OpenTelemetry.Tests/Trace/ExportProcessorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ExportProcessorTest.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Trace.Tests
             var sampler = new AlwaysOffSampler();
             var processor = new TestActivityExportProcessor(new TestExporter<Activity>(_ => { }));
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var sdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var sdk = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .SetSampler(sampler)
                 .AddProcessor(processor)
@@ -51,7 +51,7 @@ namespace OpenTelemetry.Trace.Tests
             var sampler = new RecordOnlySampler();
             var processor = new TestActivityExportProcessor(new TestExporter<Activity>(_ => { }));
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var sdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var sdk = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .SetSampler(sampler)
                 .AddProcessor(processor)
@@ -72,7 +72,7 @@ namespace OpenTelemetry.Trace.Tests
             var sampler = new AlwaysOnSampler();
             var processor = new TestActivityExportProcessor(new TestExporter<Activity>(_ => { }));
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var sdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var sdk = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .SetSampler(sampler)
                 .AddProcessor(processor)

--- a/test/OpenTelemetry.Tests/Trace/ExportProcessorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ExportProcessorTest.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Trace.Tests
             var sampler = new AlwaysOffSampler();
             var processor = new TestActivityExportProcessor(new TestExporter<Activity>(_ => { }));
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var sdk = Sdk.CreateTracerProviderBuilder()
+            using var sdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .SetSampler(sampler)
                 .AddProcessor(processor)
@@ -51,7 +51,7 @@ namespace OpenTelemetry.Trace.Tests
             var sampler = new RecordOnlySampler();
             var processor = new TestActivityExportProcessor(new TestExporter<Activity>(_ => { }));
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var sdk = Sdk.CreateTracerProviderBuilder()
+            using var sdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .SetSampler(sampler)
                 .AddProcessor(processor)
@@ -72,7 +72,7 @@ namespace OpenTelemetry.Trace.Tests
             var sampler = new AlwaysOnSampler();
             var processor = new TestActivityExportProcessor(new TestExporter<Activity>(_ => { }));
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var sdk = Sdk.CreateTracerProviderBuilder()
+            using var sdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .SetSampler(sampler)
                 .AddProcessor(processor)

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderBuilderExtensionsTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderBuilderExtensionsTest.cs
@@ -29,7 +29,7 @@ namespace OpenTelemetry.Trace.Tests
         public void SetErrorStatusOnExceptionEnabled()
         {
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .SetSampler(new AlwaysOnSampler())
                 .SetErrorStatusOnException(false)
@@ -60,7 +60,7 @@ namespace OpenTelemetry.Trace.Tests
         public void SetErrorStatusOnExceptionDisabled()
         {
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .SetSampler(new AlwaysOnSampler())
                 .SetErrorStatusOnException()
@@ -87,7 +87,7 @@ namespace OpenTelemetry.Trace.Tests
         public void SetErrorStatusOnExceptionDefault()
         {
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .SetSampler(new AlwaysOnSampler())
                 .Build();

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderBuilderExtensionsTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderBuilderExtensionsTest.cs
@@ -29,7 +29,7 @@ namespace OpenTelemetry.Trace.Tests
         public void SetErrorStatusOnExceptionEnabled()
         {
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .SetSampler(new AlwaysOnSampler())
                 .SetErrorStatusOnException(false)
@@ -60,7 +60,7 @@ namespace OpenTelemetry.Trace.Tests
         public void SetErrorStatusOnExceptionDisabled()
         {
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .SetSampler(new AlwaysOnSampler())
                 .SetErrorStatusOnException()
@@ -87,7 +87,7 @@ namespace OpenTelemetry.Trace.Tests
         public void SetErrorStatusOnExceptionDefault()
         {
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .SetSampler(new AlwaysOnSampler())
                 .Build();

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
@@ -39,7 +39,7 @@ namespace OpenTelemetry.Trace.Tests
         {
             var testSampler = new TestSampler();
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var sdk = Sdk.CreateTracerProviderBuilder()
+            using var sdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .SetSampler(testSampler)
                 .Build();
@@ -123,7 +123,7 @@ namespace OpenTelemetry.Trace.Tests
             };
 
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var sdk = Sdk.CreateTracerProviderBuilder()
+            using var sdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .SetSampler(testSampler)
                 .Build();
@@ -144,7 +144,7 @@ namespace OpenTelemetry.Trace.Tests
         {
             var testSampler = new TestSampler();
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var sdk = Sdk.CreateTracerProviderBuilder()
+            using var sdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                     .AddSource(ActivitySourceName)
                     .SetSampler(testSampler)
                     .Build();
@@ -204,7 +204,7 @@ namespace OpenTelemetry.Trace.Tests
 
             var testSampler = new TestSampler();
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var sdk = Sdk.CreateTracerProviderBuilder()
+            using var sdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
                     .AddSource(ActivitySourceName)
                     .SetSampler(testSampler)
                     .Build();
@@ -235,7 +235,7 @@ namespace OpenTelemetry.Trace.Tests
                     endCalled = true;
                 };
 
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                         .AddLegacySource("random")
                         .AddProcessor(testActivityProcessor)
                         .SetSampler(new AlwaysOnSampler())
@@ -272,7 +272,7 @@ namespace OpenTelemetry.Trace.Tests
                     endCalled = true;
                 };
 
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                         .AddSource("random")
                         .AddProcessor(testActivityProcessor)
                         .SetSampler(testSampler)
@@ -307,7 +307,7 @@ namespace OpenTelemetry.Trace.Tests
             testActivityProcessor.StartAction =
                 (a) =>
                 {
-                    Assert.False(Sdk.SuppressInstrumentation);
+                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Proccessor.OnStart is called, activity's IsAllDataRequested is set to true
                     startCalled = true;
                 };
@@ -315,7 +315,7 @@ namespace OpenTelemetry.Trace.Tests
             testActivityProcessor.EndAction =
                 (a) =>
                 {
-                    Assert.False(Sdk.SuppressInstrumentation);
+                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Processor.OnEnd is called, activity's IsAllDataRequested is set to true
                     endCalled = true;
                 };
@@ -324,7 +324,7 @@ namespace OpenTelemetry.Trace.Tests
             Assert.False(emptyActivitySource.HasListeners()); // No ActivityListener for empty ActivitySource added yet
 
             // No AddLegacyOperationName chained to TracerProviderBuilder
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                         .AddProcessor(testActivityProcessor)
                         .Build();
 
@@ -364,7 +364,7 @@ namespace OpenTelemetry.Trace.Tests
                 (a) =>
                 {
                     Assert.True(samplerCalled);
-                    Assert.False(Sdk.SuppressInstrumentation);
+                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Proccessor.OnStart is called, activity's IsAllDataRequested is set to true
                     startCalled = true;
                 };
@@ -372,7 +372,7 @@ namespace OpenTelemetry.Trace.Tests
             testActivityProcessor.EndAction =
                 (a) =>
                 {
-                    Assert.False(Sdk.SuppressInstrumentation);
+                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Processor.OnEnd is called, activity's IsAllDataRequested is set to true
                     endCalled = true;
                 };
@@ -383,7 +383,7 @@ namespace OpenTelemetry.Trace.Tests
             var operationNameForLegacyActivity = "TestOperationName";
 
             // AddLegacyOperationName chained to TracerProviderBuilder
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                         .SetSampler(sampler)
                         .AddProcessor(testActivityProcessor)
                         .AddLegacySource(operationNameForLegacyActivity)
@@ -425,7 +425,7 @@ namespace OpenTelemetry.Trace.Tests
                 (a) =>
                 {
                     Assert.True(samplerCalled);
-                    Assert.False(Sdk.SuppressInstrumentation);
+                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Proccessor.OnStart is called, activity's IsAllDataRequested is set to true
                     startCalled = true;
                 };
@@ -433,7 +433,7 @@ namespace OpenTelemetry.Trace.Tests
             testActivityProcessor.EndAction =
                 (a) =>
                 {
-                    Assert.False(Sdk.SuppressInstrumentation);
+                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Processor.OnEnd is called, activity's IsAllDataRequested is set to true
                     endCalled = true;
                 };
@@ -444,7 +444,7 @@ namespace OpenTelemetry.Trace.Tests
             var operationNameForLegacyActivity = "TestOperationName";
 
             // AddLegacyOperationName chained to TracerProviderBuilder
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                         .SetSampler(sampler)
                         .AddSource("ABCCompany.XYZProduct.*") // Adding a wild card source
                         .AddProcessor(testActivityProcessor)
@@ -474,7 +474,7 @@ namespace OpenTelemetry.Trace.Tests
             testActivityProcessor.StartAction =
                 (a) =>
                 {
-                    Assert.False(Sdk.SuppressInstrumentation);
+                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Proccessor.OnStart is called, activity's IsAllDataRequested is set to true
                     startCalled = true;
                 };
@@ -482,7 +482,7 @@ namespace OpenTelemetry.Trace.Tests
             testActivityProcessor.EndAction =
                 (a) =>
                 {
-                    Assert.False(Sdk.SuppressInstrumentation);
+                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Processor.OnEnd is called, activity's IsAllDataRequested is set to true
                     endCalled = true;
                 };
@@ -494,7 +494,7 @@ namespace OpenTelemetry.Trace.Tests
             var activitySourceForLegacyActvity = new ActivitySource("TestActivitySource", "1.0.0");
 
             // AddLegacyOperationName chained to TracerProviderBuilder
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                         .AddLegacySource(operationNameForLegacyActivity)
                         .AddProcessor(testActivityProcessor)
                         .Build();
@@ -523,7 +523,7 @@ namespace OpenTelemetry.Trace.Tests
             testActivityProcessor.StartAction =
                 (a) =>
                 {
-                    Assert.False(Sdk.SuppressInstrumentation);
+                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Proccessor.OnStart is called, activity's IsAllDataRequested is set to true
                     startCalled = true;
                 };
@@ -531,7 +531,7 @@ namespace OpenTelemetry.Trace.Tests
             testActivityProcessor.EndAction =
                 (a) =>
                 {
-                    Assert.False(Sdk.SuppressInstrumentation);
+                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Processor.OnEnd is called, activity's IsAllDataRequested is set to true
                     endCalled = true;
                 };
@@ -543,7 +543,7 @@ namespace OpenTelemetry.Trace.Tests
             var activitySourceForLegacyActvity = new ActivitySource("TestActivitySource", "1.0.0");
 
             // AddLegacyOperationName chained to TracerProviderBuilder
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                         .AddSource(activitySourceForLegacyActvity.Name) // Add the updated ActivitySource as a Source
                         .AddLegacySource(operationNameForLegacyActivity)
                         .AddProcessor(testActivityProcessor)
@@ -572,7 +572,7 @@ namespace OpenTelemetry.Trace.Tests
             testActivityProcessor.StartAction =
                 (a) =>
                 {
-                    Assert.False(Sdk.SuppressInstrumentation);
+                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Proccessor.OnStart is called, activity's IsAllDataRequested is set to true
                     startCalled = true;
                 };
@@ -580,7 +580,7 @@ namespace OpenTelemetry.Trace.Tests
             testActivityProcessor.EndAction =
                 (a) =>
                 {
-                    Assert.False(Sdk.SuppressInstrumentation);
+                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Processor.OnEnd is called, activity's IsAllDataRequested is set to true
                     endCalled = true;
                 };
@@ -588,7 +588,7 @@ namespace OpenTelemetry.Trace.Tests
             var operationNameForLegacyActivity = "TestOperationName";
 
             // AddLegacyOperationName chained to TracerProviderBuilder
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                         .AddProcessor(testActivityProcessor)
                         .AddLegacySource(operationNameForLegacyActivity)
                         .Build();
@@ -610,7 +610,7 @@ namespace OpenTelemetry.Trace.Tests
             testActivityProcessorNew.StartAction =
                 (a) =>
                 {
-                    Assert.False(Sdk.SuppressInstrumentation);
+                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Proccessor.OnStart is called, activity's IsAllDataRequested is set to true
                     startCalledNew = true;
                 };
@@ -618,7 +618,7 @@ namespace OpenTelemetry.Trace.Tests
             testActivityProcessorNew.EndAction =
                 (a) =>
                 {
-                    Assert.False(Sdk.SuppressInstrumentation);
+                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Processor.OnEnd is called, activity's IsAllDataRequested is set to true
                     endCalledNew = true;
                 };
@@ -637,7 +637,7 @@ namespace OpenTelemetry.Trace.Tests
         public void SdkSamplesLegacyActivityWithAlwaysOnSampler()
         {
             var operationNameForLegacyActivity = "TestOperationName";
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                         .SetSampler(new AlwaysOnSampler())
                         .AddLegacySource(operationNameForLegacyActivity)
                         .Build();
@@ -655,7 +655,7 @@ namespace OpenTelemetry.Trace.Tests
         public void SdkSamplesLegacyActivityWithAlwaysOffSampler()
         {
             var operationNameForLegacyActivity = "TestOperationName";
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                         .SetSampler(new AlwaysOffSampler())
                         .AddLegacySource(operationNameForLegacyActivity)
                         .Build();
@@ -678,7 +678,7 @@ namespace OpenTelemetry.Trace.Tests
             var operationNameForLegacyActivity = "TestOperationName";
             var sampler = new TestSampler() { SamplingAction = (samplingParameters) => new SamplingResult(samplingDecision) };
 
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                         .SetSampler(sampler)
                         .AddLegacySource(operationNameForLegacyActivity)
                         .Build();
@@ -705,7 +705,7 @@ namespace OpenTelemetry.Trace.Tests
                 },
             };
 
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                         .SetSampler(sampler)
                         .AddLegacySource(operationNameForLegacyActivity)
                         .Build();
@@ -746,7 +746,7 @@ namespace OpenTelemetry.Trace.Tests
                 },
             };
 
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                         .SetSampler(sampler)
                         .AddLegacySource(operationNameForLegacyActivity)
                         .Build();
@@ -777,7 +777,7 @@ namespace OpenTelemetry.Trace.Tests
 
             var operationNameForLegacyActivity = "TestOperationName";
 
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                         .SetSampler(new AlwaysOnSampler())
                         .AddLegacySource(operationNameForLegacyActivity)
                         .Build();
@@ -807,7 +807,7 @@ namespace OpenTelemetry.Trace.Tests
 
             var operationNameForLegacyActivity = "TestOperationName";
 
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                         .SetSampler(new AlwaysOffSampler())
                         .AddLegacySource(operationNameForLegacyActivity)
                         .Build();
@@ -850,7 +850,7 @@ namespace OpenTelemetry.Trace.Tests
                 },
             };
 
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                         .SetSampler(sampler)
                         .AddLegacySource(operationNameForLegacyActivity)
                         .Build();
@@ -868,7 +868,7 @@ namespace OpenTelemetry.Trace.Tests
         public void TracerProvideSdkCreatesAndDiposesInstrumentation()
         {
             TestInstrumentation testInstrumentation = null;
-            var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                         .AddInstrumentation(() =>
                         {
                             testInstrumentation = new TestInstrumentation();
@@ -885,7 +885,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void TracerProviderSdkBuildsWithDefaultResource()
         {
-            var tracerProvider = Sdk.CreateTracerProviderBuilder().Build();
+            var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder().Build();
             var resource = tracerProvider.GetResource();
             var attributes = resource.Attributes;
 
@@ -902,7 +902,7 @@ namespace OpenTelemetry.Trace.Tests
         [InlineData(" ")]
         public void AddLegacyOperationName_BadArgs(string operationName)
         {
-            var builder = Sdk.CreateTracerProviderBuilder();
+            var builder = OpenTelemetrySdk.CreateTracerProviderBuilder();
             Assert.Throws<ArgumentException>(() => builder.AddLegacySource(operationName));
         }
 
@@ -910,7 +910,7 @@ namespace OpenTelemetry.Trace.Tests
         public void AddLegacyOperationNameAddsActivityListenerForEmptyActivitySource()
         {
             var emptyActivitySource = new ActivitySource(string.Empty);
-            var builder = Sdk.CreateTracerProviderBuilder();
+            var builder = OpenTelemetrySdk.CreateTracerProviderBuilder();
             builder.AddLegacySource("TestOperationName");
 
             Assert.False(emptyActivitySource.HasListeners());
@@ -921,7 +921,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void TracerProviderSdkBuildsWithSDKResource()
         {
-            var tracerProvider = Sdk.CreateTracerProviderBuilder().SetResourceBuilder(
+            var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder().SetResourceBuilder(
                 ResourceBuilder.CreateDefault().AddTelemetrySdk()).Build();
             var resource = tracerProvider.GetResource();
             var attributes = resource.Attributes;
@@ -939,7 +939,7 @@ namespace OpenTelemetry.Trace.Tests
         {
             using TestActivityProcessor testActivityProcessor = new TestActivityProcessor();
 
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
                         .AddProcessor(testActivityProcessor)
                         .Build();
 

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
@@ -39,7 +39,7 @@ namespace OpenTelemetry.Trace.Tests
         {
             var testSampler = new TestSampler();
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var sdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var sdk = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .SetSampler(testSampler)
                 .Build();
@@ -123,7 +123,7 @@ namespace OpenTelemetry.Trace.Tests
             };
 
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var sdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var sdk = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .SetSampler(testSampler)
                 .Build();
@@ -144,7 +144,7 @@ namespace OpenTelemetry.Trace.Tests
         {
             var testSampler = new TestSampler();
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var sdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var sdk = Sdk.CreateTracerProviderBuilder()
                     .AddSource(ActivitySourceName)
                     .SetSampler(testSampler)
                     .Build();
@@ -204,7 +204,7 @@ namespace OpenTelemetry.Trace.Tests
 
             var testSampler = new TestSampler();
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var sdk = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var sdk = Sdk.CreateTracerProviderBuilder()
                     .AddSource(ActivitySourceName)
                     .SetSampler(testSampler)
                     .Build();
@@ -235,7 +235,7 @@ namespace OpenTelemetry.Trace.Tests
                     endCalled = true;
                 };
 
-            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                         .AddLegacySource("random")
                         .AddProcessor(testActivityProcessor)
                         .SetSampler(new AlwaysOnSampler())
@@ -272,7 +272,7 @@ namespace OpenTelemetry.Trace.Tests
                     endCalled = true;
                 };
 
-            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                         .AddSource("random")
                         .AddProcessor(testActivityProcessor)
                         .SetSampler(testSampler)
@@ -307,7 +307,7 @@ namespace OpenTelemetry.Trace.Tests
             testActivityProcessor.StartAction =
                 (a) =>
                 {
-                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
+                    Assert.False(Sdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Proccessor.OnStart is called, activity's IsAllDataRequested is set to true
                     startCalled = true;
                 };
@@ -315,7 +315,7 @@ namespace OpenTelemetry.Trace.Tests
             testActivityProcessor.EndAction =
                 (a) =>
                 {
-                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
+                    Assert.False(Sdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Processor.OnEnd is called, activity's IsAllDataRequested is set to true
                     endCalled = true;
                 };
@@ -324,7 +324,7 @@ namespace OpenTelemetry.Trace.Tests
             Assert.False(emptyActivitySource.HasListeners()); // No ActivityListener for empty ActivitySource added yet
 
             // No AddLegacyOperationName chained to TracerProviderBuilder
-            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                         .AddProcessor(testActivityProcessor)
                         .Build();
 
@@ -364,7 +364,7 @@ namespace OpenTelemetry.Trace.Tests
                 (a) =>
                 {
                     Assert.True(samplerCalled);
-                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
+                    Assert.False(Sdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Proccessor.OnStart is called, activity's IsAllDataRequested is set to true
                     startCalled = true;
                 };
@@ -372,7 +372,7 @@ namespace OpenTelemetry.Trace.Tests
             testActivityProcessor.EndAction =
                 (a) =>
                 {
-                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
+                    Assert.False(Sdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Processor.OnEnd is called, activity's IsAllDataRequested is set to true
                     endCalled = true;
                 };
@@ -383,7 +383,7 @@ namespace OpenTelemetry.Trace.Tests
             var operationNameForLegacyActivity = "TestOperationName";
 
             // AddLegacyOperationName chained to TracerProviderBuilder
-            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                         .SetSampler(sampler)
                         .AddProcessor(testActivityProcessor)
                         .AddLegacySource(operationNameForLegacyActivity)
@@ -425,7 +425,7 @@ namespace OpenTelemetry.Trace.Tests
                 (a) =>
                 {
                     Assert.True(samplerCalled);
-                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
+                    Assert.False(Sdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Proccessor.OnStart is called, activity's IsAllDataRequested is set to true
                     startCalled = true;
                 };
@@ -433,7 +433,7 @@ namespace OpenTelemetry.Trace.Tests
             testActivityProcessor.EndAction =
                 (a) =>
                 {
-                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
+                    Assert.False(Sdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Processor.OnEnd is called, activity's IsAllDataRequested is set to true
                     endCalled = true;
                 };
@@ -444,7 +444,7 @@ namespace OpenTelemetry.Trace.Tests
             var operationNameForLegacyActivity = "TestOperationName";
 
             // AddLegacyOperationName chained to TracerProviderBuilder
-            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                         .SetSampler(sampler)
                         .AddSource("ABCCompany.XYZProduct.*") // Adding a wild card source
                         .AddProcessor(testActivityProcessor)
@@ -474,7 +474,7 @@ namespace OpenTelemetry.Trace.Tests
             testActivityProcessor.StartAction =
                 (a) =>
                 {
-                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
+                    Assert.False(Sdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Proccessor.OnStart is called, activity's IsAllDataRequested is set to true
                     startCalled = true;
                 };
@@ -482,7 +482,7 @@ namespace OpenTelemetry.Trace.Tests
             testActivityProcessor.EndAction =
                 (a) =>
                 {
-                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
+                    Assert.False(Sdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Processor.OnEnd is called, activity's IsAllDataRequested is set to true
                     endCalled = true;
                 };
@@ -494,7 +494,7 @@ namespace OpenTelemetry.Trace.Tests
             var activitySourceForLegacyActvity = new ActivitySource("TestActivitySource", "1.0.0");
 
             // AddLegacyOperationName chained to TracerProviderBuilder
-            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                         .AddLegacySource(operationNameForLegacyActivity)
                         .AddProcessor(testActivityProcessor)
                         .Build();
@@ -523,7 +523,7 @@ namespace OpenTelemetry.Trace.Tests
             testActivityProcessor.StartAction =
                 (a) =>
                 {
-                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
+                    Assert.False(Sdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Proccessor.OnStart is called, activity's IsAllDataRequested is set to true
                     startCalled = true;
                 };
@@ -531,7 +531,7 @@ namespace OpenTelemetry.Trace.Tests
             testActivityProcessor.EndAction =
                 (a) =>
                 {
-                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
+                    Assert.False(Sdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Processor.OnEnd is called, activity's IsAllDataRequested is set to true
                     endCalled = true;
                 };
@@ -543,7 +543,7 @@ namespace OpenTelemetry.Trace.Tests
             var activitySourceForLegacyActvity = new ActivitySource("TestActivitySource", "1.0.0");
 
             // AddLegacyOperationName chained to TracerProviderBuilder
-            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                         .AddSource(activitySourceForLegacyActvity.Name) // Add the updated ActivitySource as a Source
                         .AddLegacySource(operationNameForLegacyActivity)
                         .AddProcessor(testActivityProcessor)
@@ -572,7 +572,7 @@ namespace OpenTelemetry.Trace.Tests
             testActivityProcessor.StartAction =
                 (a) =>
                 {
-                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
+                    Assert.False(Sdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Proccessor.OnStart is called, activity's IsAllDataRequested is set to true
                     startCalled = true;
                 };
@@ -580,7 +580,7 @@ namespace OpenTelemetry.Trace.Tests
             testActivityProcessor.EndAction =
                 (a) =>
                 {
-                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
+                    Assert.False(Sdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Processor.OnEnd is called, activity's IsAllDataRequested is set to true
                     endCalled = true;
                 };
@@ -588,7 +588,7 @@ namespace OpenTelemetry.Trace.Tests
             var operationNameForLegacyActivity = "TestOperationName";
 
             // AddLegacyOperationName chained to TracerProviderBuilder
-            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                         .AddProcessor(testActivityProcessor)
                         .AddLegacySource(operationNameForLegacyActivity)
                         .Build();
@@ -610,7 +610,7 @@ namespace OpenTelemetry.Trace.Tests
             testActivityProcessorNew.StartAction =
                 (a) =>
                 {
-                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
+                    Assert.False(Sdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Proccessor.OnStart is called, activity's IsAllDataRequested is set to true
                     startCalledNew = true;
                 };
@@ -618,7 +618,7 @@ namespace OpenTelemetry.Trace.Tests
             testActivityProcessorNew.EndAction =
                 (a) =>
                 {
-                    Assert.False(OpenTelemetrySdk.SuppressInstrumentation);
+                    Assert.False(Sdk.SuppressInstrumentation);
                     Assert.True(a.IsAllDataRequested); // If Processor.OnEnd is called, activity's IsAllDataRequested is set to true
                     endCalledNew = true;
                 };
@@ -637,7 +637,7 @@ namespace OpenTelemetry.Trace.Tests
         public void SdkSamplesLegacyActivityWithAlwaysOnSampler()
         {
             var operationNameForLegacyActivity = "TestOperationName";
-            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                         .SetSampler(new AlwaysOnSampler())
                         .AddLegacySource(operationNameForLegacyActivity)
                         .Build();
@@ -655,7 +655,7 @@ namespace OpenTelemetry.Trace.Tests
         public void SdkSamplesLegacyActivityWithAlwaysOffSampler()
         {
             var operationNameForLegacyActivity = "TestOperationName";
-            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                         .SetSampler(new AlwaysOffSampler())
                         .AddLegacySource(operationNameForLegacyActivity)
                         .Build();
@@ -678,7 +678,7 @@ namespace OpenTelemetry.Trace.Tests
             var operationNameForLegacyActivity = "TestOperationName";
             var sampler = new TestSampler() { SamplingAction = (samplingParameters) => new SamplingResult(samplingDecision) };
 
-            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                         .SetSampler(sampler)
                         .AddLegacySource(operationNameForLegacyActivity)
                         .Build();
@@ -705,7 +705,7 @@ namespace OpenTelemetry.Trace.Tests
                 },
             };
 
-            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                         .SetSampler(sampler)
                         .AddLegacySource(operationNameForLegacyActivity)
                         .Build();
@@ -746,7 +746,7 @@ namespace OpenTelemetry.Trace.Tests
                 },
             };
 
-            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                         .SetSampler(sampler)
                         .AddLegacySource(operationNameForLegacyActivity)
                         .Build();
@@ -777,7 +777,7 @@ namespace OpenTelemetry.Trace.Tests
 
             var operationNameForLegacyActivity = "TestOperationName";
 
-            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                         .SetSampler(new AlwaysOnSampler())
                         .AddLegacySource(operationNameForLegacyActivity)
                         .Build();
@@ -807,7 +807,7 @@ namespace OpenTelemetry.Trace.Tests
 
             var operationNameForLegacyActivity = "TestOperationName";
 
-            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                         .SetSampler(new AlwaysOffSampler())
                         .AddLegacySource(operationNameForLegacyActivity)
                         .Build();
@@ -850,7 +850,7 @@ namespace OpenTelemetry.Trace.Tests
                 },
             };
 
-            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                         .SetSampler(sampler)
                         .AddLegacySource(operationNameForLegacyActivity)
                         .Build();
@@ -868,7 +868,7 @@ namespace OpenTelemetry.Trace.Tests
         public void TracerProvideSdkCreatesAndDiposesInstrumentation()
         {
             TestInstrumentation testInstrumentation = null;
-            var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            var tracerProvider = Sdk.CreateTracerProviderBuilder()
                         .AddInstrumentation(() =>
                         {
                             testInstrumentation = new TestInstrumentation();
@@ -885,7 +885,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void TracerProviderSdkBuildsWithDefaultResource()
         {
-            var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder().Build();
+            var tracerProvider = Sdk.CreateTracerProviderBuilder().Build();
             var resource = tracerProvider.GetResource();
             var attributes = resource.Attributes;
 
@@ -902,7 +902,7 @@ namespace OpenTelemetry.Trace.Tests
         [InlineData(" ")]
         public void AddLegacyOperationName_BadArgs(string operationName)
         {
-            var builder = OpenTelemetrySdk.CreateTracerProviderBuilder();
+            var builder = Sdk.CreateTracerProviderBuilder();
             Assert.Throws<ArgumentException>(() => builder.AddLegacySource(operationName));
         }
 
@@ -910,7 +910,7 @@ namespace OpenTelemetry.Trace.Tests
         public void AddLegacyOperationNameAddsActivityListenerForEmptyActivitySource()
         {
             var emptyActivitySource = new ActivitySource(string.Empty);
-            var builder = OpenTelemetrySdk.CreateTracerProviderBuilder();
+            var builder = Sdk.CreateTracerProviderBuilder();
             builder.AddLegacySource("TestOperationName");
 
             Assert.False(emptyActivitySource.HasListeners());
@@ -921,7 +921,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void TracerProviderSdkBuildsWithSDKResource()
         {
-            var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder().SetResourceBuilder(
+            var tracerProvider = Sdk.CreateTracerProviderBuilder().SetResourceBuilder(
                 ResourceBuilder.CreateDefault().AddTelemetrySdk()).Build();
             var resource = tracerProvider.GetResource();
             var attributes = resource.Attributes;
@@ -939,7 +939,7 @@ namespace OpenTelemetry.Trace.Tests
         {
             using TestActivityProcessor testActivityProcessor = new TestActivityProcessor();
 
-            using var tracerProvider = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                         .AddProcessor(testActivityProcessor)
                         .Build();
 

--- a/test/OpenTelemetry.Tests/Trace/TracerTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerTest.cs
@@ -60,7 +60,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void Tracer_StartRootSpan_BadArgs_NullSpanName()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -77,7 +77,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void Tracer_StartSpan_BadArgs_NullSpanName()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -94,7 +94,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void Tracer_StartActiveSpan_BadArgs_NullSpanName()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -111,7 +111,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void Tracer_StartSpan_FromParent_BadArgs_NullSpanName()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -125,7 +125,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void Tracer_StartSpan_FromParentContext_BadArgs_NullSpanName()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -141,7 +141,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void Tracer_StartActiveSpan_FromParent_BadArgs_NullSpanName()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -155,7 +155,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void Tracer_StartActiveSpan_FromParentContext_BadArgs_NullSpanName()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -171,7 +171,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void Tracer_StartActiveSpan_CreatesActiveSpan()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -195,7 +195,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void GetCurrentSpanBlank()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
             Assert.False(Tracer.CurrentSpan.Context.IsValid);
@@ -204,7 +204,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void GetCurrentSpanBlankWontThrowOnEnd()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
             var current = Tracer.CurrentSpan;
@@ -214,7 +214,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void GetCurrentSpan()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -228,7 +228,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void CreateSpan_Sampled()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
             var span = this.tracer.StartSpan("foo");
@@ -238,7 +238,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void CreateSpan_NotSampled()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .SetSampler(new AlwaysOffSampler())
                 .Build();

--- a/test/OpenTelemetry.Tests/Trace/TracerTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerTest.cs
@@ -60,7 +60,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void Tracer_StartRootSpan_BadArgs_NullSpanName()
         {
-            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -77,7 +77,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void Tracer_StartSpan_BadArgs_NullSpanName()
         {
-            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -94,7 +94,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void Tracer_StartActiveSpan_BadArgs_NullSpanName()
         {
-            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -111,7 +111,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void Tracer_StartSpan_FromParent_BadArgs_NullSpanName()
         {
-            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -125,7 +125,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void Tracer_StartSpan_FromParentContext_BadArgs_NullSpanName()
         {
-            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -141,7 +141,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void Tracer_StartActiveSpan_FromParent_BadArgs_NullSpanName()
         {
-            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -155,7 +155,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void Tracer_StartActiveSpan_FromParentContext_BadArgs_NullSpanName()
         {
-            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -171,7 +171,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void Tracer_StartActiveSpan_CreatesActiveSpan()
         {
-            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -195,7 +195,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void GetCurrentSpanBlank()
         {
-            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
             Assert.False(Tracer.CurrentSpan.Context.IsValid);
@@ -204,7 +204,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void GetCurrentSpanBlankWontThrowOnEnd()
         {
-            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
             var current = Tracer.CurrentSpan;
@@ -214,7 +214,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void GetCurrentSpan()
         {
-            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -228,7 +228,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void CreateSpan_Sampled()
         {
-            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
             var span = this.tracer.StartSpan("foo");
@@ -238,7 +238,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void CreateSpan_NotSampled()
         {
-            using var openTelemetry = OpenTelemetrySdk.CreateTracerProviderBuilder()
+            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .SetSampler(new AlwaysOffSampler())
                 .Build();


### PR DESCRIPTION
## Changes

Creating the `OpenTelemetrySdk` class which is a duplicate of the `Sdk` class but with a better name.  Marked the `Sdk` class as `Obsolete` to prevent breaking changes.  The `Sdk` class can be removed completely with the next major release with the change published in the release notes.  

Sdk is very generic and implementing this class it into your code hinders its readability if there are multiple SDK's being implemented in the code.  Naming the class `Sdk` is vague and assumes future developers working on the code are familiar with this library.  Explicit naming helps future proof code as well as improve the engineering experience of your consumers.
