### PR TITLE
Avoid copy MetricPoint in exporter

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -76,7 +76,7 @@ namespace OpenTelemetry.Exporter
 
                 Console.WriteLine(msg.ToString());
 
-                foreach (var metricPoint in metric.GetMetricPoints())
+                foreach (ref var metricPoint in metric.GetMetricPoints())
                 {
                     string valueDisplay = string.Empty;
                     StringBuilder tagsBuilder = new StringBuilder();

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/MetricItemExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/MetricItemExtensions.cs
@@ -144,7 +144,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
                             sum.AggregationTemporality = OtlpMetrics.AggregationTemporality.Cumulative;
                         }
 
-                        foreach (var metricPoint in metric.GetMetricPoints())
+                        foreach (ref var metricPoint in metric.GetMetricPoints())
                         {
                             var dataPoint = new OtlpMetrics.NumberDataPoint
                             {
@@ -179,7 +179,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
                             sum.AggregationTemporality = OtlpMetrics.AggregationTemporality.Cumulative;
                         }
 
-                        foreach (var metricPoint in metric.GetMetricPoints())
+                        foreach (ref var metricPoint in metric.GetMetricPoints())
                         {
                             var dataPoint = new OtlpMetrics.NumberDataPoint
                             {
@@ -204,7 +204,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
                 case MetricType.LongGauge:
                     {
                         var gauge = new OtlpMetrics.Gauge();
-                        foreach (var metricPoint in metric.GetMetricPoints())
+                        foreach (ref var metricPoint in metric.GetMetricPoints())
                         {
                             var dataPoint = new OtlpMetrics.NumberDataPoint
                             {
@@ -229,7 +229,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
                 case MetricType.DoubleGauge:
                     {
                         var gauge = new OtlpMetrics.Gauge();
-                        foreach (var metricPoint in metric.GetMetricPoints())
+                        foreach (ref var metricPoint in metric.GetMetricPoints())
                         {
                             var dataPoint = new OtlpMetrics.NumberDataPoint
                             {
@@ -263,7 +263,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
                             histogram.AggregationTemporality = OtlpMetrics.AggregationTemporality.Cumulative;
                         }
 
-                        foreach (var metricPoint in metric.GetMetricPoints())
+                        foreach (ref var metricPoint in metric.GetMetricPoints())
                         {
                             var dataPoint = new OtlpMetrics.HistogramDataPoint
                             {

--- a/src/OpenTelemetry.Exporter.Prometheus/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Bug fixes
+  ([#2289](https://github.com/open-telemetry/opentelemetry-dotnet/issues/2289))
+  ([#2309](https://github.com/open-telemetry/opentelemetry-dotnet/issues/2309))
+
 ## 1.2.0-alpha2
 
 Released 2021-Aug-24

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterExtensions.cs
@@ -55,7 +55,7 @@ namespace OpenTelemetry.Exporter
                     case MetricType.LongSum:
                         {
                             builder = builder.WithType(PrometheusCounterType);
-                            foreach (var metricPoint in metric.GetMetricPoints())
+                            foreach (ref var metricPoint in metric.GetMetricPoints())
                             {
                                 var metricValueBuilder = builder.AddValue();
                                 metricValueBuilder = metricValueBuilder.WithValue(metricPoint.LongValue);
@@ -75,7 +75,7 @@ namespace OpenTelemetry.Exporter
                     case MetricType.DoubleSum:
                         {
                             builder = builder.WithType(PrometheusCounterType);
-                            foreach (var metricPoint in metric.GetMetricPoints())
+                            foreach (ref var metricPoint in metric.GetMetricPoints())
                             {
                                 var metricValueBuilder = builder.AddValue();
                                 metricValueBuilder = metricValueBuilder.WithValue(metricPoint.DoubleValue);
@@ -95,7 +95,7 @@ namespace OpenTelemetry.Exporter
                     case MetricType.LongGauge:
                         {
                             builder = builder.WithType(PrometheusGaugeType);
-                            foreach (var metricPoint in metric.GetMetricPoints())
+                            foreach (ref var metricPoint in metric.GetMetricPoints())
                             {
                                 var metricValueBuilder = builder.AddValue();
                                 metricValueBuilder = metricValueBuilder.WithValue(metricPoint.LongValue);
@@ -112,7 +112,7 @@ namespace OpenTelemetry.Exporter
                     case MetricType.DoubleGauge:
                         {
                             builder = builder.WithType(PrometheusGaugeType);
-                            foreach (var metricPoint in metric.GetMetricPoints())
+                            foreach (ref var metricPoint in metric.GetMetricPoints())
                             {
                                 var metricValueBuilder = builder.AddValue();
                                 metricValueBuilder = metricValueBuilder.WithValue(metricPoint.DoubleValue);
@@ -146,7 +146,7 @@ namespace OpenTelemetry.Exporter
                              *  myHistogram_bucket{tag1="value1",tag2="value2",le="+Inf"} 355 1629860660991
                             */
                             builder = builder.WithType(PrometheusHistogramType);
-                            foreach (var metricPoint in metric.GetMetricPoints())
+                            foreach (ref var metricPoint in metric.GetMetricPoints())
                             {
                                 var metricValueBuilderSum = builder.AddValue();
                                 metricValueBuilderSum.WithName(metric.Name + PrometheusHistogramSumPostFix);


### PR DESCRIPTION
Actually applying changes from https://github.com/open-telemetry/opentelemetry-dotnet/pull/2321 to each exporters.