### PR TITLE
New design for TelemetryHttpModule using ActivitySource + OpenTelemetry.API part 2

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -118,6 +118,8 @@ namespace OpenTelemetry.Instrumentation.AspNet
         {
             if (aspNetActivity == null)
             {
+                // This is the case where a start was called but no activity was
+                // created due to a sampler decision.
                 context.Items[ActivityKey] = null;
                 return;
             }

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -119,7 +119,7 @@ namespace OpenTelemetry.Instrumentation.AspNet
             if (aspNetActivity == null)
             {
                 // This is the case where a start was called but no activity was
-                // created due to a sampler decision.
+                // created due to a sampling decision.
                 context.Items[ActivityKey] = null;
                 return;
             }


### PR DESCRIPTION
Relates to #2249 

## Changes

* `TelemetryHttpModule` previously used 2 `HttpContext.Items` keys for its state management. Now it uses a single one. This really just simplifies things and makes the perf a little better avoiding an extra trip or two to the hash table.