### PR TITLE
Disable TelemetryHttpModule API Compat for now

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.csproj
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.csproj
@@ -6,6 +6,12 @@
     <MinVerTagPrefix>core-</MinVerTagPrefix>
   </PropertyGroup>
 
+  <!--Do not run ApiCompat as this package has never released a stable version.
+  Remove this property once we have released a stable version.-->
+  <PropertyGroup>
+    <RunApiCompat>false</RunApiCompat>
+  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="System.Web" />
   </ItemGroup>


### PR DESCRIPTION
Part of #2222.

Related to https://github.com/open-telemetry/opentelemetry-dotnet/pull/2233#issuecomment-896191532.