### PR TITLE
Use EventKeywords.All instead of -1 for better readability

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
@@ -75,12 +75,12 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Implementation
             if (eventSource?.Name.StartsWith(AdoNetEventSourceName, StringComparison.Ordinal) == true)
             {
                 this.adoNetEventSource = eventSource;
-                this.EnableEvents(eventSource, EventLevel.Informational, (EventKeywords)1);
+                this.EnableEvents(eventSource, EventLevel.Informational, EventKeywords.All);
             }
             else if (eventSource?.Name.StartsWith(MdsEventSourceName, StringComparison.Ordinal) == true)
             {
                 this.mdsEventSource = eventSource;
-                this.EnableEvents(eventSource, EventLevel.Informational, (EventKeywords)1);
+                this.EnableEvents(eventSource, EventLevel.Informational, EventKeywords.All);
             }
 
             base.OnEventSourceCreated(eventSource);

--- a/test/OpenTelemetry.Tests/Shared/EventSourceTestHelper.cs
+++ b/test/OpenTelemetry.Tests/Shared/EventSourceTestHelper.cs
@@ -37,8 +37,7 @@ namespace OpenTelemetry.Tests
         {
             using (var listener = new TestEventListener())
             {
-                const long AllKeywords = -1;
-                listener.EnableEvents(eventSource, EventLevel.Verbose, (EventKeywords)AllKeywords);
+                listener.EnableEvents(eventSource, EventLevel.Verbose, EventKeywords.All);
                 try
                 {
                     object[] eventArguments = GenerateEventArguments(eventMethod);


### PR DESCRIPTION
Replaced by #2297.