### PR TITLE
Add changelog for 1.2.0-alpha2

### DIFF
--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.2.0-alpha2
+
+Released 2021-Aug-24
+
 ## 1.2.0-alpha1
 
 Released 2021-Jul-23

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.2.0-alpha2
+
+Released 2021-Aug-24
+
 ## 1.2.0-alpha1
 
 Released 2021-Jul-23

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 Released 2021-Aug-24
 
+* Add Histogram Metrics support.
+* Changed default temporality to be cumulative.
+
 ## 1.2.0-alpha1
 
 Released 2021-Jul-23

--- a/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.2.0-alpha2
+
+Released 2021-Aug-24
+
 * Add Metrics
   support.([#2192](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2192))
 

--- a/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.2.0-alpha2
+
+Released 2021-Aug-24
+
 ## 1.2.0-alpha1
 
 Released 2021-Jul-23

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.2.0-alpha2
+
+Released 2021-Aug-24
+
 * The `OtlpExporterOptions` defaults can be overridden using
   `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS` and `OTEL_EXPORTER_OTLP_TIMEOUT`
   envionmental variables as defined in the

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -12,6 +12,8 @@ Released 2021-Aug-24
   [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md).
   ([#2188](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2188))
 
+* Changed default temporality for Metrics to be cumulative.
+
 ## 1.2.0-alpha1
 
 Released 2021-Jul-23

--- a/src/OpenTelemetry.Exporter.Prometheus/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 1.2.0-alpha2
+
+Released 2021-Aug-24
+
+* Revamped to support the new Metrics API/SDK.
+  Supports Counters, Gauge and Histogram.
+
 ## 1.0.0-rc1.1
 
 Released 2020-Nov-17

--- a/src/OpenTelemetry.Exporter.Prometheus/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus/CHANGELOG.md
@@ -7,7 +7,7 @@
 Released 2021-Aug-24
 
 * Revamped to support the new Metrics API/SDK.
-  Supports Counters, Gauge and Histogram.
+  Supports Counter, Gauge and Histogram.
 
 ## 1.0.0-rc1.1
 

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.2.0-alpha2
+
+Released 2021-Aug-24
+
 * Enabling endpoint configuration in ZipkinExporterOptions via
   `OTEL_EXPORTER_ZIPKIN_ENDPOINT` environment variable.
   ([#1453](https://github.com/open-telemetry/opentelemetry-dotnet/issues/1453))

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 1.2.0-alpha2
+
+Released 2021-Aug-24
+
+* More Metrics features. All instrument types, push/pull
+  exporters, Delta/Cumulative temporality supported.
+
 * `ResourceBuilder.CreateDefault` has detectors for
   `OTEL_RESOURCE_ATTRIBUTES`, `OTEL_SERVICE_NAME` environment variables
   so that explicit `AddEnvironmentVariableDetector` call is not needed. ([#2247](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2247))


### PR DESCRIPTION
Metrics are still too early to maintain full changelog, so added just a summary.
Starting beta1 onwards, will maintain changelog the usual way (with links to PRs, issues)