### PR TITLE
Set http.status_code to int

### DIFF
--- a/test/OpenTelemetry.Instrumentation.Http.Tests/http-out-test-cases.json
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/http-out-test-cases.json
@@ -9,7 +9,7 @@
     "spanAttributes": {
       "http.method": "GET",
       "http.host": "{host}:{port}",
-      "http.status_code": "200",
+      "http.status_code": 200,
       "http.url": "http://{host}:{port}/"
     }
   },
@@ -23,7 +23,7 @@
     "spanAttributes": {
       "http.method": "POST",
       "http.host": "{host}:{port}",
-      "http.status_code": "200",
+      "http.status_code": 200,
       "http.url": "http://{host}:{port}/"
     }
   },
@@ -38,7 +38,7 @@
     "spanAttributes": {
       "http.method": "GET",
       "http.host": "{host}:{port}",
-      "http.status_code": "200",
+      "http.status_code": 200,
       "http.url": "http://{host}:{port}/path/to/resource/"
     }
   },
@@ -53,7 +53,7 @@
     "spanAttributes": {
       "http.method": "GET",
       "http.host": "{host}:{port}",
-      "http.status_code": "200",
+      "http.status_code": 200,
       "http.url": "http://{host}:{port}/path/to/resource#fragment"
     }
   },
@@ -68,7 +68,7 @@
     "spanAttributes": {
       "http.method": "GET",
       "http.host": "{host}:{port}",
-      "http.status_code": "200",
+      "http.status_code": 200,
       "http.url": "http://{host}:{port}/path/to/resource#fragment"
     }
   },
@@ -113,7 +113,7 @@
     "spanAttributes": {
       "http.method": "GET",
       "http.host": "{host}:{port}",
-      "http.status_code": "200",
+      "http.status_code": 200,
       "http.url": "http://{host}:{port}/"
     }
   },
@@ -128,7 +128,7 @@
     "spanAttributes": {
       "http.method": "GET",
       "http.host": "{host}:{port}",
-      "http.status_code": "200",
+      "http.status_code": 200,
       "http.url": "http://{host}:{port}/"
     }
   },
@@ -295,7 +295,7 @@
       "http.method": "GET",
       "http.host": "{host}:{port}",
       "http.flavor": "2.0",
-      "http.status_code": "200",
+      "http.status_code": 200,
       "http.url": "http://{host}:{port}/"
     }
   }


### PR DESCRIPTION
The current [semantic convention](#https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#common-attributes) requires `http.status_code` to be int.

## Changes

Updated the test data to use int for `http.status_code`.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
