### PR TITLE
Add histogram support for Prometheus exporter

### DIFF
--- a/examples/Console/TestPrometheusExporter.cs
+++ b/examples/Console/TestPrometheusExporter.cs
@@ -28,7 +28,8 @@ namespace Examples.Console
     internal class TestPrometheusExporter
     {
         private static readonly Meter MyMeter = new Meter("TestMeter", "0.0.1");
-        private static readonly Counter<long> Counter = MyMeter.CreateCounter<long>("counter");
+        private static readonly Counter<long> Counter = MyMeter.CreateCounter<long>("myCounter");
+        private static readonly Histogram<long> MyHistogram = MyMeter.CreateHistogram<long>("myHistogram");
         private static readonly Random RandomGenerator = new Random();
 
         internal static object Run(int port, int totalDurationInMins)
@@ -78,6 +79,11 @@ namespace Examples.Console
                                 100,
                                 new KeyValuePair<string, object>("tag1", "anothervalue"),
                                 new KeyValuePair<string, object>("tag2", "somethingelse"));
+
+                    MyHistogram.Record(
+                            RandomGenerator.Next(1, 1500),
+                            new KeyValuePair<string, object>("tag1", "value1"),
+                            new KeyValuePair<string, object>("tag2", "value2"));
 
                     Task.Delay(10).Wait();
                 }


### PR DESCRIPTION
Sample output for prometheus to scrape, when running the sample in examples.

```
# TYPE myCounter counter
myCounter{tag1="value1",tag2="value2"} 570 1629860968455
# TYPE myCounter counter
myCounter{tag1="anothervalue",tag2="somethingelse"} 5700 1629860968458
# TYPE myHistogram histogram
myHistogram_sum{tag1="value1",tag2="value2"} 44620 1629860968462
myHistogram_count{tag1="value1",tag2="value2"} 57 1629860968462
myHistogram_bucket{tag1="value1",tag2="value2",le="0"} 0 1629860968462
myHistogram_bucket{tag1="value1",tag2="value2",le="5"} 0 1629860968462
myHistogram_bucket{tag1="value1",tag2="value2",le="10"} 0 1629860968462
myHistogram_bucket{tag1="value1",tag2="value2",le="25"} 0 1629860968462
myHistogram_bucket{tag1="value1",tag2="value2",le="50"} 0 1629860968462
myHistogram_bucket{tag1="value1",tag2="value2",le="75"} 0 1629860968462
myHistogram_bucket{tag1="value1",tag2="value2",le="100"} 1 1629860968462
myHistogram_bucket{tag1="value1",tag2="value2",le="250"} 4 1629860968462
myHistogram_bucket{tag1="value1",tag2="value2",le="500"} 15 1629860968462
myHistogram_bucket{tag1="value1",tag2="value2",le="1000"} 38 1629860968462
myHistogram_bucket{tag1="value1",tag2="value2",le="+Inf"} 57 1629860968462
# TYPE Gauge gauge
Gauge{tag1="value1",tag2="value2"} 998 1629860968473
```

There are issues with Prometheus exporter as it emits multiple rows with "Type" info, which is against prometheus rule. Okay to do this for the coming alpha2 release. Will address this along with rest of fixes in next release. (the fix requires change in export data structure which is anyway changing)