### PR TITLE
Replace '\n' with a call to Console.Write()

### DIFF
--- a/test/OpenTelemetry.Tests.Stress/Skeleton.cs
+++ b/test/OpenTelemetry.Tests.Stress/Skeleton.cs
@@ -31,7 +31,7 @@ public partial class Program
     public static void Stress(int concurrency = 0)
     {
 #if DEBUG
-        Console.WriteLine("***WARNING*** The current build is DEBUG which may affect timing!\n");
+        Console.WriteLine($"***WARNING*** The current build is DEBUG which may affect timing!{Environment.NewLine}");
 #endif
 
         if (concurrency < 0)

--- a/test/OpenTelemetry.Tests.Stress/Skeleton.cs
+++ b/test/OpenTelemetry.Tests.Stress/Skeleton.cs
@@ -31,7 +31,8 @@ public partial class Program
     public static void Stress(int concurrency = 0)
     {
 #if DEBUG
-        Console.WriteLine($"***WARNING*** The current build is DEBUG which may affect timing!{Environment.NewLine}");
+        Console.WriteLine("***WARNING*** The current build is DEBUG which may affect timing!");
+        Console.WriteLine();
 #endif
 
         if (concurrency < 0)


### PR DESCRIPTION
## Changes

Fixes the use of '\n' in https://github.com/open-telemetry/opentelemetry-dotnet/pull/2436.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
