### PR TITLE
Support View Part2 - specify custom buckets for Histogram

### DIFF
--- a/docs/metrics/getting-started/Program.cs
+++ b/docs/metrics/getting-started/Program.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Diagnostics.Metrics;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
@@ -27,15 +26,16 @@ public class Program
     {
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
             .AddSource("MyCompany.MyProduct.MyLibrary")
-            .AddView("MyHistogram", new HistogramConfiguration() { BucketBounds = new double[] { } })
             .AddConsoleExporter()
             .Build();
 
-        var random = new Random();
-        var histogram = MyMeter.CreateHistogram<long>("MyHistogram");
-        for (int i = 0; i < 1000; i++)
-        {
-            histogram.Record(random.Next(1, 1000));
-        }
+        var counter = MyMeter.CreateCounter<long>("MyFruitCounter");
+
+        counter.Add(1, new("name", "apple"), new("color", "red"));
+        counter.Add(2, new("name", "lemon"), new("color", "yellow"));
+        counter.Add(1, new("name", "lemon"), new("color", "yellow"));
+        counter.Add(2, new("name", "apple"), new("color", "green"));
+        counter.Add(5, new("name", "apple"), new("color", "red"));
+        counter.Add(4, new("name", "lemon"), new("color", "yellow"));
     }
 }

--- a/docs/metrics/getting-started/Program.cs
+++ b/docs/metrics/getting-started/Program.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using System.Diagnostics.Metrics;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
@@ -26,16 +27,15 @@ public class Program
     {
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
             .AddSource("MyCompany.MyProduct.MyLibrary")
+            .AddView("MyHistogram", new HistogramConfiguration() { BucketBounds = new double[] { } })
             .AddConsoleExporter()
             .Build();
 
-        var counter = MyMeter.CreateCounter<long>("MyFruitCounter");
-
-        counter.Add(1, new("name", "apple"), new("color", "red"));
-        counter.Add(2, new("name", "lemon"), new("color", "yellow"));
-        counter.Add(1, new("name", "lemon"), new("color", "yellow"));
-        counter.Add(2, new("name", "apple"), new("color", "green"));
-        counter.Add(5, new("name", "apple"), new("color", "red"));
-        counter.Add(4, new("name", "lemon"), new("color", "yellow"));
+        var random = new Random();
+        var histogram = MyMeter.CreateHistogram<long>("MyHistogram");
+        for (int i = 0; i < 1000; i++)
+        {
+            histogram.Record(random.Next(1, 1000));
+        }
     }
 }

--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -99,37 +99,41 @@ namespace OpenTelemetry.Exporter
                     {
                         var bucketsBuilder = new StringBuilder();
                         bucketsBuilder.Append($"Sum: {metricPoint.DoubleValue} Count: {metricPoint.LongValue} \n");
-                        for (int i = 0; i < metricPoint.ExplicitBounds.Length + 1; i++)
-                        {
-                            if (i == 0)
-                            {
-                                bucketsBuilder.Append("(-Infinity,");
-                                bucketsBuilder.Append(metricPoint.ExplicitBounds[i]);
-                                bucketsBuilder.Append(']');
-                                bucketsBuilder.Append(':');
-                                bucketsBuilder.Append(metricPoint.BucketCounts[i]);
-                            }
-                            else if (i == metricPoint.ExplicitBounds.Length)
-                            {
-                                bucketsBuilder.Append('(');
-                                bucketsBuilder.Append(metricPoint.ExplicitBounds[i - 1]);
-                                bucketsBuilder.Append(',');
-                                bucketsBuilder.Append("+Infinity]");
-                                bucketsBuilder.Append(':');
-                                bucketsBuilder.Append(metricPoint.BucketCounts[i]);
-                            }
-                            else
-                            {
-                                bucketsBuilder.Append('(');
-                                bucketsBuilder.Append(metricPoint.ExplicitBounds[i - 1]);
-                                bucketsBuilder.Append(',');
-                                bucketsBuilder.Append(metricPoint.ExplicitBounds[i]);
-                                bucketsBuilder.Append(']');
-                                bucketsBuilder.Append(':');
-                                bucketsBuilder.Append(metricPoint.BucketCounts[i]);
-                            }
 
-                            bucketsBuilder.AppendLine();
+                        if (metricPoint.ExplicitBounds != null)
+                        {
+                            for (int i = 0; i < metricPoint.ExplicitBounds.Length + 1; i++)
+                            {
+                                if (i == 0)
+                                {
+                                    bucketsBuilder.Append("(-Infinity,");
+                                    bucketsBuilder.Append(metricPoint.ExplicitBounds[i]);
+                                    bucketsBuilder.Append(']');
+                                    bucketsBuilder.Append(':');
+                                    bucketsBuilder.Append(metricPoint.BucketCounts[i]);
+                                }
+                                else if (i == metricPoint.ExplicitBounds.Length)
+                                {
+                                    bucketsBuilder.Append('(');
+                                    bucketsBuilder.Append(metricPoint.ExplicitBounds[i - 1]);
+                                    bucketsBuilder.Append(',');
+                                    bucketsBuilder.Append("+Infinity]");
+                                    bucketsBuilder.Append(':');
+                                    bucketsBuilder.Append(metricPoint.BucketCounts[i]);
+                                }
+                                else
+                                {
+                                    bucketsBuilder.Append('(');
+                                    bucketsBuilder.Append(metricPoint.ExplicitBounds[i - 1]);
+                                    bucketsBuilder.Append(',');
+                                    bucketsBuilder.Append(metricPoint.ExplicitBounds[i]);
+                                    bucketsBuilder.Append(']');
+                                    bucketsBuilder.Append(':');
+                                    bucketsBuilder.Append(metricPoint.BucketCounts[i]);
+                                }
+
+                                bucketsBuilder.AppendLine();
+                            }
                         }
 
                         valueDisplay = bucketsBuilder.ToString();

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/MetricItemExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/MetricItemExtensions.cs
@@ -250,12 +250,15 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
                             dataPoint.Count = (ulong)metricPoint.LongValue;
                             dataPoint.Sum = metricPoint.DoubleValue;
 
-                            for (int i = 0; i < metricPoint.BucketCounts.Length; i++)
+                            if (metricPoint.BucketCounts != null)
                             {
-                                dataPoint.BucketCounts.Add((ulong)metricPoint.BucketCounts[i]);
-                                if (i < metricPoint.BucketCounts.Length - 1)
+                                for (int i = 0; i < metricPoint.BucketCounts.Length; i++)
                                 {
-                                    dataPoint.ExplicitBounds.Add(metricPoint.ExplicitBounds[i]);
+                                    dataPoint.BucketCounts.Add((ulong)metricPoint.BucketCounts[i]);
+                                    if (i < metricPoint.BucketCounts.Length - 1)
+                                    {
+                                        dataPoint.ExplicitBounds.Add(metricPoint.ExplicitBounds[i]);
+                                    }
                                 }
                             }
 

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterExtensions.cs
@@ -164,18 +164,21 @@ namespace OpenTelemetry.Exporter.Prometheus
                 metricValueBuilderCount = metricValueBuilderCount.WithValue(metricPoint.LongValue);
                 metricValueBuilderCount.AddLabels(metricPoint.Keys, metricPoint.Values);
 
-                long totalCount = 0;
-                for (int i = 0; i < metricPoint.ExplicitBounds.Length + 1; i++)
+                if (metricPoint.ExplicitBounds != null)
                 {
-                    totalCount += metricPoint.BucketCounts[i];
-                    var metricValueBuilderBuckets = builder.AddValue();
-                    metricValueBuilderBuckets.WithName(metric.Name + PrometheusHistogramBucketPostFix);
-                    metricValueBuilderBuckets = metricValueBuilderBuckets.WithValue(totalCount);
-                    metricValueBuilderBuckets.AddLabels(metricPoint.Keys, metricPoint.Values);
+                    long totalCount = 0;
+                    for (int i = 0; i < metricPoint.ExplicitBounds.Length + 1; i++)
+                    {
+                        totalCount += metricPoint.BucketCounts[i];
+                        var metricValueBuilderBuckets = builder.AddValue();
+                        metricValueBuilderBuckets.WithName(metric.Name + PrometheusHistogramBucketPostFix);
+                        metricValueBuilderBuckets = metricValueBuilderBuckets.WithValue(totalCount);
+                        metricValueBuilderBuckets.AddLabels(metricPoint.Keys, metricPoint.Values);
 
-                    var bucketName = i == metricPoint.ExplicitBounds.Length ?
-                    PrometheusHistogramBucketLabelPositiveInfinity : metricPoint.ExplicitBounds[i].ToString(CultureInfo.InvariantCulture);
-                    metricValueBuilderBuckets.WithLabel(PrometheusHistogramBucketLabelLessThan, bucketName);
+                        var bucketName = i == metricPoint.ExplicitBounds.Length ?
+                        PrometheusHistogramBucketLabelPositiveInfinity : metricPoint.ExplicitBounds[i].ToString(CultureInfo.InvariantCulture);
+                        metricValueBuilderBuckets.WithLabel(PrometheusHistogramBucketLabelLessThan, bucketName);
+                    }
                 }
             }
         }

--- a/src/OpenTelemetry/Metrics/AggregationType.cs
+++ b/src/OpenTelemetry/Metrics/AggregationType.cs
@@ -57,5 +57,10 @@ namespace OpenTelemetry.Metrics
         /// Histogram.
         /// </summary>
         Histogram = 6,
+
+        /// <summary>
+        /// Histogram with no sum,count only.
+        /// </summary>
+        HistogramSumCount = 7,
     }
 }

--- a/src/OpenTelemetry/Metrics/AggregationType.cs
+++ b/src/OpenTelemetry/Metrics/AggregationType.cs
@@ -59,7 +59,7 @@ namespace OpenTelemetry.Metrics
         Histogram = 6,
 
         /// <summary>
-        /// Histogram with no sum,count only.
+        /// Histogram with sum,count only.
         /// </summary>
         HistogramSumCount = 7,
     }

--- a/src/OpenTelemetry/Metrics/AggregationType.cs
+++ b/src/OpenTelemetry/Metrics/AggregationType.cs
@@ -59,7 +59,7 @@ namespace OpenTelemetry.Metrics
         Histogram = 6,
 
         /// <summary>
-        /// Histogram with sum,count only.
+        /// Histogram with sum, count only.
         /// </summary>
         HistogramSumCount = 7,
     }

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -36,14 +36,16 @@ namespace OpenTelemetry.Metrics
         private int metricPointIndex = 0;
         private bool zeroTagMetricPointInitialized;
         private AggregationType aggType;
+        private double[] histogramBounds;
         private DateTimeOffset startTimeExclusive;
         private DateTimeOffset endTimeInclusive;
 
-        internal AggregatorStore(AggregationType aggType, AggregationTemporality temporality)
+        internal AggregatorStore(AggregationType aggType, AggregationTemporality temporality, double[] histogramBounds)
         {
             this.metrics = new MetricPoint[MaxMetricPoints];
             this.aggType = aggType;
             this.temporality = temporality;
+            this.histogramBounds = histogramBounds;
             this.startTimeExclusive = DateTimeOffset.UtcNow;
         }
 
@@ -59,7 +61,7 @@ namespace OpenTelemetry.Metrics
                         if (!this.zeroTagMetricPointInitialized)
                         {
                             var dt = DateTimeOffset.UtcNow;
-                            this.metrics[0] = new MetricPoint(this.aggType, dt, null, null);
+                            this.metrics[0] = new MetricPoint(this.aggType, dt, null, null, this.histogramBounds);
                             this.zeroTagMetricPointInitialized = true;
                         }
                     }
@@ -137,7 +139,7 @@ namespace OpenTelemetry.Metrics
 
                         ref var metricPoint = ref this.metrics[aggregatorIndex];
                         var dt = DateTimeOffset.UtcNow;
-                        metricPoint = new MetricPoint(this.aggType, dt, seqKey, seqVal);
+                        metricPoint = new MetricPoint(this.aggType, dt, seqKey, seqVal, this.histogramBounds);
 
                         // Add to dictionary *after* initializing MetricPoint
                         // as other threads can start writing to the

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -134,7 +134,8 @@ namespace OpenTelemetry.Metrics
                         {
                             for (int i = 0; i < maxCountMetricsToBeCreated; i++)
                             {
-                                var metricStreamName = metricStreamConfigs[i]?.Name ?? instrument.Name;
+                                var metricStreamConfig = metricStreamConfigs[i];
+                                var metricStreamName = metricStreamConfig?.Name ?? instrument.Name;
                                 if (this.metricStreamNames.ContainsKey(metricStreamName))
                                 {
                                     // TODO: Log that instrument is ignored
@@ -151,7 +152,17 @@ namespace OpenTelemetry.Metrics
                                 }
                                 else
                                 {
-                                    var metric = new Metric(instrument, temporality, metricStreamName);
+                                    Metric metric;
+                                    if (metricStreamConfig is HistogramConfiguration histogramConfig
+                                        && histogramConfig.BucketBounds != null)
+                                    {
+                                        metric = new Metric(instrument, temporality, histogramConfig.BucketBounds, metricStreamName);
+                                    }
+                                    else
+                                    {
+                                        metric = new Metric(instrument, temporality, metricStreamName);
+                                    }
+
                                     this.metrics[index] = metric;
                                     metrics.Add(metric);
                                     this.metricStreamNames.Add(metricStreamName, true);


### PR DESCRIPTION
Similar perf concern as https://github.com/open-telemetry/opentelemetry-dotnet/pull/2429, but mostly restricted to Meter creation and not in the measurement recording.


A very simple example showing custom bounds for Histogram

```
using var meterProvider = Sdk.CreateMeterProviderBuilder()
            .AddSource("MyCompany.MyProduct.MyLibrary")
           .AddView("MyHistogram", new HistogramConfiguration() { BucketBounds = new double[] { 10, 20 } })
            .AddConsoleExporter()
            .Build();

        var random = new Random();
        var histogram = MyMeter.CreateHistogram<long>("MyHistogram");
        for (int i = 0; i < 1000; i++)
        {
            histogram.Record(random.Next(1, 1000));
        }
```

The following can make the histogram just do Count,Sum with no buckets. (This needs to be adjusted once MinMax spec is ready)
` .AddView("MyHistogram", new HistogramConfiguration() { BucketBounds = new double[] {  } })`
