### PR TITLE
Stress test for Metric

### DIFF
--- a/OpenTelemetry.sln
+++ b/OpenTelemetry.sln
@@ -220,6 +220,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "getting-started-observable-
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "getting-started-counter", "docs\metrics\getting-started-counter\getting-started-counter.csproj", "{EA60B549-F712-4ABE-8E44-FCA83B78C06E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StressTestMetrics", "test\StressTestMetrics\StressTestMetrics.csproj", "{A885DBE2-4B82-432C-A77B-19844D7BBC96}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -442,6 +444,10 @@ Global
 		{EA60B549-F712-4ABE-8E44-FCA83B78C06E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EA60B549-F712-4ABE-8E44-FCA83B78C06E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EA60B549-F712-4ABE-8E44-FCA83B78C06E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A885DBE2-4B82-432C-A77B-19844D7BBC96}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A885DBE2-4B82-432C-A77B-19844D7BBC96}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A885DBE2-4B82-432C-A77B-19844D7BBC96}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A885DBE2-4B82-432C-A77B-19844D7BBC96}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -477,6 +483,7 @@ Global
 		{E7F491CC-C37E-4A56-9CA7-8F77F59E0614} = {3277B1C0-BDFE-4460-9B0D-D9A661FB48DB}
 		{43005998-0247-4620-AF88-27DACD48712E} = {3277B1C0-BDFE-4460-9B0D-D9A661FB48DB}
 		{EA60B549-F712-4ABE-8E44-FCA83B78C06E} = {3277B1C0-BDFE-4460-9B0D-D9A661FB48DB}
+		{A885DBE2-4B82-432C-A77B-19844D7BBC96} = {0169B149-FB8B-46F4-9EF7-8A0E69F8FAAF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {55639B5C-0770-4A22-AB56-859604650521}

--- a/test/Benchmarks/Metrics/MetricsBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricsBenchmarks.cs
@@ -76,13 +76,13 @@ namespace Benchmarks.Metrics
             this.provider?.Dispose();
         }
 
-        // [Benchmark]
+        [Benchmark]
         public void CounterHotPath()
         {
             this.counter?.Add(100);
         }
 
-        // [Benchmark]
+        [Benchmark]
         public void CounterWith1LabelsHotPath()
         {
             var tag1 = new KeyValuePair<string, object>("DimName1", this.dimensionValues[this.random.Next(0, 2)]);
@@ -98,15 +98,40 @@ namespace Benchmarks.Metrics
             this.counter?.Add(100, tag1, tag2, tag3);
         }
 
-        // [Benchmark]
+        [Benchmark]
         public void CounterWith5LabelsHotPath()
         {
             var tag1 = new KeyValuePair<string, object>("DimName1", this.dimensionValues[this.random.Next(0, 2)]);
             var tag2 = new KeyValuePair<string, object>("DimName2", this.dimensionValues[this.random.Next(0, 2)]);
             var tag3 = new KeyValuePair<string, object>("DimName3", this.dimensionValues[this.random.Next(0, 5)]);
             var tag4 = new KeyValuePair<string, object>("DimName4", this.dimensionValues[this.random.Next(0, 5)]);
-            var tag5 = new KeyValuePair<string, object>("DimName4", this.dimensionValues[this.random.Next(0, 10)]);
+            var tag5 = new KeyValuePair<string, object>("DimName5", this.dimensionValues[this.random.Next(0, 10)]);
             this.counter?.Add(100, tag1, tag2, tag3, tag4, tag5);
+        }
+
+        [Benchmark]
+        public void CounterWith6LabelsHotPath()
+        {
+            var tag1 = new KeyValuePair<string, object>("DimName1", this.dimensionValues[this.random.Next(0, 2)]);
+            var tag2 = new KeyValuePair<string, object>("DimName2", this.dimensionValues[this.random.Next(0, 2)]);
+            var tag3 = new KeyValuePair<string, object>("DimName3", this.dimensionValues[this.random.Next(0, 5)]);
+            var tag4 = new KeyValuePair<string, object>("DimName4", this.dimensionValues[this.random.Next(0, 5)]);
+            var tag5 = new KeyValuePair<string, object>("DimName5", this.dimensionValues[this.random.Next(0, 5)]);
+            var tag6 = new KeyValuePair<string, object>("DimName6", this.dimensionValues[this.random.Next(0, 2)]);
+            this.counter?.Add(100, tag1, tag2, tag3, tag4, tag5, tag6);
+        }
+
+        [Benchmark]
+        public void CounterWith7LabelsHotPath()
+        {
+            var tag1 = new KeyValuePair<string, object>("DimName1", this.dimensionValues[this.random.Next(0, 2)]);
+            var tag2 = new KeyValuePair<string, object>("DimName2", this.dimensionValues[this.random.Next(0, 2)]);
+            var tag3 = new KeyValuePair<string, object>("DimName3", this.dimensionValues[this.random.Next(0, 5)]);
+            var tag4 = new KeyValuePair<string, object>("DimName4", this.dimensionValues[this.random.Next(0, 5)]);
+            var tag5 = new KeyValuePair<string, object>("DimName5", this.dimensionValues[this.random.Next(0, 5)]);
+            var tag6 = new KeyValuePair<string, object>("DimName6", this.dimensionValues[this.random.Next(0, 2)]);
+            var tag7 = new KeyValuePair<string, object>("DimName7", this.dimensionValues[this.random.Next(0, 1)]);
+            this.counter?.Add(100, tag1, tag2, tag3, tag4, tag5, tag6, tag7);
         }
     }
 }

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -307,7 +307,8 @@ namespace OpenTelemetry.Metrics.Tests
 
             var sumReceived = GetDoubleSum(metricItems);
             var expectedSum = deltaDoubleValueUpdatedByEachCall * numberOfMetricUpdateByEachThread * numberOfThreads;
-            Assert.Equal(expectedSum, sumReceived);
+            var difference = Math.Abs(sumReceived - expectedSum);
+            Assert.True(difference <= 0.0001);
         }
 
         private static long GetLongSum(List<Metric> metrics)

--- a/test/StressTestMetrics/Program.cs
+++ b/test/StressTestMetrics/Program.cs
@@ -36,8 +36,8 @@ namespace OpenTelemetry.Metrics.Tests.Stress
             long maxWritesPerWriter = 10000000;
             var writes = new long[numberOfMetricWriters];
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                    .AddSource("TestMeter")
-                    .Build();
+                .AddSource("TestMeter")
+                .Build();
             Stopwatch sw = new Stopwatch();
             sw.Start();
 

--- a/test/StressTestMetrics/Program.cs
+++ b/test/StressTestMetrics/Program.cs
@@ -1,0 +1,100 @@
+// <copyright file="Program.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+
+public class Program
+{
+    private static readonly Meter MyMeter = new Meter("TestMeter", "0.0.1");
+    private static readonly Counter<long> Counter = MyMeter.CreateCounter<long>("counter");
+    private static string[] dimensionValues = new string[] { "DimVal1", "DimVal2", "DimVal3", "DimVal4", "DimVal5", "DimVal6", "DimVal7", "DimVal8", "DimVal9", "DimVal10" };
+    private static Random random = new Random();
+
+    public static void Main(string[] args)
+    {
+        long numberOfMetricWriters = Environment.ProcessorCount;
+        long maxWritesPerWriter = 10000000;
+        var writes = new long[numberOfMetricWriters];
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+                .AddSource("TestMeter")
+                .Build();
+        Stopwatch sw = new Stopwatch();
+        sw.Start();
+
+        Parallel.Invoke(
+            () =>
+            {
+                var watch = new Stopwatch();
+                while (true)
+                {
+                    long totalWrites = 0;
+                    for (int i = 0; i < numberOfMetricWriters; i++)
+                    {
+                        totalWrites += writes[i];
+                    }
+
+                    watch.Restart();
+                    Thread.Sleep(1000);
+                    watch.Stop();
+
+                    long newTotalWrites = 0;
+                    for (int i = 0; i < numberOfMetricWriters; i++)
+                    {
+                        newTotalWrites += writes[i];
+                    }
+
+                    var writesPerSec = (newTotalWrites - totalWrites) / (watch.ElapsedMilliseconds / 1000.0);
+                    Console.Title = $"Writes (Million/Sec): {writesPerSec / 1000000}";
+
+                    if (totalWrites > numberOfMetricWriters * 10000000)
+                    {
+                        break;
+                    }
+                }
+            }, () =>
+            {
+                Parallel.For(0, Environment.ProcessorCount, i
+                =>
+                {
+                    Console.WriteLine($"Metric push by {i} started.");
+                    while (true)
+                    {
+                        var tag1 = new KeyValuePair<string, object>("DimName1", dimensionValues[random.Next(0, 10)]);
+                        var tag2 = new KeyValuePair<string, object>("DimName2", dimensionValues[random.Next(0, 10)]);
+                        var tag3 = new KeyValuePair<string, object>("DimName3", dimensionValues[random.Next(0, 10)]);
+                        Counter?.Add(100, tag1, tag2, tag3);
+                        writes[i]++;
+                        if (writes[i] > maxWritesPerWriter)
+                        {
+                            break;
+                        }
+                    }
+
+                    Console.WriteLine($"Metric push by {i} completed.");
+                });
+            });
+
+        var rate = (double)(numberOfMetricWriters * 10000000) / (sw.ElapsedMilliseconds / 1000);
+        Console.WriteLine($"{rate / 1000000} Million writes Per Sec.");
+    }
+}

--- a/test/StressTestMetrics/Program.cs
+++ b/test/StressTestMetrics/Program.cs
@@ -66,7 +66,7 @@ namespace OpenTelemetry.Metrics.Tests.Stress
                         var writesPerSec = (newTotalWrites - totalWrites) / (watch.ElapsedMilliseconds / 1000.0);
                         Console.Title = $"Writes (Million/Sec): {writesPerSec / 1000000}";
 
-                        if (totalWrites > numberOfMetricWriters * 10000000)
+                        if (totalWrites > numberOfMetricWriters * maxWritesPerWriter)
                         {
                             break;
                         }
@@ -92,7 +92,7 @@ namespace OpenTelemetry.Metrics.Tests.Stress
                     });
                 });
 
-            var rate = (double)(numberOfMetricWriters * 10000000) / (sw.ElapsedMilliseconds / 1000);
+            var rate = (double)(numberOfMetricWriters * maxWritesPerWriter) / (sw.ElapsedMilliseconds / 1000);
             Console.WriteLine($"{rate / 1000000} M/sec.");
         }
     }

--- a/test/StressTestMetrics/Program.cs
+++ b/test/StressTestMetrics/Program.cs
@@ -73,11 +73,11 @@ namespace OpenTelemetry.Metrics.Tests.Stress
                     }
                 }, () =>
                 {
-                    Parallel.For(0, Environment.ProcessorCount, i
+                    Parallel.For(0, numberOfMetricWriters, i
                     =>
                     {
-                        Console.WriteLine($"Metric push by {i} started.");
-                        while (true)
+                        Console.WriteLine($"Metric writer {i} started.");
+                        while (writes[i]++ < maxWritesPerWriter)
                         {
                             // 10 * 10 * 10 = 1000 unique combination is produced
                             // which is well within the current hard-coded cap of
@@ -86,14 +86,9 @@ namespace OpenTelemetry.Metrics.Tests.Stress
                             var tag2 = new KeyValuePair<string, object>("DimName2", dimensionValues[random.Next(0, 10)]);
                             var tag3 = new KeyValuePair<string, object>("DimName3", dimensionValues[random.Next(0, 10)]);
                             Counter.Add(100, tag1, tag2, tag3);
-                            writes[i]++;
-                            if (writes[i] > maxWritesPerWriter)
-                            {
-                                break;
-                            }
                         }
 
-                        Console.WriteLine($"Metric push by {i} completed.");
+                        Console.WriteLine($"Metric writer {i} completed.");
                     });
                 });
 

--- a/test/StressTestMetrics/Program.cs
+++ b/test/StressTestMetrics/Program.cs
@@ -85,7 +85,7 @@ namespace OpenTelemetry.Metrics.Tests.Stress
                             var tag1 = new KeyValuePair<string, object>("DimName1", dimensionValues[random.Next(0, 10)]);
                             var tag2 = new KeyValuePair<string, object>("DimName2", dimensionValues[random.Next(0, 10)]);
                             var tag3 = new KeyValuePair<string, object>("DimName3", dimensionValues[random.Next(0, 10)]);
-                            Counter?.Add(100, tag1, tag2, tag3);
+                            Counter.Add(100, tag1, tag2, tag3);
                             writes[i]++;
                             if (writes[i] > maxWritesPerWriter)
                             {

--- a/test/StressTestMetrics/README.md
+++ b/test/StressTestMetrics/README.md
@@ -1,0 +1,12 @@
+# OpenTelemetry Metrics Stress Run
+
+Use the following example to run Stress test from command line:
+
+Navigate to `./test/StressTestMetrics` directory and run the following command:
+
+`dotnet run --framework netcoreapp3.1 --configuration Release`
+
+The program shows the writes/sec on the console window title
+and updates it every second.
+
+At the end of the run, it also shows the overall writes/sec.

--- a/test/StressTestMetrics/StressTestMetrics.csproj
+++ b/test/StressTestMetrics/StressTestMetrics.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net462</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry\OpenTelemetry.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
1. Modify benchmark to cover 6,7 dimension scenarios. An upcoming update to Metric API allows optimizations here, so just preparing for that.
2.  Add a test app to constantly write/report Metric measurements from parallel threads. (Benchmarks doesn't seem to be doing this, so need this alternate to really test the multi-thread write)

Want to use this to make some decisions on : 
1. the usage of Dictionary with lock, ConcurrentDictionary
2. Having 2 entries in Dictionary for key lookup - one in the sorted order, and one in whatever order the 1st measurement came in.
3. Testing other scenarios (like cleaning and re-using MetricPoints) and more :)


(The stress test can be modified to even include parallel "MetricReader.collect()" which collects and at the end validate that the outcome is correct!- similar to https://github.com/open-telemetry/opentelemetry-dotnet/pull/1086/files)


Pasting some numbers from my local run:
Runtime | Throughput
net462 | 1.455 M/sec
netcoreapp3.1 | 2.105 M/sec
net5.0 | 2 M/sec