### PR TITLE
Disallow same metric name only for same meter

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterExtensions.cs
@@ -47,7 +47,7 @@ namespace OpenTelemetry.Exporter
             foreach (var metric in exporter.Metrics)
             {
                 var builder = new PrometheusMetricBuilder()
-                    .WithName(metric.Name)
+                    .WithName(metric.Meter.Name + metric.Name)
                     .WithDescription(metric.Description);
 
                 switch (metric.MetricType)


### PR DESCRIPTION
Following up on https://github.com/open-telemetry/opentelemetry-dotnet/pull/2392#issuecomment-923622818