### PR TITLE
Refactor MetricReader Collect/OnCollect

### DIFF
--- a/docs/metrics/extending-the-sdk/MyReader.cs
+++ b/docs/metrics/extending-the-sdk/MyReader.cs
@@ -27,9 +27,10 @@ internal class MyReader : MetricReader
         this.name = name;
     }
 
-    public override void OnCollect(Batch<Metric> metrics)
+    protected override bool OnCollect(Batch<Metric> metrics, int timeoutMilliseconds)
     {
-        Console.WriteLine($"{this.name}.OnCollect({metrics})");
+        Console.WriteLine($"{this.name}.OnCollect(metrics={metrics}, timeoutMilliseconds={timeoutMilliseconds})");
+        return true;
     }
 
     protected override bool OnForceFlush(int timeoutMilliseconds)

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporter.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporter.cs
@@ -39,7 +39,7 @@ namespace OpenTelemetry.Exporter
             this.Options = options;
         }
 
-        internal Action CollectMetric { get; set; }
+        internal Func<int, bool> CollectMetric { get; set; }
 
         public override ExportResult Export(in Batch<Metric> metrics)
         {

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterMetricsHttpServer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterMetricsHttpServer.cs
@@ -124,7 +124,7 @@ namespace OpenTelemetry.Exporter
 
                     using var output = ctx.Response.OutputStream;
                     using var writer = new StreamWriter(output);
-                    this.exporter.CollectMetric();
+                    this.exporter.CollectMetric(Timeout.Infinite);
                     this.exporter.WriteMetricsCollection(writer);
                 }
             }

--- a/src/OpenTelemetry/Metrics/BaseExportingMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/BaseExportingMetricReader.cs
@@ -47,16 +47,16 @@ namespace OpenTelemetry.Metrics
 
         protected ExportModes SupportedExportModes => this.supportedExportModes;
 
-        /// <inheritdoc/>
-        public override void OnCollect(Batch<Metric> metrics)
-        {
-            this.exporter.Export(metrics);
-        }
-
         internal override void SetParentProvider(BaseProvider parentProvider)
         {
             base.SetParentProvider(parentProvider);
             this.exporter.ParentProvider = parentProvider;
+        }
+
+        /// <inheritdoc/>
+        protected override bool OnCollect(Batch<Metric> metrics, int timeoutMilliseconds)
+        {
+            return this.exporter.Export(metrics) == ExportResult.Success;
         }
 
         /// <inheritdoc/>

--- a/src/OpenTelemetry/Metrics/PeriodicExportingMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/PeriodicExportingMetricReader.cs
@@ -55,11 +55,6 @@ namespace OpenTelemetry.Metrics
             this.exportTask.Start();
         }
 
-        public override void OnCollect(Batch<Metric> metrics)
-        {
-            this.exporter.Export(metrics);
-        }
-
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)
         {


### PR DESCRIPTION
* Made `MetricReader.OnCollect` protected
* Added timeout / return value to Collect/OnCollect
* Made `CompositeMetricReader` internal for now (we probably don't need it to be public)