### PR TITLE
Do not call export when there are no metrics to export

### DIFF
--- a/src/OpenTelemetry/Metrics/Processors/PullMetricProcessor.cs
+++ b/src/OpenTelemetry/Metrics/Processors/PullMetricProcessor.cs
@@ -42,7 +42,7 @@ namespace OpenTelemetry.Metrics
             if (this.getMetrics != null)
             {
                 var metricsToExport = this.getMetrics(this.isDelta);
-                if (metricsToExport != null)
+                if (metricsToExport != null && metricsToExport.Metrics.Count > 0)
                 {
                     Batch<MetricItem> batch = new Batch<MetricItem>(metricsToExport);
                     this.exporter.Export(batch);

--- a/src/OpenTelemetry/Metrics/Processors/PushMetricProcessor.cs
+++ b/src/OpenTelemetry/Metrics/Processors/PushMetricProcessor.cs
@@ -77,7 +77,7 @@ namespace OpenTelemetry.Metrics
             if (this.getMetrics != null)
             {
                 var metricsToExport = this.getMetrics(isDelta);
-                if (metricsToExport != null)
+                if (metricsToExport != null && metricsToExport.Metrics.Count > 0)
                 {
                     Batch<MetricItem> batch = new Batch<MetricItem>(metricsToExport);
                     this.exporter.Export(batch);


### PR DESCRIPTION
Opening this to continue this conversation here: https://github.com/open-telemetry/opentelemetry-dotnet/pull/2186#discussion_r675924155

Currently, when the `Push/PullMetricProcessor`s invoke `Collect` it always yields a non-null `MetricItem` (unless `Collect` throws an  exception). This PR adds a check to see that `MetricItem.Metrics` is non-empty prior to invoking the underlying exporter.

Is this the behavior that makes sense to folks?