### PR TITLE
Change type of http.status_code to int in console example code to follow semantic convention

### DIFF
--- a/examples/Console/InstrumentationWithActivitySource.cs
+++ b/examples/Console/InstrumentationWithActivitySource.cs
@@ -136,7 +136,7 @@ namespace Examples.Console
                                 using var response = await client.PostAsync(url, content, cancellationToken).ConfigureAwait(false);
                                 activity?.AddEvent(new ActivityEvent("PostAsync:Ended"));
 
-                                activity?.SetTag("http.status_code", $"{response.StatusCode:D}");
+                                activity?.SetTag("http.status_code", (int)response.StatusCode);
 
                                 var responseContent = await response.Content.ReadAsStringAsync();
                                 activity?.SetTag("response.content", responseContent);


### PR DESCRIPTION
## Changes

OpenTelemetry trace semantic convention specified the type of `http.status_code` to `int`. Adopt this convention and convert `System.Net.HttpStatusCode` [enum](https://docs.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode) to `int` in the console example which was stored as `string`.

https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#common-attributes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
