### PR TITLE
Rename AddSource to AddMeter to better reflect intent

### DIFF
--- a/docs/metrics/customizing-the-sdk/Program.cs
+++ b/docs/metrics/customizing-the-sdk/Program.cs
@@ -27,8 +27,8 @@ public class Program
     public static void Main(string[] args)
     {
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
-            .AddSource(Meter1.Name)
-            .AddSource(Meter2.Name)
+            .AddMeter(Meter1.Name)
+            .AddMeter(Meter2.Name)
 
             // Rename an instrument to new name.
             .AddView(instrumentName: "MyCounter", name: "MyCounterRenamed")

--- a/docs/metrics/extending-the-sdk/Program.cs
+++ b/docs/metrics/extending-the-sdk/Program.cs
@@ -41,7 +41,7 @@ public class Program
     public static void Main(string[] args)
     {
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
-            .AddSource("MyCompany.MyProduct.MyLibrary")
+            .AddMeter("MyCompany.MyProduct.MyLibrary")
             /*
             TODO: revisit once this exception is removed "System.InvalidOperationException: Only one Metricreader is allowed.".
             .AddReader(new MyReader())

--- a/docs/metrics/getting-started/Program.cs
+++ b/docs/metrics/getting-started/Program.cs
@@ -26,7 +26,7 @@ public class Program
     public static void Main(string[] args)
     {
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
-            .AddSource("MyCompany.MyProduct.MyLibrary")
+            .AddMeter("MyCompany.MyProduct.MyLibrary")
             .AddConsoleExporter()
             .Build();
 

--- a/docs/metrics/learning-more-instruments/Program.cs
+++ b/docs/metrics/learning-more-instruments/Program.cs
@@ -38,7 +38,7 @@ public class Program
     public static void Main(string[] args)
     {
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
-            .AddSource("MyCompany.MyProduct.MyLibrary")
+            .AddMeter("MyCompany.MyProduct.MyLibrary")
             .AddConsoleExporter()
             .Build();
 

--- a/examples/Console/TestMetrics.cs
+++ b/examples/Console/TestMetrics.cs
@@ -32,7 +32,7 @@ namespace Examples.Console
         {
             var providerBuilder = Sdk.CreateMeterProviderBuilder()
                 .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("myservice"))
-                .AddSource("TestMeter"); // All instruments from this meter are enabled.
+                .AddMeter("TestMeter"); // All instruments from this meter are enabled.
 
             if (options.UseExporter.ToLower() == "otlp")
             {

--- a/examples/Console/TestPrometheusExporter.cs
+++ b/examples/Console/TestPrometheusExporter.cs
@@ -48,7 +48,7 @@ namespace Examples.Console
                 - targets: ['localhost:9184']
             */
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddSource("TestMeter")
+                .AddMeter("TestMeter")
                 .AddPrometheusExporter(opt =>
                 {
                     opt.StartHttpListener = true;

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Added `IDeferredMeterProviderBuilder`
   ([#2412](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2412))
 
+* Breaking: Renamed `AddSource` to `AddMeter` on MeterProviderBuilder
+  to better reflect the intent of the method.
+
 ## 1.2.0-alpha4
 
 Released 2021-Sep-23

--- a/src/OpenTelemetry.Api/Metrics/MeterProviderBuilder.cs
+++ b/src/OpenTelemetry.Api/Metrics/MeterProviderBuilder.cs
@@ -40,10 +40,10 @@ namespace OpenTelemetry.Metrics
             where TInstrumentation : class;
 
         /// <summary>
-        /// Adds given Meter names to the list of subscribed sources.
+        /// Adds given Meter names to the list of subscribed meters.
         /// </summary>
-        /// <param name="names">Meter source names.</param>
+        /// <param name="names">Meter names.</param>
         /// <returns>Returns <see cref="MeterProviderBuilder"/> for chaining.</returns>
-        public abstract MeterProviderBuilder AddSource(params string[] names);
+        public abstract MeterProviderBuilder AddMeter(params string[] names);
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/MeterProviderBuilderExtensions.cs
@@ -46,7 +46,7 @@ namespace OpenTelemetry.Metrics
             //   EnableGrpcAspNetCoreSupport - this instrumentation will also need to also handle gRPC requests
 
             var instrumentation = new AspNetCoreMetrics();
-            builder.AddSource(AspNetCoreMetrics.InstrumentationName);
+            builder.AddMeter(AspNetCoreMetrics.InstrumentationName);
             return builder.AddInstrumentation(() => instrumentation);
         }
     }

--- a/src/OpenTelemetry.Instrumentation.Http/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/MeterProviderBuilderExtensions.cs
@@ -46,7 +46,7 @@ namespace OpenTelemetry.Metrics
             //   RecordException - probably doesn't make sense for metric instrumentation
 
             var instrumentation = new HttpClientMetrics();
-            builder.AddSource(HttpClientMetrics.InstrumentationName);
+            builder.AddMeter(HttpClientMetrics.InstrumentationName);
             return builder.AddInstrumentation(() => instrumentation);
         }
     }

--- a/src/OpenTelemetry/Metrics/MeterProviderBuilderBase.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderBuilderBase.cs
@@ -56,7 +56,7 @@ namespace OpenTelemetry.Metrics
         }
 
         /// <inheritdoc />
-        public override MeterProviderBuilder AddSource(params string[] names)
+        public override MeterProviderBuilder AddMeter(params string[] names)
         {
             if (names == null)
             {

--- a/test/Benchmarks/Metrics/MetricCollectBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricCollectBenchmarks.cs
@@ -91,7 +91,7 @@ namespace Benchmarks.Metrics
                 PreferredAggregationTemporality = AggregationTemporality.Cumulative,
             };
             this.provider = Sdk.CreateMeterProviderBuilder()
-                .AddSource("TestMeter")
+                .AddMeter("TestMeter")
                 .AddReader(this.reader)
                 .Build();
 

--- a/test/Benchmarks/Metrics/MetricsBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricsBenchmarks.cs
@@ -76,7 +76,7 @@ namespace Benchmarks.Metrics
             if (this.WithSDK)
             {
                 this.provider = Sdk.CreateMeterProviderBuilder()
-                    .AddSource("TestMeter") // All instruments from this meter are enabled.
+                    .AddMeter("TestMeter") // All instruments from this meter are enabled.
                     .Build();
             }
 

--- a/test/Benchmarks/Metrics/MetricsViewBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricsViewBenchmarks.cs
@@ -84,20 +84,20 @@ namespace Benchmarks.Metrics
             if (this.ViewConfig == ViewConfiguration.NoView)
             {
                 this.provider = Sdk.CreateMeterProviderBuilder()
-                    .AddSource(this.meter.Name)
+                    .AddMeter(this.meter.Name)
                     .Build();
             }
             else if (this.ViewConfig == ViewConfiguration.ViewNoInstrSelect)
             {
                 this.provider = Sdk.CreateMeterProviderBuilder()
-                    .AddSource(this.meter.Name)
+                    .AddMeter(this.meter.Name)
                     .AddView("nomatch", new MetricStreamConfiguration() { TagKeys = new string[] { "DimName1", "DimName2", "DimName3" } })
                     .Build();
             }
             else if (this.ViewConfig == ViewConfiguration.ViewSelectsInstr)
             {
                 this.provider = Sdk.CreateMeterProviderBuilder()
-                    .AddSource(this.meter.Name)
+                    .AddMeter(this.meter.Name)
                     .AddView(this.counter.Name, new MetricStreamConfiguration() { TagKeys = new string[] { "DimName1", "DimName2", "DimName3" } })
                     .Build();
             }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
@@ -63,7 +63,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
 
             using var provider = Sdk.CreateMeterProviderBuilder()
                 .SetResourceBuilder(resourceBuilder)
-                .AddSource("TestMeter")
+                .AddMeter("TestMeter")
                 .AddReader(metricReader)
                 .Build();
 

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterExtensionsTests.cs
@@ -58,7 +58,7 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
             var testCompleted = false;
 
             using (var provider = Sdk.CreateMeterProviderBuilder()
-                .AddSource(MeterName)
+                .AddMeter(MeterName)
                 .AddReader(new BaseExportingMetricReader(new TestExporter<Metric>(RunTest)))
                 .Build())
             {

--- a/test/OpenTelemetry.Tests.Stress.Metrics/Program.cs
+++ b/test/OpenTelemetry.Tests.Stress.Metrics/Program.cs
@@ -39,7 +39,7 @@ public partial class Program
         }
 
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
-            .AddSource("TestMeter")
+            .AddMeter("TestMeter")
             .Build();
         Stress();
     }

--- a/test/OpenTelemetry.Tests/Metrics/InMemoryExporterTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/InMemoryExporterTests.cs
@@ -35,7 +35,7 @@ namespace OpenTelemetry.Metrics.Tests
             };
 
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-            .AddSource("InMemoryExporterTests")
+            .AddMeter("InMemoryExporterTests")
             .AddReader(inMemoryReader)
             .Build();
 

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -62,8 +62,8 @@ namespace OpenTelemetry.Metrics.Tests
             using var meter1 = new Meter("TestDuplicateMetricName1");
             using var meter2 = new Meter("TestDuplicateMetricName2");
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddSource("TestDuplicateMetricName1")
-                .AddSource("TestDuplicateMetricName2")
+                .AddMeter("TestDuplicateMetricName1")
+                .AddMeter("TestDuplicateMetricName2")
                 .AddReader(metricReader)
                 .Build();
 
@@ -116,7 +116,7 @@ namespace OpenTelemetry.Metrics.Tests
             using var meter = new Meter("TestMeter");
             var counterLong = meter.CreateCounter<long>("mycounter");
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddSource("TestMeter")
+                .AddMeter("TestMeter")
                 .AddReader(metricReader)
                 .Build();
 
@@ -201,7 +201,7 @@ namespace OpenTelemetry.Metrics.Tests
                 };
             });
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddSource(meterName)
+                .AddMeter(meterName)
                 .AddReader(metricReader)
                 .Build();
 
@@ -261,7 +261,7 @@ namespace OpenTelemetry.Metrics.Tests
             using var meter = new Meter("TestPointCapMeter");
             var counterLong = meter.CreateCounter<long>("mycounterCapTest");
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddSource("TestPointCapMeter")
+                .AddMeter("TestPointCapMeter")
                 .AddReader(metricReader)
                 .Build();
 
@@ -313,7 +313,7 @@ namespace OpenTelemetry.Metrics.Tests
             using var meter = new Meter("TestLongCounterMeter");
             var counterLong = meter.CreateCounter<long>("mycounter");
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddSource("TestLongCounterMeter")
+                .AddMeter("TestLongCounterMeter")
                 .AddReader(metricReader)
                 .Build();
 
@@ -382,7 +382,7 @@ namespace OpenTelemetry.Metrics.Tests
             using var meter = new Meter("TestDoubleCounterMeter");
             var counterDouble = meter.CreateCounter<double>("mycounter");
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddSource("TestDoubleCounterMeter")
+                .AddMeter("TestDoubleCounterMeter")
                 .AddReader(metricReader)
                 .Build();
 

--- a/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
@@ -39,7 +39,7 @@ namespace OpenTelemetry.Metrics.Tests
             using var meter1 = new Meter("ViewToRenameMetricTest");
             var exportedItems = new List<Metric>();
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddSource(meter1.Name)
+                .AddMeter(meter1.Name)
                 .AddView("name1", "renamed")
                 .AddInMemoryExporter(exportedItems)
                 .Build();
@@ -60,8 +60,8 @@ namespace OpenTelemetry.Metrics.Tests
             using var meter2 = new Meter("ViewToRenameMetricConditionallyTest2");
             var exportedItems = new List<Metric>();
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddSource(meter1.Name)
-                .AddSource(meter2.Name)
+                .AddMeter(meter1.Name)
+                .AddMeter(meter2.Name)
                 .AddView((instrument) =>
                 {
                     if (instrument.Meter.Name.Equals(meter2.Name, StringComparison.OrdinalIgnoreCase)
@@ -99,7 +99,7 @@ namespace OpenTelemetry.Metrics.Tests
             using var meter1 = new Meter("ViewToRenameMetricWildCardMatchTest");
             var exportedItems = new List<Metric>();
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddSource(meter1.Name)
+                .AddMeter(meter1.Name)
                 .AddView("counter*", "renamed")
                 .AddInMemoryExporter(exportedItems)
                 .Build();
@@ -126,7 +126,7 @@ namespace OpenTelemetry.Metrics.Tests
             using var meter1 = new Meter("ViewToProduceMultipleStreamsFromInstrumentTest");
             var exportedItems = new List<Metric>();
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddSource(meter1.Name)
+                .AddMeter(meter1.Name)
                 .AddView("name1", "renamedStream1")
                 .AddView("name1", "renamedStream2")
                 .AddInMemoryExporter(exportedItems)
@@ -147,7 +147,7 @@ namespace OpenTelemetry.Metrics.Tests
             using var meter1 = new Meter("ViewToProduceMultipleStreamsWithDuplicatesFromInstrumentTest");
             var exportedItems = new List<Metric>();
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddSource(meter1.Name)
+                .AddMeter(meter1.Name)
                 .AddView("name1", "renamedStream1")
                 .AddView("name1", "renamedStream2")
                 .AddView("name1", "renamedStream2")
@@ -173,7 +173,7 @@ namespace OpenTelemetry.Metrics.Tests
             var exportedItems = new List<Metric>();
             var bounds = new double[] { 10, 20 };
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddSource(meter1.Name)
+                .AddMeter(meter1.Name)
                 .AddView("MyHistogram", new HistogramConfiguration() { Name = "MyHistogramDefaultBound" })
                 .AddView("MyHistogram", new HistogramConfiguration() { BucketBounds = bounds })
                 .AddInMemoryExporter(exportedItems)
@@ -237,7 +237,7 @@ namespace OpenTelemetry.Metrics.Tests
             using var meter1 = new Meter("ViewToSelectTagKeysTest");
             var exportedItems = new List<Metric>();
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddSource(meter1.Name)
+                .AddMeter(meter1.Name)
                 .AddView("FruitCounter", new MetricStreamConfiguration()
                 { TagKeys = new string[] { "name" }, Name = "NameOnly" })
                 .AddView("FruitCounter", new MetricStreamConfiguration()
@@ -299,7 +299,7 @@ namespace OpenTelemetry.Metrics.Tests
             using var meter = new Meter("ViewToDropSingleInstrumentTest");
             var exportedItems = new List<Metric>();
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddSource(meter.Name)
+                .AddMeter(meter.Name)
                 .AddView("counterNotInteresting", new MetricStreamConfiguration() { Aggregation = Aggregation.Drop })
                 .AddInMemoryExporter(exportedItems)
                 .Build();
@@ -322,7 +322,7 @@ namespace OpenTelemetry.Metrics.Tests
             using var meter = new Meter("ViewToDropMultipleInstrumentsTest");
             var exportedItems = new List<Metric>();
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddSource(meter.Name)
+                .AddMeter(meter.Name)
                 .AddView("server*", new MetricStreamConfiguration() { Aggregation = Aggregation.Drop })
                 .AddInMemoryExporter(exportedItems)
                 .Build();
@@ -349,7 +349,7 @@ namespace OpenTelemetry.Metrics.Tests
             using var meter = new Meter("ViewToDropAndRetainInstrumentTest");
             var exportedItems = new List<Metric>();
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddSource(meter.Name)
+                .AddMeter(meter.Name)
                 .AddView("server.requests", MetricStreamConfiguration.Drop)
                 .AddView("server.requests", "server.request_renamed")
                 .AddInMemoryExporter(exportedItems)


### PR DESCRIPTION
`AddSource` was copied from TracerProviderBuilder where it made sense as it was adding `ActivitySource`. For MeterProviderBuilder, more correct name would be `AddMeter` (as there is no MeterSource , but only `Meter`)