### PR TITLE
Rename MetricExportIntervalMilliSeconds to MetricExportIntervalMilliseconds

### DIFF
--- a/examples/Console/TestMetrics.cs
+++ b/examples/Console/TestMetrics.cs
@@ -66,7 +66,7 @@ namespace Examples.Console
                 providerBuilder
                     .AddOtlpExporter(o =>
                     {
-                        o.MetricExportIntervalMilliSeconds = options.DefaultCollectionPeriodMilliseconds;
+                        o.MetricExportIntervalMilliseconds = options.DefaultCollectionPeriodMilliseconds;
                         o.IsDelta = options.IsDelta;
                     });
             }
@@ -75,7 +75,7 @@ namespace Examples.Console
                 providerBuilder
                     .AddConsoleExporter(o =>
                     {
-                        o.MetricExportIntervalMilliSeconds = options.DefaultCollectionPeriodMilliseconds;
+                        o.MetricExportIntervalMilliseconds = options.DefaultCollectionPeriodMilliseconds;
                         o.IsDelta = options.IsDelta;
                     });
             }

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterMetricHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterMetricHelperExtensions.cs
@@ -37,7 +37,7 @@ namespace OpenTelemetry.Metrics
 
             var options = new ConsoleExporterOptions();
             configure?.Invoke(options);
-            return builder.AddMetricProcessor(new PushMetricProcessor(new ConsoleMetricExporter(options), options.MetricExportIntervalMilliSeconds, options.IsDelta));
+            return builder.AddMetricProcessor(new PushMetricProcessor(new ConsoleMetricExporter(options), options.MetricExportIntervalMilliseconds, options.IsDelta));
         }
     }
 }

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterOptions.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Exporter
         /// <summary>
         /// Gets or sets the metric export interval in milliseconds. The default value is 1000 milliseconds.
         /// </summary>
-        public int MetricExportIntervalMilliSeconds { get; set; } = 1000;
+        public int MetricExportIntervalMilliseconds { get; set; } = 1000;
 
         /// <summary>
         /// Gets or sets a value indicating whether to export Delta

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterMetricHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterMetricHelperExtensions.cs
@@ -44,7 +44,7 @@ namespace OpenTelemetry.Metrics
 
             var options = new InMemoryExporterOptions();
             configure?.Invoke(options);
-            return builder.AddMetricProcessor(new PushMetricProcessor(new InMemoryExporter<MetricItem>(exportedItems), options.MetricExportIntervalMilliSeconds, options.IsDelta));
+            return builder.AddMetricProcessor(new PushMetricProcessor(new InMemoryExporter<MetricItem>(exportedItems), options.MetricExportIntervalMilliseconds, options.IsDelta));
         }
     }
 }

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterOptions.cs
@@ -21,7 +21,7 @@ namespace OpenTelemetry.Exporter
         /// <summary>
         /// Gets or sets the metric export interval in milliseconds. The default value is 1000 milliseconds.
         /// </summary>
-        public int MetricExportIntervalMilliSeconds { get; set; } = 1000;
+        public int MetricExportIntervalMilliseconds { get; set; } = 1000;
 
         /// <summary>
         /// Gets or sets a value indicating whether to export Delta

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -56,7 +56,7 @@ namespace OpenTelemetry.Exporter
         /// <summary>
         /// Gets or sets the metric export interval in milliseconds. The default value is 1000 milliseconds.
         /// </summary>
-        public int MetricExportIntervalMilliSeconds { get; set; } = 1000;
+        public int MetricExportIntervalMilliseconds { get; set; } = 1000;
 
         /// <summary>
         /// Gets or sets a value indicating whether to export Delta

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterHelperExtensions.cs
@@ -39,7 +39,7 @@ namespace OpenTelemetry.Metrics
 
             var options = new OtlpExporterOptions();
             configure?.Invoke(options);
-            return builder.AddMetricProcessor(new PushMetricProcessor(new OtlpMetricsExporter(options), options.MetricExportIntervalMilliSeconds, options.IsDelta));
+            return builder.AddMetricProcessor(new PushMetricProcessor(new OtlpMetricsExporter(options), options.MetricExportIntervalMilliseconds, options.IsDelta));
         }
     }
 }


### PR DESCRIPTION
Addresses PR comment: https://github.com/open-telemetry/opentelemetry-dotnet/pull/2193#issuecomment-887084474

## Changes
- Rename MetricExportIntervalMilliSeconds to MetricExportIntervalMilliseconds
