### PR TITLE
Support async counter for long

### DIFF
--- a/docs/metrics/getting-started-async-counter/Program.cs
+++ b/docs/metrics/getting-started-async-counter/Program.cs
@@ -31,13 +31,13 @@ public class Program
             .AddConsoleExporter()
             .Build();
 
+        int i = 1;
         var observableCounter = MyMeter.CreateObservableCounter<long>(
             "observable-counter",
             () =>
             {
                 var tag1 = new KeyValuePair<string, object>("tag1", "value1");
                 var tag2 = new KeyValuePair<string, object>("tag2", "value2");
-                int i = 1;
                 return new List<Measurement<long>>()
                 {
                     // Report an absolute value (not an increment/delta value).

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -59,14 +59,14 @@ namespace OpenTelemetry.Metrics
                 || this.instrument.GetType() == typeof(Counter<short>)
                 || this.instrument.GetType() == typeof(Counter<byte>))
             {
-                aggregators.Add(new SumMetricAggregatorLong(this.instrument.Name, this.instrument.Description, this.instrument.Unit, this.instrument.Meter, dt, tags));
+                aggregators.Add(new SumMetricAggregatorLong(this.instrument.Name, this.instrument.Description, this.instrument.Unit, this.instrument.Meter, dt, tags, true));
             }
             else if (this.instrument.GetType() == typeof(ObservableCounter<long>)
                 || this.instrument.GetType() == typeof(ObservableCounter<int>)
                 || this.instrument.GetType() == typeof(ObservableCounter<short>)
                 || this.instrument.GetType() == typeof(ObservableCounter<byte>))
             {
-                aggregators.Add(new SumMetricAggregatorLong(this.instrument.Name, this.instrument.Description, this.instrument.Unit, this.instrument.Meter, dt, tags));
+                aggregators.Add(new SumMetricAggregatorLong(this.instrument.Name, this.instrument.Description, this.instrument.Unit, this.instrument.Meter, dt, tags, false));
             }
             else if (this.instrument.GetType() == typeof(Counter<double>)
                 || this.instrument.GetType() == typeof(Counter<float>))

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -37,6 +37,155 @@ namespace OpenTelemetry.Metrics.Tests
             this.output = output;
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CounterAggregationTest(bool exportDelta)
+        {
+            var metricItems = new List<MetricItem>();
+            var metricExporter = new TestExporter<MetricItem>(ProcessExport);
+            void ProcessExport(Batch<MetricItem> batch)
+            {
+                foreach (var metricItem in batch)
+                {
+                    metricItems.Add(metricItem);
+                }
+            }
+
+            var pullProcessor = new PullMetricProcessor(metricExporter, exportDelta);
+
+            var meter = new Meter("TestMeter");
+            var counterLong = meter.CreateCounter<long>("mycounter");
+            var meterProvider = Sdk.CreateMeterProviderBuilder()
+                .AddSource("TestMeter")
+                .AddMetricProcessor(pullProcessor)
+                .Build();
+
+            counterLong.Add(10);
+            counterLong.Add(10);
+            pullProcessor.PullRequest();
+            long sumReceived = GetSum(metricItems);
+            Assert.Equal(20, sumReceived);
+
+            metricItems.Clear();
+            counterLong.Add(10);
+            counterLong.Add(10);
+            pullProcessor.PullRequest();
+            sumReceived = GetSum(metricItems);
+            if (exportDelta)
+            {
+                Assert.Equal(20, sumReceived);
+            }
+            else
+            {
+                Assert.Equal(40, sumReceived);
+            }
+
+            metricItems.Clear();
+            pullProcessor.PullRequest();
+            sumReceived = GetSum(metricItems);
+            if (exportDelta)
+            {
+                Assert.Equal(0, sumReceived);
+            }
+            else
+            {
+                Assert.Equal(40, sumReceived);
+            }
+
+            metricItems.Clear();
+            counterLong.Add(40);
+            counterLong.Add(20);
+            pullProcessor.PullRequest();
+            sumReceived = GetSum(metricItems);
+            if (exportDelta)
+            {
+                Assert.Equal(60, sumReceived);
+            }
+            else
+            {
+                Assert.Equal(100, sumReceived);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ObservableCounterAggregationTest(bool exportDelta)
+        {
+            var meterName = "TestMeter" + exportDelta;
+            var metricItems = new List<MetricItem>();
+            var metricExporter = new TestExporter<MetricItem>(ProcessExport);
+            void ProcessExport(Batch<MetricItem> batch)
+            {
+                foreach (var metricItem in batch)
+                {
+                    metricItems.Add(metricItem);
+                }
+            }
+
+            var pullProcessor = new PullMetricProcessor(metricExporter, exportDelta);
+
+            var meter = new Meter(meterName);
+            int i = 1;
+            var counterLong = meter.CreateObservableCounter<long>(
+            "observable-counter",
+            () =>
+            {
+                return new List<Measurement<long>>()
+                {
+                    new Measurement<long>(i++ * 10),
+                };
+            });
+            var meterProvider = Sdk.CreateMeterProviderBuilder()
+                .AddSource(meterName)
+                .AddMetricProcessor(pullProcessor)
+                .Build();
+
+            pullProcessor.PullRequest();
+            long sumReceived = GetSum(metricItems);
+            Assert.Equal(10, sumReceived);
+
+            metricItems.Clear();
+            pullProcessor.PullRequest();
+            sumReceived = GetSum(metricItems);
+            if (exportDelta)
+            {
+                Assert.Equal(10, sumReceived);
+            }
+            else
+            {
+                Assert.Equal(20, sumReceived);
+            }
+
+            metricItems.Clear();
+            pullProcessor.PullRequest();
+            sumReceived = GetSum(metricItems);
+            if (exportDelta)
+            {
+                Assert.Equal(10, sumReceived);
+            }
+            else
+            {
+                Assert.Equal(30, sumReceived);
+            }
+        }
+
+        private static long GetSum(List<MetricItem> metricItems)
+        {
+            long sum = 0;
+            foreach (var metricItem in metricItems)
+            {
+                var metrics = metricItem.Metrics;
+                foreach (var metric in metrics)
+                {
+                    sum += (metric as ISumMetricLong).LongSum;
+                }
+            }
+
+            return sum;
+        }
+
         [Fact]
         public void SimpleTest()
         {


### PR DESCRIPTION
Continuation of https://github.com/open-telemetry/opentelemetry-dotnet/pull/2277, this adds support for proper sum calculation for long.
Will follow up with a similar change in double as well.


(Doing this change to unblock the current release. With this PR, we'll support all 4 instruments (counter, async coutner, async gauge, histogram), for exporters expecting delta or cumulative. There will be refactoring on aggregators coming next which will affect exporter interfaces, but transparent to end users.

Removing explicit locks and proper multi-thread tests - part of refactor PRs coming next
)

