### PR TITLE
Set AggregationTemporality from exporter options

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterMetricsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterMetricsExtensions.cs
@@ -41,12 +41,13 @@ namespace OpenTelemetry.Metrics
 
             var exporter = new ConsoleMetricExporter(options);
 
-            if (options.MetricExportIntervalMilliseconds == Timeout.Infinite)
-            {
-                return builder.AddReader(new BaseExportingMetricReader(exporter));
-            }
+            var reader = options.MetricExportIntervalMilliseconds == Timeout.Infinite
+                ? new BaseExportingMetricReader(exporter)
+                : new PeriodicExportingMetricReader(exporter, options.MetricExportIntervalMilliseconds);
 
-            return builder.AddReader(new PeriodicExportingMetricReader(exporter, options.MetricExportIntervalMilliseconds));
+            reader.PreferredAggregationTemporality = options.AggregationTemporality;
+
+            return builder.AddReader(reader);
         }
     }
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
@@ -54,6 +54,7 @@ namespace OpenTelemetry.Metrics
 
             var metricExporter = new OtlpMetricExporter(options);
             var metricReader = new PeriodicExportingMetricReader(metricExporter, options.MetricExportIntervalMilliseconds);
+            metricReader.PreferredAggregationTemporality = options.AggregationTemporality;
             return builder.AddReader(metricReader);
         }
     }


### PR DESCRIPTION
The console and OTLP metric exporters have an `AggregationTemporality` option. The `PreferredAggregationTemporality` on the `MetricReader` was not getting set.