### PR TITLE
Improve source matching perf by removing unnecessary capturing groups

### DIFF
--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -177,7 +177,7 @@ namespace OpenTelemetry.Trace
 
                 if (wildcardMode)
                 {
-                    var pattern = "^(" + string.Join("|", from name in sources select '(' + Regex.Escape(name).Replace("\\*", ".*") + ')') + ")$";
+                    var pattern = '^' + string.Join("|", from name in sources select "(?:" + Regex.Escape(name).Replace("\\*", ".*") + ')') + '$';
                     var regex = new Regex(pattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
                     // Function which takes ActivitySource and returns true/false to indicate if it should be subscribed to


### PR DESCRIPTION
## Changes
1. Remove the out most capturing group - should have no functional change.
2. Update inner capturing groups to be non-capturing groups as we only care about whether there is a match but not retrieving the match.