### PR TITLE
Add Metric Reader and use IEnumerable for Metric collect instead of Batch

### DIFF
--- a/examples/Console/TestMetrics.cs
+++ b/examples/Console/TestMetrics.cs
@@ -76,7 +76,7 @@ namespace Examples.Console
                     .AddConsoleExporter(o =>
                     {
                         o.MetricExportIntervalMilliseconds = options.DefaultCollectionPeriodMilliseconds;
-                        o.IsDelta = options.IsDelta;
+                        o.AggregationTemporality = options.IsDelta ? AggregationTemporality.Delta : AggregationTemporality.Cumulative;
                     });
             }
 

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterMetricHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterMetricHelperExtensions.cs
@@ -37,7 +37,9 @@ namespace OpenTelemetry.Metrics
 
             var options = new ConsoleExporterOptions();
             configure?.Invoke(options);
-            return builder.AddMetricProcessor(new PushMetricProcessor(new ConsoleMetricExporter(options), options.MetricExportIntervalMilliseconds, options.IsDelta));
+
+            var exporter = new ConsoleMetricExporter(options);
+            return builder.AddMetricReader(new PeriodicExportingMetricReader(exporter, options.MetricExportIntervalMilliseconds));
         }
     }
 }

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterOptions.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+using OpenTelemetry.Metrics;
+
 namespace OpenTelemetry.Exporter
 {
     public class ConsoleExporterOptions
@@ -29,9 +31,9 @@ namespace OpenTelemetry.Exporter
         public int MetricExportIntervalMilliseconds { get; set; } = 1000;
 
         /// <summary>
-        /// Gets or sets a value indicating whether to export Delta
-        /// values or not (Cumulative).
+        /// Gets or sets the AggregationTemporality used for Sum, Histogram
+        /// metrics.
         /// </summary>
-        public bool IsDelta { get; set; } = false;
+        public AggregationTemporality AggregationTemporality { get; set; } = AggregationTemporality.Delta;
     }
 }

--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -23,16 +24,22 @@ using OpenTelemetry.Resources;
 
 namespace OpenTelemetry.Exporter
 {
-    public class ConsoleMetricExporter : ConsoleExporter<Metric>
+    public class ConsoleMetricExporter : MetricExporter
     {
         private Resource resource;
+        private ConsoleExporterOptions options;
 
         public ConsoleMetricExporter(ConsoleExporterOptions options)
-            : base(options)
         {
+            this.options = options;
         }
 
-        public override ExportResult Export(in Batch<Metric> batch)
+        public override AggregationTemporality GetAggregationTemporality()
+        {
+            return this.options.AggregationTemporality;
+        }
+
+        public override ExportResult Export(IEnumerable<Metric> metrics)
         {
             if (this.resource == null)
             {
@@ -49,7 +56,7 @@ namespace OpenTelemetry.Exporter
                 }
             }
 
-            foreach (var metric in batch)
+            foreach (var metric in metrics)
             {
                 var msg = new StringBuilder($"\nExport ");
                 msg.Append(metric.Name);
@@ -160,6 +167,7 @@ namespace OpenTelemetry.Exporter
                     }
 
                     msg = new StringBuilder();
+                    msg.Append("(");
                     msg.Append(metricPoint.StartTime.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", CultureInfo.InvariantCulture));
                     msg.Append(", ");
                     msg.Append(metricPoint.EndTime.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", CultureInfo.InvariantCulture));

--- a/src/OpenTelemetry.Exporter.Prometheus/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/MeterProviderBuilderExtensions.cs
@@ -38,12 +38,13 @@ namespace OpenTelemetry.Metrics
             var options = new PrometheusExporterOptions();
             configure?.Invoke(options);
             var exporter = new PrometheusExporter(options);
-            var pullMetricProcessor = new PullMetricProcessor(exporter, false);
-            exporter.MakePullRequest = pullMetricProcessor.PullRequest;
+
+            var metricReader = new BaseExportingMetricReader(exporter);
+            exporter.CollectMetric = metricReader.Collect;
 
             var metricsHttpServer = new PrometheusExporterMetricsHttpServer(exporter);
             metricsHttpServer.Start();
-            return builder.AddMetricProcessor(pullMetricProcessor);
+            return builder.AddMetricReader(metricReader);
         }
     }
 }

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporter.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporter.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using OpenTelemetry.Metrics;
 
 namespace OpenTelemetry.Exporter
@@ -22,10 +23,10 @@ namespace OpenTelemetry.Exporter
     /// <summary>
     /// Exporter of OpenTelemetry metrics to Prometheus.
     /// </summary>
-    public class PrometheusExporter : BaseExporter<Metric>
+    public class PrometheusExporter : MetricExporter
     {
         internal readonly PrometheusExporterOptions Options;
-        internal Batch<Metric> Batch;
+        internal IEnumerable<Metric> Metrics;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PrometheusExporter"/> class.
@@ -36,11 +37,11 @@ namespace OpenTelemetry.Exporter
             this.Options = options;
         }
 
-        internal Action MakePullRequest { get; set; }
+        internal Action CollectMetric { get; set; }
 
-        public override ExportResult Export(in Batch<Metric> batch)
+        public override ExportResult Export(IEnumerable<Metric> metrics)
         {
-            this.Batch = batch;
+            this.Metrics = metrics;
             return ExportResult.Success;
         }
     }

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterExtensions.cs
@@ -44,7 +44,7 @@ namespace OpenTelemetry.Exporter
         /// <param name="writer">StreamWriter to write to.</param>
         public static void WriteMetricsCollection(this PrometheusExporter exporter, StreamWriter writer)
         {
-            foreach (var metric in exporter.Batch)
+            foreach (var metric in exporter.Metrics)
             {
                 var builder = new PrometheusMetricBuilder()
                     .WithName(metric.Name)

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterMetricsHttpServer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterMetricsHttpServer.cs
@@ -124,7 +124,7 @@ namespace OpenTelemetry.Exporter
 
                     using var output = ctx.Response.OutputStream;
                     using var writer = new StreamWriter(output);
-                    this.exporter.MakePullRequest();
+                    this.exporter.CollectMetric();
                     this.exporter.WriteMetricsCollection(writer);
                 }
             }

--- a/src/OpenTelemetry/Metrics/BaseExportingMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/BaseExportingMetricReader.cs
@@ -1,0 +1,41 @@
+// <copyright file="BaseExportingMetricReader.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+
+namespace OpenTelemetry.Metrics
+{
+    public class BaseExportingMetricReader : MetricReader
+    {
+        private MetricExporter exporter;
+
+        public BaseExportingMetricReader(MetricExporter exporter)
+        {
+            this.exporter = exporter;
+        }
+
+        public override void OnCollect(IEnumerable<Metric> metrics)
+        {
+            this.exporter.Export(metrics);
+        }
+
+        public override AggregationTemporality GetAggregationTemporality()
+        {
+            return this.exporter.GetAggregationTemporality();
+        }
+    }
+}

--- a/src/OpenTelemetry/Metrics/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderBuilderExtensions.cs
@@ -40,6 +40,22 @@ namespace OpenTelemetry.Metrics
         }
 
         /// <summary>
+        /// Add metric processor.
+        /// </summary>
+        /// <param name="meterProviderBuilder"><see cref="MeterProviderBuilder"/>.</param>
+        /// <param name="metricReader">Metricreader.</param>
+        /// <returns><see cref="MeterProvider"/>.</returns>
+        public static MeterProviderBuilder AddMetricReader(this MeterProviderBuilder meterProviderBuilder, MetricReader metricReader)
+        {
+            if (meterProviderBuilder is MeterProviderBuilderSdk meterProviderBuilderSdk)
+            {
+                return meterProviderBuilderSdk.AddMetricReader(metricReader);
+            }
+
+            return meterProviderBuilder;
+        }
+
+        /// <summary>
         /// Sets the <see cref="ResourceBuilder"/> from which the Resource associated with
         /// this provider is built from. Overwrites currently set ResourceBuilder.
         /// </summary>

--- a/src/OpenTelemetry/Metrics/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderBuilderExtensions.cs
@@ -40,7 +40,7 @@ namespace OpenTelemetry.Metrics
         }
 
         /// <summary>
-        /// Add metric processor.
+        /// Add metric reader.
         /// </summary>
         /// <param name="meterProviderBuilder"><see cref="MeterProviderBuilder"/>.</param>
         /// <param name="metricReader">Metricreader.</param>

--- a/src/OpenTelemetry/Metrics/MeterProviderBuilderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderBuilderSdk.cs
@@ -32,6 +32,8 @@ namespace OpenTelemetry.Metrics
 
         internal List<MetricProcessor> MetricProcessors { get; } = new List<MetricProcessor>();
 
+        internal List<MetricReader> MetricReaders { get; } = new List<MetricReader>();
+
         public override MeterProviderBuilder AddInstrumentation<TInstrumentation>(Func<TInstrumentation> instrumentationFactory)
         {
             if (instrumentationFactory == null)
@@ -79,6 +81,12 @@ namespace OpenTelemetry.Metrics
             return this;
         }
 
+        internal MeterProviderBuilderSdk AddMetricReader(MetricReader metricReader)
+        {
+            this.MetricReaders.Add(metricReader);
+            return this;
+        }
+
         internal MeterProviderBuilderSdk SetResourceBuilder(ResourceBuilder resourceBuilder)
         {
             this.resourceBuilder = resourceBuilder ?? throw new ArgumentNullException(nameof(resourceBuilder));
@@ -91,7 +99,8 @@ namespace OpenTelemetry.Metrics
                 this.resourceBuilder.Build(),
                 this.meterSources,
                 this.instrumentationFactories,
-                this.MetricProcessors.ToArray());
+                this.MetricProcessors.ToArray(),
+                this.MetricReaders.ToArray());
         }
 
         // TODO: This is copied from TracerProviderBuilderSdk. Move to common location.

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -167,10 +167,15 @@ namespace OpenTelemetry.Metrics
 
                     return Iterate(this.metrics, indexSnapShot + 1);
 
+                    // We cannot simply return the internal structure (array)
+                    // as the user is not expected to navigate it.
+                    // properly.
                     static IEnumerable<Metric> Iterate(Metric[] metrics, long targetCount)
                     {
                         for (int i = 0; i < targetCount; i++)
                         {
+                            // Check if the Metric has valid
+                            // entries and skip, if not.
                             yield return metrics[i];
                         }
                     }

--- a/src/OpenTelemetry/Metrics/MetricExporter.cs
+++ b/src/OpenTelemetry/Metrics/MetricExporter.cs
@@ -1,0 +1,96 @@
+// <copyright file="MetricExporter.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace OpenTelemetry.Metrics
+{
+    public abstract class MetricExporter : IDisposable
+    {
+        private int shutdownCount;
+
+        public BaseProvider ParentProvider { get; internal set; }
+
+        public abstract ExportResult Export(IEnumerable<Metric> metrics);
+
+        public bool Shutdown(int timeoutMilliseconds = Timeout.Infinite)
+        {
+            if (timeoutMilliseconds < 0 && timeoutMilliseconds != Timeout.Infinite)
+            {
+                throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative.");
+            }
+
+            if (Interlocked.Increment(ref this.shutdownCount) > 1)
+            {
+                return false; // shutdown already called
+            }
+
+            try
+            {
+                return this.OnShutdown(timeoutMilliseconds);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        public bool ForceFlush(int timeoutMilliseconds = Timeout.Infinite)
+        {
+            if (timeoutMilliseconds < 0 && timeoutMilliseconds != Timeout.Infinite)
+            {
+                throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative.");
+            }
+
+            try
+            {
+                return this.OnForceFlush(timeoutMilliseconds);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        public virtual AggregationTemporality GetAggregationTemporality()
+        {
+            return AggregationTemporality.Cumulative;
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual bool OnShutdown(int timeoutMilliseconds)
+        {
+            return true;
+        }
+
+        protected virtual bool OnForceFlush(int timeoutMilliseconds)
+        {
+            return true;
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+        }
+    }
+}

--- a/src/OpenTelemetry/Metrics/MetricReader.cs
+++ b/src/OpenTelemetry/Metrics/MetricReader.cs
@@ -1,0 +1,47 @@
+// <copyright file="MetricReader.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+
+namespace OpenTelemetry.Metrics
+{
+    public abstract class MetricReader
+    {
+        public BaseProvider ParentProvider { get; private set; }
+
+        public virtual void Collect()
+        {
+            var collectMetric = this.ParentProvider.GetMetricCollect();
+            var metricsCollected = collectMetric();
+            this.OnCollect(metricsCollected);
+        }
+
+        public virtual void OnCollect(IEnumerable<Metric> metrics)
+        {
+        }
+
+        public virtual AggregationTemporality GetAggregationTemporality()
+        {
+            return AggregationTemporality.Cumulative;
+        }
+
+        internal virtual void SetParentProvider(BaseProvider parentProvider)
+        {
+            this.ParentProvider = parentProvider;
+        }
+    }
+}

--- a/src/OpenTelemetry/Metrics/PeriodicExportingMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/PeriodicExportingMetricReader.cs
@@ -1,0 +1,56 @@
+// <copyright file="PeriodicExportingMetricReader.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenTelemetry.Metrics
+{
+    public class PeriodicExportingMetricReader : MetricReader
+    {
+        private MetricExporter exporter;
+        private Task exportTask;
+        private CancellationTokenSource token;
+
+        public PeriodicExportingMetricReader(MetricExporter exporter, int exportIntervalMs)
+        {
+            this.exporter = exporter;
+            this.token = new CancellationTokenSource();
+            this.exportTask = new Task(() =>
+            {
+                while (!this.token.IsCancellationRequested)
+                {
+                    Task.Delay(exportIntervalMs).Wait();
+                    this.Collect();
+                }
+            });
+
+            this.exportTask.Start();
+        }
+
+        public override void OnCollect(IEnumerable<Metric> metrics)
+        {
+            this.exporter.Export(metrics);
+        }
+
+        public override AggregationTemporality GetAggregationTemporality()
+        {
+            return this.exporter.GetAggregationTemporality();
+        }
+    }
+}

--- a/src/OpenTelemetry/ProviderExtensions.cs
+++ b/src/OpenTelemetry/ProviderExtensions.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+using System;
+using System.Collections.Generic;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
@@ -47,6 +49,16 @@ namespace OpenTelemetry
             }
 
             return Resource.Empty;
+        }
+
+        public static Func<IEnumerable<Metric>> GetMetricCollect(this BaseProvider baseProvider)
+        {
+            if (baseProvider is MeterProviderSdk meterProviderSdk)
+            {
+                return meterProviderSdk.Collect;
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/OpenTelemetry.Instrumentation.AspNetCore.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/OpenTelemetry.Instrumentation.AspNetCore.Tests.csproj
@@ -20,6 +20,7 @@
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\EventSourceTestHelper.cs" Link="EventSourceTestHelper.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestEventListener.cs" Link="TestEventListener.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestExporter.cs" Link="TestExporter.cs" />
+    <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestMetricExporter.cs" Link="TestMetricExporter.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\InMemoryEventListener.cs" Link="InMemoryEventListener.cs" />
   </ItemGroup>
 

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/OpenTelemetry.Instrumentation.Http.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/OpenTelemetry.Instrumentation.Http.Tests.csproj
@@ -11,6 +11,7 @@
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\EventSourceTestHelper.cs" Link="EventSourceTestHelper.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestEventListener.cs" Link="TestEventListener.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestExporter.cs" Link="TestExporter.cs" />
+    <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestMetricExporter.cs" Link="TestMetricExporter.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\InMemoryEventListener.cs" Link="InMemoryEventListener.cs" />
   </ItemGroup>
 

--- a/test/OpenTelemetry.Tests/Shared/TestMetricExporter.cs
+++ b/test/OpenTelemetry.Tests/Shared/TestMetricExporter.cs
@@ -1,0 +1,39 @@
+// <copyright file="TestMetricExporter.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using OpenTelemetry.Metrics;
+
+namespace OpenTelemetry.Tests
+{
+    internal class TestMetricExporter : MetricExporter
+    {
+        private readonly Action<IEnumerable<Metric>> processBatchAction;
+
+        public TestMetricExporter(Action<IEnumerable<Metric>> processBatchAction)
+        {
+            this.processBatchAction = processBatchAction ?? throw new ArgumentNullException(nameof(processBatchAction));
+        }
+
+        public override ExportResult Export(IEnumerable<Metric> batch)
+        {
+            this.processBatchAction(batch);
+
+            return ExportResult.Success;
+        }
+    }
+}

--- a/test/OpenTelemetry.Tests/Shared/TestMetricExporter.cs
+++ b/test/OpenTelemetry.Tests/Shared/TestMetricExporter.cs
@@ -23,10 +23,17 @@ namespace OpenTelemetry.Tests
     internal class TestMetricExporter : MetricExporter
     {
         private readonly Action<IEnumerable<Metric>> processBatchAction;
+        private AggregationTemporality temporality;
 
-        public TestMetricExporter(Action<IEnumerable<Metric>> processBatchAction)
+        public TestMetricExporter(Action<IEnumerable<Metric>> processBatchAction, AggregationTemporality temporality = AggregationTemporality.Cumulative)
         {
             this.processBatchAction = processBatchAction ?? throw new ArgumentNullException(nameof(processBatchAction));
+            this.temporality = temporality;
+        }
+
+        public override AggregationTemporality GetAggregationTemporality()
+        {
+            return this.temporality;
         }
 
         public override ExportResult Export(IEnumerable<Metric> batch)

--- a/test/OpenTelemetry.Tests/Trace/BatchTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/BatchTest.cs
@@ -26,8 +26,7 @@ namespace OpenTelemetry.Trace.Tests
         public void CheckConstructorExceptions()
         {
             Assert.Throws<ArgumentNullException>(() => new Batch<string>(null));
-
-            // Assert.Throws<ArgumentNullException>(() => new Batch<string>(null, 1));
+            Assert.Throws<ArgumentNullException>(() => new Batch<string>(null, 1));
         }
 
         [Fact]


### PR DESCRIPTION
1. Trying the to-be-merged spec for MetricReader : https://github.com/open-telemetry/opentelemetry-specification/pull/1888/files
Note that we don't support multiple MetricReaders currently, this will be added in follow ups.

2. Replace Batch<Metric> with plan IEnumerable<Metric> as per discussion in https://github.com/open-telemetry/opentelemetry-dotnet/pull/2295#discussion_r700611706

3. Modified Console/Prometheus (To demonstrate one push and one pull based). Rest of the Exporters, and clean up of existing MetricProcessor,Push/PullProcessor will be follow up PR to avoid making this PR even bigger. (Same for proper implementation/lack of it for Flush/Shutdown etc)

4. Addressed this comment: https://github.com/open-telemetry/opentelemetry-dotnet/pull/2141#discussion_r670898590