### PR TITLE
Rename metrics exporter option MetricExportInterval to MetricExportIntervalMilliSeconds

### DIFF
--- a/examples/Console/TestMetrics.cs
+++ b/examples/Console/TestMetrics.cs
@@ -66,7 +66,7 @@ namespace Examples.Console
                 providerBuilder
                     .AddOtlpExporter(o =>
                     {
-                        o.MetricExportInterval = options.DefaultCollectionPeriodMilliseconds;
+                        o.MetricExportIntervalMilliSeconds = options.DefaultCollectionPeriodMilliseconds;
                         o.IsDelta = options.IsDelta;
                     });
             }
@@ -75,7 +75,7 @@ namespace Examples.Console
                 providerBuilder
                     .AddConsoleExporter(o =>
                     {
-                        o.MetricExportInterval = options.DefaultCollectionPeriodMilliseconds;
+                        o.MetricExportIntervalMilliSeconds = options.DefaultCollectionPeriodMilliseconds;
                         o.IsDelta = options.IsDelta;
                     });
             }

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterMetricHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterMetricHelperExtensions.cs
@@ -37,7 +37,7 @@ namespace OpenTelemetry.Metrics
 
             var options = new ConsoleExporterOptions();
             configure?.Invoke(options);
-            return builder.AddMetricProcessor(new PushMetricProcessor(new ConsoleMetricExporter(options), options.MetricExportInterval, options.IsDelta));
+            return builder.AddMetricProcessor(new PushMetricProcessor(new ConsoleMetricExporter(options), options.MetricExportIntervalMilliSeconds, options.IsDelta));
         }
     }
 }

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterOptions.cs
@@ -24,9 +24,9 @@ namespace OpenTelemetry.Exporter
         public ConsoleExporterOutputTargets Targets { get; set; } = ConsoleExporterOutputTargets.Console;
 
         /// <summary>
-        /// Gets or sets the metric export interval.
+        /// Gets or sets the metric export interval in milliseconds. The default value is 1000 milliseconds.
         /// </summary>
-        public int MetricExportInterval { get; set; } = 1000;
+        public int MetricExportIntervalMilliSeconds { get; set; } = 1000;
 
         /// <summary>
         /// Gets or sets a value indicating whether to export Delta

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterMetricHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterMetricHelperExtensions.cs
@@ -44,7 +44,7 @@ namespace OpenTelemetry.Metrics
 
             var options = new InMemoryExporterOptions();
             configure?.Invoke(options);
-            return builder.AddMetricProcessor(new PushMetricProcessor(new InMemoryExporter<MetricItem>(exportedItems), options.MetricExportInterval, options.IsDelta));
+            return builder.AddMetricProcessor(new PushMetricProcessor(new InMemoryExporter<MetricItem>(exportedItems), options.MetricExportIntervalMilliSeconds, options.IsDelta));
         }
     }
 }

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterOptions.cs
@@ -19,9 +19,9 @@ namespace OpenTelemetry.Exporter
     public class InMemoryExporterOptions
     {
         /// <summary>
-        /// Gets or sets the metric export interval.
+        /// Gets or sets the metric export interval in milliseconds. The default value is 1000 milliseconds.
         /// </summary>
-        public int MetricExportInterval { get; set; } = 1000;
+        public int MetricExportIntervalMilliSeconds { get; set; } = 1000;
 
         /// <summary>
         /// Gets or sets a value indicating whether to export Delta

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -54,9 +54,9 @@ namespace OpenTelemetry.Exporter
         public BatchExportProcessorOptions<Activity> BatchExportProcessorOptions { get; set; } = new BatchExportProcessorOptions<Activity>();
 
         /// <summary>
-        /// Gets or sets the metric export interval.
+        /// Gets or sets the metric export interval in milliseconds. The default value is 1000 milliseconds.
         /// </summary>
-        public int MetricExportInterval { get; set; } = 1000;
+        public int MetricExportIntervalMilliSeconds { get; set; } = 1000;
 
         /// <summary>
         /// Gets or sets a value indicating whether to export Delta

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterHelperExtensions.cs
@@ -39,7 +39,7 @@ namespace OpenTelemetry.Metrics
 
             var options = new OtlpExporterOptions();
             configure?.Invoke(options);
-            return builder.AddMetricProcessor(new PushMetricProcessor(new OtlpMetricsExporter(options), options.MetricExportInterval, options.IsDelta));
+            return builder.AddMetricProcessor(new PushMetricProcessor(new OtlpMetricsExporter(options), options.MetricExportIntervalMilliSeconds, options.IsDelta));
         }
     }
 }


### PR DESCRIPTION
Addresses the PR comment: https://github.com/open-telemetry/opentelemetry-dotnet/pull/2192#discussion_r676987433

## Changes
- Rename the metrics exporter option `MetricExportInterval` to `MetricExportIntervalMilliSeconds` for Console, InMemory and OTLP exporter
