### PR TITLE
Fix namespace names for unit tests

### DIFF
--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/Int128Test.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/Int128Test.cs
@@ -15,10 +15,9 @@
 // </copyright>
 
 using System.Diagnostics;
-using OpenTelemetry.Exporter.Jaeger.Implementation;
 using Xunit;
 
-namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
+namespace OpenTelemetry.Exporter.Jaeger.Implementation.Tests
 {
     public class Int128Test
     {

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerActivityConversionTest.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerActivityConversionTest.cs
@@ -17,14 +17,12 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-
-using OpenTelemetry.Exporter.Jaeger.Implementation;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using Xunit;
 
-namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
+namespace OpenTelemetry.Exporter.Jaeger.Implementation.Tests
 {
     public class JaegerActivityConversionTest
     {

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/ThriftUdpClientTransportTests.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/ThriftUdpClientTransportTests.cs
@@ -18,11 +18,10 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
-using OpenTelemetry.Exporter.Jaeger.Implementation;
 using Thrift.Transport;
 using Xunit;
 
-namespace OpenTelemetry.Exporter.Jaeger.Tests.Implementation
+namespace OpenTelemetry.Exporter.Jaeger.Implementation.Tests
 {
     public class ThriftUdpClientTransportTests : IDisposable
     {

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterTests.cs
@@ -19,7 +19,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using OpenTelemetry.Exporter.Jaeger.Implementation;
-using OpenTelemetry.Exporter.Jaeger.Tests.Implementation;
+using OpenTelemetry.Exporter.Jaeger.Implementation.Tests;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using Thrift.Protocol;

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
@@ -20,7 +20,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
-using Google.Protobuf.Collections;
 using Grpc.Core;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Resources;

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionExtensionsTest.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionExtensionsTest.cs
@@ -19,7 +19,7 @@ using OpenTelemetry.Internal;
 using Xunit;
 using static OpenTelemetry.Exporter.Zipkin.Implementation.ZipkinActivityConversionExtensions;
 
-namespace OpenTelemetry.Exporter.Zipkin.Tests.Implementation
+namespace OpenTelemetry.Exporter.Zipkin.Implementation.Tests
 {
     public class ZipkinActivityConversionExtensionsTest
     {

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionTest.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionTest.cs
@@ -15,12 +15,12 @@
 // </copyright>
 
 using System.Linq;
-using OpenTelemetry.Exporter.Zipkin.Implementation;
+using OpenTelemetry.Exporter.Zipkin.Tests;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
 using Xunit;
 
-namespace OpenTelemetry.Exporter.Zipkin.Tests.Implementation
+namespace OpenTelemetry.Exporter.Zipkin.Implementation.Tests
 {
     public class ZipkinActivityConversionTest
     {

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityExporterRemoteEndpointTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityExporterRemoteEndpointTests.cs
@@ -15,11 +15,11 @@
 // </copyright>
 
 using System.Collections.Generic;
-using OpenTelemetry.Exporter.Zipkin.Implementation;
+using OpenTelemetry.Exporter.Zipkin.Tests;
 using OpenTelemetry.Trace;
 using Xunit;
 
-namespace OpenTelemetry.Exporter.Zipkin.Tests.Implementation
+namespace OpenTelemetry.Exporter.Zipkin.Implementation.Tests
 {
     public class ZipkinActivityExporterRemoteEndpointTests
     {

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.server.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.server.cs
@@ -24,7 +24,7 @@ using Grpc.Core;
 using Grpc.Net.Client;
 using Moq;
 using OpenTelemetry.Context.Propagation;
-using OpenTelemetry.Instrumentation.Grpc.Tests.Services;
+using OpenTelemetry.Instrumentation.Grpc.Services.Tests;
 using OpenTelemetry.Instrumentation.GrpcNetClient;
 using OpenTelemetry.Trace;
 using Xunit;

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/Services/GreeterService.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/Services/GreeterService.cs
@@ -18,7 +18,7 @@ using Greet;
 using Grpc.Core;
 using Microsoft.Extensions.Logging;
 
-namespace OpenTelemetry.Instrumentation.Grpc.Tests.Services
+namespace OpenTelemetry.Instrumentation.Grpc.Services.Tests
 {
     public class GreeterService : Greeter.GreeterBase
     {

--- a/test/OpenTelemetry.Tests/Internal/CircularBufferTest.cs
+++ b/test/OpenTelemetry.Tests/Internal/CircularBufferTest.cs
@@ -15,10 +15,9 @@
 // </copyright>
 
 using System;
-using OpenTelemetry.Internal;
 using Xunit;
 
-namespace OpenTelemetry.Tests.Internal
+namespace OpenTelemetry.Internal.Tests
 {
     public class CircularBufferTest
     {

--- a/test/OpenTelemetry.Tests/Logs/LogRecordTest.cs
+++ b/test/OpenTelemetry.Tests/Logs/LogRecordTest.cs
@@ -23,10 +23,11 @@ using System.Linq;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Logs;
+using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
 using Xunit;
 
-namespace OpenTelemetry.Tests.Logs
+namespace OpenTelemetry.Logs.Tests
 {
     public sealed class LogRecordTest : IDisposable
     {


### PR DESCRIPTION
## Changes
- Fix namespace names for unit tests to have consistent naming
