### PR TITLE
Support View Part2 - specify tags to be used for aggregation

### DIFF
--- a/docs/metrics/customizing-the-sdk/Program.cs
+++ b/docs/metrics/customizing-the-sdk/Program.cs
@@ -34,7 +34,7 @@ public class Program
             .AddView(instrumentName: "MyCounter", name: "MyCounterRenamed")
 
             // Change Histogram bounds
-            .AddView(instrumentName: "MyHistogram", new HistogramConfiguration() { BucketBounds = new double[] { 10, 20 }, Aggregation = Aggregation.LastValue })
+            .AddView(instrumentName: "MyHistogram", new HistogramConfiguration() { BucketBounds = new double[] { 10, 20 } })
 
             // For the instrument "MyCounterCustomTags", aggregate with only the keys "tag1", "tag2".
             .AddView(instrumentName: "MyCounterCustomTags", new MetricStreamConfiguration() { TagKeys = new string[] { "tag1", "tag2" } })

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -70,7 +70,8 @@ namespace OpenTelemetry.Metrics
             int maxLength = tags.Length;
             if (maxLength == 0 || this.dropAllTags)
             {
-                return this.GetInitializedZeroTagPoint();
+                this.InitializeZeroTagPointIfNotInitialized();
+                return 0;
             }
 
             var storage = ThreadStaticStorage.GetStorage();
@@ -85,7 +86,8 @@ namespace OpenTelemetry.Metrics
 
             if (actualLength == 0)
             {
-                return this.GetInitializedZeroTagPoint();
+                this.InitializeZeroTagPointIfNotInitialized();
+                return 0;
             }
 
             if (actualLength > 1)
@@ -238,7 +240,7 @@ namespace OpenTelemetry.Metrics
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private int GetInitializedZeroTagPoint()
+        private void InitializeZeroTagPointIfNotInitialized()
         {
             if (!this.zeroTagMetricPointInitialized)
             {
@@ -252,8 +254,6 @@ namespace OpenTelemetry.Metrics
                     }
                 }
             }
-
-            return 0;
         }
     }
 }

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -187,6 +187,9 @@ namespace OpenTelemetry.Metrics
 
             storage.SplitToKeysAndValues(tags, length, this.tagKeysInteresting, out var tagKey, out var tagValue);
 
+            // Actual number of tags depend on how many
+            // of the incoming tags has user opted to
+            // select.
             var actualLength = tagKey.Length;
             if (actualLength == 0)
             {

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -134,7 +134,8 @@ namespace OpenTelemetry.Metrics
                         {
                             for (int i = 0; i < maxCountMetricsToBeCreated; i++)
                             {
-                                var metricStreamName = metricStreamConfigs[i]?.Name ?? instrument.Name;
+                                var metricStreamConfig = metricStreamConfigs[i];
+                                var metricStreamName = metricStreamConfig?.Name ?? instrument.Name;
                                 if (this.metricStreamNames.ContainsKey(metricStreamName))
                                 {
                                     // TODO: Log that instrument is ignored
@@ -151,7 +152,7 @@ namespace OpenTelemetry.Metrics
                                 }
                                 else
                                 {
-                                    var metric = new Metric(instrument, temporality, metricStreamName);
+                                    var metric = new Metric(instrument, temporality, metricStreamName, metricStreamConfig?.TagKeys);
                                     this.metrics[index] = metric;
                                     metrics.Add(metric);
                                     this.metricStreamNames.Add(metricStreamName, true);
@@ -194,7 +195,7 @@ namespace OpenTelemetry.Metrics
                             else
                             {
                                 metrics = new List<Metric>(1);
-                                var metric = new Metric(instrument, temporality);
+                                var metric = new Metric(instrument, temporality, metricName);
                                 this.metrics[index] = metric;
                                 metrics.Add(metric);
                                 this.metricStreamNames.Add(metricName, true);

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -24,9 +24,13 @@ namespace OpenTelemetry.Metrics
     {
         private AggregatorStore aggStore;
 
-        internal Metric(Instrument instrument, AggregationTemporality temporality, string metricName = "")
+        internal Metric(
+            Instrument instrument,
+            AggregationTemporality temporality,
+            string metricName,
+            string[] tagKeys = null)
         {
-            this.Name = string.IsNullOrWhiteSpace(metricName) ? instrument.Name : metricName;
+            this.Name = metricName;
             this.Description = instrument.Description;
             this.Unit = instrument.Unit;
             this.Meter = instrument.Meter;
@@ -88,7 +92,7 @@ namespace OpenTelemetry.Metrics
                 // TODO: Log and assign some invalid Enum.
             }
 
-            this.aggStore = new AggregatorStore(aggType, temporality);
+            this.aggStore = new AggregatorStore(aggType, temporality, tagKeys);
             this.Temporality = temporality;
         }
 

--- a/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
@@ -17,12 +17,12 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
-using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace OpenTelemetry.Metrics.Tests
 {
+#pragma warning disable SA1000 // KeywordsMustBeSpacedCorrectly https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3214
     public class MetricViewTests
     {
         private const int MaxTimeToAllowForFlush = 10000;
@@ -200,4 +200,6 @@ namespace OpenTelemetry.Metrics.Tests
             Assert.Single(metricPoints);
         }
     }
+#pragma warning restore SA1000 // KeywordsMustBeSpacedCorrectly
+
 }

--- a/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
@@ -177,14 +177,14 @@ namespace OpenTelemetry.Metrics.Tests
                 .Build();
 
             var counter = meter1.CreateCounter<long>("FruitCounter");
-            counter.Add(10, new ("name", "apple"), new ("color", "red"), new ("size", "small"));
-            counter.Add(10, new ("name", "apple"), new ("color", "red"), new ("size", "small"));
+            counter.Add(10, new("name", "apple"), new("color", "red"), new("size", "small"));
+            counter.Add(10, new("name", "apple"), new("color", "red"), new("size", "small"));
 
-            counter.Add(10, new ("name", "apple"), new ("color", "red"), new ("size", "medium"));
-            counter.Add(10, new ("name", "apple"), new ("color", "red"), new ("size", "medium"));
+            counter.Add(10, new("name", "apple"), new("color", "red"), new("size", "medium"));
+            counter.Add(10, new("name", "apple"), new("color", "red"), new("size", "medium"));
 
-            counter.Add(10, new ("name", "apple"), new ("color", "red"), new ("size", "large"));
-            counter.Add(10, new ("name", "apple"), new ("color", "red"), new ("size", "large"));
+            counter.Add(10, new("name", "apple"), new("color", "red"), new("size", "large"));
+            counter.Add(10, new("name", "apple"), new("color", "red"), new("size", "large"));
 
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
             Assert.Single(exportedItems);


### PR DESCRIPTION
Note on perf:
Hotpath Perf is affected by this change, as there are lot of "if" checks now added in hotpath, even when there are no views. This can be fixed by following a totally different path for Views/No Views scenario, so as to keep maximum perf for no views scenario. To follow up in subsequent PRs *after* finishing more View features (change Aggregation etc).

PR Description:
Currently, all the tags provided with measurement is used for aggregation. This PR allows user to configure View, to configure TagKeys, which will be used for aggregation. Typically used for cost control, by dropping unwanted tags.

For example, consider the following snippet of measurements being recorded (assume console exporter is configured):

```
var counter = MyMeter.CreateCounter<long>("MyFruitCounter");
counter.Add(1, new("name", "apple"), new("color", "red"));
counter.Add(2, new("name", "lemon"), new("color", "yellow"));
counter.Add(1, new("name", "lemon"), new("color", "yellow"));
counter.Add(2, new("name", "apple"), new("color", "green"));
counter.Add(5, new("name", "apple"), new("color", "red"));
counter.Add(4, new("name", "lemon"), new("color", "yellow"));
```

The output is as follows:
Output:
```
Export MyFruitCounter, Meter: MyCompany.MyProduct.MyLibrary/1.0
(2021-09-29T23:31:23.7786143Z, 2021-09-29T23:31:23.7972342Z] color:red name:apple LongSum
Value: 6
(2021-09-29T23:31:23.7786143Z, 2021-09-29T23:31:23.7972342Z] color:yellow name:lemon LongSum
Value: 7
(2021-09-29T23:31:23.7786143Z, 2021-09-29T23:31:23.7972342Z] color:green name:apple LongSum
Value: 2
```


Below snippet uses view with both tags. (i.e same as default behavior)

```
.AddView(
                "MyFruitCounter",
                new MetricStreamConfiguration()
                {
                    TagKeys = new string[] { "color", "name" },
                })
```

Output:
```
Export MyFruitCounter, Meter: MyCompany.MyProduct.MyLibrary/1.0
(2021-09-29T23:31:23.7786143Z, 2021-09-29T23:31:23.7972342Z] color:red name:apple LongSum
Value: 6
(2021-09-29T23:31:23.7786143Z, 2021-09-29T23:31:23.7972342Z] color:yellow name:lemon LongSum
Value: 7
(2021-09-29T23:31:23.7786143Z, 2021-09-29T23:31:23.7972342Z] color:green name:apple LongSum
Value: 2
```

Below snippet uses view to only pick single tag "color"
```
.AddView(
                "MyFruitCounter",
                new MetricStreamConfiguration()
                {
                    TagKeys = new string[] { "color" },
                })
```

Output:
```
Export MyFruitCounter, Meter: MyCompany.MyProduct.MyLibrary/1.0
(2021-09-29T23:34:42.3563688Z, 2021-09-29T23:34:42.3722304Z] color:red LongSum
Value: 6
(2021-09-29T23:34:42.3563688Z, 2021-09-29T23:34:42.3722304Z] color:yellow LongSum
Value: 7
(2021-09-29T23:34:42.3563688Z, 2021-09-29T23:34:42.3722304Z] color:green LongSum
Value: 2
```


Below snippet uses view to only pick single tag "name"
```
.AddView(
                "MyFruitCounter",
                new MetricStreamConfiguration()
                {
                    TagKeys = new string[] { "name" },
                })
```

Output:
```
Export MyFruitCounter, Meter: MyCompany.MyProduct.MyLibrary/1.0
(2021-09-29T23:35:38.0528475Z, 2021-09-29T23:35:38.0775305Z] name:apple LongSum
Value: 8
(2021-09-29T23:35:38.0528475Z, 2021-09-29T23:35:38.0775305Z] name:lemon LongSum
Value: 7
```

Below snippet uses view to drop all tags.
```
.AddView(
                "MyFruitCounter",
                new MetricStreamConfiguration()
                {
                    TagKeys = new string[] {  },
                })
```

Output:
```
Export MyFruitCounter, Meter: MyCompany.MyProduct.MyLibrary/1.0
(2021-09-29T23:36:54.2341730Z, 2021-09-29T23:36:54.2440246Z] LongSum
Value: 15
```

Below snippet uses view to specify some non-existent tag. (similar as no tags!)
```
.AddView(
                "MyFruitCounter",
                new MetricStreamConfiguration()
                {
                    TagKeys = new string[] {  "foo" },
                })
```

Output:
```
Export MyFruitCounter, Meter: MyCompany.MyProduct.MyLibrary/1.0
(2021-09-29T23:36:54.2341730Z, 2021-09-29T23:36:54.2440246Z] LongSum
Value: 15
```