### PR TITLE
Using `Debug.Assert` for non-public methods vs. `Guard` methods

### DIFF
--- a/build/OpenTelemetry.prod.loose.ruleset
+++ b/build/OpenTelemetry.prod.loose.ruleset
@@ -101,7 +101,7 @@
     <Rule Id="SA1402" Action="Warning" />
     <Rule Id="SA1403" Action="Warning" />
     <Rule Id="SA1404" Action="Warning" />
-    <Rule Id="SA1405" Action="Warning" />
+    <Rule Id="SA1405" Action="None" />
     <Rule Id="SA1406" Action="Warning" />
     <Rule Id="SA1407" Action="Warning" />
     <Rule Id="SA1408" Action="Warning" />

--- a/examples/AspNet/Controllers/WeatherForecastController.cs
+++ b/examples/AspNet/Controllers/WeatherForecastController.cs
@@ -199,7 +199,7 @@ namespace Examples.AspNet.Controllers
 
             using var response = await request.GetAsync(this.Url.Content("~/subroute/-1")).ConfigureAwait(false);
 
-            Debug.Assert(response.StatusCode == HttpStatusCode.InternalServerError, "response.StatusCode is InternalServerError");
+            Debug.Assert(response.StatusCode == HttpStatusCode.InternalServerError, $"{nameof(response)}.{nameof(response.StatusCode)} must be {nameof(HttpStatusCode.InternalServerError)}");
         }
 
         // Test successful dependency collection via HttpClient.

--- a/examples/AspNet/Controllers/WeatherForecastController.cs
+++ b/examples/AspNet/Controllers/WeatherForecastController.cs
@@ -199,7 +199,7 @@ namespace Examples.AspNet.Controllers
 
             using var response = await request.GetAsync(this.Url.Content("~/subroute/-1")).ConfigureAwait(false);
 
-            Debug.Assert(response.StatusCode == HttpStatusCode.InternalServerError, $"{nameof(response)}.{nameof(response.StatusCode)} must be {nameof(HttpStatusCode.InternalServerError)}");
+            Debug.Assert(response.StatusCode == HttpStatusCode.InternalServerError);
         }
 
         // Test successful dependency collection via HttpClient.

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceStateUtilsNew.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceStateUtilsNew.cs
@@ -40,7 +40,7 @@ namespace OpenTelemetry.Context.Propagation
         /// <returns>True if string was parsed successfully and tracestate was recognized, false otherwise.</returns>
         internal static bool AppendTraceState(string traceStateString, List<KeyValuePair<string, string>> tracestate)
         {
-            Debug.Assert(tracestate != null, $"{nameof(tracestate)} must not be null");
+            Debug.Assert(tracestate != null);
 
             if (string.IsNullOrEmpty(traceStateString))
             {

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceStateUtilsNew.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceStateUtilsNew.cs
@@ -40,7 +40,7 @@ namespace OpenTelemetry.Context.Propagation
         /// <returns>True if string was parsed successfully and tracestate was recognized, false otherwise.</returns>
         internal static bool AppendTraceState(string traceStateString, List<KeyValuePair<string, string>> tracestate)
         {
-            Debug.Assert(tracestate != null, "tracestate list cannot be null");
+            Debug.Assert(tracestate != null, $"{nameof(tracestate)} must not be null");
 
             if (string.IsNullOrEmpty(traceStateString))
             {

--- a/src/OpenTelemetry.Api/Internal/ActivityHelperExtensions.cs
+++ b/src/OpenTelemetry.Api/Internal/ActivityHelperExtensions.cs
@@ -40,7 +40,7 @@ namespace OpenTelemetry.Trace
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "ActivityProcessor is hot path")]
         public static bool TryGetStatus(this Activity activity, out StatusCode statusCode, out string statusDescription)
         {
-            Debug.Assert(activity != null, $"{nameof(activity)} must not be null");
+            Debug.Assert(activity != null);
 
             ActivityStatusTagEnumerator state = default;
 
@@ -68,7 +68,7 @@ namespace OpenTelemetry.Trace
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "ActivityProcessor is hot path")]
         public static object GetTagValue(this Activity activity, string tagName)
         {
-            Debug.Assert(activity != null, $"{nameof(activity)} must not be null");
+            Debug.Assert(activity != null);
 
             ActivitySingleTagEnumerator state = new ActivitySingleTagEnumerator(tagName);
 
@@ -87,7 +87,7 @@ namespace OpenTelemetry.Trace
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryCheckFirstTag(this Activity activity, string tagName, out object tagValue)
         {
-            Debug.Assert(activity != null, $"{nameof(activity)} must not be null");
+            Debug.Assert(activity != null);
 
             ActivityFirstTagEnumerator state = new ActivityFirstTagEnumerator(tagName);
 
@@ -114,7 +114,7 @@ namespace OpenTelemetry.Trace
         public static void EnumerateTags<T>(this Activity activity, ref T tagEnumerator)
             where T : struct, IActivityEnumerator<KeyValuePair<string, object>>
         {
-            Debug.Assert(activity != null, $"{nameof(activity)} must not be null");
+            Debug.Assert(activity != null);
 
             ActivityTagsEnumeratorFactory<T>.Enumerate(activity, ref tagEnumerator);
         }
@@ -130,7 +130,7 @@ namespace OpenTelemetry.Trace
         public static void EnumerateLinks<T>(this Activity activity, ref T linkEnumerator)
             where T : struct, IActivityEnumerator<ActivityLink>
         {
-            Debug.Assert(activity != null, $"{nameof(activity)} must not be null");
+            Debug.Assert(activity != null);
 
             ActivityLinksEnumeratorFactory<T>.Enumerate(activity, ref linkEnumerator);
         }
@@ -160,7 +160,7 @@ namespace OpenTelemetry.Trace
         public static void EnumerateEvents<T>(this Activity activity, ref T eventEnumerator)
             where T : struct, IActivityEnumerator<ActivityEvent>
         {
-            Debug.Assert(activity != null, $"{nameof(activity)} must not be null");
+            Debug.Assert(activity != null);
 
             ActivityEventsEnumeratorFactory<T>.Enumerate(activity, ref eventEnumerator);
         }

--- a/src/OpenTelemetry.Api/Internal/ActivityHelperExtensions.cs
+++ b/src/OpenTelemetry.Api/Internal/ActivityHelperExtensions.cs
@@ -40,7 +40,7 @@ namespace OpenTelemetry.Trace
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "ActivityProcessor is hot path")]
         public static bool TryGetStatus(this Activity activity, out StatusCode statusCode, out string statusDescription)
         {
-            Debug.Assert(activity != null, "Activity should not be null");
+            Debug.Assert(activity != null, $"{nameof(activity)} must not be null");
 
             ActivityStatusTagEnumerator state = default;
 
@@ -68,7 +68,7 @@ namespace OpenTelemetry.Trace
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "ActivityProcessor is hot path")]
         public static object GetTagValue(this Activity activity, string tagName)
         {
-            Debug.Assert(activity != null, "Activity should not be null");
+            Debug.Assert(activity != null, $"{nameof(activity)} must not be null");
 
             ActivitySingleTagEnumerator state = new ActivitySingleTagEnumerator(tagName);
 
@@ -87,7 +87,7 @@ namespace OpenTelemetry.Trace
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryCheckFirstTag(this Activity activity, string tagName, out object tagValue)
         {
-            Debug.Assert(activity != null, "Activity should not be null");
+            Debug.Assert(activity != null, $"{nameof(activity)} must not be null");
 
             ActivityFirstTagEnumerator state = new ActivityFirstTagEnumerator(tagName);
 
@@ -114,7 +114,7 @@ namespace OpenTelemetry.Trace
         public static void EnumerateTags<T>(this Activity activity, ref T tagEnumerator)
             where T : struct, IActivityEnumerator<KeyValuePair<string, object>>
         {
-            Debug.Assert(activity != null, "Activity should not be null");
+            Debug.Assert(activity != null, $"{nameof(activity)} must not be null");
 
             ActivityTagsEnumeratorFactory<T>.Enumerate(activity, ref tagEnumerator);
         }
@@ -130,7 +130,7 @@ namespace OpenTelemetry.Trace
         public static void EnumerateLinks<T>(this Activity activity, ref T linkEnumerator)
             where T : struct, IActivityEnumerator<ActivityLink>
         {
-            Debug.Assert(activity != null, "Activity should not be null");
+            Debug.Assert(activity != null, $"{nameof(activity)} must not be null");
 
             ActivityLinksEnumeratorFactory<T>.Enumerate(activity, ref linkEnumerator);
         }
@@ -160,7 +160,7 @@ namespace OpenTelemetry.Trace
         public static void EnumerateEvents<T>(this Activity activity, ref T eventEnumerator)
             where T : struct, IActivityEnumerator<ActivityEvent>
         {
-            Debug.Assert(activity != null, "Activity should not be null");
+            Debug.Assert(activity != null, $"{nameof(activity)} must not be null");
 
             ActivityEventsEnumeratorFactory<T>.Enumerate(activity, ref eventEnumerator);
         }

--- a/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
@@ -43,7 +43,7 @@ namespace OpenTelemetry.Trace
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "ActivityProcessor is hot path")]
         public static void SetStatus(this Activity activity, Status status)
         {
-            Debug.Assert(activity != null, "Activity should not be null");
+            Debug.Assert(activity != null, $"{nameof(activity)} must not be null");
 
             activity.SetTag(SpanAttributeConstants.StatusCodeKey, StatusHelper.GetTagValueForStatusCode(status.StatusCode));
             activity.SetTag(SpanAttributeConstants.StatusDescriptionKey, status.Description);

--- a/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
@@ -43,7 +43,7 @@ namespace OpenTelemetry.Trace
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "ActivityProcessor is hot path")]
         public static void SetStatus(this Activity activity, Status status)
         {
-            Debug.Assert(activity != null, $"{nameof(activity)} must not be null");
+            Debug.Assert(activity != null);
 
             activity.SetTag(SpanAttributeConstants.StatusCodeKey, StatusHelper.GetTagValueForStatusCode(status.StatusCode));
             activity.SetTag(SpanAttributeConstants.StatusDescriptionKey, status.Description);

--- a/src/OpenTelemetry.Api/Trace/SpanAttributes.cs
+++ b/src/OpenTelemetry.Api/Trace/SpanAttributes.cs
@@ -133,7 +133,7 @@ namespace OpenTelemetry.Trace
 
         private void AddInternal(string key, object value)
         {
-            Guard.Null(key, nameof(key));
+            Debug.Assert(key != null, $"{nameof(key)} must not be null");
 
             this.Attributes[key] = value;
         }

--- a/src/OpenTelemetry.Api/Trace/SpanAttributes.cs
+++ b/src/OpenTelemetry.Api/Trace/SpanAttributes.cs
@@ -133,7 +133,7 @@ namespace OpenTelemetry.Trace
 
         private void AddInternal(string key, object value)
         {
-            Debug.Assert(key != null, $"{nameof(key)} must not be null");
+            Debug.Assert(key != null);
 
             this.Attributes[key] = value;
         }

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
@@ -45,7 +45,7 @@ namespace OpenTelemetry.Exporter
 
         internal JaegerExporter(JaegerExporterOptions options, TTransport clientTransport = null)
         {
-            Debug.Assert(options != null, $"{nameof(options)} must not be null");
+            Debug.Assert(options != null);
 
             this.maxPayloadSizeInBytes = (!options.MaxPayloadSizeInBytes.HasValue || options.MaxPayloadSizeInBytes <= 0) ? JaegerExporterOptions.DefaultMaxPayloadSizeInBytes : options.MaxPayloadSizeInBytes.Value;
             this.protocolFactory = new TCompactProtocol.Factory();
@@ -92,7 +92,7 @@ namespace OpenTelemetry.Exporter
 
         internal void SetResourceAndInitializeBatch(Resource resource)
         {
-            Debug.Assert(resource != null, $"{nameof(resource)} must not be null");
+            Debug.Assert(resource != null);
 
             var process = this.Process;
 

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
@@ -20,7 +20,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using OpenTelemetry.Exporter.Jaeger.Implementation;
-using OpenTelemetry.Internal;
 using OpenTelemetry.Resources;
 using Thrift.Protocol;
 using Thrift.Transport;
@@ -46,7 +45,7 @@ namespace OpenTelemetry.Exporter
 
         internal JaegerExporter(JaegerExporterOptions options, TTransport clientTransport = null)
         {
-            Guard.Null(options, nameof(options));
+            Debug.Assert(options != null, $"{nameof(options)} must not be null");
 
             this.maxPayloadSizeInBytes = (!options.MaxPayloadSizeInBytes.HasValue || options.MaxPayloadSizeInBytes <= 0) ? JaegerExporterOptions.DefaultMaxPayloadSizeInBytes : options.MaxPayloadSizeInBytes.Value;
             this.protocolFactory = new TCompactProtocol.Factory();
@@ -93,7 +92,7 @@ namespace OpenTelemetry.Exporter
 
         internal void SetResourceAndInitializeBatch(Resource resource)
         {
-            Guard.Null(resource, nameof(resource));
+            Debug.Assert(resource != null, $"{nameof(resource)} must not be null");
 
             var process = this.Process;
 

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterExtensions.cs
@@ -396,7 +396,7 @@ namespace OpenTelemetry.Exporter.Prometheus
 #if NETCOREAPP3_1_OR_GREATER
                 Span<char> longValueCharacters = stackalloc char[MaxLongCharSize];
                 bool result = longValue.TryFormat(longValueCharacters, out int charsWritten, "G", CultureInfo.InvariantCulture);
-                Debug.Assert(result, "result was not true");
+                Debug.Assert(result, $"{nameof(result)} must be true");
                 int numberOfBytes = Encoding.UTF8.GetBytes(longValueCharacters.Slice(0, charsWritten), new Span<byte>(destination, destinationOffset, destination.Length - destinationOffset));
                 destinationOffset += numberOfBytes;
 #else
@@ -430,7 +430,7 @@ namespace OpenTelemetry.Exporter.Prometheus
 #if NETCOREAPP3_1_OR_GREATER
                 Span<char> doubleValueCharacters = stackalloc char[MaxDoubleCharSize];
                 bool result = doubleValue.TryFormat(doubleValueCharacters, out int charsWritten, "G", CultureInfo.InvariantCulture);
-                Debug.Assert(result, "result was not true");
+                Debug.Assert(result, $"{nameof(result)} must be true");
                 int numberOfBytes = Encoding.UTF8.GetBytes(doubleValueCharacters.Slice(0, charsWritten), new Span<byte>(destination, destinationOffset, destination.Length - destinationOffset));
                 destinationOffset += numberOfBytes;
 #else
@@ -452,7 +452,7 @@ namespace OpenTelemetry.Exporter.Prometheus
 #if NETCOREAPP3_1_OR_GREATER
             Span<char> nowCharacters = stackalloc char[MaxLongCharSize];
             bool result = unixNow.TryFormat(nowCharacters, out int charsWritten, "G", CultureInfo.InvariantCulture);
-            Debug.Assert(result, "result was not true");
+            Debug.Assert(result, $"{nameof(result)} must be true");
             int numberOfBytes = Encoding.UTF8.GetBytes(nowCharacters.Slice(0, charsWritten), new Span<byte>(destination, destinationOffset, destination.Length - destinationOffset));
             destinationOffset += numberOfBytes;
 #else

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterExtensions.cs
@@ -396,7 +396,7 @@ namespace OpenTelemetry.Exporter.Prometheus
 #if NETCOREAPP3_1_OR_GREATER
                 Span<char> longValueCharacters = stackalloc char[MaxLongCharSize];
                 bool result = longValue.TryFormat(longValueCharacters, out int charsWritten, "G", CultureInfo.InvariantCulture);
-                Debug.Assert(result, $"{nameof(result)} must be true");
+                Debug.Assert(result);
                 int numberOfBytes = Encoding.UTF8.GetBytes(longValueCharacters.Slice(0, charsWritten), new Span<byte>(destination, destinationOffset, destination.Length - destinationOffset));
                 destinationOffset += numberOfBytes;
 #else
@@ -430,7 +430,7 @@ namespace OpenTelemetry.Exporter.Prometheus
 #if NETCOREAPP3_1_OR_GREATER
                 Span<char> doubleValueCharacters = stackalloc char[MaxDoubleCharSize];
                 bool result = doubleValue.TryFormat(doubleValueCharacters, out int charsWritten, "G", CultureInfo.InvariantCulture);
-                Debug.Assert(result, $"{nameof(result)} must be true");
+                Debug.Assert(result);
                 int numberOfBytes = Encoding.UTF8.GetBytes(doubleValueCharacters.Slice(0, charsWritten), new Span<byte>(destination, destinationOffset, destination.Length - destinationOffset));
                 destinationOffset += numberOfBytes;
 #else
@@ -452,7 +452,7 @@ namespace OpenTelemetry.Exporter.Prometheus
 #if NETCOREAPP3_1_OR_GREATER
             Span<char> nowCharacters = stackalloc char[MaxLongCharSize];
             bool result = unixNow.TryFormat(nowCharacters, out int charsWritten, "G", CultureInfo.InvariantCulture);
-            Debug.Assert(result, $"{nameof(result)} must be true");
+            Debug.Assert(result);
             int numberOfBytes = Encoding.UTF8.GetBytes(nowCharacters.Slice(0, charsWritten), new Span<byte>(destination, destinationOffset, destination.Length - destinationOffset));
             destinationOffset += numberOfBytes;
 #else

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterMiddleware.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterMiddleware.cs
@@ -59,7 +59,7 @@ namespace OpenTelemetry.Exporter.Prometheus
         /// <returns>Task.</returns>
         public async Task InvokeAsync(HttpContext httpContext)
         {
-            Debug.Assert(httpContext != null, "httpContext should not be null");
+            Debug.Assert(httpContext != null, $"{nameof(httpContext)} must not be null");
 
             var response = httpContext.Response;
 

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterMiddleware.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterMiddleware.cs
@@ -59,7 +59,7 @@ namespace OpenTelemetry.Exporter.Prometheus
         /// <returns>Task.</returns>
         public async Task InvokeAsync(HttpContext httpContext)
         {
-            Debug.Assert(httpContext != null, $"{nameof(httpContext)} must not be null");
+            Debug.Assert(httpContext != null);
 
             var response = httpContext.Response;
 

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusMetricsFormatHelper.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusMetricsFormatHelper.cs
@@ -100,7 +100,7 @@ namespace OpenTelemetry.Exporter.Prometheus
             // Label names may contain ASCII letters, numbers, as well as underscores. They must match the regex [a-zA-Z_][a-zA-Z0-9_]*. Label names beginning with __ are reserved for internal use.
             // Label values may contain any Unicode characters.
 
-            Debug.Assert(!string.IsNullOrEmpty(name), "name is empty or null");
+            Debug.Assert(!string.IsNullOrEmpty(name), $"{nameof(name)} must not be null or empty");
 
 #if NETCOREAPP3_1_OR_GREATER
             return string.Create(name.Length, (name, isCharacterAllowedFunc), CreateName);

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusMetricsFormatHelper.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusMetricsFormatHelper.cs
@@ -100,7 +100,7 @@ namespace OpenTelemetry.Exporter.Prometheus
             // Label names may contain ASCII letters, numbers, as well as underscores. They must match the regex [a-zA-Z_][a-zA-Z0-9_]*. Label names beginning with __ are reserved for internal use.
             // Label values may contain any Unicode characters.
 
-            Debug.Assert(!string.IsNullOrEmpty(name), $"{nameof(name)} must not be null or empty");
+            Debug.Assert(!string.IsNullOrEmpty(name));
 
 #if NETCOREAPP3_1_OR_GREATER
             return string.Create(name.Length, (name, isCharacterAllowedFunc), CreateName);

--- a/src/OpenTelemetry.Exporter.ZPages/ZPagesProcessor.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/ZPagesProcessor.cs
@@ -41,7 +41,7 @@ namespace OpenTelemetry.Exporter.ZPages
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "ActivityProcessor is hot path")]
         public override void OnStart(Activity activity)
         {
-            Debug.Assert(activity != null, $"{nameof(activity)} must not be null");
+            Debug.Assert(activity != null);
 
             if (!ZPagesActivityTracker.ProcessingList.ContainsKey(activity.DisplayName))
             {
@@ -66,7 +66,7 @@ namespace OpenTelemetry.Exporter.ZPages
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "ActivityProcessor is hot path")]
         public override void OnEnd(Activity activity)
         {
-            Debug.Assert(activity != null, $"{nameof(activity)} must not be null");
+            Debug.Assert(activity != null);
             try
             {
                 // If the span name is not in the current minute list, add it to the span list.

--- a/src/OpenTelemetry.Exporter.ZPages/ZPagesProcessor.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/ZPagesProcessor.cs
@@ -41,7 +41,7 @@ namespace OpenTelemetry.Exporter.ZPages
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "ActivityProcessor is hot path")]
         public override void OnStart(Activity activity)
         {
-            Debug.Assert(activity != null, "Activity should not be null");
+            Debug.Assert(activity != null, $"{nameof(activity)} must not be null");
 
             if (!ZPagesActivityTracker.ProcessingList.ContainsKey(activity.DisplayName))
             {
@@ -66,7 +66,7 @@ namespace OpenTelemetry.Exporter.ZPages
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "ActivityProcessor is hot path")]
         public override void OnEnd(Activity activity)
         {
-            Debug.Assert(activity != null, "Activity should not be null");
+            Debug.Assert(activity != null, $"{nameof(activity)} must not be null");
             try
             {
                 // If the span name is not in the current minute list, add it to the span list.

--- a/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryServicesExtensions.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryServicesExtensions.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
         public static IServiceCollection AddOpenTelemetryTracing(this IServiceCollection services)
         {
+            Guard.Null(services, nameof(services));
+
             return services.AddOpenTelemetryTracing(builder => { });
         }
 

--- a/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryServicesExtensions.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryServicesExtensions.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 using System;
+using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using OpenTelemetry.Extensions.Hosting.Implementation;
@@ -90,8 +91,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
         private static IServiceCollection AddOpenTelemetryTracing(this IServiceCollection services, Func<IServiceProvider, TracerProvider> createTracerProvider)
         {
-            Guard.Null(services, nameof(services));
-            Guard.Null(createTracerProvider, nameof(createTracerProvider));
+            Debug.Assert(services != null, $"{nameof(services)} must not be null");
+            Debug.Assert(createTracerProvider != null, $"{nameof(createTracerProvider)} must not be null");
 
             try
             {

--- a/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryServicesExtensions.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryServicesExtensions.cs
@@ -93,8 +93,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
         private static IServiceCollection AddOpenTelemetryTracing(this IServiceCollection services, Func<IServiceProvider, TracerProvider> createTracerProvider)
         {
-            Debug.Assert(services != null, $"{nameof(services)} must not be null");
-            Debug.Assert(createTracerProvider != null, $"{nameof(createTracerProvider)} must not be null");
+            Debug.Assert(services != null);
+            Debug.Assert(createTracerProvider != null);
 
             try
             {

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -52,7 +52,7 @@ namespace OpenTelemetry.Instrumentation.AspNet
         /// <returns><see langword="true"/> if start has been called.</returns>
         public static bool HasStarted(HttpContext context, out Activity aspNetActivity)
         {
-            Debug.Assert(context != null, "Context is null.");
+            Debug.Assert(context != null, $"{nameof(context)} must not be null");
 
             object itemValue = context.Items[ContextKey];
             if (itemValue is ContextHolder contextHolder)
@@ -74,7 +74,7 @@ namespace OpenTelemetry.Instrumentation.AspNet
         /// <returns>New root activity.</returns>
         public static Activity StartAspNetActivity(TextMapPropagator textMapPropagator, HttpContext context, Action<Activity, HttpContext> onRequestStartedCallback)
         {
-            Debug.Assert(context != null, "Context is null.");
+            Debug.Assert(context != null, $"{nameof(context)} must not be null");
 
             PropagationContext propagationContext = textMapPropagator.Extract(default, context.Request, HttpRequestHeaderValuesGetter);
 
@@ -122,11 +122,11 @@ namespace OpenTelemetry.Instrumentation.AspNet
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void StopAspNetActivity(TextMapPropagator textMapPropagator, Activity aspNetActivity, HttpContext context, Action<Activity, HttpContext> onRequestStoppedCallback)
         {
-            Debug.Assert(context != null, "Context is null.");
+            Debug.Assert(context != null, $"{nameof(context)} must not be null");
 
             if (aspNetActivity == null)
             {
-                Debug.Assert(context.Items[ContextKey] == StartedButNotSampledObj, "Context item is not StartedButNotSampledObj.");
+                Debug.Assert(context.Items[ContextKey] == StartedButNotSampledObj, $"{nameof(context)}.{nameof(context.Items)}[{ContextKey}] must equal {nameof(StartedButNotSampledObj)}");
 
                 // This is the case where a start was called but no activity was
                 // created due to a sampling decision.
@@ -134,7 +134,7 @@ namespace OpenTelemetry.Instrumentation.AspNet
                 return;
             }
 
-            Debug.Assert(context.Items[ContextKey] is ContextHolder, "Context item is not an ContextHolder instance.");
+            Debug.Assert(context.Items[ContextKey] is ContextHolder, $"{nameof(context)}.{nameof(context.Items)}[{ContextKey}] must be of type {nameof(ContextHolder)}");
 
             var currentActivity = Activity.Current;
 
@@ -173,8 +173,8 @@ namespace OpenTelemetry.Instrumentation.AspNet
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteActivityException(Activity aspNetActivity, HttpContext context, Exception exception, Action<Activity, HttpContext, Exception> onExceptionCallback)
         {
-            Debug.Assert(context != null, "Context is null.");
-            Debug.Assert(exception != null, "Exception is null.");
+            Debug.Assert(context != null, $"{nameof(context)} must not be null");
+            Debug.Assert(exception != null, $"{nameof(exception)} must not be null");
 
             if (aspNetActivity != null)
             {
@@ -201,7 +201,7 @@ namespace OpenTelemetry.Instrumentation.AspNet
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void RestoreContextIfNeeded(HttpContext context)
         {
-            Debug.Assert(context != null, "Context is null.");
+            Debug.Assert(context != null, $"{nameof(context)} must not be null");
 
             if (context.Items[ContextKey] is ContextHolder contextHolder && Activity.Current != contextHolder.Activity)
             {

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -52,7 +52,7 @@ namespace OpenTelemetry.Instrumentation.AspNet
         /// <returns><see langword="true"/> if start has been called.</returns>
         public static bool HasStarted(HttpContext context, out Activity aspNetActivity)
         {
-            Debug.Assert(context != null, $"{nameof(context)} must not be null");
+            Debug.Assert(context != null);
 
             object itemValue = context.Items[ContextKey];
             if (itemValue is ContextHolder contextHolder)
@@ -74,7 +74,7 @@ namespace OpenTelemetry.Instrumentation.AspNet
         /// <returns>New root activity.</returns>
         public static Activity StartAspNetActivity(TextMapPropagator textMapPropagator, HttpContext context, Action<Activity, HttpContext> onRequestStartedCallback)
         {
-            Debug.Assert(context != null, $"{nameof(context)} must not be null");
+            Debug.Assert(context != null);
 
             PropagationContext propagationContext = textMapPropagator.Extract(default, context.Request, HttpRequestHeaderValuesGetter);
 
@@ -122,11 +122,11 @@ namespace OpenTelemetry.Instrumentation.AspNet
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void StopAspNetActivity(TextMapPropagator textMapPropagator, Activity aspNetActivity, HttpContext context, Action<Activity, HttpContext> onRequestStoppedCallback)
         {
-            Debug.Assert(context != null, $"{nameof(context)} must not be null");
+            Debug.Assert(context != null);
 
             if (aspNetActivity == null)
             {
-                Debug.Assert(context.Items[ContextKey] == StartedButNotSampledObj, $"{nameof(context)}.{nameof(context.Items)}[{ContextKey}] must equal {nameof(StartedButNotSampledObj)}");
+                Debug.Assert(context.Items[ContextKey] == StartedButNotSampledObj);
 
                 // This is the case where a start was called but no activity was
                 // created due to a sampling decision.
@@ -134,7 +134,7 @@ namespace OpenTelemetry.Instrumentation.AspNet
                 return;
             }
 
-            Debug.Assert(context.Items[ContextKey] is ContextHolder, $"{nameof(context)}.{nameof(context.Items)}[{ContextKey}] must be of type {nameof(ContextHolder)}");
+            Debug.Assert(context.Items[ContextKey] is ContextHolder);
 
             var currentActivity = Activity.Current;
 
@@ -173,8 +173,8 @@ namespace OpenTelemetry.Instrumentation.AspNet
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteActivityException(Activity aspNetActivity, HttpContext context, Exception exception, Action<Activity, HttpContext, Exception> onExceptionCallback)
         {
-            Debug.Assert(context != null, $"{nameof(context)} must not be null");
-            Debug.Assert(exception != null, $"{nameof(exception)} must not be null");
+            Debug.Assert(context != null);
+            Debug.Assert(exception != null);
 
             if (aspNetActivity != null)
             {
@@ -201,7 +201,7 @@ namespace OpenTelemetry.Instrumentation.AspNet
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void RestoreContextIfNeeded(HttpContext context)
         {
-            Debug.Assert(context != null, $"{nameof(context)} must not be null");
+            Debug.Assert(context != null);
 
             if (context.Items[ContextKey] is ContextHolder contextHolder && Activity.Current != contextHolder.Activity)
             {

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
@@ -321,7 +321,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <exception cref="ArgumentException">span is not a valid SpanShim object.</exception>
         private static TelemetrySpan GetOpenTelemetrySpan(ISpan span)
         {
-            Debug.Assert(span is SpanShim shim, $"Cannot cast '{nameof(span)}' from '{span.GetType().Name}' to '{nameof(SpanShim)}'");
+            Debug.Assert(span is SpanShim shim);
 
             return (span as SpanShim).Span;
         }
@@ -334,7 +334,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <exception cref="ArgumentException">context is not a valid SpanContextShim object.</exception>
         private static SpanContext GetOpenTelemetrySpanContext(ISpanContext spanContext)
         {
-            Debug.Assert(spanContext is SpanContextShim shim, $"Cannot cast '{nameof(spanContext)}' from '{spanContext.GetType().Name}' to '{nameof(SpanContextShim)}'");
+            Debug.Assert(spanContext is SpanContextShim shim);
 
             return (spanContext as SpanContextShim).SpanContext;
         }

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
@@ -321,9 +321,9 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <exception cref="ArgumentException">span is not a valid SpanShim object.</exception>
         private static TelemetrySpan GetOpenTelemetrySpan(ISpan span)
         {
-            var shim = Guard.Type<SpanShim>(span, nameof(span));
+            Debug.Assert(span is SpanShim shim, $"Cannot cast '{nameof(span)}' from '{span.GetType().Name}' to '{nameof(SpanShim)}'");
 
-            return shim.Span;
+            return (span as SpanShim).Span;
         }
 
         /// <summary>
@@ -334,9 +334,9 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <exception cref="ArgumentException">context is not a valid SpanContextShim object.</exception>
         private static SpanContext GetOpenTelemetrySpanContext(ISpanContext spanContext)
         {
-            var shim = Guard.Type<SpanContextShim>(spanContext, nameof(spanContext));
+            Debug.Assert(spanContext is SpanContextShim shim, $"Cannot cast '{nameof(spanContext)}' from '{spanContext.GetType().Name}' to '{nameof(SpanContextShim)}'");
 
-            return shim.SpanContext;
+            return (spanContext as SpanContextShim).SpanContext;
         }
     }
 }

--- a/src/OpenTelemetry/Batch.cs
+++ b/src/OpenTelemetry/Batch.cs
@@ -47,7 +47,7 @@ namespace OpenTelemetry
 
         internal Batch(CircularBuffer<T> circularBuffer, int maxSize)
         {
-            Debug.Assert(maxSize > 0, $"{nameof(maxSize)} must be a positive number.");
+            Debug.Assert(maxSize > 0, $"{nameof(maxSize)} must be a positive number");
             Debug.Assert(circularBuffer != null, $"{nameof(circularBuffer)} must not be null");
 
             this.item = null;
@@ -58,7 +58,7 @@ namespace OpenTelemetry
 
         internal Batch(T[] metrics, int maxSize)
         {
-            Debug.Assert(maxSize > 0, $"{nameof(maxSize)} must be a positive number.");
+            Debug.Assert(maxSize > 0, $"{nameof(maxSize)} must be a positive number");
             Debug.Assert(metrics != null, $"{nameof(metrics)} must not be null");
 
             this.item = null;

--- a/src/OpenTelemetry/Batch.cs
+++ b/src/OpenTelemetry/Batch.cs
@@ -47,8 +47,8 @@ namespace OpenTelemetry
 
         internal Batch(CircularBuffer<T> circularBuffer, int maxSize)
         {
-            Debug.Assert(maxSize > 0, $"{nameof(maxSize)} should be a positive number.");
-            Guard.Null(circularBuffer, nameof(circularBuffer));
+            Debug.Assert(maxSize > 0, $"{nameof(maxSize)} must be a positive number.");
+            Debug.Assert(circularBuffer != null, $"{nameof(circularBuffer)} must not be null");
 
             this.item = null;
             this.metrics = null;
@@ -58,8 +58,8 @@ namespace OpenTelemetry
 
         internal Batch(T[] metrics, int maxSize)
         {
-            Debug.Assert(maxSize > 0, $"{nameof(maxSize)} should be a positive number.");
-            Guard.Null(metrics, nameof(metrics));
+            Debug.Assert(maxSize > 0, $"{nameof(maxSize)} must be a positive number.");
+            Debug.Assert(metrics != null, $"{nameof(metrics)} must not be null");
 
             this.item = null;
             this.circularBuffer = null;

--- a/src/OpenTelemetry/Batch.cs
+++ b/src/OpenTelemetry/Batch.cs
@@ -37,7 +37,7 @@ namespace OpenTelemetry
 
         internal Batch(T item)
         {
-            Debug.Assert(item != null, $"{nameof(item)} must not be null");
+            Guard.Null(item, nameof(item));
 
             this.item = item;
             this.circularBuffer = null;

--- a/src/OpenTelemetry/Batch.cs
+++ b/src/OpenTelemetry/Batch.cs
@@ -47,8 +47,8 @@ namespace OpenTelemetry
 
         internal Batch(CircularBuffer<T> circularBuffer, int maxSize)
         {
-            Debug.Assert(maxSize > 0, $"{nameof(maxSize)} must be a positive number");
-            Debug.Assert(circularBuffer != null, $"{nameof(circularBuffer)} must not be null");
+            Debug.Assert(maxSize > 0);
+            Debug.Assert(circularBuffer != null);
 
             this.item = null;
             this.metrics = null;

--- a/src/OpenTelemetry/Batch.cs
+++ b/src/OpenTelemetry/Batch.cs
@@ -58,8 +58,8 @@ namespace OpenTelemetry
 
         internal Batch(T[] metrics, int maxSize)
         {
-            Debug.Assert(maxSize > 0, $"{nameof(maxSize)} must be a positive number");
-            Debug.Assert(metrics != null, $"{nameof(metrics)} must not be null");
+            Debug.Assert(maxSize > 0);
+            Debug.Assert(metrics != null);
 
             this.item = null;
             this.circularBuffer = null;

--- a/src/OpenTelemetry/Batch.cs
+++ b/src/OpenTelemetry/Batch.cs
@@ -37,7 +37,7 @@ namespace OpenTelemetry
 
         internal Batch(T item)
         {
-            Guard.Null(item, nameof(item));
+            Debug.Assert(item != null, $"{nameof(item)} must not be null");
 
             this.item = item;
             this.circularBuffer = null;

--- a/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
@@ -16,9 +16,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
-using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Logs
 {
@@ -29,8 +29,8 @@ namespace OpenTelemetry.Logs
 
         internal OpenTelemetryLogger(string categoryName, OpenTelemetryLoggerProvider provider)
         {
-            Guard.Null(categoryName, nameof(categoryName));
-            Guard.Null(provider, nameof(provider));
+            Debug.Assert(categoryName != null, $"{nameof(categoryName)} must not be null");
+            Debug.Assert(provider != null, $"{nameof(provider)} must not be null");
 
             this.categoryName = categoryName;
             this.provider = provider;

--- a/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
@@ -29,8 +29,8 @@ namespace OpenTelemetry.Logs
 
         internal OpenTelemetryLogger(string categoryName, OpenTelemetryLoggerProvider provider)
         {
-            Debug.Assert(categoryName != null, $"{nameof(categoryName)} must not be null");
-            Debug.Assert(provider != null, $"{nameof(provider)} must not be null");
+            Debug.Assert(categoryName != null);
+            Debug.Assert(provider != null);
 
             this.categoryName = categoryName;
             this.provider = provider;

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggerProvider.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggerProvider.cs
@@ -15,9 +15,9 @@
 // </copyright>
 
 using System.Collections;
+using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using OpenTelemetry.Internal;
 using OpenTelemetry.Resources;
 
 namespace OpenTelemetry.Logs
@@ -46,7 +46,7 @@ namespace OpenTelemetry.Logs
 
         internal OpenTelemetryLoggerProvider(OpenTelemetryLoggerOptions options)
         {
-            Guard.Null(options, nameof(options));
+            Debug.Assert(options != null, $"{nameof(options)} must not be null");
 
             this.Options = options;
             this.Resource = options.ResourceBuilder.Build();
@@ -97,7 +97,7 @@ namespace OpenTelemetry.Logs
 
         internal OpenTelemetryLoggerProvider AddProcessor(BaseProcessor<LogRecord> processor)
         {
-            Guard.Null(processor, nameof(processor));
+            Debug.Assert(processor != null, $"{nameof(processor)} must not be null");
 
             processor.SetParentProvider(this);
 

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggerProvider.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggerProvider.cs
@@ -46,7 +46,7 @@ namespace OpenTelemetry.Logs
 
         internal OpenTelemetryLoggerProvider(OpenTelemetryLoggerOptions options)
         {
-            Debug.Assert(options != null, $"{nameof(options)} must not be null");
+            Debug.Assert(options != null);
 
             this.Options = options;
             this.Resource = options.ResourceBuilder.Build();

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggerProvider.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggerProvider.cs
@@ -97,7 +97,7 @@ namespace OpenTelemetry.Logs
 
         internal OpenTelemetryLoggerProvider AddProcessor(BaseProcessor<LogRecord> processor)
         {
-            Debug.Assert(processor != null, $"{nameof(processor)} must not be null");
+            Debug.Assert(processor != null);
 
             processor.SetParentProvider(this);
 

--- a/src/OpenTelemetry/Metrics/BatchMetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/BatchMetricPoint.cs
@@ -17,7 +17,6 @@
 using System;
 using System.Collections;
 using System.Diagnostics;
-using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Metrics
 {
@@ -31,7 +30,7 @@ namespace OpenTelemetry.Metrics
         internal BatchMetricPoint(MetricPoint[] metricsPoints, int maxSize, DateTimeOffset start, DateTimeOffset end)
         {
             Debug.Assert(maxSize > 0, $"{nameof(maxSize)} must be a positive number");
-            Guard.Null(metricsPoints, nameof(metricsPoints));
+            Debug.Assert(metricsPoints != null, $"{nameof(metricsPoints)} must not be null");
 
             this.metricsPoints = metricsPoints;
             this.targetCount = maxSize;

--- a/src/OpenTelemetry/Metrics/BatchMetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/BatchMetricPoint.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Metrics
 
         internal BatchMetricPoint(MetricPoint[] metricsPoints, int maxSize, DateTimeOffset start, DateTimeOffset end)
         {
-            Debug.Assert(maxSize > 0, $"{nameof(maxSize)} should be a positive number.");
+            Debug.Assert(maxSize > 0, $"{nameof(maxSize)} must be a positive number");
             Guard.Null(metricsPoints, nameof(metricsPoints));
 
             this.metricsPoints = metricsPoints;

--- a/src/OpenTelemetry/Metrics/BatchMetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/BatchMetricPoint.cs
@@ -29,8 +29,8 @@ namespace OpenTelemetry.Metrics
 
         internal BatchMetricPoint(MetricPoint[] metricsPoints, int maxSize, DateTimeOffset start, DateTimeOffset end)
         {
-            Debug.Assert(maxSize > 0, $"{nameof(maxSize)} must be a positive number");
-            Debug.Assert(metricsPoints != null, $"{nameof(metricsPoints)} must not be null");
+            Debug.Assert(maxSize > 0);
+            Debug.Assert(metricsPoints != null);
 
             this.metricsPoints = metricsPoints;
             this.targetCount = maxSize;

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -55,7 +55,7 @@ namespace OpenTelemetry.Metrics
 
             foreach (var reader in readers)
             {
-                Guard.Null(reader, nameof(reader));
+                Debug.Assert(reader != null, $"{nameof(reader)} must not be null");
 
                 reader.SetParentProvider(this);
 

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -284,7 +284,7 @@ namespace OpenTelemetry.Metrics
 
         internal void MeasurementRecordedDouble(Instrument instrument, double value, ReadOnlySpan<KeyValuePair<string, object>> tagsRos, object state)
         {
-            Debug.Assert(instrument != null, $"{nameof(instrument)} must not be null");
+            Debug.Assert(instrument != null);
 
             // Get Instrument State
             var metrics = state as List<Metric>;
@@ -313,7 +313,7 @@ namespace OpenTelemetry.Metrics
 
         internal void MeasurementRecordedLong(Instrument instrument, long value, ReadOnlySpan<KeyValuePair<string, object>> tagsRos, object state)
         {
-            Debug.Assert(instrument != null, $"{nameof(instrument)} must not be null");
+            Debug.Assert(instrument != null);
 
             // Get Instrument State
             var metrics = state as List<Metric>;
@@ -342,7 +342,7 @@ namespace OpenTelemetry.Metrics
 
         internal void MeasurementRecordedLongSingleStream(Instrument instrument, long value, ReadOnlySpan<KeyValuePair<string, object>> tagsRos, object state)
         {
-            Debug.Assert(instrument != null, $"{nameof(instrument)} must not be null");
+            Debug.Assert(instrument != null);
 
             // Get Instrument State
             var metric = state as Metric;
@@ -358,7 +358,7 @@ namespace OpenTelemetry.Metrics
 
         internal void MeasurementRecordedDoubleSingleStream(Instrument instrument, double value, ReadOnlySpan<KeyValuePair<string, object>> tagsRos, object state)
         {
-            Debug.Assert(instrument != null, $"{nameof(instrument)} must not be null");
+            Debug.Assert(instrument != null);
 
             // Get Instrument State
             var metric = state as Metric;

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -55,7 +55,7 @@ namespace OpenTelemetry.Metrics
 
             foreach (var reader in readers)
             {
-                Debug.Assert(reader != null, $"{nameof(reader)} must not be null");
+                Debug.Assert(reader != null);
 
                 reader.SetParentProvider(this);
 

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -284,10 +284,11 @@ namespace OpenTelemetry.Metrics
 
         internal void MeasurementRecordedDouble(Instrument instrument, double value, ReadOnlySpan<KeyValuePair<string, object>> tagsRos, object state)
         {
+            Debug.Assert(instrument != null, $"{nameof(instrument)} must not be null");
+
             // Get Instrument State
             var metrics = state as List<Metric>;
 
-            Debug.Assert(instrument != null, "instrument must be non-null.");
             if (metrics == null)
             {
                 // TODO: log
@@ -312,10 +313,11 @@ namespace OpenTelemetry.Metrics
 
         internal void MeasurementRecordedLong(Instrument instrument, long value, ReadOnlySpan<KeyValuePair<string, object>> tagsRos, object state)
         {
+            Debug.Assert(instrument != null, $"{nameof(instrument)} must not be null");
+
             // Get Instrument State
             var metrics = state as List<Metric>;
 
-            Debug.Assert(instrument != null, "instrument must be non-null.");
             if (metrics == null)
             {
                 // TODO: log
@@ -340,10 +342,11 @@ namespace OpenTelemetry.Metrics
 
         internal void MeasurementRecordedLongSingleStream(Instrument instrument, long value, ReadOnlySpan<KeyValuePair<string, object>> tagsRos, object state)
         {
+            Debug.Assert(instrument != null, $"{nameof(instrument)} must not be null");
+
             // Get Instrument State
             var metric = state as Metric;
 
-            Debug.Assert(instrument != null, "instrument must be non-null.");
             if (metric == null)
             {
                 // TODO: log
@@ -355,10 +358,11 @@ namespace OpenTelemetry.Metrics
 
         internal void MeasurementRecordedDoubleSingleStream(Instrument instrument, double value, ReadOnlySpan<KeyValuePair<string, object>> tagsRos, object state)
         {
+            Debug.Assert(instrument != null, $"{nameof(instrument)} must not be null");
+
             // Get Instrument State
             var metric = state as Metric;
 
-            Debug.Assert(instrument != null, "instrument must be non-null.");
             if (metric == null)
             {
                 // TODO: log

--- a/src/OpenTelemetry/Metrics/MetricReader.cs
+++ b/src/OpenTelemetry/Metrics/MetricReader.cs
@@ -264,9 +264,8 @@ namespace OpenTelemetry.Metrics
 
         private static void ValidateAggregationTemporality(AggregationTemporality preferred, AggregationTemporality supported)
         {
-            Guard.Zero((int)(preferred & CumulativeAndDelta), $"PreferredAggregationTemporality has an invalid value {preferred}", nameof(preferred));
-            Guard.Zero((int)(supported & CumulativeAndDelta), $"SupportedAggregationTemporality has an invalid value {supported}", nameof(supported));
-
+            Debug.Assert((int)(preferred & CumulativeAndDelta) != 0, $"PreferredAggregationTemporality has an invalid value {preferred}");
+            Debug.Assert((int)(supported & CumulativeAndDelta) != 0, $"SupportedAggregationTemporality has an invalid value {supported}");
             /*
             | Preferred  | Supported  | Valid |
             | ---------- | ---------- | ----- |
@@ -280,9 +279,7 @@ namespace OpenTelemetry.Metrics
             | Delta      | Cumulative | false |
             | Delta      | Delta      | true  |
             */
-            string message = $"PreferredAggregationTemporality {preferred} and SupportedAggregationTemporality {supported} are incompatible";
-            Guard.Zero((int)(preferred & supported), message, nameof(preferred));
-            Guard.Range((int)preferred, nameof(preferred), max: (int)supported, maxName: nameof(supported), message: message);
+            Debug.Assert((int)(preferred & supported) != 0 && preferred <= supported, $"PreferredAggregationTemporality {preferred} and SupportedAggregationTemporality {supported} are incompatible");
         }
     }
 }

--- a/src/OpenTelemetry/Metrics/MetricReader.cs
+++ b/src/OpenTelemetry/Metrics/MetricReader.cs
@@ -264,8 +264,8 @@ namespace OpenTelemetry.Metrics
 
         private static void ValidateAggregationTemporality(AggregationTemporality preferred, AggregationTemporality supported)
         {
-            Debug.Assert((int)(preferred & CumulativeAndDelta) != 0, $"PreferredAggregationTemporality has an invalid value {preferred}");
-            Debug.Assert((int)(supported & CumulativeAndDelta) != 0, $"SupportedAggregationTemporality has an invalid value {supported}");
+            Debug.Assert((int)(preferred & CumulativeAndDelta) != 0);
+            Debug.Assert((int)(supported & CumulativeAndDelta) != 0);
             /*
             | Preferred  | Supported  | Valid |
             | ---------- | ---------- | ----- |
@@ -279,7 +279,7 @@ namespace OpenTelemetry.Metrics
             | Delta      | Cumulative | false |
             | Delta      | Delta      | true  |
             */
-            Debug.Assert((int)(preferred & supported) != 0 && preferred <= supported, $"PreferredAggregationTemporality {preferred} and SupportedAggregationTemporality {supported} are incompatible");
+            Debug.Assert((int)(preferred & supported) != 0 && preferred <= supported);
         }
     }
 }

--- a/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
+++ b/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
@@ -52,7 +52,7 @@ namespace OpenTelemetry.Metrics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void SplitToKeysAndValues(ReadOnlySpan<KeyValuePair<string, object>> tags, int tagLength, out string[] tagKeys, out object[] tagValues)
         {
-            Debug.Assert(tagLength > 0, $"There must be at least one tag to use {nameof(ThreadStaticStorage)}");
+            Debug.Assert(tagLength > 0);
 
             if (tagLength <= MaxTagCacheSize)
             {

--- a/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
+++ b/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
@@ -16,8 +16,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Metrics
 {
@@ -52,7 +52,7 @@ namespace OpenTelemetry.Metrics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void SplitToKeysAndValues(ReadOnlySpan<KeyValuePair<string, object>> tags, int tagLength, out string[] tagKeys, out object[] tagValues)
         {
-            Guard.Zero(tagLength, $"There must be at least one tag to use {nameof(ThreadStaticStorage)}", $"{nameof(tagLength)}");
+            Debug.Assert(tagLength > 0, $"There must be at least one tag to use {nameof(ThreadStaticStorage)}");
 
             if (tagLength <= MaxTagCacheSize)
             {

--- a/src/OpenTelemetry/Resources/Resource.cs
+++ b/src/OpenTelemetry/Resources/Resource.cs
@@ -109,7 +109,7 @@ namespace OpenTelemetry.Resources
 
         private static object SanitizeValue(object value, string keyName)
         {
-            Debug.Assert(keyName != null, $"{nameof(keyName)} must not be null");
+            Debug.Assert(keyName != null);
 
             if (value is string || value is bool || value is double || value is long)
             {

--- a/src/OpenTelemetry/Resources/Resource.cs
+++ b/src/OpenTelemetry/Resources/Resource.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using OpenTelemetry.Internal;
 
@@ -108,7 +109,7 @@ namespace OpenTelemetry.Resources
 
         private static object SanitizeValue(object value, string keyName)
         {
-            Guard.Null(keyName, nameof(keyName));
+            Debug.Assert(keyName != null, $"{nameof(keyName)} must not be null");
 
             if (value is string || value is bool || value is double || value is long)
             {

--- a/src/OpenTelemetry/Resources/ResourceBuilder.cs
+++ b/src/OpenTelemetry/Resources/ResourceBuilder.cs
@@ -15,7 +15,7 @@
 // </copyright>
 
 using System.Collections.Generic;
-using OpenTelemetry.Internal;
+using System.Diagnostics;
 
 namespace OpenTelemetry.Resources
 {
@@ -33,9 +33,9 @@ namespace OpenTelemetry.Resources
         private static Resource DefaultResource { get; } = new Resource(new Dictionary<string, object>
         {
             [ResourceSemanticConventions.AttributeServiceName] = "unknown_service"
-                + (string.IsNullOrWhiteSpace(System.Diagnostics.Process.GetCurrentProcess().ProcessName)
+                + (string.IsNullOrWhiteSpace(Process.GetCurrentProcess().ProcessName)
                 ? string.Empty :
-                ":" + System.Diagnostics.Process.GetCurrentProcess().ProcessName),
+                ":" + Process.GetCurrentProcess().ProcessName),
         });
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace OpenTelemetry.Resources
         // https://github.com/open-telemetry/oteps/blob/master/text/0111-auto-resource-detection.md
         internal ResourceBuilder AddDetector(IResourceDetector resourceDetector)
         {
-            Guard.Null(resourceDetector, nameof(resourceDetector));
+            Debug.Assert(resourceDetector != null, $"{nameof(resourceDetector)} must not be null");
 
             Resource resource = resourceDetector.Detect();
 
@@ -104,7 +104,7 @@ namespace OpenTelemetry.Resources
 
         internal ResourceBuilder AddResource(Resource resource)
         {
-            Guard.Null(resource, nameof(resource));
+            Debug.Assert(resource != null, $"{nameof(resource)} must not be null");
 
             this.resources.Add(resource);
 

--- a/src/OpenTelemetry/Resources/ResourceBuilder.cs
+++ b/src/OpenTelemetry/Resources/ResourceBuilder.cs
@@ -90,7 +90,7 @@ namespace OpenTelemetry.Resources
         // https://github.com/open-telemetry/oteps/blob/master/text/0111-auto-resource-detection.md
         internal ResourceBuilder AddDetector(IResourceDetector resourceDetector)
         {
-            Debug.Assert(resourceDetector != null, $"{nameof(resourceDetector)} must not be null");
+            Debug.Assert(resourceDetector != null);
 
             Resource resource = resourceDetector.Detect();
 
@@ -104,7 +104,7 @@ namespace OpenTelemetry.Resources
 
         internal ResourceBuilder AddResource(Resource resource)
         {
-            Debug.Assert(resource != null, $"{nameof(resource)} must not be null");
+            Debug.Assert(resource != null);
 
             this.resources.Add(resource);
 

--- a/src/OpenTelemetry/Trace/TracerProviderBuilderBase.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderBuilderBase.cs
@@ -156,7 +156,7 @@ namespace OpenTelemetry.Trace
         /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
         internal TracerProviderBuilder AddProcessor(BaseProcessor<Activity> processor)
         {
-            Debug.Assert(processor != null, $"{nameof(processor)} must not be null");
+            Debug.Assert(processor != null);
 
             this.processors.Add(processor);
 

--- a/src/OpenTelemetry/Trace/TracerProviderBuilderBase.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderBuilderBase.cs
@@ -129,7 +129,7 @@ namespace OpenTelemetry.Trace
         /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
         internal TracerProviderBuilder SetSampler(Sampler sampler)
         {
-            Guard.Null(sampler, nameof(sampler));
+            Debug.Assert(sampler != null, $"{nameof(sampler)} must not be null");
 
             this.sampler = sampler;
             return this;
@@ -143,7 +143,7 @@ namespace OpenTelemetry.Trace
         /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
         internal TracerProviderBuilder SetResourceBuilder(ResourceBuilder resourceBuilder)
         {
-            Guard.Null(resourceBuilder, nameof(resourceBuilder));
+            Debug.Assert(resourceBuilder != null, $"{nameof(resourceBuilder)} must not be null");
 
             this.resourceBuilder = resourceBuilder;
             return this;
@@ -156,7 +156,7 @@ namespace OpenTelemetry.Trace
         /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
         internal TracerProviderBuilder AddProcessor(BaseProcessor<Activity> processor)
         {
-            Guard.Null(processor, nameof(processor));
+            Debug.Assert(processor != null, $"{nameof(processor)} must not be null");
 
             this.processors.Add(processor);
 

--- a/src/OpenTelemetry/Trace/TracerProviderBuilderBase.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderBuilderBase.cs
@@ -129,7 +129,7 @@ namespace OpenTelemetry.Trace
         /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
         internal TracerProviderBuilder SetSampler(Sampler sampler)
         {
-            Debug.Assert(sampler != null, $"{nameof(sampler)} must not be null");
+            Debug.Assert(sampler != null);
 
             this.sampler = sampler;
             return this;
@@ -143,7 +143,7 @@ namespace OpenTelemetry.Trace
         /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
         internal TracerProviderBuilder SetResourceBuilder(ResourceBuilder resourceBuilder)
         {
-            Debug.Assert(resourceBuilder != null, $"{nameof(resourceBuilder)} must not be null");
+            Debug.Assert(resourceBuilder != null);
 
             this.resourceBuilder = resourceBuilder;
             return this;

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -287,7 +287,7 @@ namespace OpenTelemetry.Trace
 
         internal TracerProviderSdk AddProcessor(BaseProcessor<Activity> processor)
         {
-            Guard.Null(processor, nameof(processor));
+            Debug.Assert(processor != null, $"{nameof(processor)} must not be null");
 
             processor.SetParentProvider(this);
 

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -287,7 +287,7 @@ namespace OpenTelemetry.Trace
 
         internal TracerProviderSdk AddProcessor(BaseProcessor<Activity> processor)
         {
-            Debug.Assert(processor != null, $"{nameof(processor)} must not be null");
+            Debug.Assert(processor != null);
 
             processor.SetParentProvider(this);
 

--- a/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/ActivityHelperTest.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/ActivityHelperTest.cs
@@ -447,7 +447,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
 
         private void EnableListener(Action<Activity> onStarted = null, Action<Activity> onStopped = null, Func<ActivityContext, ActivitySamplingResult> onSample = null)
         {
-            Debug.Assert(this.activitySourceListener == null, "Cannot attach multiple listeners in tests");
+            Debug.Assert(this.activitySourceListener == null);
 
             this.activitySourceListener = new ActivityListener
             {

--- a/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/ActivityHelperTest.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/ActivityHelperTest.cs
@@ -447,7 +447,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
 
         private void EnableListener(Action<Activity> onStarted = null, Action<Activity> onStopped = null, Func<ActivityContext, ActivitySamplingResult> onSample = null)
         {
-            Debug.Assert(this.activitySourceListener == null, "Cannot attach multiple listeners in tests.");
+            Debug.Assert(this.activitySourceListener == null, "Cannot attach multiple listeners in tests");
 
             this.activitySourceListener = new ActivityListener
             {


### PR DESCRIPTION
Fixes #2495

## Changes
- Formatting of existing `Debug.Assert` calls (remove periods, use `nameof(variable)`, etc.)
- Replace all `Guard` method calls within `internal` or `private` methods with `Debug.Assert`

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
