### PR TITLE
Remove unnecessary try catch for SecurityException

### DIFF
--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -314,12 +314,6 @@ namespace OpenTelemetry.Internal
             this.WriteEvent(26, logDirectory, exception);
         }
 
-        [Event(27, Message = "Failed to create resource from ResourceDetector: '{0}' due to '{1}'.", Level = EventLevel.Warning)]
-        public void ResourceDetectorFailed(string resourceDetector, string issue)
-        {
-            this.WriteEvent(27, resourceDetector, issue);
-        }
-
         [Event(28, Message = "Unknown error in TracerProvider '{0}': '{1}'.", Level = EventLevel.Error)]
         public void TracerProviderException(string evnt, string ex)
         {

--- a/src/OpenTelemetry/Resources/OtelEnvResourceDetector.cs
+++ b/src/OpenTelemetry/Resources/OtelEnvResourceDetector.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 using System.Collections.Generic;
-using System.Security;
 using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Resources
@@ -30,17 +29,10 @@ namespace OpenTelemetry.Resources
         {
             var resource = Resource.Empty;
 
-            try
+            if (EnvironmentVariableHelper.LoadString(EnvVarKey, out string envResourceAttributeValue))
             {
-                if (EnvironmentVariableHelper.LoadString(EnvVarKey, out string envResourceAttributeValue))
-                {
-                    var attributes = ParseResourceAttributes(envResourceAttributeValue);
-                    resource = new Resource(attributes);
-                }
-            }
-            catch (SecurityException ex)
-            {
-                OpenTelemetrySdkEventSource.Log.ResourceDetectorFailed(nameof(OtelEnvResourceDetector), ex.Message);
+                var attributes = ParseResourceAttributes(envResourceAttributeValue);
+                resource = new Resource(attributes);
             }
 
             return resource;

--- a/src/OpenTelemetry/Resources/OtelServiceNameEnvVarDetector.cs
+++ b/src/OpenTelemetry/Resources/OtelServiceNameEnvVarDetector.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 using System.Collections.Generic;
-using System.Security;
 using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Resources
@@ -28,19 +27,12 @@ namespace OpenTelemetry.Resources
         {
             var resource = Resource.Empty;
 
-            try
+            if (EnvironmentVariableHelper.LoadString(EnvVarKey, out string envResourceAttributeValue))
             {
-                if (EnvironmentVariableHelper.LoadString(EnvVarKey, out string envResourceAttributeValue))
+                resource = new Resource(new Dictionary<string, object>
                 {
-                    resource = new Resource(new Dictionary<string, object>
-                    {
-                        [ResourceSemanticConventions.AttributeServiceName] = envResourceAttributeValue,
-                    });
-                }
-            }
-            catch (SecurityException ex)
-            {
-                OpenTelemetrySdkEventSource.Log.ResourceDetectorFailed(nameof(OtelServiceNameEnvVarDetector), ex.Message);
+                    [ResourceSemanticConventions.AttributeServiceName] = envResourceAttributeValue,
+                });
             }
 
             return resource;


### PR DESCRIPTION
Addresses @alanwest comment: https://github.com/open-telemetry/opentelemetry-dotnet/pull/2500#discussion_r736925257.

## Changes

Remove unnecessary try-catch for SecurityException since LoadString already does it.