### PR TITLE
Add environment variable detectors to the default ResourceBuilder

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* `ResourceBuilder.CreateDefault` has detectors for
+  `OTEL_RESOURCE_ATTRIBUTES`, `OTEL_SERVICE_NAME` environment variables
+  so that explicit `AddEnvironmentVariableDetector` call is not needed. ([#2247](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2247))
+
 * `ResourceBuilder.AddEnvironmentVariableDetector` handles `OTEL_SERVICE_NAME`
    environmental variable. ([#2209](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2209))
 

--- a/src/OpenTelemetry/README.md
+++ b/src/OpenTelemetry/README.md
@@ -245,8 +245,8 @@ using var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .Build();
 ```
 
-It is also possible to configure the `Resource` by using `AddEnvironmentVariableDetector`
-together with following environmental variables:
+It is also possible to configure the `Resource` by using following
+environmental variables:
 
 <!-- markdownlint-disable MD013 -->
 | Environment variable       | Description                                        |

--- a/src/OpenTelemetry/Resources/ResourceBuilder.cs
+++ b/src/OpenTelemetry/Resources/ResourceBuilder.cs
@@ -43,10 +43,14 @@ namespace OpenTelemetry.Resources
         /// service.name added. See <a
         /// href="https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/resource/semantic_conventions#semantic-attributes-with-sdk-provided-default-value">resource
         /// semantic conventions</a> for details.
+        /// Additionally it adds resource attributes parsed from OTEL_RESOURCE_ATTRIBUTES, OTEL_SERVICE_NAME environment variables
+        /// to a <see cref="ResourceBuilder"/> following the <a
+        /// href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#specifying-resource-information-via-an-environment-variable">Resource
+        /// SDK</a>.
         /// </summary>
         /// <returns>Created <see cref="ResourceBuilder"/>.</returns>
         public static ResourceBuilder CreateDefault()
-            => new ResourceBuilder().AddResource(DefaultResource);
+            => new ResourceBuilder().AddResource(DefaultResource).AddEnvironmentVariableDetector();
 
         /// <summary>
         /// Creates an empty <see cref="ResourceBuilder"/> instance.

--- a/test/OpenTelemetry.Tests/Resources/ResourceTest.cs
+++ b/test/OpenTelemetry.Tests/Resources/ResourceTest.cs
@@ -391,7 +391,7 @@ namespace OpenTelemetry.Resources.Tests
         public void GetResourceWithTelemetrySDKAttributes()
         {
             // Arrange
-            var resource = ResourceBuilder.CreateDefault().AddTelemetrySdk().AddEnvironmentVariableDetector().Build();
+            var resource = ResourceBuilder.CreateDefault().AddTelemetrySdk().Build();
 
             // Assert
             var attributes = resource.Attributes;
@@ -403,7 +403,7 @@ namespace OpenTelemetry.Resources.Tests
         public void GetResourceWithDefaultAttributes_EmptyResource()
         {
             // Arrange
-            var resource = ResourceBuilder.CreateDefault().AddEnvironmentVariableDetector().Build();
+            var resource = ResourceBuilder.CreateDefault().Build();
 
             // Assert
             var attributes = resource.Attributes;
@@ -415,7 +415,7 @@ namespace OpenTelemetry.Resources.Tests
         public void GetResourceWithDefaultAttributes_ResourceWithAttrs()
         {
             // Arrange
-            var resource = ResourceBuilder.CreateDefault().AddEnvironmentVariableDetector().AddAttributes(this.CreateAttributes(2)).Build();
+            var resource = ResourceBuilder.CreateDefault().AddAttributes(this.CreateAttributes(2)).Build();
 
             // Assert
             var attributes = resource.Attributes;
@@ -429,7 +429,7 @@ namespace OpenTelemetry.Resources.Tests
         {
             // Arrange
             Environment.SetEnvironmentVariable(OtelEnvResourceDetector.EnvVarKey, "EVKey1=EVVal1,EVKey2=EVVal2");
-            var resource = ResourceBuilder.CreateDefault().AddEnvironmentVariableDetector().AddAttributes(this.CreateAttributes(2)).Build();
+            var resource = ResourceBuilder.CreateDefault().AddAttributes(this.CreateAttributes(2)).Build();
 
             // Assert
             var attributes = resource.Attributes;
@@ -445,7 +445,7 @@ namespace OpenTelemetry.Resources.Tests
         {
             // Arrange
             Environment.SetEnvironmentVariable(OtelServiceNameEnvVarDetector.EnvVarKey, "some-service");
-            var resource = ResourceBuilder.CreateDefault().AddEnvironmentVariableDetector().AddAttributes(this.CreateAttributes(2)).Build();
+            var resource = ResourceBuilder.CreateDefault().AddAttributes(this.CreateAttributes(2)).Build();
 
             // Assert
             var attributes = resource.Attributes;
@@ -460,7 +460,7 @@ namespace OpenTelemetry.Resources.Tests
             // Arrange
             Environment.SetEnvironmentVariable(OtelEnvResourceDetector.EnvVarKey, "service.name=from-resource-attr");
             Environment.SetEnvironmentVariable(OtelServiceNameEnvVarDetector.EnvVarKey, "from-service-name");
-            var resource = ResourceBuilder.CreateDefault().AddEnvironmentVariableDetector().AddAttributes(this.CreateAttributes(2)).Build();
+            var resource = ResourceBuilder.CreateDefault().AddAttributes(this.CreateAttributes(2)).Build();
 
             // Assert
             var attributes = resource.Attributes;
@@ -475,7 +475,7 @@ namespace OpenTelemetry.Resources.Tests
             // Arrange
             Environment.SetEnvironmentVariable(OtelEnvResourceDetector.EnvVarKey, "service.name=from-resource-attr");
             Environment.SetEnvironmentVariable(OtelServiceNameEnvVarDetector.EnvVarKey, "from-service-name");
-            var resource = ResourceBuilder.CreateDefault().AddEnvironmentVariableDetector().AddService("from-code").AddAttributes(this.CreateAttributes(2)).Build();
+            var resource = ResourceBuilder.CreateDefault().AddService("from-code").AddAttributes(this.CreateAttributes(2)).Build();
 
             // Assert
             var attributes = resource.Attributes;

--- a/test/OpenTelemetry.Tests/Resources/ResourceTest.cs
+++ b/test/OpenTelemetry.Tests/Resources/ResourceTest.cs
@@ -441,6 +441,20 @@ namespace OpenTelemetry.Resources.Tests
         }
 
         [Fact]
+        public void EnvironmentVariableDetectors_DoNotDuplicateAttributes()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable(OtelEnvResourceDetector.EnvVarKey, "EVKey1=EVVal1,EVKey2=EVVal2");
+            var resource = ResourceBuilder.CreateDefault().AddEnvironmentVariableDetector().AddEnvironmentVariableDetector().Build();
+
+            // Assert
+            var attributes = resource.Attributes;
+            Assert.Equal(3, attributes.Count());
+            Assert.Contains(new KeyValuePair<string, object>("EVKey1", "EVVal1"), attributes);
+            Assert.Contains(new KeyValuePair<string, object>("EVKey2", "EVVal2"), attributes);
+        }
+
+        [Fact]
         public void GetResource_WithServiceEnvVar()
         {
             // Arrange


### PR DESCRIPTION
Per discussion: https://github.com/open-telemetry/opentelemetry-dotnet/pull/2209#discussion_r679131449

## Changes

Add `AddEnvironmentVariableDetector` to `ResourceBuilder.CreateDefault`