### PR TITLE
Skeleton for Metrics extensibility doc/tutorial

### DIFF
--- a/OpenTelemetry.sln
+++ b/OpenTelemetry.sln
@@ -220,7 +220,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "getting-started-observable-
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "getting-started-counter", "docs\metrics\getting-started-counter\getting-started-counter.csproj", "{EA60B549-F712-4ABE-8E44-FCA83B78C06E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StressTestMetrics", "test\StressTestMetrics\StressTestMetrics.csproj", "{A885DBE2-4B82-432C-A77B-19844D7BBC96}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "extending-the-sdk", "docs\metrics\extending-the-sdk\extending-the-sdk.csproj", "{1F9D7748-D099-4E25-97F5-9C969D6FF969}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StressTestMetrics", "test\StressTestMetrics\StressTestMetrics.csproj", "{A885DBE2-4B82-432C-A77B-19844D7BBC96}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -448,6 +450,10 @@ Global
 		{A885DBE2-4B82-432C-A77B-19844D7BBC96}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A885DBE2-4B82-432C-A77B-19844D7BBC96}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A885DBE2-4B82-432C-A77B-19844D7BBC96}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1F9D7748-D099-4E25-97F5-9C969D6FF969}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1F9D7748-D099-4E25-97F5-9C969D6FF969}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1F9D7748-D099-4E25-97F5-9C969D6FF969}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1F9D7748-D099-4E25-97F5-9C969D6FF969}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -484,6 +490,7 @@ Global
 		{43005998-0247-4620-AF88-27DACD48712E} = {3277B1C0-BDFE-4460-9B0D-D9A661FB48DB}
 		{EA60B549-F712-4ABE-8E44-FCA83B78C06E} = {3277B1C0-BDFE-4460-9B0D-D9A661FB48DB}
 		{A885DBE2-4B82-432C-A77B-19844D7BBC96} = {0169B149-FB8B-46F4-9EF7-8A0E69F8FAAF}
+		{1F9D7748-D099-4E25-97F5-9C969D6FF969} = {3277B1C0-BDFE-4460-9B0D-D9A661FB48DB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {55639B5C-0770-4A22-AB56-859604650521}

--- a/docs/metrics/extending-the-sdk/MyExporter.cs
+++ b/docs/metrics/extending-the-sdk/MyExporter.cs
@@ -1,0 +1,63 @@
+// <copyright file="MyExporter.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Text;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+
+internal class MyExporter : BaseExporter<Metric>
+{
+    private readonly string name;
+
+    public MyExporter(string name = "MyExporter")
+    {
+        this.name = name;
+    }
+
+    public override ExportResult Export(in Batch<Metric> batch)
+    {
+        // SuppressInstrumentationScope should be used to prevent exporter
+        // code from generating telemetry and causing live-loop.
+        using var scope = SuppressInstrumentationScope.Begin();
+
+        var sb = new StringBuilder();
+        foreach (var record in batch)
+        {
+            if (sb.Length > 0)
+            {
+                sb.Append(", ");
+            }
+
+            sb.Append($"{record}");
+            sb.Append(')');
+        }
+
+        Console.WriteLine($"{this.name}.Export([{sb.ToString()}])");
+        return ExportResult.Success;
+    }
+
+    protected override bool OnShutdown(int timeoutMilliseconds)
+    {
+        Console.WriteLine($"{this.name}.OnShutdown(timeoutMilliseconds={timeoutMilliseconds})");
+        return true;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        Console.WriteLine($"{this.name}.Dispose({disposing})");
+    }
+}

--- a/docs/metrics/extending-the-sdk/MyReader.cs
+++ b/docs/metrics/extending-the-sdk/MyReader.cs
@@ -1,0 +1,39 @@
+// <copyright file="MyReader.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+
+internal class MyReader : MetricReader
+{
+    private readonly string name;
+
+    public MyReader(string name = "MyReader")
+    {
+        this.name = name;
+    }
+
+    public override void OnCollect(Batch<Metric> metrics)
+    {
+        Console.WriteLine($"{this.name}.OnCollect({metrics})");
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        Console.WriteLine($"{this.name}.Dispose({disposing})");
+    }
+}

--- a/docs/metrics/extending-the-sdk/Program.cs
+++ b/docs/metrics/extending-the-sdk/Program.cs
@@ -1,0 +1,52 @@
+// <copyright file="Program.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+
+public class Program
+{
+    private static readonly Meter MyMeter = new Meter("MyCompany.MyProduct.MyLibrary", "1.0");
+
+    public static void Main(string[] args)
+    {
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddSource("MyCompany.MyProduct.MyLibrary")
+            .AddMetricReader(new MyReader())
+            /** /
+            TODO: revisit once this exception is removed "System.InvalidOperationException: Only one Metricreader is allowed.".
+            .AddMetricReader(new BaseExportingMetricReader(new MyExporter()))
+            /**/
+            .Build();
+
+        var process = Process.GetCurrentProcess();
+        MyMeter.CreateObservableGauge<long>(
+            "MyGauge",
+            () => new List<Measurement<long>>()
+            {
+                new(process.WorkingSet64, new("process.id", process.Id), new("process.bitness", IntPtr.Size << 3)),
+            });
+
+        var counter = MyMeter.CreateCounter<long>("MyCounter");
+
+        counter.Add(1, new("tag1", "value1"), new("tag2", "value2"));
+        counter.Add(2, new("tag1", "value1"), new("tag2", "value2"));
+    }
+}

--- a/docs/metrics/extending-the-sdk/README.md
+++ b/docs/metrics/extending-the-sdk/README.md
@@ -1,0 +1,20 @@
+# Extending the OpenTelemetry .NET SDK
+
+* [Building your own exporter](#exporter)
+* [Building your own reader](#reader)
+* [Building your own exemplar](#exemplar)
+* [References](#references)
+
+## Exporter
+
+TBD
+
+## Reader
+
+TBD
+
+## Exemplar
+
+TBD
+
+## References

--- a/docs/metrics/extending-the-sdk/extending-the-sdk.csproj
+++ b/docs/metrics/extending-the-sdk/extending-the-sdk.csproj
@@ -1,0 +1,5 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry\OpenTelemetry.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Similar like what we did for tracing/logging, have an `extending-the-sdk` project to show users how to write custom readers and exporters (and exemplars).