### PR TITLE
Docfx temp fix by pinning a known working version

### DIFF
--- a/.github/workflows/docfx.yml
+++ b/.github/workflows/docfx.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: install docfx
-      run: choco install docfx -y
+      run: choco install docfx -y --version=2.58
 
     - name: run .\build\docfx.cmd
       shell: cmd


### PR DESCRIPTION
2.58.1 is the latest version released today which seem to have an checksum validation issue. Temporarily using the last known good version.

ERROR: Checksum for 'C:\Users\cithomas\AppData\Local\Temp\chocolatey\docfx\2.58.1\docfx.zip' did not meet '94085d7ee874c786909ba23e0f436c4aeffa3f6057a39d2229e70bd1b5e710ba' for checksum type 'SHA256'. Consider passing the actual checksums through with --checksum --checksum64 once you validate the checksums are appropriate. A less secure option is to pass --ignore-checksums if necessary.
The install of docfx was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\docfx\tools\chocolateyinstall.ps1'.

Docfx issue: https://github.com/dotnet/docfx/issues/7562