### PR TITLE
Multithreaded Metrics Tests

### DIFF
--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -307,7 +307,8 @@ namespace OpenTelemetry.Metrics.Tests
 
             var sumReceived = GetDoubleSum(metricItems);
             var expectedSum = deltaDoubleValueUpdatedByEachCall * numberOfMetricUpdateByEachThread * numberOfThreads;
-            Assert.Equal(expectedSum, sumReceived);
+            var difference = Math.Abs(sumReceived - expectedSum);
+            Assert.True(difference <= 0.0001);
         }
 
         private static long GetLongSum(List<Metric> metrics)


### PR DESCRIPTION
Changes
- Added a similar test to the existing Counter but for doubles

Design questions:

- Would this make more sense as a separate file `MetricAPIDoubleCounterTest.cs` and rename the existing one to `MetricAPILongCounterTest.cs`?
- Should I go the route of templating?
  - Bring templating even further by trying to template the tests to be `MultithreadedCounterTest<long>` and `MultithreadedCounterTest<double>` for example.