### PR TITLE
New design for TelemetryHttpModule using ActivitySource + OpenTelemetry.API part 3

### DIFF
--- a/examples/AspNet/Examples.AspNet.csproj
+++ b/examples/AspNet/Examples.AspNet.csproj
@@ -61,6 +61,7 @@
     </Compile>
     <Compile Include="Models\WeatherForecast.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SuppressInstrumentationHttpModule.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Views\_ViewStart.cshtml" />

--- a/examples/AspNet/SuppressInstrumentationHttpModule.cs
+++ b/examples/AspNet/SuppressInstrumentationHttpModule.cs
@@ -1,0 +1,58 @@
+// <copyright file="SuppressInstrumentationHttpModule.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Web;
+using OpenTelemetry;
+
+namespace Examples.AspNet
+{
+    /// <summary>
+    /// A demo <see cref="IHttpModule"/> which will suppress ASP.NET
+    /// instrumentation if a request contains "suppress=true" on the query
+    /// string. Suppressed spans will not be processed/exported by the
+    /// OpenTelemetry SDK.
+    /// </summary>
+    public class SuppressInstrumentationHttpModule : IHttpModule
+    {
+        private IDisposable suppressionScope;
+
+        public void Init(HttpApplication context)
+        {
+            context.BeginRequest += this.Application_BeginRequest;
+            context.EndRequest += this.Application_EndRequest;
+        }
+
+        public void Dispose()
+        {
+        }
+
+        private void Application_BeginRequest(object sender, EventArgs e)
+        {
+            var context = ((HttpApplication)sender).Context;
+
+            if (context.Request.QueryString["suppress"] == "true")
+            {
+                this.suppressionScope = SuppressInstrumentationScope.Begin();
+            }
+        }
+
+        private void Application_EndRequest(object sender, EventArgs e)
+        {
+            this.suppressionScope?.Dispose();
+        }
+    }
+}

--- a/examples/AspNet/Web.config
+++ b/examples/AspNet/Web.config
@@ -23,6 +23,7 @@
 			<add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
 		</handlers>
 		<modules>
+			<add name="SuppressInstrumentationHttpModule" type="Examples.AspNet.SuppressInstrumentationHttpModule" preCondition="integratedMode,managedHandler"/>
 			<add name="TelemetryHttpModule" type="OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule, OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule" preCondition="integratedMode,managedHandler"/>
 		</modules>
 	</system.webServer>

--- a/examples/AspNet/Web.config
+++ b/examples/AspNet/Web.config
@@ -37,20 +37,16 @@
 				<bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Buffers" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
+				<assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Memory" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
 				<bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1"/>
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.1"/>
+				<assemblyIdentity name="System.Buffers" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
 			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -3,12 +3,14 @@ const OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.AspNetSourceName 
 OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule
 OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Dispose() -> void
 OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Init(System.Web.HttpApplication context) -> void
-OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.OnExceptionCallback.get -> System.Action<System.Diagnostics.Activity, System.Exception>
-OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.OnExceptionCallback.set -> void
-OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.OnRequestStartedCallback.get -> System.Action<System.Diagnostics.Activity, System.Web.HttpContext>
-OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.OnRequestStartedCallback.set -> void
-OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.OnRequestStoppedCallback.get -> System.Action<System.Diagnostics.Activity, System.Web.HttpContext>
-OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.OnRequestStoppedCallback.set -> void
 OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.TelemetryHttpModule() -> void
-OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.TextMapPropagator.get -> OpenTelemetry.Context.Propagation.TraceContextPropagator
-OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.TextMapPropagator.set -> void
+OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModuleOptions
+OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModuleOptions.OnExceptionCallback.get -> System.Action<System.Diagnostics.Activity, System.Web.HttpContext, System.Exception>
+OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModuleOptions.OnExceptionCallback.set -> void
+OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModuleOptions.OnRequestStartedCallback.get -> System.Action<System.Diagnostics.Activity, System.Web.HttpContext>
+OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModuleOptions.OnRequestStartedCallback.set -> void
+OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModuleOptions.OnRequestStoppedCallback.get -> System.Action<System.Diagnostics.Activity, System.Web.HttpContext>
+OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModuleOptions.OnRequestStoppedCallback.set -> void
+OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModuleOptions.TextMapPropagator.get -> OpenTelemetry.Context.Propagation.TextMapPropagator
+OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModuleOptions.TextMapPropagator.set -> void
+static OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Options.get -> OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModuleOptions

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -72,7 +72,7 @@ namespace OpenTelemetry.Instrumentation.AspNet
         {
             PropagationContext propagationContext = textMapPropagator.Extract(default, context.Request, HttpRequestHeaderValuesGetter);
 
-            Activity activity = AspNetSource.CreateActivity(TelemetryHttpModule.AspNetActivityName, ActivityKind.Server, propagationContext.ActivityContext);
+            Activity activity = AspNetSource.StartActivity(TelemetryHttpModule.AspNetActivityName, ActivityKind.Server, propagationContext.ActivityContext);
 
             if (activity != null)
             {

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -34,7 +34,8 @@ namespace OpenTelemetry.Instrumentation.AspNet
         /// </summary>
         private const string ActivityKey = "__AspnetActivity__";
 
-        private static readonly ActivitySource AspNetSource = new ActivitySource(TelemetryHttpModule.AspNetSourceName);
+        private static readonly Version Version = typeof(ActivityHelper).Assembly.GetName().Version;
+        private static readonly ActivitySource AspNetSource = new ActivitySource(TelemetryHttpModule.AspNetSourceName, Version.ToString());
         private static readonly Func<HttpRequest, string, IEnumerable<string>> HttpRequestHeaderValuesGetter = (request, name) => request.Headers.GetValues(name);
         private static readonly object StartedButNotSampledObj = new object();
 
@@ -147,13 +148,13 @@ namespace OpenTelemetry.Instrumentation.AspNet
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteActivityException(Activity aspNetActivity, Exception exception, Action<Activity, Exception> onExceptionCallback)
+        public static void WriteActivityException(Activity aspNetActivity, HttpContext context, Exception exception, Action<Activity, HttpContext, Exception> onExceptionCallback)
         {
             if (aspNetActivity != null)
             {
                 try
                 {
-                    onExceptionCallback?.Invoke(aspNetActivity, exception);
+                    onExceptionCallback?.Invoke(aspNetActivity, context, exception);
                 }
                 catch (Exception callbackEx)
                 {

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/AspNetTelemetryEventSource.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/AspNetTelemetryEventSource.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
+using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Instrumentation.AspNet
 {
@@ -63,7 +64,7 @@ namespace OpenTelemetry.Instrumentation.AspNet
         {
             if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
             {
-                this.ActivityException(activity?.Id, ex.ToString());
+                this.ActivityException(activity?.Id, ex.ToInvariantString());
             }
         }
 
@@ -72,7 +73,7 @@ namespace OpenTelemetry.Instrumentation.AspNet
         {
             if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
             {
-                this.CallbackException(activity?.Id, eventName, ex.ToString());
+                this.CallbackException(activity?.Id, eventName, ex.ToInvariantString());
             }
         }
 

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.csproj
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.csproj
@@ -13,6 +13,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\ExceptionExtensions.cs" Link="Includes\ExceptionExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="System.Web" />
   </ItemGroup>
 

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/TelemetryHttpModuleOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/TelemetryHttpModuleOptions.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 using System;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Web;
 using OpenTelemetry.Context.Propagation;
@@ -37,7 +36,6 @@ namespace OpenTelemetry.Instrumentation.AspNet
         /// Gets or sets the <see cref=" Context.Propagation.TextMapPropagator"/> to use to
         /// extract <see cref="PropagationContext"/> from incoming requests.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public TextMapPropagator TextMapPropagator
         {
             get => this.textMapPropagator;
@@ -47,20 +45,17 @@ namespace OpenTelemetry.Instrumentation.AspNet
         /// <summary>
         /// Gets or sets a callback action to be fired when a request is started.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public Action<Activity, HttpContext> OnRequestStartedCallback { get; set; }
 
         /// <summary>
         /// Gets or sets a callback action to be fired when a request is stopped.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public Action<Activity, HttpContext> OnRequestStoppedCallback { get; set; }
 
         /// <summary>
         /// Gets or sets a callback action to be fired when an unhandled
         /// exception is thrown processing a request.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public Action<Activity, HttpContext, Exception> OnExceptionCallback { get; set; }
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/TelemetryHttpModuleOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/TelemetryHttpModuleOptions.cs
@@ -1,0 +1,66 @@
+// <copyright file="TelemetryHttpModuleOptions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Web;
+using OpenTelemetry.Context.Propagation;
+
+namespace OpenTelemetry.Instrumentation.AspNet
+{
+    /// <summary>
+    /// Stores options for the <see cref="TelemetryHttpModule"/>.
+    /// </summary>
+    public class TelemetryHttpModuleOptions
+    {
+        private TextMapPropagator textMapPropagator = new TraceContextPropagator();
+
+        internal TelemetryHttpModuleOptions()
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref=" Context.Propagation.TextMapPropagator"/> to use to
+        /// extract <see cref="PropagationContext"/> from incoming requests.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public TextMapPropagator TextMapPropagator
+        {
+            get => this.textMapPropagator;
+            set => this.textMapPropagator = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        /// <summary>
+        /// Gets or sets a callback action to be fired when a request is started.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Action<Activity, HttpContext> OnRequestStartedCallback { get; set; }
+
+        /// <summary>
+        /// Gets or sets a callback action to be fired when a request is stopped.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Action<Activity, HttpContext> OnRequestStoppedCallback { get; set; }
+
+        /// <summary>
+        /// Gets or sets a callback action to be fired when an unhandled
+        /// exception is thrown processing a request.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Action<Activity, HttpContext, Exception> OnExceptionCallback { get; set; }
+    }
+}

--- a/src/OpenTelemetry.Instrumentation.AspNet/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.AspNet/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -4,5 +4,7 @@ OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions.Enrich.get -> 
 OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions.Enrich.set -> void
 OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions.Filter.get -> System.Func<System.Web.HttpContext, bool>
 OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions.Filter.set -> void
+OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions.RecordException.get -> bool
+OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions.RecordException.set -> void
 OpenTelemetry.Trace.TracerProviderBuilderExtensions
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions> configureAspNetInstrumentationOptions = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentation.cs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 using System;
 using OpenTelemetry.Instrumentation.AspNet.Implementation;
 
@@ -21,11 +22,9 @@ namespace OpenTelemetry.Instrumentation.AspNet
     /// <summary>
     /// Asp.Net Requests instrumentation.
     /// </summary>
-    internal class AspNetInstrumentation : IDisposable
+    internal sealed class AspNetInstrumentation : IDisposable
     {
-        internal const string AspNetDiagnosticListenerName = "OpenTelemetry.Instrumentation.AspNet.Telemetry";
-
-        private readonly DiagnosticSourceSubscriber diagnosticSourceSubscriber;
+        private readonly HttpInListener httpInListener;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AspNetInstrumentation"/> class.
@@ -33,17 +32,13 @@ namespace OpenTelemetry.Instrumentation.AspNet
         /// <param name="options">Configuration options for ASP.NET instrumentation.</param>
         public AspNetInstrumentation(AspNetInstrumentationOptions options)
         {
-            this.diagnosticSourceSubscriber = new DiagnosticSourceSubscriber(
-                name => new HttpInListener(name, options),
-                listener => listener.Name == AspNetDiagnosticListenerName,
-                null);
-            this.diagnosticSourceSubscriber.Subscribe();
+            this.httpInListener = new HttpInListener(options);
         }
 
         /// <inheritdoc/>
         public void Dispose()
         {
-            this.diagnosticSourceSubscriber?.Dispose();
+            this.httpInListener?.Dispose();
         }
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationOptions.cs
@@ -43,5 +43,13 @@ namespace OpenTelemetry.Instrumentation.AspNet
         /// The type of this object depends on the event, which is given by the above parameter.</para>
         /// </remarks>
         public Action<Activity, string, object> Enrich { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the exception will be recorded as ActivityEvent or not.
+        /// </summary>
+        /// <remarks>
+        /// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/exceptions.md.
+        /// </remarks>
+        public bool RecordException { get; set; }
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetInstrumentationOptions.cs
@@ -26,11 +26,19 @@ namespace OpenTelemetry.Instrumentation.AspNet
     public class AspNetInstrumentationOptions
     {
         /// <summary>
-        /// Gets or sets a Filter function that determines whether or not to collect telemetry about requests on a per request basis.
-        /// The Filter gets the HttpContext, and should return a boolean.
-        /// If Filter returns true, the request is collected.
-        /// If Filter returns false or throw exception, the request is filtered out.
+        /// Gets or sets a filter callback function that determines on a per
+        /// request basis whether or not to collect telemetry.
         /// </summary>
+        /// <remarks>
+        /// The filter callback receives the <see cref="HttpContext"/> for the
+        /// current request and should return a boolean.
+        /// <list type="bullet">
+        /// <item>If filter returns <see langword="true"/> the request is
+        /// collected.</item>
+        /// <item>If filter returns <see langword="false"/> or throws an
+        /// exception the request is filtered out (NOT collected).</item>
+        /// </list>
+        /// </remarks>
         public Func<HttpContext, bool> Filter { get; set; }
 
         /// <summary>
@@ -48,7 +56,7 @@ namespace OpenTelemetry.Instrumentation.AspNet
         /// Gets or sets a value indicating whether the exception will be recorded as ActivityEvent or not.
         /// </summary>
         /// <remarks>
-        /// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/exceptions.md.
+        /// See: <see href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/exceptions.md"/>.
         /// </remarks>
         public bool RecordException { get; set; }
     }

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/AspNetInstrumentationEventSource.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/AspNetInstrumentationEventSource.cs
@@ -46,28 +46,22 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
             }
         }
 
-        [Event(1, Message = "Payload is NULL in event '{1}' from handler '{0}', span will not be recorded.", Level = EventLevel.Warning)]
-        public void NullPayload(string handlerName, string eventName)
-        {
-            this.WriteEvent(1, handlerName, eventName);
-        }
-
-        [Event(2, Message = "Request is filtered out and will not be collected. Operation='{0}'", Level = EventLevel.Verbose)]
+        [Event(1, Message = "Request is filtered out and will not be collected. Operation='{0}'", Level = EventLevel.Verbose)]
         public void RequestIsFilteredOut(string operationName)
         {
-            this.WriteEvent(2, operationName);
+            this.WriteEvent(1, operationName);
         }
 
-        [Event(3, Message = "InstrumentationFilter threw an exception. Request will not be collected. Operation='{0}': {1}", Level = EventLevel.Error)]
+        [Event(2, Message = "Filter callback threw an exception. Request will not be collected. Operation='{0}': {1}", Level = EventLevel.Error)]
         public void RequestFilterException(string operationName, string exception)
         {
-            this.WriteEvent(3, operationName, exception);
+            this.WriteEvent(2, operationName, exception);
         }
 
-        [Event(4, Message = "Enrichment threw an exception. Event='{0}': {1}", Level = EventLevel.Error)]
+        [Event(3, Message = "Enrich callback threw an exception. Event='{0}': {1}", Level = EventLevel.Error)]
         public void EnrichmentException(string eventName, string exception)
         {
-            this.WriteEvent(4, eventName, exception);
+            this.WriteEvent(3, eventName, exception);
         }
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/AspNetInstrumentationEventSource.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/AspNetInstrumentationEventSource.cs
@@ -29,11 +29,20 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
         public static AspNetInstrumentationEventSource Log = new AspNetInstrumentationEventSource();
 
         [NonEvent]
-        public void RequestFilterException(Exception ex)
+        public void RequestFilterException(string operationName, Exception ex)
         {
             if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
             {
-                this.RequestFilterException(ex.ToInvariantString());
+                this.RequestFilterException(operationName, ex.ToInvariantString());
+            }
+        }
+
+        [NonEvent]
+        public void EnrichmentException(string eventName, Exception ex)
+        {
+            if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
+            {
+                this.EnrichmentException(eventName, ex.ToInvariantString());
             }
         }
 
@@ -43,31 +52,22 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
             this.WriteEvent(1, handlerName, eventName);
         }
 
-        [Event(2, Message = "Request is filtered out.", Level = EventLevel.Verbose)]
-        public void RequestIsFilteredOut(string eventName)
+        [Event(2, Message = "Request is filtered out and will not be collected. Operation='{0}'", Level = EventLevel.Verbose)]
+        public void RequestIsFilteredOut(string operationName)
         {
-            this.WriteEvent(2, eventName);
+            this.WriteEvent(2, operationName);
         }
 
-        [Event(3, Message = "InstrumentationFilter threw exception. Request will not be collected. Exception {0}.", Level = EventLevel.Error)]
-        public void RequestFilterException(string exception)
+        [Event(3, Message = "InstrumentationFilter threw an exception. Request will not be collected. Operation='{0}': {1}", Level = EventLevel.Error)]
+        public void RequestFilterException(string operationName, string exception)
         {
-            this.WriteEvent(3, exception);
+            this.WriteEvent(3, operationName, exception);
         }
 
-        [NonEvent]
-        public void EnrichmentException(Exception ex)
+        [Event(4, Message = "Enrichment threw an exception. Event='{0}': {1}", Level = EventLevel.Error)]
+        public void EnrichmentException(string eventName, string exception)
         {
-            if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
-            {
-                this.EnrichmentException(ex.ToInvariantString());
-            }
-        }
-
-        [Event(4, Message = "Enrichment threw exception. Exception {0}.", Level = EventLevel.Error)]
-        public void EnrichmentException(string exception)
-        {
-            this.WriteEvent(4, exception);
+            this.WriteEvent(4, eventName, exception);
         }
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/AspNetInstrumentationEventSource.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/AspNetInstrumentationEventSource.cs
@@ -24,7 +24,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
     /// EventSource events emitted from the project.
     /// </summary>
     [EventSource(Name = "OpenTelemetry-Instrumentation-AspNet")]
-    internal class AspNetInstrumentationEventSource : EventSource
+    internal sealed class AspNetInstrumentationEventSource : EventSource
     {
         public static AspNetInstrumentationEventSource Log = new AspNetInstrumentationEventSource();
 

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -15,9 +15,7 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Reflection;
 using System.Web;
 using System.Web.Routing;
 using OpenTelemetry.Context.Propagation;
@@ -25,91 +23,52 @@ using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.AspNet.Implementation
 {
-    internal class HttpInListener : ListenerHandler
+    internal sealed class HttpInListener : IDisposable
     {
-        internal const string ActivityNameByHttpInListener = "ActivityCreatedByHttpInListener";
-        internal const string ActivityOperationName = "Microsoft.AspNet.HttpReqIn";
-        internal static readonly AssemblyName AssemblyName = typeof(HttpInListener).Assembly.GetName();
-        internal static readonly string ActivitySourceName = AssemblyName.Name;
-        internal static readonly Version Version = AssemblyName.Version;
-        internal static readonly ActivitySource ActivitySource = new ActivitySource(ActivitySourceName, Version.ToString());
-        private static readonly Func<HttpRequest, string, IEnumerable<string>> HttpRequestHeaderValuesGetter = (request, name) => request.Headers.GetValues(name);
         private readonly PropertyFetcher<object> routeFetcher = new PropertyFetcher<object>("Route");
         private readonly PropertyFetcher<string> routeTemplateFetcher = new PropertyFetcher<string>("RouteTemplate");
         private readonly AspNetInstrumentationOptions options;
 
-        public HttpInListener(string name, AspNetInstrumentationOptions options)
-            : base(name)
+        public HttpInListener(AspNetInstrumentationOptions options)
         {
             this.options = options ?? throw new ArgumentNullException(nameof(options));
+
+            TelemetryHttpModule.Options.TextMapPropagator = Propagators.DefaultTextMapPropagator;
+
+            TelemetryHttpModule.Options.OnRequestStartedCallback += this.OnStartActivity;
+            TelemetryHttpModule.Options.OnRequestStoppedCallback += this.OnStopActivity;
+            TelemetryHttpModule.Options.OnExceptionCallback += this.OnException;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Activity is retrieved from Activity.Current later and disposed.")]
-        public override void OnStartActivity(Activity activity, object payload)
+        public void Dispose()
         {
-            // The overall flow of what AspNet library does is as below:
-            // Activity.Start()
-            // DiagnosticSource.WriteEvent("Start", payload)
-            // DiagnosticSource.WriteEvent("Stop", payload)
-            // Activity.Stop()
+            TelemetryHttpModule.Options.OnRequestStartedCallback -= this.OnStartActivity;
+            TelemetryHttpModule.Options.OnRequestStoppedCallback -= this.OnStopActivity;
+            TelemetryHttpModule.Options.OnExceptionCallback -= this.OnException;
+        }
 
-            // This method is in the WriteEvent("Start", payload) path.
-            // By this time, samplers have already run and
-            // activity.IsAllDataRequested populated accordingly.
-
-            if (Sdk.SuppressInstrumentation)
+        /// <summary>
+        /// Gets the OpenTelemetry standard uri tag value for a span based on its request <see cref="Uri"/>.
+        /// </summary>
+        /// <param name="uri"><see cref="Uri"/>.</param>
+        /// <returns>Span uri value.</returns>
+        private static string GetUriTagValueFromRequestUri(Uri uri)
+        {
+            if (string.IsNullOrEmpty(uri.UserInfo))
             {
-                return;
+                return uri.ToString();
             }
 
-            // Ensure context extraction irrespective of sampling decision
-            var context = HttpContext.Current;
-            if (context == null)
-            {
-                AspNetInstrumentationEventSource.Log.NullPayload(nameof(HttpInListener), nameof(this.OnStartActivity));
-                return;
-            }
+            return string.Concat(uri.Scheme, Uri.SchemeDelimiter, uri.Authority, uri.PathAndQuery, uri.Fragment);
+        }
 
-            var request = context.Request;
-            var requestValues = request.Unvalidated;
-            var textMapPropagator = Propagators.DefaultTextMapPropagator;
-
-            if (!(textMapPropagator is TraceContextPropagator))
-            {
-                var ctx = textMapPropagator.Extract(default, request, HttpRequestHeaderValuesGetter);
-
-                if (ctx.ActivityContext.IsValid()
-                    && ctx.ActivityContext != new ActivityContext(activity.TraceId, activity.ParentSpanId, activity.ActivityTraceFlags, activity.TraceStateString, true))
-                {
-                    // Create a new activity with its parent set from the extracted context.
-                    // This makes the new activity as a "sibling" of the activity created by
-                    // ASP.NET.
-                    Activity newOne = new Activity(ActivityNameByHttpInListener);
-                    newOne.SetParentId(ctx.ActivityContext.TraceId, ctx.ActivityContext.SpanId, ctx.ActivityContext.TraceFlags);
-                    newOne.TraceStateString = ctx.ActivityContext.TraceState;
-
-                    // Starting the new activity make it the Activity.Current one.
-                    newOne.Start();
-
-                    // Both new activity and old one store the other activity
-                    // inside them. This is required in the Stop step to
-                    // correctly stop and restore Activity.Current.
-                    newOne.SetCustomProperty("OTel.ActivityByAspNet", activity);
-                    activity.SetCustomProperty("OTel.ActivityByHttpInListener", newOne);
-
-                    // Set IsAllDataRequested to false for the activity created by the framework to only export the sibling activity and not the framework activity
-                    activity.IsAllDataRequested = false;
-                    activity = newOne;
-                }
-
-                if (ctx.Baggage != default)
-                {
-                    Baggage.Current = ctx.Baggage;
-                }
-            }
-
+        private void OnStartActivity(Activity activity, HttpContext context)
+        {
             if (activity.IsAllDataRequested)
             {
+                var request = context.Request;
+                var requestValues = request.Unvalidated;
+
                 try
                 {
                     if (this.options.Filter?.Invoke(context) == false)
@@ -127,9 +86,6 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
                     activity.ActivityTraceFlags &= ~ActivityTraceFlags.Recorded;
                     return;
                 }
-
-                ActivityInstrumentationHelper.SetActivitySourceProperty(activity, ActivitySource);
-                ActivityInstrumentationHelper.SetKindProperty(activity, ActivityKind.Server);
 
                 // see the spec https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md
                 var path = requestValues.Path;
@@ -160,47 +116,17 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
             }
         }
 
-        public override void OnStopActivity(Activity activity, object payload)
+        private void OnStopActivity(Activity activity, HttpContext context)
         {
-            Activity activityToEnrich = activity;
-            Activity createdActivity = null;
-
-            var textMapPropagator = Propagators.DefaultTextMapPropagator;
-            bool isCustomPropagator = !(textMapPropagator is TraceContextPropagator);
-
-            if (isCustomPropagator)
+            if (activity.IsAllDataRequested)
             {
-                // If using custom context propagator, then the activity here
-                // could be either the one from Asp.Net, or the one
-                // this instrumentation created in Start.
-                // This is because Asp.Net, under certain circumstances, restores Activity.Current
-                // to its own activity.
-                if (activity.OperationName.Equals(ActivityOperationName, StringComparison.Ordinal))
-                {
-                    // This block is hit if Asp.Net did restore Current to its own activity,
-                    // and we need to retrieve the one created by HttpInListener,
-                    // or an additional activity was never created.
-                    createdActivity = (Activity)activity.GetCustomProperty("OTel.ActivityByHttpInListener");
-                    activityToEnrich = createdActivity ?? activity;
-                }
-            }
-
-            if (activityToEnrich.IsAllDataRequested)
-            {
-                var context = HttpContext.Current;
-                if (context == null)
-                {
-                    AspNetInstrumentationEventSource.Log.NullPayload(nameof(HttpInListener), nameof(this.OnStopActivity));
-                    return;
-                }
-
                 var response = context.Response;
 
-                activityToEnrich.SetTag(SemanticConventions.AttributeHttpStatusCode, response.StatusCode);
+                activity.SetTag(SemanticConventions.AttributeHttpStatusCode, response.StatusCode);
 
-                if (activityToEnrich.GetStatus().StatusCode == StatusCode.Unset)
+                if (activity.GetStatus().StatusCode == StatusCode.Unset)
                 {
-                    activityToEnrich.SetStatus(SpanHelper.ResolveSpanStatusForHttpStatusCode(response.StatusCode));
+                    activity.SetStatus(SpanHelper.ResolveSpanStatusForHttpStatusCode(response.StatusCode));
                 }
 
                 var routeData = context.Request.RequestContext.RouteData;
@@ -227,58 +153,45 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
                 if (!string.IsNullOrEmpty(template))
                 {
                     // Override the name that was previously set to the path part of URL.
-                    activityToEnrich.DisplayName = template;
-                    activityToEnrich.SetTag(SemanticConventions.AttributeHttpRoute, template);
+                    activity.DisplayName = template;
+                    activity.SetTag(SemanticConventions.AttributeHttpRoute, template);
                 }
 
                 try
                 {
-                    this.options.Enrich?.Invoke(activityToEnrich, "OnStopActivity", response);
+                    this.options.Enrich?.Invoke(activity, "OnStopActivity", response);
                 }
                 catch (Exception ex)
                 {
                     AspNetInstrumentationEventSource.Log.EnrichmentException(ex);
                 }
             }
-
-            if (isCustomPropagator)
-            {
-                if (activity.OperationName.Equals(ActivityNameByHttpInListener, StringComparison.Ordinal))
-                {
-                    // If instrumentation started a new Activity, it must
-                    // be stopped here.
-                    activity.Stop();
-
-                    // Restore the original activity as Current.
-                    var activityByAspNet = (Activity)activity.GetCustomProperty("OTel.ActivityByAspNet");
-                    Activity.Current = activityByAspNet;
-                }
-                else if (createdActivity != null)
-                {
-                    // This block is hit if Asp.Net did restore Current to its own activity,
-                    // then we need to retrieve the one created by HttpInListener
-                    // and stop it.
-                    createdActivity.Stop();
-
-                    // Restore current back to the one created by Asp.Net
-                    Activity.Current = activity;
-                }
-            }
         }
 
-        /// <summary>
-        /// Gets the OpenTelemetry standard uri tag value for a span based on its request <see cref="Uri"/>.
-        /// </summary>
-        /// <param name="uri"><see cref="Uri"/>.</param>
-        /// <returns>Span uri value.</returns>
-        private static string GetUriTagValueFromRequestUri(Uri uri)
+        private void OnException(Activity activity, HttpContext context, Exception exception)
         {
-            if (string.IsNullOrEmpty(uri.UserInfo))
+            if (activity.IsAllDataRequested)
             {
-                return uri.ToString();
-            }
+                if (this.options.RecordException)
+                {
+                    activity.RecordException(exception);
+                }
 
-            return string.Concat(uri.Scheme, Uri.SchemeDelimiter, uri.Authority, uri.PathAndQuery, uri.Fragment);
+                activity.SetStatus(Status.Error.WithDescription(exception.Message));
+
+                try
+                {
+                    this.options.Enrich?.Invoke(activity, "OnException", exception);
+                }
+                catch (Exception ex)
+                {
+                    AspNetInstrumentationEventSource.Log.EnrichmentException(ex);
+                }
+            }
+            else
+            {
+                activity.SetStatus(Status.Error);
+            }
         }
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AspNet/OpenTelemetry.Instrumentation.AspNet.csproj
+++ b/src/OpenTelemetry.Instrumentation.AspNet/OpenTelemetry.Instrumentation.AspNet.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net461</TargetFrameworks>
     <Description>ASP.NET instrumentation for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);distributed-tracing;AspNet;MVC;WebAPI</PackageTags>
-    <IncludeDiagnosticSourceInstrumentationHelpers>true</IncludeDiagnosticSourceInstrumentationHelpers>
+    <IncludeInstrumentationHelpers>true</IncludeInstrumentationHelpers>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,7 +11,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry\OpenTelemetry.csproj" />
+    <Compile Include="$(RepoRoot)\src\OpenTelemetry\DiagnosticSourceInstrumentation\PropertyFetcher.cs" Link="Includes\PropertyFetcher.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Api\OpenTelemetry.Api.csproj" />
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule\OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.csproj" />
   </ItemGroup>
 

--- a/src/OpenTelemetry.Instrumentation.AspNet/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/TracerProviderBuilderExtensions.cs
@@ -16,7 +16,6 @@
 
 using System;
 using OpenTelemetry.Instrumentation.AspNet;
-using OpenTelemetry.Instrumentation.AspNet.Implementation;
 
 namespace OpenTelemetry.Trace
 {
@@ -44,9 +43,7 @@ namespace OpenTelemetry.Trace
             configureAspNetInstrumentationOptions?.Invoke(aspnetOptions);
 
             builder.AddInstrumentation(() => new AspNetInstrumentation(aspnetOptions));
-            builder.AddSource(HttpInListener.ActivitySourceName);
-            builder.AddLegacySource("Microsoft.AspNet.HttpReqIn"); // for the activities created by AspNetCore
-            builder.AddLegacySource("ActivityCreatedByHttpInListener"); // for the sibling activities created by the instrumentation library
+            builder.AddSource(TelemetryHttpModule.AspNetSourceName);
 
             return builder;
         }


### PR DESCRIPTION
Relates to #2249 

## Changes

* Moved TelemetryHttpModule options to their own class and exposed as a static. See below.
* Updated ASP.NET instrumentation to use the new TelemetryHttpModule. We no longer need to create extra Activity instances just to switch propagation! 🥂 
* Added RecordException option in ASP.NET instrumentation. The one thing I set out to do that spawned all of this 😄
 
## Notes & interesting lessons learned

Turns out there is no single instance of HttpApplication and HttpModules aren't singletons. Check it out:

https://github.com/microsoft/referencesource/blob/5697c29004a34d80acdaf5742d7e699022c64ecd/System.Web/HttpApplicationFactory.cs#L67-L71

There are two different bags of HttpApplications. The "special" ones are for application-level events (ex Application_Start). The "free" ones are created/re-used for each request and are sent request-level events (ex Begin_Request). This makes it much more difficult than I anticipated to find the TelemetryHttpModule and attach callbacks for instrumentation. I ended up just adding a static for the options. Not the most elegant solution but probably the least code. We could try to hook into HttpApplicationFactory with reflection and monkey patch in some code to call us anytime an HttpApplication is created/re-used.