### PR TITLE
Remove duplicated src from proj file

### DIFF
--- a/src/OpenTelemetry.Api/OpenTelemetry.Api.csproj
+++ b/src/OpenTelemetry.Api/OpenTelemetry.Api.csproj
@@ -18,9 +18,4 @@
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticSourcePkgVer)" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="$(SystemReflectionEmitLightweightPkgVer)" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\Guard.cs" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Fix the compile time warning: **CSC : warning CS2002: Source file 'E:\opentelemetry-dotnet\src\OpenTelemetry.Api\Internal\Guard.cs' specified multiple times [E:\opentelemetry-dotnet\src\OpenTelemetry.Api\OpenTelemetry.Api.csproj]**