### PR TITLE
Leverage new TagList for avoid allocs in metric reporting

### DIFF
--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -152,28 +152,40 @@ namespace OpenTelemetry.Metrics
 
         internal void UpdateLong(long value, ReadOnlySpan<KeyValuePair<string, object>> tags)
         {
-            var index = this.FindMetricAggregators(tags);
-            if (index < 0)
+            try
             {
-                // Log that measurement is dropped as max MetricPoints reached
-                // for this instrument.
-                return;
-            }
+                var index = this.FindMetricAggregators(tags);
+                if (index < 0)
+                {
+                    // TODO: Measurement dropped due to MemoryPoint cap hit.
+                    return;
+                }
 
-            this.metrics[index].Update(value);
+                this.metrics[index].Update(value);
+            }
+            catch (Exception)
+            {
+                // TODO: Measurement dropped due to internal exception.
+            }
         }
 
         internal void UpdateDouble(double value, ReadOnlySpan<KeyValuePair<string, object>> tags)
         {
-            var index = this.FindMetricAggregators(tags);
-            if (index < 0)
+            try
             {
-                // Log that measurement is dropped as max MetricPoints reached
-                // for this instrument.
-                return;
-            }
+                var index = this.FindMetricAggregators(tags);
+                if (index < 0)
+                {
+                    // TODO: Measurement dropped due to MemoryPoint cap hit.
+                    return;
+                }
 
-            this.metrics[index].Update(value);
+                this.metrics[index].Update(value);
+            }
+            catch (Exception)
+            {
+                // TODO: Measurement dropped due to internal exception.
+            }
         }
 
         internal void SnapShot()

--- a/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
+++ b/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
@@ -22,18 +22,18 @@ namespace OpenTelemetry.Metrics
 {
     internal class ThreadStaticStorage
     {
-        private const int MaxTagCacheSize = 3;
+        private const int MaxTagCacheSize = 8;
 
         [ThreadStatic]
         private static ThreadStaticStorage storage;
 
-        private readonly TagStorage[] tagStorage = new TagStorage[MaxTagCacheSize + 1];
+        private readonly TagStorage[] tagStorage = new TagStorage[MaxTagCacheSize];
 
         private ThreadStaticStorage()
         {
-            for (int i = 0; i <= MaxTagCacheSize; i++)
+            for (int i = 0; i < MaxTagCacheSize; i++)
             {
-                this.tagStorage[i] = new TagStorage(i);
+                this.tagStorage[i] = new TagStorage(i + 1);
             }
         }
 
@@ -53,10 +53,15 @@ namespace OpenTelemetry.Metrics
         {
             var len = tags.Length;
 
+            if (len == 0)
+            {
+                throw new InvalidOperationException("There must be atleast one tag to use ThreadStaticStorage.");
+            }
+
             if (len <= MaxTagCacheSize)
             {
-                tagKeys = this.tagStorage[len].TagKey;
-                tagValues = this.tagStorage[len].TagValue;
+                tagKeys = this.tagStorage[len - 1].TagKey;
+                tagValues = this.tagStorage[len - 1].TagValue;
             }
             else
             {
@@ -73,17 +78,12 @@ namespace OpenTelemetry.Metrics
 
         internal class TagStorage
         {
-            // Used to copy ReadOnlySpan from API
-            internal readonly KeyValuePair<string, object>[] Tags;
-
-            // Used to split into Key sequence, Value sequence, and KVPs for Aggregator Processor
+            // Used to split into Key sequence, Value sequence.
             internal readonly string[] TagKey;
             internal readonly object[] TagValue;
 
             internal TagStorage(int n)
             {
-                this.Tags = new KeyValuePair<string, object>[n];
-
                 this.TagKey = new string[n];
                 this.TagValue = new object[n];
             }

--- a/test/Benchmarks/Metrics/MetricsBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricsBenchmarks.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using BenchmarkDotNet.Attributes;
 using OpenTelemetry;
@@ -56,7 +57,7 @@ namespace Benchmarks.Metrics
         private Random random = new Random();
         private string[] dimensionValues = new string[] { "DimVal1", "DimVal2", "DimVal3", "DimVal4", "DimVal5", "DimVal6", "DimVal7", "DimVal8", "DimVal9", "DimVal10" };
 
-        [Params(false, true)]
+        [Params(true)]
         public bool WithSDK { get; set; }
 
         [GlobalSetup]
@@ -80,20 +81,20 @@ namespace Benchmarks.Metrics
             this.provider?.Dispose();
         }
 
-        [Benchmark]
+        // [Benchmark]
         public void CounterHotPath()
         {
             this.counter?.Add(100);
         }
 
-        [Benchmark]
+        // [Benchmark]
         public void CounterWith1LabelsHotPath()
         {
             var tag1 = new KeyValuePair<string, object>("DimName1", this.dimensionValues[this.random.Next(0, 2)]);
             this.counter?.Add(100, tag1);
         }
 
-        [Benchmark]
+        // [Benchmark]
         public void CounterWith3LabelsHotPath()
         {
             var tag1 = new KeyValuePair<string, object>("DimName1", this.dimensionValues[this.random.Next(0, 10)]);
@@ -105,37 +106,46 @@ namespace Benchmarks.Metrics
         [Benchmark]
         public void CounterWith5LabelsHotPath()
         {
-            var tag1 = new KeyValuePair<string, object>("DimName1", this.dimensionValues[this.random.Next(0, 2)]);
-            var tag2 = new KeyValuePair<string, object>("DimName2", this.dimensionValues[this.random.Next(0, 2)]);
-            var tag3 = new KeyValuePair<string, object>("DimName3", this.dimensionValues[this.random.Next(0, 5)]);
-            var tag4 = new KeyValuePair<string, object>("DimName4", this.dimensionValues[this.random.Next(0, 5)]);
-            var tag5 = new KeyValuePair<string, object>("DimName5", this.dimensionValues[this.random.Next(0, 10)]);
-            this.counter?.Add(100, tag1, tag2, tag3, tag4, tag5);
+            var tags = new TagList
+            {
+                { "DimName1", this.dimensionValues[this.random.Next(0, 2)] },
+                { "DimName2", this.dimensionValues[this.random.Next(0, 2)] },
+                { "DimName3", this.dimensionValues[this.random.Next(0, 5)] },
+                { "DimName4", this.dimensionValues[this.random.Next(0, 5)] },
+                { "DimName5", this.dimensionValues[this.random.Next(0, 10)] },
+            };
+            this.counter?.Add(100, tags);
         }
 
         [Benchmark]
         public void CounterWith6LabelsHotPath()
         {
-            var tag1 = new KeyValuePair<string, object>("DimName1", this.dimensionValues[this.random.Next(0, 2)]);
-            var tag2 = new KeyValuePair<string, object>("DimName2", this.dimensionValues[this.random.Next(0, 2)]);
-            var tag3 = new KeyValuePair<string, object>("DimName3", this.dimensionValues[this.random.Next(0, 5)]);
-            var tag4 = new KeyValuePair<string, object>("DimName4", this.dimensionValues[this.random.Next(0, 5)]);
-            var tag5 = new KeyValuePair<string, object>("DimName5", this.dimensionValues[this.random.Next(0, 5)]);
-            var tag6 = new KeyValuePair<string, object>("DimName6", this.dimensionValues[this.random.Next(0, 2)]);
-            this.counter?.Add(100, tag1, tag2, tag3, tag4, tag5, tag6);
+            var tags = new TagList
+            {
+                { "DimName1", this.dimensionValues[this.random.Next(0, 2)] },
+                { "DimName2", this.dimensionValues[this.random.Next(0, 2)] },
+                { "DimName3", this.dimensionValues[this.random.Next(0, 5)] },
+                { "DimName4", this.dimensionValues[this.random.Next(0, 5)] },
+                { "DimName5", this.dimensionValues[this.random.Next(0, 5)] },
+                { "DimName6", this.dimensionValues[this.random.Next(0, 2)] },
+            };
+            this.counter?.Add(100, tags);
         }
 
         [Benchmark]
         public void CounterWith7LabelsHotPath()
         {
-            var tag1 = new KeyValuePair<string, object>("DimName1", this.dimensionValues[this.random.Next(0, 2)]);
-            var tag2 = new KeyValuePair<string, object>("DimName2", this.dimensionValues[this.random.Next(0, 2)]);
-            var tag3 = new KeyValuePair<string, object>("DimName3", this.dimensionValues[this.random.Next(0, 5)]);
-            var tag4 = new KeyValuePair<string, object>("DimName4", this.dimensionValues[this.random.Next(0, 5)]);
-            var tag5 = new KeyValuePair<string, object>("DimName5", this.dimensionValues[this.random.Next(0, 5)]);
-            var tag6 = new KeyValuePair<string, object>("DimName6", this.dimensionValues[this.random.Next(0, 2)]);
-            var tag7 = new KeyValuePair<string, object>("DimName7", this.dimensionValues[this.random.Next(0, 1)]);
-            this.counter?.Add(100, tag1, tag2, tag3, tag4, tag5, tag6, tag7);
+            var tags = new TagList
+            {
+                { "DimName1", this.dimensionValues[this.random.Next(0, 2)] },
+                { "DimName2", this.dimensionValues[this.random.Next(0, 2)] },
+                { "DimName3", this.dimensionValues[this.random.Next(0, 5)] },
+                { "DimName4", this.dimensionValues[this.random.Next(0, 5)] },
+                { "DimName5", this.dimensionValues[this.random.Next(0, 5)] },
+                { "DimName6", this.dimensionValues[this.random.Next(0, 2)] },
+                { "DimName7", this.dimensionValues[this.random.Next(0, 1)] },
+            };
+            this.counter?.Add(100, tags);
         }
     }
 }

--- a/test/Benchmarks/Metrics/MetricsBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricsBenchmarks.cs
@@ -81,20 +81,17 @@ namespace Benchmarks.Metrics
             this.provider?.Dispose();
         }
 
-        // [Benchmark]
         public void CounterHotPath()
         {
             this.counter?.Add(100);
         }
 
-        // [Benchmark]
         public void CounterWith1LabelsHotPath()
         {
             var tag1 = new KeyValuePair<string, object>("DimName1", this.dimensionValues[this.random.Next(0, 2)]);
             this.counter?.Add(100, tag1);
         }
 
-        // [Benchmark]
         public void CounterWith3LabelsHotPath()
         {
             var tag1 = new KeyValuePair<string, object>("DimName1", this.dimensionValues[this.random.Next(0, 10)]);
@@ -114,7 +111,7 @@ namespace Benchmarks.Metrics
                 { "DimName4", this.dimensionValues[this.random.Next(0, 5)] },
                 { "DimName5", this.dimensionValues[this.random.Next(0, 10)] },
             };
-            this.counter?.Add(100, tags);
+            this.counter?.Add(100,tags);
         }
 
         [Benchmark]


### PR DESCRIPTION
Taking advantage of new RC1 feature - using TagList.
Also modified ThreadStaticStorage to support alloc-free upto 8.

Will post benchmarks here. (an initial ran show allocs going to 0, as expected, but the duration increased by ~100ns)
Running once more.