### PR TITLE
Initial framework for Aggregators

### DIFF
--- a/examples/Console/Program.cs
+++ b/examples/Console/Program.cs
@@ -34,7 +34,7 @@ namespace Examples.Console
         /// dotnet run -p Examples.Console.csproj prometheus -i 15 -p 9184 -d 2
         /// dotnet run -p Examples.Console.csproj otlp -e "http://localhost:4317"
         /// dotnet run -p Examples.Console.csproj zpages
-        /// dotnet run -p Examples.Console.csproj metrics -p 100 -e 500
+        /// dotnet run -p Examples.Console.csproj metrics --help
         ///
         /// The above must be run from the project root folder
         /// (eg: C:\repos\opentelemetry-dotnet\examples\Console\).
@@ -42,12 +42,14 @@ namespace Examples.Console
         /// <param name="args">Arguments from command line.</param>
         public static void Main(string[] args)
         {
+            bool prompt = true;
+
             Parser.Default.ParseArguments<JaegerOptions, ZipkinOptions, PrometheusOptions, MetricsOptions, GrpcNetClientOptions, HttpClientOptions, RedisOptions, ZPagesOptions, ConsoleOptions, OpenTelemetryShimOptions, OpenTracingShimOptions, OtlpOptions, InMemoryOptions>(args)
                 .MapResult(
                     (JaegerOptions options) => TestJaegerExporter.Run(options.Host, options.Port),
                     (ZipkinOptions options) => TestZipkinExporter.Run(options.Uri),
                     (PrometheusOptions options) => TestPrometheusExporter.Run(options.Port, options.PushIntervalInSecs, options.DurationInMins),
-                    (MetricsOptions options) => TestMetrics.Run(options.ObservationPeriodMilliseconds, options.CollectionPeriodMilliseconds),
+                    (MetricsOptions options) => TestMetrics.Run(options, ref prompt),
                     (GrpcNetClientOptions options) => TestGrpcNetClient.Run(),
                     (HttpClientOptions options) => TestHttpClient.Run(),
                     (RedisOptions options) => TestRedis.Run(options.Uri),
@@ -59,7 +61,10 @@ namespace Examples.Console
                     (InMemoryOptions options) => TestInMemoryExporter.Run(options),
                     errs => 1);
 
-            System.Console.ReadLine();
+            if (prompt)
+            {
+                System.Console.ReadLine();
+            }
         }
     }
 
@@ -98,11 +103,26 @@ namespace Examples.Console
     [Verb("metrics", HelpText = "Specify the options required to test Metrics")]
     internal class MetricsOptions
     {
-        [Option('p', "observationPeriodMilliseconds", Default = 100, HelpText = "Observation period.", Required = false)]
+        [Option('p', "prompt", HelpText = "Prompt for exit", Default = false)]
+        public bool? Prompt { get; set; }
+
+        [Option("runtime", Default = 5000, HelpText = "Run time in milliseconds.", Required = false)]
+        public int RunTime { get; set; }
+
+        [Option("observationPeriodMilliseconds", Default = 100, HelpText = "Observation period.", Required = false)]
         public int ObservationPeriodMilliseconds { get; set; }
 
-        [Option('c', "collectionPeriodMilliseconds", Default = 500, HelpText = "Collection period.", Required = false)]
+        [Option("collectionPeriodMilliseconds", Default = 500, HelpText = "Collection period.", Required = false)]
         public int CollectionPeriodMilliseconds { get; set; }
+
+        [Option('o', "runObservable", Default = true, HelpText = "Run observable counters.", Required = false)]
+        public bool? RunObservable { get; set; }
+
+        [Option('t', "numTasks", Default = 1, HelpText = "Run # of tasks.", Required = false)]
+        public int NumTasks { get; set; }
+
+        [Option("maxLoops", Default = 0, HelpText = "Maximum number of loops. 0 = No Limit", Required = false)]
+        public int MaxLoops { get; set; }
     }
 
     [Verb("grpc", HelpText = "Specify the options required to test Grpc.Net.Client")]

--- a/src/OpenTelemetry/Metrics/Aggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregator.cs
@@ -20,14 +20,14 @@ using System.Linq;
 
 namespace OpenTelemetry.Metrics
 {
-    public abstract class Aggregator
+    internal abstract class Aggregator
     {
-        public virtual void Update<T>(DateTimeOffset dt, T value)
+        internal virtual void Update<T>(DateTimeOffset dt, T value)
             where T : struct
         {
         }
 
-        public virtual IEnumerable<Metric> Collect()
+        internal virtual IEnumerable<Metric> Collect()
         {
             return Enumerable.Empty<Metric>();
         }

--- a/src/OpenTelemetry/Metrics/Aggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregator.cs
@@ -14,15 +14,16 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
-using System.Diagnostics.Metrics;
 using System.Linq;
 
 namespace OpenTelemetry.Metrics
 {
     public abstract class Aggregator
     {
-        public virtual void Update(IDataPoint value)
+        public virtual void Update<T>(DateTimeOffset dt, T value)
+            where T : struct
         {
         }
 

--- a/src/OpenTelemetry/Metrics/Aggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregator.cs
@@ -1,4 +1,4 @@
-// <copyright file="DataPoint{T}.cs" company="OpenTelemetry Authors">
+// <copyright file="Aggregator.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,33 +14,21 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Collections.Generic;
-
-#nullable enable
+using System.Diagnostics.Metrics;
+using System.Linq;
 
 namespace OpenTelemetry.Metrics
 {
-    internal class DataPoint<T> : DataPoint
-        where T : unmanaged
+    public abstract class Aggregator
     {
-        internal readonly T Value;
-
-        public DataPoint(T value, params KeyValuePair<string, object?>[] tags)
-            : base(new ReadOnlySpan<KeyValuePair<string, object?>>(tags))
+        public virtual void Update(IDataPoint value)
         {
-            this.Value = value;
         }
 
-        public DataPoint(T value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
-            : base(tags)
+        public virtual IEnumerable<Metric> Collect()
         {
-            this.Value = value;
-        }
-
-        public override string ValueAsString()
-        {
-            return this.Value.ToString();
+            return Enumerable.Empty<Metric>();
         }
     }
 }

--- a/src/OpenTelemetry/Metrics/Aggregator/LastValueAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregator/LastValueAggregator.cs
@@ -36,7 +36,7 @@ namespace OpenTelemetry.Metrics
 
             if (names.Length != values.Length)
             {
-                throw new ArgumentException("Length of names[] and values[] must match.");
+                throw new ArgumentException($"Length of {nameof(names)} and {nameof(values)} must match.");
             }
 
             this.tags = new KeyValuePair<string, object>[names.Length];

--- a/src/OpenTelemetry/Metrics/Aggregator/LastValueAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregator/LastValueAggregator.cs
@@ -21,7 +21,7 @@ using System.Linq;
 
 namespace OpenTelemetry.Metrics
 {
-    public class LastValueAggregator : Aggregator
+    internal class LastValueAggregator : Aggregator
     {
         private readonly Instrument instrument;
         private readonly KeyValuePair<string, object>[] tags;
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Metrics
         private int count = 0;
         private DataPoint lastDataPoint;
 
-        public LastValueAggregator(Instrument instrument, string[] names, object[] values)
+        internal LastValueAggregator(Instrument instrument, string[] names, object[] values)
         {
             this.instrument = instrument;
 
@@ -46,7 +46,7 @@ namespace OpenTelemetry.Metrics
             }
         }
 
-        public override void Update<T>(DateTimeOffset dt, T value)
+        internal override void Update<T>(DateTimeOffset dt, T value)
             where T : struct
         {
             lock (this.lockUpdate)
@@ -56,7 +56,7 @@ namespace OpenTelemetry.Metrics
             }
         }
 
-        public override IEnumerable<Metric> Collect()
+        internal override IEnumerable<Metric> Collect()
         {
             // TODO: Need to determine how to convert to Metric
 

--- a/src/OpenTelemetry/Metrics/Aggregator/LastValueAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregator/LastValueAggregator.cs
@@ -31,6 +31,11 @@ namespace OpenTelemetry.Metrics
 
         public LastValueAggregator(Instrument instrument, string[] names, object[] values)
         {
+            if (names.Length != values.Length)
+            {
+                throw new ArgumentException("Length of names[] and values[] must match.");
+            }
+
             this.instrument = instrument;
             this.names = names;
             this.values = values;
@@ -57,8 +62,7 @@ namespace OpenTelemetry.Metrics
                 attribs.Add(new KeyValuePair<string, object>(this.names[i], this.values[i]));
             }
 
-            var dp = this.lastValue.NewWithValue();
-            dp.ResetTags(attribs.ToArray());
+            var dp = this.lastValue.Clone(attribs.ToArray());
 
             var metrics = new Metric[]
             {

--- a/src/OpenTelemetry/Metrics/Aggregator/LastValueAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregator/LastValueAggregator.cs
@@ -23,31 +23,48 @@ namespace OpenTelemetry.Metrics
 {
     public class LastValueAggregator : Aggregator
     {
-        private readonly KeyValuePair<string, object>[] emptyKVP = new KeyValuePair<string, object>[0];
         private readonly Instrument instrument;
-        private readonly string[] names;
-        private readonly object[] values;
+        private readonly KeyValuePair<string, object>[] tags;
 
-        private IDataPoint lastValue;
+        private readonly object lockLastValue = new object();
         private int count = 0;
+        private DataPoint lastDataPoint;
 
         public LastValueAggregator(Instrument instrument, string[] names, object[] values)
         {
+            this.instrument = instrument;
+
             if (names.Length != values.Length)
             {
                 throw new ArgumentException("Length of names[] and values[] must match.");
             }
 
-            this.instrument = instrument;
-            this.names = names;
-            this.values = values;
+            this.tags = new KeyValuePair<string, object>[names.Length];
+            for (int i = 0; i < names.Length; i++)
+            {
+                this.tags[i] = new KeyValuePair<string, object>(names[i], values[i]);
+            }
         }
 
         public override void Update<T>(DateTimeOffset dt, T value)
             where T : struct
         {
-            this.count++;
-            this.lastValue = new DataPoint<T>(dt, value, this.emptyKVP);
+            lock (this.lockLastValue)
+            {
+                this.count++;
+                if (typeof(T) == typeof(int))
+                {
+                    this.lastDataPoint = new DataPoint(dt, (int)(object)value, this.tags);
+                }
+                else if (typeof(T) == typeof(double))
+                {
+                    this.lastDataPoint = new DataPoint(dt, (double)(object)value, this.tags);
+                }
+                else
+                {
+                    throw new Exception("Unsupported Type");
+                }
+            }
         }
 
         public override IEnumerable<Metric> Collect()
@@ -59,20 +76,19 @@ namespace OpenTelemetry.Metrics
                 return Enumerable.Empty<Metric>();
             }
 
-            var attribs = new List<KeyValuePair<string, object>>();
-            for (int i = 0; i < this.names.Length; i++)
+            DataPoint lastValue;
+            lock (this.lockLastValue)
             {
-                attribs.Add(new KeyValuePair<string, object>(this.names[i], this.values[i]));
+                lastValue = this.lastDataPoint;
+                this.count = 0;
             }
 
             var metrics = new Metric[]
             {
                 new Metric(
                     $"{this.instrument.Meter.Name}:{this.instrument.Name}:LastValue",
-                    this.lastValue),
+                    lastValue),
             };
-
-            this.count = 0;
 
             return metrics;
         }

--- a/src/OpenTelemetry/Metrics/Aggregator/LastValueAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregator/LastValueAggregator.cs
@@ -1,0 +1,75 @@
+// <copyright file="LastValueAggregator.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Linq;
+
+namespace OpenTelemetry.Metrics
+{
+    public class LastValueAggregator : Aggregator
+    {
+        private readonly Instrument instrument;
+        private readonly string[] names;
+        private readonly object[] values;
+        private IDataPoint lastValue = null;
+        private int count = 0;
+
+        public LastValueAggregator(Instrument instrument, string[] names, object[] values)
+        {
+            this.instrument = instrument;
+            this.names = names;
+            this.values = values;
+        }
+
+        public override void Update(IDataPoint value)
+        {
+            this.count++;
+            this.lastValue = value;
+        }
+
+        public override IEnumerable<Metric> Collect()
+        {
+            // TODO: Need to determine how to convert to Metric
+
+            if (this.count == 0)
+            {
+                return Enumerable.Empty<Metric>();
+            }
+
+            var attribs = new List<KeyValuePair<string, object>>();
+            for (int i = 0; i < this.names.Length; i++)
+            {
+                attribs.Add(new KeyValuePair<string, object>(this.names[i], this.values[i]));
+            }
+
+            var dp = this.lastValue.NewWithValue();
+            dp.ResetTags(attribs.ToArray());
+
+            var metrics = new Metric[]
+            {
+                new Metric(
+                    $"{this.instrument.Meter.Name}:{this.instrument.Name}:LastValue",
+                    dp),
+            };
+
+            this.count = 0;
+
+            return metrics;
+        }
+    }
+}

--- a/src/OpenTelemetry/Metrics/Aggregator/SumAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregator/SumAggregator.cs
@@ -21,7 +21,7 @@ using System.Linq;
 
 namespace OpenTelemetry.Metrics
 {
-    public class SumAggregator : Aggregator
+    internal class SumAggregator : Aggregator
     {
         private readonly Instrument instrument;
         private readonly KeyValuePair<string, object>[] tags;
@@ -31,7 +31,7 @@ namespace OpenTelemetry.Metrics
         private double dsum = 0;
         private long count = 0;
 
-        public SumAggregator(Instrument instrument, string[] names, object[] values)
+        internal SumAggregator(Instrument instrument, string[] names, object[] values)
         {
             this.instrument = instrument;
 
@@ -47,7 +47,7 @@ namespace OpenTelemetry.Metrics
             }
         }
 
-        public override void Update<T>(DateTimeOffset dt, T value)
+        internal override void Update<T>(DateTimeOffset dt, T value)
             where T : struct
         {
             lock (this.lockUpdate)
@@ -72,7 +72,7 @@ namespace OpenTelemetry.Metrics
             }
         }
 
-        public override IEnumerable<Metric> Collect()
+        internal override IEnumerable<Metric> Collect()
         {
             // TODO: Need to determine how to convert to Metric
 

--- a/src/OpenTelemetry/Metrics/Aggregator/SumAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregator/SumAggregator.cs
@@ -31,6 +31,11 @@ namespace OpenTelemetry.Metrics
 
         public SumAggregator(Instrument instrument, string[] names, object[] values)
         {
+            if (names.Length != values.Length)
+            {
+                throw new ArgumentException("Length of names[] and values[] must match.");
+            }
+
             this.instrument = instrument;
             this.names = names;
             this.values = values;

--- a/src/OpenTelemetry/Metrics/Aggregator/SumAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregator/SumAggregator.cs
@@ -1,0 +1,92 @@
+// <copyright file="SumAggregator.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Linq;
+
+namespace OpenTelemetry.Metrics
+{
+    public class SumAggregator : Aggregator
+    {
+        private readonly Instrument instrument;
+        private readonly string[] names;
+        private readonly object[] values;
+        private long sum = 0;
+        private long count = 0;
+
+        public SumAggregator(Instrument instrument, string[] names, object[] values)
+        {
+            this.instrument = instrument;
+            this.names = names;
+            this.values = values;
+        }
+
+        public override void Update(IDataPoint value)
+        {
+            this.count++;
+
+            // TODO: Need to handle DataPoint<T> appropriately
+
+            if (value is DataPoint<int> intV)
+            {
+                this.sum += intV.Value;
+            }
+            else if (value is DataPoint<long> longV)
+            {
+                this.sum += longV.Value;
+            }
+            else
+            {
+                throw new Exception("Unsupported Type");
+            }
+        }
+
+        public override IEnumerable<Metric> Collect()
+        {
+            // TODO: Need to determine how to convert to Metric
+
+            if (this.count == 0)
+            {
+                return Enumerable.Empty<Metric>();
+            }
+
+            var attribs = new List<KeyValuePair<string, object>>();
+            for (int i = 0; i < this.names.Length; i++)
+            {
+                attribs.Add(new KeyValuePair<string, object>(this.names[i], this.values[i]));
+            }
+
+            var tags = attribs.ToArray();
+
+            var metrics = new Metric[]
+            {
+                new Metric(
+                    $"{this.instrument.Meter.Name}:{this.instrument.Name}:Count",
+                    new DataPoint<int>((int)this.count, tags)),
+                new Metric(
+                    $"{this.instrument.Meter.Name}:{this.instrument.Name}:Sum",
+                    new DataPoint<int>((int)this.sum, tags)),
+            };
+
+            this.count = 0;
+            this.sum = 0;
+
+            return metrics;
+        }
+    }
+}

--- a/src/OpenTelemetry/Metrics/Aggregator/SumAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregator/SumAggregator.cs
@@ -24,41 +24,51 @@ namespace OpenTelemetry.Metrics
     public class SumAggregator : Aggregator
     {
         private readonly Instrument instrument;
-        private readonly string[] names;
-        private readonly object[] values;
+        private readonly KeyValuePair<string, object>[] tags;
+        private readonly object lockUpdate = new object();
+        private Type valueType;
         private long sum = 0;
+        private double dsum = 0;
         private long count = 0;
 
         public SumAggregator(Instrument instrument, string[] names, object[] values)
         {
+            this.instrument = instrument;
+
             if (names.Length != values.Length)
             {
                 throw new ArgumentException("Length of names[] and values[] must match.");
             }
 
-            this.instrument = instrument;
-            this.names = names;
-            this.values = values;
+            this.tags = new KeyValuePair<string, object>[names.Length];
+            for (int i = 0; i < names.Length; i++)
+            {
+                this.tags[i] = new KeyValuePair<string, object>(names[i], values[i]);
+            }
         }
 
         public override void Update<T>(DateTimeOffset dt, T value)
             where T : struct
         {
-            this.count++;
+            lock (this.lockUpdate)
+            {
+                this.count++;
+                this.valueType = typeof(T);
 
-            // TODO: Need to handle DataPoint<T> appropriately
+                // TODO: Need to handle DataPoint<T> appropriately
 
-            if (typeof(T) == typeof(int))
-            {
-                this.sum += (int)(object)value;
-            }
-            else if (typeof(T) == typeof(double))
-            {
-                this.sum += (int)(double)(object)value;
-            }
-            else
-            {
-                throw new Exception("Unsupported Type");
+                if (typeof(T) == typeof(int))
+                {
+                    this.sum += (int)(object)value;
+                }
+                else if (typeof(T) == typeof(double))
+                {
+                    this.dsum += (double)(object)value;
+                }
+                else
+                {
+                    throw new Exception("Unsupported Type");
+                }
             }
         }
 
@@ -71,27 +81,37 @@ namespace OpenTelemetry.Metrics
                 return Enumerable.Empty<Metric>();
             }
 
-            var attribs = new List<KeyValuePair<string, object>>();
-            for (int i = 0; i < this.names.Length; i++)
-            {
-                attribs.Add(new KeyValuePair<string, object>(this.names[i], this.values[i]));
-            }
-
-            var tags = attribs.ToArray();
             var dt = MeterProviderSdk.GetDateTimeOffset();
+
+            IDataPoint datapointSum;
+            IDataPoint datapointCount;
+            lock (this.lockUpdate)
+            {
+                datapointCount = new DataPoint<int>(dt, (int)this.count, this.tags);
+
+                if (this.valueType == typeof(int))
+                {
+                    datapointSum = new DataPoint<int>(dt, (int)this.sum, this.tags);
+                    this.sum = 0;
+                }
+                else if (this.valueType == typeof(double))
+                {
+                    datapointSum = new DataPoint<double>(dt, (double)this.dsum, this.tags);
+                    this.dsum = 0;
+                }
+                else
+                {
+                    throw new Exception("Unsupported Type");
+                }
+
+                this.count = 0;
+            }
 
             var metrics = new Metric[]
             {
-                new Metric(
-                    $"{this.instrument.Meter.Name}:{this.instrument.Name}:Count",
-                    new DataPoint<int>(dt, (int)this.count, tags)),
-                new Metric(
-                    $"{this.instrument.Meter.Name}:{this.instrument.Name}:Sum",
-                    new DataPoint<int>(dt, (int)this.sum, tags)),
+                new Metric($"{this.instrument.Meter.Name}:{this.instrument.Name}:Count", datapointCount),
+                new Metric($"{this.instrument.Meter.Name}:{this.instrument.Name}:Sum", datapointSum),
             };
-
-            this.count = 0;
-            this.sum = 0;
 
             return metrics;
         }

--- a/src/OpenTelemetry/Metrics/Aggregator/SumAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregator/SumAggregator.cs
@@ -48,13 +48,11 @@ namespace OpenTelemetry.Metrics
 
             // TODO: Need to handle DataPoint<T> appropriately
 
-            var valuetype = value.GetType();
-
-            if (valuetype == typeof(int))
+            if (typeof(T) == typeof(int))
             {
                 this.sum += (int)(object)value;
             }
-            else if (valuetype == typeof(double))
+            else if (typeof(T) == typeof(double))
             {
                 this.sum += (int)(double)(object)value;
             }

--- a/src/OpenTelemetry/Metrics/Aggregator/SumAggregator.cs
+++ b/src/OpenTelemetry/Metrics/Aggregator/SumAggregator.cs
@@ -41,19 +41,22 @@ namespace OpenTelemetry.Metrics
             this.values = values;
         }
 
-        public override void Update(IDataPoint value)
+        public override void Update<T>(DateTimeOffset dt, T value)
+            where T : struct
         {
             this.count++;
 
             // TODO: Need to handle DataPoint<T> appropriately
 
-            if (value is DataPoint<int> intV)
+            var valuetype = value.GetType();
+
+            if (valuetype == typeof(int))
             {
-                this.sum += intV.Value;
+                this.sum += (int)(object)value;
             }
-            else if (value is DataPoint<long> longV)
+            else if (valuetype == typeof(double))
             {
-                this.sum += longV.Value;
+                this.sum += (int)(double)(object)value;
             }
             else
             {
@@ -77,15 +80,16 @@ namespace OpenTelemetry.Metrics
             }
 
             var tags = attribs.ToArray();
+            var dt = MeterProviderSdk.GetDateTimeOffset();
 
             var metrics = new Metric[]
             {
                 new Metric(
                     $"{this.instrument.Meter.Name}:{this.instrument.Name}:Count",
-                    new DataPoint<int>((int)this.count, tags)),
+                    new DataPoint<int>(dt, (int)this.count, tags)),
                 new Metric(
                     $"{this.instrument.Meter.Name}:{this.instrument.Name}:Sum",
-                    new DataPoint<int>((int)this.sum, tags)),
+                    new DataPoint<int>(dt, (int)this.sum, tags)),
             };
 
             this.count = 0;

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -64,7 +64,7 @@ namespace OpenTelemetry.Metrics
             };
         }
 
-        internal Aggregator[] FindAggregators(KeyValuePair<string, object>[] tags)
+        internal Aggregator[] FindAggregators(ReadOnlySpan<KeyValuePair<string, object>> tags)
         {
             int len = tags.Length;
 
@@ -80,7 +80,7 @@ namespace OpenTelemetry.Metrics
 
             var storage = ThreadStaticStorage.GetStorage();
 
-            storage.GetKeysValues(tags, out var tagKey, out var tagValue);
+            storage.SplitToKeysAndValues(tags, out var tagKey, out var tagValue);
 
             if (len > 1)
             {
@@ -125,13 +125,14 @@ namespace OpenTelemetry.Metrics
             return aggregators;
         }
 
-        internal void Update(IDataPoint point)
+        internal void Update<T>(DateTimeOffset dt, T value, ReadOnlySpan<KeyValuePair<string, object>> tags)
+            where T : struct
         {
-            var aggs = this.FindAggregators(point.Tags);
+            var aggs = this.FindAggregators(tags);
 
             foreach (var agg in aggs)
             {
-                agg.Update(point);
+                agg.Update(dt, value);
             }
         }
 

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -1,0 +1,178 @@
+// <copyright file="AggregatorStore.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+
+namespace OpenTelemetry.Metrics
+{
+    public class AggregatorStore
+    {
+        private static readonly string[] EmptySeqKey = new string[0];
+        private static readonly object[] EmptySeqValue = new object[0];
+
+        private readonly Instrument instrument;
+        private readonly MeterProviderSdk sdk;
+
+        // Two-Level lookup. TagKeys x [ TagValues x Aggregators ]
+        private readonly Dictionary<string[], Dictionary<object[], Aggregator[]>> keyValue2MetricAggs =
+            new Dictionary<string[], Dictionary<object[], Aggregator[]>>(new StringArrayEquaityComparer());
+
+        private Aggregator[] tag0Aggregators = null;
+
+        public AggregatorStore(MeterProviderSdk sdk, Instrument instrument)
+        {
+            this.sdk = sdk;
+            this.instrument = instrument;
+
+            foreach (var processor in this.sdk.AggregateProcessors)
+            {
+                processor.Register(this);
+            }
+        }
+
+        internal Aggregator[] GetDefaultAggregator(string[] seqKey, object[] seqVal)
+        {
+            // TODO: Figure out default aggregator/s based on Instrument and configs
+
+            if (!this.instrument.IsObservable)
+            {
+                return new Aggregator[]
+                {
+                    new SumAggregator(this.instrument, seqKey, seqVal),
+                };
+            }
+
+            return new Aggregator[]
+            {
+                new LastValueAggregator(this.instrument, seqKey, seqVal),
+            };
+        }
+
+        internal Aggregator[] FindAggregators(KeyValuePair<string, object>[] tags)
+        {
+            int len = tags.Length;
+
+            if (len == 0)
+            {
+                if (this.tag0Aggregators == null)
+                {
+                    this.tag0Aggregators = this.GetDefaultAggregator(AggregatorStore.EmptySeqKey, AggregatorStore.EmptySeqValue);
+                }
+
+                return this.tag0Aggregators;
+            }
+
+            var storage = ThreadStaticStorage.GetStorage();
+
+            storage.GetKeysValuesKvp(len, out var tagKey, out var tagValue, out var tagKvp);
+
+            if (len == 1)
+            {
+                tagKey[0] = tags[0].Key;
+                tagValue[0] = tags[0].Value;
+            }
+            else
+            {
+                // Sort by Tag Key
+
+                for (var n = 0; n < len; n++)
+                {
+                    tagKvp[n] = tags[n];
+                }
+
+                Array.Sort(tagKvp, (x, y) => x.Key.CompareTo(y.Key));
+
+                for (var n = 0; n < len; n++)
+                {
+                    tagKey[n] = tagKvp[n].Key;
+                    tagValue[n] = tagKvp[n].Value;
+                }
+            }
+
+            string[] seqKey = null;
+
+            // GetOrAdd by TagKey at 1st Level of 2-level dictionary structure.
+            // Get back a Dictionary of [ Values x Aggregators[] ].
+            if (!this.keyValue2MetricAggs.TryGetValue(tagKey, out var value2metrics))
+            {
+                // Note: We are using storage from ThreadStatic, so need to make a deep copy for Dictionary storage.
+
+                seqKey = new string[len];
+                tagKey.CopyTo(seqKey, 0);
+
+                value2metrics = new Dictionary<object[], Aggregator[]>(new ObjectArrayEquaityComparer());
+                this.keyValue2MetricAggs.Add(seqKey, value2metrics);
+            }
+
+            // GetOrAdd by TagValue at 2st Level of 2-level dictionary structure.
+            // Get back Aggregators[].
+            if (!value2metrics.TryGetValue(tagValue, out var aggregators))
+            {
+                // Note: We are using storage from ThreadStatic, so need to make a deep copy for Dictionary storage.
+
+                if (seqKey == null)
+                {
+                    seqKey = new string[len];
+                    tagKey.CopyTo(seqKey, 0);
+                }
+
+                var seqVal = new object[len];
+                tagValue.CopyTo(seqVal, 0);
+
+                aggregators = this.GetDefaultAggregator(seqKey, seqVal);
+
+                value2metrics.Add(seqVal, aggregators);
+            }
+
+            return aggregators;
+        }
+
+        internal void Update(IDataPoint point)
+        {
+            var aggs = this.FindAggregators(point.Tags);
+
+            foreach (var agg in aggs)
+            {
+                agg.Update(point);
+            }
+        }
+
+        internal List<Metric> Collect()
+        {
+            var aggs = new List<Aggregator>();
+
+            foreach (var keys in this.keyValue2MetricAggs)
+            {
+                foreach (var values in keys.Value)
+                {
+                    aggs.AddRange(values.Value);
+                }
+            }
+
+            var metrics = new List<Metric>();
+
+            foreach (var aggregator in aggs)
+            {
+                metrics.AddRange(aggregator.Collect());
+            }
+
+            return metrics;
+        }
+    }
+}

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -21,7 +21,7 @@ using System.Diagnostics.Metrics;
 
 namespace OpenTelemetry.Metrics
 {
-    public class AggregatorStore
+    internal class AggregatorStore
     {
         private static readonly string[] EmptySeqKey = new string[0];
         private static readonly object[] EmptySeqValue = new object[0];
@@ -37,7 +37,7 @@ namespace OpenTelemetry.Metrics
 
         private Aggregator[] tag0Aggregators = null;
 
-        public AggregatorStore(MeterProviderSdk sdk, Instrument instrument)
+        internal AggregatorStore(MeterProviderSdk sdk, Instrument instrument)
         {
             this.sdk = sdk;
             this.instrument = instrument;

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -80,29 +80,11 @@ namespace OpenTelemetry.Metrics
 
             var storage = ThreadStaticStorage.GetStorage();
 
-            storage.GetKeysValuesKvp(len, out var tagKey, out var tagValue, out var tagKvp);
+            storage.GetKeysValues(tags, out var tagKey, out var tagValue);
 
-            if (len == 1)
+            if (len > 1)
             {
-                tagKey[0] = tags[0].Key;
-                tagValue[0] = tags[0].Value;
-            }
-            else
-            {
-                // Sort by Tag Key
-
-                for (var n = 0; n < len; n++)
-                {
-                    tagKvp[n] = tags[n];
-                }
-
-                Array.Sort(tagKvp, (x, y) => x.Key.CompareTo(y.Key));
-
-                for (var n = 0; n < len; n++)
-                {
-                    tagKey[n] = tagKvp[n].Key;
-                    tagValue[n] = tagKvp[n].Value;
-                }
+                Array.Sort<string, object>(tagKey, tagValue);
             }
 
             string[] seqKey = null;

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -31,7 +31,7 @@ namespace OpenTelemetry.Metrics
 
         // Two-Level lookup. TagKeys x [ TagValues x Aggregators ]
         private readonly Dictionary<string[], Dictionary<object[], Aggregator[]>> keyValue2MetricAggs =
-            new Dictionary<string[], Dictionary<object[], Aggregator[]>>(new StringArrayEquaityComparer());
+            new Dictionary<string[], Dictionary<object[], Aggregator[]>>(new StringArrayEqualityComparer());
 
         private Aggregator[] tag0Aggregators = null;
 
@@ -98,7 +98,7 @@ namespace OpenTelemetry.Metrics
                 seqKey = new string[len];
                 tagKey.CopyTo(seqKey, 0);
 
-                value2metrics = new Dictionary<object[], Aggregator[]>(new ObjectArrayEquaityComparer());
+                value2metrics = new Dictionary<object[], Aggregator[]>(new ObjectArrayEqualityComparer());
                 this.keyValue2MetricAggs.Add(seqKey, value2metrics);
             }
 

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -55,6 +55,7 @@ namespace OpenTelemetry.Metrics
                 return new Aggregator[]
                 {
                     new SumAggregator(this.instrument, seqKey, seqVal),
+                    new LastValueAggregator(this.instrument, seqKey, seqVal),
                 };
             }
 
@@ -128,6 +129,11 @@ namespace OpenTelemetry.Metrics
         internal void Update<T>(DateTimeOffset dt, T value, ReadOnlySpan<KeyValuePair<string, object>> tags)
             where T : struct
         {
+            // TODO: We can isolate the cost of each user-added aggregator in
+            // the hot path by queuing the DataPoint, and doing the Update as
+            // part of the Collect() instead. Thus, we only pay for the price
+            // of queueing a DataPoint in the Hot Path
+
             var aggs = this.FindAggregators(tags);
 
             foreach (var agg in aggs)

--- a/src/OpenTelemetry/Metrics/DataPoint.cs
+++ b/src/OpenTelemetry/Metrics/DataPoint.cs
@@ -55,12 +55,9 @@ namespace OpenTelemetry.Metrics
             }
         }
 
-        public string ValueAsString
+        public string ValueAsString()
         {
-            get
-            {
-                return this.Value.ToString();
-            }
+            return this.Value.ToString();
         }
 
         public void Reset<T1>(T1 value, KeyValuePair<string, object>[] tags)
@@ -68,17 +65,12 @@ namespace OpenTelemetry.Metrics
         {
             this.timestamp = DataPoint<T>.GetDateTimeOffset();
             this.tags = tags;
-            this.Value = (T)((object)value);
+            this.Value = (T)(object)value;
         }
 
-        public void ResetTags(KeyValuePair<string, object>[] tags)
+        public IDataPoint Clone(KeyValuePair<string, object>[] tags)
         {
-            this.tags = tags;
-        }
-
-        public IDataPoint NewWithValue()
-        {
-            return new DataPoint<T>(this.Value, new KeyValuePair<string, object>[0]);
+            return new DataPoint<T>(this.Value, tags);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/OpenTelemetry/Metrics/DataPoint.cs
+++ b/src/OpenTelemetry/Metrics/DataPoint.cs
@@ -78,7 +78,7 @@ namespace OpenTelemetry.Metrics
         }
 
         /// <summary>
-        /// Reset (e.g. new Datapoint(...)) this object for reused.
+        /// Reset (e.g. new DataPointT(...)) this object for reused.
         /// This is provided to avoid additional allocation in Hot Path.
         /// </summary>
         /// <typeparam name="T1">T.</typeparam>

--- a/src/OpenTelemetry/Metrics/DataPoint.cs
+++ b/src/OpenTelemetry/Metrics/DataPoint.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Metrics
 
         private readonly KeyValuePair<string, object>[] tags;
 
-        public DataPoint(DateTimeOffset timestamp, int value, KeyValuePair<string, object>[] tags)
+        internal DataPoint(DateTimeOffset timestamp, int value, KeyValuePair<string, object>[] tags)
         {
             this.timestamp = timestamp;
             this.tags = tags;
@@ -39,7 +39,7 @@ namespace OpenTelemetry.Metrics
             this.DoubleValue = 0;
         }
 
-        public DataPoint(DateTimeOffset timestamp, double value, KeyValuePair<string, object>[] tags)
+        internal DataPoint(DateTimeOffset timestamp, double value, KeyValuePair<string, object>[] tags)
         {
             this.timestamp = timestamp;
             this.tags = tags;
@@ -83,7 +83,7 @@ namespace OpenTelemetry.Metrics
             }
         }
 
-        public static DataPoint CreateDataPoint<T>(DateTimeOffset timestamp, T value, KeyValuePair<string, object>[] tags)
+        internal static DataPoint CreateDataPoint<T>(DateTimeOffset timestamp, T value, KeyValuePair<string, object>[] tags)
         {
             DataPoint dp;
 

--- a/src/OpenTelemetry/Metrics/DataPoint.cs
+++ b/src/OpenTelemetry/Metrics/DataPoint.cs
@@ -82,5 +82,25 @@ namespace OpenTelemetry.Metrics
                 }
             }
         }
+
+        public static DataPoint CreateDataPoint<T>(DateTimeOffset timestamp, T value, KeyValuePair<string, object>[] tags)
+        {
+            DataPoint dp;
+
+            if (typeof(T) == typeof(int))
+            {
+                dp = new DataPoint(timestamp, (int)(object)value, tags);
+            }
+            else if (typeof(T) == typeof(double))
+            {
+                dp = new DataPoint(timestamp, (double)(object)value, tags);
+            }
+            else
+            {
+                throw new Exception("Unsupported Type");
+            }
+
+            return dp;
+        }
     }
 }

--- a/src/OpenTelemetry/Metrics/DataPoint.cs
+++ b/src/OpenTelemetry/Metrics/DataPoint.cs
@@ -39,6 +39,13 @@ namespace OpenTelemetry.Metrics
             this.tags = tags;
         }
 
+        private DataPoint(DateTimeOffset timestamp, T value, KeyValuePair<string, object>[] tags)
+        {
+            this.timestamp = timestamp;
+            this.Value = value;
+            this.tags = tags;
+        }
+
         public KeyValuePair<string, object>[] Tags
         {
             get
@@ -60,17 +67,29 @@ namespace OpenTelemetry.Metrics
             return this.Value.ToString();
         }
 
-        public void Reset<T1>(T1 value, KeyValuePair<string, object>[] tags)
+        public IDataPoint Clone(KeyValuePair<string, object>[] tags)
+        {
+            return new DataPoint<T>(this.timestamp, this.Value, tags);
+        }
+
+        public IDataPoint Clone()
+        {
+            return new DataPoint<T>(this.timestamp, this.Value, this.tags);
+        }
+
+        /// <summary>
+        /// Reset (e.g. new Datapoint(...)) this object for reused.
+        /// This is provided to avoid additional allocation in Hot Path.
+        /// </summary>
+        /// <typeparam name="T1">T.</typeparam>
+        /// <param name="value">value.</param>
+        /// <param name="tags">tags.</param>
+        internal void Reset<T1>(T1 value, KeyValuePair<string, object>[] tags)
             where T1 : struct
         {
             this.timestamp = DataPoint<T>.GetDateTimeOffset();
             this.tags = tags;
             this.Value = (T)(object)value;
-        }
-
-        public IDataPoint Clone(KeyValuePair<string, object>[] tags)
-        {
-            return new DataPoint<T>(this.Value, tags);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/OpenTelemetry/Metrics/DataPoint.cs
+++ b/src/OpenTelemetry/Metrics/DataPoint.cs
@@ -20,26 +20,16 @@ using System.Runtime.CompilerServices;
 
 namespace OpenTelemetry.Metrics
 {
-    internal struct DataPoint<T> : IDataPoint
+    internal readonly struct DataPoint<T> : IDataPoint
         where T : struct
     {
-        internal T Value;
+        internal readonly T Value;
 
-        private static int lastTick = -1;
-        private static DateTimeOffset lastTimestamp = DateTimeOffset.MinValue;
+        private readonly DateTimeOffset timestamp;
 
-        private DateTimeOffset timestamp;
+        private readonly KeyValuePair<string, object>[] tags;
 
-        private KeyValuePair<string, object>[] tags;
-
-        public DataPoint(T value, KeyValuePair<string, object>[] tags)
-        {
-            this.timestamp = DataPoint<T>.GetDateTimeOffset();
-            this.Value = value;
-            this.tags = tags;
-        }
-
-        private DataPoint(DateTimeOffset timestamp, T value, KeyValuePair<string, object>[] tags)
+        public DataPoint(DateTimeOffset timestamp, T value, KeyValuePair<string, object>[] tags)
         {
             this.timestamp = timestamp;
             this.Value = value;
@@ -65,47 +55,6 @@ namespace OpenTelemetry.Metrics
         public string ValueAsString()
         {
             return this.Value.ToString();
-        }
-
-        public IDataPoint Clone(KeyValuePair<string, object>[] tags)
-        {
-            return new DataPoint<T>(this.timestamp, this.Value, tags);
-        }
-
-        public IDataPoint Clone()
-        {
-            return new DataPoint<T>(this.timestamp, this.Value, this.tags);
-        }
-
-        /// <summary>
-        /// Reset (e.g. new DataPointT(...)) this object for reused.
-        /// This is provided to avoid additional allocation in Hot Path.
-        /// </summary>
-        /// <typeparam name="T1">T.</typeparam>
-        /// <param name="value">value.</param>
-        /// <param name="tags">tags.</param>
-        internal void Reset<T1>(T1 value, KeyValuePair<string, object>[] tags)
-            where T1 : struct
-        {
-            this.timestamp = DataPoint<T>.GetDateTimeOffset();
-            this.tags = tags;
-            this.Value = (T)(object)value;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static DateTimeOffset GetDateTimeOffset()
-        {
-            int tick = Environment.TickCount;
-            if (tick == DataPoint<T>.lastTick)
-            {
-                return DataPoint<T>.lastTimestamp;
-            }
-
-            var dt = DateTimeOffset.UtcNow;
-            DataPoint<T>.lastTimestamp = dt;
-            DataPoint<T>.lastTick = tick;
-
-            return dt;
         }
     }
 }

--- a/src/OpenTelemetry/Metrics/DataPoint{T}.cs
+++ b/src/OpenTelemetry/Metrics/DataPoint{T}.cs
@@ -29,7 +29,7 @@ namespace OpenTelemetry.Metrics
 
         private readonly KeyValuePair<string, object>[] tags;
 
-        public DataPoint(DateTimeOffset timestamp, T value, KeyValuePair<string, object>[] tags)
+        internal DataPoint(DateTimeOffset timestamp, T value, KeyValuePair<string, object>[] tags)
         {
             this.timestamp = timestamp;
             this.value = value;

--- a/src/OpenTelemetry/Metrics/DataPoint{T}.cs
+++ b/src/OpenTelemetry/Metrics/DataPoint{T}.cs
@@ -1,4 +1,4 @@
-// <copyright file="DataPoint.cs" company="OpenTelemetry Authors">
+// <copyright file="DataPoint{T}.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,32 +20,20 @@ using System.Runtime.CompilerServices;
 
 namespace OpenTelemetry.Metrics
 {
-    internal readonly struct DataPoint : IDataPoint
+    internal readonly struct DataPoint<T> : IDataPoint
+        where T : struct
     {
-        internal readonly Type ValueType;
-        internal readonly int IntValue;
-        internal readonly double DoubleValue;
+        private readonly T value;
 
         private readonly DateTimeOffset timestamp;
 
         private readonly KeyValuePair<string, object>[] tags;
 
-        public DataPoint(DateTimeOffset timestamp, int value, KeyValuePair<string, object>[] tags)
+        public DataPoint(DateTimeOffset timestamp, T value, KeyValuePair<string, object>[] tags)
         {
             this.timestamp = timestamp;
+            this.value = value;
             this.tags = tags;
-            this.ValueType = value.GetType();
-            this.IntValue = value;
-            this.DoubleValue = 0;
-        }
-
-        public DataPoint(DateTimeOffset timestamp, double value, KeyValuePair<string, object>[] tags)
-        {
-            this.timestamp = timestamp;
-            this.tags = tags;
-            this.ValueType = value.GetType();
-            this.IntValue = 0;
-            this.DoubleValue = value;
         }
 
         public KeyValuePair<string, object>[] Tags
@@ -68,18 +56,7 @@ namespace OpenTelemetry.Metrics
         {
             get
             {
-                if (this.ValueType == typeof(int))
-                {
-                    return this.IntValue;
-                }
-                else if (this.ValueType == typeof(double))
-                {
-                    return this.DoubleValue;
-                }
-                else
-                {
-                    throw new Exception("Unsupported Type");
-                }
+                return (object)this.value;
             }
         }
     }

--- a/src/OpenTelemetry/Metrics/IDataPoint.cs
+++ b/src/OpenTelemetry/Metrics/IDataPoint.cs
@@ -1,4 +1,4 @@
-// <copyright file="AggregateState.cs" company="OpenTelemetry Authors">
+// <copyright file="IDataPoint.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,26 +14,24 @@
 // limitations under the License.
 // </copyright>
 
-#nullable enable
+using System;
+using System.Collections.Generic;
 
 namespace OpenTelemetry.Metrics
 {
-    internal class AggregateState
+    public interface IDataPoint
     {
-        internal long Count = 0;
-        internal long Sum = 0;
+        public DateTimeOffset Timestamp { get; }
 
-        public virtual void Update(DataPoint? value)
-        {
-            long val = 0;
+        public KeyValuePair<string, object>[] Tags { get; }
 
-            if (value is DataPoint<int> idp)
-            {
-                val = idp.Value;
-            }
+        public string ValueAsString { get; }
 
-            this.Count++;
-            this.Sum += val;
-        }
+        public void ResetTags(KeyValuePair<string, object>[] tags);
+
+        public void Reset<T>(T value, KeyValuePair<string, object>[] tags)
+            where T : struct;
+
+        public IDataPoint NewWithValue();
     }
 }

--- a/src/OpenTelemetry/Metrics/IDataPoint.cs
+++ b/src/OpenTelemetry/Metrics/IDataPoint.cs
@@ -25,6 +25,6 @@ namespace OpenTelemetry.Metrics
 
         KeyValuePair<string, object>[] Tags { get; }
 
-        string ValueAsString();
+        object Value { get; }
     }
 }

--- a/src/OpenTelemetry/Metrics/IDataPoint.cs
+++ b/src/OpenTelemetry/Metrics/IDataPoint.cs
@@ -25,7 +25,7 @@ namespace OpenTelemetry.Metrics
 
         KeyValuePair<string, object>[] Tags { get; }
 
-        string ValueAsString()
+        string ValueAsString();
 
         IDataPoint Clone(KeyValuePair<string, object>[] tags);
 

--- a/src/OpenTelemetry/Metrics/IDataPoint.cs
+++ b/src/OpenTelemetry/Metrics/IDataPoint.cs
@@ -26,14 +26,5 @@ namespace OpenTelemetry.Metrics
         KeyValuePair<string, object>[] Tags { get; }
 
         string ValueAsString();
-
-        /// <summary>
-        /// Clone a DataPoint but with different tags.
-        /// </summary>
-        /// <param name="tags">Tags to use in clone.</param>
-        /// <returns>IDataPoint.</returns>
-        IDataPoint Clone(KeyValuePair<string, object>[] tags);
-
-        IDataPoint Clone();
     }
 }

--- a/src/OpenTelemetry/Metrics/IDataPoint.cs
+++ b/src/OpenTelemetry/Metrics/IDataPoint.cs
@@ -25,13 +25,11 @@ namespace OpenTelemetry.Metrics
 
         public KeyValuePair<string, object>[] Tags { get; }
 
-        public string ValueAsString { get; }
+        public string ValueAsString();
 
-        public void ResetTags(KeyValuePair<string, object>[] tags);
+        public IDataPoint Clone(KeyValuePair<string, object>[] tags);
 
         public void Reset<T>(T value, KeyValuePair<string, object>[] tags)
             where T : struct;
-
-        public IDataPoint NewWithValue();
     }
 }

--- a/src/OpenTelemetry/Metrics/IDataPoint.cs
+++ b/src/OpenTelemetry/Metrics/IDataPoint.cs
@@ -27,9 +27,13 @@ namespace OpenTelemetry.Metrics
 
         string ValueAsString();
 
+        /// <summary>
+        /// Clone a DataPoint but with different tags.
+        /// </summary>
+        /// <param name="tags">Tags to use in clone.</param>
+        /// <returns>IDataPoint.</returns>
         IDataPoint Clone(KeyValuePair<string, object>[] tags);
 
-        void Reset<T>(T value, KeyValuePair<string, object>[] tags)
-            where T : struct;
+        IDataPoint Clone();
     }
 }

--- a/src/OpenTelemetry/Metrics/IDataPoint.cs
+++ b/src/OpenTelemetry/Metrics/IDataPoint.cs
@@ -21,15 +21,15 @@ namespace OpenTelemetry.Metrics
 {
     public interface IDataPoint
     {
-        public DateTimeOffset Timestamp { get; }
+        DateTimeOffset Timestamp { get; }
 
-        public KeyValuePair<string, object>[] Tags { get; }
+        KeyValuePair<string, object>[] Tags { get; }
 
-        public string ValueAsString();
+        string ValueAsString()
 
-        public IDataPoint Clone(KeyValuePair<string, object>[] tags);
+        IDataPoint Clone(KeyValuePair<string, object>[] tags);
 
-        public void Reset<T>(T value, KeyValuePair<string, object>[] tags)
+        void Reset<T>(T value, KeyValuePair<string, object>[] tags)
             where T : struct;
     }
 }

--- a/src/OpenTelemetry/Metrics/IDataPoint.cs
+++ b/src/OpenTelemetry/Metrics/IDataPoint.cs
@@ -19,7 +19,7 @@ using System.Collections.Generic;
 
 namespace OpenTelemetry.Metrics
 {
-    public interface IDataPoint
+    internal interface IDataPoint
     {
         DateTimeOffset Timestamp { get; }
 

--- a/src/OpenTelemetry/Metrics/InstrumentState.cs
+++ b/src/OpenTelemetry/Metrics/InstrumentState.cs
@@ -24,7 +24,6 @@ namespace OpenTelemetry.Metrics
     public class InstrumentState
     {
         private readonly AggregatorStore store;
-        private readonly object lockStore = new object();
 
         public InstrumentState(MeterProviderSdk sdk, Instrument instrument)
         {
@@ -34,10 +33,7 @@ namespace OpenTelemetry.Metrics
         public void Update<T>(DateTimeOffset dt, T value, ReadOnlySpan<KeyValuePair<string, object>> tags)
             where T : struct
         {
-            lock (this.lockStore)
-            {
-                this.store.Update(dt, value, tags);
-            }
+            this.store.Update(dt, value, tags);
         }
     }
 }

--- a/src/OpenTelemetry/Metrics/InstrumentState.cs
+++ b/src/OpenTelemetry/Metrics/InstrumentState.cs
@@ -1,4 +1,4 @@
-// <copyright file="MeasurementProcessor.cs" company="OpenTelemetry Authors">
+// <copyright file="InstrumentState.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,9 +14,29 @@
 // limitations under the License.
 // </copyright>
 
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+
 namespace OpenTelemetry.Metrics
 {
-    public abstract class MeasurementProcessor : BaseProcessor<MeasurementItem>
+    public class InstrumentState
     {
+        private readonly AggregatorStore store;
+        private readonly object lockStore = new object();
+
+        public InstrumentState(MeterProviderSdk sdk, Instrument instrument)
+        {
+            this.store = new AggregatorStore(sdk, instrument);
+        }
+
+        public void Update(IDataPoint value)
+        {
+            lock (this.lockStore)
+            {
+                this.store.Update(value);
+            }
+        }
     }
 }

--- a/src/OpenTelemetry/Metrics/InstrumentState.cs
+++ b/src/OpenTelemetry/Metrics/InstrumentState.cs
@@ -31,11 +31,12 @@ namespace OpenTelemetry.Metrics
             this.store = new AggregatorStore(sdk, instrument);
         }
 
-        public void Update(IDataPoint value)
+        public void Update<T>(DateTimeOffset dt, T value, ReadOnlySpan<KeyValuePair<string, object>> tags)
+            where T : struct
         {
             lock (this.lockStore)
             {
-                this.store.Update(value);
+                this.store.Update(dt, value, tags);
             }
         }
     }

--- a/src/OpenTelemetry/Metrics/InstrumentState.cs
+++ b/src/OpenTelemetry/Metrics/InstrumentState.cs
@@ -21,16 +21,16 @@ using System.Diagnostics.Metrics;
 
 namespace OpenTelemetry.Metrics
 {
-    public class InstrumentState
+    internal class InstrumentState
     {
         private readonly AggregatorStore store;
 
-        public InstrumentState(MeterProviderSdk sdk, Instrument instrument)
+        internal InstrumentState(MeterProviderSdk sdk, Instrument instrument)
         {
             this.store = new AggregatorStore(sdk, instrument);
         }
 
-        public void Update<T>(DateTimeOffset dt, T value, ReadOnlySpan<KeyValuePair<string, object>> tags)
+        internal void Update<T>(DateTimeOffset dt, T value, ReadOnlySpan<KeyValuePair<string, object>> tags)
             where T : struct
         {
             this.store.Update(dt, value, tags);

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -154,6 +154,8 @@ namespace OpenTelemetry.Metrics
 
         protected override void Dispose(bool disposing)
         {
+            this.listener.Dispose();
+
             this.cts.Cancel();
 
             this.observerTask.Wait();

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -112,7 +112,7 @@ namespace OpenTelemetry.Metrics
         internal List<MetricProcessor> ExportProcessors { get; } = new List<MetricProcessor>();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static DateTimeOffset GetDateTimeOffset()
+        internal static DateTimeOffset GetDateTimeOffset()
         {
             int tick = Environment.TickCount;
             if (tick == MeterProviderSdk.lastTick)

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -22,7 +22,7 @@ namespace OpenTelemetry.Metrics
 {
     // TODO: Need to determine what a Metric actually contains
 
-    public struct Metric
+    internal struct Metric
     {
         internal readonly string Name;
         internal IDataPoint Point;

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -1,4 +1,4 @@
-// <copyright file="MeasurementProcessor.cs" company="OpenTelemetry Authors">
+// <copyright file="Metric.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,9 +14,23 @@
 // limitations under the License.
 // </copyright>
 
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+
 namespace OpenTelemetry.Metrics
 {
-    public abstract class MeasurementProcessor : BaseProcessor<MeasurementItem>
+    // TODO: Need to determine what a Metric actually contains
+
+    public struct Metric
     {
+        internal readonly string Name;
+        internal IDataPoint Point;
+
+        public Metric(string name, IDataPoint point)
+        {
+            this.Name = name;
+            this.Point = point;
+        }
     }
 }

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -27,7 +27,7 @@ namespace OpenTelemetry.Metrics
         internal readonly string Name;
         internal IDataPoint Point;
 
-        public Metric(string name, IDataPoint point)
+        internal Metric(string name, IDataPoint point)
         {
             this.Name = name;
             this.Point = point;

--- a/src/OpenTelemetry/Metrics/ObjectArrayEquaityComparer.cs
+++ b/src/OpenTelemetry/Metrics/ObjectArrayEquaityComparer.cs
@@ -1,0 +1,60 @@
+// <copyright file="ObjectArrayEquaityComparer.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OpenTelemetry.Metrics
+{
+    public class ObjectArrayEquaityComparer : IEqualityComparer<object[]>
+    {
+        public bool Equals(object[] obj1, object[] obj2)
+        {
+            var len1 = obj1.Length;
+
+            if (len1 != obj2.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < len1; i++)
+            {
+                if (obj1[i] != obj2[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public int GetHashCode(object[] objs)
+        {
+            int hash = 17;
+
+            unchecked
+            {
+                for (int i = 0; i < objs.Length; i++)
+                {
+                    hash = (hash * 31) + objs[i].GetHashCode();
+                }
+            }
+
+            return hash;
+        }
+    }
+}

--- a/src/OpenTelemetry/Metrics/ObjectArrayEqualityComparer.cs
+++ b/src/OpenTelemetry/Metrics/ObjectArrayEqualityComparer.cs
@@ -14,9 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace OpenTelemetry.Metrics
 {
@@ -24,6 +22,16 @@ namespace OpenTelemetry.Metrics
     {
         public bool Equals(object[] obj1, object[] obj2)
         {
+            if (ReferenceEquals(obj1, obj2))
+            {
+                return true;
+            }
+
+            if (ReferenceEquals(obj1, null) || ReferenceEquals(obj2, null))
+            {
+                return false;
+            }
+
             var len1 = obj1.Length;
 
             if (len1 != obj2.Length)

--- a/src/OpenTelemetry/Metrics/ObjectArrayEqualityComparer.cs
+++ b/src/OpenTelemetry/Metrics/ObjectArrayEqualityComparer.cs
@@ -18,7 +18,7 @@ using System.Collections.Generic;
 
 namespace OpenTelemetry.Metrics
 {
-    public class ObjectArrayEqualityComparer : IEqualityComparer<object[]>
+    internal class ObjectArrayEqualityComparer : IEqualityComparer<object[]>
     {
         public bool Equals(object[] obj1, object[] obj2)
         {

--- a/src/OpenTelemetry/Metrics/ObjectArrayEqualityComparer.cs
+++ b/src/OpenTelemetry/Metrics/ObjectArrayEqualityComparer.cs
@@ -1,4 +1,4 @@
-// <copyright file="StringArrayEquaityComparer.cs" company="OpenTelemetry Authors">
+// <copyright file="ObjectArrayEqualityComparer.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,20 +20,20 @@ using System.Text;
 
 namespace OpenTelemetry.Metrics
 {
-    public class StringArrayEquaityComparer : IEqualityComparer<string[]>
+    public class ObjectArrayEqualityComparer : IEqualityComparer<object[]>
     {
-        public bool Equals(string[] strings1, string[] strings2)
+        public bool Equals(object[] obj1, object[] obj2)
         {
-            var len1 = strings1.Length;
+            var len1 = obj1.Length;
 
-            if (len1 != strings2.Length)
+            if (len1 != obj2.Length)
             {
                 return false;
             }
 
             for (int i = 0; i < len1; i++)
             {
-                if (!strings1[i].Equals(strings2[i], StringComparison.Ordinal))
+                if (obj1[i] != obj2[i])
                 {
                     return false;
                 }
@@ -42,15 +42,15 @@ namespace OpenTelemetry.Metrics
             return true;
         }
 
-        public int GetHashCode(string[] strings)
+        public int GetHashCode(object[] objs)
         {
             int hash = 17;
 
             unchecked
             {
-                for (int i = 0; i < strings.Length; i++)
+                for (int i = 0; i < objs.Length; i++)
                 {
-                    hash = (hash * 31) + strings[i].GetHashCode();
+                    hash = (hash * 31) + objs[i].GetHashCode();
                 }
             }
 

--- a/src/OpenTelemetry/Metrics/Processors/AggregateProcessor.cs
+++ b/src/OpenTelemetry/Metrics/Processors/AggregateProcessor.cs
@@ -14,10 +14,10 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
-using System.Threading;
 
 namespace OpenTelemetry.Metrics
 {
@@ -25,9 +25,10 @@ namespace OpenTelemetry.Metrics
     {
         internal ConcurrentDictionary<AggregatorStore, bool> AggregatorStores { get; } = new ConcurrentDictionary<AggregatorStore, bool>();
 
-        public override void OnEnd(MeasurementItem data)
+        public override void OnEnd<T>(MeasurementItem measurementItem, ref DateTimeOffset dt, ref T value, ref ReadOnlySpan<KeyValuePair<string, object>> tags)
+            where T : struct
         {
-            data.State.Update(data.Point);
+            measurementItem.State.Update(dt, value, tags);
         }
 
         public void Register(AggregatorStore store)

--- a/src/OpenTelemetry/Metrics/Processors/AggregateProcessor.cs
+++ b/src/OpenTelemetry/Metrics/Processors/AggregateProcessor.cs
@@ -25,18 +25,18 @@ namespace OpenTelemetry.Metrics
     {
         internal ConcurrentDictionary<AggregatorStore, bool> AggregatorStores { get; } = new ConcurrentDictionary<AggregatorStore, bool>();
 
-        public override void OnEnd<T>(MeasurementItem measurementItem, ref DateTimeOffset dt, ref T value, ref ReadOnlySpan<KeyValuePair<string, object>> tags)
+        internal override void OnEnd<T>(MeasurementItem measurementItem, ref DateTimeOffset dt, ref T value, ref ReadOnlySpan<KeyValuePair<string, object>> tags)
             where T : struct
         {
             measurementItem.State.Update(dt, value, tags);
         }
 
-        public void Register(AggregatorStore store)
+        internal void Register(AggregatorStore store)
         {
             this.AggregatorStores.TryAdd(store, true);
         }
 
-        public IEnumerable<Metric> Collect()
+        internal IEnumerable<Metric> Collect()
         {
             var metrics = new List<Metric>();
 

--- a/src/OpenTelemetry/Metrics/Processors/MeasurementItem.cs
+++ b/src/OpenTelemetry/Metrics/Processors/MeasurementItem.cs
@@ -16,19 +16,12 @@
 
 using System.Diagnostics.Metrics;
 
-#nullable enable
-
 namespace OpenTelemetry.Metrics
 {
     public class MeasurementItem
     {
-        internal readonly Instrument Instrument;
-        internal DataPoint? Point;
-
-        public MeasurementItem(Instrument instrument, DataPoint point)
-        {
-            this.Instrument = instrument;
-            this.Point = point;
-        }
+        internal Instrument Instrument;
+        internal InstrumentState State;
+        internal IDataPoint Point;
     }
 }

--- a/src/OpenTelemetry/Metrics/Processors/MeasurementItem.cs
+++ b/src/OpenTelemetry/Metrics/Processors/MeasurementItem.cs
@@ -18,10 +18,15 @@ using System.Diagnostics.Metrics;
 
 namespace OpenTelemetry.Metrics
 {
-    public class MeasurementItem
+    public readonly struct MeasurementItem
     {
-        internal Instrument Instrument;
-        internal InstrumentState State;
-        internal IDataPoint Point;
+        internal readonly Instrument Instrument;
+        internal readonly InstrumentState State;
+
+        public MeasurementItem(Instrument instrument, InstrumentState state)
+        {
+            this.Instrument = instrument;
+            this.State = state;
+        }
     }
 }

--- a/src/OpenTelemetry/Metrics/Processors/MeasurementItem.cs
+++ b/src/OpenTelemetry/Metrics/Processors/MeasurementItem.cs
@@ -23,7 +23,7 @@ namespace OpenTelemetry.Metrics
         internal readonly Instrument Instrument;
         internal readonly InstrumentState State;
 
-        public MeasurementItem(Instrument instrument, InstrumentState state)
+        internal MeasurementItem(Instrument instrument, InstrumentState state)
         {
             this.Instrument = instrument;
             this.State = state;

--- a/src/OpenTelemetry/Metrics/Processors/MeasurementProcessor.cs
+++ b/src/OpenTelemetry/Metrics/Processors/MeasurementProcessor.cs
@@ -22,7 +22,7 @@ namespace OpenTelemetry.Metrics
 {
     public abstract class MeasurementProcessor : BaseProcessor<MeasurementItem>
     {
-        public abstract void OnEnd<T>(MeasurementItem measurementItem, ref DateTimeOffset dt, ref T value, ref ReadOnlySpan<KeyValuePair<string, object>> tags)
+        internal abstract void OnEnd<T>(MeasurementItem measurementItem, ref DateTimeOffset dt, ref T value, ref ReadOnlySpan<KeyValuePair<string, object>> tags)
             where T : struct;
     }
 }

--- a/src/OpenTelemetry/Metrics/Processors/MeasurementProcessor.cs
+++ b/src/OpenTelemetry/Metrics/Processors/MeasurementProcessor.cs
@@ -14,9 +14,15 @@
 // limitations under the License.
 // </copyright>
 
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+
 namespace OpenTelemetry.Metrics
 {
     public abstract class MeasurementProcessor : BaseProcessor<MeasurementItem>
     {
+        public abstract void OnEnd<T>(MeasurementItem measurementItem, ref DateTimeOffset dt, ref T value, ref ReadOnlySpan<KeyValuePair<string, object>> tags)
+            where T : struct;
     }
 }

--- a/src/OpenTelemetry/Metrics/Processors/MetricConsoleExporter.cs
+++ b/src/OpenTelemetry/Metrics/Processors/MetricConsoleExporter.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Metrics
             foreach (var metric in data.Metrics)
             {
                 var tags = metric.Point?.Tags.ToArray().Select(k => $"{k.Key}={k.Value?.ToString()}");
-                var msg = $"{metric.Name}[{string.Join(";", tags)}] = {metric.Point?.ValueAsString}";
+                var msg = $"{metric.Name}[{string.Join(";", tags)}] = {metric.Point?.ValueAsString()}";
                 Console.WriteLine($"Export: {msg}");
             }
         }

--- a/src/OpenTelemetry/Metrics/Processors/MetricConsoleExporter.cs
+++ b/src/OpenTelemetry/Metrics/Processors/MetricConsoleExporter.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Metrics
             foreach (var metric in data.Metrics)
             {
                 var tags = metric.Point?.Tags.ToArray().Select(k => $"{k.Key}={k.Value?.ToString()}");
-                var msg = $"{metric.Name}[{string.Join(";", tags)}] = {metric.Point?.ValueAsString()}";
+                var msg = $"{metric.Name}[{string.Join(";", tags)}] = {metric.Point?.Value.ToString()}";
                 Console.WriteLine($"Export: {msg}");
             }
         }

--- a/src/OpenTelemetry/Metrics/Processors/MetricConsoleExporter.cs
+++ b/src/OpenTelemetry/Metrics/Processors/MetricConsoleExporter.cs
@@ -15,11 +15,7 @@
 // </copyright>
 
 using System;
-using System.Collections.Concurrent;
-using System.Diagnostics.Metrics;
-using System.Threading;
-
-#nullable enable
+using System.Linq;
 
 namespace OpenTelemetry.Metrics
 {
@@ -27,13 +23,11 @@ namespace OpenTelemetry.Metrics
     {
         public override void OnEnd(MetricItem data)
         {
-            foreach (var exports in data.Metrics)
+            foreach (var metric in data.Metrics)
             {
-                foreach (var item in exports)
-                {
-                    var msg = $"{item.Key.Meter.Name}:{item.Key.Name} = count:{item.Value.Count}, sum:{item.Value.Sum}";
-                    Console.WriteLine($"Export: {msg}");
-                }
+                var tags = metric.Point?.Tags.ToArray().Select(k => $"{k.Key}={k.Value?.ToString()}");
+                var msg = $"{metric.Name}[{string.Join(";", tags)}] = {metric.Point?.ValueAsString}";
+                Console.WriteLine($"Export: {msg}");
             }
         }
     }

--- a/src/OpenTelemetry/Metrics/Processors/MetricItem.cs
+++ b/src/OpenTelemetry/Metrics/Processors/MetricItem.cs
@@ -25,7 +25,7 @@ namespace OpenTelemetry.Metrics
     {
         internal List<Metric> Metrics = new List<Metric>();
 
-        public MetricItem()
+        internal MetricItem()
         {
         }
     }

--- a/src/OpenTelemetry/Metrics/Processors/MetricItem.cs
+++ b/src/OpenTelemetry/Metrics/Processors/MetricItem.cs
@@ -19,13 +19,11 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 
-#nullable enable
-
 namespace OpenTelemetry.Metrics
 {
     public class MetricItem
     {
-        internal List<ConcurrentDictionary<Instrument, AggregateState>> Metrics = new List<ConcurrentDictionary<Instrument, AggregateState>>();
+        internal List<Metric> Metrics = new List<Metric>();
 
         public MetricItem()
         {

--- a/src/OpenTelemetry/Metrics/Processors/MetricProcessor.cs
+++ b/src/OpenTelemetry/Metrics/Processors/MetricProcessor.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-#nullable enable
-
 namespace OpenTelemetry.Metrics
 {
     public abstract class MetricProcessor : BaseProcessor<MetricItem>

--- a/src/OpenTelemetry/Metrics/Processors/TagEnrichmentProcessor.cs
+++ b/src/OpenTelemetry/Metrics/Processors/TagEnrichmentProcessor.cs
@@ -32,7 +32,7 @@ namespace OpenTelemetry.Metrics
             this.extraAttrib = new KeyValuePair<string, object>(name, value);
         }
 
-        public override void OnEnd<T>(MeasurementItem measurementItem, ref DateTimeOffset dt, ref T value, ref ReadOnlySpan<KeyValuePair<string, object>> tags)
+        internal override void OnEnd<T>(MeasurementItem measurementItem, ref DateTimeOffset dt, ref T value, ref ReadOnlySpan<KeyValuePair<string, object>> tags)
             where T : struct
         {
             var list = new List<KeyValuePair<string, object>>(tags.ToArray());

--- a/src/OpenTelemetry/Metrics/Processors/TagEnrichmentProcessor.cs
+++ b/src/OpenTelemetry/Metrics/Processors/TagEnrichmentProcessor.cs
@@ -36,8 +36,7 @@ namespace OpenTelemetry.Metrics
             data.Point.Tags.CopyTo(newArray, 0);
             newArray[newArray.Length - 1] = this.extraAttrib;
 
-            data.Point = data.Point.NewWithValue();
-            data.Point.ResetTags(newArray);
+            data.Point = data.Point.Clone(newArray);
         }
     }
 }

--- a/src/OpenTelemetry/Metrics/Processors/TagEnrichmentProcessor.cs
+++ b/src/OpenTelemetry/Metrics/Processors/TagEnrichmentProcessor.cs
@@ -14,7 +14,9 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics.Metrics;
 
 namespace OpenTelemetry.Metrics
 {
@@ -30,13 +32,13 @@ namespace OpenTelemetry.Metrics
             this.extraAttrib = new KeyValuePair<string, object>(name, value);
         }
 
-        public override void OnEnd(MeasurementItem data)
+        public override void OnEnd<T>(MeasurementItem measurementItem, ref DateTimeOffset dt, ref T value, ref ReadOnlySpan<KeyValuePair<string, object>> tags)
+            where T : struct
         {
-            var newArray = new KeyValuePair<string, object>[data.Point.Tags.Length + 1];
-            data.Point.Tags.CopyTo(newArray, 0);
-            newArray[newArray.Length - 1] = this.extraAttrib;
+            var list = new List<KeyValuePair<string, object>>(tags.ToArray());
+            list.Add(this.extraAttrib);
 
-            data.Point = data.Point.Clone(newArray);
+            tags = new ReadOnlySpan<KeyValuePair<string, object>>(list.ToArray());
         }
     }
 }

--- a/src/OpenTelemetry/Metrics/Processors/TagEnrichmentProcessor.cs
+++ b/src/OpenTelemetry/Metrics/Processors/TagEnrichmentProcessor.cs
@@ -16,23 +16,28 @@
 
 using System.Collections.Generic;
 
-#nullable enable
-
 namespace OpenTelemetry.Metrics
 {
+    /// <summary>
+    /// Example of a MeasurmentProcessor that adds a new attribute to all measurements.
+    /// </summary>
     public class TagEnrichmentProcessor : MeasurementProcessor
     {
+        private KeyValuePair<string, object> extraAttrib;
+
+        public TagEnrichmentProcessor(string name, string value)
+        {
+            this.extraAttrib = new KeyValuePair<string, object>(name, value);
+        }
+
         public override void OnEnd(MeasurementItem data)
         {
-            var oldArray = data.Point!.Tags.ToArray();
-            int len = oldArray.Length;
+            var newArray = new KeyValuePair<string, object>[data.Point.Tags.Length + 1];
+            data.Point.Tags.CopyTo(newArray, 0);
+            newArray[newArray.Length - 1] = this.extraAttrib;
 
-            var newArray = new KeyValuePair<string, object?>[len + 1];
-            oldArray.CopyTo(newArray, 0);
-
-            newArray[len] = new KeyValuePair<string, object?>("newLabel", "newValue");
-
-            data.Point.SetTags(newArray);
+            data.Point = data.Point.NewWithValue();
+            data.Point.ResetTags(newArray);
         }
     }
 }

--- a/src/OpenTelemetry/Metrics/StringArrayEquaityComparer.cs
+++ b/src/OpenTelemetry/Metrics/StringArrayEquaityComparer.cs
@@ -33,7 +33,7 @@ namespace OpenTelemetry.Metrics
 
             for (int i = 0; i < len1; i++)
             {
-                if (!strings1[i].Equals(strings2[i]))
+                if (!strings1[i].Equals(strings2[i], StringComparison.Ordinal))
                 {
                     return false;
                 }

--- a/src/OpenTelemetry/Metrics/StringArrayEquaityComparer.cs
+++ b/src/OpenTelemetry/Metrics/StringArrayEquaityComparer.cs
@@ -1,0 +1,60 @@
+// <copyright file="StringArrayEquaityComparer.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OpenTelemetry.Metrics
+{
+    public class StringArrayEquaityComparer : IEqualityComparer<string[]>
+    {
+        public bool Equals(string[] strings1, string[] strings2)
+        {
+            var len1 = strings1.Length;
+
+            if (len1 != strings2.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < len1; i++)
+            {
+                if (!strings1[i].Equals(strings2[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public int GetHashCode(string[] strings)
+        {
+            int hash = 17;
+
+            unchecked
+            {
+                for (int i = 0; i < strings.Length; i++)
+                {
+                    hash = (hash * 31) + strings[i].GetHashCode();
+                }
+            }
+
+            return hash;
+        }
+    }
+}

--- a/src/OpenTelemetry/Metrics/StringArrayEqualityComparer.cs
+++ b/src/OpenTelemetry/Metrics/StringArrayEqualityComparer.cs
@@ -1,4 +1,4 @@
-// <copyright file="ObjectArrayEquaityComparer.cs" company="OpenTelemetry Authors">
+// <copyright file="StringArrayEqualityComparer.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,20 +20,20 @@ using System.Text;
 
 namespace OpenTelemetry.Metrics
 {
-    public class ObjectArrayEquaityComparer : IEqualityComparer<object[]>
+    public class StringArrayEqualityComparer : IEqualityComparer<string[]>
     {
-        public bool Equals(object[] obj1, object[] obj2)
+        public bool Equals(string[] strings1, string[] strings2)
         {
-            var len1 = obj1.Length;
+            var len1 = strings1.Length;
 
-            if (len1 != obj2.Length)
+            if (len1 != strings2.Length)
             {
                 return false;
             }
 
             for (int i = 0; i < len1; i++)
             {
-                if (obj1[i] != obj2[i])
+                if (!strings1[i].Equals(strings2[i], StringComparison.Ordinal))
                 {
                     return false;
                 }
@@ -42,15 +42,15 @@ namespace OpenTelemetry.Metrics
             return true;
         }
 
-        public int GetHashCode(object[] objs)
+        public int GetHashCode(string[] strings)
         {
             int hash = 17;
 
             unchecked
             {
-                for (int i = 0; i < objs.Length; i++)
+                for (int i = 0; i < strings.Length; i++)
                 {
-                    hash = (hash * 31) + objs[i].GetHashCode();
+                    hash = (hash * 31) + strings[i].GetHashCode();
                 }
             }
 

--- a/src/OpenTelemetry/Metrics/StringArrayEqualityComparer.cs
+++ b/src/OpenTelemetry/Metrics/StringArrayEqualityComparer.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace OpenTelemetry.Metrics
 {
@@ -24,6 +23,16 @@ namespace OpenTelemetry.Metrics
     {
         public bool Equals(string[] strings1, string[] strings2)
         {
+            if (ReferenceEquals(strings1, strings2))
+            {
+                return true;
+            }
+
+            if (ReferenceEquals(strings1, null) || ReferenceEquals(strings2, null))
+            {
+                return false;
+            }
+
             var len1 = strings1.Length;
 
             if (len1 != strings2.Length)

--- a/src/OpenTelemetry/Metrics/StringArrayEqualityComparer.cs
+++ b/src/OpenTelemetry/Metrics/StringArrayEqualityComparer.cs
@@ -19,7 +19,7 @@ using System.Collections.Generic;
 
 namespace OpenTelemetry.Metrics
 {
-    public class StringArrayEqualityComparer : IEqualityComparer<string[]>
+    internal class StringArrayEqualityComparer : IEqualityComparer<string[]>
     {
         public bool Equals(string[] strings1, string[] strings2)
         {

--- a/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
+++ b/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
@@ -104,7 +104,10 @@ namespace OpenTelemetry.Metrics
             else
             {
                 // We are resetting/reusing the same DataPoint<T> object to avoid a new alloc in the hot path.
-                dp.Reset<T>(value, tags);
+                if (dp is DataPoint<T> dpT)
+                {
+                    dpT.Reset(value, tags);
+                }
             }
 
             return dp;

--- a/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
+++ b/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
@@ -110,19 +110,25 @@ namespace OpenTelemetry.Metrics
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void GetKeysValuesKvp(int len, out string[] tagKeys, out object[] tagValues, out KeyValuePair<string, object>[] tagKvps)
+        internal void GetKeysValues(KeyValuePair<string, object>[] tags, out string[] tagKeys, out object[] tagValues)
         {
+            var len = tags.Length;
+
             if (len <= MaxTagCacheSize)
             {
                 tagKeys = this.tagStorage[len].TagKey;
                 tagValues = this.tagStorage[len].TagValue;
-                tagKvps = this.tagStorage[len].TagKvp;
             }
             else
             {
                 tagKeys = new string[len];
                 tagValues = new object[len];
-                tagKvps = new KeyValuePair<string, object>[len];
+            }
+
+            for (var n = 0; n < len; n++)
+            {
+                tagKeys[n] = tags[n].Key;
+                tagValues[n] = tags[n].Value;
             }
         }
 
@@ -134,7 +140,6 @@ namespace OpenTelemetry.Metrics
             // Used to split into Key sequence, Value sequence, and KVPs for Aggregator Processor
             internal readonly string[] TagKey;
             internal readonly object[] TagValue;
-            internal readonly KeyValuePair<string, object>[] TagKvp;
 
             internal TagStorage(int n)
             {
@@ -142,7 +147,6 @@ namespace OpenTelemetry.Metrics
 
                 this.TagKey = new string[n];
                 this.TagValue = new object[n];
-                this.TagKvp = new KeyValuePair<string, object>[n];
             }
         }
     }

--- a/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
+++ b/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
@@ -1,0 +1,149 @@
+// <copyright file="ThreadStaticStorage.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Runtime.CompilerServices;
+
+namespace OpenTelemetry.Metrics
+{
+    internal class ThreadStaticStorage
+    {
+        private const int MaxTagCacheSize = 3;
+
+        [ThreadStatic]
+        private static ThreadStaticStorage storage;
+
+        private readonly TagStorage[] tagStorage = new TagStorage[MaxTagCacheSize + 1];
+
+        // .NET Metrics API allows for byte, short, int, long, float, double, decimal
+        private readonly Dictionary<Type, IDataPoint> pointT = new Dictionary<Type, IDataPoint>();
+
+        private readonly MeasurementItem measurementItem = new MeasurementItem();
+
+        private ThreadStaticStorage()
+        {
+            for (int i = 0; i <= MaxTagCacheSize; i++)
+            {
+                this.tagStorage[i] = new TagStorage(i);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static ThreadStaticStorage GetStorage()
+        {
+            if (ThreadStaticStorage.storage == null)
+            {
+                ThreadStaticStorage.storage = new ThreadStaticStorage();
+            }
+
+            return ThreadStaticStorage.storage;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal KeyValuePair<string, object>[] GetTags(ReadOnlySpan<KeyValuePair<string, object>> tagsRos)
+        {
+            var len = tagsRos.Length;
+
+            KeyValuePair<string, object>[] tags;
+
+            if (len == 0)
+            {
+                tags = this.tagStorage[0].Tags;
+            }
+            else if (len <= MaxTagCacheSize)
+            {
+                tags = this.tagStorage[len].Tags;
+
+                int i = 0;
+                foreach (var tag in tagsRos)
+                {
+                    tags[i++] = tag;
+                }
+            }
+            else
+            {
+                tags = tagsRos.ToArray();
+            }
+
+            return tags;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal MeasurementItem GetMeasurementItem(Instrument instrument, InstrumentState state, IDataPoint point)
+        {
+            this.measurementItem.Instrument = instrument;
+            this.measurementItem.State = state;
+            this.measurementItem.Point = point;
+
+            return this.measurementItem;
+        }
+
+        internal IDataPoint GetDataPoint<T>(T value, KeyValuePair<string, object>[] tags)
+            where T : struct
+        {
+            if (!this.pointT.TryGetValue(typeof(T), out var dp))
+            {
+                dp = new DataPoint<T>(value, tags);
+                this.pointT.Add(typeof(T), dp);
+            }
+            else
+            {
+                dp.Reset<T>(value, tags);
+            }
+
+            return dp;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void GetKeysValuesKvp(int len, out string[] tagKeys, out object[] tagValues, out KeyValuePair<string, object>[] tagKvps)
+        {
+            if (len <= MaxTagCacheSize)
+            {
+                tagKeys = this.tagStorage[len].TagKey;
+                tagValues = this.tagStorage[len].TagValue;
+                tagKvps = this.tagStorage[len].TagKvp;
+            }
+            else
+            {
+                tagKeys = new string[len];
+                tagValues = new object[len];
+                tagKvps = new KeyValuePair<string, object>[len];
+            }
+        }
+
+        internal class TagStorage
+        {
+            // Used to copy ReadOnlySpan from API
+            internal readonly KeyValuePair<string, object>[] Tags;
+
+            // Used to split into Key sequence, Value sequence, and KVPs for Aggregator Processor
+            internal readonly string[] TagKey;
+            internal readonly object[] TagValue;
+            internal readonly KeyValuePair<string, object>[] TagKvp;
+
+            internal TagStorage(int n)
+            {
+                this.Tags = new KeyValuePair<string, object>[n];
+
+                this.TagKey = new string[n];
+                this.TagValue = new object[n];
+                this.TagKvp = new KeyValuePair<string, object>[n];
+            }
+        }
+    }
+}

--- a/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
+++ b/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
@@ -103,6 +103,7 @@ namespace OpenTelemetry.Metrics
             }
             else
             {
+                // We are resetting/reusing the same DataPoint<T> object to avoid a new alloc in the hot path.
                 dp.Reset<T>(value, tags);
             }
 

--- a/src/System.Diagnostics.Metrics.Temp/Counter.cs
+++ b/src/System.Diagnostics.Metrics.Temp/Counter.cs
@@ -92,7 +92,7 @@ namespace System.Diagnostics.Metrics
             T delta,
             params KeyValuePair<string, object?>[] tags)
         {
-            this.RecordMeasurement(delta, tags);
+            this.RecordMeasurement(delta, new ReadOnlySpan<KeyValuePair<string, object?>>(tags));
         }
     }
 }

--- a/src/System.Diagnostics.Metrics.Temp/Instrument.cs
+++ b/src/System.Diagnostics.Metrics.Temp/Instrument.cs
@@ -29,6 +29,7 @@ namespace System.Diagnostics.Metrics
     public abstract class Instrument
     {
         internal ConcurrentDictionary<MeterListener, bool> Listeners = new ConcurrentDictionary<MeterListener, bool>();
+        internal KeyValuePair<MeterListener, bool>[] CachedListeners = new KeyValuePair<MeterListener, bool>[0];
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Instrument"/> class.
@@ -71,6 +72,14 @@ namespace System.Diagnostics.Metrics
         /// A property tells if the instrument is a regular instrument or an observable instrument.
         /// </summary>
         public virtual bool IsObservable => false;
+
+        public void Register(MeterListener listener)
+        {
+            this.Listeners.TryAdd(listener, true);
+
+            // use CachedListener to avoid an alloc when enumerating this.Listener in HotPath
+            this.CachedListeners = this.Listeners.ToArray();
+        }
 
         /// <summary>
         /// Publish is to allow activating the instrument to start recording measurements and to allow

--- a/src/System.Diagnostics.Metrics.Temp/InstrumentT.cs
+++ b/src/System.Diagnostics.Metrics.Temp/InstrumentT.cs
@@ -29,6 +29,17 @@ namespace System.Diagnostics.Metrics
     public abstract class Instrument<T> : Instrument
         where T : struct
     {
+        private static readonly KeyValuePair<string, object?>[] Tags0 = new KeyValuePair<string, object?>[0];
+
+        [ThreadStatic]
+        private static KeyValuePair<string, object?>[] tags1 = new KeyValuePair<string, object?>[1];
+
+        [ThreadStatic]
+        private static KeyValuePair<string, object?>[] tags2 = new KeyValuePair<string, object?>[2];
+
+        [ThreadStatic]
+        private static KeyValuePair<string, object?>[] tags3 = new KeyValuePair<string, object?>[3];
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Instrument{T}"/> class.
         /// Protected constructor to create the instrument with the common properties.
@@ -43,8 +54,9 @@ namespace System.Diagnostics.Metrics
         /// </summary>
         protected void RecordMeasurement(T measurement)
         {
-            var ros = new KeyValuePair<string, object?>[0];
-            this.RecordMeasurement(measurement, new ReadOnlySpan<KeyValuePair<string, object?>>(ros));
+            var ros = new ReadOnlySpan<KeyValuePair<string, object?>>(Instrument<T>.Tags0);
+
+            this.RecordMeasurement(measurement, ros);
         }
 
         /// <summary>
@@ -54,9 +66,15 @@ namespace System.Diagnostics.Metrics
             T measurement,
             KeyValuePair<string, object?> tag1)
         {
-            var ros = new KeyValuePair<string, object?>[1];
-            ros[0] = tag1;
-            this.RecordMeasurement(measurement, new ReadOnlySpan<KeyValuePair<string, object?>>(ros));
+            if (Instrument<T>.tags1 == null)
+            {
+                Instrument<T>.tags1 = new KeyValuePair<string, object?>[1];
+            }
+
+            Instrument<T>.tags1[0] = tag1;
+            var ros = new ReadOnlySpan<KeyValuePair<string, object?>>(Instrument<T>.tags1);
+
+            this.RecordMeasurement(measurement, ros);
         }
 
         /// <summary>
@@ -67,10 +85,16 @@ namespace System.Diagnostics.Metrics
             KeyValuePair<string, object?> tag1,
             KeyValuePair<string, object?> tag2)
         {
-            var ros = new KeyValuePair<string, object?>[2];
-            ros[0] = tag1;
-            ros[1] = tag2;
-            this.RecordMeasurement(measurement, new ReadOnlySpan<KeyValuePair<string, object?>>(ros));
+            if (Instrument<T>.tags2 == null)
+            {
+                Instrument<T>.tags2 = new KeyValuePair<string, object?>[2];
+            }
+
+            Instrument<T>.tags2[0] = tag1;
+            Instrument<T>.tags2[1] = tag2;
+            var ros = new ReadOnlySpan<KeyValuePair<string, object?>>(Instrument<T>.tags2);
+
+            this.RecordMeasurement(measurement, ros);
         }
 
         /// <summary>
@@ -82,11 +106,17 @@ namespace System.Diagnostics.Metrics
             KeyValuePair<string, object?> tag2,
             KeyValuePair<string, object?> tag3)
         {
-            var ros = new KeyValuePair<string, object?>[3];
-            ros[0] = tag1;
-            ros[1] = tag2;
-            ros[2] = tag3;
-            this.RecordMeasurement(measurement, new ReadOnlySpan<KeyValuePair<string, object?>>(ros));
+            if (Instrument<T>.tags3 == null)
+            {
+                Instrument<T>.tags3 = new KeyValuePair<string, object?>[3];
+            }
+
+            Instrument<T>.tags3[0] = tag1;
+            Instrument<T>.tags3[1] = tag2;
+            Instrument<T>.tags3[2] = tag3;
+            var ros = new ReadOnlySpan<KeyValuePair<string, object?>>(Instrument<T>.tags3);
+
+            this.RecordMeasurement(measurement, ros);
         }
 
         /// <summary>
@@ -96,7 +126,7 @@ namespace System.Diagnostics.Metrics
             T measurement,
             ReadOnlySpan<KeyValuePair<string, object?>> tags)
         {
-            foreach (var listener in this.Listeners)
+            foreach (var listener in this.CachedListeners)
             {
                 if (listener.Key.Instruments.TryGetValue(this, out var state))
                 {

--- a/src/System.Diagnostics.Metrics.Temp/MeterListener.cs
+++ b/src/System.Diagnostics.Metrics.Temp/MeterListener.cs
@@ -72,7 +72,7 @@ namespace System.Diagnostics.Metrics
         public void EnableMeasurementEvents(Instrument instrument, object? state = null)
         {
             this.Instruments.TryAdd(instrument, state);
-            instrument.Listeners.TryAdd(this, true);
+            instrument.Register(this);
         }
 
         /// <summary>

--- a/test/Benchmarks/Metrics/MetricsBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricsBenchmarks.cs
@@ -1,0 +1,111 @@
+// <copyright file="MetricsBenchmarks.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using BenchmarkDotNet.Attributes;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+
+/*
+BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
+Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
+.NET Core SDK=5.0.202
+  [Host]     : .NET Core 3.1.13 (CoreCLR 4.700.21.11102, CoreFX 4.700.21.11602), X64 RyuJIT
+  DefaultJob : .NET Core 3.1.13 (CoreCLR 4.700.21.11102, CoreFX 4.700.21.11602), X64 RyuJIT
+
+
+|                    Method | WithSDK |       Mean |      Error |     StdDev |     Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|-------------------------- |-------- |-----------:|-----------:|-----------:|-----------:|-------:|------:|------:|----------:|
+|            CounterHotPath |   False |   3.204 ns |  0.0908 ns |  0.1243 ns |   3.198 ns |      - |     - |     - |         - |
+| CounterWith1LabelsHotPath |   False |  12.410 ns |  0.4258 ns |  1.1799 ns |  12.152 ns |      - |     - |     - |         - |
+| CounterWith3LabelsHotPath |   False |  32.479 ns |  0.6774 ns |  1.1129 ns |  31.992 ns |      - |     - |     - |         - |
+| CounterWith5LabelsHotPath |   False |  25.496 ns |  0.5394 ns |  0.7907 ns |  25.134 ns | 0.0249 |     - |     - |     104 B |
+|            CounterHotPath |    True | 133.484 ns |  1.8963 ns |  1.5835 ns | 133.144 ns |      - |     - |     - |         - |
+| CounterWith1LabelsHotPath |    True | 213.571 ns |  4.2343 ns |  5.7959 ns | 211.255 ns |      - |     - |     - |         - |
+| CounterWith3LabelsHotPath |    True | 617.793 ns | 21.9452 ns | 59.3302 ns | 595.162 ns |      - |     - |     - |         - |
+| CounterWith5LabelsHotPath |    True | 743.170 ns | 13.6878 ns | 18.2728 ns | 738.229 ns | 0.1049 |     - |     - |     440 B |
+*/
+
+namespace Benchmarks.Metrics
+{
+    [MemoryDiagnoser]
+    public class MetricsBenchmarks
+    {
+        private readonly KeyValuePair<string, object> tag1 = new KeyValuePair<string, object>("attrib1", "value1");
+        private readonly KeyValuePair<string, object> tag2 = new KeyValuePair<string, object>("attrib2", "value2");
+        private readonly KeyValuePair<string, object> tag3 = new KeyValuePair<string, object>("attrib3", "value3");
+        private readonly KeyValuePair<string, object> tag4 = new KeyValuePair<string, object>("attrib4", "value4");
+        private readonly KeyValuePair<string, object> tag5 = new KeyValuePair<string, object>("attrib5", "value5");
+
+        private Counter<int> counter;
+        private MeterProvider provider;
+        private Meter meter;
+
+        [Params(false, true)]
+        public bool WithSDK { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            if (this.WithSDK)
+            {
+                this.provider = Sdk.CreateMeterProviderBuilder()
+                    .AddSource("TestMeter") // All instruments from this meter are enabled.
+                    .SetObservationPeriod(10000)
+                    .SetCollectionPeriod(10000)
+
+                    // .AddExportProcessor(new MetricConsoleExporter())
+                    .Build();
+            }
+
+            this.meter = new Meter("TestMeter");
+            this.counter = this.meter.CreateCounter<int>("counter");
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            this.meter?.Dispose();
+            this.provider?.Dispose();
+        }
+
+        [Benchmark]
+        public void CounterHotPath()
+        {
+            this.counter?.Add(100);
+        }
+
+        [Benchmark]
+        public void CounterWith1LabelsHotPath()
+        {
+            this.counter?.Add(100, this.tag1);
+        }
+
+        [Benchmark]
+        public void CounterWith3LabelsHotPath()
+        {
+            this.counter?.Add(100, this.tag1, this.tag2, this.tag3);
+        }
+
+        [Benchmark]
+        public void CounterWith5LabelsHotPath()
+        {
+            this.counter?.Add(100, this.tag1, this.tag2, this.tag3, this.tag4, this.tag5);
+        }
+    }
+}

--- a/test/Benchmarks/Metrics/MetricsBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricsBenchmarks.cs
@@ -28,16 +28,16 @@ Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
   [Host]     : .NET Core 3.1.13 (CoreCLR 4.700.21.11102, CoreFX 4.700.21.11602), X64 RyuJIT
   DefaultJob : .NET Core 3.1.13 (CoreCLR 4.700.21.11102, CoreFX 4.700.21.11602), X64 RyuJIT
 
-|                    Method | WithSDK |         Mean |      Error |     StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-|-------------------------- |-------- |-------------:|-----------:|-----------:|-------:|------:|------:|----------:|
-|            CounterHotPath |   False |     4.930 ns |  0.1334 ns |  0.3443 ns |      - |     - |     - |         - |
-| CounterWith1LabelsHotPath |   False |    20.730 ns |  0.4458 ns |  0.5475 ns |      - |     - |     - |         - |
-| CounterWith3LabelsHotPath |   False |    43.788 ns |  0.7995 ns |  0.7479 ns |      - |     - |     - |         - |
-| CounterWith5LabelsHotPath |   False |    37.191 ns |  0.3754 ns |  0.3135 ns | 0.0249 |     - |     - |     104 B |
-|            CounterHotPath |    True |   209.193 ns |  2.5954 ns |  2.1673 ns |      - |     - |     - |         - |
-| CounterWith1LabelsHotPath |    True |   354.471 ns |  7.0792 ns | 11.0214 ns |      - |     - |     - |         - |
-| CounterWith3LabelsHotPath |    True |   914.992 ns | 18.2393 ns | 46.4248 ns |      - |     - |     - |         - |
-| CounterWith5LabelsHotPath |    True | 1,167.378 ns | 23.1794 ns | 24.8017 ns | 0.0553 |     - |     - |     232 B |
+|                    Method | WithSDK |       Mean |      Error |     StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|-------------------------- |-------- |-----------:|-----------:|-----------:|-------:|------:|------:|----------:|
+|            CounterHotPath |   False |   2.780 ns |  0.0847 ns |  0.1160 ns |      - |     - |     - |         - |
+| CounterWith1LabelsHotPath |   False |  10.794 ns |  0.2408 ns |  0.3045 ns |      - |     - |     - |         - |
+| CounterWith3LabelsHotPath |   False |  30.275 ns |  0.6320 ns |  0.6207 ns |      - |     - |     - |         - |
+| CounterWith5LabelsHotPath |   False |  23.985 ns |  0.4932 ns |  0.5482 ns | 0.0249 |     - |     - |     104 B |
+|            CounterHotPath |    True | 133.180 ns |  2.6609 ns |  6.5771 ns |      - |     - |     - |         - |
+| CounterWith1LabelsHotPath |    True | 213.185 ns |  2.8988 ns |  2.4207 ns |      - |     - |     - |         - |
+| CounterWith3LabelsHotPath |    True | 524.721 ns |  9.9822 ns |  8.8490 ns |      - |     - |     - |         - |
+| CounterWith5LabelsHotPath |    True | 682.824 ns | 18.3456 ns | 53.8045 ns | 0.0553 |     - |     - |     232 B |
 
 
 BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
@@ -45,16 +45,16 @@ Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
   [Host]     : .NET Framework 4.8 (4.8.4341.0), X64 RyuJIT
   DefaultJob : .NET Framework 4.8 (4.8.4341.0), X64 RyuJIT
 
-|                    Method | WithSDK |        Mean |      Error |     StdDev |      Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-|-------------------------- |-------- |------------:|-----------:|-----------:|------------:|-------:|------:|------:|----------:|
-|            CounterHotPath |   False |    22.27 ns |   0.465 ns |   0.457 ns |    22.27 ns |      - |     - |     - |         - |
-| CounterWith1LabelsHotPath |   False |    33.08 ns |   0.664 ns |   0.554 ns |    32.89 ns |      - |     - |     - |         - |
-| CounterWith3LabelsHotPath |   False |    56.24 ns |   1.089 ns |   1.119 ns |    55.75 ns |      - |     - |     - |         - |
-| CounterWith5LabelsHotPath |   False |    50.67 ns |   0.523 ns |   0.489 ns |    50.69 ns | 0.0248 |     - |     - |     104 B |
-|            CounterHotPath |    True |   204.64 ns |   4.100 ns |   5.186 ns |   202.99 ns |      - |     - |     - |         - |
-| CounterWith1LabelsHotPath |    True |   294.17 ns |   5.902 ns |   6.561 ns |   291.02 ns |      - |     - |     - |         - |
-| CounterWith3LabelsHotPath |    True | 1,306.52 ns |  94.197 ns | 277.742 ns | 1,151.40 ns |      - |     - |     - |         - |
-| CounterWith5LabelsHotPath |    True | 3,152.20 ns | 213.046 ns | 628.171 ns | 3,274.49 ns | 0.0534 |     - |     - |     233 B |
+|                    Method | WithSDK |        Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|-------------------------- |-------- |------------:|----------:|----------:|-------:|------:|------:|----------:|
+|            CounterHotPath |   False |    19.78 ns |  0.261 ns |  0.244 ns |      - |     - |     - |         - |
+| CounterWith1LabelsHotPath |   False |    28.94 ns |  0.585 ns |  0.626 ns |      - |     - |     - |         - |
+| CounterWith3LabelsHotPath |   False |    50.82 ns |  1.046 ns |  1.027 ns |      - |     - |     - |         - |
+| CounterWith5LabelsHotPath |   False |    44.11 ns |  0.303 ns |  0.298 ns | 0.0249 |     - |     - |     104 B |
+|            CounterHotPath |    True |   175.06 ns |  1.296 ns |  1.083 ns |      - |     - |     - |         - |
+| CounterWith1LabelsHotPath |    True |   267.81 ns |  4.409 ns |  3.442 ns |      - |     - |     - |         - |
+| CounterWith3LabelsHotPath |    True |   935.55 ns | 11.504 ns | 10.198 ns |      - |     - |     - |         - |
+| CounterWith5LabelsHotPath |    True | 1,913.39 ns | 37.111 ns | 55.546 ns | 0.0553 |     - |     - |     233 B |
 */
 
 namespace Benchmarks.Metrics

--- a/test/Benchmarks/Metrics/MetricsBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricsBenchmarks.cs
@@ -28,16 +28,16 @@ Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
   [Host]     : .NET Core 3.1.13 (CoreCLR 4.700.21.11102, CoreFX 4.700.21.11602), X64 RyuJIT
   DefaultJob : .NET Core 3.1.13 (CoreCLR 4.700.21.11102, CoreFX 4.700.21.11602), X64 RyuJIT
 
-|                    Method | WithSDK |       Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-|-------------------------- |-------- |-----------:|----------:|----------:|-------:|------:|------:|----------:|
-|            CounterHotPath |   False |   2.872 ns | 0.0849 ns | 0.1190 ns |      - |     - |     - |         - |
-| CounterWith1LabelsHotPath |   False |  10.889 ns | 0.2090 ns | 0.1852 ns |      - |     - |     - |         - |
-| CounterWith3LabelsHotPath |   False |  33.151 ns | 0.3697 ns | 0.2886 ns |      - |     - |     - |         - |
-| CounterWith5LabelsHotPath |   False |  25.051 ns | 0.4204 ns | 0.3932 ns | 0.0249 |     - |     - |     104 B |
-|            CounterHotPath |    True |  82.304 ns | 1.6376 ns | 2.5495 ns |      - |     - |     - |         - |
-| CounterWith1LabelsHotPath |    True | 150.810 ns | 2.1988 ns | 1.9492 ns |      - |     - |     - |         - |
-| CounterWith3LabelsHotPath |    True | 465.500 ns | 8.0853 ns | 7.1674 ns |      - |     - |     - |         - |
-| CounterWith5LabelsHotPath |    True | 590.172 ns | 7.9478 ns | 7.0455 ns | 0.0553 |     - |     - |     232 B |
+|                    Method | WithSDK |         Mean |      Error |     StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|-------------------------- |-------- |-------------:|-----------:|-----------:|-------:|------:|------:|----------:|
+|            CounterHotPath |   False |     4.930 ns |  0.1334 ns |  0.3443 ns |      - |     - |     - |         - |
+| CounterWith1LabelsHotPath |   False |    20.730 ns |  0.4458 ns |  0.5475 ns |      - |     - |     - |         - |
+| CounterWith3LabelsHotPath |   False |    43.788 ns |  0.7995 ns |  0.7479 ns |      - |     - |     - |         - |
+| CounterWith5LabelsHotPath |   False |    37.191 ns |  0.3754 ns |  0.3135 ns | 0.0249 |     - |     - |     104 B |
+|            CounterHotPath |    True |   209.193 ns |  2.5954 ns |  2.1673 ns |      - |     - |     - |         - |
+| CounterWith1LabelsHotPath |    True |   354.471 ns |  7.0792 ns | 11.0214 ns |      - |     - |     - |         - |
+| CounterWith3LabelsHotPath |    True |   914.992 ns | 18.2393 ns | 46.4248 ns |      - |     - |     - |         - |
+| CounterWith5LabelsHotPath |    True | 1,167.378 ns | 23.1794 ns | 24.8017 ns | 0.0553 |     - |     - |     232 B |
 
 
 BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
@@ -45,16 +45,16 @@ Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
   [Host]     : .NET Framework 4.8 (4.8.4341.0), X64 RyuJIT
   DefaultJob : .NET Framework 4.8 (4.8.4341.0), X64 RyuJIT
 
-|                    Method | WithSDK |        Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-|-------------------------- |-------- |------------:|----------:|----------:|-------:|------:|------:|----------:|
-|            CounterHotPath |   False |    19.70 ns |  0.325 ns |  0.304 ns |      - |     - |     - |         - |
-| CounterWith1LabelsHotPath |   False |    28.97 ns |  0.586 ns |  0.802 ns |      - |     - |     - |         - |
-| CounterWith3LabelsHotPath |   False |    49.78 ns |  0.785 ns |  0.696 ns |      - |     - |     - |         - |
-| CounterWith5LabelsHotPath |   False |    44.14 ns |  0.620 ns |  0.550 ns | 0.0249 |     - |     - |     104 B |
-|            CounterHotPath |    True |   131.35 ns |  2.401 ns |  2.358 ns |      - |     - |     - |         - |
-| CounterWith1LabelsHotPath |    True |   205.92 ns |  3.455 ns |  3.063 ns |      - |     - |     - |         - |
-| CounterWith3LabelsHotPath |    True |   885.30 ns | 10.616 ns |  9.410 ns |      - |     - |     - |         - |
-| CounterWith5LabelsHotPath |    True | 1,807.11 ns | 17.611 ns | 15.612 ns | 0.0553 |     - |     - |     233 B |
+|                    Method | WithSDK |        Mean |      Error |     StdDev |      Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|-------------------------- |-------- |------------:|-----------:|-----------:|------------:|-------:|------:|------:|----------:|
+|            CounterHotPath |   False |    22.27 ns |   0.465 ns |   0.457 ns |    22.27 ns |      - |     - |     - |         - |
+| CounterWith1LabelsHotPath |   False |    33.08 ns |   0.664 ns |   0.554 ns |    32.89 ns |      - |     - |     - |         - |
+| CounterWith3LabelsHotPath |   False |    56.24 ns |   1.089 ns |   1.119 ns |    55.75 ns |      - |     - |     - |         - |
+| CounterWith5LabelsHotPath |   False |    50.67 ns |   0.523 ns |   0.489 ns |    50.69 ns | 0.0248 |     - |     - |     104 B |
+|            CounterHotPath |    True |   204.64 ns |   4.100 ns |   5.186 ns |   202.99 ns |      - |     - |     - |         - |
+| CounterWith1LabelsHotPath |    True |   294.17 ns |   5.902 ns |   6.561 ns |   291.02 ns |      - |     - |     - |         - |
+| CounterWith3LabelsHotPath |    True | 1,306.52 ns |  94.197 ns | 277.742 ns | 1,151.40 ns |      - |     - |     - |         - |
+| CounterWith5LabelsHotPath |    True | 3,152.20 ns | 213.046 ns | 628.171 ns | 3,274.49 ns | 0.0534 |     - |     - |     233 B |
 */
 
 namespace Benchmarks.Metrics

--- a/test/Benchmarks/Metrics/MetricsBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricsBenchmarks.cs
@@ -28,17 +28,33 @@ Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
   [Host]     : .NET Core 3.1.13 (CoreCLR 4.700.21.11102, CoreFX 4.700.21.11602), X64 RyuJIT
   DefaultJob : .NET Core 3.1.13 (CoreCLR 4.700.21.11102, CoreFX 4.700.21.11602), X64 RyuJIT
 
+|                    Method | WithSDK |       Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|-------------------------- |-------- |-----------:|----------:|----------:|-------:|------:|------:|----------:|
+|            CounterHotPath |   False |   2.792 ns | 0.0792 ns | 0.0702 ns |      - |     - |     - |         - |
+| CounterWith1LabelsHotPath |   False |  11.394 ns | 0.2440 ns | 0.2712 ns |      - |     - |     - |         - |
+| CounterWith3LabelsHotPath |   False |  29.669 ns | 0.3933 ns | 0.3486 ns |      - |     - |     - |         - |
+| CounterWith5LabelsHotPath |   False |  23.727 ns | 0.3956 ns | 0.4397 ns | 0.0249 |     - |     - |     104 B |
+|            CounterHotPath |    True | 129.288 ns | 2.3708 ns | 2.1016 ns |      - |     - |     - |         - |
+| CounterWith1LabelsHotPath |    True | 201.401 ns | 2.6410 ns | 2.3412 ns |      - |     - |     - |         - |
+| CounterWith3LabelsHotPath |    True | 534.127 ns | 7.1438 ns | 5.9654 ns |      - |     - |     - |         - |
+| CounterWith5LabelsHotPath |    True | 647.037 ns | 6.2771 ns | 5.2416 ns | 0.0801 |     - |     - |     336 B |
 
-|                    Method | WithSDK |       Mean |      Error |     StdDev |     Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-|-------------------------- |-------- |-----------:|-----------:|-----------:|-----------:|-------:|------:|------:|----------:|
-|            CounterHotPath |   False |   3.204 ns |  0.0908 ns |  0.1243 ns |   3.198 ns |      - |     - |     - |         - |
-| CounterWith1LabelsHotPath |   False |  12.410 ns |  0.4258 ns |  1.1799 ns |  12.152 ns |      - |     - |     - |         - |
-| CounterWith3LabelsHotPath |   False |  32.479 ns |  0.6774 ns |  1.1129 ns |  31.992 ns |      - |     - |     - |         - |
-| CounterWith5LabelsHotPath |   False |  25.496 ns |  0.5394 ns |  0.7907 ns |  25.134 ns | 0.0249 |     - |     - |     104 B |
-|            CounterHotPath |    True | 133.484 ns |  1.8963 ns |  1.5835 ns | 133.144 ns |      - |     - |     - |         - |
-| CounterWith1LabelsHotPath |    True | 213.571 ns |  4.2343 ns |  5.7959 ns | 211.255 ns |      - |     - |     - |         - |
-| CounterWith3LabelsHotPath |    True | 617.793 ns | 21.9452 ns | 59.3302 ns | 595.162 ns |      - |     - |     - |         - |
-| CounterWith5LabelsHotPath |    True | 743.170 ns | 13.6878 ns | 18.2728 ns | 738.229 ns | 0.1049 |     - |     - |     440 B |
+
+BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
+Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
+  [Host]     : .NET Framework 4.8 (4.8.4341.0), X64 RyuJIT
+  DefaultJob : .NET Framework 4.8 (4.8.4341.0), X64 RyuJIT
+
+|                    Method | WithSDK |        Mean |     Error |    StdDev |      Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|-------------------------- |-------- |------------:|----------:|----------:|------------:|-------:|------:|------:|----------:|
+|            CounterHotPath |   False |    19.44 ns |  0.188 ns |  0.157 ns |    19.49 ns |      - |     - |     - |         - |
+| CounterWith1LabelsHotPath |   False |    29.16 ns |  0.604 ns |  1.043 ns |    28.83 ns |      - |     - |     - |         - |
+| CounterWith3LabelsHotPath |   False |    49.66 ns |  0.860 ns |  1.118 ns |    49.24 ns |      - |     - |     - |         - |
+| CounterWith5LabelsHotPath |   False |    44.24 ns |  0.844 ns |  0.790 ns |    44.03 ns | 0.0249 |     - |     - |     104 B |
+|            CounterHotPath |    True |   167.68 ns |  4.819 ns | 13.905 ns |   167.76 ns |      - |     - |     - |         - |
+| CounterWith1LabelsHotPath |    True |   247.20 ns |  7.750 ns | 22.609 ns |   233.91 ns |      - |     - |     - |         - |
+| CounterWith3LabelsHotPath |    True |   918.33 ns | 14.140 ns | 11.808 ns |   916.30 ns |      - |     - |     - |         - |
+| CounterWith5LabelsHotPath |    True | 1,903.26 ns | 21.358 ns | 17.835 ns | 1,901.57 ns | 0.0801 |     - |     - |     337 B |
 */
 
 namespace Benchmarks.Metrics

--- a/test/Benchmarks/Metrics/MetricsBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricsBenchmarks.cs
@@ -28,16 +28,16 @@ Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
   [Host]     : .NET Core 3.1.13 (CoreCLR 4.700.21.11102, CoreFX 4.700.21.11602), X64 RyuJIT
   DefaultJob : .NET Core 3.1.13 (CoreCLR 4.700.21.11102, CoreFX 4.700.21.11602), X64 RyuJIT
 
-|                    Method | WithSDK |       Mean |      Error |     StdDev |     Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-|-------------------------- |-------- |-----------:|-----------:|-----------:|-----------:|-------:|------:|------:|----------:|
-|            CounterHotPath |   False |   3.098 ns |  0.0924 ns |  0.2231 ns |   3.039 ns |      - |     - |     - |         - |
-| CounterWith1LabelsHotPath |   False |  12.696 ns |  0.4042 ns |  1.0859 ns |  12.367 ns |      - |     - |     - |         - |
-| CounterWith3LabelsHotPath |   False |  33.626 ns |  0.6625 ns |  1.1428 ns |  33.502 ns |      - |     - |     - |         - |
-| CounterWith5LabelsHotPath |   False |  28.656 ns |  0.5640 ns |  0.6035 ns |  28.817 ns | 0.0249 |     - |     - |     104 B |
-|            CounterHotPath |    True | 132.766 ns |  2.0410 ns |  1.9092 ns | 132.664 ns |      - |     - |     - |         - |
-| CounterWith1LabelsHotPath |    True | 221.057 ns |  4.1977 ns |  3.9265 ns | 222.972 ns |      - |     - |     - |         - |
-| CounterWith3LabelsHotPath |    True | 594.423 ns | 11.8099 ns | 21.2957 ns | 595.432 ns |      - |     - |     - |         - |
-| CounterWith5LabelsHotPath |    True | 724.727 ns | 14.3369 ns | 14.0807 ns | 725.218 ns | 0.0801 |     - |     - |     336 B |
+|                    Method | WithSDK |       Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|-------------------------- |-------- |-----------:|----------:|----------:|-------:|------:|------:|----------:|
+|            CounterHotPath |   False |   2.872 ns | 0.0849 ns | 0.1190 ns |      - |     - |     - |         - |
+| CounterWith1LabelsHotPath |   False |  10.889 ns | 0.2090 ns | 0.1852 ns |      - |     - |     - |         - |
+| CounterWith3LabelsHotPath |   False |  33.151 ns | 0.3697 ns | 0.2886 ns |      - |     - |     - |         - |
+| CounterWith5LabelsHotPath |   False |  25.051 ns | 0.4204 ns | 0.3932 ns | 0.0249 |     - |     - |     104 B |
+|            CounterHotPath |    True |  82.304 ns | 1.6376 ns | 2.5495 ns |      - |     - |     - |         - |
+| CounterWith1LabelsHotPath |    True | 150.810 ns | 2.1988 ns | 1.9492 ns |      - |     - |     - |         - |
+| CounterWith3LabelsHotPath |    True | 465.500 ns | 8.0853 ns | 7.1674 ns |      - |     - |     - |         - |
+| CounterWith5LabelsHotPath |    True | 590.172 ns | 7.9478 ns | 7.0455 ns | 0.0553 |     - |     - |     232 B |
 
 
 BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
@@ -45,17 +45,16 @@ Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
   [Host]     : .NET Framework 4.8 (4.8.4341.0), X64 RyuJIT
   DefaultJob : .NET Framework 4.8 (4.8.4341.0), X64 RyuJIT
 
-
 |                    Method | WithSDK |        Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
 |-------------------------- |-------- |------------:|----------:|----------:|-------:|------:|------:|----------:|
-|            CounterHotPath |   False |    20.60 ns |  0.341 ns |  0.319 ns |      - |     - |     - |         - |
-| CounterWith1LabelsHotPath |   False |    31.10 ns |  0.629 ns |  0.961 ns |      - |     - |     - |         - |
-| CounterWith3LabelsHotPath |   False |    52.88 ns |  1.090 ns |  2.322 ns |      - |     - |     - |         - |
-| CounterWith5LabelsHotPath |   False |    50.22 ns |  1.003 ns |  2.202 ns | 0.0249 |     - |     - |     104 B |
-|            CounterHotPath |    True |   153.21 ns |  2.963 ns |  2.475 ns |      - |     - |     - |         - |
-| CounterWith1LabelsHotPath |    True |   240.46 ns |  4.353 ns |  3.635 ns |      - |     - |     - |         - |
-| CounterWith3LabelsHotPath |    True |   973.99 ns | 12.978 ns | 10.837 ns |      - |     - |     - |         - |
-| CounterWith5LabelsHotPath |    True | 2,068.10 ns | 39.119 ns | 43.481 ns | 0.0801 |     - |     - |     337 B |
+|            CounterHotPath |   False |    19.70 ns |  0.325 ns |  0.304 ns |      - |     - |     - |         - |
+| CounterWith1LabelsHotPath |   False |    28.97 ns |  0.586 ns |  0.802 ns |      - |     - |     - |         - |
+| CounterWith3LabelsHotPath |   False |    49.78 ns |  0.785 ns |  0.696 ns |      - |     - |     - |         - |
+| CounterWith5LabelsHotPath |   False |    44.14 ns |  0.620 ns |  0.550 ns | 0.0249 |     - |     - |     104 B |
+|            CounterHotPath |    True |   131.35 ns |  2.401 ns |  2.358 ns |      - |     - |     - |         - |
+| CounterWith1LabelsHotPath |    True |   205.92 ns |  3.455 ns |  3.063 ns |      - |     - |     - |         - |
+| CounterWith3LabelsHotPath |    True |   885.30 ns | 10.616 ns |  9.410 ns |      - |     - |     - |         - |
+| CounterWith5LabelsHotPath |    True | 1,807.11 ns | 17.611 ns | 15.612 ns | 0.0553 |     - |     - |     233 B |
 */
 
 namespace Benchmarks.Metrics

--- a/test/Benchmarks/Metrics/MetricsBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricsBenchmarks.cs
@@ -28,16 +28,16 @@ Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
   [Host]     : .NET Core 3.1.13 (CoreCLR 4.700.21.11102, CoreFX 4.700.21.11602), X64 RyuJIT
   DefaultJob : .NET Core 3.1.13 (CoreCLR 4.700.21.11102, CoreFX 4.700.21.11602), X64 RyuJIT
 
-|                    Method | WithSDK |       Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-|-------------------------- |-------- |-----------:|----------:|----------:|-------:|------:|------:|----------:|
-|            CounterHotPath |   False |   2.792 ns | 0.0792 ns | 0.0702 ns |      - |     - |     - |         - |
-| CounterWith1LabelsHotPath |   False |  11.394 ns | 0.2440 ns | 0.2712 ns |      - |     - |     - |         - |
-| CounterWith3LabelsHotPath |   False |  29.669 ns | 0.3933 ns | 0.3486 ns |      - |     - |     - |         - |
-| CounterWith5LabelsHotPath |   False |  23.727 ns | 0.3956 ns | 0.4397 ns | 0.0249 |     - |     - |     104 B |
-|            CounterHotPath |    True | 129.288 ns | 2.3708 ns | 2.1016 ns |      - |     - |     - |         - |
-| CounterWith1LabelsHotPath |    True | 201.401 ns | 2.6410 ns | 2.3412 ns |      - |     - |     - |         - |
-| CounterWith3LabelsHotPath |    True | 534.127 ns | 7.1438 ns | 5.9654 ns |      - |     - |     - |         - |
-| CounterWith5LabelsHotPath |    True | 647.037 ns | 6.2771 ns | 5.2416 ns | 0.0801 |     - |     - |     336 B |
+|                    Method | WithSDK |       Mean |      Error |     StdDev |     Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|-------------------------- |-------- |-----------:|-----------:|-----------:|-----------:|-------:|------:|------:|----------:|
+|            CounterHotPath |   False |   3.098 ns |  0.0924 ns |  0.2231 ns |   3.039 ns |      - |     - |     - |         - |
+| CounterWith1LabelsHotPath |   False |  12.696 ns |  0.4042 ns |  1.0859 ns |  12.367 ns |      - |     - |     - |         - |
+| CounterWith3LabelsHotPath |   False |  33.626 ns |  0.6625 ns |  1.1428 ns |  33.502 ns |      - |     - |     - |         - |
+| CounterWith5LabelsHotPath |   False |  28.656 ns |  0.5640 ns |  0.6035 ns |  28.817 ns | 0.0249 |     - |     - |     104 B |
+|            CounterHotPath |    True | 132.766 ns |  2.0410 ns |  1.9092 ns | 132.664 ns |      - |     - |     - |         - |
+| CounterWith1LabelsHotPath |    True | 221.057 ns |  4.1977 ns |  3.9265 ns | 222.972 ns |      - |     - |     - |         - |
+| CounterWith3LabelsHotPath |    True | 594.423 ns | 11.8099 ns | 21.2957 ns | 595.432 ns |      - |     - |     - |         - |
+| CounterWith5LabelsHotPath |    True | 724.727 ns | 14.3369 ns | 14.0807 ns | 725.218 ns | 0.0801 |     - |     - |     336 B |
 
 
 BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
@@ -45,16 +45,17 @@ Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
   [Host]     : .NET Framework 4.8 (4.8.4341.0), X64 RyuJIT
   DefaultJob : .NET Framework 4.8 (4.8.4341.0), X64 RyuJIT
 
-|                    Method | WithSDK |        Mean |     Error |    StdDev |      Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-|-------------------------- |-------- |------------:|----------:|----------:|------------:|-------:|------:|------:|----------:|
-|            CounterHotPath |   False |    19.44 ns |  0.188 ns |  0.157 ns |    19.49 ns |      - |     - |     - |         - |
-| CounterWith1LabelsHotPath |   False |    29.16 ns |  0.604 ns |  1.043 ns |    28.83 ns |      - |     - |     - |         - |
-| CounterWith3LabelsHotPath |   False |    49.66 ns |  0.860 ns |  1.118 ns |    49.24 ns |      - |     - |     - |         - |
-| CounterWith5LabelsHotPath |   False |    44.24 ns |  0.844 ns |  0.790 ns |    44.03 ns | 0.0249 |     - |     - |     104 B |
-|            CounterHotPath |    True |   167.68 ns |  4.819 ns | 13.905 ns |   167.76 ns |      - |     - |     - |         - |
-| CounterWith1LabelsHotPath |    True |   247.20 ns |  7.750 ns | 22.609 ns |   233.91 ns |      - |     - |     - |         - |
-| CounterWith3LabelsHotPath |    True |   918.33 ns | 14.140 ns | 11.808 ns |   916.30 ns |      - |     - |     - |         - |
-| CounterWith5LabelsHotPath |    True | 1,903.26 ns | 21.358 ns | 17.835 ns | 1,901.57 ns | 0.0801 |     - |     - |     337 B |
+
+|                    Method | WithSDK |        Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|-------------------------- |-------- |------------:|----------:|----------:|-------:|------:|------:|----------:|
+|            CounterHotPath |   False |    20.60 ns |  0.341 ns |  0.319 ns |      - |     - |     - |         - |
+| CounterWith1LabelsHotPath |   False |    31.10 ns |  0.629 ns |  0.961 ns |      - |     - |     - |         - |
+| CounterWith3LabelsHotPath |   False |    52.88 ns |  1.090 ns |  2.322 ns |      - |     - |     - |         - |
+| CounterWith5LabelsHotPath |   False |    50.22 ns |  1.003 ns |  2.202 ns | 0.0249 |     - |     - |     104 B |
+|            CounterHotPath |    True |   153.21 ns |  2.963 ns |  2.475 ns |      - |     - |     - |         - |
+| CounterWith1LabelsHotPath |    True |   240.46 ns |  4.353 ns |  3.635 ns |      - |     - |     - |         - |
+| CounterWith3LabelsHotPath |    True |   973.99 ns | 12.978 ns | 10.837 ns |      - |     - |     - |         - |
+| CounterWith5LabelsHotPath |    True | 2,068.10 ns | 39.119 ns | 43.481 ns | 0.0801 |     - |     - |     337 B |
 */
 
 namespace Benchmarks.Metrics

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -32,7 +32,7 @@ namespace OpenTelemetry.Metrics.Tests
                 .AddSource("BasicAllTest")
                 .SetObservationPeriod(300)
                 .SetCollectionPeriod(1000)
-                .AddProcessor(new TagEnrichmentProcessor())
+                .AddProcessor(new TagEnrichmentProcessor("newAttrib", "newAttribValue"))
                 .AddExportProcessor(new MetricConsoleExporter())
                 .Build();
 


### PR DESCRIPTION
Introduce initial framework for plumbing in Aggregators into Metrics pipeline.

One goal is to avoid any allocations in the "Hot Path".