### PR TITLE
Otlp Exporter: Http trace export perf

### DIFF
--- a/test/Benchmarks/Exporter/OtlpGrpcExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/OtlpGrpcExporterBenchmarks.cs
@@ -1,4 +1,4 @@
-// <copyright file="OtlpExporterBenchmarks.cs" company="OpenTelemetry Authors">
+// <copyright file="OtlpGrpcExporterBenchmarks.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +29,7 @@ using OtlpCollector = Opentelemetry.Proto.Collector.Trace.V1;
 namespace Benchmarks.Exporter
 {
     [MemoryDiagnoser]
-    public class OtlpExporterBenchmarks
+    public class OtlpGrpcExporterBenchmarks
     {
         private OtlpTraceExporter exporter;
         private Activity activity;

--- a/test/Benchmarks/Exporter/OtlpHttpExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/OtlpHttpExporterBenchmarks.cs
@@ -1,0 +1,104 @@
+// <copyright file="OtlpHttpExporterBenchmarks.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using BenchmarkDotNet.Attributes;
+using Benchmarks.Helper;
+using OpenTelemetry;
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
+using OpenTelemetry.Internal;
+using OpenTelemetry.Tests;
+
+namespace Benchmarks.Exporter
+{
+    [MemoryDiagnoser]
+    public class OtlpHttpExporterBenchmarks
+    {
+        private readonly byte[] buffer = new byte[1024 * 1024];
+        private IDisposable server;
+        private string serverHost;
+        private int serverPort;
+        private OtlpTraceExporter exporter;
+        private Activity activity;
+        private CircularBuffer<Activity> activityBatch;
+
+        [Params(1, 10, 100)]
+        public int NumberOfBatches { get; set; }
+
+        [Params(10000)]
+        public int NumberOfSpans { get; set; }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            this.server = TestHttpServer.RunServer(
+                (ctx) =>
+                {
+                    using (Stream receiveStream = ctx.Request.InputStream)
+                    {
+                        while (true)
+                        {
+                            if (receiveStream.Read(this.buffer, 0, this.buffer.Length) == 0)
+                            {
+                                break;
+                            }
+                        }
+                    }
+
+                    ctx.Response.StatusCode = 200;
+                    ctx.Response.OutputStream.Close();
+                },
+                out this.serverHost,
+                out this.serverPort);
+
+            var options = new OtlpExporterOptions
+            {
+                Endpoint = new Uri($"http://{this.serverHost}:{this.serverPort}"),
+            };
+            this.exporter = new OtlpTraceExporter(
+                options,
+                new OtlpHttpTraceExportClient(options));
+
+            this.activity = ActivityHelper.CreateTestActivity();
+            this.activityBatch = new CircularBuffer<Activity>(this.NumberOfSpans);
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            this.exporter.Shutdown();
+            this.exporter.Dispose();
+            this.server.Dispose();
+        }
+
+        [Benchmark]
+        public void OtlpExporter_Batching()
+        {
+            for (int i = 0; i < this.NumberOfBatches; i++)
+            {
+                for (int c = 0; c < this.NumberOfSpans; c++)
+                {
+                    this.activityBatch.Add(this.activity);
+                }
+
+                this.exporter.Export(new Batch<Activity>(this.activityBatch, this.NumberOfSpans));
+            }
+        }
+    }
+}

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/ExportClient/OtlpHttpTraceExportClientTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/ExportClient/OtlpHttpTraceExportClientTests.cs
@@ -181,7 +181,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.Implementation.Expo
                 Assert.Contains(httpRequest.Headers, h => h.Key == header2.Name && h.Value.First() == header2.Value);
 
                 Assert.NotNull(httpRequest.Content);
-                Assert.IsType<ByteArrayContent>(httpRequest.Content);
+                Assert.IsType<OtlpHttpTraceExportClient.ExportRequestContent>(httpRequest.Content);
                 Assert.Contains(httpRequest.Content.Headers, h => h.Key == "Content-Type" && h.Value.First() == OtlpHttpTraceExportClient.MediaContentType);
 
                 var exportTraceRequest = OtlpCollector.ExportTraceServiceRequest.Parser.ParseFrom(httpRequestContent);


### PR DESCRIPTION
Write directly to the output stream inside of `OtlpHttpTraceExportClient` instead of buffering into memory to save some bytes.

## Before

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19043.1288 (21H1/May2021Update)
Intel Core i9-9880H CPU 2.30GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK=5.0.402
  [Host]     : .NET 5.0.11 (5.0.1121.47308), X64 RyuJIT
  DefaultJob : .NET 5.0.11 (5.0.1121.47308), X64 RyuJIT


|                Method | NumberOfBatches | NumberOfSpans |        Mean |     Error |    StdDev |       Gen 0 |       Gen 1 |       Gen 2 | Allocated |
|---------------------- |---------------- |-------------- |------------:|----------:|----------:|------------:|------------:|------------:|----------:|
| OtlpExporter_Batching |               1 |         10000 |    107.0 ms |   2.13 ms |   3.89 ms |   3400.0000 |   2000.0000 |   1000.0000 |     32 MB |
| OtlpExporter_Batching |              10 |         10000 |  1,105.7 ms |  21.77 ms |  33.89 ms |  37000.0000 |  23000.0000 |  11000.0000 |    323 MB |
| OtlpExporter_Batching |             100 |         10000 | 11,364.7 ms | 115.06 ms | 107.62 ms | 397000.0000 | 263000.0000 | 131000.0000 |  3,234 MB |

## After

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19043.1288 (21H1/May2021Update)
Intel Core i9-9880H CPU 2.30GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK=5.0.402
  [Host]     : .NET 5.0.11 (5.0.1121.47308), X64 RyuJIT
  DefaultJob : .NET 5.0.11 (5.0.1121.47308), X64 RyuJIT


|                Method | NumberOfBatches | NumberOfSpans |        Mean |     Error |    StdDev |       Gen 0 |       Gen 1 |      Gen 2 | Allocated |
|---------------------- |---------------- |-------------- |------------:|----------:|----------:|------------:|------------:|-----------:|----------:|
| OtlpExporter_Batching |               1 |         10000 |    103.6 ms |   2.06 ms |   3.82 ms |   3200.0000 |   1800.0000 |   600.0000 |     22 MB |
| OtlpExporter_Batching |              10 |         10000 |  1,076.3 ms |  19.10 ms |  16.93 ms |  33000.0000 |  19000.0000 |  6000.0000 |    217 MB |
| OtlpExporter_Batching |             100 |         10000 | 10,924.7 ms | 122.67 ms | 114.74 ms | 338000.0000 | 202000.0000 | 67000.0000 |  2,169 MB |