### PR TITLE
Bug fix: Call Dispose for ThreadLocal variables

### DIFF
--- a/src/OpenTelemetry/Internal/SelfDiagnosticsConfigRefresher.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnosticsConfigRefresher.cs
@@ -43,15 +43,14 @@ namespace OpenTelemetry.Internal
         private readonly SelfDiagnosticsConfigParser configParser;
 
         /// <summary>
-        /// t_memoryMappedFileCache is a handle kept in thread-local storage as a cache to indicate whether the cached
-        /// t_viewStream is created from the current m_memoryMappedFile.
+        /// memoryMappedFileCache is a handle kept in thread-local storage as a cache to indicate whether the cached
+        /// viewStream is created from the current m_memoryMappedFile.
         /// </summary>
         private readonly ThreadLocal<MemoryMappedFile> memoryMappedFileCache = new ThreadLocal<MemoryMappedFile>(true);
         private readonly ThreadLocal<MemoryMappedViewStream> viewStream = new ThreadLocal<MemoryMappedViewStream>(true);
         private bool disposedValue;
 
         // Once the configuration file is valid, an eventListener object will be created.
-        // Commented out for now to avoid the "field was never used" compiler error.
         private SelfDiagnosticsEventListener eventListener;
         private volatile FileStream underlyingFileStreamForMemoryMappedFile;
         private volatile MemoryMappedFile memoryMappedFile;
@@ -279,6 +278,8 @@ namespace OpenTelemetry.Internal
                     // Or it might have created another MemoryMappedFile in that thread
                     // after the CloseLogFile() below is called.
                     this.CloseLogFile();
+                    this.viewStream.Dispose();
+                    this.memoryMappedFileCache.Dispose();
                 }
 
                 this.disposedValue = true;


### PR DESCRIPTION
Fixes #.

## Changes

Call Dispose for ThreadLocal variables, because [ThreadLocal](https://docs.microsoft.com/en-us/dotnet/api/system.threading.threadlocal-1?view=net-5.0) class is IDisposable.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
