### PR TITLE
Hosting: README documentation + tweaks

### DIFF
--- a/src/OpenTelemetry.Extensions.Hosting/Implementation/TracerProviderBuilderHosting.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Implementation/TracerProviderBuilderHosting.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace OpenTelemetry.Trace
@@ -26,10 +25,7 @@ namespace OpenTelemetry.Trace
     /// </summary>
     internal class TracerProviderBuilderHosting : TracerProviderBuilderBase, IDeferredTracerProviderBuilder
     {
-        private readonly List<InstrumentationFactory> instrumentationFactories = new List<InstrumentationFactory>();
-        private readonly List<Type> processorTypes = new List<Type>();
         private readonly List<Action<IServiceProvider, TracerProviderBuilder>> configurationActions = new List<Action<IServiceProvider, TracerProviderBuilder>>();
-        private Type samplerType;
 
         public TracerProviderBuilderHosting(IServiceCollection services)
         {
@@ -37,38 +33,6 @@ namespace OpenTelemetry.Trace
         }
 
         public IServiceCollection Services { get; }
-
-        public TracerProviderBuilder AddInstrumentation<TInstrumentation>(
-            Func<IServiceProvider, TInstrumentation> instrumentationFactory)
-            where TInstrumentation : class
-        {
-            if (instrumentationFactory == null)
-            {
-                throw new ArgumentNullException(nameof(instrumentationFactory));
-            }
-
-            this.instrumentationFactories.Add(
-                new InstrumentationFactory(
-                    typeof(TInstrumentation).Name,
-                    "semver:" + typeof(TInstrumentation).Assembly.GetName().Version,
-                    typeof(TInstrumentation)));
-
-            return this;
-        }
-
-        public TracerProviderBuilder AddProcessor<T>()
-            where T : BaseProcessor<Activity>
-        {
-            this.processorTypes.Add(typeof(T));
-            return this;
-        }
-
-        public TracerProviderBuilder SetSampler<T>()
-            where T : Sampler
-        {
-            this.samplerType = typeof(T);
-            return this;
-        }
 
         public TracerProviderBuilder Configure(Action<IServiceProvider, TracerProviderBuilder> configure)
         {
@@ -89,39 +53,7 @@ namespace OpenTelemetry.Trace
                 this.configurationActions[i++](serviceProvider, this);
             }
 
-            foreach (InstrumentationFactory instrumentationFactory in this.instrumentationFactories)
-            {
-                this.AddInstrumentation(
-                    instrumentationFactory.Name,
-                    instrumentationFactory.Version,
-                    () => serviceProvider.GetRequiredService(instrumentationFactory.Type));
-            }
-
-            foreach (Type processorType in this.processorTypes)
-            {
-                this.AddProcessor((BaseProcessor<Activity>)serviceProvider.GetRequiredService(processorType));
-            }
-
-            if (this.samplerType != null)
-            {
-                this.SetSampler((Sampler)serviceProvider.GetRequiredService(this.samplerType));
-            }
-
             return this.Build();
-        }
-
-        private readonly struct InstrumentationFactory
-        {
-            public readonly string Name;
-            public readonly string Version;
-            public readonly Type Type;
-
-            internal InstrumentationFactory(string name, string version, Type type)
-            {
-                this.Name = name;
-                this.Version = version;
-                this.Type = type;
-            }
         }
     }
 }

--- a/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryServicesExtensions.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryServicesExtensions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Adds OpenTelemetry TracerProvider to the specified <see cref="IServiceCollection" />.
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
-        /// <param name="configure">The <see cref="TracerProviderBuilder"/> action to configure TracerProviderBuilder.</param>
+        /// <param name="configure">Callback action to configure the <see cref="TracerProviderBuilder"/>.</param>
         /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
         public static IServiceCollection AddOpenTelemetryTracing(this IServiceCollection services, Action<TracerProviderBuilder> configure)
         {

--- a/src/OpenTelemetry.Extensions.Hosting/README.md
+++ b/src/OpenTelemetry.Extensions.Hosting/README.md
@@ -98,8 +98,8 @@ Such an extension method can be consumed like this:
 services.AddOpenTelemetryTracing((builder) => builder
     .AddAspNetCoreInstrumentation()
     .AddHttpClientInstrumentation()
-    .AddZipkinExporter()
-    .AddMyFeature());
+    .AddMyFeature()
+    .AddZipkinExporter());
 ```
 
 ## References

--- a/src/OpenTelemetry.Extensions.Hosting/README.md
+++ b/src/OpenTelemetry.Extensions.Hosting/README.md
@@ -75,7 +75,8 @@ public static class MyLibraryExtensions
     {
         if (!(tracerProviderBuilder is IDeferredTracerProviderBuilder deferredTracerProviderBuilder))
         {
-            throw new NotSupportedException("MyFeature requires an IDeferredTracerProviderBuilder instance.");
+            throw new NotSupportedException(
+                "MyFeature requires an IDeferredTracerProviderBuilder instance.");
         }
 
         deferredTracerProviderBuilder.Services

--- a/src/OpenTelemetry.Extensions.Hosting/README.md
+++ b/src/OpenTelemetry.Extensions.Hosting/README.md
@@ -9,6 +9,98 @@
 dotnet add package OpenTelemetry.Extensions.Hosting
 ```
 
+## Usage
+
+### Tracing
+
+#### Simple Configuration
+
+The following example registers tracing using the `ZipkinExporter` and binds
+options to the "Zipkin" configuration section:
+
+```csharp
+services.AddOpenTelemetryTracing((builder) => builder
+    .AddAspNetCoreInstrumentation()
+    .AddHttpClientInstrumentation()
+    .AddZipkinExporter());
+
+services.Configure<ZipkinExporterOptions>(this.Configuration.GetSection("Zipkin"));
+```
+
+#### Using Dependency Injection
+
+The following example registers a processor of the type "MyProcessor" which has
+been registered as a singleton with the `IServiceCollection`:
+
+```csharp
+services.AddSingleton<MyProcessor>();
+
+services.AddOpenTelemetryTracing((builder) => builder
+    .AddAspNetCoreInstrumentation()
+    .AddHttpClientInstrumentation()
+    .AddProcessor<MyProcessor>());
+```
+
+Similar methods exist for registering instrumentation (`AddInstrumentation<T>`)
+and setting a sampler (`SetSampler<T>`).
+
+You can also access the application `IServiceProvider` directly and accomplish
+the same registration using the `Configure` extension like this:
+
+```csharp
+services.AddSingleton<MyProcessor>();
+
+services.AddOpenTelemetryTracing(hostingBuilder => hostingBuilder
+    .Configure((sp, builder) => builder
+        .AddAspNetCoreInstrumentation()
+        .AddHttpClientInstrumentation()
+        .AddProcessor(sp.GetRequiredService<MyProcessor>())));
+```
+
+**Note:** `Configure` is called _after_ the `IServiceProvider` has been built
+from the application `IServiceCollection` so any services registered in the
+`Configure` callback will be ignored.
+
+#### Building Extension Methods
+
+Library authors may want to configure the OpenTelemetry `TracerProvider` and
+register application services to provide more complex features. This can be
+accomplished concisely by casting the `TracerProviderBuilder` into an
+`IDeferredTracerProviderBuilder` instance in an extension method like this:
+
+```csharp
+public static class MyLibraryExtensions
+{
+    public static TracerProviderBuilder AddMyFeature(this TracerProviderBuilder tracerProviderBuilder)
+    {
+        if (!(tracerProviderBuilder is IDeferredTracerProviderBuilder deferredTracerProviderBuilder))
+        {
+            throw new NotSupportedException("MyFeature requires an IDeferredTracerProviderBuilder instance.");
+        }
+
+        deferredTracerProviderBuilder.Services
+            .AddHostedService<MyHostedService>()
+            .AddSingleton<MyService>()
+            .AddSingleton<MyProcessor>()
+            .AddSingleton<MySampler>();
+
+        return tracerProviderBuilder
+            .AddProcessor<MyProcessor>()
+            .SetSampler<MySampler>();
+    }
+}
+```
+
+Such an extension method can be consumed like this:
+
+```csharp
+services.AddOpenTelemetryTracing((builder) => builder
+    .AddAspNetCoreInstrumentation()
+    .AddHttpClientInstrumentation()
+    .AddZipkinExporter()
+    .AddMyFeature());
+```
+
 ## References
 
 * [OpenTelemetry Project](https://opentelemetry.io/)

--- a/src/OpenTelemetry.Extensions.Hosting/Trace/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Trace/TracerProviderBuilderExtensions.cs
@@ -76,7 +76,9 @@ namespace OpenTelemetry.Trace
         }
 
         /// <summary>
-        /// Register a callback action to configure the <see cref="TracerProviderBuilder"/> during initialization.
+        /// Register a callback action to configure the <see
+        /// cref="TracerProviderBuilder"/> once the application <see
+        /// cref="IServiceProvider"/> is available.
         /// </summary>
         /// <param name="tracerProviderBuilder"><see cref="TracerProviderBuilder"/>.</param>
         /// <param name="configure">Configuration callback.</param>

--- a/src/OpenTelemetry.Extensions.Hosting/Trace/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Trace/TracerProviderBuilderExtensions.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace OpenTelemetry.Trace
 {
@@ -35,7 +36,8 @@ namespace OpenTelemetry.Trace
         {
             if (tracerProviderBuilder is TracerProviderBuilderHosting tracerProviderBuilderHosting)
             {
-                tracerProviderBuilderHosting.AddInstrumentation<T>();
+                tracerProviderBuilderHosting.Configure((sp, builder) => builder
+                    .AddInstrumentation(() => sp.GetRequiredService<T>()));
             }
 
             return tracerProviderBuilder;
@@ -52,7 +54,8 @@ namespace OpenTelemetry.Trace
         {
             if (tracerProviderBuilder is TracerProviderBuilderHosting tracerProviderBuilderHosting)
             {
-                tracerProviderBuilderHosting.AddProcessor<T>();
+                tracerProviderBuilderHosting.Configure((sp, builder) => builder
+                    .AddProcessor(sp.GetRequiredService<T>()));
             }
 
             return tracerProviderBuilder;
@@ -69,7 +72,8 @@ namespace OpenTelemetry.Trace
         {
             if (tracerProviderBuilder is TracerProviderBuilderHosting tracerProviderBuilderHosting)
             {
-                tracerProviderBuilderHosting.SetSampler<T>();
+                tracerProviderBuilderHosting.Configure((sp, builder) => builder
+                    .SetSampler(sp.GetRequiredService<T>()));
             }
 
             return tracerProviderBuilder;

--- a/src/OpenTelemetry/AssemblyInfo.cs
+++ b/src/OpenTelemetry/AssemblyInfo.cs
@@ -17,5 +17,6 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("OpenTelemetry.Tests" + AssemblyInfo.PublicKey)]
+[assembly: InternalsVisibleTo("OpenTelemetry.Extensions.Hosting.Tests" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2" + AssemblyInfo.MoqPublicKey)]
 [assembly: InternalsVisibleTo("Benchmarks" + AssemblyInfo.PublicKey)]

--- a/src/OpenTelemetry/Trace/IDeferredTracerProviderBuilder.cs
+++ b/src/OpenTelemetry/Trace/IDeferredTracerProviderBuilder.cs
@@ -29,11 +29,16 @@ namespace OpenTelemetry.Trace
     public interface IDeferredTracerProviderBuilder
     {
 #if NET461_OR_GREATER || NETSTANDARD2_0
+        /// <summary>
+        /// Gets the application <see cref="IServiceCollection"/>.
+        /// </summary>
         IServiceCollection Services { get; }
 #endif
 
         /// <summary>
-        /// Register a callback action to configure the <see cref="TracerProviderBuilder"/> during initialization.
+        /// Register a callback action to configure the <see
+        /// cref="TracerProviderBuilder"/> once the application <see
+        /// cref="IServiceProvider"/> is available.
         /// </summary>
         /// <param name="configure">Configuration callback.</param>
         /// <returns>The supplied <see cref="TracerProviderBuilder"/> for chaining.</returns>

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -32,10 +32,9 @@ namespace OpenTelemetry.Trace
         private readonly List<object> instrumentations = new List<object>();
         private readonly ActivityListener listener;
         private readonly Sampler sampler;
-        private readonly Dictionary<string, bool> legacyActivityOperationNames;
+        private readonly Action<Activity> getRequestedDataAction;
+        private readonly bool supportLegacyActivity;
         private BaseProcessor<Activity> processor;
-        private Action<Activity> getRequestedDataAction;
-        private bool supportLegacyActivity;
 
         internal TracerProviderSdk(
             Resource resource,
@@ -47,7 +46,6 @@ namespace OpenTelemetry.Trace
         {
             this.Resource = resource;
             this.sampler = sampler;
-            this.legacyActivityOperationNames = legacyActivityOperationNames;
             this.supportLegacyActivity = legacyActivityOperationNames.Count > 0;
 
             foreach (var processor in processors)
@@ -221,6 +219,12 @@ namespace OpenTelemetry.Trace
         }
 
         internal Resource Resource { get; }
+
+        internal List<object> Instrumentations => this.instrumentations;
+
+        internal BaseProcessor<Activity> Processor => this.processor;
+
+        internal Sampler Sampler => this.sampler;
 
         internal TracerProviderSdk AddProcessor(BaseProcessor<Activity> processor)
         {

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/HostingExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/HostingExtensionsTests.cs
@@ -118,6 +118,28 @@ namespace OpenTelemetry.Extensions.Hosting.Tests
                 }));
         }
 
+        [Fact]
+        public void AddOpenTelemetryTracerProvider_NestedConfigureCallbacks()
+        {
+            int configureCalls = 0;
+            var services = new ServiceCollection();
+            services.AddOpenTelemetryTracing(builder => builder
+                .Configure((sp1, builder1) =>
+                {
+                    configureCalls++;
+                    builder1.Configure((sp2, builder2) =>
+                    {
+                        configureCalls++;
+                    });
+                }));
+
+            using var serviceProvider = services.BuildServiceProvider();
+
+            var tracerFactory = serviceProvider.GetRequiredService<TracerProvider>();
+
+            Assert.Equal(2, configureCalls);
+        }
+
         [Fact(Skip = "Known limitation. See issue 1215.")]
         public void AddOpenTelemetryTracerProvider_Idempotent()
         {

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/HostingExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/HostingExtensionsTests.cs
@@ -15,6 +15,8 @@
 // </copyright>
 
 using System;
+using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -140,6 +142,33 @@ namespace OpenTelemetry.Extensions.Hosting.Tests
             Assert.Equal(2, configureCalls);
         }
 
+        [Fact]
+        public void AddOpenTelemetryTracerProvider_ConfigureCallbacksUsingExtensions()
+        {
+            var services = new ServiceCollection();
+
+            services.AddSingleton<TestInstrumentation>();
+            services.AddSingleton<TestProcessor>();
+            services.AddSingleton<TestSampler>();
+
+            services.AddOpenTelemetryTracing(builder => builder
+                .Configure((sp1, builder1) =>
+                {
+                    builder1
+                        .AddInstrumentation<TestInstrumentation>()
+                        .AddProcessor<TestProcessor>()
+                        .SetSampler<TestSampler>();
+                }));
+
+            using var serviceProvider = services.BuildServiceProvider();
+
+            var tracerProvider = (TracerProviderSdk)serviceProvider.GetRequiredService<TracerProvider>();
+
+            Assert.True(tracerProvider.Instrumentations.FirstOrDefault() is TestInstrumentation);
+            Assert.True(tracerProvider.Processor is TestProcessor);
+            Assert.True(tracerProvider.Sampler is TestSampler);
+        }
+
         [Fact(Skip = "Known limitation. See issue 1215.")]
         public void AddOpenTelemetryTracerProvider_Idempotent()
         {
@@ -177,6 +206,18 @@ namespace OpenTelemetry.Extensions.Hosting.Tests
             public void Dispose()
             {
                 this.Disposed = true;
+            }
+        }
+
+        internal class TestProcessor : BaseProcessor<Activity>
+        {
+        }
+
+        internal class TestSampler : Sampler
+        {
+            public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
+            {
+                return new SamplingResult(SamplingDecision.RecordAndSample);
             }
         }
     }


### PR DESCRIPTION
Added documentation to the hosting README with usage examples. Tweaked some of the XML comments for clarity. Allowed configuration callbacks to be registered inside themselves. Fixed some bugs. And, best of all, simplified things.