### PR TITLE
Logformatter null check

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -5,8 +5,8 @@
 * Removes upper constraint for Microsoft.Extensions.Logging
   dependencies. ([#2179](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2179))
 
-* Fix bug which caused ILogger.Log calls to throw exception, when the
-  formatter supplied is null.
+* OpenTelemetryLogger modified to not throw, when the
+  formatter supplied in ILogger.Log call is null. ([#2200](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2200))
 
 ## 1.2.0-alpha1
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Removes upper constraint for Microsoft.Extensions.Logging
   dependencies. ([#2179](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2179))
 
+* Fix bug which caused ILogger.Log calls to throw exception, when the
+  formatter supplied is null.
+
 ## 1.2.0-alpha1
 
 Released 2021-Jul-23

--- a/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
@@ -47,13 +47,22 @@ namespace OpenTelemetry.Logs
             {
                 var options = this.provider.Options;
 
+                string formattedMessage = null;
+                if (options.IncludeFormattedMessage)
+                {
+                    if (formatter != null)
+                    {
+                        formattedMessage = formatter(state, exception);
+                    }
+                }
+
                 var record = new LogRecord(
                     options.IncludeScopes ? this.ScopeProvider : null,
                     DateTime.UtcNow,
                     this.categoryName,
                     logLevel,
                     eventId,
-                    options.IncludeFormattedMessage ? formatter(state, exception) : null,
+                    formattedMessage,
                     options.ParseStateValues ? null : (object)state,
                     exception,
                     options.ParseStateValues ? this.ParseState(state) : null);

--- a/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
@@ -47,22 +47,13 @@ namespace OpenTelemetry.Logs
             {
                 var options = this.provider.Options;
 
-                string formattedMessage = null;
-                if (options.IncludeFormattedMessage)
-                {
-                    if (formatter != null)
-                    {
-                        formattedMessage = formatter(state, exception);
-                    }
-                }
-
                 var record = new LogRecord(
                     options.IncludeScopes ? this.ScopeProvider : null,
                     DateTime.UtcNow,
                     this.categoryName,
                     logLevel,
                     eventId,
-                    formattedMessage,
+                    options.IncludeFormattedMessage ? formatter?.Invoke(state, exception) : null,
                     options.ParseStateValues ? null : (object)state,
                     exception,
                     options.ParseStateValues ? this.ParseState(state) : null);

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
@@ -31,9 +31,7 @@ using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Instrumentation.AspNetCore.Implementation;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
-#if NETCOREAPP2_1
-using TestApp.AspNetCore._2._1;
-#elif NETCOREAPP3_1
+#if NETCOREAPP3_1
 using TestApp.AspNetCore._3._1;
 #else
 using TestApp.AspNetCore._5._0;

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/DependencyInjectionConfigTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/DependencyInjectionConfigTests.cs
@@ -20,9 +20,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Trace;
-#if NETCOREAPP2_1
-using TestApp.AspNetCore._2._1;
-#elif NETCOREAPP3_1
+#if NETCOREAPP3_1
 using TestApp.AspNetCore._3._1;
 #else
 using TestApp.AspNetCore._5._0;

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
@@ -25,9 +25,7 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using OpenTelemetry.Trace;
-#if NETCOREAPP2_1
-using TestApp.AspNetCore._2._1;
-#elif NETCOREAPP3_1
+#if NETCOREAPP3_1
 using TestApp.AspNetCore._3._1;
 #else
 using TestApp.AspNetCore._5._0;

--- a/test/OpenTelemetry.Tests/Logs/LogRecordTest.cs
+++ b/test/OpenTelemetry.Tests/Logs/LogRecordTest.cs
@@ -13,11 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
-
 #if !NET461
-#if NETCOREAPP2_1
-using Microsoft.Extensions.DependencyInjection;
-#endif
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -36,11 +32,7 @@ namespace OpenTelemetry.Tests.Logs
     {
         private readonly ILogger logger;
         private readonly List<LogRecord> exportedItems = new List<LogRecord>();
-#if NETCOREAPP2_1
-        private readonly ServiceProvider serviceProvider;
-#else
         private readonly ILoggerFactory loggerFactory;
-#endif
         private readonly BaseExportProcessor<LogRecord> processor;
         private readonly BaseExporter<LogRecord> exporter;
         private OpenTelemetryLoggerOptions options;
@@ -49,11 +41,7 @@ namespace OpenTelemetry.Tests.Logs
         {
             this.exporter = new InMemoryExporter<LogRecord>(this.exportedItems);
             this.processor = new TestLogRecordProcessor(this.exporter);
-#if NETCOREAPP2_1
-            var serviceCollection = new ServiceCollection().AddLogging(builder =>
-#else
             this.loggerFactory = LoggerFactory.Create(builder =>
-#endif
             {
                 builder.AddOpenTelemetry(options =>
                 {
@@ -64,12 +52,7 @@ namespace OpenTelemetry.Tests.Logs
                 builder.AddFilter(typeof(LogRecordTest).FullName, LogLevel.Trace);
             });
 
-#if NETCOREAPP2_1
-            this.serviceProvider = serviceCollection.BuildServiceProvider();
-            this.logger = this.serviceProvider.GetRequiredService<ILogger<LogRecordTest>>();
-#else
             this.logger = this.loggerFactory.CreateLogger<LogRecordTest>();
-#endif
         }
 
         [Fact]
@@ -340,6 +323,32 @@ namespace OpenTelemetry.Tests.Logs
         }
 
         [Fact]
+        public void IncludeFormattedMessageTestWhenFormatterNull()
+        {
+            this.logger.Log(LogLevel.Information, default, "Hello World!", null, null);
+            var logRecord = this.exportedItems[0];
+            Assert.Null(logRecord.FormattedMessage);
+
+            this.options.IncludeFormattedMessage = true;
+            try
+            {
+                // Pass null as formatter function
+                this.logger.Log(LogLevel.Information, default, "Hello World!", null, null);
+                logRecord = this.exportedItems[1];
+                Assert.Null(logRecord.FormattedMessage);
+
+                var expectedFormattedMessage = "formatted message";
+                this.logger.Log(LogLevel.Information, default, "Hello World!", null, (state, ex) => expectedFormattedMessage);
+                logRecord = this.exportedItems[2];
+                Assert.Equal(expectedFormattedMessage, logRecord.FormattedMessage);
+            }
+            finally
+            {
+                this.options.IncludeFormattedMessage = false;
+            }
+        }
+
+        [Fact]
         public void IncludeScopesTest()
         {
             using var scope = this.logger.BeginScope("string_scope");
@@ -598,11 +607,7 @@ namespace OpenTelemetry.Tests.Logs
 
         public void Dispose()
         {
-#if NETCOREAPP2_1
-            this.serviceProvider?.Dispose();
-#else
             this.loggerFactory?.Dispose();
-#endif
         }
 
         internal struct Food


### PR DESCRIPTION
`ilogger.Log(LogLevel.Information, default, "Hello World!", null, null);` (note the last param is null, which is the formatter) when combined with `IncludeFormattedMessage=true` will result in an unhandled exception. This PR check if formatter is not null, before invoking it.

Also removed some netcoreapp2.1 checks. (leftover cleanups)