### PR TITLE
Install OTel 1.2+ so metrics are available

### DIFF
--- a/docs/metrics/getting-started-async-counter/README.md
+++ b/docs/metrics/getting-started-async-counter/README.md
@@ -22,7 +22,7 @@ Install the
 package:
 
 ```sh
-dotnet add package OpenTelemetry.Exporter.Console
+dotnet add package OpenTelemetry.Exporter.Console --version 1.2.*.*
 ```
 
 Update the `Program.cs` file with the code from [Program.cs](./Program.cs):

--- a/docs/metrics/getting-started-gauge/README.md
+++ b/docs/metrics/getting-started-gauge/README.md
@@ -22,7 +22,7 @@ Install the
 package:
 
 ```sh
-dotnet add package OpenTelemetry.Exporter.Console
+dotnet add package OpenTelemetry.Exporter.Console --version 1.2.*.*
 ```
 
 Update the `Program.cs` file with the code from [Program.cs](./Program.cs):

--- a/docs/metrics/getting-started-histogram/README.md
+++ b/docs/metrics/getting-started-histogram/README.md
@@ -22,7 +22,7 @@ Install the
 package:
 
 ```sh
-dotnet add package OpenTelemetry.Exporter.Console
+dotnet add package OpenTelemetry.Exporter.Console --version 1.2.*.*
 ```
 
 Update the `Program.cs` file with the code from [Program.cs](./Program.cs):

--- a/docs/metrics/getting-started/README.md
+++ b/docs/metrics/getting-started/README.md
@@ -22,7 +22,7 @@ Install the
 package:
 
 ```sh
-dotnet add package OpenTelemetry.Exporter.Console
+dotnet add package OpenTelemetry.Exporter.Console --version 1.2.*.*
 ```
 
 Update the `Program.cs` file with the code from [Program.cs](./Program.cs):


### PR DESCRIPTION
Since the latest non-pre-release version is 1.1.0 without metrics the modified `dotnet add package` command doesn't work as is.
We can revert this change once 1.2.0 is stable.