### PR TITLE
Remove timestamp read per metric update

### DIFF
--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -152,7 +152,7 @@ namespace OpenTelemetry.Metrics
             return metrics;
         }
 
-        internal void Update<T>(DateTimeOffset dt, T value, ReadOnlySpan<KeyValuePair<string, object>> tags)
+        internal void Update<T>(T value, ReadOnlySpan<KeyValuePair<string, object>> tags)
             where T : struct
         {
             // TODO: We can isolate the cost of each user-added aggregator in
@@ -164,7 +164,7 @@ namespace OpenTelemetry.Metrics
 
             foreach (var pair in metricPairs)
             {
-                pair.Metric.Update(dt, value);
+                pair.Metric.Update(value);
             }
         }
 

--- a/src/OpenTelemetry/Metrics/InstrumentState.cs
+++ b/src/OpenTelemetry/Metrics/InstrumentState.cs
@@ -31,10 +31,10 @@ namespace OpenTelemetry.Metrics
             sdk.AggregatorStores.TryAdd(this.store, true);
         }
 
-        internal void Update<T>(DateTimeOffset dt, T value, ReadOnlySpan<KeyValuePair<string, object>> tags)
+        internal void Update<T>(T value, ReadOnlySpan<KeyValuePair<string, object>> tags)
             where T : struct
         {
-            this.store.Update(dt, value, tags);
+            this.store.Update(value, tags);
         }
     }
 }

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -99,22 +99,6 @@ namespace OpenTelemetry.Metrics
 
         internal List<KeyValuePair<MetricProcessor, int>> ExportProcessors { get; } = new List<KeyValuePair<MetricProcessor, int>>();
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static DateTimeOffset GetDateTimeOffset()
-        {
-            int tick = Environment.TickCount;
-            if (tick == MeterProviderSdk.lastTick)
-            {
-                return MeterProviderSdk.lastTimestamp;
-            }
-
-            var dt = DateTimeOffset.UtcNow;
-            MeterProviderSdk.lastTimestamp = dt;
-            MeterProviderSdk.lastTick = tick;
-
-            return dt;
-        }
-
         internal void MeasurementsCompleted(Instrument instrument, object state)
         {
             Console.WriteLine($"Instrument {instrument.Meter.Name}:{instrument.Name} completed.");
@@ -126,24 +110,23 @@ namespace OpenTelemetry.Metrics
             // Get Instrument State
             var instrumentState = state as InstrumentState;
 
-            if (instrument == null)
+            if (instrumentState == null)
             {
                 // TODO: log
                 return;
             }
 
             var measurementItem = new MeasurementItem(instrument, instrumentState);
-            var dt = MeterProviderSdk.GetDateTimeOffset();
             var tags = tagsRos;
             var val = value;
 
             // Run Pre Aggregator Processors
             foreach (var processor in this.MeasurementProcessors)
             {
-                processor.OnEnd(measurementItem, ref dt, ref val, ref tags);
+                processor.OnEnd(measurementItem, ref val, ref tags);
             }
 
-            instrumentState.Update(dt, val, tags);
+            instrumentState.Update(val, tags);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -30,9 +30,6 @@ namespace OpenTelemetry.Metrics
     {
         internal readonly ConcurrentDictionary<AggregatorStore, bool> AggregatorStores = new ConcurrentDictionary<AggregatorStore, bool>();
 
-        private static int lastTick = -1;
-        private static DateTimeOffset lastTimestamp = DateTimeOffset.MinValue;
-
         private readonly CancellationTokenSource cts = new CancellationTokenSource();
         private readonly List<Task> collectorTasks = new List<Task>();
         private readonly MeterListener listener;
@@ -110,7 +107,7 @@ namespace OpenTelemetry.Metrics
             // Get Instrument State
             var instrumentState = state as InstrumentState;
 
-            if (instrumentState == null)
+            if (instrument == null || instrumentState == null)
             {
                 // TODO: log
                 return;

--- a/src/OpenTelemetry/Metrics/MetricAggregators/GaugeMetricAggregator.cs
+++ b/src/OpenTelemetry/Metrics/MetricAggregators/GaugeMetricAggregator.cs
@@ -28,7 +28,6 @@ namespace OpenTelemetry.Metrics
         {
             this.Name = name;
             this.StartTimeExclusive = startTimeExclusive;
-            this.EndTimeInclusive = startTimeExclusive;
             this.Attributes = attributes;
         }
 
@@ -44,12 +43,11 @@ namespace OpenTelemetry.Metrics
 
         public IDataValue LastValue => this.value;
 
-        public void Update<T>(DateTimeOffset dt, T value)
+        public void Update<T>(T value)
             where T : struct
         {
             lock (this.lockUpdate)
             {
-                this.EndTimeInclusive = dt;
                 this.value = new DataValue<T>(value);
             }
         }

--- a/src/OpenTelemetry/Metrics/MetricAggregators/HistogramMetricAggregator.cs
+++ b/src/OpenTelemetry/Metrics/MetricAggregators/HistogramMetricAggregator.cs
@@ -28,7 +28,6 @@ namespace OpenTelemetry.Metrics
         {
             this.Name = name;
             this.StartTimeExclusive = startTimeExclusive;
-            this.EndTimeInclusive = startTimeExclusive;
             this.Attributes = attributes;
             this.IsDeltaTemporality = isDelta;
         }
@@ -51,14 +50,13 @@ namespace OpenTelemetry.Metrics
 
         public IEnumerable<HistogramBucket> Buckets => this.buckets;
 
-        public void Update<T>(DateTimeOffset dt, T value)
+        public void Update<T>(T value)
             where T : struct
         {
             // TODO: Implement Histogram!
 
             lock (this.lockUpdate)
             {
-                this.EndTimeInclusive = dt;
                 this.PopulationCount++;
             }
         }

--- a/src/OpenTelemetry/Metrics/MetricAggregators/IAggregator.cs
+++ b/src/OpenTelemetry/Metrics/MetricAggregators/IAggregator.cs
@@ -20,7 +20,7 @@ namespace OpenTelemetry.Metrics
 {
     internal interface IAggregator
     {
-        void Update<T>(DateTimeOffset dt, T value)
+        void Update<T>(T value)
             where T : struct;
 
         IMetric Collect(DateTimeOffset dt);

--- a/src/OpenTelemetry/Metrics/MetricAggregators/SumMetricAggregator.cs
+++ b/src/OpenTelemetry/Metrics/MetricAggregators/SumMetricAggregator.cs
@@ -30,7 +30,6 @@ namespace OpenTelemetry.Metrics
         {
             this.Name = name;
             this.StartTimeExclusive = startTimeExclusive;
-            this.EndTimeInclusive = startTimeExclusive;
             this.Attributes = attributes;
             this.IsDeltaTemporality = isDelta;
             this.IsMonotonic = true;
@@ -67,13 +66,11 @@ namespace OpenTelemetry.Metrics
             }
         }
 
-        public void Update<T>(DateTimeOffset dt, T value)
+        public void Update<T>(T value)
             where T : struct
         {
             lock (this.lockUpdate)
             {
-                this.EndTimeInclusive = dt;
-
                 if (typeof(T) == typeof(long))
                 {
                     this.valueType = typeof(T);

--- a/src/OpenTelemetry/Metrics/MetricAggregators/SummaryMetricAggregator.cs
+++ b/src/OpenTelemetry/Metrics/MetricAggregators/SummaryMetricAggregator.cs
@@ -29,7 +29,6 @@ namespace OpenTelemetry.Metrics
         {
             this.Name = name;
             this.StartTimeExclusive = startTimeExclusive;
-            this.EndTimeInclusive = startTimeExclusive;
             this.Attributes = attributes;
             this.IsMonotonic = isMonotonic;
         }
@@ -50,25 +49,14 @@ namespace OpenTelemetry.Metrics
 
         public IEnumerable<ValueAtQuantile> Quantiles => this.quantiles;
 
-        public void Update<T>(DateTimeOffset dt, T value)
+        public void Update<T>(T value)
             where T : struct
         {
             // TODO: Implement Summary!
 
             lock (this.lockUpdate)
             {
-                this.EndTimeInclusive = dt;
-
-                if (typeof(T) == typeof(int))
-                {
-                    var val = (int)(object)value;
-                    if (val > 0 || !this.IsMonotonic)
-                    {
-                        this.PopulationSum += (double)val;
-                        this.PopulationCount++;
-                    }
-                }
-                else if (typeof(T) == typeof(long))
+                if (typeof(T) == typeof(long))
                 {
                     var val = (long)(object)value;
                     if (val > 0 || !this.IsMonotonic)

--- a/src/OpenTelemetry/Metrics/Processors/MeasurementProcessor.cs
+++ b/src/OpenTelemetry/Metrics/Processors/MeasurementProcessor.cs
@@ -22,7 +22,7 @@ namespace OpenTelemetry.Metrics
 {
     public abstract class MeasurementProcessor : BaseProcessor<MeasurementItem>
     {
-        internal abstract void OnEnd<T>(MeasurementItem measurementItem, ref DateTimeOffset dt, ref T value, ref ReadOnlySpan<KeyValuePair<string, object>> tags)
+        internal abstract void OnEnd<T>(MeasurementItem measurementItem, ref T value, ref ReadOnlySpan<KeyValuePair<string, object>> tags)
             where T : struct;
     }
 }

--- a/src/OpenTelemetry/Metrics/Processors/TagEnrichmentProcessor.cs
+++ b/src/OpenTelemetry/Metrics/Processors/TagEnrichmentProcessor.cs
@@ -32,7 +32,7 @@ namespace OpenTelemetry.Metrics
             this.extraAttrib = new KeyValuePair<string, object>(name, value);
         }
 
-        internal override void OnEnd<T>(MeasurementItem measurementItem, ref DateTimeOffset dt, ref T value, ref ReadOnlySpan<KeyValuePair<string, object>> tags)
+        internal override void OnEnd<T>(MeasurementItem measurementItem, ref T value, ref ReadOnlySpan<KeyValuePair<string, object>> tags)
             where T : struct
         {
             var list = new List<KeyValuePair<string, object>>(tags.ToArray());


### PR DESCRIPTION
## Changes
Removes the usage of DateTimeOffset in every measurement record event. There seems to be no need of paying cost for reading/passingaround/storing the time with every Update call.

The StartTime is read when the Aggregators start up. (same as before)
The EndTime is ready when "collect" occurs. (same as before)

There can be some more changes done the same area (in future PRs), where we read system time just once at startup, and then rely purely on tick counts, to calculate endtimes for each Collect/Export cycle.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
