### PR TITLE
Async counter doc

### DIFF
--- a/OpenTelemetry.sln
+++ b/OpenTelemetry.sln
@@ -216,7 +216,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.Instrumentati
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "getting-started-histogram", "docs\metrics\getting-started-histogram\getting-started-histogram.csproj", "{92ED77A6-37B4-447D-B4C4-15DB005A589C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "getting-started-async-gauge", "docs\metrics\getting-started-gauge\getting-started-async-gauge.csproj", "{E7F491CC-C37E-4A56-9CA7-8F77F59E0614}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "getting-started-async-gauge", "docs\metrics\getting-started-gauge\getting-started-async-gauge.csproj", "{E7F491CC-C37E-4A56-9CA7-8F77F59E0614}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "getting-started-async-counter", "docs\metrics\getting-started-async-counter\getting-started-async-counter.csproj", "{54263F0D-23CB-4580-9133-03B2C3575919}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -436,6 +438,10 @@ Global
 		{E7F491CC-C37E-4A56-9CA7-8F77F59E0614}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E7F491CC-C37E-4A56-9CA7-8F77F59E0614}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E7F491CC-C37E-4A56-9CA7-8F77F59E0614}.Release|Any CPU.Build.0 = Release|Any CPU
+		{54263F0D-23CB-4580-9133-03B2C3575919}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{54263F0D-23CB-4580-9133-03B2C3575919}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{54263F0D-23CB-4580-9133-03B2C3575919}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{54263F0D-23CB-4580-9133-03B2C3575919}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -470,6 +476,7 @@ Global
 		{DFB0AD2F-11BE-4BCD-A77B-1018C3344FA8} = {3277B1C0-BDFE-4460-9B0D-D9A661FB48DB}
 		{92ED77A6-37B4-447D-B4C4-15DB005A589C} = {3277B1C0-BDFE-4460-9B0D-D9A661FB48DB}
 		{E7F491CC-C37E-4A56-9CA7-8F77F59E0614} = {3277B1C0-BDFE-4460-9B0D-D9A661FB48DB}
+		{54263F0D-23CB-4580-9133-03B2C3575919} = {3277B1C0-BDFE-4460-9B0D-D9A661FB48DB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {55639B5C-0770-4A22-AB56-859604650521}

--- a/docs/metrics/getting-started-async-counter/Program.cs
+++ b/docs/metrics/getting-started-async-counter/Program.cs
@@ -1,0 +1,50 @@
+// <copyright file="Program.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Threading.Tasks;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+
+public class Program
+{
+    private static readonly Meter MyMeter = new Meter("TestMeter", "0.0.1");
+
+    public static async Task Main(string[] args)
+    {
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddSource("TestMeter")
+            .AddConsoleExporter()
+            .Build();
+
+        var observableCounter = MyMeter.CreateObservableCounter<long>(
+            "observable-counter",
+            () =>
+            {
+                var tag1 = new KeyValuePair<string, object>("tag1", "value1");
+                var tag2 = new KeyValuePair<string, object>("tag2", "value2");
+                int i = 1;
+                return new List<Measurement<long>>()
+                {
+                    // Report an absolute value (not an increment/delta value).
+                    new Measurement<long>(i++ * 10, tag1, tag2),
+                };
+            });
+
+        await Task.Delay(10000);
+    }
+}

--- a/docs/metrics/getting-started-async-counter/README.md
+++ b/docs/metrics/getting-started-async-counter/README.md
@@ -32,13 +32,15 @@ output from the console, similar to shown below:
 
 <!-- markdownlint-disable MD013 -->
 ```text
-Service.Nameunknown_service:getting-started-gauge
-Export 15:44:05.262 15:44:05.263 Gauge [tag1=value1;tag2=value2] LongGauge, Meter: TestMeter/0.0.1
-Value: 306
-Export 15:44:05.262 15:44:06.290 Gauge [tag1=value1;tag2=value2] LongGauge, Meter: TestMeter/0.0.1
-Value: 693
-Export 15:44:05.262 15:44:07.302 Gauge [tag1=value1;tag2=value2] LongGauge, Meter: TestMeter/0.0.1
-Value: 78
+Service.Nameunknown_service:getting-started-async-counter
+Export 16:35:25.669 16:35:25.670 observable-counter [tag1=value1;tag2=value2] LongSum, Meter: TestMeter/0.0.1
+Value: 10
+Export 16:35:25.669 16:35:26.698 observable-counter [tag1=value1;tag2=value2] LongSum, Meter: TestMeter/0.0.1
+Value: 20
+Export 16:35:25.669 16:35:27.711 observable-counter [tag1=value1;tag2=value2] LongSum, Meter: TestMeter/0.0.1
+Value: 30
+Export 16:35:25.669 16:35:28.729 observable-counter [tag1=value1;tag2=value2] LongSum, Meter: TestMeter/0.0.1
+Value: 40
 ```
 <!-- markdownlint-enable MD013 -->
 

--- a/docs/metrics/getting-started-async-counter/README.md
+++ b/docs/metrics/getting-started-async-counter/README.md
@@ -1,0 +1,61 @@
+# Getting Started with OpenTelemetry .NET in 5 Minutes
+
+First, download and install the [.NET Core
+SDK](https://dotnet.microsoft.com/download) on your computer.
+
+Create a new console application and run it:
+
+```sh
+dotnet new console --output getting-started-async-counter
+cd getting-started-async-counter
+dotnet run
+```
+
+You should see the following output:
+
+```text
+Hello World!
+```
+
+Install the
+[OpenTelemetry.Exporter.Console](../../../src/OpenTelemetry.Exporter.Console/README.md)
+package:
+
+```sh
+dotnet add package OpenTelemetry.Exporter.Console
+```
+
+Update the `Program.cs` file with the code from [Program.cs](./Program.cs):
+
+Run the application again (using `dotnet run`) and you should see the metric
+output from the console, similar to shown below:
+
+<!-- markdownlint-disable MD013 -->
+```text
+Service.Nameunknown_service:getting-started-gauge
+Export 15:44:05.262 15:44:05.263 Gauge [tag1=value1;tag2=value2] LongGauge, Meter: TestMeter/0.0.1
+Value: 306
+Export 15:44:05.262 15:44:06.290 Gauge [tag1=value1;tag2=value2] LongGauge, Meter: TestMeter/0.0.1
+Value: 693
+Export 15:44:05.262 15:44:07.302 Gauge [tag1=value1;tag2=value2] LongGauge, Meter: TestMeter/0.0.1
+Value: 78
+```
+<!-- markdownlint-enable MD013 -->
+
+Congratulations! You are now collecting metrics using OpenTelemetry.
+
+What does the above program do?
+
+The program creates a
+[Meter](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#meter)
+instance named "TestMeter" and then creates a
+[Asynchronous Counter](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#asynchronous-counter)
+instrument from it. This Counter reports an ever increasing number as its
+measurement until exited after 10 seconds.
+
+An OpenTelemetry
+[MeterProvider](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#meterprovider)
+is configured to subscribe to instruments from the Meter `TestMeter`, and
+aggregate the measurements in-memory. The pre-aggregated metrics are exported
+every 1 second to a `ConsoleExporter`. `ConsoleExporter` simply displays it on
+the console.

--- a/docs/metrics/getting-started-async-counter/getting-started-async-counter.csproj
+++ b/docs/metrics/getting-started-async-counter/getting-started-async-counter.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry\OpenTelemetry.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Console\OpenTelemetry.Exporter.Console.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterOptions.cs
@@ -32,6 +32,6 @@ namespace OpenTelemetry.Exporter
         /// Gets or sets a value indicating whether to export Delta
         /// values or not (Cumulative).
         /// </summary>
-        public bool IsDelta { get; set; } = true;
+        public bool IsDelta { get; set; } = false;
     }
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -115,6 +115,6 @@ namespace OpenTelemetry.Exporter
         /// Gets or sets a value indicating whether to export Delta
         /// values or not (Cumulative).
         /// </summary>
-        public bool IsDelta { get; set; } = true;
+        public bool IsDelta { get; set; } = false;
     }
 }

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -61,8 +61,20 @@ namespace OpenTelemetry.Metrics
             {
                 aggregators.Add(new SumMetricAggregatorLong(this.instrument.Name, this.instrument.Description, this.instrument.Unit, this.instrument.Meter, dt, tags));
             }
+            else if (this.instrument.GetType() == typeof(ObservableCounter<long>)
+                || this.instrument.GetType() == typeof(ObservableCounter<int>)
+                || this.instrument.GetType() == typeof(ObservableCounter<short>)
+                || this.instrument.GetType() == typeof(ObservableCounter<byte>))
+            {
+                aggregators.Add(new SumMetricAggregatorLong(this.instrument.Name, this.instrument.Description, this.instrument.Unit, this.instrument.Meter, dt, tags));
+            }
             else if (this.instrument.GetType() == typeof(Counter<double>)
                 || this.instrument.GetType() == typeof(Counter<float>))
+            {
+                aggregators.Add(new SumMetricAggregatorDouble(this.instrument.Name, this.instrument.Description, this.instrument.Unit, this.instrument.Meter, dt, tags));
+            }
+            else if (this.instrument.GetType() == typeof(ObservableCounter<double>)
+                || this.instrument.GetType() == typeof(ObservableCounter<float>))
             {
                 aggregators.Add(new SumMetricAggregatorDouble(this.instrument.Name, this.instrument.Description, this.instrument.Unit, this.instrument.Meter, dt, tags));
             }


### PR DESCRIPTION
Adds doc for async-counter.
Changes default temporality to cumulative for Console, OTLP as the spec now defaults to cumulative.

This is part1 of changes to support async counter. Part2 will cover the actual aggregator logic to be copied from https://github.com/open-telemetry/opentelemetry-dotnet/pull/2262.