### PR TITLE
ASP.NET & ASP.NET Core: Clear baggage when root activity is complete

### DIFF
--- a/src/OpenTelemetry.Api/Baggage.cs
+++ b/src/OpenTelemetry.Api/Baggage.cs
@@ -94,7 +94,7 @@ namespace OpenTelemetry
                 return default;
             }
 
-            Dictionary<string, string> baggageCopy = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            Dictionary<string, string> baggageCopy = new Dictionary<string, string>(baggageItems.Count, StringComparer.OrdinalIgnoreCase);
             foreach (KeyValuePair<string, string> baggageItem in baggageItems)
             {
                 if (string.IsNullOrEmpty(baggageItem.Value))
@@ -233,7 +233,7 @@ namespace OpenTelemetry
         /// <returns>New <see cref="Baggage"/> containing the key/value pair.</returns>
         public Baggage SetBaggage(IEnumerable<KeyValuePair<string, string>> baggageItems)
         {
-            if ((baggageItems?.Count() ?? 0) <= 0)
+            if (baggageItems?.Any() != true)
             {
                 return this;
             }

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/TelemetryHttpModule.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/TelemetryHttpModule.cs
@@ -145,7 +145,7 @@ namespace OpenTelemetry.Instrumentation.AspNet
 
             if (trackActivity)
             {
-                ActivityHelper.StopAspNetActivity(aspNetActivity, context, Options.OnRequestStoppedCallback);
+                ActivityHelper.StopAspNetActivity(Options.TextMapPropagator, aspNetActivity, context, Options.OnRequestStoppedCallback);
             }
         }
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentation.cs
@@ -25,13 +25,9 @@ namespace OpenTelemetry.Instrumentation.AspNetCore
     {
         private readonly DiagnosticSourceSubscriber diagnosticSourceSubscriber;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AspNetCoreInstrumentation"/> class.
-        /// </summary>
-        /// <param name="options">Configuration options for ASP.NET Core instrumentation.</param>
-        public AspNetCoreInstrumentation(AspNetCoreInstrumentationOptions options)
+        public AspNetCoreInstrumentation(HttpInListener httpInListener)
         {
-            this.diagnosticSourceSubscriber = new DiagnosticSourceSubscriber(new HttpInListener("Microsoft.AspNetCore", options), null);
+            this.diagnosticSourceSubscriber = new DiagnosticSourceSubscriber(httpInListener, null);
             this.diagnosticSourceSubscriber.Subscribe();
         }
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -19,11 +19,15 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+#if NETSTANDARD2_1 || NETCOREAPP3_1 || NET5_0
 using System.Runtime.CompilerServices;
+#endif
 using System.Text;
 using Microsoft.AspNetCore.Http;
 using OpenTelemetry.Context.Propagation;
+#if NETSTANDARD2_1 || NETCOREAPP3_1 || NET5_0
 using OpenTelemetry.Instrumentation.GrpcNetClient;
+#endif
 using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
@@ -35,6 +39,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
         internal static readonly string ActivitySourceName = AssemblyName.Name;
         internal static readonly Version Version = AssemblyName.Version;
         internal static readonly ActivitySource ActivitySource = new ActivitySource(ActivitySourceName, Version.ToString());
+        private const string DiagnosticSourceName = "Microsoft.AspNetCore";
         private const string UnknownHostName = "UNKNOWN-HOST";
         private static readonly Func<HttpRequest, string, IEnumerable<string>> HttpRequestHeaderValuesGetter = (request, name) => request.Headers[name];
         private readonly PropertyFetcher<HttpContext> startContextFetcher = new PropertyFetcher<HttpContext>("HttpContext");
@@ -45,8 +50,8 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
         private readonly PropertyFetcher<string> beforeActionTemplateFetcher = new PropertyFetcher<string>("Template");
         private readonly AspNetCoreInstrumentationOptions options;
 
-        public HttpInListener(string name, AspNetCoreInstrumentationOptions options)
-            : base(name)
+        public HttpInListener(AspNetCoreInstrumentationOptions options)
+            : base(DiagnosticSourceName)
         {
             this.options = options ?? throw new ArgumentNullException(nameof(options));
         }
@@ -103,10 +108,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
                     activity = newOne;
                 }
 
-                if (ctx.Baggage != default)
-                {
-                    Baggage.Current = ctx.Baggage;
-                }
+                Baggage.Current = ctx.Baggage;
             }
 
             // enrich Activity from payload only if sampling decision
@@ -230,6 +232,12 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
                 // If yes, then we need to store the asp.net core activity inside
                 // the one created by the instrumentation.
                 // And retrieve it here, and set it to Current.
+            }
+
+            var textMapPropagator = Propagators.DefaultTextMapPropagator;
+            if (!(textMapPropagator is TraceContextPropagator))
+            {
+                Baggage.Current = default;
             }
         }
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -19,13 +19,13 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
-#if NETSTANDARD2_1 || NETCOREAPP3_1 || NET5_0
+#if !NETSTANDARD2_0
 using System.Runtime.CompilerServices;
 #endif
 using System.Text;
 using Microsoft.AspNetCore.Http;
 using OpenTelemetry.Context.Propagation;
-#if NETSTANDARD2_1 || NETCOREAPP3_1 || NET5_0
+#if !NETSTANDARD2_0
 using OpenTelemetry.Instrumentation.GrpcNetClient;
 #endif
 using OpenTelemetry.Trace;
@@ -186,17 +186,14 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
 
                 activity.SetTag(SemanticConventions.AttributeHttpStatusCode, response.StatusCode);
 
-#if NETSTANDARD2_1 || NETCOREAPP3_1 || NET5_0
+#if !NETSTANDARD2_0
                 if (this.options.EnableGrpcAspNetCoreSupport && TryGetGrpcMethod(activity, out var grpcMethod))
                 {
                     AddGrpcAttributes(activity, grpcMethod, context);
                 }
-                else
+                else if (activity.GetStatus().StatusCode == StatusCode.Unset)
                 {
-                    if (activity.GetStatus().StatusCode == StatusCode.Unset)
-                    {
-                        activity.SetStatus(SpanHelper.ResolveSpanStatusForHttpStatusCode(response.StatusCode));
-                    }
+                    activity.SetStatus(SpanHelper.ResolveSpanStatusForHttpStatusCode(response.StatusCode));
                 }
 #else
                 if (activity.GetStatus().StatusCode == StatusCode.Unset)
@@ -333,7 +330,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
             return builder.ToString();
         }
 
-#if NETSTANDARD2_1 || NETCOREAPP3_1 || NET5_0
+#if !NETSTANDARD2_0
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool TryGetGrpcMethod(Activity activity, out string grpcMethod)
         {

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/TracerProviderBuilderExtensions.cs
@@ -51,13 +51,24 @@ namespace OpenTelemetry.Trace
             return AddAspNetCoreInstrumentation(builder, new AspNetCoreInstrumentationOptions(), configureAspNetCoreInstrumentationOptions);
         }
 
-        private static TracerProviderBuilder AddAspNetCoreInstrumentation(TracerProviderBuilder builder, AspNetCoreInstrumentationOptions options, Action<AspNetCoreInstrumentationOptions> configure = null)
+        internal static TracerProviderBuilder AddAspNetCoreInstrumentation(
+            this TracerProviderBuilder builder,
+            AspNetCoreInstrumentation instrumentation)
         {
-            configure?.Invoke(options);
-            var instrumentation = new AspNetCoreInstrumentation(options);
             builder.AddSource(HttpInListener.ActivitySourceName);
             builder.AddLegacySource(HttpInListener.ActivityOperationName); // for the activities created by AspNetCore
             return builder.AddInstrumentation(() => instrumentation);
+        }
+
+        private static TracerProviderBuilder AddAspNetCoreInstrumentation(
+            TracerProviderBuilder builder,
+            AspNetCoreInstrumentationOptions options,
+            Action<AspNetCoreInstrumentationOptions> configure = null)
+        {
+            configure?.Invoke(options);
+            return AddAspNetCoreInstrumentation(
+                builder,
+                new AspNetCoreInstrumentation(new HttpInListener(options)));
         }
     }
 }

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -167,7 +167,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
                     ActivityHelper.WriteActivityException(activity, HttpContext.Current, new InvalidOperationException(), TelemetryHttpModule.Options.OnExceptionCallback);
                 }
 
-                ActivityHelper.StopAspNetActivity(activity, HttpContext.Current, TelemetryHttpModule.Options.OnRequestStoppedCallback);
+                ActivityHelper.StopAspNetActivity(Propagators.DefaultTextMapPropagator, activity, HttpContext.Current, TelemetryHttpModule.Options.OnRequestStoppedCallback);
             }
 
             if (HttpContext.Current.Request.Path == filter || filter == "{ThrowException}")
@@ -281,7 +281,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
                 .AddProcessor(activityProcessor.Object).Build())
             {
                 var activity = ActivityHelper.StartAspNetActivity(Propagators.DefaultTextMapPropagator, HttpContext.Current, TelemetryHttpModule.Options.OnRequestStartedCallback);
-                ActivityHelper.StopAspNetActivity(activity, HttpContext.Current, TelemetryHttpModule.Options.OnRequestStoppedCallback);
+                ActivityHelper.StopAspNetActivity(Propagators.DefaultTextMapPropagator, activity, HttpContext.Current, TelemetryHttpModule.Options.OnRequestStoppedCallback);
             }
 
             Assert.True(isPropagatorCalled);
@@ -324,7 +324,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
                 .AddProcessor(activityProcessor.Object).Build())
             {
                 var activity = ActivityHelper.StartAspNetActivity(Propagators.DefaultTextMapPropagator, HttpContext.Current, TelemetryHttpModule.Options.OnRequestStartedCallback);
-                ActivityHelper.StopAspNetActivity(activity, HttpContext.Current, TelemetryHttpModule.Options.OnRequestStoppedCallback);
+                ActivityHelper.StopAspNetActivity(Propagators.DefaultTextMapPropagator, activity, HttpContext.Current, TelemetryHttpModule.Options.OnRequestStoppedCallback);
             }
 
             Assert.True(isFilterCalled);

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
@@ -41,7 +41,7 @@ using Xunit;
 namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
 {
     // See https://github.com/aspnet/Docs/tree/master/aspnetcore/test/integration-tests/samples/2.x/IntegrationTestsSample
-    public class BasicTests
+    public sealed class BasicTests
         : IClassFixture<WebApplicationFactory<Startup>>, IDisposable
     {
         private readonly WebApplicationFactory<Startup> factory;
@@ -508,6 +508,55 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             }
         }
 
+        [Fact]
+        public async Task BaggageClearedWhenActivityStopped()
+        {
+            int? baggageCountAfterStart = null;
+            int? baggageCountAfterStop = null;
+            using EventWaitHandle stopSignal = new EventWaitHandle(false, EventResetMode.ManualReset);
+
+            void ConfigureTestServices(IServiceCollection services)
+            {
+                this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+                    .AddAspNetCoreInstrumentation(new AspNetCoreInstrumentation(
+                        new TestHttpInListener(new AspNetCoreInstrumentationOptions())
+                        {
+                            OnStartActivityCallback = (activity, payload) =>
+                            {
+                                baggageCountAfterStart = Baggage.Current.Count;
+                            },
+                            OnStopActivityCallback = (activity, payload) =>
+                            {
+                                baggageCountAfterStop = Baggage.Current.Count;
+                                stopSignal.Set();
+                            },
+                        }))
+                    .Build();
+            }
+
+            // Arrange
+            using (var client = this.factory
+                .WithWebHostBuilder(builder =>
+                    builder.ConfigureTestServices(ConfigureTestServices))
+                .CreateClient())
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Get, "/api/values");
+
+                request.Headers.TryAddWithoutValidation("baggage", "TestKey1=123,TestKey2=456");
+
+                // Act
+                using var response = await client.SendAsync(request);
+            }
+
+            stopSignal.WaitOne(5000);
+
+            // Assert
+            Assert.NotNull(baggageCountAfterStart);
+            Assert.Equal(2, baggageCountAfterStart);
+            Assert.NotNull(baggageCountAfterStop);
+            Assert.Equal(0, baggageCountAfterStop);
+        }
+
         [Theory]
         [InlineData(SamplingDecision.Drop, false, false)]
         [InlineData(SamplingDecision.RecordOnly, true, true)]
@@ -622,7 +671,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
 
         private class TestSampler : Sampler
         {
-            private SamplingDecision samplingDecision;
+            private readonly SamplingDecision samplingDecision;
 
             public TestSampler(SamplingDecision samplingDecision)
             {
@@ -632,6 +681,32 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
             {
                 return new SamplingResult(this.samplingDecision);
+            }
+        }
+
+        private class TestHttpInListener : HttpInListener
+        {
+            public Action<Activity, object> OnStartActivityCallback;
+
+            public Action<Activity, object> OnStopActivityCallback;
+
+            public TestHttpInListener(AspNetCoreInstrumentationOptions options)
+                : base(options)
+            {
+            }
+
+            public override void OnStartActivity(Activity activity, object payload)
+            {
+                base.OnStartActivity(activity, payload);
+
+                this.OnStartActivityCallback?.Invoke(activity, payload);
+            }
+
+            public override void OnStopActivity(Activity activity, object payload)
+            {
+                base.OnStopActivity(activity, payload);
+
+                this.OnStopActivityCallback?.Invoke(activity, payload);
             }
         }
     }

--- a/test/OpenTelemetry.Tests/BaggageTests.cs
+++ b/test/OpenTelemetry.Tests/BaggageTests.cs
@@ -16,6 +16,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace OpenTelemetry.Tests
@@ -268,6 +270,39 @@ namespace OpenTelemetry.Tests
             var expectedBaggage = Baggage.Create(new Dictionary<string, string> { [K1] = V1 });
 
             Assert.Equal(expectedBaggage.GetHashCode(), baggage.GetHashCode());
+        }
+
+        [Fact]
+        public async Task AsyncLocalTests()
+        {
+            int threadId = Thread.CurrentThread.ManagedThreadId;
+
+            Baggage.SetBaggage("key1", "value1");
+
+            await InnerTask().ConfigureAwait(false);
+
+            Assert.NotEqual(threadId, Thread.CurrentThread.ManagedThreadId);
+
+            Baggage.SetBaggage("key4", "value4");
+
+            Assert.Equal(4, Baggage.Current.Count);
+            Assert.Equal("value1", Baggage.GetBaggage("key1"));
+            Assert.Equal("value2", Baggage.GetBaggage("key2"));
+            Assert.Equal("value3", Baggage.GetBaggage("key3"));
+            Assert.Equal("value4", Baggage.GetBaggage("key4"));
+
+            static async Task InnerTask()
+            {
+                Baggage.SetBaggage("key2", "value2");
+
+                int threadId = Thread.CurrentThread.ManagedThreadId;
+
+                await Task.Yield();
+
+                Assert.NotEqual(threadId, Thread.CurrentThread.ManagedThreadId);
+
+                Baggage.SetBaggage("key3", "value3"); // Changes to this AsyncLocal don't flow backwards automatically.
+            }
         }
     }
 }

--- a/test/OpenTelemetry.Tests/BaggageTests.cs
+++ b/test/OpenTelemetry.Tests/BaggageTests.cs
@@ -275,13 +275,9 @@ namespace OpenTelemetry.Tests
         [Fact]
         public async Task AsyncLocalTests()
         {
-            int threadId = Thread.CurrentThread.ManagedThreadId;
-
             Baggage.SetBaggage("key1", "value1");
 
             await InnerTask().ConfigureAwait(false);
-
-            Assert.NotEqual(threadId, Thread.CurrentThread.ManagedThreadId);
 
             Baggage.SetBaggage("key4", "value4");
 
@@ -295,13 +291,11 @@ namespace OpenTelemetry.Tests
             {
                 Baggage.SetBaggage("key2", "value2");
 
-                int threadId = Thread.CurrentThread.ManagedThreadId;
-
                 await Task.Yield();
 
-                Assert.NotEqual(threadId, Thread.CurrentThread.ManagedThreadId);
+                Baggage.SetBaggage("key3", "value3");
 
-                Baggage.SetBaggage("key3", "value3"); // Changes to this AsyncLocal don't flow backwards automatically.
+                // key2 & key3 changes don't flow backward automatically
             }
         }
     }


### PR DESCRIPTION
## Issue

Changes to `AsyncLocal`s flow forward but they don't flow backward. This test will fail on the current codebase:

```csharp
        [Fact]
        public async Task AsyncLocalTests()
        {
            int threadId = Thread.CurrentThread.ManagedThreadId; // Let's say this is t8

            Baggage.SetBaggage("key1", "value1");

            await InnerTask().ConfigureAwait(false);

            Assert.NotEqual(threadId, Thread.CurrentThread.ManagedThreadId); // This can be t10 when continuation is run in sync or another thread if run async

            Baggage.SetBaggage("key4", "value4");

            Assert.Equal(4, Baggage.Current.Count); // FAIL -> This thread only sees 2 items in baggage (key1 & key4)

            static async Task InnerTask()
            {
                Assert.Equal(1, Baggage.Current.Count); // AsyncLocal flowed forward to this point
                Baggage.SetBaggage("key2", "value2");

                int threadId = Thread.CurrentThread.ManagedThreadId; // Should also be t8 here

                await Task.Yield();

                Assert.NotEqual(threadId, Thread.CurrentThread.ManagedThreadId); // Now we're on a new thread, call it t10

                Assert.Equal(2, Baggage.Current.Count); // AsyncLocal flowed forward to this point
                Baggage.SetBaggage("key3", "value3"); 

                // Issue: key2 & key3 changes don't flow backward automatically
            }
        }
``` 

## Changes

* This PR changes baggage so that it stores the value inside a class. What that does is cause the `AsyncLocal` to flow a pointer instead of a value. All threads will have a pointer to the same memory so changes are visible everywhere.

   ASP.NET Core does the same for HttpContext: https://github.com/dotnet/aspnetcore/blob/8b30d862de6c9146f466061d51aa3f1414ee2337/src/Http/Http/src/HttpContextAccessor.cs#L42

* That pointer now also allows the root span to clear the baggage from all captured `AsyncLocal`s once the span is done.

* All the other changes are so I could add a test in ASP.NET Core instrumentation.
