### PR TITLE
.NET Framework HttpClient Instrumentation: Fix missing events on instances created before TracerProvider (Part 2)

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Removes .NET Framework 4.5.2 support. The minimum .NET Framework
   version supported is .NET 4.6.1. ([#2138](https://github.com/open-telemetry/opentelemetry-dotnet/issues/2138))
 
+* HttpClient instances created before AddHttpClientInstrumentation is called on
+  .NET Framework will now also be instrumented
+  ([#2364](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2364))
+
 ## 1.0.0-rc7
 
 Released 2021-Jul-12

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -5,8 +5,8 @@
 * Removes .NET Framework 4.5.2 support. The minimum .NET Framework
   version supported is .NET 4.6.1. ([#2138](https://github.com/open-telemetry/opentelemetry-dotnet/issues/2138))
 
-* `HttpClient` instances created before `AddHttpClientInstrumentation` is called on
-  .NET Framework will now also be instrumented
+* `HttpClient` instances created before `AddHttpClientInstrumentation` is called
+  on .NET Framework will now also be instrumented
   ([#2364](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2364))
 
 ## 1.0.0-rc7

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Removes .NET Framework 4.5.2 support. The minimum .NET Framework
   version supported is .NET 4.6.1. ([#2138](https://github.com/open-telemetry/opentelemetry-dotnet/issues/2138))
 
-* HttpClient instances created before AddHttpClientInstrumentation is called on
+* `HttpClient` instances created before `AddHttpClientInstrumentation` is called on
   .NET Framework will now also be instrumented
   ([#2364](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2364))
 

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.Basic.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.Basic.netfx.cs
@@ -264,6 +264,24 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
                 })
                 .Build();
         }
+
+        [Fact]
+        public async Task HttpWebRequestInstrumentationOnExistingInstance()
+        {
+            using HttpClient client = new HttpClient();
+
+            await client.GetAsync(this.url).ConfigureAwait(false);
+
+            var activityProcessor = new Mock<BaseProcessor<Activity>>();
+            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+                .AddProcessor(activityProcessor.Object)
+                .AddHttpClientInstrumentation()
+                .Build();
+
+            await client.GetAsync(this.url).ConfigureAwait(false);
+
+            Assert.Equal(3, activityProcessor.Invocations.Count);  // SetParentProvider/Begin/End called
+        }
     }
 }
 #endif


### PR DESCRIPTION
Follow-up to #2364 

## Changes

* Updated CHANGELOG
* Added a unit test
* Fixed an issue the unit test exposed
