### PR TITLE
Delete unused `using` statements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -63,6 +63,9 @@ dotnet_naming_symbols.constant_fields.required_modifiers          = const
 [*.cs] 
 dotnet_diagnostic.CA1031.severity = none
 dotnet_diagnostic.CA1303.severity = none
+dotnet_diagnostic.IDE0001.severity = warning
+dotnet_diagnostic.IDE0002.severity = warning
+dotnet_diagnostic.IDE0005.severity = warning
 # var preferences 
 csharp_style_var_for_built_in_types = true:silent 
 csharp_style_var_when_type_is_apparent = true:silent 

--- a/build/Common.props
+++ b/build/Common.props
@@ -5,6 +5,7 @@
     <RepoRoot>$([System.IO.Directory]::GetParent($(MSBuildThisFileDirectory)).Parent.FullName)</RepoRoot>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)debug.snk</AssemblyOriginatorKeyFile>
     <DefineConstants>$(DefineConstants);SIGNED</DefineConstants>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/docs/metrics/getting-started/README.md
+++ b/docs/metrics/getting-started/README.md
@@ -33,11 +33,11 @@ output from the console, similar to shown below:
 <!-- markdownlint-disable MD013 -->
 ```text
 Export MyFruitCounter, Meter: MyCompany.MyProduct.MyLibrary/1.0
-2021-09-23T03:17:30.6198292Z, 2021-09-23T03:17:30.6356517Z] color:redname:apple LongSum
+(2021-09-23T22:00:08.4399776Z, 2021-09-23T22:00:08.4510115Z] color:red name:apple LongSum
 Value: 6
-2021-09-23T03:17:30.6198292Z, 2021-09-23T03:17:30.6356517Z] color:yellowname:lemon LongSum
+(2021-09-23T22:00:08.4399776Z, 2021-09-23T22:00:08.4510115Z] color:yellow name:lemon LongSum
 Value: 7
-2021-09-23T03:17:30.6198292Z, 2021-09-23T03:17:30.6356517Z] color:greenname:apple LongSum
+(2021-09-23T22:00:08.4399776Z, 2021-09-23T22:00:08.4510115Z] color:green name:apple LongSum
 Value: 2
 ```
 <!-- markdownlint-enable MD013 -->

--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -86,12 +86,13 @@ namespace OpenTelemetry.Exporter
                         for (int i = 0; i < metricPoint.Keys.Length; i++)
                         {
                             tagsBuilder.Append(metricPoint.Keys[i]);
-                            tagsBuilder.Append(":");
+                            tagsBuilder.Append(':');
                             tagsBuilder.Append(metricPoint.Values[i]);
+                            tagsBuilder.Append(' ');
                         }
                     }
 
-                    var tags = tagsBuilder.ToString();
+                    var tags = tagsBuilder.ToString().TrimEnd();
 
                     var metricType = metric.MetricType;
 
@@ -105,27 +106,27 @@ namespace OpenTelemetry.Exporter
                             {
                                 bucketsBuilder.Append("(-Infinity,");
                                 bucketsBuilder.Append(metricPoint.ExplicitBounds[i]);
-                                bucketsBuilder.Append("]");
-                                bucketsBuilder.Append(":");
+                                bucketsBuilder.Append(']');
+                                bucketsBuilder.Append(':');
                                 bucketsBuilder.Append(metricPoint.BucketCounts[i]);
                             }
                             else if (i == metricPoint.ExplicitBounds.Length)
                             {
-                                bucketsBuilder.Append("(");
+                                bucketsBuilder.Append('(');
                                 bucketsBuilder.Append(metricPoint.ExplicitBounds[i - 1]);
-                                bucketsBuilder.Append(",");
+                                bucketsBuilder.Append(',');
                                 bucketsBuilder.Append("+Infinity]");
-                                bucketsBuilder.Append(":");
+                                bucketsBuilder.Append(':');
                                 bucketsBuilder.Append(metricPoint.BucketCounts[i]);
                             }
                             else
                             {
-                                bucketsBuilder.Append("(");
+                                bucketsBuilder.Append('(');
                                 bucketsBuilder.Append(metricPoint.ExplicitBounds[i - 1]);
-                                bucketsBuilder.Append(",");
+                                bucketsBuilder.Append(',');
                                 bucketsBuilder.Append(metricPoint.ExplicitBounds[i]);
-                                bucketsBuilder.Append("]");
-                                bucketsBuilder.Append(":");
+                                bucketsBuilder.Append(']');
+                                bucketsBuilder.Append(':');
                                 bucketsBuilder.Append(metricPoint.BucketCounts[i]);
                             }
 
@@ -144,12 +145,17 @@ namespace OpenTelemetry.Exporter
                     }
 
                     msg = new StringBuilder();
+                    msg.Append('(');
                     msg.Append(metricPoint.StartTime.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", CultureInfo.InvariantCulture));
                     msg.Append(", ");
                     msg.Append(metricPoint.EndTime.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", CultureInfo.InvariantCulture));
                     msg.Append("] ");
-                    msg.Append(string.Join(";", tags));
-                    msg.Append(' ');
+                    msg.Append(tags);
+                    if (tags != string.Empty)
+                    {
+                        msg.Append(' ');
+                    }
+
                     msg.Append(metric.MetricType);
                     msg.AppendLine();
                     msg.Append($"Value: {valueDisplay}");

--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Globalization;
-using System.Linq;
 using System.Text;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricsExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricsExporter.cs
@@ -24,7 +24,6 @@ using OpenTelemetry.Exporter.OpenTelemetryProtocol;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Metrics;
 using OtlpCollector = Opentelemetry.Proto.Collector.Metrics.V1;
-using OtlpResource = Opentelemetry.Proto.Resource.V1;
 
 namespace OpenTelemetry.Exporter
 {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricsExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricsExporter.cs
@@ -17,9 +17,6 @@
 using System;
 using System.Threading.Tasks;
 using Grpc.Core;
-#if NETSTANDARD2_1
-using Grpc.Net.Client;
-#endif
 using OpenTelemetry.Exporter.OpenTelemetryProtocol;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Metrics;

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporter.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporter.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
 using OpenTelemetry.Metrics;
 
 namespace OpenTelemetry.Exporter

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterMiddleware.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterMiddleware.cs
@@ -15,6 +15,9 @@
 // </copyright>
 
 #if NETSTANDARD2_0
+
+using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
 namespace OpenTelemetry.Exporter

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterMiddleware.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterMiddleware.cs
@@ -14,9 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Threading.Tasks;
-
 #if NETSTANDARD2_0
 using Microsoft.AspNetCore.Http;
 

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -15,11 +15,9 @@
 // </copyright>
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using System.Web;
 using OpenTelemetry.Context;
 using OpenTelemetry.Context.Propagation;

--- a/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
@@ -24,7 +24,7 @@ namespace OpenTelemetry.Shims.OpenTracing
 {
     internal sealed class ScopeManagerShim : IScopeManager
     {
-        private static readonly ConditionalWeakTable<TelemetrySpan, global::OpenTracing.IScope> SpanScopeTable = new ConditionalWeakTable<TelemetrySpan, global::OpenTracing.IScope>();
+        private static readonly ConditionalWeakTable<TelemetrySpan, IScope> SpanScopeTable = new ConditionalWeakTable<TelemetrySpan, IScope>();
 
         private readonly Tracer tracer;
 
@@ -32,7 +32,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         private int spanScopeTableCount;
 #endif
 
-        public ScopeManagerShim(Trace.Tracer tracer)
+        public ScopeManagerShim(Tracer tracer)
         {
             this.tracer = tracer ?? throw new ArgumentNullException(nameof(tracer));
         }
@@ -42,7 +42,7 @@ namespace OpenTelemetry.Shims.OpenTracing
 #endif
 
         /// <inheritdoc/>
-        public global::OpenTracing.IScope Active
+        public IScope Active
         {
             get
             {
@@ -62,7 +62,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         }
 
         /// <inheritdoc/>
-        public global::OpenTracing.IScope Activate(ISpan span, bool finishSpanOnDispose)
+        public IScope Activate(ISpan span, bool finishSpanOnDispose)
         {
             if (!(span is SpanShim shim))
             {
@@ -93,7 +93,7 @@ namespace OpenTelemetry.Shims.OpenTracing
             return instrumentation;
         }
 
-        private class ScopeInstrumentation : global::OpenTracing.IScope
+        private class ScopeInstrumentation : IScope
         {
             private readonly Action disposeAction;
 

--- a/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
@@ -17,8 +17,8 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using global::OpenTracing;
 using OpenTelemetry.Trace;
+using OpenTracing;
 
 namespace OpenTelemetry.Shims.OpenTracing
 {

--- a/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
@@ -16,7 +16,9 @@
 
 using System;
 using System.Runtime.CompilerServices;
+#if DEBUG
 using System.Threading;
+#endif
 using OpenTelemetry.Trace;
 using OpenTracing;
 

--- a/src/OpenTelemetry/Metrics/BatchMetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/BatchMetricPoint.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace OpenTelemetry.Metrics

--- a/src/OpenTelemetry/Metrics/CompositeMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/CompositeMetricReader.cs
@@ -18,7 +18,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
-using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Metrics
 {

--- a/src/OpenTelemetry/Metrics/MeterProviderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderExtensions.cs
@@ -15,9 +15,7 @@
 // </copyright>
 
 using System;
-using System.Diagnostics;
 using System.Threading;
-using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Metrics
 {

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using System.Linq;

--- a/src/OpenTelemetry/ProviderExtensions.cs
+++ b/src/OpenTelemetry/ProviderExtensions.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;

--- a/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/ActivityHelperTest.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/ActivityHelperTest.cs
@@ -24,7 +24,6 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
     using System.Threading;
     using System.Threading.Tasks;
     using System.Web;
-    using OpenTelemetry.Context;
     using OpenTelemetry.Context.Propagation;
     using Xunit;
 

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
@@ -17,7 +17,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Testing;
 using OpenTelemetry.Metrics;

--- a/test/OpenTelemetry.Tests/Metrics/AggregatorTest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/AggregatorTest.cs
@@ -15,8 +15,6 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics.Metrics;
 using Xunit;
 
 namespace OpenTelemetry.Metrics.Tests

--- a/test/OpenTelemetry.Tests/Metrics/MetricExporterTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricExporterTests.cs
@@ -15,8 +15,6 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics.Metrics;
 using Xunit;
 
 namespace OpenTelemetry.Metrics.Tests


### PR DESCRIPTION
Ran code cleanup in Visual Studio

Adding rules to `.editorconfig`
- [Simplify name](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0001)
- [Simplify member access](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0002)
- [Remove unnecessary import](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0002)