### PR TITLE
View - support for dropping instrument

### DIFF
--- a/docs/metrics/customizing-the-sdk/Program.cs
+++ b/docs/metrics/customizing-the-sdk/Program.cs
@@ -34,7 +34,7 @@ public class Program
             .AddView(instrumentName: "MyCounter", name: "MyCounterRenamed")
 
             // Change Histogram bounds
-            .AddView(instrumentName: "MyHistogram", new HistogramConfiguration() { BucketBounds = new double[] { 10, 20 }, Aggregation = Aggregation.LastValue })
+            .AddView(instrumentName: "MyHistogram", new HistogramConfiguration() { BucketBounds = new double[] { 10, 20 } })
 
             // For the instrument "MyCounterCustomTags", aggregate with only the keys "tag1", "tag2".
             .AddView(instrumentName: "MyCounterCustomTags", new MetricStreamConfiguration() { TagKeys = new string[] { "tag1", "tag2" } })

--- a/src/OpenTelemetry/Metrics/DropConfiguration.cs
+++ b/src/OpenTelemetry/Metrics/DropConfiguration.cs
@@ -1,4 +1,4 @@
-// <copyright file="HistogramConfiguration.cs" company="OpenTelemetry Authors">
+// <copyright file="DropConfiguration.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/OpenTelemetry/Metrics/DropConfiguration.cs
+++ b/src/OpenTelemetry/Metrics/DropConfiguration.cs
@@ -1,0 +1,35 @@
+// <copyright file="HistogramConfiguration.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+
+namespace OpenTelemetry.Metrics
+{
+    internal class DropConfiguration : MetricStreamConfiguration
+    {
+        private Aggregation aggregation = Aggregation.Drop;
+
+        public override Aggregation Aggregation
+        {
+            get => this.aggregation;
+
+            set
+            {
+                throw new ArgumentException($"Aggregation cannot be set.");
+            }
+        }
+    }
+}

--- a/src/OpenTelemetry/Metrics/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderBuilderExtensions.cs
@@ -66,14 +66,14 @@ namespace OpenTelemetry.Metrics
         /// </summary>
         /// <param name="meterProviderBuilder"><see cref="MeterProviderBuilder"/>.</param>
         /// <param name="instrumentName">Name of the instrument, to be used as part of Instrument selection criteria.</param>
-        /// <param name="aggregationConfig">Aggregation configuration used to produce metrics stream.</param>
+        /// <param name="metricStreamConfiguration">Aggregation configuration used to produce metrics stream.</param>
         /// <returns><see cref="MeterProvider"/>.</returns>
         /// <remarks>See View specification here : https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view.</remarks>
-        public static MeterProviderBuilder AddView(this MeterProviderBuilder meterProviderBuilder, string instrumentName, MetricStreamConfiguration aggregationConfig)
+        public static MeterProviderBuilder AddView(this MeterProviderBuilder meterProviderBuilder, string instrumentName, MetricStreamConfiguration metricStreamConfiguration)
         {
             if (meterProviderBuilder is MeterProviderBuilderBase meterProviderBuilderBase)
             {
-                return meterProviderBuilderBase.AddView(instrumentName, aggregationConfig);
+                return meterProviderBuilderBase.AddView(instrumentName, metricStreamConfiguration);
             }
 
             return meterProviderBuilder;

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -145,6 +145,14 @@ namespace OpenTelemetry.Metrics
                                     continue;
                                 }
 
+                                if (metricStreamConfig?.Aggregation == Aggregation.None)
+                                {
+                                    // TODO: Log that instrument is ignored
+                                    // as user explicitily asked to drop it
+                                    // with View.
+                                    continue;
+                                }
+
                                 var index = ++this.metricIndex;
                                 if (index >= MaxMetrics)
                                 {

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -148,7 +148,7 @@ namespace OpenTelemetry.Metrics
                                 if (metricStreamConfig?.Aggregation == Aggregation.None)
                                 {
                                     // TODO: Log that instrument is ignored
-                                    // as user explicitily asked to drop it
+                                    // as user explicitly asked to drop it
                                     // with View.
                                     continue;
                                 }

--- a/src/OpenTelemetry/Metrics/MetricStreamConfiguration.cs
+++ b/src/OpenTelemetry/Metrics/MetricStreamConfiguration.cs
@@ -31,6 +31,8 @@ namespace OpenTelemetry.Metrics
 
     public class MetricStreamConfiguration
     {
+        public static readonly MetricStreamConfiguration Drop = new DropConfiguration();
+
         public string Name { get; set; }
 
         public string Description { get; set; }

--- a/test/OpenTelemetry.Tests.Stress.Metrics/Program.cs
+++ b/test/OpenTelemetry.Tests.Stress.Metrics/Program.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 using System;
-using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Runtime.CompilerServices;
 using System.Threading;

--- a/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
@@ -350,7 +350,7 @@ namespace OpenTelemetry.Metrics.Tests
             var exportedItems = new List<Metric>();
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
                 .AddSource(meter.Name)
-                .AddView("server.requests", new MetricStreamConfiguration() { Aggregation = Aggregation.Drop })
+                .AddView("server.requests", MetricStreamConfiguration.Drop)
                 .AddView("server.requests", "server.request_renamed")
                 .AddInMemoryExporter(exportedItems)
                 .Build();
@@ -365,6 +365,12 @@ namespace OpenTelemetry.Metrics.Tests
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
             Assert.Single(exportedItems);
             Assert.Equal("server.request_renamed", exportedItems[0].Name);
+        }
+
+        [Fact]
+        public void MetricStreamConfigurationForDropMustNotAllowOverriding()
+        {
+            Assert.Throws<ArgumentException>(() => MetricStreamConfiguration.Drop.Aggregation = Aggregation.Histogram);
         }
     }
 #pragma warning restore SA1000 // KeywordsMustBeSpacedCorrectly


### PR DESCRIPTION
More View capabilities:
This PR allows user to configure View to indicate that an instrument must be dropped.
example usages:

```
// Drop all instruments, whose name starts with server
.AddView("server*", new MetricStreamConfiguration() { Aggregation = Aggregation.Drop })

// Drop a particular instrument with the name "counternotinteresting"
.AddView("counterNotInteresting", new MetricStreamConfiguration() { Aggregation = Aggregation.Drop })
```