### PR TITLE
Remove unsupported frameworks from CI checks

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        version: [net452,net46,net461,netcoreapp2.1,netcoreapp3.1,net5.0]
+        version: [net461,netcoreapp2.1,netcoreapp3.1,net5.0]
 
     steps:
     - uses: actions/checkout@v2

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -10,7 +10,7 @@ please check the latest changes
 ## Unreleased
 
 * Removes .NET Framework 4.5.2 support. The minimum .NET Framework version
-  supported is .NET 4.6.1. [2138](https://github.com/open-telemetry/opentelemetry-dotnet/issues/2138)
+  supported is .NET 4.6.1. ([2138](https://github.com/open-telemetry/opentelemetry-dotnet/issues/2138))
 
 ## 1.1.0
 


### PR DESCRIPTION
Part of #2138.
Remove CI now itself, to free up some CI machines, which is getting clogged with a flood of PR/merge activity.