### PR TITLE
Use `Stopwatch.StartNew()`

### DIFF
--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -284,8 +284,7 @@ namespace OpenTelemetry.Metrics.Tests
             // Block until all threads started.
             mreToEnsureAllThreadsStarted.WaitOne();
 
-            Stopwatch sw = new Stopwatch();
-            sw.Start();
+            Stopwatch sw = Stopwatch.StartNew();
 
             // unblock all the threads.
             // (i.e let them start counter.Add)
@@ -354,8 +353,7 @@ namespace OpenTelemetry.Metrics.Tests
             // Block until all threads started.
             mreToEnsureAllThreadsStarted.WaitOne();
 
-            Stopwatch sw = new Stopwatch();
-            sw.Start();
+            Stopwatch sw = Stopwatch.StartNew();
 
             // unblock all the threads.
             // (i.e let them start counter.Add)

--- a/test/StressTestMetrics/Program.cs
+++ b/test/StressTestMetrics/Program.cs
@@ -38,8 +38,7 @@ namespace OpenTelemetry.Metrics.Tests.Stress
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
                 .AddSource("TestMeter")
                 .Build();
-            Stopwatch sw = new Stopwatch();
-            sw.Start();
+            Stopwatch sw = Stopwatch.StartNew();
 
             Parallel.Invoke(
                 () =>


### PR DESCRIPTION
Use `Stopwatch.StartNew();` instead of `new Stopwatch(); sw.Start();`

This was the only occurrence other than in `MetricAPITest.cs` which I am working on changing in another branch