### PR TITLE
Update ConsoleMetricExporter to add a space between the attributes

### DIFF
--- a/docs/metrics/getting-started/README.md
+++ b/docs/metrics/getting-started/README.md
@@ -33,11 +33,11 @@ output from the console, similar to shown below:
 <!-- markdownlint-disable MD013 -->
 ```text
 Export MyFruitCounter, Meter: MyCompany.MyProduct.MyLibrary/1.0
-2021-09-23T03:17:30.6198292Z, 2021-09-23T03:17:30.6356517Z] color:redname:apple LongSum
+2021-09-23T21:34:11.7728070Z, 2021-09-23T21:34:11.7843300Z] color:red name:apple LongSum
 Value: 6
-2021-09-23T03:17:30.6198292Z, 2021-09-23T03:17:30.6356517Z] color:yellowname:lemon LongSum
+2021-09-23T21:34:11.7728070Z, 2021-09-23T21:34:11.7843300Z] color:yellow name:lemon LongSum
 Value: 7
-2021-09-23T03:17:30.6198292Z, 2021-09-23T03:17:30.6356517Z] color:greenname:apple LongSum
+2021-09-23T21:34:11.7728070Z, 2021-09-23T21:34:11.7843300Z] color:green name:apple LongSum
 Value: 2
 ```
 <!-- markdownlint-enable MD013 -->

--- a/docs/metrics/getting-started/README.md
+++ b/docs/metrics/getting-started/README.md
@@ -33,11 +33,11 @@ output from the console, similar to shown below:
 <!-- markdownlint-disable MD013 -->
 ```text
 Export MyFruitCounter, Meter: MyCompany.MyProduct.MyLibrary/1.0
-2021-09-23T21:34:11.7728070Z, 2021-09-23T21:34:11.7843300Z] color:red name:apple LongSum
+(2021-09-23T22:00:08.4399776Z, 2021-09-23T22:00:08.4510115Z] color:red name:apple LongSum
 Value: 6
-2021-09-23T21:34:11.7728070Z, 2021-09-23T21:34:11.7843300Z] color:yellow name:lemon LongSum
+(2021-09-23T22:00:08.4399776Z, 2021-09-23T22:00:08.4510115Z] color:yellow name:lemon LongSum
 Value: 7
-2021-09-23T21:34:11.7728070Z, 2021-09-23T21:34:11.7843300Z] color:green name:apple LongSum
+(2021-09-23T22:00:08.4399776Z, 2021-09-23T22:00:08.4510115Z] color:green name:apple LongSum
 Value: 2
 ```
 <!-- markdownlint-enable MD013 -->

--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -145,6 +145,7 @@ namespace OpenTelemetry.Exporter
                     }
 
                     msg = new StringBuilder();
+                    msg.Append('(');
                     msg.Append(metricPoint.StartTime.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", CultureInfo.InvariantCulture));
                     msg.Append(", ");
                     msg.Append(metricPoint.EndTime.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", CultureInfo.InvariantCulture));

--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -86,12 +86,13 @@ namespace OpenTelemetry.Exporter
                         for (int i = 0; i < metricPoint.Keys.Length; i++)
                         {
                             tagsBuilder.Append(metricPoint.Keys[i]);
-                            tagsBuilder.Append(":");
+                            tagsBuilder.Append(':');
                             tagsBuilder.Append(metricPoint.Values[i]);
+                            tagsBuilder.Append(' ');
                         }
                     }
 
-                    var tags = tagsBuilder.ToString();
+                    var tags = tagsBuilder.ToString().TrimEnd();
 
                     var metricType = metric.MetricType;
 
@@ -105,27 +106,27 @@ namespace OpenTelemetry.Exporter
                             {
                                 bucketsBuilder.Append("(-Infinity,");
                                 bucketsBuilder.Append(metricPoint.ExplicitBounds[i]);
-                                bucketsBuilder.Append("]");
-                                bucketsBuilder.Append(":");
+                                bucketsBuilder.Append(']');
+                                bucketsBuilder.Append(':');
                                 bucketsBuilder.Append(metricPoint.BucketCounts[i]);
                             }
                             else if (i == metricPoint.ExplicitBounds.Length)
                             {
-                                bucketsBuilder.Append("(");
+                                bucketsBuilder.Append('(');
                                 bucketsBuilder.Append(metricPoint.ExplicitBounds[i - 1]);
-                                bucketsBuilder.Append(",");
+                                bucketsBuilder.Append(',');
                                 bucketsBuilder.Append("+Infinity]");
-                                bucketsBuilder.Append(":");
+                                bucketsBuilder.Append(':');
                                 bucketsBuilder.Append(metricPoint.BucketCounts[i]);
                             }
                             else
                             {
-                                bucketsBuilder.Append("(");
+                                bucketsBuilder.Append('(');
                                 bucketsBuilder.Append(metricPoint.ExplicitBounds[i - 1]);
-                                bucketsBuilder.Append(",");
+                                bucketsBuilder.Append(',');
                                 bucketsBuilder.Append(metricPoint.ExplicitBounds[i]);
-                                bucketsBuilder.Append("]");
-                                bucketsBuilder.Append(":");
+                                bucketsBuilder.Append(']');
+                                bucketsBuilder.Append(':');
                                 bucketsBuilder.Append(metricPoint.BucketCounts[i]);
                             }
 
@@ -148,8 +149,12 @@ namespace OpenTelemetry.Exporter
                     msg.Append(", ");
                     msg.Append(metricPoint.EndTime.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", CultureInfo.InvariantCulture));
                     msg.Append("] ");
-                    msg.Append(string.Join(";", tags));
-                    msg.Append(' ');
+                    msg.Append(tags);
+                    if (tags != string.Empty)
+                    {
+                        msg.Append(' ');
+                    }
+
                     msg.Append(metric.MetricType);
                     msg.AppendLine();
                     msg.Append($"Value: {valueDisplay}");


### PR DESCRIPTION
## Changes
- Add space between metric attributes when printing to console
- Update `StringBuilder.Append` method calls to use character when possible: [CA1834: Use StringBuilder.Append(char) for single character strings](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1834)
