### PR TITLE
Unique test meter names

### DIFF
--- a/docs/metrics/extending-the-sdk/Program.cs
+++ b/docs/metrics/extending-the-sdk/Program.cs
@@ -30,7 +30,7 @@ public class Program
     {
         var process = Process.GetCurrentProcess();
 
-        MyMeter.CreateObservableGauge<long>(
+        MyMeter.CreateObservableGauge(
             "MyProcessWorkingSetGauge",
             () => new List<Measurement<long>>()
             {

--- a/docs/metrics/learning-more-instruments/Program.cs
+++ b/docs/metrics/learning-more-instruments/Program.cs
@@ -30,9 +30,9 @@ public class Program
     {
         var process = Process.GetCurrentProcess();
 
-        MyMeter.CreateObservableCounter<double>("Thread.CpuTime", () => GetThreadCpuTime(process), "seconds");
+        MyMeter.CreateObservableCounter("Thread.CpuTime", () => GetThreadCpuTime(process), "seconds");
 
-        MyMeter.CreateObservableGauge<int>("Thread.State", () => GetThreadState(process));
+        MyMeter.CreateObservableGauge("Thread.State", () => GetThreadState(process));
     }
 
     public static void Main(string[] args)

--- a/examples/Console/TestMetrics.cs
+++ b/examples/Console/TestMetrics.cs
@@ -30,7 +30,7 @@ namespace Examples.Console
     {
         internal static object Run(MetricsOptions options)
         {
-            using var meter = new Meter("TestMeter", "0.0.1");
+            using var meter = new Meter("TestMeter");
 
             var providerBuilder = Sdk.CreateMeterProviderBuilder()
                 .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("myservice"))

--- a/examples/Console/TestMetrics.cs
+++ b/examples/Console/TestMetrics.cs
@@ -98,7 +98,7 @@ namespace Examples.Console
 
             if (options.FlagGauge ?? false)
             {
-                var observableCounter = meter.CreateObservableGauge<int>("gauge", () =>
+                var observableCounter = meter.CreateObservableGauge("gauge", () =>
                 {
                     return new List<Measurement<int>>()
                     {

--- a/examples/Console/TestMetrics.cs
+++ b/examples/Console/TestMetrics.cs
@@ -30,9 +30,11 @@ namespace Examples.Console
     {
         internal static object Run(MetricsOptions options)
         {
+            using var meter = new Meter("TestMeter", "0.0.1");
+
             var providerBuilder = Sdk.CreateMeterProviderBuilder()
                 .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("myservice"))
-                .AddMeter("TestMeter"); // All instruments from this meter are enabled.
+                .AddMeter(meter.Name); // All instruments from this meter are enabled.
 
             if (options.UseExporter.ToLower() == "otlp")
             {
@@ -81,8 +83,6 @@ namespace Examples.Console
             }
 
             using var provider = providerBuilder.Build();
-
-            using var meter = new Meter("TestMeter", "0.0.1");
 
             Counter<int> counter = null;
             if (options.FlagCounter ?? true)

--- a/examples/Console/TestPrometheusExporter.cs
+++ b/examples/Console/TestPrometheusExporter.cs
@@ -27,7 +27,7 @@ namespace Examples.Console
 {
     internal class TestPrometheusExporter
     {
-        private static readonly Meter MyMeter = new Meter("TestMeter", "0.0.1");
+        private static readonly Meter MyMeter = new Meter("TestMeter");
         private static readonly Counter<long> Counter = MyMeter.CreateCounter<long>("myCounter");
         private static readonly Histogram<long> MyHistogram = MyMeter.CreateHistogram<long>("myHistogram");
         private static readonly Random RandomGenerator = new Random();

--- a/examples/Console/TestPrometheusExporter.cs
+++ b/examples/Console/TestPrometheusExporter.cs
@@ -48,7 +48,7 @@ namespace Examples.Console
                 - targets: ['localhost:9184']
             */
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddMeter("TestMeter")
+                .AddMeter(MyMeter.Name)
                 .AddPrometheusExporter(opt =>
                 {
                     opt.StartHttpListener = true;

--- a/examples/Console/TestPrometheusExporter.cs
+++ b/examples/Console/TestPrometheusExporter.cs
@@ -56,7 +56,7 @@ namespace Examples.Console
                 })
                 .Build();
 
-            ObservableGauge<long> gauge = MyMeter.CreateObservableGauge<long>(
+            ObservableGauge<long> gauge = MyMeter.CreateObservableGauge(
             "Gauge",
             () =>
             {

--- a/src/OpenTelemetry/Trace/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderBuilderExtensions.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Trace
     public static class TracerProviderBuilderExtensions
     {
         /// <summary>
-        /// Sets whether the status of <see cref="System.Diagnostics.Activity"/>
+        /// Sets whether the status of <see cref="Activity"/>
         /// should be set to <c>Status.Error</c> when it ended abnormally due to an unhandled exception.
         /// </summary>
         /// <param name="tracerProviderBuilder">TracerProviderBuilder instance.</param>

--- a/test/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestHttpServer.cs" Link="Includes\TestHttpServer.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestExporter.cs" Link="TestExporter.cs" />
+    <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\Utils.cs" Link="Utils.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Benchmarks/Exporter/PrometheusExporterMiddlewareBenchmarks.cs
+++ b/test/Benchmarks/Exporter/PrometheusExporterMiddlewareBenchmarks.cs
@@ -27,6 +27,7 @@ using OpenTelemetry;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Exporter.Prometheus;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Tests;
 
 namespace Benchmarks.Exporter
 {
@@ -45,11 +46,11 @@ namespace Benchmarks.Exporter
         [GlobalSetup]
         public void GlobalSetup()
         {
-            this.meter = new Meter("TestMeter", "1.0.0");
+            this.meter = new Meter(Utils.GetCurrentMethodName(), "1.0.0");
             this.responseStream = new MemoryStream(1024 * 1024);
 
             this.meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddMeter("TestMeter")
+                .AddMeter(this.meter.Name)
                 .AddPrometheusExporter()
                 .Build();
 

--- a/test/Benchmarks/Exporter/PrometheusExporterMiddlewareBenchmarks.cs
+++ b/test/Benchmarks/Exporter/PrometheusExporterMiddlewareBenchmarks.cs
@@ -46,7 +46,7 @@ namespace Benchmarks.Exporter
         [GlobalSetup]
         public void GlobalSetup()
         {
-            this.meter = new Meter(Utils.GetCurrentMethodName(), "1.0.0");
+            this.meter = new Meter(Utils.GetCurrentMethodName());
             this.responseStream = new MemoryStream(1024 * 1024);
 
             this.meterProvider = Sdk.CreateMeterProviderBuilder()

--- a/test/Benchmarks/Metrics/MetricCollectBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricCollectBenchmarks.cs
@@ -90,12 +90,14 @@ namespace Benchmarks.Metrics
             {
                 PreferredAggregationTemporality = AggregationTemporality.Cumulative,
             };
+
+            this.meter = new Meter(Utils.GetCurrentMethodName());
+
             this.provider = Sdk.CreateMeterProviderBuilder()
-                .AddMeter("TestMeter")
+                .AddMeter(this.meter.Name)
                 .AddReader(this.reader)
                 .Build();
 
-            this.meter = new Meter("TestMeter");
             this.counter = this.meter.CreateCounter<double>("counter");
             this.token = new CancellationTokenSource();
             this.writeMetricTask = new Task(() =>

--- a/test/Benchmarks/Metrics/MetricsBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricsBenchmarks.cs
@@ -21,6 +21,7 @@ using System.Diagnostics.Metrics;
 using BenchmarkDotNet.Attributes;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Tests;
 
 /*
 BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19043
@@ -73,14 +74,15 @@ namespace Benchmarks.Metrics
         [GlobalSetup]
         public void Setup()
         {
+            this.meter = new Meter(Utils.GetCurrentMethodName());
+
             if (this.WithSDK)
             {
                 this.provider = Sdk.CreateMeterProviderBuilder()
-                    .AddMeter("TestMeter") // All instruments from this meter are enabled.
+                    .AddMeter(this.meter.Name) // All instruments from this meter are enabled.
                     .Build();
             }
 
-            this.meter = new Meter("TestMeter");
             this.counter = this.meter.CreateCounter<long>("counter");
         }
 

--- a/test/Benchmarks/Metrics/MetricsViewBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricsViewBenchmarks.cs
@@ -21,6 +21,7 @@ using System.Threading;
 using BenchmarkDotNet.Attributes;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Tests;
 
 /*
 BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19043
@@ -78,7 +79,7 @@ namespace Benchmarks.Metrics
         [GlobalSetup]
         public void Setup()
         {
-            this.meter = new Meter("TestMeter");
+            this.meter = new Meter(Utils.GetCurrentMethodName());
             this.counter = this.meter.CreateCounter<long>("counter");
 
             if (this.ViewConfig == ViewConfiguration.NoView)

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.csproj
@@ -28,6 +28,7 @@
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestActivityProcessor.cs" Link="Includes\TestActivityProcessor.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestEventListener.cs" Link="Includes\TestEventListener.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestExporter.cs" Link="Includes\TestExporter.cs" />
+    <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\Utils.cs" Link="Includes\Utils.cs" />
   </ItemGroup>
 
 </Project>

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
@@ -55,7 +55,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
                 new KeyValuePair<string, object>("key2", "value2"),
             };
 
-            using var meter = new Meter(Utils.GetCurrentMethodName() + (includeServiceNameInResource ? '1' : '0'), "0.0.1");
+            using var meter = new Meter(Utils.GetCurrentMethodName() + includeServiceNameInResource, "0.0.1");
 
             var metricReader = new BaseExportingMetricReader(new TestExporter<Metric>(RunTest))
             {

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
@@ -20,7 +20,6 @@ using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Threading;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
-using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Tests;
@@ -56,6 +55,8 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
                 new KeyValuePair<string, object>("key2", "value2"),
             };
 
+            using var meter = new Meter(Utils.GetCurrentMethodName() + (includeServiceNameInResource ? '1' : '0'), "0.0.1");
+
             var metricReader = new BaseExportingMetricReader(new TestExporter<Metric>(RunTest))
             {
                 PreferredAggregationTemporality = AggregationTemporality.Delta,
@@ -63,11 +64,9 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
 
             using var provider = Sdk.CreateMeterProviderBuilder()
                 .SetResourceBuilder(resourceBuilder)
-                .AddMeter("TestMeter")
+                .AddMeter(meter.Name)
                 .AddReader(metricReader)
                 .Build();
-
-            using var meter = new Meter("TestMeter", "0.0.1");
 
             var counter = meter.CreateCounter<int>("counter");
 
@@ -102,7 +101,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
                 Assert.Single(resourceMetric.InstrumentationLibraryMetrics);
                 var instrumentationLibraryMetrics = resourceMetric.InstrumentationLibraryMetrics.First();
                 Assert.Equal(string.Empty, instrumentationLibraryMetrics.SchemaUrl);
-                Assert.Equal("TestMeter", instrumentationLibraryMetrics.InstrumentationLibrary.Name);
+                Assert.Equal(meter.Name, instrumentationLibraryMetrics.InstrumentationLibrary.Name);
                 Assert.Equal("0.0.1", instrumentationLibraryMetrics.InstrumentationLibrary.Version);
 
                 Assert.Single(instrumentationLibraryMetrics.Metrics);

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
@@ -55,7 +55,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
                 new KeyValuePair<string, object>("key2", "value2"),
             };
 
-            using var meter = new Meter(Utils.GetCurrentMethodName() + includeServiceNameInResource, "0.0.1");
+            using var meter = new Meter($"{Utils.GetCurrentMethodName()}.{includeServiceNameInResource}", "0.0.1");
 
             var metricReader = new BaseExportingMetricReader(new TestExporter<Metric>(RunTest))
             {

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/OpenTelemetry.Exporter.Prometheus.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/OpenTelemetry.Exporter.Prometheus.Tests.csproj
@@ -33,6 +33,7 @@
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestExporter.cs" Link="Includes\TestExporter.cs" />
+    <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\Utils.cs" Link="Includes\Utils.cs" />
   </ItemGroup>
 
 </Project>

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterExtensionsTests.cs
@@ -37,7 +37,7 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
         [InlineData(nameof(WriteMultiple))]
         public void WriteMetricsCollectionTest(string writeActionMethodName)
         {
-            using var meter = new Meter(Utils.GetCurrentMethodName() + writeActionMethodName);
+            using var meter = new Meter($"{Utils.GetCurrentMethodName()}.{writeActionMethodName}");
 
             MethodInfo writeAction = typeof(PrometheusExporterExtensionsTests).GetMethod(writeActionMethodName, BindingFlags.NonPublic | BindingFlags.Static);
             if (writeAction == null)

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterExtensionsTests.cs
@@ -28,8 +28,6 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
 {
     public sealed class PrometheusExporterExtensionsTests
     {
-        private const string MeterName = "PrometheusExporterExtensionsTests.Meter";
-
         [Theory]
         [InlineData(nameof(WriteLongSum))]
         [InlineData(nameof(WriteDoubleSum))]
@@ -39,7 +37,7 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
         [InlineData(nameof(WriteMultiple))]
         public void WriteMetricsCollectionTest(string writeActionMethodName)
         {
-            using var meter = new Meter(MeterName, "0.0.1");
+            using var meter = new Meter(Utils.GetCurrentMethodName() + writeActionMethodName, "0.0.1");
 
             MethodInfo writeAction = typeof(PrometheusExporterExtensionsTests).GetMethod(writeActionMethodName, BindingFlags.NonPublic | BindingFlags.Static);
             if (writeAction == null)
@@ -59,7 +57,7 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
             var testCompleted = false;
 
             using (var provider = Sdk.CreateMeterProviderBuilder()
-                .AddMeter(MeterName)
+                .AddMeter(meter.Name)
                 .AddReader(new BaseExportingMetricReader(new TestExporter<Metric>(RunTest)))
                 .Build())
             {

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterExtensionsTests.cs
@@ -37,7 +37,7 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
         [InlineData(nameof(WriteMultiple))]
         public void WriteMetricsCollectionTest(string writeActionMethodName)
         {
-            using var meter = new Meter(Utils.GetCurrentMethodName() + writeActionMethodName, "0.0.1");
+            using var meter = new Meter(Utils.GetCurrentMethodName() + writeActionMethodName);
 
             MethodInfo writeAction = typeof(PrometheusExporterExtensionsTests).GetMethod(writeActionMethodName, BindingFlags.NonPublic | BindingFlags.Static);
             if (writeAction == null)

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterMetricsHttpServerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterMetricsHttpServerTests.cs
@@ -37,7 +37,7 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
             MeterProvider provider;
             string address = null;
 
-            using var meter = new Meter(Utils.GetCurrentMethodName(), "0.0.1");
+            using var meter = new Meter(Utils.GetCurrentMethodName());
 
             while (true)
             {

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterMetricsHttpServerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterMetricsHttpServerTests.cs
@@ -21,14 +21,13 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Tests;
 using Xunit;
 
 namespace OpenTelemetry.Exporter.Prometheus.Tests
 {
     public class PrometheusExporterMetricsHttpServerTests
     {
-        private const string MeterName = "PrometheusExporterMetricsHttpServerTests.Meter";
-
         [Fact]
         public async Task PrometheusExporterMetricsHttpServerIntegration()
         {
@@ -38,13 +37,15 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
             MeterProvider provider;
             string address = null;
 
+            using var meter = new Meter(Utils.GetCurrentMethodName(), "0.0.1");
+
             while (true)
             {
                 try
                 {
                     port = random.Next(2000, 5000);
                     provider = Sdk.CreateMeterProviderBuilder()
-                        .AddMeter(MeterName)
+                        .AddMeter(meter.Name)
                         .AddPrometheusExporter(o =>
                         {
                             o.GetUtcNowDateTimeOffset = () => new DateTimeOffset(2021, 9, 30, 22, 30, 0, TimeSpan.Zero);
@@ -88,8 +89,6 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
                 new KeyValuePair<string, object>("key1", "value1"),
                 new KeyValuePair<string, object>("key2", "value2"),
             };
-
-            using var meter = new Meter(MeterName, "0.0.1");
 
             var counter = meter.CreateCounter<double>("counter_double");
             counter.Add(100.18D, tags);

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterMiddlewareTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterMiddlewareTests.cs
@@ -50,7 +50,7 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
                 new KeyValuePair<string, object>("key2", "value2"),
             };
 
-            using var meter = new Meter(MeterName, "0.0.1");
+            using var meter = new Meter(MeterName);
 
             var counter = meter.CreateCounter<double>("counter_double");
             counter.Add(100.18D, tags);

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterMiddlewareTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterMiddlewareTests.cs
@@ -26,13 +26,14 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Tests;
 using Xunit;
 
 namespace OpenTelemetry.Exporter.Prometheus.Tests
 {
     public sealed class PrometheusExporterMiddlewareTests
     {
-        private const string MeterName = "PrometheusExporterMiddlewareTests.Meter";
+        private static readonly string MeterName = Utils.GetCurrentMethodName();
 
         [Fact]
         public async Task PrometheusExporterMiddlewareIntegration()

--- a/test/OpenTelemetry.Tests.Stress.Metrics/OpenTelemetry.Tests.Stress.Metrics.csproj
+++ b/test/OpenTelemetry.Tests.Stress.Metrics/OpenTelemetry.Tests.Stress.Metrics.csproj
@@ -12,4 +12,8 @@
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry\OpenTelemetry.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\Utils.cs" Link="Includes\Utils.cs" />
+  </ItemGroup>
+
 </Project>

--- a/test/OpenTelemetry.Tests.Stress.Metrics/Program.cs
+++ b/test/OpenTelemetry.Tests.Stress.Metrics/Program.cs
@@ -27,7 +27,7 @@ using OpenTelemetry.Tests;
 public partial class Program
 {
     private const int ArraySize = 10;
-    private static readonly Meter TestMeter = new Meter(Utils.GetCurrentMethodName(), "1.0.0");
+    private static readonly Meter TestMeter = new Meter(Utils.GetCurrentMethodName());
     private static readonly Counter<long> TestCounter = TestMeter.CreateCounter<long>("TestCounter");
     private static readonly string[] DimensionValues = new string[ArraySize];
     private static readonly ThreadLocal<Random> ThreadLocalRandom = new ThreadLocal<Random>(() => new Random());

--- a/test/OpenTelemetry.Tests.Stress.Metrics/Program.cs
+++ b/test/OpenTelemetry.Tests.Stress.Metrics/Program.cs
@@ -20,13 +20,14 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Tests;
 
 // namespace OpenTelemetry.Tests.Stress;
 
 public partial class Program
 {
     private const int ArraySize = 10;
-    private static readonly Meter TestMeter = new Meter("TestMeter", "1.0.0");
+    private static readonly Meter TestMeter = new Meter(Utils.GetCurrentMethodName(), "1.0.0");
     private static readonly Counter<long> TestCounter = TestMeter.CreateCounter<long>("TestCounter");
     private static readonly string[] DimensionValues = new string[ArraySize];
     private static readonly ThreadLocal<Random> ThreadLocalRandom = new ThreadLocal<Random>(() => new Random());
@@ -39,7 +40,7 @@ public partial class Program
         }
 
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
-            .AddMeter("TestMeter")
+            .AddMeter(TestMeter.Name)
             .Build();
         Stress();
     }

--- a/test/OpenTelemetry.Tests/Metrics/InMemoryExporterTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/InMemoryExporterTests.cs
@@ -17,6 +17,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using OpenTelemetry.Exporter;
+using OpenTelemetry.Tests;
 using Xunit;
 
 namespace OpenTelemetry.Metrics.Tests
@@ -26,7 +27,7 @@ namespace OpenTelemetry.Metrics.Tests
         [Fact(Skip = "To be run after https://github.com/open-telemetry/opentelemetry-dotnet/issues/2361 is fixed")]
         public void InMemoryExporterShouldDeepCopyMetricPoints()
         {
-            var meter = new Meter("InMemoryExporterTests", "1.0");
+            var meter = new Meter(Utils.GetCurrentMethodName(), "1.0");
 
             var exportedItems = new List<Metric>();
             using var inMemoryReader = new BaseExportingMetricReader(new InMemoryExporter<Metric>(exportedItems))
@@ -35,7 +36,7 @@ namespace OpenTelemetry.Metrics.Tests
             };
 
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-            .AddMeter("InMemoryExporterTests")
+            .AddMeter(meter.Name)
             .AddReader(inMemoryReader)
             .Build();
 

--- a/test/OpenTelemetry.Tests/Metrics/InMemoryExporterTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/InMemoryExporterTests.cs
@@ -27,7 +27,7 @@ namespace OpenTelemetry.Metrics.Tests
         [Fact(Skip = "To be run after https://github.com/open-telemetry/opentelemetry-dotnet/issues/2361 is fixed")]
         public void InMemoryExporterShouldDeepCopyMetricPoints()
         {
-            var meter = new Meter(Utils.GetCurrentMethodName(), "1.0");
+            var meter = new Meter(Utils.GetCurrentMethodName());
 
             var exportedItems = new List<Metric>();
             using var inMemoryReader = new BaseExportingMetricReader(new InMemoryExporter<Metric>(exportedItems))

--- a/test/OpenTelemetry.Tests/Metrics/MemoryEfficiencyTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MemoryEfficiencyTests.cs
@@ -29,7 +29,7 @@ namespace OpenTelemetry.Metrics.Tests
         [InlineData(AggregationTemporality.Delta)]
         public void ExportOnlyWhenPointChanged(AggregationTemporality temporality)
         {
-            using var meter = new Meter(Utils.GetCurrentMethodName() + temporality);
+            using var meter = new Meter($"{Utils.GetCurrentMethodName()}.{temporality}");
 
             var exportedItems = new List<Metric>();
 

--- a/test/OpenTelemetry.Tests/Metrics/MemoryEfficiencyTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MemoryEfficiencyTests.cs
@@ -29,7 +29,7 @@ namespace OpenTelemetry.Metrics.Tests
         [InlineData(AggregationTemporality.Delta)]
         public void ExportOnlyWhenPointChanged(AggregationTemporality temporality)
         {
-            using var meter = new Meter(Utils.GetCurrentMethodName() + temporality, "1.0");
+            using var meter = new Meter(Utils.GetCurrentMethodName() + temporality);
 
             var exportedItems = new List<Metric>();
 

--- a/test/OpenTelemetry.Tests/Metrics/MemoryEfficiencyTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MemoryEfficiencyTests.cs
@@ -29,7 +29,7 @@ namespace OpenTelemetry.Metrics.Tests
         [InlineData(AggregationTemporality.Delta)]
         public void ExportOnlyWhenPointChanged(AggregationTemporality temporality)
         {
-            using var meter = new Meter(Utils.GetCurrentMethodName(), "1.0");
+            using var meter = new Meter(Utils.GetCurrentMethodName() + temporality, "1.0");
 
             var exportedItems = new List<Metric>();
 

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -343,7 +343,7 @@ namespace OpenTelemetry.Metrics.Tests
 
             using var meter = new Meter(Utils.GetCurrentMethodName() + (exportDelta ? '1' : '0'));
             int i = 1;
-            var counterLong = meter.CreateObservableCounter<long>(
+            var counterLong = meter.CreateObservableCounter(
             "observable-counter",
             () =>
             {

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -43,7 +43,7 @@ namespace OpenTelemetry.Metrics.Tests
         [Fact]
         public void ObserverCallbackTest()
         {
-            using var meter = new Meter("ObserverCallbackErrorTest");
+            using var meter = new Meter(Utils.GetCurrentMethodName());
             var exportedItems = new List<Metric>();
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
                 .AddMeter(meter.Name)
@@ -73,7 +73,7 @@ namespace OpenTelemetry.Metrics.Tests
         [Fact]
         public void ObserverCallbackExceptionTest()
         {
-            using var meter = new Meter("ObserverCallbackErrorTest");
+            using var meter = new Meter(Utils.GetCurrentMethodName());
             var exportedItems = new List<Metric>();
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
                 .AddMeter(meter.Name)
@@ -132,11 +132,11 @@ namespace OpenTelemetry.Metrics.Tests
             {
                 PreferredAggregationTemporality = temporality,
             };
-            using var meter1 = new Meter("TestDuplicateMetricName1");
-            using var meter2 = new Meter("TestDuplicateMetricName2");
+            using var meter1 = new Meter(Utils.GetCurrentMethodName() + temporality + '1');
+            using var meter2 = new Meter(Utils.GetCurrentMethodName() + temporality + '2');
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddMeter("TestDuplicateMetricName1")
-                .AddMeter("TestDuplicateMetricName2")
+                .AddMeter(meter1.Name)
+                .AddMeter(meter2.Name)
                 .AddReader(metricReader)
                 .Build();
 
@@ -170,22 +170,12 @@ namespace OpenTelemetry.Metrics.Tests
         [InlineData(false)]
         public void MeterSourcesWildcardSupportMatchTest(bool hasView)
         {
-            var meterNames = new[]
-            {
-                "AbcCompany.XyzProduct.ComponentA",
-                "abcCompany.xYzProduct.componentC", // Wildcard match is case insensitive.
-                "DefCompany.AbcProduct.ComponentC",
-                "DefCompany.XyzProduct.ComponentC", // Wildcard match supports matching multiple patterns.
-                "GhiCompany.qweProduct.ComponentN",
-                "SomeCompany.SomeProduct.SomeComponent",
-            };
-
-            using var meter1 = new Meter(meterNames[0]);
-            using var meter2 = new Meter(meterNames[1]);
-            using var meter3 = new Meter(meterNames[2]);
-            using var meter4 = new Meter(meterNames[3]);
-            using var meter5 = new Meter(meterNames[4]);
-            using var meter6 = new Meter(meterNames[5]);
+            using var meter1 = new Meter("AbcCompany.XyzProduct.ComponentA");
+            using var meter2 = new Meter("abcCompany.xYzProduct.componentC"); // Wildcard match is case insensitive.
+            using var meter3 = new Meter("DefCompany.AbcProduct.ComponentC");
+            using var meter4 = new Meter("DefCompany.XyzProduct.ComponentC"); // Wildcard match supports matching multiple patterns.
+            using var meter5 = new Meter("GhiCompany.qweProduct.ComponentN");
+            using var meter6 = new Meter("SomeCompany.SomeProduct.SomeComponent");
 
             var exportedItems = new List<Metric>();
             var meterProviderBuilder = Sdk.CreateMeterProviderBuilder()
@@ -233,14 +223,8 @@ namespace OpenTelemetry.Metrics.Tests
         [InlineData(false)]
         public void MeterSourcesWildcardSupportNegativeTestNoMeterAdded(bool hasView)
         {
-            var meterNames = new[]
-            {
-                "AbcCompany.XyzProduct.ComponentA",
-                "abcCompany.xYzProduct.componentC",
-            };
-
-            using var meter1 = new Meter(meterNames[0]);
-            using var meter2 = new Meter(meterNames[1]);
+            using var meter1 = new Meter("AbcCompany.XyzProduct.ComponentA" + (hasView ? '1' : '0'));
+            using var meter2 = new Meter("abcCompany.xYzProduct.componentC" + (hasView ? '1' : '0'));
 
             var exportedItems = new List<Metric>();
             var meterProviderBuilder = Sdk.CreateMeterProviderBuilder()
@@ -282,10 +266,10 @@ namespace OpenTelemetry.Metrics.Tests
                 PreferredAggregationTemporality = exportDelta ? AggregationTemporality.Delta : AggregationTemporality.Cumulative,
             };
 
-            using var meter = new Meter("TestMeter");
+            using var meter = new Meter(Utils.GetCurrentMethodName() + (exportDelta ? '1' : '0'));
             var counterLong = meter.CreateCounter<long>("mycounter");
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddMeter("TestMeter")
+                .AddMeter(meter.Name)
                 .AddReader(metricReader)
                 .Build();
 
@@ -341,7 +325,6 @@ namespace OpenTelemetry.Metrics.Tests
         [InlineData(false)]
         public void ObservableCounterAggregationTest(bool exportDelta)
         {
-            var meterName = "TestMeter" + exportDelta;
             var metricItems = new List<Metric>();
             var metricExporter = new TestExporter<Metric>(ProcessExport);
 
@@ -358,7 +341,7 @@ namespace OpenTelemetry.Metrics.Tests
                 PreferredAggregationTemporality = exportDelta ? AggregationTemporality.Delta : AggregationTemporality.Cumulative,
             };
 
-            using var meter = new Meter(meterName);
+            using var meter = new Meter(Utils.GetCurrentMethodName() + (exportDelta ? '1' : '0'));
             int i = 1;
             var counterLong = meter.CreateObservableCounter<long>(
             "observable-counter",
@@ -370,7 +353,7 @@ namespace OpenTelemetry.Metrics.Tests
                 };
             });
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddMeter(meterName)
+                .AddMeter(meter.Name)
                 .AddReader(metricReader)
                 .Build();
 
@@ -427,10 +410,10 @@ namespace OpenTelemetry.Metrics.Tests
             {
                 PreferredAggregationTemporality = temporality,
             };
-            using var meter = new Meter("TestPointCapMeter");
+            using var meter = new Meter(Utils.GetCurrentMethodName() + temporality);
             var counterLong = meter.CreateCounter<long>("mycounterCapTest");
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddMeter("TestPointCapMeter")
+                .AddMeter(meter.Name)
                 .AddReader(metricReader)
                 .Build();
 
@@ -479,10 +462,10 @@ namespace OpenTelemetry.Metrics.Tests
                 PreferredAggregationTemporality = AggregationTemporality.Cumulative,
             };
 
-            using var meter = new Meter("TestLongCounterMeter");
+            using var meter = new Meter(Utils.GetCurrentMethodName());
             var counterLong = meter.CreateCounter<long>("mycounter");
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddMeter("TestLongCounterMeter")
+                .AddMeter(meter.Name)
                 .AddReader(metricReader)
                 .Build();
 
@@ -548,10 +531,10 @@ namespace OpenTelemetry.Metrics.Tests
                 PreferredAggregationTemporality = AggregationTemporality.Cumulative,
             };
 
-            using var meter = new Meter("TestDoubleCounterMeter");
+            using var meter = new Meter(Utils.GetCurrentMethodName());
             var counterDouble = meter.CreateCounter<double>("mycounter");
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddMeter("TestDoubleCounterMeter")
+                .AddMeter(meter.Name)
                 .AddReader(metricReader)
                 .Build();
 

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -132,8 +132,8 @@ namespace OpenTelemetry.Metrics.Tests
             {
                 PreferredAggregationTemporality = temporality,
             };
-            using var meter1 = new Meter(Utils.GetCurrentMethodName() + '1' + temporality);
-            using var meter2 = new Meter(Utils.GetCurrentMethodName() + '2' + temporality);
+            using var meter1 = new Meter($"{Utils.GetCurrentMethodName()}.1.{temporality}");
+            using var meter2 = new Meter($"{Utils.GetCurrentMethodName()}.2.{temporality}");
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
                 .AddMeter(meter1.Name)
                 .AddMeter(meter2.Name)
@@ -223,8 +223,8 @@ namespace OpenTelemetry.Metrics.Tests
         [InlineData(false)]
         public void MeterSourcesWildcardSupportNegativeTestNoMeterAdded(bool hasView)
         {
-            using var meter1 = new Meter("AbcCompany.XyzProduct.ComponentA" + hasView);
-            using var meter2 = new Meter("abcCompany.xYzProduct.componentC" + hasView);
+            using var meter1 = new Meter($"AbcCompany.XyzProduct.ComponentA.{hasView}");
+            using var meter2 = new Meter($"abcCompany.xYzProduct.componentC.{hasView}");
 
             var exportedItems = new List<Metric>();
             var meterProviderBuilder = Sdk.CreateMeterProviderBuilder()
@@ -266,7 +266,7 @@ namespace OpenTelemetry.Metrics.Tests
                 PreferredAggregationTemporality = exportDelta ? AggregationTemporality.Delta : AggregationTemporality.Cumulative,
             };
 
-            using var meter = new Meter(Utils.GetCurrentMethodName() + exportDelta);
+            using var meter = new Meter($"{Utils.GetCurrentMethodName()}.{exportDelta}");
             var counterLong = meter.CreateCounter<long>("mycounter");
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
                 .AddMeter(meter.Name)
@@ -341,7 +341,7 @@ namespace OpenTelemetry.Metrics.Tests
                 PreferredAggregationTemporality = exportDelta ? AggregationTemporality.Delta : AggregationTemporality.Cumulative,
             };
 
-            using var meter = new Meter(Utils.GetCurrentMethodName() + exportDelta);
+            using var meter = new Meter($"{Utils.GetCurrentMethodName()}.{exportDelta}");
             int i = 1;
             var counterLong = meter.CreateObservableCounter(
             "observable-counter",
@@ -410,7 +410,7 @@ namespace OpenTelemetry.Metrics.Tests
             {
                 PreferredAggregationTemporality = temporality,
             };
-            using var meter = new Meter(Utils.GetCurrentMethodName() + temporality);
+            using var meter = new Meter($"{Utils.GetCurrentMethodName()}.{temporality}");
             var counterLong = meter.CreateCounter<long>("mycounterCapTest");
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
                 .AddMeter(meter.Name)

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -223,8 +223,8 @@ namespace OpenTelemetry.Metrics.Tests
         [InlineData(false)]
         public void MeterSourcesWildcardSupportNegativeTestNoMeterAdded(bool hasView)
         {
-            using var meter1 = new Meter("AbcCompany.XyzProduct.ComponentA" + (hasView ? '1' : '0'));
-            using var meter2 = new Meter("abcCompany.xYzProduct.componentC" + (hasView ? '1' : '0'));
+            using var meter1 = new Meter("AbcCompany.XyzProduct.ComponentA" + hasView);
+            using var meter2 = new Meter("abcCompany.xYzProduct.componentC" + hasView);
 
             var exportedItems = new List<Metric>();
             var meterProviderBuilder = Sdk.CreateMeterProviderBuilder()
@@ -266,7 +266,7 @@ namespace OpenTelemetry.Metrics.Tests
                 PreferredAggregationTemporality = exportDelta ? AggregationTemporality.Delta : AggregationTemporality.Cumulative,
             };
 
-            using var meter = new Meter(Utils.GetCurrentMethodName() + (exportDelta ? '1' : '0'));
+            using var meter = new Meter(Utils.GetCurrentMethodName() + exportDelta);
             var counterLong = meter.CreateCounter<long>("mycounter");
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
                 .AddMeter(meter.Name)
@@ -341,7 +341,7 @@ namespace OpenTelemetry.Metrics.Tests
                 PreferredAggregationTemporality = exportDelta ? AggregationTemporality.Delta : AggregationTemporality.Cumulative,
             };
 
-            using var meter = new Meter(Utils.GetCurrentMethodName() + (exportDelta ? '1' : '0'));
+            using var meter = new Meter(Utils.GetCurrentMethodName() + exportDelta);
             int i = 1;
             var counterLong = meter.CreateObservableCounter(
             "observable-counter",

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -132,8 +132,8 @@ namespace OpenTelemetry.Metrics.Tests
             {
                 PreferredAggregationTemporality = temporality,
             };
-            using var meter1 = new Meter(Utils.GetCurrentMethodName() + temporality + '1');
-            using var meter2 = new Meter(Utils.GetCurrentMethodName() + temporality + '2');
+            using var meter1 = new Meter(Utils.GetCurrentMethodName() + '1' + temporality);
+            using var meter2 = new Meter(Utils.GetCurrentMethodName() + '2' + temporality);
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
                 .AddMeter(meter1.Name)
                 .AddMeter(meter2.Name)

--- a/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
+using OpenTelemetry.Tests;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -36,16 +37,16 @@ namespace OpenTelemetry.Metrics.Tests
         [Fact]
         public void ViewToRenameMetric()
         {
-            using var meter1 = new Meter("ViewToRenameMetricTest");
+            using var meter = new Meter(Utils.GetCurrentMethodName());
             var exportedItems = new List<Metric>();
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddMeter(meter1.Name)
+                .AddMeter(meter.Name)
                 .AddView("name1", "renamed")
                 .AddInMemoryExporter(exportedItems)
                 .Build();
 
             // Expecting one metric stream.
-            var counterLong = meter1.CreateCounter<long>("name1");
+            var counterLong = meter.CreateCounter<long>("name1");
             counterLong.Add(10);
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
             Assert.Single(exportedItems);
@@ -56,8 +57,8 @@ namespace OpenTelemetry.Metrics.Tests
         [Fact]
         public void ViewToRenameMetricConditionally()
         {
-            using var meter1 = new Meter("ViewToRenameMetricConditionallyTest");
-            using var meter2 = new Meter("ViewToRenameMetricConditionallyTest2");
+            using var meter1 = new Meter(Utils.GetCurrentMethodName() + '1');
+            using var meter2 = new Meter(Utils.GetCurrentMethodName() + '2');
             var exportedItems = new List<Metric>();
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
                 .AddMeter(meter1.Name)
@@ -96,20 +97,20 @@ namespace OpenTelemetry.Metrics.Tests
         [Fact]
         public void ViewToRenameMetricWildCardMatch()
         {
-            using var meter1 = new Meter("ViewToRenameMetricWildCardMatchTest");
+            using var meter = new Meter(Utils.GetCurrentMethodName());
             var exportedItems = new List<Metric>();
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddMeter(meter1.Name)
+                .AddMeter(meter.Name)
                 .AddView("counter*", "renamed")
                 .AddInMemoryExporter(exportedItems)
                 .Build();
 
             // Expecting one metric stream.
-            var counter1 = meter1.CreateCounter<long>("counterA");
+            var counter1 = meter.CreateCounter<long>("counterA");
             counter1.Add(10);
-            var counter2 = meter1.CreateCounter<long>("counterB");
+            var counter2 = meter.CreateCounter<long>("counterB");
             counter2.Add(10);
-            var counter3 = meter1.CreateCounter<long>("counterC");
+            var counter3 = meter.CreateCounter<long>("counterC");
             counter3.Add(10);
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
 
@@ -123,17 +124,17 @@ namespace OpenTelemetry.Metrics.Tests
         [Fact]
         public void ViewToProduceMultipleStreamsFromInstrument()
         {
-            using var meter1 = new Meter("ViewToProduceMultipleStreamsFromInstrumentTest");
+            using var meter = new Meter(Utils.GetCurrentMethodName());
             var exportedItems = new List<Metric>();
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddMeter(meter1.Name)
+                .AddMeter(meter.Name)
                 .AddView("name1", "renamedStream1")
                 .AddView("name1", "renamedStream2")
                 .AddInMemoryExporter(exportedItems)
                 .Build();
 
             // Expecting two metric stream.
-            var counterLong = meter1.CreateCounter<long>("name1");
+            var counterLong = meter.CreateCounter<long>("name1");
             counterLong.Add(10);
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
             Assert.Equal(2, exportedItems.Count);
@@ -144,10 +145,10 @@ namespace OpenTelemetry.Metrics.Tests
         [Fact]
         public void ViewToProduceMultipleStreamsWithDuplicatesFromInstrument()
         {
-            using var meter1 = new Meter("ViewToProduceMultipleStreamsWithDuplicatesFromInstrumentTest");
+            using var meter = new Meter(Utils.GetCurrentMethodName());
             var exportedItems = new List<Metric>();
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddMeter(meter1.Name)
+                .AddMeter(meter.Name)
                 .AddView("name1", "renamedStream1")
                 .AddView("name1", "renamedStream2")
                 .AddView("name1", "renamedStream2")
@@ -158,7 +159,7 @@ namespace OpenTelemetry.Metrics.Tests
             // the .AddView("name1", "renamedStream2")
             // won't produce new Metric as the name
             // conflicts.
-            var counterLong = meter1.CreateCounter<long>("name1");
+            var counterLong = meter.CreateCounter<long>("name1");
             counterLong.Add(10);
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
             Assert.Equal(2, exportedItems.Count);
@@ -169,17 +170,17 @@ namespace OpenTelemetry.Metrics.Tests
         [Fact]
         public void ViewToProduceCustomHistogramBound()
         {
-            using var meter1 = new Meter("ViewToProduceCustomHistogramBoundTest");
+            using var meter = new Meter(Utils.GetCurrentMethodName());
             var exportedItems = new List<Metric>();
             var bounds = new double[] { 10, 20 };
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddMeter(meter1.Name)
+                .AddMeter(meter.Name)
                 .AddView("MyHistogram", new HistogramConfiguration() { Name = "MyHistogramDefaultBound" })
                 .AddView("MyHistogram", new HistogramConfiguration() { BucketBounds = bounds })
                 .AddInMemoryExporter(exportedItems)
                 .Build();
 
-            var histogram = meter1.CreateHistogram<long>("MyHistogram");
+            var histogram = meter.CreateHistogram<long>("MyHistogram");
             histogram.Record(-10);
             histogram.Record(0);
             histogram.Record(1);
@@ -234,10 +235,10 @@ namespace OpenTelemetry.Metrics.Tests
         [Fact]
         public void ViewToSelectTagKeys()
         {
-            using var meter1 = new Meter("ViewToSelectTagKeysTest");
+            using var meter = new Meter(Utils.GetCurrentMethodName());
             var exportedItems = new List<Metric>();
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddMeter(meter1.Name)
+                .AddMeter(meter.Name)
                 .AddView("FruitCounter", new MetricStreamConfiguration()
                 { TagKeys = new string[] { "name" }, Name = "NameOnly" })
                 .AddView("FruitCounter", new MetricStreamConfiguration()
@@ -247,7 +248,7 @@ namespace OpenTelemetry.Metrics.Tests
                 .AddInMemoryExporter(exportedItems)
                 .Build();
 
-            var counter = meter1.CreateCounter<long>("FruitCounter");
+            var counter = meter.CreateCounter<long>("FruitCounter");
             counter.Add(10, new("name", "apple"), new("color", "red"), new("size", "small"));
             counter.Add(10, new("name", "apple"), new("color", "red"), new("size", "small"));
 
@@ -296,7 +297,7 @@ namespace OpenTelemetry.Metrics.Tests
         [Fact]
         public void ViewToDropSingleInstrument()
         {
-            using var meter = new Meter("ViewToDropSingleInstrumentTest");
+            using var meter = new Meter(Utils.GetCurrentMethodName());
             var exportedItems = new List<Metric>();
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
                 .AddMeter(meter.Name)
@@ -319,7 +320,7 @@ namespace OpenTelemetry.Metrics.Tests
         [Fact]
         public void ViewToDropMultipleInstruments()
         {
-            using var meter = new Meter("ViewToDropMultipleInstrumentsTest");
+            using var meter = new Meter(Utils.GetCurrentMethodName());
             var exportedItems = new List<Metric>();
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
                 .AddMeter(meter.Name)
@@ -346,7 +347,7 @@ namespace OpenTelemetry.Metrics.Tests
         [Fact]
         public void ViewToDropAndRetainInstrument()
         {
-            using var meter = new Meter("ViewToDropAndRetainInstrumentTest");
+            using var meter = new Meter(Utils.GetCurrentMethodName());
             var exportedItems = new List<Metric>();
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
                 .AddMeter(meter.Name)

--- a/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
@@ -57,8 +57,8 @@ namespace OpenTelemetry.Metrics.Tests
         [Fact]
         public void ViewToRenameMetricConditionally()
         {
-            using var meter1 = new Meter(Utils.GetCurrentMethodName() + '1');
-            using var meter2 = new Meter(Utils.GetCurrentMethodName() + '2');
+            using var meter1 = new Meter($"{Utils.GetCurrentMethodName()}.1");
+            using var meter2 = new Meter($"{Utils.GetCurrentMethodName()}.2");
             var exportedItems = new List<Metric>();
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
                 .AddMeter(meter1.Name)


### PR DESCRIPTION
Fixes #2533

## Changes

Make meter names unique in test suite
- Use `Utils.GetCurrentMethodName` for `Meter` constructors
  - Also if the test case includes parameters those should also be joined to end of the meter name separated with periods `.`
- Use `meter.Name` rather than using a matching string literal, requires `meter` to be initialized before call to `MeterProviderBuilder.AddMeter`
- Rename `meter1` to `meter` when only 1 `Meter` is created in the test function

All `Meter`'s currently being created are all added to a `MeterProvider` except a few (that were found manually by searching for references to the `Meter` constructor in filepaths containing the `test` substring) listed here by filepath, function name and variable name:
-`test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs`
  - `MeterSourcesWildcardSupportMatchTest`
    - `meter6`
  - `MeterSourcesWildcardSupportNegativeTestNoMeterAdded`
    - `meter1`
    - `meter2`
- `test\OpenTelemetry.Exporter.Prometheus.Tests\PrometheusExporterMiddlewareTests.cs`
  - `PrometheusExporterMiddlewareIntegration`
    - `meter`

Meter Names:
Manually gathered:
- `SomeCompany.SomeProduct.SomeComponent`
- `AbcCompany.XyzProduct.ComponentA.True`
- `AbcCompany.XyzProduct.ComponentA.False`
- `abcCompany.xYzProduct.componentC.True`
- `abcCompany.xYzProduct.componentC.False`
- `OpenTelemetry.Exporter.Prometheus.Tests.PrometheusExporterMiddlewareTests..cctor`

Printed by debugger
```text
$ findstr "^Meter added:" .\meter.txt | sort

[Note: Start of wildcard naming test]
Meter Added: AbcCompany.XyzProduct.*
Meter Added: AbcCompany.XyzProduct.*
Meter Added: DefCompany.*.ComponentC
Meter Added: DefCompany.*.ComponentC
Meter Added: GhiCompany.qweProduct.ComponentN
Meter Added: GhiCompany.qweProduct.ComponentN
[Note: End of wildcard naming test]

Meter Added: OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.OtlpMetricsExporterTests.ToOtlpResourceMetricsTest.False
Meter Added: OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.OtlpMetricsExporterTests.ToOtlpResourceMetricsTest.True
Meter Added: OpenTelemetry.Exporter.Prometheus.Tests.PrometheusExporterExtensionsTests.WriteMetricsCollectionTestWriteDoubleGauge
Meter Added: OpenTelemetry.Exporter.Prometheus.Tests.PrometheusExporterExtensionsTests.WriteMetricsCollectionTestWriteDoubleSum
Meter Added: OpenTelemetry.Exporter.Prometheus.Tests.PrometheusExporterExtensionsTests.WriteMetricsCollectionTestWriteHistogram
Meter Added: OpenTelemetry.Exporter.Prometheus.Tests.PrometheusExporterExtensionsTests.WriteMetricsCollectionTestWriteLongGauge
Meter Added: OpenTelemetry.Exporter.Prometheus.Tests.PrometheusExporterExtensionsTests.WriteMetricsCollectionTestWriteLongSum
Meter Added: OpenTelemetry.Exporter.Prometheus.Tests.PrometheusExporterExtensionsTests.WriteMetricsCollectionTestWriteMultiple
Meter Added: OpenTelemetry.Exporter.Prometheus.Tests.PrometheusExporterMetricsHttpServerTests+<PrometheusExporterMetricsHttpServerIntegration>d__0.MoveNext
Meter Added: OpenTelemetry.Exporter.Prometheus.Tests.PrometheusExporterMiddlewareTests..cctor
Meter Added: OpenTelemetry.Instrumentation.AspNetCore
[Printed 21 times] Meter Added: OpenTelemetry.Instrumentation.Http
Meter Added: OpenTelemetry.Metrics.Tests.MetricApiTest.CounterAggregationTest.False
Meter Added: OpenTelemetry.Metrics.Tests.MetricApiTest.CounterAggregationTest.True
Meter Added: OpenTelemetry.Metrics.Tests.MetricApiTest.MultithreadedDoubleCounterTest
Meter Added: OpenTelemetry.Metrics.Tests.MetricApiTest.MultithreadedLongCounterTest
Meter Added: OpenTelemetry.Metrics.Tests.MetricApiTest.ObservableCounterAggregationTest.False
Meter Added: OpenTelemetry.Metrics.Tests.MetricApiTest.ObservableCounterAggregationTest.True
Meter Added: OpenTelemetry.Metrics.Tests.MetricApiTest.ObserverCallbackExceptionTest
Meter Added: OpenTelemetry.Metrics.Tests.MetricApiTest.ObserverCallbackTest
Meter Added: OpenTelemetry.Metrics.Tests.MetricApiTest.StreamNamesDuplicatesAreNotAllowedTest.1.Cumulative
Meter Added: OpenTelemetry.Metrics.Tests.MetricApiTest.StreamNamesDuplicatesAreNotAllowedTest.1.Delta
Meter Added: OpenTelemetry.Metrics.Tests.MetricApiTest.StreamNamesDuplicatesAreNotAllowedTest.2.Cumulative
Meter Added: OpenTelemetry.Metrics.Tests.MetricApiTest.StreamNamesDuplicatesAreNotAllowedTest.2.Delta
Meter Added: OpenTelemetry.Metrics.Tests.MetricApiTest.TestMetricPointCap.Cumulative
Meter Added: OpenTelemetry.Metrics.Tests.MetricApiTest.TestMetricPointCap.Delta
Meter Added: OpenTelemetry.Metrics.Tests.MetricViewTests.ViewToDropAndRetainInstrument
Meter Added: OpenTelemetry.Metrics.Tests.MetricViewTests.ViewToDropMultipleInstruments
Meter Added: OpenTelemetry.Metrics.Tests.MetricViewTests.ViewToDropSingleInstrument
Meter Added: OpenTelemetry.Metrics.Tests.MetricViewTests.ViewToProduceCustomHistogramBound
Meter Added: OpenTelemetry.Metrics.Tests.MetricViewTests.ViewToProduceMultipleStreamsFromInstrument
Meter Added: OpenTelemetry.Metrics.Tests.MetricViewTests.ViewToProduceMultipleStreamsWithDuplicatesFromInstrument
Meter Added: OpenTelemetry.Metrics.Tests.MetricViewTests.ViewToRenameMetric
Meter Added: OpenTelemetry.Metrics.Tests.MetricViewTests.ViewToRenameMetricConditionally1
Meter Added: OpenTelemetry.Metrics.Tests.MetricViewTests.ViewToRenameMetricConditionally2
Meter Added: OpenTelemetry.Metrics.Tests.MetricViewTests.ViewToRenameMetricWildCardMatch
Meter Added: OpenTelemetry.Metrics.Tests.MetricViewTests.ViewToSelectTagKeys
```

Aside: I added `Debug.WriteLine($"Meter Added: {name}");` to `src\OpenTelemetry\Metrics\MeterProviderBuilderBase.cs:AddMeter()` function, then selected all tests and ran in debug mode and copied the output from here to a text file
![Visual Studio output window with "Show output from:" set to "Debug"](https://user-images.githubusercontent.com/15165028/139954009-a6709d46-6316-4947-8bc7-4c529dccc414.png)
