### PR TITLE
Fix ObjectEqualityComparer used in aggregatorstore

### DIFF
--- a/src/OpenTelemetry/Metrics/ObjectArrayEqualityComparer.cs
+++ b/src/OpenTelemetry/Metrics/ObjectArrayEqualityComparer.cs
@@ -41,7 +41,7 @@ namespace OpenTelemetry.Metrics
 
             for (int i = 0; i < len1; i++)
             {
-                if (obj1[i] != obj2[i])
+                if (!obj1[i].Equals(obj2[i]))
                 {
                     return false;
                 }

--- a/test/Benchmarks/Metrics/MetricsBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricsBenchmarks.cs
@@ -110,6 +110,11 @@ namespace Benchmarks.Metrics
         }
 
         [Benchmark]
+        public void CounterWith1LabelLocal()
+        {
+            this.counter?.Add(100, new KeyValuePair<string, object>("key", "value"));
+        }
+
         public void CounterWith3LabelsHotPath()
         {
             this.counter?.Add(100, this.tag1, this.tag2, this.tag3);


### PR DESCRIPTION
The ObjectEqualityComparer bug caused the AggregatorStore dictionary to grow forever. The benchmark (newly added to demo this issue), was literally stuck, as dictionary became too huge.

This temporarily fixes the issue. Its to be decided if we want to have the 2 level dictionary or 1 level dictionary, and what the key should be. 

Also the "collect" is not threadsafe, as it iterates through  the dictionary, while more entries could be added to it (if a new label combination comes.) This is to be addressed separately.