### PR TITLE
Update ForceFlush behavior to meet with the latest spec requirements

### DIFF
--- a/src/OpenTelemetry/BaseExporter.cs
+++ b/src/OpenTelemetry/BaseExporter.cs
@@ -62,8 +62,8 @@ namespace OpenTelemetry
         /// shutdown completed or timed out.
         /// </summary>
         /// <param name="timeoutMilliseconds">
-        /// The number of milliseconds to wait, or <c>Timeout.Infinite</c> to
-        /// wait indefinitely.
+        /// The number (non-negative) of milliseconds to wait, or
+        /// <c>Timeout.Infinite</c> to wait indefinitely.
         /// </param>
         /// <returns>
         /// Returns <c>true</c> when shutdown succeeded; otherwise, <c>false</c>.
@@ -110,8 +110,8 @@ namespace OpenTelemetry
         /// thread until shutdown completed or timed out.
         /// </summary>
         /// <param name="timeoutMilliseconds">
-        /// The number of milliseconds to wait, or <c>Timeout.Infinite</c> to
-        /// wait indefinitely.
+        /// The number (non-negative) of milliseconds to wait, or
+        /// <c>Timeout.Infinite</c> to wait indefinitely.
         /// </param>
         /// <returns>
         /// Returns <c>true</c> when shutdown succeeded; otherwise, <c>false</c>.

--- a/src/OpenTelemetry/BaseExporter.cs
+++ b/src/OpenTelemetry/BaseExporter.cs
@@ -79,7 +79,7 @@ namespace OpenTelemetry
         {
             if (timeoutMilliseconds < 0 && timeoutMilliseconds != Timeout.Infinite)
             {
-                throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative.");
+                throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative or Timeout.Infinite.");
             }
 
             if (Interlocked.Increment(ref this.shutdownCount) > 1)

--- a/src/OpenTelemetry/BaseProcessor.cs
+++ b/src/OpenTelemetry/BaseProcessor.cs
@@ -84,7 +84,7 @@ namespace OpenTelemetry
         {
             if (timeoutMilliseconds < 0 && timeoutMilliseconds != Timeout.Infinite)
             {
-                throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative.");
+                throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative or Timeout.Infinite.");
             }
 
             try
@@ -120,7 +120,7 @@ namespace OpenTelemetry
         {
             if (timeoutMilliseconds < 0 && timeoutMilliseconds != Timeout.Infinite)
             {
-                throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative.");
+                throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative or Timeout.Infinite.");
             }
 
             if (Interlocked.Increment(ref this.shutdownCount) > 1)

--- a/src/OpenTelemetry/BaseProcessor.cs
+++ b/src/OpenTelemetry/BaseProcessor.cs
@@ -68,8 +68,8 @@ namespace OpenTelemetry
         /// completed, shutdown signaled or timed out.
         /// </summary>
         /// <param name="timeoutMilliseconds">
-        /// The number of milliseconds to wait, or <c>Timeout.Infinite</c> to
-        /// wait indefinitely.
+        /// The number (non-negative) of milliseconds to wait, or
+        /// <c>Timeout.Infinite</c> to wait indefinitely.
         /// </param>
         /// <returns>
         /// Returns <c>true</c> when flush succeeded; otherwise, <c>false</c>.
@@ -103,8 +103,8 @@ namespace OpenTelemetry
         /// shutdown completed or timed out.
         /// </summary>
         /// <param name="timeoutMilliseconds">
-        /// The number of milliseconds to wait, or <c>Timeout.Infinite</c> to
-        /// wait indefinitely.
+        /// The number (non-negative) of milliseconds to wait, or
+        /// <c>Timeout.Infinite</c> to wait indefinitely.
         /// </param>
         /// <returns>
         /// Returns <c>true</c> when shutdown succeeded; otherwise, <c>false</c>.
@@ -156,8 +156,8 @@ namespace OpenTelemetry
         /// thread until flush completed, shutdown signaled or timed out.
         /// </summary>
         /// <param name="timeoutMilliseconds">
-        /// The number of milliseconds to wait, or <c>Timeout.Infinite</c> to
-        /// wait indefinitely.
+        /// The number (non-negative) of milliseconds to wait, or
+        /// <c>Timeout.Infinite</c> to wait indefinitely.
         /// </param>
         /// <returns>
         /// Returns <c>true</c> when flush succeeded; otherwise, <c>false</c>.
@@ -177,8 +177,8 @@ namespace OpenTelemetry
         /// thread until shutdown completed or timed out.
         /// </summary>
         /// <param name="timeoutMilliseconds">
-        /// The number of milliseconds to wait, or <c>Timeout.Infinite</c> to
-        /// wait indefinitely.
+        /// The number (non-negative) of milliseconds to wait, or
+        /// <c>Timeout.Infinite</c> to wait indefinitely.
         /// </param>
         /// <returns>
         /// Returns <c>true</c> when shutdown succeeded; otherwise, <c>false</c>.

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Changed `CompositeProcessor<T>.OnForceFlush` to meet with the spec
+  requirement. Now the SDK will invoke `ForceFlush` on all registered
+  processors, even if there is a timeout.
+  ([#2388](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2388))
+
 ## 1.2.0-alpha3
 
 Released 2021-Sep-13

--- a/src/OpenTelemetry/Metrics/CompositeMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/CompositeMetricReader.cs
@@ -79,11 +79,6 @@ namespace OpenTelemetry.Metrics
         /// <inheritdoc/>
         protected override bool OnCollect(int timeoutMilliseconds = Timeout.Infinite)
         {
-            if (timeoutMilliseconds < 0 && timeoutMilliseconds != Timeout.Infinite)
-            {
-                throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative.");
-            }
-
             var result = true;
             var cur = this.head;
             var sw = Stopwatch.StartNew();

--- a/src/OpenTelemetry/Metrics/MeterProviderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderExtensions.cs
@@ -50,7 +50,7 @@ namespace OpenTelemetry.Metrics
 
             if (timeoutMilliseconds < 0 && timeoutMilliseconds != Timeout.Infinite)
             {
-                throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative.");
+                throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative or Timeout.Infinite.");
             }
 
             if (provider is MeterProviderSdk meterProviderSdk)
@@ -98,7 +98,7 @@ namespace OpenTelemetry.Metrics
 
             if (timeoutMilliseconds < 0 && timeoutMilliseconds != Timeout.Infinite)
             {
-                throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative.");
+                throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative or Timeout.Infinite.");
             }
 
             if (provider is MeterProviderSdk meterProviderSdk)

--- a/src/OpenTelemetry/Metrics/MeterProviderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderExtensions.cs
@@ -29,8 +29,8 @@ namespace OpenTelemetry.Metrics
         /// </summary>
         /// <param name="provider">MeterProviderSdk instance on which ForceFlush will be called.</param>
         /// <param name="timeoutMilliseconds">
-        /// The number of milliseconds to wait, or <c>Timeout.Infinite</c> to
-        /// wait indefinitely.
+        /// The number (non-negative) of milliseconds to wait, or
+        /// <c>Timeout.Infinite</c> to wait indefinitely.
         /// </param>
         /// <returns>
         /// Returns <c>true</c> when force flush succeeded; otherwise, <c>false</c>.
@@ -48,13 +48,13 @@ namespace OpenTelemetry.Metrics
                 throw new ArgumentNullException(nameof(provider));
             }
 
+            if (timeoutMilliseconds < 0 && timeoutMilliseconds != Timeout.Infinite)
+            {
+                throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative.");
+            }
+
             if (provider is MeterProviderSdk meterProviderSdk)
             {
-                if (timeoutMilliseconds < 0 && timeoutMilliseconds != Timeout.Infinite)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative.");
-                }
-
                 try
                 {
                     return meterProviderSdk.OnForceFlush(timeoutMilliseconds);
@@ -76,8 +76,8 @@ namespace OpenTelemetry.Metrics
         /// </summary>
         /// <param name="provider">MeterProviderSdk instance on which Shutdown will be called.</param>
         /// <param name="timeoutMilliseconds">
-        /// The number of milliseconds to wait, or <c>Timeout.Infinite</c> to
-        /// wait indefinitely.
+        /// The number (non-negative) of milliseconds to wait, or
+        /// <c>Timeout.Infinite</c> to wait indefinitely.
         /// </param>
         /// <returns>
         /// Returns <c>true</c> when shutdown succeeded; otherwise, <c>false</c>.
@@ -96,13 +96,13 @@ namespace OpenTelemetry.Metrics
                 throw new ArgumentNullException(nameof(provider));
             }
 
+            if (timeoutMilliseconds < 0 && timeoutMilliseconds != Timeout.Infinite)
+            {
+                throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative.");
+            }
+
             if (provider is MeterProviderSdk meterProviderSdk)
             {
-                if (timeoutMilliseconds < 0 && timeoutMilliseconds != Timeout.Infinite)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative.");
-                }
-
                 if (Interlocked.Increment(ref meterProviderSdk.ShutdownCount) > 1)
                 {
                     return false; // shutdown already called

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -187,8 +187,8 @@ namespace OpenTelemetry.Metrics
         /// thread until flush completed or timed out.
         /// </summary>
         /// <param name="timeoutMilliseconds">
-        /// The number of milliseconds to wait, or <c>Timeout.Infinite</c> to
-        /// wait indefinitely.
+        /// The number (non-negative) of milliseconds to wait, or
+        /// <c>Timeout.Infinite</c> to wait indefinitely.
         /// </param>
         /// <returns>
         /// Returns <c>true</c> when flush succeeded; otherwise, <c>false</c>.
@@ -208,8 +208,8 @@ namespace OpenTelemetry.Metrics
         /// thread until shutdown completed or timed out.
         /// </summary>
         /// <param name="timeoutMilliseconds">
-        /// The number of milliseconds to wait, or <c>Timeout.Infinite</c> to
-        /// wait indefinitely.
+        /// The number (non-negative) of milliseconds to wait, or
+        /// <c>Timeout.Infinite</c> to wait indefinitely.
         /// </param>
         /// <returns>
         /// Returns <c>true</c> when shutdown succeeded; otherwise, <c>false</c>.

--- a/src/OpenTelemetry/Metrics/MetricReader.cs
+++ b/src/OpenTelemetry/Metrics/MetricReader.cs
@@ -70,7 +70,7 @@ namespace OpenTelemetry.Metrics
         {
             if (timeoutMilliseconds < 0 && timeoutMilliseconds != Timeout.Infinite)
             {
-                throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative.");
+                throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative or Timeout.Infinite.");
             }
 
             try
@@ -106,7 +106,7 @@ namespace OpenTelemetry.Metrics
         {
             if (timeoutMilliseconds < 0 && timeoutMilliseconds != Timeout.Infinite)
             {
-                throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative.");
+                throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative or Timeout.Infinite.");
             }
 
             if (Interlocked.Increment(ref this.shutdownCount) > 1)

--- a/src/OpenTelemetry/Trace/TracerProviderExtensions.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderExtensions.cs
@@ -49,8 +49,8 @@ namespace OpenTelemetry.Trace
         /// </summary>
         /// <param name="provider">TracerProviderSdk instance on which ForceFlush will be called.</param>
         /// <param name="timeoutMilliseconds">
-        /// The number of milliseconds to wait, or <c>Timeout.Infinite</c> to
-        /// wait indefinitely.
+        /// The number (non-negative) of milliseconds to wait, or
+        /// <c>Timeout.Infinite</c> to wait indefinitely.
         /// </param>
         /// <returns>
         /// Returns <c>true</c> when force flush succeeded; otherwise, <c>false</c>.
@@ -68,13 +68,13 @@ namespace OpenTelemetry.Trace
                 throw new ArgumentNullException(nameof(provider));
             }
 
+            if (timeoutMilliseconds < 0 && timeoutMilliseconds != Timeout.Infinite)
+            {
+                throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative.");
+            }
+
             if (provider is TracerProviderSdk tracerProviderSdk)
             {
-                if (timeoutMilliseconds < 0 && timeoutMilliseconds != Timeout.Infinite)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative.");
-                }
-
                 try
                 {
                     return tracerProviderSdk.OnForceFlush(timeoutMilliseconds);
@@ -95,8 +95,8 @@ namespace OpenTelemetry.Trace
         /// </summary>
         /// <param name="provider">TracerProviderSdk instance on which Shutdown will be called.</param>
         /// <param name="timeoutMilliseconds">
-        /// The number of milliseconds to wait, or <c>Timeout.Infinite</c> to
-        /// wait indefinitely.
+        /// The number (non-negative) of milliseconds to wait, or
+        /// <c>Timeout.Infinite</c> to wait indefinitely.
         /// </param>
         /// <returns>
         /// Returns <c>true</c> when shutdown succeeded; otherwise, <c>false</c>.
@@ -115,13 +115,13 @@ namespace OpenTelemetry.Trace
                 throw new ArgumentNullException(nameof(provider));
             }
 
+            if (timeoutMilliseconds < 0 && timeoutMilliseconds != Timeout.Infinite)
+            {
+                throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative.");
+            }
+
             if (provider is TracerProviderSdk tracerProviderSdk)
             {
-                if (timeoutMilliseconds < 0 && timeoutMilliseconds != Timeout.Infinite)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative.");
-                }
-
                 if (Interlocked.Increment(ref tracerProviderSdk.ShutdownCount) > 1)
                 {
                     return false; // shutdown already called

--- a/src/OpenTelemetry/Trace/TracerProviderExtensions.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderExtensions.cs
@@ -70,7 +70,7 @@ namespace OpenTelemetry.Trace
 
             if (timeoutMilliseconds < 0 && timeoutMilliseconds != Timeout.Infinite)
             {
-                throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative.");
+                throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative or Timeout.Infinite.");
             }
 
             if (provider is TracerProviderSdk tracerProviderSdk)
@@ -117,7 +117,7 @@ namespace OpenTelemetry.Trace
 
             if (timeoutMilliseconds < 0 && timeoutMilliseconds != Timeout.Infinite)
             {
-                throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative.");
+                throw new ArgumentOutOfRangeException(nameof(timeoutMilliseconds), timeoutMilliseconds, "timeoutMilliseconds should be non-negative or Timeout.Infinite.");
             }
 
             if (provider is TracerProviderSdk tracerProviderSdk)

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -265,8 +265,8 @@ namespace OpenTelemetry.Trace
         /// thread until shutdown completed or timed out.
         /// </summary>
         /// <param name="timeoutMilliseconds">
-        /// The number of milliseconds to wait, or <c>Timeout.Infinite</c> to
-        /// wait indefinitely.
+        /// The number (non-negative) of milliseconds to wait, or
+        /// <c>Timeout.Infinite</c> to wait indefinitely.
         /// </param>
         /// <returns>
         /// Returns <c>true</c> when shutdown succeeded; otherwise, <c>false</c>.

--- a/test/OpenTelemetry.Tests/Trace/CompositeActivityProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/CompositeActivityProcessorTests.cs
@@ -101,16 +101,8 @@ namespace OpenTelemetry.Trace.Tests
             {
                 processor.ForceFlush(timeout);
 
-                if (timeout != 0)
-                {
-                    Assert.True(p1.ForceFlushCalled);
-                    Assert.True(p2.ForceFlushCalled);
-                }
-                else
-                {
-                    Assert.False(p1.ForceFlushCalled);
-                    Assert.False(p2.ForceFlushCalled);
-                }
+                Assert.True(p1.ForceFlushCalled);
+                Assert.True(p2.ForceFlushCalled);
             }
         }
     }


### PR DESCRIPTION
Fixes #2386.
Related to #2385.

## Changes

* Updated the comments across the entire repo to clarify that timeout should be non-negative or `Infinite` (`-1).
* Updated the `CompositeProcessor.OnForceFlush` logic to meet with the [latest spec requirement](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#forceflush) (also aligns with metrics SDK spec).
* Removed the unnecessary argument validation in `On...` callbacks (because they will not be called by end users).
 
For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
