### PR TITLE
Remove 'en-us' from URLs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,7 @@ jobs:
         # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
         language: ['csharp']
         # Learn more...
-        # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
+        # https://docs.github.com/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
 
     steps:
     - name: configure Pagefile

--- a/build/Common.nonprod.props
+++ b/build/Common.nonprod.props
@@ -22,7 +22,7 @@
   <PropertyGroup Label="Package versions used by test and example projects">
     <!--
       Please sort alphabetically.
-      Refer to https://docs.microsoft.com/en-us/nuget/concepts/package-versioning for semver syntax.
+      Refer to https://docs.microsoft.com/nuget/concepts/package-versioning for semver syntax.
     -->
     <BenchmarkDotNetPkgVer>[0.12.1,0.13)</BenchmarkDotNetPkgVer>
     <CommandLineParserPkgVer>[2.3.0,3.0)</CommandLineParserPkgVer>

--- a/build/Common.props
+++ b/build/Common.props
@@ -19,7 +19,7 @@
   <PropertyGroup Label="Package versions used in this repository">
     <!--
       Please sort alphabetically.
-      Refer to https://docs.microsoft.com/en-us/nuget/concepts/package-versioning for semver syntax.
+      Refer to https://docs.microsoft.com/nuget/concepts/package-versioning for semver syntax.
     -->
     <MinVerPkgVer>[2.3.0,3.0)</MinVerPkgVer>
     <GoogleProtobufPkgVer>[3.15.5,4.0)</GoogleProtobufPkgVer>

--- a/docs/Directory.Build.props
+++ b/docs/Directory.Build.props
@@ -12,7 +12,7 @@
   <PropertyGroup Label="Package versions used in this folder">
     <!--
       Please sort alphabetically.
-      Refer to https://docs.microsoft.com/en-us/nuget/concepts/package-versioning for semver syntax.
+      Refer to https://docs.microsoft.com/nuget/concepts/package-versioning for semver syntax.
     -->
     <MicrosoftExtensionsLoggingPkgVer>[5.0.0,6.0)</MicrosoftExtensionsLoggingPkgVer>
   </PropertyGroup>

--- a/examples/MicroserviceExample/README.md
+++ b/examples/MicroserviceExample/README.md
@@ -55,5 +55,5 @@ With everything running:
 * [Docker Desktop](https://www.docker.com/products/docker-desktop)
 * [OpenTelemetry Project](https://opentelemetry.io/)
 * [RabbitMQ](https://www.rabbitmq.com/)
-* [Worker Service](https://docs.microsoft.com/en-us/azure/azure-monitor/app/worker-service)
+* [Worker Service](https://docs.microsoft.com/azure/azure-monitor/app/worker-service)
 * [Zipkin](https://zipkin.io)

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/CHANGELOG.md
@@ -18,7 +18,7 @@
   [#2240](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2240))
 
 * Updated to use
-  [ActivitySource](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.activitysource)
+  [ActivitySource](https://docs.microsoft.com/dotnet/api/system.diagnostics.activitysource)
   & OpenTelemetry.API
   ([#2249](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2249) &
   follow-ups (linked to #2249))

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/README.md
@@ -14,7 +14,7 @@ If you are using the traditional `packages.config` reference style, a
 `TelemetryHttpModule` for you. If you are using the more modern PackageReference
 style, this may be needed to be done manually. For more information, see:
 [Migrate from packages.config to
-PackageReference](https://docs.microsoft.com/en-us/nuget/consume-packages/migrate-packages-config-to-package-reference).
+PackageReference](https://docs.microsoft.com/nuget/consume-packages/migrate-packages-config-to-package-reference).
 
 To configure your `web.config` manually, add this:
 

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcServer.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcServer.cs
@@ -33,7 +33,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
         public GrpcServer()
         {
             // Allows gRPC client to call insecure gRPC services
-            // https://docs.microsoft.com/en-us/aspnet/core/grpc/troubleshoot?view=aspnetcore-3.1#call-insecure-grpc-services-with-net-core-client
+            // https://docs.microsoft.com/aspnet/core/grpc/troubleshoot?view=aspnetcore-3.1#call-insecure-grpc-services-with-net-core-client
             AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
 
             this.Port = 0;


### PR DESCRIPTION
## Changes

- Removes localization information from URLs so they will bring the clicker to the page of their appropriate language.
- Verified that the URLs all still work properly after the change.