### PR TITLE
Make Delta vs Cumulative based purely on Exporter

### DIFF
--- a/examples/Console/Program.cs
+++ b/examples/Console/Program.cs
@@ -96,6 +96,9 @@ namespace Examples.Console
     [Verb("metrics", HelpText = "Specify the options required to test Metrics")]
     internal class MetricsOptions
     {
+        [Option('d', "IsDelta", HelpText = "Export Delta metrics", Required = false, Default = true)]
+        public bool IsDelta { get; set; }
+
         [Option('g', "Gauge", HelpText = "Include Observable Gauge.", Required = false)]
         public bool? FlagGauge { get; set; }
 

--- a/examples/Console/TestMetrics.cs
+++ b/examples/Console/TestMetrics.cs
@@ -30,8 +30,11 @@ namespace Examples.Console
         {
             using var provider = Sdk.CreateMeterProviderBuilder()
                 .AddSource("TestMeter") // All instruments from this meter are enabled.
-                .AddMeasurementProcessor(new TagEnrichmentProcessor("resource", "here"))
-                .AddConsoleExporter(o => o.MetricExportInterval = options.DefaultCollectionPeriodMilliseconds)
+                .AddConsoleExporter(o =>
+                    {
+                        o.MetricExportInterval = options.DefaultCollectionPeriodMilliseconds;
+                        o.IsDelta = options.IsDelta;
+                    })
                 .Build();
 
             using var meter = new Meter("TestMeter", "0.0.1");
@@ -43,12 +46,12 @@ namespace Examples.Console
             }
 
             Histogram<int> histogram = null;
-            if (options.FlagHistogram ?? true)
+            if (options.FlagHistogram ?? false)
             {
                 histogram = meter.CreateHistogram<int>("histogram");
             }
 
-            if (options.FlagGauge ?? true)
+            if (options.FlagGauge ?? false)
             {
                 var observableCounter = meter.CreateObservableGauge<int>("gauge", () =>
                 {

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterMetricHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterMetricHelperExtensions.cs
@@ -37,7 +37,7 @@ namespace OpenTelemetry.Metrics
 
             var options = new ConsoleExporterOptions();
             configure?.Invoke(options);
-            return builder.AddMetricProcessor(new PushMetricProcessor(new ConsoleMetricExporter(options), options.MetricExportInterval));
+            return builder.AddMetricProcessor(new PushMetricProcessor(new ConsoleMetricExporter(options), options.MetricExportInterval, options.IsDelta));
         }
     }
 }

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterOptions.cs
@@ -27,5 +27,11 @@ namespace OpenTelemetry.Exporter
         /// Gets or sets the metric export interval.
         /// </summary>
         public int MetricExportInterval { get; set; } = 1000;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to export Delta
+        /// values or not (Cumulative).
+        /// </summary>
+        public bool IsDelta { get; set; } = true;
     }
 }

--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -74,7 +74,7 @@ namespace OpenTelemetry.Exporter
 
                     string time = $"{metric.StartTimeExclusive.ToLocalTime().ToString("HH:mm:ss.fff")} {metric.EndTimeInclusive.ToLocalTime().ToString("HH:mm:ss.fff")}";
 
-                    var msg = $"Export {time} {metric.Name} [{string.Join(";", tags)}] {kind} Value: {valueDisplay}, Details: {metric.ToDisplayString()}";
+                    var msg = $"Export {time} {metric.Name} [{string.Join(";", tags)}] {kind} Value: {valueDisplay}";
                     Console.WriteLine(msg);
                 }
             }

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -56,7 +56,7 @@ namespace OpenTelemetry.Metrics
             // TODO: Need to map each instrument to metrics (based on View API)
             if (this.instrument.GetType().Name.Contains("Counter"))
             {
-                aggregators.Add(new SumMetricAggregator(name, dt, tags, true));
+                aggregators.Add(new SumMetricAggregator(name, dt, tags));
             }
             else if (this.instrument.GetType().Name.Contains("Gauge"))
             {
@@ -64,7 +64,7 @@ namespace OpenTelemetry.Metrics
             }
             else if (this.instrument.GetType().Name.Contains("Histogram"))
             {
-                aggregators.Add(new HistogramMetricAggregator(name, dt, tags, false));
+                aggregators.Add(new HistogramMetricAggregator(name, dt, tags));
             }
             else
             {
@@ -156,7 +156,7 @@ namespace OpenTelemetry.Metrics
             }
         }
 
-        internal List<IMetric> Collect()
+        internal List<IMetric> Collect(bool isDelta)
         {
             var collectedMetrics = new List<IMetric>();
 
@@ -168,7 +168,7 @@ namespace OpenTelemetry.Metrics
                 {
                     foreach (var metric in values.Value)
                     {
-                        var m = metric.Collect(dt);
+                        var m = metric.Collect(dt, isDelta);
                         if (m != null)
                         {
                             collectedMetrics.Add(m);

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -127,7 +127,7 @@ namespace OpenTelemetry.Metrics
             }
         }
 
-        private MetricItem Collect()
+        private MetricItem Collect(bool isDelta)
         {
             lock (this.collectLock)
             {
@@ -137,7 +137,7 @@ namespace OpenTelemetry.Metrics
 
                 foreach (var kv in this.AggregatorStores)
                 {
-                    var metrics = kv.Key.Collect();
+                    var metrics = kv.Key.Collect(isDelta);
                     metricItem.Metrics.AddRange(metrics);
                 }
 

--- a/src/OpenTelemetry/Metrics/MetricAggregators/GaugeMetricAggregator.cs
+++ b/src/OpenTelemetry/Metrics/MetricAggregators/GaugeMetricAggregator.cs
@@ -52,7 +52,7 @@ namespace OpenTelemetry.Metrics
             }
         }
 
-        public IMetric Collect(DateTimeOffset dt)
+        public IMetric Collect(DateTimeOffset dt, bool isDelta)
         {
             var cloneItem = new GaugeMetricAggregator(this.Name, this.StartTimeExclusive, this.Attributes);
 

--- a/src/OpenTelemetry/Metrics/MetricAggregators/HistogramMetricAggregator.cs
+++ b/src/OpenTelemetry/Metrics/MetricAggregators/HistogramMetricAggregator.cs
@@ -24,12 +24,11 @@ namespace OpenTelemetry.Metrics
         private readonly object lockUpdate = new object();
         private List<HistogramBucket> buckets = new List<HistogramBucket>();
 
-        internal HistogramMetricAggregator(string name, DateTimeOffset startTimeExclusive, KeyValuePair<string, object>[] attributes, bool isDelta)
+        internal HistogramMetricAggregator(string name, DateTimeOffset startTimeExclusive, KeyValuePair<string, object>[] attributes)
         {
             this.Name = name;
             this.StartTimeExclusive = startTimeExclusive;
             this.Attributes = attributes;
-            this.IsDeltaTemporality = isDelta;
         }
 
         public string Name { get; private set; }
@@ -40,7 +39,7 @@ namespace OpenTelemetry.Metrics
 
         public KeyValuePair<string, object>[] Attributes { get; private set; }
 
-        public bool IsDeltaTemporality { get; }
+        public bool IsDeltaTemporality { get; private set; }
 
         public IEnumerable<IExemplar> Exemplars { get; private set; } = new List<IExemplar>();
 
@@ -61,7 +60,7 @@ namespace OpenTelemetry.Metrics
             }
         }
 
-        public IMetric Collect(DateTimeOffset dt)
+        public IMetric Collect(DateTimeOffset dt, bool isDelta)
         {
             if (this.PopulationCount == 0)
             {
@@ -69,7 +68,7 @@ namespace OpenTelemetry.Metrics
                 return null;
             }
 
-            var cloneItem = new HistogramMetricAggregator(this.Name, this.StartTimeExclusive, this.Attributes, this.IsDeltaTemporality);
+            var cloneItem = new HistogramMetricAggregator(this.Name, this.StartTimeExclusive, this.Attributes);
 
             lock (this.lockUpdate)
             {
@@ -78,10 +77,14 @@ namespace OpenTelemetry.Metrics
                 cloneItem.PopulationCount = this.PopulationCount;
                 cloneItem.PopulationSum = this.PopulationSum;
                 cloneItem.buckets = this.buckets;
+                cloneItem.IsDeltaTemporality = isDelta;
 
-                this.StartTimeExclusive = dt;
-                this.PopulationCount = 0;
-                this.PopulationSum = 0;
+                if (isDelta)
+                {
+                    this.StartTimeExclusive = dt;
+                    this.PopulationCount = 0;
+                    this.PopulationSum = 0;
+                }
             }
 
             return cloneItem;

--- a/src/OpenTelemetry/Metrics/MetricAggregators/IAggregator.cs
+++ b/src/OpenTelemetry/Metrics/MetricAggregators/IAggregator.cs
@@ -23,6 +23,6 @@ namespace OpenTelemetry.Metrics
         void Update<T>(T value)
             where T : struct;
 
-        IMetric Collect(DateTimeOffset dt);
+        IMetric Collect(DateTimeOffset dt, bool isDelta);
     }
 }

--- a/src/OpenTelemetry/Metrics/MetricAggregators/SumMetricAggregator.cs
+++ b/src/OpenTelemetry/Metrics/MetricAggregators/SumMetricAggregator.cs
@@ -26,12 +26,11 @@ namespace OpenTelemetry.Metrics
         private long sumLong = 0;
         private double sumDouble = 0;
 
-        internal SumMetricAggregator(string name, DateTimeOffset startTimeExclusive, KeyValuePair<string, object>[] attributes, bool isDelta)
+        internal SumMetricAggregator(string name, DateTimeOffset startTimeExclusive, KeyValuePair<string, object>[] attributes)
         {
             this.Name = name;
             this.StartTimeExclusive = startTimeExclusive;
             this.Attributes = attributes;
-            this.IsDeltaTemporality = isDelta;
             this.IsMonotonic = true;
         }
 
@@ -43,7 +42,7 @@ namespace OpenTelemetry.Metrics
 
         public KeyValuePair<string, object>[] Attributes { get; private set; }
 
-        public bool IsDeltaTemporality { get; }
+        public bool IsDeltaTemporality { get; private set; }
 
         public bool IsMonotonic { get; }
 
@@ -106,9 +105,9 @@ namespace OpenTelemetry.Metrics
             }
         }
 
-        public IMetric Collect(DateTimeOffset dt)
+        public IMetric Collect(DateTimeOffset dt, bool isDelta)
         {
-            var cloneItem = new SumMetricAggregator(this.Name, this.StartTimeExclusive, this.Attributes, this.IsDeltaTemporality);
+            var cloneItem = new SumMetricAggregator(this.Name, this.StartTimeExclusive, this.Attributes);
 
             lock (this.lockUpdate)
             {
@@ -117,8 +116,9 @@ namespace OpenTelemetry.Metrics
                 cloneItem.valueType = this.valueType;
                 cloneItem.sumLong = this.sumLong;
                 cloneItem.sumDouble = this.sumDouble;
+                cloneItem.IsDeltaTemporality = isDelta;
 
-                if (this.IsDeltaTemporality)
+                if (isDelta)
                 {
                     this.StartTimeExclusive = dt;
                     this.sumLong = 0;
@@ -131,7 +131,7 @@ namespace OpenTelemetry.Metrics
 
         public string ToDisplayString()
         {
-            return $"Delta={this.IsDeltaTemporality},Monotonic={this.IsMonotonic},Sum={this.Sum.Value}";
+            return $"Sum={this.Sum.Value}";
         }
     }
 }

--- a/src/OpenTelemetry/Metrics/MetricAggregators/SummaryMetricAggregator.cs
+++ b/src/OpenTelemetry/Metrics/MetricAggregators/SummaryMetricAggregator.cs
@@ -77,7 +77,7 @@ namespace OpenTelemetry.Metrics
             }
         }
 
-        public IMetric Collect(DateTimeOffset dt)
+        public IMetric Collect(DateTimeOffset dt, bool isDelta)
         {
             if (this.PopulationCount == 0)
             {

--- a/src/OpenTelemetry/Metrics/Processors/MetricProcessor.cs
+++ b/src/OpenTelemetry/Metrics/Processors/MetricProcessor.cs
@@ -22,6 +22,6 @@ namespace OpenTelemetry.Metrics
     {
         // GetMetric or GetMemoryState or GetAggregatedMetrics..
         // ...or some other names
-        public abstract void SetGetMetricFunction(Func<MetricItem> getMetrics);
+        public abstract void SetGetMetricFunction(Func<bool, MetricItem> getMetrics);
     }
 }

--- a/src/OpenTelemetry/Metrics/Processors/PullMetricProcessor.cs
+++ b/src/OpenTelemetry/Metrics/Processors/PullMetricProcessor.cs
@@ -22,16 +22,18 @@ namespace OpenTelemetry.Metrics
 {
     public class PullMetricProcessor : MetricProcessor, IDisposable
     {
-        private Func<MetricItem> getMetrics;
+        private Func<bool, MetricItem> getMetrics;
         private BaseExporter<MetricItem> exporter;
         private bool disposed;
+        private bool isDelta;
 
-        public PullMetricProcessor(BaseExporter<MetricItem> exporter)
+        public PullMetricProcessor(BaseExporter<MetricItem> exporter, bool isDelta)
         {
             this.exporter = exporter;
+            this.isDelta = isDelta;
         }
 
-        public override void SetGetMetricFunction(Func<MetricItem> getMetrics)
+        public override void SetGetMetricFunction(Func<bool, MetricItem> getMetrics)
         {
             this.getMetrics = getMetrics;
         }
@@ -40,7 +42,7 @@ namespace OpenTelemetry.Metrics
         {
             if (this.getMetrics != null)
             {
-                var metricsToExport = this.getMetrics();
+                var metricsToExport = this.getMetrics(this.isDelta);
                 Batch<MetricItem> batch = new Batch<MetricItem>(metricsToExport);
                 this.exporter.Export(batch);
             }


### PR DESCRIPTION
## Changes
1. Makes Delta vs Cumulative decision tied to exporter. Its an exporter level setting, so *all* metrics either becomes delta or cumulative.
Once Views are in, this'd require rework anyway, as views likely would allow per-instrument delta vs cumulative setting.

2. Modified ConsoleExporter to pick between delta and cumulative, defaulting to delta

Cumulative Console Exporter
```
using var meterProvider = Sdk.CreateMeterProviderBuilder()
                .AddSource("TestMeter")
                .AddConsoleExporter(options => options.IsDelta = false)
                .Build();
```

Delta Console Exporter
```
using var meterProvider = Sdk.CreateMeterProviderBuilder()
                .AddSource("TestMeter")
                .AddConsoleExporter(options => options.IsDelta = true) //default
                .Build();
```