### PR TITLE
MetricReader cleanups

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterOptions.cs
@@ -31,8 +31,8 @@ namespace OpenTelemetry.Exporter
         public int MetricExportIntervalMilliseconds { get; set; } = 1000;
 
         /// <summary>
-        /// Gets or sets the AggregationTemporality used for Sum, Histogram
-        /// metrics.
+        /// Gets or sets the AggregationTemporality used for Histogram
+        /// and Sum metrics.
         /// </summary>
         public AggregationTemporality AggregationTemporality { get; set; } = AggregationTemporality.Delta;
     }

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterMetricHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterMetricHelperExtensions.cs
@@ -44,7 +44,8 @@ namespace OpenTelemetry.Metrics
 
             var options = new InMemoryExporterOptions();
             configure?.Invoke(options);
-            return builder.AddMetricProcessor(new PushMetricProcessor(new InMemoryExporter<Metric>(exportedItems), options.MetricExportIntervalMilliseconds, options.IsDelta));
+            var exporter = new InMemoryMetricExporter(exportedItems, options);
+            return builder.AddMetricReader(new PeriodicExportingMetricReader(exporter, options.MetricExportIntervalMilliseconds));
         }
     }
 }

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterOptions.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+using OpenTelemetry.Metrics;
+
 namespace OpenTelemetry.Exporter
 {
     public class InMemoryExporterOptions
@@ -24,9 +26,9 @@ namespace OpenTelemetry.Exporter
         public int MetricExportIntervalMilliseconds { get; set; } = 1000;
 
         /// <summary>
-        /// Gets or sets a value indicating whether to export Delta
-        /// values or not (Cumulative).
+        /// Gets or sets the AggregationTemporality used for Histogram
+        /// and Sum metrics.
         /// </summary>
-        public bool IsDelta { get; set; } = true;
+        public AggregationTemporality AggregationTemporality { get; set; } = AggregationTemporality.Delta;
     }
 }

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryMetricExporter.cs
@@ -1,0 +1,53 @@
+// <copyright file="InMemoryMetricExporter.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Collections.Generic;
+using OpenTelemetry.Metrics;
+
+namespace OpenTelemetry.Exporter
+{
+    public class InMemoryMetricExporter : MetricExporter
+    {
+        private readonly ICollection<Metric> exportedItems;
+        private InMemoryExporterOptions options;
+
+        public InMemoryMetricExporter(ICollection<Metric> exportedItems, InMemoryExporterOptions options)
+        {
+            this.exportedItems = exportedItems;
+            this.options = options;
+        }
+
+        public override AggregationTemporality GetAggregationTemporality()
+        {
+            return this.options.AggregationTemporality;
+        }
+
+        public override ExportResult Export(IEnumerable<Metric> metrics)
+        {
+            if (this.exportedItems == null)
+            {
+                return ExportResult.Failure;
+            }
+
+            foreach (var metric in metrics)
+            {
+                this.exportedItems.Add(metric);
+            }
+
+            return ExportResult.Success;
+        }
+    }
+}

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterHelperExtensions.cs
@@ -39,7 +39,7 @@ namespace OpenTelemetry.Metrics
 
             var options = new OtlpExporterOptions();
             configure?.Invoke(options);
-            return builder.AddMetricProcessor(new PushMetricProcessor(new OtlpMetricsExporter(options), options.MetricExportIntervalMilliseconds, options.IsDelta));
+            return builder; // .AddMetricProcessor(new PushMetricProcessor(new OtlpMetricsExporter(options), options.MetricExportIntervalMilliseconds, options.IsDelta));
         }
     }
 }

--- a/src/OpenTelemetry/Metrics/BaseExportingMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/BaseExportingMetricReader.cs
@@ -21,7 +21,8 @@ namespace OpenTelemetry.Metrics
 {
     public class BaseExportingMetricReader : MetricReader
     {
-        private MetricExporter exporter;
+        private readonly MetricExporter exporter;
+        private bool disposed;
 
         public BaseExportingMetricReader(MetricExporter exporter)
         {
@@ -36,6 +37,32 @@ namespace OpenTelemetry.Metrics
         public override AggregationTemporality GetAggregationTemporality()
         {
             return this.exporter.GetAggregationTemporality();
+        }
+
+        internal override void SetParentProvider(BaseProvider parentProvider)
+        {
+            base.SetParentProvider(parentProvider);
+            this.exporter.ParentProvider = parentProvider;
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing && !this.disposed)
+            {
+                try
+                {
+                    this.exporter.Dispose();
+                }
+                catch (Exception)
+                {
+                    // TODO: Log
+                }
+
+                this.disposed = true;
+            }
         }
     }
 }

--- a/src/OpenTelemetry/Metrics/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderBuilderExtensions.cs
@@ -24,22 +24,6 @@ namespace OpenTelemetry.Metrics
     public static class MeterProviderBuilderExtensions
     {
         /// <summary>
-        /// Add metric processor.
-        /// </summary>
-        /// <param name="meterProviderBuilder"><see cref="MeterProviderBuilder"/>.</param>
-        /// <param name="processor">Measurement Processors.</param>
-        /// <returns><see cref="MeterProvider"/>.</returns>
-        public static MeterProviderBuilder AddMetricProcessor(this MeterProviderBuilder meterProviderBuilder, MetricProcessor processor)
-        {
-            if (meterProviderBuilder is MeterProviderBuilderSdk meterProviderBuilderSdk)
-            {
-                return meterProviderBuilderSdk.AddMetricProcessor(processor);
-            }
-
-            return meterProviderBuilder;
-        }
-
-        /// <summary>
         /// Add metric reader.
         /// </summary>
         /// <param name="meterProviderBuilder"><see cref="MeterProviderBuilder"/>.</param>

--- a/src/OpenTelemetry/Metrics/MeterProviderBuilderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderBuilderSdk.cs
@@ -30,8 +30,6 @@ namespace OpenTelemetry.Metrics
         {
         }
 
-        internal List<MetricProcessor> MetricProcessors { get; } = new List<MetricProcessor>();
-
         internal List<MetricReader> MetricReaders { get; } = new List<MetricReader>();
 
         public override MeterProviderBuilder AddInstrumentation<TInstrumentation>(Func<TInstrumentation> instrumentationFactory)
@@ -70,19 +68,13 @@ namespace OpenTelemetry.Metrics
             return this;
         }
 
-        internal MeterProviderBuilderSdk AddMetricProcessor(MetricProcessor processor)
-        {
-            if (this.MetricProcessors.Count >= 1)
-            {
-                throw new InvalidOperationException("Only one MetricProcessor is allowed.");
-            }
-
-            this.MetricProcessors.Add(processor);
-            return this;
-        }
-
         internal MeterProviderBuilderSdk AddMetricReader(MetricReader metricReader)
         {
+            if (this.MetricReaders.Count >= 1)
+            {
+                throw new InvalidOperationException("Only one Metricreader is allowed.");
+            }
+
             this.MetricReaders.Add(metricReader);
             return this;
         }
@@ -99,7 +91,6 @@ namespace OpenTelemetry.Metrics
                 this.resourceBuilder.Build(),
                 this.meterSources,
                 this.instrumentationFactories,
-                this.MetricProcessors.ToArray(),
                 this.MetricReaders.ToArray());
         }
 

--- a/src/OpenTelemetry/Metrics/MetricExporter.cs
+++ b/src/OpenTelemetry/Metrics/MetricExporter.cs
@@ -69,6 +69,9 @@ namespace OpenTelemetry.Metrics
 
         public virtual AggregationTemporality GetAggregationTemporality()
         {
+            // TODO: One suggestion is to have SupportedTemporality
+            // and PrefferedTemporality.
+            // see https://github.com/open-telemetry/opentelemetry-dotnet/pull/2306#discussion_r701532743
             return AggregationTemporality.Cumulative;
         }
 

--- a/src/OpenTelemetry/Metrics/MetricReader.cs
+++ b/src/OpenTelemetry/Metrics/MetricReader.cs
@@ -19,7 +19,7 @@ using System.Collections.Generic;
 
 namespace OpenTelemetry.Metrics
 {
-    public abstract class MetricReader
+    public abstract class MetricReader : IDisposable
     {
         public BaseProvider ParentProvider { get; private set; }
 
@@ -39,9 +39,20 @@ namespace OpenTelemetry.Metrics
             return AggregationTemporality.Cumulative;
         }
 
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
         internal virtual void SetParentProvider(BaseProvider parentProvider)
         {
             this.ParentProvider = parentProvider;
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
         }
     }
 }

--- a/src/OpenTelemetry/Metrics/PeriodicExportingMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/PeriodicExportingMetricReader.cs
@@ -71,6 +71,7 @@ namespace OpenTelemetry.Metrics
             {
                 try
                 {
+                    this.token.Cancel();
                     this.token.Dispose();
                     this.exportTask.Wait();
                     this.exporter.Dispose();

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
@@ -33,7 +33,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
 {
     public class OtlpMetricsExporterTests
     {
-        [Theory]
+        [Theory(Skip = "temporarily disabling")]
         [InlineData(true)]
         [InlineData(false)]
         public void ToOtlpResourceMetricsTest(bool includeServiceNameInResource)
@@ -64,7 +64,6 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
             using var provider = Sdk.CreateMeterProviderBuilder()
                 .SetResourceBuilder(resourceBuilder)
                 .AddSource("TestMeter")
-                .AddMetricProcessor(processor)
                 .Build();
 
             exporter.ParentProvider = provider;


### PR DESCRIPTION
Cleanups following https://github.com/open-telemetry/opentelemetry-dotnet/pull/2306
Temporary disabled OTLP Exporter - @alanwest agreed to modify them to match MetricReader model.