### PR TITLE
Using Microsoft.DotNet.ApiCompat

### DIFF
--- a/.github/workflows/apicompatibility.yml
+++ b/.github/workflows/apicompatibility.yml
@@ -1,0 +1,21 @@
+name: API Compatibility
+
+on:
+  pull_request:
+    branches: [ main, metrics ]
+    paths-ignore:
+    - '**.md'
+
+jobs:
+  build-test:
+    runs-on: windows-latest
+    env:
+      CheckAPICompatibility: true
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: dotnet restore
+
+    - name: Build
+      run: dotnet build --configuration Release --no-restore

--- a/.gitignore
+++ b/.gitignore
@@ -340,3 +340,5 @@ ASALocalRun/
 
 # SonarQube folder
 /.sonarqube
+
+/src/LastMajorVersionBinaries

--- a/NuGet.config
+++ b/NuGet.config
@@ -3,6 +3,7 @@
   <packageSources>
     <clear />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+    <add key=".Net Core Tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/OpenTelemetry.sln
+++ b/OpenTelemetry.sln
@@ -101,6 +101,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ISSUE_TEMPLATE", "ISSUE_TEM
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{E69578EB-B456-4062-A645-877CD964528B}"
 	ProjectSection(SolutionItems) = preProject
+		.github\workflows\apicompatibility.yml = .github\workflows\apicompatibility.yml
 		.github\workflows\code-coverage.yml = .github\workflows\code-coverage.yml
 		.github\workflows\codeql-analysis.yml = .github\workflows\codeql-analysis.yml
 		.github\workflows\docfx.yml = .github\workflows\docfx.yml

--- a/OpenTelemetry.sln
+++ b/OpenTelemetry.sln
@@ -33,6 +33,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{7CB2F02E
 		build\OpenTelemetry.prod.loose.ruleset = build\OpenTelemetry.prod.loose.ruleset
 		build\OpenTelemetry.prod.ruleset = build\OpenTelemetry.prod.ruleset
 		build\OpenTelemetry.test.ruleset = build\OpenTelemetry.test.ruleset
+		build\PreBuild.ps1 = build\PreBuild.ps1
 		build\process-codecoverage.ps1 = build\process-codecoverage.ps1
 		build\RELEASING.md = build\RELEASING.md
 		build\stylecop.json = build\stylecop.json
@@ -199,7 +200,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestApp.AspNetCore.5.0", "t
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "exception-reporting", "docs\trace\exception-reporting\exception-reporting.csproj", "{08D29501-F0A3-468F-B18D-BD1821A72383}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "customizing-the-sdk", "docs\trace\customizing-the-sdk\customizing-the-sdk.csproj", "{64E3D8BB-93AB-4571-93F7-ED8D64DFFD06}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "customizing-the-sdk", "docs\trace\customizing-the-sdk\customizing-the-sdk.csproj", "{64E3D8BB-93AB-4571-93F7-ED8D64DFFD06}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -15,10 +15,10 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(OS)' == 'Windows_NT'">
     <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="6.0.0-beta.21308.1" PrivateAssets="All" />
-    <ResolvedMatchingContract Include="..\LastMajorVersionBinaries\$(AssemblyName)\1.0.1\lib\$(TargetFramework)\$(AssemblyName).dll" />
+    <ResolvedMatchingContract Include="..\LastMajorVersionBinaries\$(AssemblyName)\$(OTelPreviousStableVer)\lib\$(TargetFramework)\$(AssemblyName).dll" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent" Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(OS)' == 'Windows_NT'">
-    <Exec Command="powershell -ExecutionPolicy Unrestricted -File &quot;$(RepoRoot)\build\PreBuild.ps1&quot; -package $(AssemblyName) -version 1.0.1" />
+    <Exec Command="powershell -ExecutionPolicy Unrestricted -File &quot;$(RepoRoot)\build\PreBuild.ps1&quot; -package $(AssemblyName) -version &quot;$(OTelPreviousStableVer)&quot;" />
   </Target>
 
   <PropertyGroup>

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -10,9 +10,6 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-  <PropertyGroup>
-    <AdditionalApiCompatOptions>--exclude-non-browsable --exclude-compiler-generated</AdditionalApiCompatOptions>
-  </PropertyGroup>
   <ItemGroup Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(OS)' == 'Windows_NT'">
     <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="6.0.0-beta.21308.1" PrivateAssets="All" />
     <ResolvedMatchingContract Include="..\LastMajorVersionBinaries\$(AssemblyName)\$(OTelPreviousStableVer)\lib\$(TargetFramework)\$(AssemblyName).dll" />

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -10,11 +10,11 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(OS)' == 'Windows_NT'">
+  <ItemGroup Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(CheckAPICompatibility)' == 'true'">
     <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="6.0.0-beta.21308.1" PrivateAssets="All" />
     <ResolvedMatchingContract Include="..\LastMajorVersionBinaries\$(AssemblyName)\$(OTelPreviousStableVer)\lib\$(TargetFramework)\$(AssemblyName).dll" />
   </ItemGroup>
-  <Target Name="PreBuild" BeforeTargets="PreBuildEvent" Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(OS)' == 'Windows_NT'">
+  <Target Name="PreBuild" BeforeTargets="PreBuildEvent" Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(CheckAPICompatibility)' == 'true'">
     <Exec Command="powershell -ExecutionPolicy Unrestricted -File &quot;$(RepoRoot)\build\PreBuild.ps1&quot; -package $(AssemblyName) -version &quot;$(OTelPreviousStableVer)&quot;" />
   </Target>
 

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -10,6 +10,16 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>
+  <PropertyGroup>
+    <AdditionalApiCompatOptions>--exclude-non-browsable --exclude-compiler-generated</AdditionalApiCompatOptions>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(MinVerTagPrefix)' == 'core-'">
+    <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="6.0.0-beta.21308.1" PrivateAssets="All" />
+    <ResolvedMatchingContract Include="..\LastMajorVersionBinaries\$(AssemblyName)\1.0.1\lib\$(TargetFramework)\$(AssemblyName).dll" />
+  </ItemGroup>
+  <Target Name="PreBuild" BeforeTargets="PreBuildEvent" Condition="'$(MinVerTagPrefix)' == 'core-'">
+    <Exec Command="powershell -ExecutionPolicy Unrestricted -File &quot;$(RepoRoot)\build\PreBuild.ps1&quot; -package $(AssemblyName) -version 1.0.1" />
+  </Target>
 
   <PropertyGroup>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)/OpenTelemetry.prod.ruleset</CodeAnalysisRuleSet>

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -13,11 +13,11 @@
   <PropertyGroup>
     <AdditionalApiCompatOptions>--exclude-non-browsable --exclude-compiler-generated</AdditionalApiCompatOptions>
   </PropertyGroup>
-  <ItemGroup Condition="'$(MinVerTagPrefix)' == 'core-'">
+  <ItemGroup Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(OS)' == 'Windows_NT'">
     <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="6.0.0-beta.21308.1" PrivateAssets="All" />
     <ResolvedMatchingContract Include="..\LastMajorVersionBinaries\$(AssemblyName)\1.0.1\lib\$(TargetFramework)\$(AssemblyName).dll" />
   </ItemGroup>
-  <Target Name="PreBuild" BeforeTargets="PreBuildEvent" Condition="'$(MinVerTagPrefix)' == 'core-'">
+  <Target Name="PreBuild" BeforeTargets="PreBuildEvent" Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(OS)' == 'Windows_NT'">
     <Exec Command="powershell -ExecutionPolicy Unrestricted -File &quot;$(RepoRoot)\build\PreBuild.ps1&quot; -package $(AssemblyName) -version 1.0.1" />
   </Target>
 

--- a/build/Common.props
+++ b/build/Common.props
@@ -38,6 +38,7 @@
     <MicrosoftSourceLinkGitHubPkgVer>[1.0.0,2.0)</MicrosoftSourceLinkGitHubPkgVer>
     <NewtonsoftJsonPkgVer>[12.0.2,13.0)</NewtonsoftJsonPkgVer>
     <OpenTracingPkgVer>[0.12.1,0.13)</OpenTracingPkgVer>
+    <OTelPreviousStableVer>1.0.1</OTelPreviousStableVer>
     <StackExchangeRedisPkgVer>[2.1.58,3.0)</StackExchangeRedisPkgVer>
     <StyleCopAnalyzersPkgVer>[1.1.118,2.0)</StyleCopAnalyzersPkgVer>
     <SystemCollectionsImmutablePkgVer>1.4.0</SystemCollectionsImmutablePkgVer>

--- a/build/PreBuild.ps1
+++ b/build/PreBuild.ps1
@@ -13,16 +13,10 @@ if (Test-Path -Path "$workDir\$package.$version.zip")
 }
 else
 {
-    # because this script will be hit for each target framework in each project, there might be several copies running simultaneously
-    # wait a random couple of seconds before continuing, checking again for the zip file
-    Start-Sleep -Seconds (Get-Random -Minimum 0 -Maximum 3)
-    if (Test-Path -Path "$workDir\$package.$version.zip")
-    {
-        Write-Host "Retrieving $package @$version for compatibility check"
-        Invoke-WebRequest -Uri https://www.nuget.org/api/v2/package/$package/$version -Outfile "$workDir\$package.$version.zip"
-    }
+    Write-Host "Retrieving $package @$version for compatibility check"
+    Invoke-WebRequest -Uri https://www.nuget.org/api/v2/package/$package/$version -Outfile "$workDir\$package.$version.zip"
 }
-if (Test-Path -Path "$workDir\$package\$version")
+if (Test-Path -Path "$workDir\$package\$version\lib")
 {
     Write-Debug "Previous package version already extracted"
 }

--- a/build/PreBuild.ps1
+++ b/build/PreBuild.ps1
@@ -1,8 +1,16 @@
 param([string]$package, [string]$version)
+
 $tempFile = "..\LastMajorVersionBinaries\$package.$version.txt"
-if ((Test-Path -Path $tempFile) -OR (Test-Path -Path "..\LastMajorVersionBinaries\$package.$version.zip"))
+$retryCount = 0
+while ((Test-Path -Path $tempFile) -and ($retryCount -Lt 10))
 {
-    Write-Debug "Previous package version already exists or retrieval is in progress"
+    Write-Host "Previous version retrieval in progress, waiting..."
+    $retryCount++
+    Start-Sleep -s 1
+}
+if (Test-Path -Path "..\LastMajorVersionBinaries\$package.$version.zip")
+{
+    Write-Debug "Previous package version already exists"
 }
 else
 {
@@ -11,5 +19,9 @@ else
 
     Invoke-WebRequest -Uri https://www.nuget.org/api/v2/package/$package/$version -Outfile ..\LastMajorVersionBinaries\$package.$version.zip
     Expand-Archive -LiteralPath ..\LastMajorVersionBinaries\$package.$version.zip -DestinationPath ..\LastMajorVersionBinaries\$package\$version
+}
+
+if (Test-Path -Path $tempFile)
+{
     Remove-Item $tempFile
 }

--- a/build/PreBuild.ps1
+++ b/build/PreBuild.ps1
@@ -1,0 +1,15 @@
+param([string]$package, [string]$version)
+$tempFile = "..\LastMajorVersionBinaries\$package.$version.txt"
+if ((Test-Path -Path $tempFile) -OR (Test-Path -Path "..\LastMajorVersionBinaries\$package.$version.zip"))
+{
+    Write-Debug "Previous package version already exists or retrieval is in progress"
+}
+else
+{
+    New-Item $tempFile
+    Write-Host "Retrieving $package @$version for compatibility check"
+
+    Invoke-WebRequest -Uri https://www.nuget.org/api/v2/package/$package/$version -Outfile ..\LastMajorVersionBinaries\$package.$version.zip
+    Expand-Archive -LiteralPath ..\LastMajorVersionBinaries\$package.$version.zip -DestinationPath ..\LastMajorVersionBinaries\$package\$version
+    Remove-Item $tempFile
+}


### PR DESCRIPTION
(Eventually) fixes #1711.

## Changes

Add `Microsoft.DotNet.ApiCompat` and a pre-build script to pull previous major release for API comparison.

Concerns with current state:
~- Previous version is currently hardcoded to 1.0.1~
~- Build fails due to detected changes~
~- Usage of ApiCompat is conditional on `'$(MinVerTagPrefix)' == 'core-'` which may not be ideal~

~If this should replace `Microsoft.CodeAnalysis.PublicApiAnalyzers`~
~* [ ] Update [`CONTRIBUTING.MD`](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md#public-api)~
~* [ ] Remove `Microsoft.CodeAnalysis.PublicApiAnalyzers`~
* [ ] `CHANGELOG.md` updated for non-trivial changes