### PR TITLE
Add basic wildcard support for listening to legacy activities.

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -5,6 +5,9 @@
 * SDK is allocation-free on recording of measurements with
   upto 8 tags.
 
+* TracerProviderBuilder.AddLegacySource now supports wildcard activity names.
+  ([#2183](https://github.com/open-telemetry/opentelemetry-dotnet/issues/2183))
+
 ## 1.2.0-alpha4
 
 Released 2021-Sep-23

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -52,7 +52,7 @@ namespace OpenTelemetry.Trace
 
             foreach (var legacyName in legacyActivityOperationNames)
             {
-                if (legacyName.Key.EndsWith("*"))
+                if (legacyName.Key.Contains('*'))
                 {
                     this.legacyActivityWildcardMode = true;
                     this.legacyActivityWildcardModeRegex = GetWildcardRegex(legacyActivityOperationNames.Keys);

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -56,7 +56,6 @@ namespace OpenTelemetry.Trace
                 {
                     this.legacyActivityWildcardMode = true;
                     this.legacyActivityWildcardModeRegex = GetWildcardRegex(legacyActivityOperationNames.Keys);
-
                     break;
                 }
             }
@@ -242,10 +241,8 @@ namespace OpenTelemetry.Trace
                 {
                     return this.legacyActivityWildcardModeRegex.IsMatch(activity.OperationName);
                 }
-                else
-                {
-                    return legacyActivityOperationNames.ContainsKey(activity.OperationName);
-                }
+
+                return legacyActivityOperationNames.ContainsKey(activity.OperationName);
             }
         }
 

--- a/test/Benchmarks/Trace/TraceBenchmarks.cs
+++ b/test/Benchmarks/Trace/TraceBenchmarks.cs
@@ -97,6 +97,19 @@ namespace Benchmarks.Trace
                 .AddLegacySource("TestOperationName2")
                 .AddProcessor(new DummyActivityProcessor())
                 .Build();
+
+            Sdk.CreateTracerProviderBuilder()
+                .SetSampler(new AlwaysOnSampler())
+                .AddLegacySource("ExactMatch.OperationName1")
+                .AddProcessor(new DummyActivityProcessor())
+                .Build();
+
+            Sdk.CreateTracerProviderBuilder()
+                .SetSampler(new AlwaysOnSampler())
+                .AddSource(this.sourceWithTwoLegacyActivityOperationNameSubscriptions.Name)
+                .AddLegacySource("WildcardMatch.*")
+                .AddProcessor(new DummyActivityProcessor())
+                .Build();
         }
 
         [Benchmark]
@@ -171,6 +184,22 @@ namespace Benchmarks.Trace
         public void TwoInstrumentations()
         {
             using (var activity = this.sourceWithTwoLegacyActivityOperationNameSubscriptions.StartActivity("Benchmark"))
+            {
+            }
+        }
+
+        [Benchmark]
+        public void LegacyDiagnosticActivity_ExactMatchMode()
+        {
+            using (var activity = new Activity("ExactMatch.OperationName1"))
+            {
+            }
+        }
+
+        [Benchmark]
+        public void LegacyDiagnosticActivity_WildcardMatchMode()
+        {
+            using (var activity = new Activity("WildcardMatch.OperationName1"))
             {
             }
         }

--- a/test/Benchmarks/Trace/TraceBenchmarks.cs
+++ b/test/Benchmarks/Trace/TraceBenchmarks.cs
@@ -106,7 +106,6 @@ namespace Benchmarks.Trace
 
             Sdk.CreateTracerProviderBuilder()
                 .SetSampler(new AlwaysOnSampler())
-                .AddSource(this.sourceWithTwoLegacyActivityOperationNameSubscriptions.Name)
                 .AddLegacySource("WildcardMatch.*")
                 .AddProcessor(new DummyActivityProcessor())
                 .Build();

--- a/test/Benchmarks/Trace/TraceBenchmarks.cs
+++ b/test/Benchmarks/Trace/TraceBenchmarks.cs
@@ -189,17 +189,17 @@ namespace Benchmarks.Trace
         }
 
         [Benchmark]
-        public void LegacyDiagnosticActivity_ExactMatchMode()
+        public void LegacyActivity_ExactMatchMode()
         {
-            using (var activity = new Activity("ExactMatch.OperationName1"))
+            using (var activity = new Activity("ExactMatch.OperationName1").Start())
             {
             }
         }
 
         [Benchmark]
-        public void LegacyDiagnosticActivity_WildcardMatchMode()
+        public void LegacyActivity_WildcardMatchMode()
         {
-            using (var activity = new Activity("WildcardMatch.OperationName1"))
+            using (var activity = new Activity("WildcardMatch.OperationName1").Start())
             {
             }
         }

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
@@ -985,6 +985,7 @@ namespace OpenTelemetry.Trace.Tests
                 };
 
             var legacySourceNamespaces = new[] { "LegacyNamespace.*", "Namespace.*.Operation" };
+            using var activitySource = new ActivitySource(ActivitySourceName);
 
             // AddLegacyOperationName chained to TracerProviderBuilder
             using var tracerProvider = Sdk.CreateTracerProviderBuilder()
@@ -992,6 +993,7 @@ namespace OpenTelemetry.Trace.Tests
                         .AddProcessor(testActivityProcessor)
                         .AddLegacySource(legacySourceNamespaces[0])
                         .AddLegacySource(legacySourceNamespaces[1])
+                        .AddSource(ActivitySourceName)
                         .Build();
 
             foreach (var ns in legacySourceNamespaces)
@@ -1012,6 +1014,13 @@ namespace OpenTelemetry.Trace.Tests
                 Assert.Contains(stopOpName, onStartProcessedActivities); // Processor.OnStart is called since we added a legacy OperationName
                 Assert.Contains(stopOpName, onStopProcessedActivities);  // Processor.OnEnd is called since we added a legacy OperationName
             }
+
+            Activity nonLegacyActivity = new Activity("TestActivity");
+            nonLegacyActivity.Start();
+            nonLegacyActivity.Stop();
+
+            Assert.Contains(nonLegacyActivity.OperationName, onStartProcessedActivities); // Processor.OnStart is called since we added a legacy OperationName
+            Assert.Contains(nonLegacyActivity.OperationName, onStopProcessedActivities);  // Processor.OnEnd is called since we added a legacy OperationName
         }
 
         public void Dispose()

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
@@ -984,19 +984,19 @@ namespace OpenTelemetry.Trace.Tests
                     onStopProcessedActivities.Add(a.OperationName);
                 };
 
-            var legacySourceNamespaces = new[] { "LegacyNamespace", "OtherLegacyNamespace" };
+            var legacySourceNamespaces = new[] { "LegacyNamespace.*", "Namespace.*.Operation" };
 
             // AddLegacyOperationName chained to TracerProviderBuilder
             using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                         .SetSampler(sampler)
                         .AddProcessor(testActivityProcessor)
-                        .AddLegacySource($"{legacySourceNamespaces[0]}.*")
-                        .AddLegacySource($"{legacySourceNamespaces[1]}.*")
+                        .AddLegacySource(legacySourceNamespaces[0])
+                        .AddLegacySource(legacySourceNamespaces[1])
                         .Build();
 
             foreach (var ns in legacySourceNamespaces)
             {
-                var startOpName = $"{ns}.Start";
+                var startOpName = ns.Replace("*", "Start");
                 Activity startOperation = new Activity(startOpName);
                 startOperation.Start();
                 startOperation.Stop();
@@ -1004,7 +1004,7 @@ namespace OpenTelemetry.Trace.Tests
                 Assert.Contains(startOpName, onStartProcessedActivities); // Processor.OnStart is called since we added a legacy OperationName
                 Assert.Contains(startOpName, onStopProcessedActivities);  // Processor.OnEnd is called since we added a legacy OperationName
 
-                var stopOpName = $"{ns}.Stop";
+                var stopOpName = ns.Replace("*", "Stop");
                 Activity stopOperation = new Activity(stopOpName);
                 stopOperation.Start();
                 stopOperation.Stop();

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
@@ -1015,7 +1015,8 @@ namespace OpenTelemetry.Trace.Tests
                 Assert.Contains(stopOpName, onStopProcessedActivities);  // Processor.OnEnd is called since we added a legacy OperationName
             }
 
-            Activity nonLegacyActivity = new Activity("TestActivity");
+            // Ensure we can still process "normal" activities when in legacy wildcard mode.
+            Activity nonLegacyActivity = activitySource.StartActivity("TestActivity");
             nonLegacyActivity.Start();
             nonLegacyActivity.Stop();
 


### PR DESCRIPTION
Fixes #2183.

## Changes

Add support for wildcards for legacy (DiagnosticSource) events.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
