### PR TITLE
Fix incorrect comment for OTLP exporter Endpoint option

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -111,7 +111,7 @@ namespace OpenTelemetry.Exporter
         public string Headers { get; set; }
 
         /// <summary>
-        /// Gets or sets the max waiting time (in milliseconds) for the backend to process each span batch. The default value is 10000.
+        /// Gets or sets the max waiting time (in milliseconds) for the backend to process each batch. The default value is 10000.
         /// </summary>
         public int TimeoutMilliseconds { get; set; } = 10000;
 


### PR DESCRIPTION
Fixes #2463.

Fixes stale comment indicating that the OTLP exporter does not support secure connections. It does. A secure connection is assumed when using the `https` scheme.