### PR TITLE
Modify benchmarks to use tags created locally

### DIFF
--- a/test/Benchmarks/Metrics/MetricsBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricsBenchmarks.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using BenchmarkDotNet.Attributes;
@@ -22,40 +23,22 @@ using OpenTelemetry.Metrics;
 
 /*
 BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19043
-Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
-.NET Core SDK=5.0.202
-  [Host]     : .NET Core 3.1.13 (CoreCLR 4.700.21.11102, CoreFX 4.700.21.11602), X64 RyuJIT
-  DefaultJob : .NET Core 3.1.13 (CoreCLR 4.700.21.11102, CoreFX 4.700.21.11602), X64 RyuJIT
+Intel Core i7-8650U CPU 1.90GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
+.NET Core SDK=5.0.302
+  [Host]     : .NET Core 3.1.17 (CoreCLR 4.700.21.31506, CoreFX 4.700.21.31502), X64 RyuJIT
+  DefaultJob : .NET Core 3.1.17 (CoreCLR 4.700.21.31506, CoreFX 4.700.21.31502), X64 RyuJIT
 
 
-|                    Method | WithSDK |       Mean |      Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-|-------------------------- |-------- |-----------:|-----------:|----------:|-------:|------:|------:|----------:|
-|            CounterHotPath |   False |  15.126 ns |  0.3228 ns | 0.3965 ns |      - |     - |     - |         - |
-| CounterWith1LabelsHotPath |   False |   9.766 ns |  0.2268 ns | 0.3530 ns |      - |     - |     - |         - |
-| CounterWith3LabelsHotPath |   False |  25.240 ns |  0.2876 ns | 0.2690 ns |      - |     - |     - |         - |
-| CounterWith5LabelsHotPath |   False |  37.929 ns |  0.7512 ns | 0.5865 ns | 0.0249 |     - |     - |     104 B |
-|            CounterHotPath |    True |  44.790 ns |  0.9101 ns | 1.3621 ns |      - |     - |     - |         - |
-| CounterWith1LabelsHotPath |    True | 115.023 ns |  2.1001 ns | 1.9644 ns |      - |     - |     - |         - |
-| CounterWith3LabelsHotPath |    True | 436.527 ns |  6.5121 ns | 5.7728 ns |      - |     - |     - |         - |
-| CounterWith5LabelsHotPath |    True | 586.498 ns | 11.4783 ns | 9.5849 ns | 0.0553 |     - |     - |     232 B |
-
-
-BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19043
-Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
-  [Host]     : .NET Framework 4.8 (4.8.4360.0), X64 RyuJIT
-  DefaultJob : .NET Framework 4.8 (4.8.4360.0), X64 RyuJIT
-
-
-|                    Method | WithSDK |        Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-|-------------------------- |-------- |------------:|----------:|----------:|-------:|------:|------:|----------:|
-|            CounterHotPath |   False |    23.53 ns |  0.480 ns |  0.401 ns |      - |     - |     - |         - |
-| CounterWith1LabelsHotPath |   False |    28.70 ns |  0.592 ns |  0.770 ns |      - |     - |     - |         - |
-| CounterWith3LabelsHotPath |   False |    46.27 ns |  0.942 ns |  1.157 ns |      - |     - |     - |         - |
-| CounterWith5LabelsHotPath |   False |    51.66 ns |  1.060 ns |  1.857 ns | 0.0249 |     - |     - |     104 B |
-|            CounterHotPath |    True |    70.44 ns |  1.029 ns |  0.912 ns |      - |     - |     - |         - |
-| CounterWith1LabelsHotPath |    True |   151.92 ns |  3.067 ns |  3.651 ns |      - |     - |     - |         - |
-| CounterWith3LabelsHotPath |    True |   876.20 ns | 15.920 ns | 14.892 ns |      - |     - |     - |         - |
-| CounterWith5LabelsHotPath |    True | 1,973.64 ns | 38.393 ns | 45.705 ns | 0.0534 |     - |     - |     233 B |
+|                    Method | WithSDK |      Mean |     Error |     StdDev |    Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+|-------------------------- |-------- |----------:|----------:|-----------:|----------:|-------:|------:|------:|----------:|
+|            CounterHotPath |   False |  18.48 ns |  0.366 ns |   0.570 ns |  18.52 ns |      - |     - |     - |         - |
+| CounterWith1LabelsHotPath |   False |  30.25 ns |  1.274 ns |   3.530 ns |  29.14 ns |      - |     - |     - |         - |
+| CounterWith3LabelsHotPath |   False |  82.93 ns |  2.586 ns |   7.124 ns |  81.79 ns |      - |     - |     - |         - |
+| CounterWith5LabelsHotPath |   False | 134.94 ns |  4.756 ns |  13.491 ns | 132.45 ns | 0.0248 |     - |     - |     104 B |
+|            CounterHotPath |    True |  68.58 ns |  1.417 ns |   3.228 ns |  68.40 ns |      - |     - |     - |         - |
+| CounterWith1LabelsHotPath |    True | 192.19 ns |  8.114 ns |  23.151 ns | 184.06 ns |      - |     - |     - |         - |
+| CounterWith3LabelsHotPath |    True | 799.33 ns | 47.442 ns | 136.882 ns | 757.73 ns |      - |     - |     - |         - |
+| CounterWith5LabelsHotPath |    True | 972.16 ns | 45.809 ns | 133.626 ns | 939.95 ns | 0.0553 |     - |     - |     232 B |
 */
 
 namespace Benchmarks.Metrics
@@ -63,15 +46,11 @@ namespace Benchmarks.Metrics
     [MemoryDiagnoser]
     public class MetricsBenchmarks
     {
-        private readonly KeyValuePair<string, object> tag1 = new KeyValuePair<string, object>("attrib1", "value1");
-        private readonly KeyValuePair<string, object> tag2 = new KeyValuePair<string, object>("attrib2", "value2");
-        private readonly KeyValuePair<string, object> tag3 = new KeyValuePair<string, object>("attrib3", "value3");
-        private readonly KeyValuePair<string, object> tag4 = new KeyValuePair<string, object>("attrib4", "value4");
-        private readonly KeyValuePair<string, object> tag5 = new KeyValuePair<string, object>("attrib5", "value5");
-
-        private Counter<int> counter;
+        private Counter<long> counter;
         private MeterProvider provider;
         private Meter meter;
+        private Random random = new Random();
+        private string[] dimensionValues = new string[] { "DimVal1", "DimVal2", "DimVal3", "DimVal4", "DimVal5", "DimVal6", "DimVal7", "DimVal8", "DimVal9", "DimVal10" };
 
         [Params(false, true)]
         public bool WithSDK { get; set; }
@@ -87,7 +66,7 @@ namespace Benchmarks.Metrics
             }
 
             this.meter = new Meter("TestMeter");
-            this.counter = this.meter.CreateCounter<int>("counter");
+            this.counter = this.meter.CreateCounter<long>("counter");
         }
 
         [GlobalCleanup]
@@ -106,24 +85,28 @@ namespace Benchmarks.Metrics
         [Benchmark]
         public void CounterWith1LabelsHotPath()
         {
-            this.counter?.Add(100, this.tag1);
+            var tag1 = new KeyValuePair<string, object>("DimName1", this.dimensionValues[this.random.Next(0, 2)]);
+            this.counter?.Add(100, tag1);
         }
 
         [Benchmark]
-        public void CounterWith1LabelLocal()
-        {
-            this.counter?.Add(100, new KeyValuePair<string, object>("key", "value"));
-        }
-
         public void CounterWith3LabelsHotPath()
         {
-            this.counter?.Add(100, this.tag1, this.tag2, this.tag3);
+            var tag1 = new KeyValuePair<string, object>("DimName1", this.dimensionValues[this.random.Next(0, 10)]);
+            var tag2 = new KeyValuePair<string, object>("DimName2", this.dimensionValues[this.random.Next(0, 10)]);
+            var tag3 = new KeyValuePair<string, object>("DimName3", this.dimensionValues[this.random.Next(0, 10)]);
+            this.counter?.Add(100, tag1, tag2, tag3);
         }
 
         [Benchmark]
         public void CounterWith5LabelsHotPath()
         {
-            this.counter?.Add(100, this.tag1, this.tag2, this.tag3, this.tag4, this.tag5);
+            var tag1 = new KeyValuePair<string, object>("DimName1", this.dimensionValues[this.random.Next(0, 2)]);
+            var tag2 = new KeyValuePair<string, object>("DimName2", this.dimensionValues[this.random.Next(0, 2)]);
+            var tag3 = new KeyValuePair<string, object>("DimName3", this.dimensionValues[this.random.Next(0, 5)]);
+            var tag4 = new KeyValuePair<string, object>("DimName4", this.dimensionValues[this.random.Next(0, 5)]);
+            var tag5 = new KeyValuePair<string, object>("DimName4", this.dimensionValues[this.random.Next(0, 10)]);
+            this.counter?.Add(100, tag1, tag2, tag3, tag4, tag5);
         }
     }
 }


### PR DESCRIPTION
More matches the typical usage patterns:
https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInMetricsListener.cs#L67-L75