### PR TITLE
Add note about Metrics API being part of DotNet

### DIFF
--- a/docs/metrics/getting-started/README.md
+++ b/docs/metrics/getting-started/README.md
@@ -57,3 +57,24 @@ An OpenTelemetry
 is configured to subscribe to instruments from the Meter
 `MyCompany.MyProduct.MyLibrary`, and aggregate the measurements in-memory. The
 pre-aggregated metrics are exported to a `ConsoleExporter`.
+
+## OpenTelemetry .NET special note
+
+Metrics in OpenTelemetry .NET is a somewhat unique implementation of the
+OpenTelemetry project, as most of the Metrics API are incorporated directly
+into the .NET runtime itself. From a high level, what this means is that you
+can instrument your application by simply depending on
+`System.Diagnostics.DiagnosticSource` package.
+
+Read
+[this](../../../src/OpenTelemetry.Api/README.md#introduction-to-opentelemetry-net-tracing-api)
+to learn more.
+
+## Learn more
+
+* If you want to learn about more instruments, refer to [learning
+  more about instruments](../learning-more-instruments/README.md).
+
+* If you want to customize the Sdk, refer to [customizing
+  the SDK](../customizing-the-sdk/README.md).
+


### PR DESCRIPTION
Want to add some hint in the basic readme itself that Metrics API is part of .NET runtime.

if this is agreeable, then I want to next write a basic Metric API doc, similar to the tracing one, to highlight some key differences in .NET https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Api#introduction-to-opentelemetry-net-tracing-api