### PR TITLE
Add support for batch span processor env vars

### DIFF
--- a/src/OpenTelemetry/BatchExportProcessorEventSource.cs
+++ b/src/OpenTelemetry/BatchExportProcessorEventSource.cs
@@ -1,0 +1,52 @@
+// <copyright file="BatchExportProcessorEventSource.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Diagnostics.Tracing;
+using System.Security;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry
+{
+    /// <summary>
+    /// EventSource events emitted from the project.
+    /// </summary>
+    [EventSource(Name = "OpenTelemetry-BatchExporter")]
+    internal class BatchExportProcessorEventSource : EventSource
+    {
+        public static BatchExportProcessorEventSource Log = new BatchExportProcessorEventSource();
+
+        [NonEvent]
+        public void MissingPermissionsToReadEnvironmentVariable(SecurityException ex)
+        {
+            if (this.IsEnabled(EventLevel.Warning, EventKeywords.All))
+            {
+                this.MissingPermissionsToReadEnvironmentVariable(ex.ToInvariantString());
+            }
+        }
+
+        [Event(1, Message = "Failed to parse environment variable: '{0}', value: '{1}'.", Level = EventLevel.Warning)]
+        public void FailedToParseEnvironmentVariable(string name, string value)
+        {
+            this.WriteEvent(1, name, value);
+        }
+
+        [Event(2, Message = "Missing permissions to read environment variable: '{0}'", Level = EventLevel.Warning)]
+        public void MissingPermissionsToReadEnvironmentVariable(string exception)
+        {
+            this.WriteEvent(2, exception);
+        }
+    }
+}

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -11,7 +11,7 @@
 * The `BatchExportProcessor` defaults can be overridden using
   envionmental variables as defined in the
   [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#batch-span-processor).
-  ([#??](https://github.com/open-telemetry/opentelemetry-dotnet/pull/??))
+  ([#2228](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2228))
 
 ## 1.2.0-alpha1
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -8,6 +8,11 @@
 * OpenTelemetryLogger modified to not throw, when the
   formatter supplied in ILogger.Log call is null. ([#2200](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2200))
 
+* The `BatchExportProcessor` defaults can be overridden using
+  envionmental variables as defined in the
+  [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#batch-span-processor).
+  ([#??](https://github.com/open-telemetry/opentelemetry-dotnet/pull/??))
+
 ## 1.2.0-alpha1
 
 Released 2021-Jul-23

--- a/test/OpenTelemetry.Tests/BatchExportProcessorOptionsTests.cs
+++ b/test/OpenTelemetry.Tests/BatchExportProcessorOptionsTests.cs
@@ -1,0 +1,144 @@
+// <copyright file="BatchExportProcessorOptionsTests.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using Xunit;
+
+namespace OpenTelemetry.Tests
+{
+    public class BatchExportProcessorOptionsTests : IDisposable
+    {
+        public BatchExportProcessorOptionsTests()
+        {
+            ClearEnvVars();
+        }
+
+        public void Dispose()
+        {
+            ClearEnvVars();
+        }
+
+        [Fact]
+        public void BatchExportProcessorOptions_Defaults()
+        {
+            var options = new BatchExportProcessorOptions<TestClass>();
+
+            Assert.Equal(30000, options.ExporterTimeoutMilliseconds);
+            Assert.Equal(512, options.MaxExportBatchSize);
+            Assert.Equal(2048, options.MaxQueueSize);
+            Assert.Equal(5000, options.ScheduledDelayMilliseconds);
+        }
+
+        [Fact]
+        public void BatchExportProcessorOptions_EnvironmentVariableOverride()
+        {
+            Environment.SetEnvironmentVariable(BatchExportProcessorOptions<TestClass>.ExportTimeoutEnvVarName, "100");
+            Environment.SetEnvironmentVariable(BatchExportProcessorOptions<TestClass>.MaxExportBatchSizeEnvVarName, "200");
+            Environment.SetEnvironmentVariable(BatchExportProcessorOptions<TestClass>.MaxQueueSizeEnvVarName, "300");
+            Environment.SetEnvironmentVariable(BatchExportProcessorOptions<TestClass>.ScheduleDelayEnvVarName, "400");
+
+            var options = new BatchExportProcessorOptions<TestClass>();
+
+            Assert.Equal(100, options.ExporterTimeoutMilliseconds);
+            Assert.Equal(200, options.MaxExportBatchSize);
+            Assert.Equal(300, options.MaxQueueSize);
+            Assert.Equal(400, options.ScheduledDelayMilliseconds);
+        }
+
+        [Fact]
+        public void BatchExportProcessorOptions_InvalidExporterTimeoutMillisecondsOverride()
+        {
+            Environment.SetEnvironmentVariable(BatchExportProcessorOptions<TestClass>.ExportTimeoutEnvVarName, "invalid");
+
+            var options = new BatchExportProcessorOptions<TestClass>();
+
+            Assert.Equal(30000, options.ExporterTimeoutMilliseconds); // use default
+        }
+
+        [Fact]
+        public void BatchExportProcessorOptions_InvalidMaxExportBatchSizeOverride()
+        {
+            Environment.SetEnvironmentVariable(BatchExportProcessorOptions<TestClass>.MaxExportBatchSizeEnvVarName, "invalid");
+
+            var options = new BatchExportProcessorOptions<TestClass>();
+
+            Assert.Equal(512, options.MaxExportBatchSize); // use default
+        }
+
+        [Fact]
+        public void BatchExportProcessorOptions_InvalidMaxQueueSizeOverride()
+        {
+            Environment.SetEnvironmentVariable(BatchExportProcessorOptions<TestClass>.MaxQueueSizeEnvVarName, "invalid");
+
+            var options = new BatchExportProcessorOptions<TestClass>();
+
+            Assert.Equal(2048, options.MaxQueueSize); // use default
+        }
+
+        [Fact]
+        public void BatchExportProcessorOptions_InvalidScheduledDelayMillisecondsOverride()
+        {
+            Environment.SetEnvironmentVariable(BatchExportProcessorOptions<TestClass>.ScheduleDelayEnvVarName, "invalid");
+
+            var options = new BatchExportProcessorOptions<TestClass>();
+
+            Assert.Equal(5000, options.ScheduledDelayMilliseconds); // use default
+        }
+
+        [Fact]
+        public void BatchExportProcessorOptions_SetterOverridesEnvironmentVariable()
+        {
+            Environment.SetEnvironmentVariable(BatchExportProcessorOptions<TestClass>.ExportTimeoutEnvVarName, "100");
+            Environment.SetEnvironmentVariable(BatchExportProcessorOptions<TestClass>.MaxExportBatchSizeEnvVarName, "200");
+            Environment.SetEnvironmentVariable(BatchExportProcessorOptions<TestClass>.MaxQueueSizeEnvVarName, "300");
+            Environment.SetEnvironmentVariable(BatchExportProcessorOptions<TestClass>.ScheduleDelayEnvVarName, "400");
+
+            var options = new BatchExportProcessorOptions<TestClass>
+            {
+                ExporterTimeoutMilliseconds = 10,
+                MaxExportBatchSize = 20,
+                MaxQueueSize = 30,
+                ScheduledDelayMilliseconds = 40,
+            };
+
+            Assert.Equal(10, options.ExporterTimeoutMilliseconds);
+            Assert.Equal(20, options.MaxExportBatchSize);
+            Assert.Equal(30, options.MaxQueueSize);
+            Assert.Equal(40, options.ScheduledDelayMilliseconds);
+        }
+
+        [Fact]
+        public void BatchExportProcessorOptions_EnvironmentVariableNames()
+        {
+            Assert.Equal("OTEL_BSP_EXPORT_TIMEOUT", BatchExportProcessorOptions<TestClass>.ExportTimeoutEnvVarName);
+            Assert.Equal("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", BatchExportProcessorOptions<TestClass>.MaxExportBatchSizeEnvVarName);
+            Assert.Equal("OTEL_BSP_MAX_QUEUE_SIZE", BatchExportProcessorOptions<TestClass>.MaxQueueSizeEnvVarName);
+            Assert.Equal("OTEL_BSP_SCHEDULE_DELAY", BatchExportProcessorOptions<TestClass>.ScheduleDelayEnvVarName);
+        }
+
+        private static void ClearEnvVars()
+        {
+            Environment.SetEnvironmentVariable(BatchExportProcessorOptions<TestClass>.ExportTimeoutEnvVarName, null);
+            Environment.SetEnvironmentVariable(BatchExportProcessorOptions<TestClass>.MaxExportBatchSizeEnvVarName, null);
+            Environment.SetEnvironmentVariable(BatchExportProcessorOptions<TestClass>.MaxQueueSizeEnvVarName, null);
+            Environment.SetEnvironmentVariable(BatchExportProcessorOptions<TestClass>.ScheduleDelayEnvVarName, null);
+        }
+
+        private class TestClass
+        {
+        }
+    }
+}


### PR DESCRIPTION
Partially addresses [#1453](https://github.com/open-telemetry/opentelemetry-dotnet/issues/1453).

This feature is important so that we can reuse the SDK in https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation.

## Changes

The BatchExportProcessorOptions defaults can be overridden using environmental variables as defined in the [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#batch-span-processor).

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
