### PR TITLE
Seal Metric class for improved perf

### DIFF
--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -22,7 +22,7 @@ using System.Threading;
 
 namespace OpenTelemetry.Metrics
 {
-    internal class AggregatorStore
+    internal sealed class AggregatorStore
     {
         internal const int MaxMetricPoints = 2000;
         private static readonly ObjectArrayEqualityComparer ObjectArrayComparer = new ObjectArrayEqualityComparer();

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -20,7 +20,7 @@ using System.Diagnostics.Metrics;
 
 namespace OpenTelemetry.Metrics
 {
-    public class Metric
+    public sealed class Metric
     {
         internal static readonly double[] DefaultHistogramBounds = new double[] { 0, 5, 10, 25, 50, 75, 100, 250, 500, 1000 };
         private AggregatorStore aggStore;


### PR DESCRIPTION
`Metric` is used as instrument state, so casting the state from `Object` to `Metric` is done in hot path. Making it sealed should make `as` typecheck (https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry/Metrics/MeterProviderSdk.cs#L318) and the method calls faster (https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry/Metrics/MeterProviderSdk.cs#L327)

Before:
* Total Loops: 103,670,988
* Average Loops/Second: 4,118,177
* Average CPU Cycles/Loop: 3,628

After
* Total Loops: 103,113,327
* Average Loops/Second: 4,267,936
* Average CPU Cycles/Loop: 3,574