### PR TITLE
Moving IDeferredTracerProviderBuilder to API

### DIFF
--- a/src/OpenTelemetry.Api/.publicApi/net452/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/net452/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
 abstract OpenTelemetry.Trace.TracerProviderBuilder.AddLegacySource(string operationName) -> OpenTelemetry.Trace.TracerProviderBuilder
+OpenTelemetry.Trace.IDeferredTracerProviderBuilder
+OpenTelemetry.Trace.IDeferredTracerProviderBuilder.Configure(System.Action<System.IServiceProvider, OpenTelemetry.Trace.TracerProviderBuilder> configure) -> OpenTelemetry.Trace.TracerProviderBuilder
 OpenTelemetry.Trace.TracerProviderBuilder.TracerProviderBuilder() -> void

--- a/src/OpenTelemetry.Api/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
 abstract OpenTelemetry.Trace.TracerProviderBuilder.AddLegacySource(string operationName) -> OpenTelemetry.Trace.TracerProviderBuilder
+OpenTelemetry.Trace.IDeferredTracerProviderBuilder
+OpenTelemetry.Trace.IDeferredTracerProviderBuilder.Configure(System.Action<System.IServiceProvider, OpenTelemetry.Trace.TracerProviderBuilder> configure) -> OpenTelemetry.Trace.TracerProviderBuilder
 OpenTelemetry.Trace.TracerProviderBuilder.TracerProviderBuilder() -> void

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -9,6 +9,9 @@ please check the latest changes
 
 ## Unreleased
 
+* Added `IDeferredTracerProviderBuilder`.
+  ([#2058](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2100))
+
 ## 1.1.0-beta4
 
 Released 2021-Jun-09

--- a/src/OpenTelemetry.Api/Trace/IDeferredTracerProviderBuilder.cs
+++ b/src/OpenTelemetry.Api/Trace/IDeferredTracerProviderBuilder.cs
@@ -15,9 +15,6 @@
 // </copyright>
 
 using System;
-#if NET461_OR_GREATER || NETSTANDARD2_0
-using Microsoft.Extensions.DependencyInjection;
-#endif
 
 namespace OpenTelemetry.Trace
 {
@@ -28,13 +25,6 @@ namespace OpenTelemetry.Trace
     /// </summary>
     public interface IDeferredTracerProviderBuilder
     {
-#if NET461_OR_GREATER || NETSTANDARD2_0
-        /// <summary>
-        /// Gets the application <see cref="IServiceCollection"/>.
-        /// </summary>
-        IServiceCollection Services { get; }
-#endif
-
         /// <summary>
         /// Register a callback action to configure the <see
         /// cref="TracerProviderBuilder"/> once the application <see

--- a/src/OpenTelemetry.Extensions.Hosting/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions.Hosting/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -6,4 +6,5 @@ static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddInstrumentation<T>
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddProcessor<T>(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder) -> OpenTelemetry.Trace.TracerProviderBuilder
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.Build(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, System.IServiceProvider serviceProvider) -> OpenTelemetry.Trace.TracerProvider
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.Configure(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder, System.Action<System.IServiceProvider, OpenTelemetry.Trace.TracerProviderBuilder> configure) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.GetServices(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.SetSampler<T>(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added `GetServices` extension.
+  ([#2058](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2100))
+
 ## 1.0.0-rc5
 
 Released 2021-Jun-09

--- a/src/OpenTelemetry.Extensions.Hosting/README.md
+++ b/src/OpenTelemetry.Extensions.Hosting/README.md
@@ -73,7 +73,8 @@ public static class MyLibraryExtensions
 {
     public static TracerProviderBuilder AddMyFeature(this TracerProviderBuilder tracerProviderBuilder)
     {
-        (tracerProviderBuilder.GetServices() ?? throw new NotSupportedException("MyFeature requires a hosting TracerProviderBuilder instance."))
+        (tracerProviderBuilder.GetServices()
+            ?? throw new NotSupportedException("MyFeature requires a hosting TracerProviderBuilder instance."))
             .AddHostedService<MyHostedService>()
             .AddSingleton<MyService>()
             .AddSingleton<MyProcessor>()

--- a/src/OpenTelemetry.Extensions.Hosting/README.md
+++ b/src/OpenTelemetry.Extensions.Hosting/README.md
@@ -65,21 +65,15 @@ from the application `IServiceCollection` so any services registered in the
 
 Library authors may want to configure the OpenTelemetry `TracerProvider` and
 register application services to provide more complex features. This can be
-accomplished concisely by casting the `TracerProviderBuilder` into an
-`IDeferredTracerProviderBuilder` instance in an extension method like this:
+accomplished concisely by using the `GetServices` extension inside of an
+`TracerProviderBuilder` extension method like this:
 
 ```csharp
 public static class MyLibraryExtensions
 {
     public static TracerProviderBuilder AddMyFeature(this TracerProviderBuilder tracerProviderBuilder)
     {
-        if (!(tracerProviderBuilder is IDeferredTracerProviderBuilder deferredTracerProviderBuilder))
-        {
-            throw new NotSupportedException(
-                "MyFeature requires an IDeferredTracerProviderBuilder instance.");
-        }
-
-        deferredTracerProviderBuilder.Services
+        (tracerProviderBuilder.GetServices() ?? throw new NotSupportedException("MyFeature requires a hosting TracerProviderBuilder instance."))
             .AddHostedService<MyHostedService>()
             .AddSingleton<MyService>()
             .AddSingleton<MyProcessor>()

--- a/src/OpenTelemetry.Extensions.Hosting/README.md
+++ b/src/OpenTelemetry.Extensions.Hosting/README.md
@@ -65,8 +65,9 @@ from the application `IServiceCollection` so any services registered in the
 
 Library authors may want to configure the OpenTelemetry `TracerProvider` and
 register application services to provide more complex features. This can be
-accomplished concisely by using the `GetServices` extension inside of an
-`TracerProviderBuilder` extension method like this:
+accomplished concisely by using the `TracerProviderBuilder.GetServices`
+extension method inside of a more general `TracerProviderBuilder` configuration
+extension like this:
 
 ```csharp
 public static class MyLibraryExtensions

--- a/src/OpenTelemetry.Extensions.Hosting/README.md
+++ b/src/OpenTelemetry.Extensions.Hosting/README.md
@@ -74,7 +74,8 @@ public static class MyLibraryExtensions
     public static TracerProviderBuilder AddMyFeature(this TracerProviderBuilder tracerProviderBuilder)
     {
         (tracerProviderBuilder.GetServices()
-            ?? throw new NotSupportedException("MyFeature requires a hosting TracerProviderBuilder instance."))
+            ?? throw new NotSupportedException(
+                "MyFeature requires a hosting TracerProviderBuilder instance."))
             .AddHostedService<MyHostedService>()
             .AddSingleton<MyService>()
             .AddSingleton<MyProcessor>()

--- a/src/OpenTelemetry.Extensions.Hosting/Trace/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Trace/TracerProviderBuilderExtensions.cs
@@ -98,6 +98,23 @@ namespace OpenTelemetry.Trace
         }
 
         /// <summary>
+        /// Gets the application <see cref="IServiceCollection"/> attached to
+        /// the <see cref="TracerProviderBuilder"/>.
+        /// </summary>
+        /// <param name="tracerProviderBuilder"><see cref="TracerProviderBuilder"/>.</param>
+        /// <returns><see cref="IServiceCollection"/> or <see langword="null"/>
+        /// if services are unavailable.</returns>
+        public static IServiceCollection GetServices(this TracerProviderBuilder tracerProviderBuilder)
+        {
+            if (tracerProviderBuilder is TracerProviderBuilderHosting tracerProviderBuilderHosting)
+            {
+                return tracerProviderBuilderHosting.Services;
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Run the configured actions to initialize the <see cref="TracerProvider"/>.
         /// </summary>
         /// <param name="tracerProviderBuilder"><see cref="TracerProviderBuilder"/>.</param>

--- a/src/OpenTelemetry/.publicApi/net452/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net452/PublicAPI.Unshipped.txt
@@ -1,5 +1,3 @@
-OpenTelemetry.Trace.IDeferredTracerProviderBuilder
-OpenTelemetry.Trace.IDeferredTracerProviderBuilder.Configure(System.Action<System.IServiceProvider, OpenTelemetry.Trace.TracerProviderBuilder> configure) -> OpenTelemetry.Trace.TracerProviderBuilder
 OpenTelemetry.Trace.ParentBasedSampler.ParentBasedSampler(OpenTelemetry.Trace.Sampler rootSampler, OpenTelemetry.Trace.Sampler remoteParentSampled = null, OpenTelemetry.Trace.Sampler remoteParentNotSampled = null, OpenTelemetry.Trace.Sampler localParentSampled = null, OpenTelemetry.Trace.Sampler localParentNotSampled = null) -> void
 OpenTelemetry.Trace.TracerProviderBuilderBase
 OpenTelemetry.Trace.TracerProviderBuilderBase.AddInstrumentation(string instrumentationName, string instrumentationVersion, System.Func<object> instrumentationFactory) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry/.publicApi/net46/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net46/PublicAPI.Unshipped.txt
@@ -1,5 +1,3 @@
-OpenTelemetry.Trace.IDeferredTracerProviderBuilder
-OpenTelemetry.Trace.IDeferredTracerProviderBuilder.Configure(System.Action<System.IServiceProvider, OpenTelemetry.Trace.TracerProviderBuilder> configure) -> OpenTelemetry.Trace.TracerProviderBuilder
 OpenTelemetry.Trace.ParentBasedSampler.ParentBasedSampler(OpenTelemetry.Trace.Sampler rootSampler, OpenTelemetry.Trace.Sampler remoteParentSampled = null, OpenTelemetry.Trace.Sampler remoteParentNotSampled = null, OpenTelemetry.Trace.Sampler localParentSampled = null, OpenTelemetry.Trace.Sampler localParentNotSampled = null) -> void
 OpenTelemetry.Trace.TracerProviderBuilderBase
 OpenTelemetry.Trace.TracerProviderBuilderBase.AddInstrumentation(string instrumentationName, string instrumentationVersion, System.Func<object> instrumentationFactory) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -19,9 +19,6 @@ OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeScopes.set -> void
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.get -> bool
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.set -> void
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.SetResourceBuilder(OpenTelemetry.Resources.ResourceBuilder resourceBuilder) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions
-OpenTelemetry.Trace.IDeferredTracerProviderBuilder
-OpenTelemetry.Trace.IDeferredTracerProviderBuilder.Configure(System.Action<System.IServiceProvider, OpenTelemetry.Trace.TracerProviderBuilder> configure) -> OpenTelemetry.Trace.TracerProviderBuilder
-OpenTelemetry.Trace.IDeferredTracerProviderBuilder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection
 OpenTelemetry.Trace.ParentBasedSampler.ParentBasedSampler(OpenTelemetry.Trace.Sampler rootSampler, OpenTelemetry.Trace.Sampler remoteParentSampled = null, OpenTelemetry.Trace.Sampler remoteParentNotSampled = null, OpenTelemetry.Trace.Sampler localParentSampled = null, OpenTelemetry.Trace.Sampler localParentNotSampled = null) -> void
 OpenTelemetry.Trace.TracerProviderBuilderBase
 OpenTelemetry.Trace.TracerProviderBuilderBase.AddInstrumentation(string instrumentationName, string instrumentationVersion, System.Func<object> instrumentationFactory) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -19,9 +19,6 @@ OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeScopes.set -> void
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.get -> bool
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.set -> void
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.SetResourceBuilder(OpenTelemetry.Resources.ResourceBuilder resourceBuilder) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions
-OpenTelemetry.Trace.IDeferredTracerProviderBuilder
-OpenTelemetry.Trace.IDeferredTracerProviderBuilder.Configure(System.Action<System.IServiceProvider, OpenTelemetry.Trace.TracerProviderBuilder> configure) -> OpenTelemetry.Trace.TracerProviderBuilder
-OpenTelemetry.Trace.IDeferredTracerProviderBuilder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection
 OpenTelemetry.Trace.ParentBasedSampler.ParentBasedSampler(OpenTelemetry.Trace.Sampler rootSampler, OpenTelemetry.Trace.Sampler remoteParentSampled = null, OpenTelemetry.Trace.Sampler remoteParentNotSampled = null, OpenTelemetry.Trace.Sampler localParentSampled = null, OpenTelemetry.Trace.Sampler localParentNotSampled = null) -> void
 OpenTelemetry.Trace.TracerProviderBuilderBase
 OpenTelemetry.Trace.TracerProviderBuilderBase.AddInstrumentation(string instrumentationName, string instrumentationVersion, System.Func<object> instrumentationFactory) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -9,6 +9,9 @@ please check the latest changes
 
 ## Unreleased
 
+* Moved `IDeferredTracerProviderBuilder` to API library.
+  ([#2058](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2100))
+
 ## 1.1.0-beta4
 
 Released 2021-Jun-09


### PR DESCRIPTION
Related to #1889, #2058

## Changes

Moved IDeferredTracerProviderBuilder from SDK to API. The goal is to allow instrumentation libraries to be written without a dependency on SDK.

## Public API

API doesn't have a dependency on Microsoft.Extensions.DependencyInjection so IDeferredTracerProviderBuilder can no longer expose `IServiceCollection`.

```csharp
// Moved from OpenTelemetry to OpenTelemetry.Api
namespace OpenTelemetry.Trace
{
    public interface IDeferredTracerProviderBuilder
    {
        // removed
        // IServiceCollection Services { get; }

        // existing
        TracerProviderBuilder Configure(Action<IServiceProvider, TracerProviderBuilder> configure);
    }
}

// Added to OpenTelemetry.Extensions.Hosting
namespace OpenTelemetry.Trace
{
    public static class TracerProviderBuilderExtensions
    {
       public static IServiceCollection GetServices(this TracerProviderBuilder tracerProviderBuilder) {}
    }
}
```

## TODOs

* [X] `CHANGELOG.md` updated for non-trivial changes
* [ ] Changes in public API reviewed
