### PR TITLE
Modify minvertag prefix for aspnet telemetry module project

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.csproj
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.csproj
@@ -3,13 +3,6 @@
     <TargetFrameworks>net461</TargetFrameworks>
     <Description>A module that instruments incoming request with System.Diagnostics.Activity and notifies listeners with DiagnosticsSource.</Description>
     <PackageTags>$(PackageTags);distributed-tracing;AspNet;MVC;WebAPI</PackageTags>
-    <MinVerTagPrefix>core-</MinVerTagPrefix>
-  </PropertyGroup>
-
-  <!--Do not run ApiCompat as this package has never released a stable version.
-  Remove this property once we have released a stable version.-->
-  <PropertyGroup>
-    <RunApiCompat>false</RunApiCompat>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We didn't need to exclude apicompat as it was only run for core packages and this package is not part of the core package.