### PR TITLE
Remove unused new (found in disassembly in public nuget)

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
@@ -35,7 +35,6 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
             OtlpResource.Resource processResource,
             in Batch<LogRecord> logRecordBatch)
         {
-            Dictionary<string, OtlpLogs.InstrumentationLibraryLogs> logRecordsByLibrary = new Dictionary<string, OtlpLogs.InstrumentationLibraryLogs>();
             OtlpLogs.ResourceLogs resourceLogs = new OtlpLogs.ResourceLogs
             {
                 Resource = processResource,

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Google.Protobuf;
 using Google.Protobuf.Collections;


### PR DESCRIPTION
```
internal static void AddBatch(this ExportLogsServiceRequest request, Resource processResource, in Batch<OpenTelemetry.Logs.LogRecord> logRecordBatch)
{
	new Dictionary<string, InstrumentationLibraryLogs>();
	ResourceLogs resourceLogs = new ResourceLogs
	{
		Resource = processResource
	};
```

Fixes #.

## Changes

This may hint that there's a logic library further down, that was supposed to be using this field. Original author, please review with care as I did not review closely the intent.
