### PR TITLE
New ApiCompat

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <SignAssembly>true</SignAssembly>
     <RepoRoot>$([System.IO.Directory]::GetParent($(MSBuildThisFileDirectory)).Parent.FullName)</RepoRoot>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)debug.snk</AssemblyOriginatorKeyFile>

--- a/src/OpenTelemetry/OpenTelemetry.csproj
+++ b/src/OpenTelemetry/OpenTelemetry.csproj
@@ -1,6 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
+
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;net6.0</TargetFrameworks>
     <Description>OpenTelemetry .NET SDK</Description>
     <!--
     TODO: Disable this exception, and actually do document all public API.

--- a/src/OpenTelemetry/OpenTelemetry.csproj
+++ b/src/OpenTelemetry/OpenTelemetry.csproj
@@ -5,6 +5,8 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461;net6.0</TargetFrameworks>
     <Description>OpenTelemetry .NET SDK</Description>
+    <PackageVersion>1.2.0</PackageVersion>
+    <PackageValidationBaselineVersion>1.1.0</PackageValidationBaselineVersion>
     <!--
     TODO: Disable this exception, and actually do document all public API.
     -->


### PR DESCRIPTION
Fixes #2081 

## Changes

- Added dotnet package validation following this guide: https://devblogs.microsoft.com/dotnet/package-validation
- Had to increase `LangVersion` from `8.0` to `10.0` due to this error
  - `F:\Git\mic-max\opentelemetry-dotnet\src\OpenTelemetry\obj\Debug\net6.0\OpenTelemetry.ImplicitNamespaceImports.cs(8,1): error CS8400: Feature 'global using directive' is not available in C# 8.0. Please use language version 10.0 or greater. [F:\Git\mic-max\opentelemetry-dotnet\src\OpenTelemetry\OpenTelemetry.csproj]`

`PackageVersion` and `PackageValidationBaselineVersion` need to be decided on.