### PR TITLE
Throw an exception when parsing an env var fails

### DIFF
--- a/src/OpenTelemetry/Trace/BatchExportActivityProcessorOptions.cs
+++ b/src/OpenTelemetry/Trace/BatchExportActivityProcessorOptions.cs
@@ -78,13 +78,7 @@ namespace OpenTelemetry.Trace
                 return false;
             }
 
-            if (!int.TryParse(value, out var parsedValue))
-            {
-                OpenTelemetrySdkEventSource.Log.FailedToParseEnvironmentVariable(envVarKey, value);
-                return false;
-            }
-
-            result = parsedValue;
+            result = int.Parse(value); // throws FormatException or OverflowException for bad input
             return true;
         }
     }

--- a/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorOptionsTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorOptionsTest.cs
@@ -63,9 +63,7 @@ namespace OpenTelemetry.Trace.Tests
         {
             Environment.SetEnvironmentVariable(BatchExportActivityProcessorOptions.ExporterTimeoutEnvVarKey, "invalid");
 
-            var options = new BatchExportActivityProcessorOptions();
-
-            Assert.Equal(30000, options.ExporterTimeoutMilliseconds); // use default
+            Assert.Throws<FormatException>(() => new BatchExportActivityProcessorOptions());
         }
 
         [Fact]


### PR DESCRIPTION
## Why

By @reyang from [Slack thread](https://cloud-native.slack.com/archives/C01N3BC2W7Q/p1631125173035600):

Environmental variables handling:

1. If we don't have access to the environment variable (due to security reasons), we'll proceed as if nothing is set in the env vars (just log)
2. When we process the environment variables, anything that wouldn't make logical sense (e.g. we expect int, but we got a string that doesn't look like int) would result in exceptions
3. We only process environment variables during the SDK initialize (e.g. by taking a snapshot), any env vars change later will not be used or picked up.

Reference: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/error-handling.md#basic-error-handling-principles

## Remarks

This PR is so small just to make sure we agree that this is the way want to handle invalid values of env vars.

The only problem with this approach is that if an env var is invalid e.g. `OTEL_BSP_EXPORT_TIMEOUT=invalid` then there is no other way of fixing it than changing or clearing the env var. Code like:

```csharp
 var options = new BatchExportActivityProcessorOptions
{
    ExporterTimeoutMilliseconds = 89000,
};
``` 

won't help as the env var parsing is in the constructor.

TBH I do not think it is bad but I prefer to double-check it with you.