### PR TITLE
Add MeterProvider.ForceFlush and Shutdown

### DIFF
--- a/src/OpenTelemetry/Metrics/CompositeMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/CompositeMetricReader.cs
@@ -97,6 +97,8 @@ namespace OpenTelemetry.Metrics
 
         protected override bool OnCollect(Batch<Metric> metrics, int timeoutMilliseconds)
         {
+            // CompositeMetricReader delegates the work to its underlying readers,
+            // so CompositeMetricReader.OnCollect should never be called.
             throw new NotImplementedException();
         }
 

--- a/src/OpenTelemetry/Metrics/MeterProviderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderExtensions.cs
@@ -1,0 +1,126 @@
+// <copyright file="MeterProviderExtensions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Metrics
+{
+    public static class MeterProviderExtensions
+    {
+        /// <summary>
+        /// Flushes the all the processors at MeterProviderSdk, blocks the current thread until flush
+        /// completed, shutdown signaled or timed out.
+        /// </summary>
+        /// <param name="provider">MeterProviderSdk instance on which ForceFlush will be called.</param>
+        /// <param name="timeoutMilliseconds">
+        /// The number of milliseconds to wait, or <c>Timeout.Infinite</c> to
+        /// wait indefinitely.
+        /// </param>
+        /// <returns>
+        /// Returns <c>true</c> when force flush succeeded; otherwise, <c>false</c>.
+        /// </returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the <c>timeoutMilliseconds</c> is smaller than -1.
+        /// </exception>
+        /// <remarks>
+        /// This function guarantees thread-safety.
+        /// </remarks>
+        public static bool ForceFlush(this MeterProvider provider, int timeoutMilliseconds = Timeout.Infinite)
+        {
+            if (provider == null)
+            {
+                throw new ArgumentNullException(nameof(provider));
+            }
+
+            if (provider is MeterProviderSdk meterProviderSdk)
+            {
+                if (timeoutMilliseconds < 0 && timeoutMilliseconds != Timeout.Infinite)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative.");
+                }
+
+                try
+                {
+                    return meterProviderSdk.OnForceFlush(timeoutMilliseconds);
+                }
+                catch (Exception)
+                {
+                    // TODO: what event source do we use?
+                    // OpenTelemetrySdkEventSource.Log.MeterProviderException(nameof(meterProviderSdk.OnForceFlush), ex);
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Attempts to shutdown the MeterProviderSdk, blocks the current thread until
+        /// shutdown completed or timed out.
+        /// </summary>
+        /// <param name="provider">MeterProviderSdk instance on which Shutdown will be called.</param>
+        /// <param name="timeoutMilliseconds">
+        /// The number of milliseconds to wait, or <c>Timeout.Infinite</c> to
+        /// wait indefinitely.
+        /// </param>
+        /// <returns>
+        /// Returns <c>true</c> when shutdown succeeded; otherwise, <c>false</c>.
+        /// </returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the <c>timeoutMilliseconds</c> is smaller than -1.
+        /// </exception>
+        /// <remarks>
+        /// This function guarantees thread-safety. Only the first call will
+        /// win, subsequent calls will be no-op.
+        /// </remarks>
+        public static bool Shutdown(this MeterProvider provider, int timeoutMilliseconds = Timeout.Infinite)
+        {
+            if (provider == null)
+            {
+                throw new ArgumentNullException(nameof(provider));
+            }
+
+            if (provider is MeterProviderSdk meterProviderSdk)
+            {
+                if (timeoutMilliseconds < 0 && timeoutMilliseconds != Timeout.Infinite)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative.");
+                }
+
+                if (Interlocked.Increment(ref meterProviderSdk.ShutdownCount) > 1)
+                {
+                    return false; // shutdown already called
+                }
+
+                try
+                {
+                    return meterProviderSdk.OnShutdown(timeoutMilliseconds);
+                }
+                catch (Exception)
+                {
+                    // TODO: what event source do we use?
+                    // OpenTelemetrySdkEventSource.Log.MeterProviderException(nameof(meterProviderSdk.OnShutdown), ex);
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/OpenTelemetry/Metrics/MeterProviderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderExtensions.cs
@@ -24,8 +24,8 @@ namespace OpenTelemetry.Metrics
     public static class MeterProviderExtensions
     {
         /// <summary>
-        /// Flushes the all the processors at MeterProviderSdk, blocks the current thread until flush
-        /// completed, shutdown signaled or timed out.
+        /// Flushes all the readers registered under MeterProviderSdk, blocks the current thread
+        /// until flush completed, shutdown signaled or timed out.
         /// </summary>
         /// <param name="provider">MeterProviderSdk instance on which ForceFlush will be called.</param>
         /// <param name="timeoutMilliseconds">

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -24,10 +24,10 @@ using OpenTelemetry.Resources;
 
 namespace OpenTelemetry.Metrics
 {
-    public class MeterProviderSdk
-        : MeterProvider
+    internal sealed class MeterProviderSdk : MeterProvider
     {
         internal const int MaxMetrics = 1000;
+        internal int ShutdownCount;
         private readonly Metric[] metrics;
         private readonly List<object> instrumentations = new List<object>();
         private readonly object collectLock = new object();

--- a/src/OpenTelemetry/Trace/TracerProviderExtensions.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderExtensions.cs
@@ -44,8 +44,8 @@ namespace OpenTelemetry.Trace
         }
 
         /// <summary>
-        /// Flushes the all the processors at TracerProviderSdk, blocks the current thread until flush
-        /// completed, shutdown signaled or timed out.
+        /// Flushes all the processors registered under TracerProviderSdk, blocks the current thread
+        /// until flush completed, shutdown signaled or timed out.
         /// </summary>
         /// <param name="provider">TracerProviderSdk instance on which ForceFlush will be called.</param>
         /// <param name="timeoutMilliseconds">


### PR DESCRIPTION
* Added extension methods `MeterProvider.ForceFlush` and `MeterProvider.Shutdown`.
* Changed `MeterProviderSdk` class from public to internal.
* Added a comment per suggestion from https://github.com/open-telemetry/opentelemetry-dotnet/pull/2380/files#r711395454.