### PR TITLE
Install prerelease 'OpenTelemetry.Exporter.Console' in metric docs

### DIFF
--- a/docs/metrics/getting-started-async-counter/README.md
+++ b/docs/metrics/getting-started-async-counter/README.md
@@ -22,7 +22,7 @@ Install the
 package:
 
 ```sh
-dotnet add package OpenTelemetry.Exporter.Console
+dotnet add package OpenTelemetry.Exporter.Console --version 1.2.*.*
 ```
 
 Update the `Program.cs` file with the code from [Program.cs](./Program.cs):

--- a/docs/metrics/getting-started-async-counter/README.md
+++ b/docs/metrics/getting-started-async-counter/README.md
@@ -22,7 +22,7 @@ Install the
 package:
 
 ```sh
-dotnet add package OpenTelemetry.Exporter.Console --version 1.2.*.*
+dotnet add package --prerelease OpenTelemetry.Exporter.Console
 ```
 
 Update the `Program.cs` file with the code from [Program.cs](./Program.cs):

--- a/docs/metrics/getting-started-gauge/README.md
+++ b/docs/metrics/getting-started-gauge/README.md
@@ -22,7 +22,7 @@ Install the
 package:
 
 ```sh
-dotnet add package OpenTelemetry.Exporter.Console
+dotnet add package OpenTelemetry.Exporter.Console --version 1.2.*.*
 ```
 
 Update the `Program.cs` file with the code from [Program.cs](./Program.cs):

--- a/docs/metrics/getting-started-gauge/README.md
+++ b/docs/metrics/getting-started-gauge/README.md
@@ -22,7 +22,7 @@ Install the
 package:
 
 ```sh
-dotnet add package OpenTelemetry.Exporter.Console --version 1.2.*.*
+dotnet add package --prerelease OpenTelemetry.Exporter.Console
 ```
 
 Update the `Program.cs` file with the code from [Program.cs](./Program.cs):

--- a/docs/metrics/getting-started-histogram/README.md
+++ b/docs/metrics/getting-started-histogram/README.md
@@ -22,7 +22,7 @@ Install the
 package:
 
 ```sh
-dotnet add package OpenTelemetry.Exporter.Console
+dotnet add package OpenTelemetry.Exporter.Console --version 1.2.*.*
 ```
 
 Update the `Program.cs` file with the code from [Program.cs](./Program.cs):

--- a/docs/metrics/getting-started-histogram/README.md
+++ b/docs/metrics/getting-started-histogram/README.md
@@ -22,7 +22,7 @@ Install the
 package:
 
 ```sh
-dotnet add package OpenTelemetry.Exporter.Console --version 1.2.*.*
+dotnet add package --prerelease OpenTelemetry.Exporter.Console
 ```
 
 Update the `Program.cs` file with the code from [Program.cs](./Program.cs):

--- a/docs/metrics/getting-started/README.md
+++ b/docs/metrics/getting-started/README.md
@@ -22,7 +22,7 @@ Install the
 package:
 
 ```sh
-dotnet add package OpenTelemetry.Exporter.Console
+dotnet add package OpenTelemetry.Exporter.Console --version 1.2.*.*
 ```
 
 Update the `Program.cs` file with the code from [Program.cs](./Program.cs):

--- a/docs/metrics/getting-started/README.md
+++ b/docs/metrics/getting-started/README.md
@@ -22,7 +22,7 @@ Install the
 package:
 
 ```sh
-dotnet add package OpenTelemetry.Exporter.Console --version 1.2.*.*
+dotnet add package --prerelease OpenTelemetry.Exporter.Console
 ```
 
 Update the `Program.cs` file with the code from [Program.cs](./Program.cs):


### PR DESCRIPTION
Thanks to @utpilla comment on the previous PR that was merged before I could make the suggested change.

https://github.com/open-telemetry/opentelemetry-dotnet/pull/2299/commits/11d2e60cebd741f3a101b64b293c417972b9c821#r700541143