### PR TITLE
Change http.path to http.target in aspnet and aspnetcore instrumentations

### DIFF
--- a/src/OpenTelemetry.Api/Internal/SemanticConventions.cs
+++ b/src/OpenTelemetry.Api/Internal/SemanticConventions.cs
@@ -49,8 +49,6 @@ namespace OpenTelemetry.Trace
         public const string AttributeHttpStatusText = "http.status_text";
         public const string AttributeHttpFlavor = "http.flavor";
         public const string AttributeHttpServerName = "http.server_name";
-        public const string AttributeHttpHostName = "host.name";
-        public const string AttributeHttpHostPort = "host.port";
         public const string AttributeHttpRoute = "http.route";
         public const string AttributeHttpClientIP = "http.client_ip";
         public const string AttributeHttpUserAgent = "http.user_agent";

--- a/src/OpenTelemetry.Api/Internal/SpanAttributeConstants.cs
+++ b/src/OpenTelemetry.Api/Internal/SpanAttributeConstants.cs
@@ -24,9 +24,6 @@ namespace OpenTelemetry.Trace
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
         public const string StatusCodeKey = "otel.status_code";
         public const string StatusDescriptionKey = "otel.status_description";
-
-        public const string HttpPathKey = "http.path";
-
         public const string DatabaseStatementTypeKey = "db.statement_type";
 
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Removes .NET Framework 4.5.2, .NET 4.6 support. The minimum .NET Framework
   version supported is .NET 4.6.1. ([#2138](https://github.com/open-telemetry/opentelemetry-dotnet/issues/2138))
 
+* Replaced `http.path` tag on activity with `http.target`.
+  ([#2266](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2266))
+
 ## 1.0.0-rc7
 
 Released 2021-Jul-12

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -145,7 +145,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
                 }
 
                 activity.SetTag(SemanticConventions.AttributeHttpMethod, request.HttpMethod);
-                activity.SetTag(SpanAttributeConstants.HttpPathKey, path);
+                activity.SetTag(SemanticConventions.AttributeHttpTarget, path);
                 activity.SetTag(SemanticConventions.AttributeHttpUserAgent, request.UserAgent);
                 activity.SetTag(SemanticConventions.AttributeHttpUrl, GetUriTagValueFromRequestUri(request.Url));
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Replaced `http.path` tag on activity with `http.target`.
+  ([#2266](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2266))
+
 ## 1.0.0-rc7
 
 Released 2021-Jul-12

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -151,7 +151,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
                 }
 
                 activity.SetTag(SemanticConventions.AttributeHttpMethod, request.Method);
-                activity.SetTag(SpanAttributeConstants.HttpPathKey, path);
+                activity.SetTag(SemanticConventions.AttributeHttpTarget, path);
                 activity.SetTag(SemanticConventions.AttributeHttpUrl, GetUri(request));
 
                 var userAgent = request.Headers["User-Agent"].FirstOrDefault();

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -336,7 +336,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
             }
 
             Assert.Equal(HttpContext.Current.Request.HttpMethod, span.GetTagValue(SemanticConventions.AttributeHttpMethod) as string);
-            Assert.Equal(HttpContext.Current.Request.Path, span.GetTagValue(SpanAttributeConstants.HttpPathKey) as string);
+            Assert.Equal(HttpContext.Current.Request.Path, span.GetTagValue(SemanticConventions.AttributeHttpTarget) as string);
             Assert.Equal(HttpContext.Current.Request.UserAgent, span.GetTagValue(SemanticConventions.AttributeHttpUserAgent) as string);
         }
 

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
@@ -573,7 +573,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             Assert.Equal(ActivityKind.Server, activityToValidate.Kind);
             Assert.Equal(HttpInListener.ActivitySourceName, activityToValidate.Source.Name);
             Assert.Equal(HttpInListener.Version.ToString(), activityToValidate.Source.Version);
-            Assert.Equal(expectedHttpPath, activityToValidate.GetTagValue(SpanAttributeConstants.HttpPathKey) as string);
+            Assert.Equal(expectedHttpPath, activityToValidate.GetTagValue(SemanticConventions.AttributeHttpTarget) as string);
         }
 
         private static void ActivityEnrichment(Activity activity, string method, object obj)

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
@@ -104,7 +104,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             Assert.Equal(ActivityKind.Server, activity.Kind);
             Assert.Equal("localhost", activity.GetTagValue(SemanticConventions.AttributeHttpHost));
             Assert.Equal("GET", activity.GetTagValue(SemanticConventions.AttributeHttpMethod));
-            Assert.Equal(urlPath, activity.GetTagValue(SpanAttributeConstants.HttpPathKey));
+            Assert.Equal(urlPath, activity.GetTagValue(SemanticConventions.AttributeHttpTarget));
             Assert.Equal($"http://localhost{urlPath}", activity.GetTagValue(SemanticConventions.AttributeHttpUrl));
             Assert.Equal(statusCode, activity.GetTagValue(SemanticConventions.AttributeHttpStatusCode));
 

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.server.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.server.cs
@@ -107,7 +107,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
             // The following are http.* attributes that are also included on the span for the gRPC invocation.
             Assert.Equal($"localhost:{this.server.Port}", activity.GetTagValue(SemanticConventions.AttributeHttpHost));
             Assert.Equal("POST", activity.GetTagValue(SemanticConventions.AttributeHttpMethod));
-            Assert.Equal("/greet.Greeter/SayHello", activity.GetTagValue(SpanAttributeConstants.HttpPathKey));
+            Assert.Equal("/greet.Greeter/SayHello", activity.GetTagValue(SemanticConventions.AttributeHttpTarget));
             Assert.Equal($"http://localhost:{this.server.Port}/greet.Greeter/SayHello", activity.GetTagValue(SemanticConventions.AttributeHttpUrl));
             Assert.StartsWith("grpc-dotnet", activity.GetTagValue(SemanticConventions.AttributeHttpUserAgent) as string);
         }
@@ -182,7 +182,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
                 // The following are http.* attributes that are also included on the span for the gRPC invocation.
                 Assert.Equal($"localhost:{this.server.Port}", activity.GetTagValue(SemanticConventions.AttributeHttpHost));
                 Assert.Equal("POST", activity.GetTagValue(SemanticConventions.AttributeHttpMethod));
-                Assert.Equal("/greet.Greeter/SayHello", activity.GetTagValue(SpanAttributeConstants.HttpPathKey));
+                Assert.Equal("/greet.Greeter/SayHello", activity.GetTagValue(SemanticConventions.AttributeHttpTarget));
                 Assert.Equal($"http://localhost:{this.server.Port}/greet.Greeter/SayHello", activity.GetTagValue(SemanticConventions.AttributeHttpUrl));
                 Assert.StartsWith("grpc-dotnet", activity.GetTagValue(SemanticConventions.AttributeHttpUserAgent) as string);
             }


### PR DESCRIPTION
`http.path` is not a semantic convention defined by spec. `http.path` was used in OpenCensus and is mapped to `http.target` in OpenTelemetry as per [this](https://github.com/open-telemetry/opentelemetry-specification/blob/87a5ed7f0d4c403e2b336f275ce3e7fd66a8041b/specification/compatibility/opencensus.md#http-attributes)