### PR TITLE
View Part 3 - Support for configuring tagkeys to be used for aggregation

### DIFF
--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -326,14 +326,24 @@ namespace OpenTelemetry.Metrics
 
             var storage = ThreadStaticStorage.GetStorage();
 
-            storage.SplitToKeysAndValues(tags, tagLength, out var tagKey, out var tagValue);
+            storage.SplitToKeysAndValues(tags, tagLength, this.tagKeysInteresting, out var tagKey, out var tagValue);
 
-            if (tagLength > 1)
+            // Actual number of tags depend on how many
+            // of the incoming tags has user opted to
+            // select.
+            var actualLength = tagKey.Length;
+            if (actualLength == 0)
+            {
+                this.InitializeZeroTagPointIfNotInitialized();
+                return 0;
+            }
+
+            if (actualLength > 1)
             {
                 Array.Sort<string, object>(tagKey, tagValue);
             }
 
-            return this.LookupAggregatorStore(tagKey, tagValue, tagLength);
+            return this.LookupAggregatorStore(tagKey, tagValue, actualLength);
         }
     }
 }

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -321,6 +321,9 @@ namespace OpenTelemetry.Metrics
                 return 0;
             }
 
+            // TODO: Get only interesting tags
+            // from the incoming tags
+
             var storage = ThreadStaticStorage.GetStorage();
 
             storage.SplitToKeysAndValues(tags, tagLength, out var tagKey, out var tagValue);

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -326,12 +326,11 @@ namespace OpenTelemetry.Metrics
 
             var storage = ThreadStaticStorage.GetStorage();
 
-            storage.SplitToKeysAndValues(tags, tagLength, this.tagKeysInteresting, out var tagKey, out var tagValue);
+            storage.SplitToKeysAndValues(tags, tagLength, this.tagKeysInteresting, out var tagKey, out var tagValue, out var actualLength);
 
             // Actual number of tags depend on how many
             // of the incoming tags has user opted to
             // select.
-            var actualLength = tagKey.Length;
             if (actualLength == 0)
             {
                 this.InitializeZeroTagPointIfNotInitialized();

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -219,7 +219,7 @@ namespace OpenTelemetry.Metrics
         {
             try
             {
-                var index = this.FindMetricAggregators(tags);
+                var index = this.FindMetricAggregatorsDefault(tags);
                 if (index < 0)
                 {
                     // TODO: Measurement dropped due to MemoryPoint cap hit.
@@ -257,7 +257,7 @@ namespace OpenTelemetry.Metrics
         {
             try
             {
-                var index = this.FindMetricAggregators(tags);
+                var index = this.FindMetricAggregatorsDefault(tags);
                 if (index < 0)
                 {
                     // TODO: Measurement dropped due to MemoryPoint cap hit.

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -155,15 +155,10 @@ namespace OpenTelemetry.Metrics
                                 {
                                     Metric metric;
                                     var metricDescription = metricStreamConfig?.Description ?? instrument.Description;
-                                    if (metricStreamConfig is HistogramConfiguration histogramConfig
-                                        && histogramConfig.BucketBounds != null)
-                                    {
-                                        metric = new Metric(instrument, temporality, metricStreamName, metricDescription, histogramConfig.BucketBounds);
-                                    }
-                                    else
-                                    {
-                                        metric = new Metric(instrument, temporality, metricStreamName, metricDescription);
-                                    }
+                                    string[] tagKeysInteresting = metricStreamConfig?.TagKeys;
+                                    double[] histogramBucketBounds = (metricStreamConfig is HistogramConfiguration histogramConfig
+                                        && histogramConfig.BucketBounds != null) ? histogramConfig.BucketBounds : null;
+                                    metric = new Metric(instrument, temporality, metricStreamName, metricDescription, histogramBucketBounds, tagKeysInteresting);
 
                                     this.metrics[index] = metric;
                                     metrics.Add(metric);

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -30,7 +30,8 @@ namespace OpenTelemetry.Metrics
             AggregationTemporality temporality,
             string metricName,
             string metricDescription,
-            double[] histogramBounds = null)
+            double[] histogramBounds = null,
+            string[] tagKeysInteresting = null)
         {
             this.Name = metricName;
             this.Description = metricDescription;
@@ -103,7 +104,7 @@ namespace OpenTelemetry.Metrics
                 // TODO: Log and assign some invalid Enum.
             }
 
-            this.aggStore = new AggregatorStore(aggType, temporality, histogramBounds ?? DefaultHistogramBounds);
+            this.aggStore = new AggregatorStore(aggType, temporality, histogramBounds ?? DefaultHistogramBounds, tagKeysInteresting);
             this.Temporality = temporality;
         }
 
@@ -126,12 +127,12 @@ namespace OpenTelemetry.Metrics
 
         internal void UpdateLong(long value, ReadOnlySpan<KeyValuePair<string, object>> tags)
         {
-            this.aggStore.UpdateLong(value, tags);
+            this.aggStore.Update(value, tags);
         }
 
         internal void UpdateDouble(double value, ReadOnlySpan<KeyValuePair<string, object>> tags)
         {
-            this.aggStore.UpdateDouble(value, tags);
+            this.aggStore.Update(value, tags);
         }
 
         internal void SnapShot()

--- a/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
+++ b/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
@@ -69,6 +69,54 @@ namespace OpenTelemetry.Metrics
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void SplitToKeysAndValues(ReadOnlySpan<KeyValuePair<string, object>> tags, int tagLength, HashSet<string> tagKeysInteresting, out string[] tagKeys, out object[] tagValues)
+        {
+            // Iterate over tags to find the exact length.
+            int i = 0;
+            for (var n = 0; n < tagLength; n++)
+            {
+                if (tagKeysInteresting.Contains(tags[n].Key))
+                {
+                    i++;
+                }
+            }
+
+            int actualLength = i;
+
+            if (actualLength <= MaxTagCacheSize)
+            {
+                tagKeys = this.tagStorage[actualLength - 1].TagKey;
+                tagValues = this.tagStorage[actualLength - 1].TagValue;
+            }
+            else
+            {
+                tagKeys = new string[actualLength];
+                tagValues = new object[actualLength];
+            }
+
+            // Iterate again (!) to assign the actual value.
+            // TODO: The dual iteration over tags might be
+            // avoidable if we change the tagKey and tagObject
+            // to be a different type (eg: List).
+            // It might lead to some wasted memory.
+            // Also, it requires changes to the Dictionary
+            // used for lookup.
+            // The TODO here is to make that change
+            // separately, after benchmarking.
+            i = 0;
+            for (var n = 0; n < tagLength; n++)
+            {
+                var tag = tags[n];
+                if (tagKeysInteresting.Contains(tag.Key))
+                {
+                    tagKeys[i] = tag.Key;
+                    tagValues[i] = tag.Value;
+                    i++;
+                }
+            }
+        }
+
         internal class TagStorage
         {
             // Used to split into Key sequence, Value sequence.

--- a/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
+++ b/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
@@ -70,7 +70,7 @@ namespace OpenTelemetry.Metrics
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void SplitToKeysAndValues(ReadOnlySpan<KeyValuePair<string, object>> tags, int tagLength, HashSet<string> tagKeysInteresting, out string[] tagKeys, out object[] tagValues)
+        internal void SplitToKeysAndValues(ReadOnlySpan<KeyValuePair<string, object>> tags, int tagLength, HashSet<string> tagKeysInteresting, out string[] tagKeys, out object[] tagValues, out int actualLength)
         {
             // Iterate over tags to find the exact length.
             int i = 0;
@@ -82,9 +82,14 @@ namespace OpenTelemetry.Metrics
                 }
             }
 
-            int actualLength = i;
+            actualLength = i;
 
-            if (actualLength <= MaxTagCacheSize)
+            if (actualLength == 0)
+            {
+                tagKeys = null;
+                tagValues = null;
+            }
+            else if (actualLength <= MaxTagCacheSize)
             {
                 tagKeys = this.tagStorage[actualLength - 1].TagKey;
                 tagValues = this.tagStorage[actualLength - 1].TagValue;


### PR DESCRIPTION
Mostly same as #2429 but also addresses the perf concern from https://github.com/open-telemetry/opentelemetry-dotnet/pull/2429/files#r719040932 

PR Description:

Currently, all the tags provided with measurement is used for aggregation. This PR allows user to configure View, to configure 
TagKeys, which will be used for aggregation. Typically used for cost control, by dropping unwanted tags.

For example, consider the following snippet of measurements being recorded (assume console exporter is configured):

```
var counter = MyMeter.CreateCounter<long>("MyFruitCounter");
counter.Add(1, new("name", "apple"), new("color", "red"));
counter.Add(2, new("name", "lemon"), new("color", "yellow"));
counter.Add(1, new("name", "lemon"), new("color", "yellow"));
counter.Add(2, new("name", "apple"), new("color", "green"));
counter.Add(5, new("name", "apple"), new("color", "red"));
counter.Add(4, new("name", "lemon"), new("color", "yellow"));
```

The output is as follows:
Output:
```
Export MyFruitCounter, Meter: MyCompany.MyProduct.MyLibrary/1.0
(2021-09-29T23:31:23.7786143Z, 2021-09-29T23:31:23.7972342Z] color:red name:apple LongSum
Value: 6
(2021-09-29T23:31:23.7786143Z, 2021-09-29T23:31:23.7972342Z] color:yellow name:lemon LongSum
Value: 7
(2021-09-29T23:31:23.7786143Z, 2021-09-29T23:31:23.7972342Z] color:green name:apple LongSum
Value: 2
```


Below snippet uses view with both tags. (i.e same as default behavior)

```
.AddView(
                "MyFruitCounter",
                new MetricStreamConfiguration()
                {
                    TagKeys = new string[] { "color", "name" },
                })
```

Output:
```
Export MyFruitCounter, Meter: MyCompany.MyProduct.MyLibrary/1.0
(2021-09-29T23:31:23.7786143Z, 2021-09-29T23:31:23.7972342Z] color:red name:apple LongSum
Value: 6
(2021-09-29T23:31:23.7786143Z, 2021-09-29T23:31:23.7972342Z] color:yellow name:lemon LongSum
Value: 7
(2021-09-29T23:31:23.7786143Z, 2021-09-29T23:31:23.7972342Z] color:green name:apple LongSum
Value: 2
```

Below snippet uses view to only pick single tag "color"
```
.AddView(
                "MyFruitCounter",
                new MetricStreamConfiguration()
                {
                    TagKeys = new string[] { "color" },
                })
```

Output:
```
Export MyFruitCounter, Meter: MyCompany.MyProduct.MyLibrary/1.0
(2021-09-29T23:34:42.3563688Z, 2021-09-29T23:34:42.3722304Z] color:red LongSum
Value: 6
(2021-09-29T23:34:42.3563688Z, 2021-09-29T23:34:42.3722304Z] color:yellow LongSum
Value: 7
(2021-09-29T23:34:42.3563688Z, 2021-09-29T23:34:42.3722304Z] color:green LongSum
Value: 2
```


Below snippet uses view to only pick single tag "name"
```
.AddView(
                "MyFruitCounter",
                new MetricStreamConfiguration()
                {
                    TagKeys = new string[] { "name" },
                })
```

Output:
```
Export MyFruitCounter, Meter: MyCompany.MyProduct.MyLibrary/1.0
(2021-09-29T23:35:38.0528475Z, 2021-09-29T23:35:38.0775305Z] name:apple LongSum
Value: 8
(2021-09-29T23:35:38.0528475Z, 2021-09-29T23:35:38.0775305Z] name:lemon LongSum
Value: 7
```

Below snippet uses view to drop all tags.
```
.AddView(
                "MyFruitCounter",
                new MetricStreamConfiguration()
                {
                    TagKeys = new string[] {  },
                })
```

Output:
```
Export MyFruitCounter, Meter: MyCompany.MyProduct.MyLibrary/1.0
(2021-09-29T23:36:54.2341730Z, 2021-09-29T23:36:54.2440246Z] LongSum
Value: 15
```

Below snippet uses view to specify some non-existent tag. (similar as no tags!)
```
.AddView(
                "MyFruitCounter",
                new MetricStreamConfiguration()
                {
                    TagKeys = new string[] {  "foo" },
                })
```

Output:
```
Export MyFruitCounter, Meter: MyCompany.MyProduct.MyLibrary/1.0
(2021-09-29T23:36:54.2341730Z, 2021-09-29T23:36:54.2440246Z] LongSum
Value: 15
```