### PR TITLE
Update code coverage script to fetch the MicrosoftCodeCoverage package version from Common.props

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -57,7 +57,6 @@
     <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopAnalyzersPkgVer)" Condition="'$(SkipAnalysis)'!='true'">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <!--When updating the Microsoft.CodeCoverage package, update the version number in .\build\process-codecoverage.ps1 as well-->
     <PackageReference Include="Microsoft.CodeCoverage" Version="$(MicrosoftCodeCoveragePkgVer)" Condition="'$(Configuration)'=='Release'"/>
     <!--<PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="$(MicrosoftCodeAnalysisAnalyzersPkgVer)" Condition="'$(SkipAnalysis)'!='true'">
       <PrivateAssets>all</PrivateAssets>

--- a/build/process-codecoverage.ps1
+++ b/build/process-codecoverage.ps1
@@ -1,6 +1,7 @@
-﻿$commonProps = Get-Content -Path 'Common.props' -Raw
-$commonProps -match '<MicrosoftCodeCoveragePkgVer>\[(.+)\]</MicrosoftCodeCoveragePkgVer>'
-$microsoftCodeCoveragePkgVer = $Matches[1]
+﻿[xml]$commonProps = Get-Content -Path $PSScriptRoot\Common.props
+$microsoftCodeCoveragePkgVer = [string]$commonProps.Project.PropertyGroup.MicrosoftCodeCoveragePkgVer # This is collected in the format: "[16.10.0]"
+$microsoftCodeCoveragePkgVer = $microsoftCodeCoveragePkgVer.Trim();
+$microsoftCodeCoveragePkgVer = $microsoftCodeCoveragePkgVer.SubString(1, $microsoftCodeCoveragePkgVer.Length - 2) # Removing square brackets
 $files = Get-ChildItem "TestResults" -Filter "*.coverage" -Recurse
 Write-Host $env:USERPROFILE
 foreach ($file in $files)

--- a/build/process-codecoverage.ps1
+++ b/build/process-codecoverage.ps1
@@ -1,8 +1,11 @@
-﻿$files = Get-ChildItem "TestResults" -Filter "*.coverage" -Recurse
+﻿$commonProps = Get-Content -Path 'Common.props' -Raw
+$commonProps -match '<MicrosoftCodeCoveragePkgVer>\[(.+)\]</MicrosoftCodeCoveragePkgVer>'
+$microsoftCodeCoveragePkgVer = $Matches[1]
+$files = Get-ChildItem "TestResults" -Filter "*.coverage" -Recurse
 Write-Host $env:USERPROFILE
 foreach ($file in $files)
 {
-    $command = $env:USERPROFILE+ '\.nuget\packages\microsoft.codecoverage\16.10.0\build\netstandard1.0\CodeCoverage\CodeCoverage.exe analyze /output:' + $file.DirectoryName + '\' + $file.Name + '.xml '+ $file.FullName
+    $command = $env:USERPROFILE+ '\.nuget\packages\microsoft.codecoverage\' + $microsoftCodeCoveragePkgVer + '\build\netstandard1.0\CodeCoverage\CodeCoverage.exe analyze /output:' + $file.DirectoryName + '\' + $file.Name + '.xml '+ $file.FullName
     Write-Host $command
     Invoke-Expression $command
 }


### PR DESCRIPTION
Addressing [comment](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2085#discussion_r652902301).

## Changes
- Update code coverage script to fetch the MicrosoftCodeCoverage package version from Common.props instead of using a hardcoded value