### PR TITLE
Fix thread safety for collect in MeterProvider and AggregatorStores

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-* Add Metrics support.
+* Add basic Metrics support with a single pipeline,
+  and supporting Counter (sync) instrument. Push
+  and Pull exporters are supported.
 
 * Removes .NET Framework 4.5.2, .NET 4.6 support. The minimum .NET Framework
   version supported is .NET 4.6.1. ([#2138](https://github.com/open-telemetry/opentelemetry-dotnet/issues/2138))

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 ## Unreleased
 
-* Add basic Metrics support with a single pipeline,
-  and supporting Counter (sync) instrument. Push
-  and Pull exporters are supported.
+* Add basic Metrics support with a single pipeline, and supporting Counter
+  (sync) instrument. Push and Pull exporters are supported.
 
 * Removes .NET Framework 4.5.2, .NET 4.6 support. The minimum .NET Framework
   version supported is .NET 4.6.1. ([#2138](https://github.com/open-telemetry/opentelemetry-dotnet/issues/2138))


### PR DESCRIPTION
Adds lock to prevent
1. New instrument (i.e new aggregatorstore as we have aggregatorstore per instrument) from being added while Collect() is going on.
2. New timeseries within aggregatorstore from being added, while Collect() is going on.

Doing the easy fix, to unblock alpha1 release, as optimizing these would require more rearchitecting.

🔒 🔒 