### PR TITLE
Disallow multiple metric streams of same name.

### DIFF
--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -185,7 +185,7 @@ namespace OpenTelemetry.Metrics
                         this.metrics[i].SnapShot();
                     }
 
-                    return (target > 0) ? new Batch<Metric>(this.metrics, indexSnapShot + 1) : default;
+                    return (target > 0) ? new Batch<Metric>(this.metrics, target) : default;
                 }
                 catch (Exception)
                 {

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -32,7 +32,7 @@ namespace OpenTelemetry.Metrics
         private readonly List<object> instrumentations = new List<object>();
         private readonly object collectLock = new object();
         private readonly object instrumentCreationLock = new object();
-        private readonly Dictionary<string, byte> metricStreamNames = new Dictionary<string, byte>();
+        private readonly Dictionary<string, bool> metricStreamNames = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
         private readonly MeterListener listener;
         private readonly MetricReader reader;
         private int metricIndex = -1;
@@ -100,7 +100,7 @@ namespace OpenTelemetry.Metrics
                         {
                             if (this.metricStreamNames.ContainsKey(instrument.Name))
                             {
-                                // log and return.
+                                // log and ignore this instrument.
                                 return;
                             }
 
@@ -113,7 +113,7 @@ namespace OpenTelemetry.Metrics
                             {
                                 var metric = new Metric(instrument, temporality);
                                 this.metrics[index] = metric;
-                                this.metricStreamNames.Add(instrument.Name, 0);
+                                this.metricStreamNames.Add(instrument.Name, true);
                                 listener.EnableMeasurementEvents(instrument, metric);
                             }
                         }

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -59,7 +59,7 @@ namespace OpenTelemetry.Metrics.Tests
                 PreferredAggregationTemporality = exportDelta ? AggregationTemporality.Delta : AggregationTemporality.Cumulative,
             };
 
-            var meter = new Meter("TestMeter");
+            using var meter = new Meter("TestMeter");
             var counterLong = meter.CreateCounter<long>("mycounter");
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
                 .AddSource("TestMeter")
@@ -135,7 +135,7 @@ namespace OpenTelemetry.Metrics.Tests
                 PreferredAggregationTemporality = exportDelta ? AggregationTemporality.Delta : AggregationTemporality.Cumulative,
             };
 
-            var meter = new Meter(meterName);
+            using var meter = new Meter(meterName);
             int i = 1;
             var counterLong = meter.CreateObservableCounter<long>(
             "observable-counter",
@@ -204,7 +204,7 @@ namespace OpenTelemetry.Metrics.Tests
             {
                 PreferredAggregationTemporality = temporality,
             };
-            var meter = new Meter("TestPointCapMeter");
+            using var meter = new Meter("TestPointCapMeter");
             var counterLong = meter.CreateCounter<long>("mycounterCapTest");
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
                 .AddSource("TestPointCapMeter")
@@ -256,7 +256,7 @@ namespace OpenTelemetry.Metrics.Tests
                 PreferredAggregationTemporality = AggregationTemporality.Cumulative,
             };
 
-            var meter = new Meter("TestLongCounterMeter");
+            using var meter = new Meter("TestLongCounterMeter");
             var counterLong = meter.CreateCounter<long>("mycounter");
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
                 .AddSource("TestLongCounterMeter")
@@ -326,7 +326,7 @@ namespace OpenTelemetry.Metrics.Tests
                 PreferredAggregationTemporality = AggregationTemporality.Cumulative,
             };
 
-            var meter = new Meter("TestDoubleCounterMeter");
+            using var meter = new Meter("TestDoubleCounterMeter");
             var counterDouble = meter.CreateCounter<double>("mycounter");
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
                 .AddSource("TestDoubleCounterMeter")


### PR DESCRIPTION
Can occur today if same named instrument is created more than once. Need to add some tests now.
Also required before views, views can "rename" the name used for metric stream to be different from the instrument name.

Qn:
If user do 
createCounter("name1");
createHistogram("name2"); // this gets dropped... 

Should we do more advanced checks like name, type ?
Also, do we need to make this liberal, by disallowing name clashes within same Meter?  - (This would mean the Prometheus exporter should start using meter_name+instrument_name as the name)... 