### PR TITLE
Use ActivityTraceId/ActivitySpanId for exemplars

### DIFF
--- a/src/OpenTelemetry/Metrics/DataPoint/Exemplar.cs
+++ b/src/OpenTelemetry/Metrics/DataPoint/Exemplar.cs
@@ -16,17 +16,17 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace OpenTelemetry.Metrics
 {
     internal readonly struct Exemplar : IExemplar
     {
         private static readonly KeyValuePair<string, object>[] EmptyTag = new KeyValuePair<string, object>[0];
-        private static readonly byte[] EmptyId = new byte[0];
 
         private readonly IDataValue value;
 
-        internal Exemplar(DateTimeOffset timestamp, long value, byte[] spanId, byte[] traceId, KeyValuePair<string, object>[] filteredTags)
+        internal Exemplar(DateTimeOffset timestamp, long value, ActivityTraceId traceId, ActivitySpanId spanId, KeyValuePair<string, object>[] filteredTags)
         {
             this.Timestamp = timestamp;
             this.FilteredTags = filteredTags;
@@ -35,7 +35,7 @@ namespace OpenTelemetry.Metrics
             this.value = new DataValue<long>(value);
         }
 
-        internal Exemplar(DateTimeOffset timestamp, double value, byte[] spanId, byte[] traceId, KeyValuePair<string, object>[] filteredTags)
+        internal Exemplar(DateTimeOffset timestamp, double value, ActivityTraceId traceId, ActivitySpanId spanId, KeyValuePair<string, object>[] filteredTags)
         {
             this.Timestamp = timestamp;
             this.FilteredTags = filteredTags;
@@ -44,7 +44,7 @@ namespace OpenTelemetry.Metrics
             this.value = new DataValue<double>(value);
         }
 
-        internal Exemplar(DateTimeOffset timestamp, IDataValue value, byte[] spanId, byte[] traceId, KeyValuePair<string, object>[] filteredTags)
+        internal Exemplar(DateTimeOffset timestamp, IDataValue value, ActivityTraceId traceId, ActivitySpanId spanId, KeyValuePair<string, object>[] filteredTags)
         {
             this.Timestamp = timestamp;
             this.FilteredTags = filteredTags;
@@ -54,17 +54,17 @@ namespace OpenTelemetry.Metrics
         }
 
         internal Exemplar(DateTimeOffset timestamp, long value)
-            : this(timestamp, value, Exemplar.EmptyId, Exemplar.EmptyId, Exemplar.EmptyTag)
+            : this(timestamp, value, default, default, Exemplar.EmptyTag)
         {
         }
 
         internal Exemplar(DateTimeOffset timestamp, double value)
-            : this(timestamp, value, Exemplar.EmptyId, Exemplar.EmptyId, Exemplar.EmptyTag)
+            : this(timestamp, value, default, default, Exemplar.EmptyTag)
         {
         }
 
         internal Exemplar(DateTimeOffset timestamp, IDataValue value)
-            : this(timestamp, value, Exemplar.EmptyId, Exemplar.EmptyId, Exemplar.EmptyTag)
+            : this(timestamp, value, default, default, Exemplar.EmptyTag)
         {
         }
 
@@ -72,9 +72,9 @@ namespace OpenTelemetry.Metrics
 
         public readonly KeyValuePair<string, object>[] FilteredTags { get; }
 
-        public readonly byte[] SpanId { get; }
+        public readonly ActivityTraceId TraceId { get; }
 
-        public readonly byte[] TraceId { get; }
+        public readonly ActivitySpanId SpanId { get; }
 
         public object Value => this.value.Value;
     }

--- a/src/OpenTelemetry/Metrics/DataPoint/Exemplar{T}.cs
+++ b/src/OpenTelemetry/Metrics/DataPoint/Exemplar{T}.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace OpenTelemetry.Metrics
 {
@@ -23,11 +24,10 @@ namespace OpenTelemetry.Metrics
         where T : struct
     {
         private static readonly KeyValuePair<string, object>[] EmptyTag = new KeyValuePair<string, object>[0];
-        private static readonly byte[] EmptyId = new byte[0];
 
         private readonly IDataValue value;
 
-        internal Exemplar(DateTimeOffset timestamp, T value, byte[] spanId, byte[] traceId, KeyValuePair<string, object>[] filteredTags)
+        internal Exemplar(DateTimeOffset timestamp, T value, ActivityTraceId traceId, ActivitySpanId spanId, KeyValuePair<string, object>[] filteredTags)
         {
             this.Timestamp = timestamp;
             this.FilteredTags = filteredTags;
@@ -36,7 +36,7 @@ namespace OpenTelemetry.Metrics
             this.value = new DataValue<T>(value);
         }
 
-        internal Exemplar(DateTimeOffset timestamp, IDataValue value, byte[] spanId, byte[] traceId, KeyValuePair<string, object>[] filteredTags)
+        internal Exemplar(DateTimeOffset timestamp, IDataValue value, ActivityTraceId traceId, ActivitySpanId spanId, KeyValuePair<string, object>[] filteredTags)
         {
             this.Timestamp = timestamp;
             this.FilteredTags = filteredTags;
@@ -46,12 +46,12 @@ namespace OpenTelemetry.Metrics
         }
 
         internal Exemplar(DateTimeOffset timestamp, T value)
-            : this(timestamp, value, Exemplar<T>.EmptyId, Exemplar<T>.EmptyId, Exemplar<T>.EmptyTag)
+            : this(timestamp, value, default, default, Exemplar<T>.EmptyTag)
         {
         }
 
         internal Exemplar(DateTimeOffset timestamp, IDataValue value)
-            : this(timestamp, value, Exemplar<T>.EmptyId, Exemplar<T>.EmptyId, Exemplar<T>.EmptyTag)
+            : this(timestamp, value, default, default, Exemplar<T>.EmptyTag)
         {
         }
 
@@ -59,9 +59,9 @@ namespace OpenTelemetry.Metrics
 
         public readonly KeyValuePair<string, object>[] FilteredTags { get; }
 
-        public readonly byte[] SpanId { get; }
+        public readonly ActivityTraceId TraceId { get; }
 
-        public readonly byte[] TraceId { get; }
+        public readonly ActivitySpanId SpanId { get; }
 
         public object Value => this.value.Value;
     }

--- a/src/OpenTelemetry/Metrics/DataPoint/IExemplar.cs
+++ b/src/OpenTelemetry/Metrics/DataPoint/IExemplar.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace OpenTelemetry.Metrics
 {
@@ -25,8 +26,8 @@ namespace OpenTelemetry.Metrics
 
         KeyValuePair<string, object>[] FilteredTags { get; }
 
-        byte[] SpanId { get; }
+        ActivityTraceId TraceId { get; }
 
-        byte[] TraceId { get; }
+        ActivitySpanId SpanId { get; }
     }
 }


### PR DESCRIPTION
@victlu I think it might make sense to use the .NET `ActivityTraceId` and `ActivitySpanId` types on exemplars. Or was your choice of `byte[]` intentional?