### PR TITLE
Catch exception from Metric collect, stop daily publish from metrics branch

### DIFF
--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -2,7 +2,7 @@
 ################### IMPORTANT ###################
 # DON'T RENAME THIS FILE UNLESS WE START
 # RELEASING THE VERSION 2.*
-################### IMPORTANT ################### 
+################### IMPORTANT ###################
 #################################################
 
 name: Pack and publish to Myget
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        branches: [main,metrics]
+        branches: [main]
 
     steps:
     - uses: actions/checkout@v2

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -138,14 +138,22 @@ namespace OpenTelemetry.Metrics
         {
             lock (this.collectLock)
             {
-                // Record all observable instruments
-                this.listener.RecordObservableInstruments();
-                var metricItem = new MetricItem();
-
-                foreach (var kv in this.AggregatorStores)
+                MetricItem metricItem = null;
+                try
                 {
-                    var metrics = kv.Key.Collect(isDelta);
-                    metricItem.Metrics.AddRange(metrics);
+                    // Record all observable instruments
+                    this.listener.RecordObservableInstruments();
+                    metricItem = new MetricItem();
+
+                    foreach (var kv in this.AggregatorStores)
+                    {
+                        var metrics = kv.Key.Collect(isDelta);
+                        metricItem.Metrics.AddRange(metrics);
+                    }
+                }
+                catch (Exception)
+                {
+                    // TODO: Log
                 }
 
                 return metricItem;

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -19,8 +19,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using OpenTelemetry.Resources;
 
 namespace OpenTelemetry.Metrics

--- a/src/OpenTelemetry/Metrics/Processors/PullMetricProcessor.cs
+++ b/src/OpenTelemetry/Metrics/Processors/PullMetricProcessor.cs
@@ -42,8 +42,11 @@ namespace OpenTelemetry.Metrics
             if (this.getMetrics != null)
             {
                 var metricsToExport = this.getMetrics(this.isDelta);
-                Batch<MetricItem> batch = new Batch<MetricItem>(metricsToExport);
-                this.exporter.Export(batch);
+                if (metricsToExport != null)
+                {
+                    Batch<MetricItem> batch = new Batch<MetricItem>(metricsToExport);
+                    this.exporter.Export(batch);
+                }
             }
         }
 

--- a/src/OpenTelemetry/Metrics/Processors/PushMetricProcessor.cs
+++ b/src/OpenTelemetry/Metrics/Processors/PushMetricProcessor.cs
@@ -77,8 +77,11 @@ namespace OpenTelemetry.Metrics
             if (this.getMetrics != null)
             {
                 var metricsToExport = this.getMetrics(isDelta);
-                Batch<MetricItem> batch = new Batch<MetricItem>(metricsToExport);
-                this.exporter.Export(batch);
+                if (metricsToExport != null)
+                {
+                    Batch<MetricItem> batch = new Batch<MetricItem>(metricsToExport);
+                    this.exporter.Export(batch);
+                }
             }
         }
     }


### PR DESCRIPTION
1. Catch exception from Collect in the meter provider.
2. Stop publish daily nugets to myget.org from the metrics branch.
(Other CIs are still not removed from metrics branch, as we may want to keep metrics branch for few weeks to help prototyping some big changes)