### PR TITLE
Add basic test for MetricPoint capping

### DIFF
--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -151,8 +151,7 @@ namespace OpenTelemetry.Metrics
 
         internal void SnapShot()
         {
-            var indexSnapShot = this.metricPointIndex;
-            indexSnapShot = Math.Min(this.metricPointIndex, MaxMetricPoints - 1);
+            var indexSnapShot = Math.Min(this.metricPointIndex, MaxMetricPoints - 1);
 
             for (int i = 0; i <= indexSnapShot; i++)
             {

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -151,7 +151,10 @@ namespace OpenTelemetry.Metrics
 
         internal void SnapShot()
         {
-            for (int i = 0; i <= this.metricPointIndex; i++)
+            var indexSnapShot = this.metricPointIndex;
+            indexSnapShot = Math.Min(this.metricPointIndex, MaxMetricPoints - 1);
+
+            for (int i = 0; i <= indexSnapShot; i++)
             {
                 this.metrics[i].TakeSnapShot(this.temporality == AggregationTemporality.Delta ? true : false);
             }
@@ -170,7 +173,8 @@ namespace OpenTelemetry.Metrics
 
         internal BatchMetricPoint GetMetricPoints()
         {
-            return new BatchMetricPoint(this.metrics, this.metricPointIndex + 1, this.startTimeExclusive, this.endTimeInclusive);
+            var indexSnapShot = Math.Min(this.metricPointIndex, MaxMetricPoints - 1);
+            return new BatchMetricPoint(this.metrics, indexSnapShot + 1, this.startTimeExclusive, this.endTimeInclusive);
         }
     }
 }

--- a/src/OpenTelemetry/Metrics/BatchMetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/BatchMetricPoint.cs
@@ -85,7 +85,7 @@ namespace OpenTelemetry.Metrics
             public bool MoveNext()
             {
                 var metricPoints = this.metricsPoints;
-                if (metricPoints[this.index].StartTime == default)
+                if (this.index < this.targetCount && metricPoints[this.index].StartTime == default)
                 {
                     this.index++;
                 }


### PR DESCRIPTION
Adding very basic tests. @mic-max is working to add more coverage.