### PR TITLE
Add warning when running stress test with DEBUG build

### DIFF
--- a/test/OpenTelemetry.Tests.Stress/Skeleton.cs
+++ b/test/OpenTelemetry.Tests.Stress/Skeleton.cs
@@ -83,7 +83,7 @@ public partial class Program
                     var cntCpuCyclesOld = GetCpuCycles();
 
                     watch.Restart();
-                    Thread.Sleep(2000);
+                    Thread.Sleep(200);
                     watch.Stop();
 
                     var cntLoopsNew = (ulong)statistics.Sum();

--- a/test/OpenTelemetry.Tests.Stress/Skeleton.cs
+++ b/test/OpenTelemetry.Tests.Stress/Skeleton.cs
@@ -30,6 +30,10 @@ public partial class Program
 
     public static void Stress(int concurrency = 0)
     {
+#if DEBUG
+        Console.WriteLine("***WARNING*** The current build is DEBUG which may affect timing!\n");
+#endif
+
         if (concurrency < 0)
         {
             throw new ArgumentOutOfRangeException(nameof(concurrency), "concurrency level should be a non-negative number.");
@@ -79,7 +83,7 @@ public partial class Program
                     var cntCpuCyclesOld = GetCpuCycles();
 
                     watch.Restart();
-                    Thread.Sleep(200);
+                    Thread.Sleep(2000);
                     watch.Stop();
 
                     var cntLoopsNew = (ulong)statistics.Sum();


### PR DESCRIPTION
## Changes

Running stress test with DEBUG build may not be expected. Add warning message in this scenario before running the stress test.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
