### PR TITLE
Improve the metrics console output

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -92,7 +92,12 @@ namespace OpenTelemetry.Exporter
                                 bucketsBuilder.Append($"Sum: {histogramMetric.PopulationSum} Count: {histogramMetric.PopulationCount} \n");
                                 foreach (var bucket in histogramMetric.Buckets)
                                 {
-                                    bucketsBuilder.Append($"({bucket.LowBoundary} - {bucket.HighBoundary}) : {bucket.Count}");
+                                    bucketsBuilder.Append('(');
+                                    bucketsBuilder.Append(double.IsInfinity(bucket.LowBoundary) ? "-Infinity" : $"{bucket.LowBoundary}");
+                                    bucketsBuilder.Append(", ");
+                                    bucketsBuilder.Append(double.IsInfinity(bucket.HighBoundary) ? "+Infinity" : $"{bucket.HighBoundary}");
+                                    bucketsBuilder.Append(double.IsInfinity(bucket.HighBoundary) ? ')' : ']');
+                                    bucketsBuilder.Append($": {bucket.Count}");
                                     bucketsBuilder.AppendLine();
                                 }
 
@@ -108,9 +113,16 @@ namespace OpenTelemetry.Exporter
                             }
                     }
 
-                    string time = $"{metric.StartTimeExclusive.ToLocalTime().ToString("HH:mm:ss.fff")} {metric.EndTimeInclusive.ToLocalTime().ToString("HH:mm:ss.fff")}";
-
-                    var msg = new StringBuilder($"Export {time} {metric.Name} [{string.Join(";", tags)}] {metric.MetricType}");
+                    var msg = new StringBuilder($"Export (");
+                    msg.Append(metric.StartTimeExclusive.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", CultureInfo.InvariantCulture));
+                    msg.Append(", ");
+                    msg.Append(metric.EndTimeInclusive.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", CultureInfo.InvariantCulture));
+                    msg.Append("] ");
+                    msg.Append(metric.Name);
+                    msg.Append(' ');
+                    msg.Append(string.Join(";", tags));
+                    msg.Append(' ');
+                    msg.Append(metric.MetricType);
 
                     if (!string.IsNullOrEmpty(metric.Description))
                     {


### PR DESCRIPTION
Couple minor improvements:
1. Reduced the number of string formats, use string builder instead (we might want to pre-alloc and cache the string builder in a separate PR).
2. Be explicit on whether the intervals are inclusive or exclusive. refer to this https://github.com/open-telemetry/opentelemetry-proto/blob/e57e8494433f26e9050835c76e74282b0cd718a8/opentelemetry/proto/metrics/v1/metrics.proto#L437
3. Used `+Infinite` and `-Infinite` rather than `∞` and `-∞` to improve portability.
4. Used UTC time.