### PR TITLE
Add Prometheus to the core package

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## Experimental - Metrics
-
-Note: the metrics work is happening in the [metrics feature
-branch](https://github.com/open-telemetry/opentelemetry-dotnet/tree/metrics),
-please check the latest changes
-[here](https://github.com/open-telemetry/opentelemetry-dotnet/blob/metrics/src/OpenTelemetry.Exporter.Console/CHANGELOG.md#experimental---metrics).
-
 ## Unreleased
 
 ## 1.2.0-alpha1

--- a/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## Experimental - Metrics
-
-Note: the metrics work is happening in the [metrics feature
-branch](https://github.com/open-telemetry/opentelemetry-dotnet/tree/metrics),
-please check the latest changes
-[here](https://github.com/open-telemetry/opentelemetry-dotnet/blob/metrics/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md#experimental---metrics).
-
 ## Unreleased
 
 ## 1.2.0-alpha1

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## Experimental - Metrics
-
-Note: the metrics work is happening in the [metrics feature
-branch](https://github.com/open-telemetry/opentelemetry-dotnet/tree/metrics),
-please check the latest changes
-[here](https://github.com/open-telemetry/opentelemetry-dotnet/blob/metrics/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md#experimental---metrics).
-
 ## Unreleased
 
 ## 1.2.0-alpha1
@@ -15,6 +8,8 @@ Released 2021-Jul-23
 
 * Removes .NET Framework 4.5.2, .NET 4.6 support. The minimum .NET Framework
   version supported is .NET 4.6.1. ([#2138](https://github.com/open-telemetry/opentelemetry-dotnet/issues/2138))
+
+* Add Metrics support.([#2174](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2174))
 
 ## 1.1.0
 

--- a/src/OpenTelemetry.Exporter.Prometheus/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+
+## 1.0.0-rc1.1
+
+Released 2020-Nov-17
+
+* Initial release

--- a/src/OpenTelemetry.Exporter.Prometheus/OpenTelemetry.Exporter.Prometheus.csproj
+++ b/src/OpenTelemetry.Exporter.Prometheus/OpenTelemetry.Exporter.Prometheus.csproj
@@ -11,6 +11,12 @@
     <NoWarn>$(NoWarn),1591</NoWarn>
   </PropertyGroup>
 
+  <!--Do not run ApiCompat as this package has never released a stable version.
+  Remove this property once we have released a stable version.-->
+  <PropertyGroup>
+    <RunApiCompat>false</RunApiCompat>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry\OpenTelemetry.csproj" />
   </ItemGroup>

--- a/src/OpenTelemetry.Exporter.Prometheus/OpenTelemetry.Exporter.Prometheus.csproj
+++ b/src/OpenTelemetry.Exporter.Prometheus/OpenTelemetry.Exporter.Prometheus.csproj
@@ -2,8 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <Description>Console exporter for OpenTelemetry .NET</Description>
+    <Description>Prometheus exporter for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);prometheus;metrics</PackageTags>
+    <MinVerTagPrefix>core-</MinVerTagPrefix>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
We had released prometheus from the "old" metrics on Nov 2020. https://www.nuget.org/packages/OpenTelemetry.Exporter.Prometheus/1.0.0-rc1.1

We'll be resurrecting Prometheus exporter as core package (i.e versioned same as API/SDK/other exporters), starting with 1.2.0-alpha2.

To be decided if we want to "unlist" the existing nugets of Prometheus from nuget.org