### PR TITLE
[Do Not Merge] Metrics Async Pull API

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterExtensions.cs
@@ -198,19 +198,19 @@ namespace OpenTelemetry.Exporter.Prometheus
         /// <summary>
         /// Serialize metrics to prometheus format.
         /// </summary>
-        /// <param name="exporter"><see cref="PrometheusExporter"/>.</param>
+        /// <param name="metrics">Metrics to write.</param>
         /// <param name="stream">Stream to write to.</param>
         /// <param name="getUtcNowDateTimeOffset">Optional function to resolve the current date &amp; time.</param>
         /// <returns><see cref="Task"/> to await the operation.</returns>
         public static async Task WriteMetricsCollection(
-            this PrometheusExporter exporter,
+            Batch<Metric> metrics,
             Stream stream,
             Func<DateTimeOffset> getUtcNowDateTimeOffset)
         {
             byte[] buffer = ArrayPool<byte>.Shared.Rent(8192);
             try
             {
-                foreach (var metric in exporter.Metrics)
+                foreach (var metric in metrics)
                 {
                     if (!MetricInfoCache.TryGetValue(metric.Name, out MetricInfo metricInfo))
                     {

--- a/src/OpenTelemetry/BaseExporter.cs
+++ b/src/OpenTelemetry/BaseExporter.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using OpenTelemetry.Internal;
 
 namespace OpenTelemetry
@@ -56,6 +57,11 @@ namespace OpenTelemetry
         /// <param name="batch">Batch of telemetry objects to export.</param>
         /// <returns>Result of the export operation.</returns>
         public abstract ExportResult Export(in Batch<T> batch);
+
+        public virtual Task<ExportResult> ExportAsync(Batch<T> batch)
+        {
+            return Task.FromResult(this.Export(batch));
+        }
 
         /// <summary>
         /// Attempts to shutdown the exporter, blocks the current thread until

--- a/src/OpenTelemetry/BaseExporter.cs
+++ b/src/OpenTelemetry/BaseExporter.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Threading;
-using System.Threading.Tasks;
 using OpenTelemetry.Internal;
 
 namespace OpenTelemetry
@@ -57,11 +56,6 @@ namespace OpenTelemetry
         /// <param name="batch">Batch of telemetry objects to export.</param>
         /// <returns>Result of the export operation.</returns>
         public abstract ExportResult Export(in Batch<T> batch);
-
-        public virtual Task<ExportResult> ExportAsync(Batch<T> batch)
-        {
-            return Task.FromResult(this.Export(batch));
-        }
 
         /// <summary>
         /// Attempts to shutdown the exporter, blocks the current thread until

--- a/src/OpenTelemetry/Metrics/BaseExportingMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/BaseExportingMetricReader.cs
@@ -96,7 +96,7 @@ namespace OpenTelemetry.Metrics
             }
 
             // TODO: Do we need to consider timeout here?
-            return await this.exporter.ExportAsync(metrics).ConfigureAwait(false) == ExportResult.Success;
+            return this.exporter.Export(metrics) == ExportResult.Success;
         }
 
         /// <inheritdoc />

--- a/src/OpenTelemetry/Metrics/IPullMetricExporter.cs
+++ b/src/OpenTelemetry/Metrics/IPullMetricExporter.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 using System;
+using System.Threading.Tasks;
 
 namespace OpenTelemetry.Metrics
 {
@@ -23,6 +24,8 @@ namespace OpenTelemetry.Metrics
     /// </summary>
     public interface IPullMetricExporter
     {
-        Func<int, bool> Collect { get; set; }
+        Func<int, Task<bool>> CollectAndPullAsync { get; set; }
+
+        Task<ExportResult> PullAsync(Batch<Metric> batch);
     }
 }

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterExtensionsTests.cs
@@ -70,13 +70,9 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
 
             void RunTest(Batch<Metric> metrics)
             {
-                using PrometheusExporter prometheusExporter = new PrometheusExporter(new PrometheusExporterOptions());
-
-                prometheusExporter.Metrics = metrics;
-
                 using MemoryStream ms = new MemoryStream();
 
-                PrometheusExporterExtensions.WriteMetricsCollection(prometheusExporter, ms, () => new DateTimeOffset(2021, 9, 30, 22, 30, 0, TimeSpan.Zero)).GetAwaiter().GetResult();
+                PrometheusExporterExtensions.WriteMetricsCollection(metrics, ms, () => new DateTimeOffset(2021, 9, 30, 22, 30, 0, TimeSpan.Zero)).GetAwaiter().GetResult();
 
                 Assert.Equal(
                     expected,


### PR DESCRIPTION
Related to #2511 

This PR is a demo implementation of two theories people may or may not agree with in order to gather feedback.

* Pull API should be asynchronous 

  For push export, on some timer, with a dedicated thread, synchronous export is desired. But for externally initiated pull, writing to some output stream, I think we should have an asynchronous API. In the case of Prometheus middleware, running in ASP.NET Core, this allows for nice thread sharing when that output stream is waiting on some network IO.

* We should differentiate between Push & Pull in exporters.

   With a single Export entry point in PrometheusExporter I don't know how we could decide if we need to push or pull, assuming we will eventually also support push. We would have to take a dependency on the `PullMetricScope` which is internal to SDK, or perhaps ask users to register multiple exporters with different configurations. Since we have `IPullMetricExporter`, which exporters use to opt-into pull, it seemed simple enough to define a dedicated entry point.