### PR TITLE
Refactor MetricReader AggregationTemporality

### DIFF
--- a/src/OpenTelemetry/Metrics/AggregationTemporality.cs
+++ b/src/OpenTelemetry/Metrics/AggregationTemporality.cs
@@ -14,18 +14,31 @@
 // limitations under the License.
 // </copyright>
 
+using System;
+
 namespace OpenTelemetry.Metrics
 {
-    public enum AggregationTemporality
+    [Flags]
+    public enum AggregationTemporality : byte
     {
         /// <summary>
         /// Cumulative.
         /// </summary>
-        Cumulative = 1,
+        Cumulative = 0b1,
 
         /// <summary>
         /// Delta.
         /// </summary>
-        Delta = 2,
+        Delta = 0b10,
+
+        /// <summary>
+        /// Neither.
+        /// </summary>
+        Neither = 0b0,
+
+        /// <summary>
+        /// Both.
+        /// </summary>
+        Both = 0b11,
     }
 }

--- a/src/OpenTelemetry/Metrics/BaseExportingMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/BaseExportingMetricReader.cs
@@ -20,22 +20,19 @@ namespace OpenTelemetry.Metrics
 {
     public class BaseExportingMetricReader : MetricReader
     {
-        private readonly BaseExporter<Metric> exporter;
-        private bool disposed;
+        protected readonly BaseExporter<Metric> exporter;
+        protected bool disposed;
 
         public BaseExportingMetricReader(BaseExporter<Metric> exporter)
         {
-            this.exporter = exporter;
+            this.exporter = exporter ?? throw new ArgumentNullException(nameof(exporter));
+            this.PreferredAggregationTemporality = exporter.GetAggregationTemporality();
+            this.SupportedAggregationTemporality = exporter.GetAggregationTemporality();
         }
 
         public override void OnCollect(Batch<Metric> metrics)
         {
             this.exporter.Export(metrics);
-        }
-
-        public override AggregationTemporality GetAggregationTemporality()
-        {
-            return this.exporter.GetAggregationTemporality();
         }
 
         internal override void SetParentProvider(BaseProvider parentProvider)

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -53,7 +53,7 @@ namespace OpenTelemetry.Metrics
             foreach (var reader in this.metricReaders)
             {
                 reader.SetParentProvider(this);
-                temporality = reader.GetAggregationTemporality();
+                temporality = reader.PreferredAggregationTemporality;
             }
 
             if (instrumentationFactories.Any())

--- a/src/OpenTelemetry/Metrics/MetricReader.cs
+++ b/src/OpenTelemetry/Metrics/MetricReader.cs
@@ -20,7 +20,30 @@ namespace OpenTelemetry.Metrics
 {
     public abstract class MetricReader : IDisposable
     {
+        private AggregationTemporality preferredAggregationTemporality = AggregationTemporality.Both;
+        private AggregationTemporality supportedAggregationTemporality = AggregationTemporality.Both;
+
         public BaseProvider ParentProvider { get; private set; }
+
+        public AggregationTemporality PreferredAggregationTemporality
+        {
+            get => this.preferredAggregationTemporality;
+            set
+            {
+                ValidateAggregationTemporality(value, this.supportedAggregationTemporality);
+                this.preferredAggregationTemporality = value;
+            }
+        }
+
+        public AggregationTemporality SupportedAggregationTemporality
+        {
+            get => this.supportedAggregationTemporality;
+            set
+            {
+                ValidateAggregationTemporality(this.preferredAggregationTemporality, value);
+                this.supportedAggregationTemporality = value;
+            }
+        }
 
         public virtual void Collect()
         {
@@ -31,11 +54,6 @@ namespace OpenTelemetry.Metrics
 
         public virtual void OnCollect(Batch<Metric> metrics)
         {
-        }
-
-        public virtual AggregationTemporality GetAggregationTemporality()
-        {
-            return AggregationTemporality.Cumulative;
         }
 
         /// <inheritdoc/>
@@ -52,6 +70,37 @@ namespace OpenTelemetry.Metrics
 
         protected virtual void Dispose(bool disposing)
         {
+        }
+
+        private static void ValidateAggregationTemporality(AggregationTemporality preferred, AggregationTemporality supported)
+        {
+            if ((int)(preferred & AggregationTemporality.Both) == 0)
+            {
+                throw new ArgumentException($"PreferredAggregationTemporality has an invalid value {preferred}.", nameof(preferred));
+            }
+
+            if ((int)(supported & AggregationTemporality.Both) == 0)
+            {
+                throw new ArgumentException($"SupportedAggregationTemporality has an invalid value {supported}.", nameof(supported));
+            }
+
+            /*
+            | Preferred  | Supported  | Valid |
+            | ---------- | ---------- | ----- |
+            | Both       | Both       | true  |
+            | Both       | Cumulative | false |
+            | Both       | Delta      | false |
+            | Cumulative | Both       | true  |
+            | Cumulative | Cumulative | true  |
+            | Cumulative | Delta      | false |
+            | Delta      | Both       | true  |
+            | Delta      | Cumulative | false |
+            | Delta      | Delta      | true  |
+            */
+            if ((int)(preferred & supported) == 0 || preferred > supported)
+            {
+                throw new ArgumentException($"PreferredAggregationTemporality {preferred} and SupportedAggregationTemporality {supported} are incompatible.");
+            }
         }
     }
 }

--- a/test/Benchmarks/Metrics/MetricCollectBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricCollectBenchmarks.cs
@@ -60,7 +60,7 @@ namespace Benchmarks.Metrics
         [GlobalSetup]
         public void Setup()
         {
-            var metricExporter = new TestExporter<Metric>(ProcessExport);
+            var metricExporter = new TestExporter<Metric>(ProcessExport, AggregationTemporality.Cumulative);
             void ProcessExport(Batch<Metric> batch)
             {
                 double sum = 0;

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
@@ -54,7 +54,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
         public async Task RequestMetricIsCaptured()
         {
             var metricItems = new List<Metric>();
-            var metricExporter = new TestExporter<Metric>(ProcessExport);
+            var metricExporter = new TestExporter<Metric>(ProcessExport, AggregationTemporality.Cumulative);
 
             void ProcessExport(Batch<Metric> batch)
             {

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.netcore31.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.netcore31.cs
@@ -55,7 +55,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
             tc.Url = HttpTestData.NormalizeValues(tc.Url, host, port);
 
             var metricItems = new List<Metric>();
-            var metricExporter = new TestExporter<Metric>(ProcessExport);
+            var metricExporter = new TestExporter<Metric>(ProcessExport, AggregationTemporality.Cumulative);
 
             void ProcessExport(Batch<Metric> batch)
             {

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -232,7 +232,7 @@ namespace OpenTelemetry.Metrics.Tests
         public void MultithreadedLongCounterTest()
         {
             var metricItems = new List<Metric>();
-            var metricExporter = new TestExporter<Metric>(ProcessExport);
+            var metricExporter = new TestExporter<Metric>(ProcessExport, AggregationTemporality.Cumulative);
 
             void ProcessExport(Batch<Metric> batch)
             {
@@ -300,7 +300,7 @@ namespace OpenTelemetry.Metrics.Tests
         public void MultithreadedDoubleCounterTest()
         {
             var metricItems = new List<Metric>();
-            var metricExporter = new TestExporter<Metric>(ProcessExport);
+            var metricExporter = new TestExporter<Metric>(ProcessExport, AggregationTemporality.Cumulative);
 
             void ProcessExport(Batch<Metric> batch)
             {


### PR DESCRIPTION
Follow up https://github.com/open-telemetry/opentelemetry-dotnet/pull/2306#discussion_r701532743.

The eventual goal:
1. MetricExporter should not own `exporting interval`, all the exporters should not know the `exporting interval`.
2. A reader should be able to express `both`, rather than stick with `cumulative` or `delta`, this will be useful for InMemory/Console/OTLP.
3. Simplify the class hierarchy.

## Changes

Please provide a brief description of the changes here.

* introduced `PreferredAggregationTemporality` and `SupportedAggregationTemporality` to `MetricReader`
* optimized the enum
* fixed the base dispose ordering
* added null argument check in MeterReader ctor