### PR TITLE
Change `paths-ignore` to `paths` in `markdownlint.yml`

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -3,7 +3,7 @@ name: markdownlint
 on:
   push:
     branches: [ main, metrics ]
-    paths-ignore:
+    paths:
     - '**.md'
   pull_request:
     branches: [ main, metrics ]


### PR DESCRIPTION
Markdown lint should only run when a `*.md` file has changed. This was likely a copy paste mistake when this GitHub action was created.

Fixes https://github.com/open-telemetry/opentelemetry-dotnet/pull/2084#pullrequestreview-717519638
