### PR TITLE
OTLP Exporter: Support IDeferredMeterProviderBuilder in AddOtlpExporter

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * `MeterProviderBuilder` extension methods now support `OtlpExporterOptions`
   bound to `IConfiguration` when using OpenTelemetry.Extensions.Hosting
-  ([#TBD](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TBD))
+  ([#2413](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2413))
 
 ## 1.2.0-alpha4
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* `MeterProviderBuilder` extension methods now support `OtlpExporterOptions`
+  bound to `IConfiguration` when using OpenTelemetry.Extensions.Hosting
+  ([#TBD](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TBD))
+
 ## 1.2.0-alpha4
 
 Released 2021-Sep-23

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
@@ -25,7 +25,7 @@ namespace OpenTelemetry.Metrics
     public static class OtlpMetricExporterExtensions
     {
         /// <summary>
-        /// Adds OpenTelemetry Protocol (OTLP) exporter to the MeterProvider.
+        /// Adds <see cref="OtlpMetricsExporter"/> to the <see cref="MeterProviderBuilder"/>.
         /// </summary>
         /// <param name="builder"><see cref="MeterProviderBuilder"/> builder to use.</param>
         /// <param name="configure">Exporter configuration options.</param>
@@ -37,7 +37,19 @@ namespace OpenTelemetry.Metrics
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            var options = new OtlpExporterOptions();
+            if (builder is IDeferredMeterProviderBuilder deferredMeterProviderBuilder)
+            {
+                return deferredMeterProviderBuilder.Configure((sp, builder) =>
+                {
+                    AddOtlpExporter(builder, sp.GetOptions<OtlpExporterOptions>(), configure);
+                });
+            }
+
+            return AddOtlpExporter(builder, new OtlpExporterOptions(), configure);
+        }
+
+        private static MeterProviderBuilder AddOtlpExporter(MeterProviderBuilder builder, OtlpExporterOptions options, Action<OtlpExporterOptions> configure = null)
+        {
             configure?.Invoke(options);
 
             var metricExporter = new OtlpMetricsExporter(options);


### PR DESCRIPTION
## Changes

Adds support for `IOptions<OtlpExporterOptions>` in `MeterProviderBuilder` "AddOtlpExporter" extension .

## TODOs

* [ ] `CHANGELOG.md` updated for non-trivial changes

