### PR TITLE
Modify MetricPoint to avoid copy

### DIFF
--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -19,7 +19,7 @@ using System.Threading;
 
 namespace OpenTelemetry.Metrics
 {
-    public struct MetricPoint
+    internal struct MetricPoint
     {
         private long longVal;
         private long lastLongSum;

--- a/src/OpenTelemetry/Metrics/MetricPointPointer.cs
+++ b/src/OpenTelemetry/Metrics/MetricPointPointer.cs
@@ -1,0 +1,101 @@
+// <copyright file="MetricPointPointer.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Threading;
+
+namespace OpenTelemetry.Metrics
+{
+    public readonly struct MetricPointPointer
+    {
+        private readonly Memory<MetricPoint> point;
+
+        internal MetricPointPointer(
+            Memory<MetricPoint> point)
+        {
+            if (point.Length != 1)
+            {
+                // TODO: throw
+            }
+
+            this.point = point;
+        }
+
+        public long LongValue
+        {
+            get
+            {
+                return this.point.Span[0].LongValue;
+            }
+        }
+
+        public double DoubleValue
+        {
+            get
+            {
+                return this.point.Span[0].DoubleValue;
+            }
+        }
+
+        public string[] Keys
+        {
+            get
+            {
+                return this.point.Span[0].Keys;
+            }
+        }
+
+        public object[] Values
+        {
+            get
+            {
+                return this.point.Span[0].Values;
+            }
+        }
+
+        public long[] BucketCounts
+        {
+            get
+            {
+                return this.point.Span[0].BucketCounts;
+            }
+        }
+
+        public double[] ExplicitBounds
+        {
+            get
+            {
+                return this.point.Span[0].ExplicitBounds;
+            }
+        }
+
+        public DateTimeOffset StartTime
+        {
+            get
+            {
+                return this.point.Span[0].StartTime;
+            }
+        }
+
+        public DateTimeOffset EndTime
+        {
+            get
+            {
+                return this.point.Span[0].EndTime;
+            }
+        }
+    }
+}

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
@@ -95,7 +95,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             var metric = requestMetrics[0];
             Assert.NotNull(metric);
             Assert.True(metric.MetricType == MetricType.Histogram);
-            var metricPoints = new List<MetricPoint>();
+            var metricPoints = new List<MetricPointPointer>();
             foreach (var p in metric.GetMetricPoints())
             {
                 metricPoints.Add(p);

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.netcore31.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.netcore31.cs
@@ -158,7 +158,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
                 Assert.NotNull(metric);
                 Assert.True(metric.MetricType == MetricType.Histogram);
 
-                var metricPoints = new List<MetricPoint>();
+                var metricPoints = new List<MetricPointPointer>();
                 foreach (var p in metric.GetMetricPoints())
                 {
                     metricPoints.Add(p);
@@ -188,7 +188,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
             else
             {
                 Assert.Single(requestMetrics);
-                var metricPoints = new List<MetricPoint>();
+                var metricPoints = new List<MetricPointPointer>();
                 foreach (var p in requestMetrics[0].GetMetricPoints())
                 {
                     metricPoints.Add(p);


### PR DESCRIPTION
Modify BatchMetricPoint to use MetricPointPointer, which is essentially a pointer to the MetricPoint.
(need better names, if this approach is reasonable.
One option is to rename the current MetricPoint as MetricState, as its an internal state. And use the name "MetricPoint" to the publicly exposed thing (called MetricPointPointer in this PR)).