### PR TITLE
Add Robert as approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Approvers
 * [Eddy Nakamura](https://github.com/eddynaka), Microsoft
 * [Paulo Janotti](https://github.com/pjanotti), Splunk
 * [Reiley Yang](https://github.com/reyang), Microsoft
-* [Robert Pająk](https://github.com/pellared), Splunk
+* [Robert Pajak](https://github.com/pellared), Splunk
 * [Utkarsh Umesan Pillai](https://github.com/utpilla), Microsoft
 
 *Find more about the approver role in [community


### PR DESCRIPTION
@pellared  has been an active contributor to the project for few months now. He is already an approver and among top contributors to the [Auto-instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation) efforts, which recently switched to be building on top of SDK from this repo. Robert's expertise in auto-instrumentation would be a bonus addition to this team!

Contributions include not only [PRs](https://github.com/open-telemetry/opentelemetry-dotnet/pulls?q=is%3Apr+author%3Apellared), but active engagement in reviews, responding to issues/slack conversations and SIG meetings (despite odd timings!)

