### PR TITLE
Small cleanup on MeterProvider

### DIFF
--- a/src/OpenTelemetry/Metrics/Processors/PushMetricProcessor.cs
+++ b/src/OpenTelemetry/Metrics/Processors/PushMetricProcessor.cs
@@ -61,6 +61,7 @@ namespace OpenTelemetry.Metrics
                 {
                     this.token.Cancel();
                     this.exporter.Dispose();
+                    this.exportTask.Wait();
                 }
                 catch (Exception)
                 {


### PR DESCRIPTION
Provider doesn't have any tasks, so its dispose simply calls dispose on the processors (which may have tasks to be disposed)