### PR TITLE
Add Utkarsh Umesan Pillai as approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Approvers
 * [Eddy Nakamura](https://github.com/eddynaka), Microsoft
 * [Paulo Janotti](https://github.com/pjanotti), Splunk
 * [Reiley Yang](https://github.com/reyang), Microsoft
+* [Utkarsh Umesan Pillai](https://github.com/utpilla), Microsoft
 
 *Find more about the approver role in [community
 repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver).*


### PR DESCRIPTION
@utpilla has been actively contributing to this project for months now and has demonstrated sufficient technical expertise.

Contributions include active reviews, improving instrumentation and exporters, expanding test coverage and documentation, and actively responding to the community via issues and slack.

Link to all PRs submitted by Utkarsh : https://github.com/open-telemetry/opentelemetry-dotnet/pulls?q=is%3Apr+author%3Autpilla