### PR TITLE
Alloc-free recording of measurements upto 8 tags

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* SDK is allocation-free on recording of measurements with
+  upto 8 tags.
+
 ## 1.2.0-alpha4
 
 Released 2021-Sep-23

--- a/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
+++ b/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
@@ -22,7 +22,7 @@ namespace OpenTelemetry.Metrics
 {
     internal class ThreadStaticStorage
     {
-        private const int MaxTagCacheSize = 3;
+        private const int MaxTagCacheSize = 8;
 
         [ThreadStatic]
         private static ThreadStaticStorage storage;


### PR DESCRIPTION
Based on feedback from https://github.com/open-telemetry/opentelemetry-dotnet/issues/2221, modifying SDK to support alloc-free recording for upto 8 tags. This, when combined with TagList from RC1 (benchmark is here: https://github.com/open-telemetry/opentelemetry-dotnet/pull/2418), will give 0 alloc recording for upto 8 tags.