### PR TITLE
Enable .net6.0 build and add net6.0 target

### DIFF
--- a/.github/workflows/apicompatibility.yml
+++ b/.github/workflows/apicompatibility.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build-test:
     runs-on: windows-latest
+    # https://github.com/actions/setup-dotnet/issues/122
+    env:
+      DOTNET_MULTILEVEL_LOOKUP: 1
     env:
       CheckAPICompatibility: true
     steps:

--- a/.github/workflows/apicompatibility.yml
+++ b/.github/workflows/apicompatibility.yml
@@ -11,9 +11,8 @@ jobs:
     runs-on: windows-latest
     # https://github.com/actions/setup-dotnet/issues/122
     env:
-      DOTNET_MULTILEVEL_LOOKUP: 1
-    env:
       CheckAPICompatibility: true
+      DOTNET_MULTILEVEL_LOOKUP: 1
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/apicompatibility.yml
+++ b/.github/workflows/apicompatibility.yml
@@ -14,6 +14,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0.x'
+        include-prerelease: true
+
     - name: Install dependencies
       run: dotnet restore
 

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -26,18 +26,18 @@ jobs:
       with:
         fetch-depth: 0 # fetching all
 
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
+    # - uses: actions/setup-dotnet@v1
+    #   with:
+    #     dotnet-version: '3.1.x'
 
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '5.0.x'
+    # - uses: actions/setup-dotnet@v1
+    #   with:
+    #     dotnet-version: '5.0.x'
 
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '6.0.x'
-        include-prerelease: true
+    # - uses: actions/setup-dotnet@v1
+    #   with:
+    #     dotnet-version: '6.0.x'
+    #     include-prerelease: true
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -14,8 +14,6 @@ jobs:
   build-test-report:
     runs-on: ${{ matrix.os }}
     # https://github.com/actions/setup-dotnet/issues/122
-    env:
-      DOTNET_MULTILEVEL_LOOKUP: 1
 
     strategy:
       fail-fast: false
@@ -23,6 +21,7 @@ jobs:
         os: [windows-latest]
     env:
       OS: ${{ matrix.os }}
+      DOTNET_MULTILEVEL_LOOKUP: 1
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -28,6 +28,14 @@ jobs:
 
     - uses: actions/setup-dotnet@v1
       with:
+        dotnet-version: '3.1.x'
+
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.x'
+
+    - uses: actions/setup-dotnet@v1
+      with:
         dotnet-version: '6.0.x'
         include-prerelease: true
 

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   build-test-report:
     runs-on: ${{ matrix.os }}
+    # https://github.com/actions/setup-dotnet/issues/122
+    env:
+      DOTNET_MULTILEVEL_LOOKUP: 1
 
     strategy:
       fail-fast: false
@@ -25,14 +28,6 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0 # fetching all
-
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
-
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '5.0.x'
 
     - uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -26,18 +26,18 @@ jobs:
       with:
         fetch-depth: 0 # fetching all
 
-    # - uses: actions/setup-dotnet@v1
-    #   with:
-    #     dotnet-version: '3.1.x'
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
 
-    # - uses: actions/setup-dotnet@v1
-    #   with:
-    #     dotnet-version: '5.0.x'
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.x'
 
-    # - uses: actions/setup-dotnet@v1
-    #   with:
-    #     dotnet-version: '6.0.x'
-    #     include-prerelease: true
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0.x'
+        include-prerelease: true
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -26,6 +26,11 @@ jobs:
       with:
         fetch-depth: 0 # fetching all
 
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0.x'
+        include-prerelease: true
+
     - name: Install dependencies
       run: dotnet restore
 

--- a/.github/workflows/docfx.yml
+++ b/.github/workflows/docfx.yml
@@ -15,6 +15,8 @@ jobs:
       uses: actions/checkout@v2
 
     - name: install docfx
+      # specifying 2.58.5 version as latest release (2.58.8) has an issue
+      # https://github.com/dotnet/docfx/issues/7689
       run: choco install docfx -y --version=2.58.5
 
     - name: run .\build\docfx.cmd

--- a/.github/workflows/docfx.yml
+++ b/.github/workflows/docfx.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: install docfx
-      run: choco install docfx -y
+      run: choco install docfx -y --version=2.58.5
 
     - name: run .\build\docfx.cmd
       shell: cmd

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,20 +13,15 @@ on:
 jobs:
   redis-test:
     runs-on: ubuntu-latest
+    # https://github.com/actions/setup-dotnet/issues/122
+    env:
+      DOTNET_MULTILEVEL_LOOKUP: 1
     strategy:
       fail-fast: false
       matrix:
         version: [netcoreapp3.1,net5.0,net6.0]
     steps:
       - uses: actions/checkout@v2
-
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '3.1.x'
-
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '5.0.x'
 
       - uses: actions/setup-dotnet@v1
         with:
@@ -38,20 +33,15 @@ jobs:
 
   sql-test:
     runs-on: ubuntu-latest
+    # https://github.com/actions/setup-dotnet/issues/122
+    env:
+      DOTNET_MULTILEVEL_LOOKUP: 1
     strategy:
       fail-fast: false
       matrix:
         version: [netcoreapp3.1,net5.0,net6.0]
     steps:
       - uses: actions/checkout@v2
-
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '3.1.x'
-
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '5.0.x'
 
       - uses: actions/setup-dotnet@v1
         with:
@@ -63,20 +53,15 @@ jobs:
 
   w3c-trace-context-test:
     runs-on: ubuntu-latest
+    # https://github.com/actions/setup-dotnet/issues/122
+    env:
+      DOTNET_MULTILEVEL_LOOKUP: 1
     strategy:
       fail-fast: false
       matrix:
         version: [netcoreapp3.1,net5.0,net6.0]
     steps:
       - uses: actions/checkout@v2
-
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '3.1.x'
-
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '5.0.x'
 
       - uses: actions/setup-dotnet@v1
         with:
@@ -88,20 +73,15 @@ jobs:
 
   otlp-exporter-test:
     runs-on: ubuntu-latest
+    # https://github.com/actions/setup-dotnet/issues/122
+    env:
+      DOTNET_MULTILEVEL_LOOKUP: 1
     strategy:
       fail-fast: false
       matrix:
         version: [netcoreapp3.1,net5.0,net6.0]
     steps:
       - uses: actions/checkout@v2
-
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '3.1.x'
-
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '5.0.x'
 
       - uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [netcoreapp3.1,net5.0]
+        version: [netcoreapp3.1,net5.0,net6.0]
     steps:
       - uses: actions/checkout@v2
       - name: Run redis docker-compose.integration
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [netcoreapp3.1,net5.0]
+        version: [netcoreapp3.1,net5.0,net6.0]
     steps:
       - uses: actions/checkout@v2
       - name: Run sql docker-compose.integration
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [netcoreapp3.1,net5.0]
+        version: [netcoreapp3.1,net5.0,net6.0]
     steps:
       - uses: actions/checkout@v2
       - name: Run W3C Trace Context docker-compose.integration
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [netcoreapp3.1,net5.0]
+        version: [netcoreapp3.1,net5.0,net6.0]
     steps:
       - uses: actions/checkout@v2
       - name: Run OTLP Exporter docker-compose.integration

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,6 +19,20 @@ jobs:
         version: [netcoreapp3.1,net5.0,net6.0]
     steps:
       - uses: actions/checkout@v2
+
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
+
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '5.0.x'
+
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
+          include-prerelease: true
+
       - name: Run redis docker-compose.integration
         run: docker-compose --file=test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/docker-compose.yml --file=build/docker-compose.${{ matrix.version }}.yml --project-directory=. up --exit-code-from=tests --build
 
@@ -30,6 +44,20 @@ jobs:
         version: [netcoreapp3.1,net5.0,net6.0]
     steps:
       - uses: actions/checkout@v2
+
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
+
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '5.0.x'
+
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
+          include-prerelease: true
+
       - name: Run sql docker-compose.integration
         run: docker-compose --file=test/OpenTelemetry.Instrumentation.SqlClient.Tests/docker-compose.yml --file=build/docker-compose.${{ matrix.version }}.yml --project-directory=. up --exit-code-from=tests --build
 
@@ -41,6 +69,20 @@ jobs:
         version: [netcoreapp3.1,net5.0,net6.0]
     steps:
       - uses: actions/checkout@v2
+
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
+
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '5.0.x'
+
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
+          include-prerelease: true
+
       - name: Run W3C Trace Context docker-compose.integration
         run: docker-compose --file=test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/docker-compose.yml --file=build/docker-compose.${{ matrix.version }}.yml --project-directory=. up --exit-code-from=tests --build
 
@@ -52,5 +94,19 @@ jobs:
         version: [netcoreapp3.1,net5.0,net6.0]
     steps:
       - uses: actions/checkout@v2
+
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
+
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '5.0.x'
+
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
+          include-prerelease: true
+
       - name: Run OTLP Exporter docker-compose.integration
         run: docker-compose --file=test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/docker-compose.yml --file=build/docker-compose.${{ matrix.version }}.yml --project-directory=. up --exit-code-from=tests --build

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -18,8 +18,8 @@ jobs:
       matrix:
         version: [netcoreapp3.1,net5.0,net6.0]
 
-    # steps:
-    # - uses: actions/checkout@v2
+    steps:
+    - uses: actions/checkout@v2
 
     # - uses: actions/setup-dotnet@v1
     #   with:

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
+    - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '6.0.x'
         include-prerelease: true

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   build-test:
     runs-on: ubuntu-latest
+    # https://github.com/actions/setup-dotnet/issues/122
+    env:
+      DOTNET_MULTILEVEL_LOOKUP: 1
 
     strategy:
       matrix:
@@ -20,14 +23,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
-
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '5.0.x'
 
     - uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -21,6 +21,19 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
+
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.x'
+
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0.x'
+        include-prerelease: true
+
     - name: Install dependencies
       run: dotnet restore
 

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -36,4 +36,6 @@ jobs:
       run: dotnet build --configuration Release --no-restore
 
     - name: Test ${{ matrix.version }}
+      env:
+        DOTNET_MULTILEVEL_LOOKUP: 1
       run: dotnet test **/bin/**/${{ matrix.version }}/*.Tests.dll --configuration Release --no-build --logger:"console;verbosity=detailed"

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -21,11 +21,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '6.0.x'
-        include-prerelease: true
-
     - name: Install dependencies
       run: dotnet restore
 

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -16,19 +16,17 @@ jobs:
     # https://github.com/actions/setup-dotnet/issues/122
     env:
       DOTNET_MULTILEVEL_LOOKUP: 1
-
     strategy:
       fail-fast: false
       matrix:
         version: [netcoreapp3.1,net5.0,net6.0]
-
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '6.0.x'
-        include-prerelease: true
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
+          include-prerelease: true
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -20,6 +20,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        dotnet-version: '6.0.x'
+        include-prerelease: true
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -18,6 +18,7 @@ jobs:
       DOTNET_MULTILEVEL_LOOKUP: 1
 
     strategy:
+      fail-fast: false
       matrix:
         version: [netcoreapp3.1,net5.0,net6.0]
 

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -18,21 +18,21 @@ jobs:
       matrix:
         version: [netcoreapp3.1,net5.0,net6.0]
 
-    steps:
-    - uses: actions/checkout@v2
+    # steps:
+    # - uses: actions/checkout@v2
 
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
+    # - uses: actions/setup-dotnet@v1
+    #   with:
+    #     dotnet-version: '3.1.x'
 
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '5.0.x'
+    # - uses: actions/setup-dotnet@v1
+    #   with:
+    #     dotnet-version: '5.0.x'
 
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '6.0.x'
-        include-prerelease: true
+    # - uses: actions/setup-dotnet@v1
+    #   with:
+    #     dotnet-version: '6.0.x'
+    #     include-prerelease: true
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        version: [netcoreapp3.1,net5.0]
+        version: [netcoreapp3.1,net5.0,net6.0]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -16,17 +16,18 @@ jobs:
     # https://github.com/actions/setup-dotnet/issues/122
     env:
       DOTNET_MULTILEVEL_LOOKUP: 1
+
     strategy:
-      fail-fast: false
       matrix:
         version: [netcoreapp3.1,net5.0,net6.0]
-    steps:
-      - uses: actions/checkout@v2
 
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '6.0.x'
-          include-prerelease: true
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0.x'
+        include-prerelease: true
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -21,18 +21,18 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # - uses: actions/setup-dotnet@v1
-    #   with:
-    #     dotnet-version: '3.1.x'
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
 
-    # - uses: actions/setup-dotnet@v1
-    #   with:
-    #     dotnet-version: '5.0.x'
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.x'
 
-    # - uses: actions/setup-dotnet@v1
-    #   with:
-    #     dotnet-version: '6.0.x'
-    #     include-prerelease: true
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0.x'
+        include-prerelease: true
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -26,6 +26,14 @@ jobs:
 
     - uses: actions/setup-dotnet@v1
       with:
+        dotnet-version: '3.1.x'
+
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.x'
+
+    - uses: actions/setup-dotnet@v1
+      with:
         dotnet-version: '6.0.x'
         include-prerelease: true
 

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
+    - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '6.0.x'
         include-prerelease: true

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -21,6 +21,19 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
+
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.x'
+
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0.x'
+        include-prerelease: true
+
     - name: Install dependencies
       run: dotnet restore
 

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -21,13 +21,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # - uses: actions/setup-dotnet@v1
-    #   with:
-    #     dotnet-version: '3.1.x'
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
 
-    # - uses: actions/setup-dotnet@v1
-    #   with:
-    #     dotnet-version: '5.0.x'
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.x'
 
     - uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -21,11 +21,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '6.0.x'
-        include-prerelease: true
-
     - name: Install dependencies
       run: dotnet restore
 

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -20,6 +20,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        dotnet-version: '6.0.x'
+        include-prerelease: true
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   build-test:
     runs-on: windows-latest
+    env:
+      DOTNET_MULTILEVEL_LOOKUP: 1
 
     strategy:
       matrix:
@@ -21,13 +23,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
+    # - uses: actions/setup-dotnet@v1
+    #   with:
+    #     dotnet-version: '3.1.x'
 
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '5.0.x'
+    # - uses: actions/setup-dotnet@v1
+    #   with:
+    #     dotnet-version: '5.0.x'
 
     - uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        version: [net461,netcoreapp3.1,net5.0]
+        version: [net461,netcoreapp3.1,net5.0,net6.0]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -18,21 +18,21 @@ jobs:
       matrix:
         version: [net461,netcoreapp3.1,net5.0,net6.0]
 
-    steps:
-    - uses: actions/checkout@v2
+    # steps:
+    # - uses: actions/checkout@v2
 
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
+    # - uses: actions/setup-dotnet@v1
+    #   with:
+    #     dotnet-version: '3.1.x'
 
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '5.0.x'
+    # - uses: actions/setup-dotnet@v1
+    #   with:
+    #     dotnet-version: '5.0.x'
 
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '6.0.x'
-        include-prerelease: true
+    # - uses: actions/setup-dotnet@v1
+    #   with:
+    #     dotnet-version: '6.0.x'
+    #     include-prerelease: true
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -21,18 +21,18 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # - uses: actions/setup-dotnet@v1
-    #   with:
-    #     dotnet-version: '3.1.x'
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.x'
 
-    # - uses: actions/setup-dotnet@v1
-    #   with:
-    #     dotnet-version: '5.0.x'
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0.x'
 
-    # - uses: actions/setup-dotnet@v1
-    #   with:
-    #     dotnet-version: '6.0.x'
-    #     include-prerelease: true
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0.x'
+        include-prerelease: true
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -18,8 +18,8 @@ jobs:
       matrix:
         version: [net461,netcoreapp3.1,net5.0,net6.0]
 
-    # steps:
-    # - uses: actions/checkout@v2
+    steps:
+    - uses: actions/checkout@v2
 
     # - uses: actions/setup-dotnet@v1
     #   with:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   build-test:
     runs-on: windows-latest
+    # https://github.com/actions/setup-dotnet/issues/122
     env:
       DOTNET_MULTILEVEL_LOOKUP: 1
 
@@ -22,14 +23,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
-    # - uses: actions/setup-dotnet@v1
-    #   with:
-    #     dotnet-version: '3.1.x'
-
-    # - uses: actions/setup-dotnet@v1
-    #   with:
-    #     dotnet-version: '5.0.x'
 
     - uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -21,13 +21,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
+    # - uses: actions/setup-dotnet@v1
+    #   with:
+    #     dotnet-version: '3.1.x'
 
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '5.0.x'
+    # - uses: actions/setup-dotnet@v1
+    #   with:
+    #     dotnet-version: '5.0.x'
 
     - uses: actions/setup-dotnet@v1
       with:

--- a/OpenTelemetry.sln
+++ b/OpenTelemetry.sln
@@ -222,6 +222,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.Exporter.Prom
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs", "src\OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs\OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs.csproj", "{6E1A5FA3-E024-4972-9EDC-11E36C5A0D6F}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestApp.AspNetCore.6.0", "test\TestApp.AspNetCore.6.0\TestApp.AspNetCore.6.0.csproj", "{0076C657-564F-4787-9FFF-52D9D55166E8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -460,6 +462,10 @@ Global
 		{6E1A5FA3-E024-4972-9EDC-11E36C5A0D6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6E1A5FA3-E024-4972-9EDC-11E36C5A0D6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6E1A5FA3-E024-4972-9EDC-11E36C5A0D6F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0076C657-564F-4787-9FFF-52D9D55166E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0076C657-564F-4787-9FFF-52D9D55166E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0076C657-564F-4787-9FFF-52D9D55166E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0076C657-564F-4787-9FFF-52D9D55166E8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -494,6 +500,7 @@ Global
 		{EA60B549-F712-4ABE-8E44-FCA83B78C06E} = {3277B1C0-BDFE-4460-9B0D-D9A661FB48DB}
 		{1F9D7748-D099-4E25-97F5-9C969D6FF969} = {3277B1C0-BDFE-4460-9B0D-D9A661FB48DB}
 		{81234AFA-B4E7-4D0D-AB97-FD559C78EDA2} = {3277B1C0-BDFE-4460-9B0D-D9A661FB48DB}
+		{0076C657-564F-4787-9FFF-52D9D55166E8} = {77C7929A-2EED-4AA6-8705-B5C443C8AA0F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {55639B5C-0770-4A22-AB56-859604650521}

--- a/build/docker-compose.net6.0.yml
+++ b/build/docker-compose.net6.0.yml
@@ -1,0 +1,8 @@
+﻿version: '3.7'
+
+services:
+  tests:
+    build:
+      args:
+        PUBLISH_FRAMEWORK: net6.0
+        SDK_VERSION: 6.0

--- a/build/docker-compose.net6.0.yml
+++ b/build/docker-compose.net6.0.yml
@@ -5,4 +5,4 @@ services:
     build:
       args:
         PUBLISH_FRAMEWORK: net6.0
-        SDK_VERSION: 6.0.100-rc.2.21505.57
+        SDK_VERSION: 6.0

--- a/build/docker-compose.net6.0.yml
+++ b/build/docker-compose.net6.0.yml
@@ -5,4 +5,4 @@ services:
     build:
       args:
         PUBLISH_FRAMEWORK: net6.0
-        SDK_VERSION: 6.0
+        SDK_VERSION: 6.0.100-rc.2.21505.57

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationOptions.cs
@@ -52,7 +52,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore
         /// </remarks>
         public bool RecordException { get; set; }
 
-#if NETSTANDARD2_1 || NETCOREAPP3_1 || NET5_0
+#if NETSTANDARD2_1 || NETCOREAPP3_1 || NET5_0_OR_GREATER
         /// <summary>
         /// Gets or sets a value indicating whether RPC attributes are added to an Activity when using Grpc.AspNetCore. Default is true.
         /// </summary>

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Description>ASP.NET Core instrumentation for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);distributed-tracing;AspNetCore</PackageTags>
     <IncludeDiagnosticSourceInstrumentationHelpers>true</IncludeDiagnosticSourceInstrumentationHelpers>
@@ -31,6 +31,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/OpenTelemetry.Exporter.Jaeger.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/OpenTelemetry.Exporter.Jaeger.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Unit test project for Jaeger Exporter for OpenTelemetry</Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
 
     <IsPackable>false</IsPackable>

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Dockerfile
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Dockerfile
@@ -2,10 +2,10 @@
 # This should be run from the root of the repo:
 # docker build --file test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Dockerfile
 
-ARG SDK_VERSION=5.0
+ARG SDK_VERSION=6.0
 FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS build
 ARG PUBLISH_CONFIGURATION=Release
-ARG PUBLISH_FRAMEWORK=net5.0
+ARG PUBLISH_FRAMEWORK=net6.0
 WORKDIR /repo
 COPY . ./
 WORKDIR "/repo/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests"

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Dockerfile
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Dockerfile
@@ -3,7 +3,7 @@
 # docker build --file test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Dockerfile
 
 ARG SDK_VERSION=6.0
-FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS build
 ARG PUBLISH_CONFIGURATION=Release
 ARG PUBLISH_FRAMEWORK=net6.0
 WORKDIR /repo

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="$(TARGET_FRAMEWORK) == ''">netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(TARGET_FRAMEWORK) == ''">netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="$(TARGET_FRAMEWORK) == '' AND $(OS) == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
     <TargetFrameworks Condition="$(TARGET_FRAMEWORK) != ''">$(TARGET_FRAMEWORK)</TargetFrameworks>
     <IsPackable>false</IsPackable>

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/OpenTelemetry.Exporter.Prometheus.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/OpenTelemetry.Exporter.Prometheus.Tests.csproj
@@ -23,6 +23,10 @@
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Extensions.Hosting\OpenTelemetry.Extensions.Hosting.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.0-rc.2.21480.10" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="5.0.0" />
   </ItemGroup>

--- a/test/OpenTelemetry.Exporter.ZPages.Tests/OpenTelemetry.Exporter.ZPages.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.ZPages.Tests/OpenTelemetry.Exporter.ZPages.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/OpenTelemetry.Exporter.Zipkin.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/OpenTelemetry.Exporter.Zipkin.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Unit test project for Zipkin Exporter for OpenTelemetry</Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetry.Extensions.Hosting.Tests.csproj
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetry.Extensions.Hosting.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Unit test project for OpenTelemetry .NET Core hosting library</Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
   </PropertyGroup>
 

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
@@ -31,10 +31,15 @@ using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Instrumentation.AspNetCore.Implementation;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
+
 #if NETCOREAPP3_1
 using TestApp.AspNetCore._3._1;
-#else
+#endif
+#if NET5_0
 using TestApp.AspNetCore._5._0;
+#endif
+#if NET6_0
+using TestApp.AspNetCore._6._0;
 #endif
 using Xunit;
 

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/DependencyInjectionConfigTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/DependencyInjectionConfigTests.cs
@@ -20,8 +20,12 @@ using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Trace;
 #if NETCOREAPP3_1
 using TestApp.AspNetCore._3._1;
-#else
+#endif
+#if NET5_0
 using TestApp.AspNetCore._5._0;
+#endif
+#if NET6_0
+using TestApp.AspNetCore._6._0;
 #endif
 using Xunit;
 

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
@@ -27,8 +27,12 @@ using Moq;
 using OpenTelemetry.Trace;
 #if NETCOREAPP3_1
 using TestApp.AspNetCore._3._1;
-#else
+#endif
+#if NET5_0
 using TestApp.AspNetCore._5._0;
+#endif
+#if NET6_0
+using TestApp.AspNetCore._6._0;
 #endif
 using Xunit;
 

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
@@ -24,8 +24,12 @@ using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
 #if NETCOREAPP3_1
 using TestApp.AspNetCore._3._1;
-#else
+#endif
+#if NET5_0
 using TestApp.AspNetCore._5._0;
+#endif
+#if NET6_0
+using TestApp.AspNetCore._6._0;
 #endif
 using Xunit;
 

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/OpenTelemetry.Instrumentation.AspNetCore.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/OpenTelemetry.Instrumentation.AspNetCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Unit test project for OpenTelemetry ASP.NET Core instrumentation</Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,6 +21,11 @@
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestEventListener.cs" Link="TestEventListener.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestExporter.cs" Link="TestExporter.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\InMemoryEventListener.cs" Link="InMemoryEventListener.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <ProjectReference Include="$(RepoRoot)\test\TestApp.AspNetCore.6.0\TestApp.AspNetCore.6.0.csproj" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0-rc.2.21480.10" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/OpenTelemetry.Instrumentation.Http.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/OpenTelemetry.Instrumentation.Http.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Unit test project for OpenTelemetry HTTP instrumentations</Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
   </PropertyGroup>
 

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/OpenTelemetry.Instrumentation.SqlClient.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/OpenTelemetry.Instrumentation.SqlClient.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Unit test project for OpenTelemetry SqlClient instrumentations</Description>
-    <TargetFrameworks Condition="$(TARGET_FRAMEWORK) == ''">netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(TARGET_FRAMEWORK) == ''">netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="$(TARGET_FRAMEWORK) == '' and $(OS) == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
     <TargetFrameworks Condition="$(TARGET_FRAMEWORK) != ''">$(TARGET_FRAMEWORK)</TargetFrameworks>
   </PropertyGroup>

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/dockerfile
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/dockerfile
@@ -3,7 +3,7 @@
 # docker build --file test/OpenTelemetry.Instrumentation.SqlClient.Tests/dockerfile .
 
 ARG SDK_VERSION=6.0
-FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS build
 ARG PUBLISH_CONFIGURATION=Release
 ARG PUBLISH_FRAMEWORK=net6.0
 WORKDIR /repo

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/dockerfile
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/dockerfile
@@ -2,10 +2,10 @@
 # This should be run from the root of the repo:
 # docker build --file test/OpenTelemetry.Instrumentation.SqlClient.Tests/dockerfile .
 
-ARG SDK_VERSION=5.0
+ARG SDK_VERSION=6.0
 FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS build
 ARG PUBLISH_CONFIGURATION=Release
-ARG PUBLISH_FRAMEWORK=net5.0
+ARG PUBLISH_FRAMEWORK=net6.0
 WORKDIR /repo
 COPY . ./
 RUN ls -la /repo

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Unit test project for OpenTelemetry StackExchangeRedis instrumentation</Description>
-    <TargetFrameworks Condition="$(TARGET_FRAMEWORK) == ''">netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(TARGET_FRAMEWORK) == ''">netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="$(TARGET_FRAMEWORK) == '' and $(OS) == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
     <TargetFrameworks Condition="$(TARGET_FRAMEWORK) != ''">$(TARGET_FRAMEWORK)</TargetFrameworks>
   </PropertyGroup>

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/dockerfile
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/dockerfile
@@ -2,10 +2,10 @@
 # This should be run from the root of the repo:
 # docker build --file test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/dockerfile .
 
-ARG SDK_VERSION=5.0
+ARG SDK_VERSION=6.0
 FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS build
 ARG PUBLISH_CONFIGURATION=Release
-ARG PUBLISH_FRAMEWORK=net5.0
+ARG PUBLISH_FRAMEWORK=net6.0
 WORKDIR /repo
 COPY . ./
 WORKDIR "/repo/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests"

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/dockerfile
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/dockerfile
@@ -3,7 +3,7 @@
 # docker build --file test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/dockerfile .
 
 ARG SDK_VERSION=6.0
-FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS build
 ARG PUBLISH_CONFIGURATION=Release
 ARG PUBLISH_FRAMEWORK=net6.0
 WORKDIR /repo

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/Dockerfile
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/Dockerfile
@@ -2,7 +2,7 @@
 # This should be run from the root of the repo:
 # docker build --file test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/Dockerfile .
 
-ARG SDK_VERSION=5.0
+ARG SDK_VERSION=6.0
 FROM ubuntu AS w3c
 #Install git
 WORKDIR /w3c
@@ -11,7 +11,7 @@ RUN git clone https://github.com/w3c/trace-context.git
 
 FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS build
 ARG PUBLISH_CONFIGURATION=Release
-ARG PUBLISH_FRAMEWORK=net5.0
+ARG PUBLISH_FRAMEWORK=net6.0
 WORKDIR /repo
 COPY . ./
 WORKDIR "/repo/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests"

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/Dockerfile
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /w3c
 RUN apt-get update && apt-get install -y git
 RUN git clone https://github.com/w3c/trace-context.git
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS build
 ARG PUBLISH_CONFIGURATION=Release
 ARG PUBLISH_FRAMEWORK=net6.0
 WORKDIR /repo

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/InProcessServer.cs
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/InProcessServer.cs
@@ -22,9 +22,11 @@ using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Trace;
 #if NETCOREAPP3_1
 using TestApp.AspNetCore._3._1;
-#elif NET5_0
+#endif
+#if NET5_0
 using TestApp.AspNetCore._5._0;
-#else
+#endif
+#if NET6_0
 using TestApp.AspNetCore._6._0;
 #endif
 using Xunit.Abstractions;

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/InProcessServer.cs
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/InProcessServer.cs
@@ -22,8 +22,10 @@ using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Trace;
 #if NETCOREAPP3_1
 using TestApp.AspNetCore._3._1;
-#else
+#elif NET5_0
 using TestApp.AspNetCore._5._0;
+#else
+using TestApp.AspNetCore._6._0;
 #endif
 using Xunit.Abstractions;
 

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/OpenTelemetry.Instrumentation.W3cTraceContext.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/OpenTelemetry.Instrumentation.W3cTraceContext.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Unit test project for OpenTelemetry ASP.NET Core instrumentation for W3C Trace Context Trace</Description>
-    <TargetFrameworks Condition="$(TARGET_FRAMEWORK) == ''">netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(TARGET_FRAMEWORK) == ''">netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="$(TARGET_FRAMEWORK) != ''">$(TARGET_FRAMEWORK)</TargetFrameworks>
   </PropertyGroup>
 
@@ -26,6 +26,10 @@
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\IActivityEnumerator.cs" Link="Includes\IActivityEnumerator.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\EnumerationHelper.cs" Link="Includes\EnumerationHelper.cs" />
   <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\SpanAttributeConstants.cs" Link="Includes\SpanAttributeConstants.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <ProjectReference Include="$(RepoRoot)\test\TestApp.AspNetCore.6.0\TestApp.AspNetCore.6.0.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/OpenTelemetry.Shims.OpenTracing.Tests.csproj
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/OpenTelemetry.Shims.OpenTracing.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Unit test project for OpenTelemetry.Shims.OpenTracing</Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Tests.Stress.Metrics/OpenTelemetry.Tests.Stress.Metrics.csproj
+++ b/test/OpenTelemetry.Tests.Stress.Metrics/OpenTelemetry.Tests.Stress.Metrics.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <NoWarn>$(NoWarn),SA1000</NoWarn>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net462</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/OpenTelemetry.Tests.Stress/OpenTelemetry.Tests.Stress.csproj
+++ b/test/OpenTelemetry.Tests.Stress/OpenTelemetry.Tests.Stress.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net462</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 </Project>

--- a/test/OpenTelemetry.Tests/OpenTelemetry.Tests.csproj
+++ b/test/OpenTelemetry.Tests/OpenTelemetry.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Unit test project for OpenTelemetry</Description>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
     <NoWarn>$(NoWarn),CS0618</NoWarn>
   </PropertyGroup>

--- a/test/TestApp.AspNetCore.6.0/AssemblyInfo.cs
+++ b/test/TestApp.AspNetCore.6.0/AssemblyInfo.cs
@@ -1,0 +1,24 @@
+// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage(
+    "StyleCop.CSharp.NamingRules",
+    "SA1300",
+    Justification = "Reviewed.",
+    Scope = "namespaceanddescendants",
+    Target = "TestApp.AspNetCore._6._0")]

--- a/test/TestApp.AspNetCore.6.0/CallbackMiddleware.cs
+++ b/test/TestApp.AspNetCore.6.0/CallbackMiddleware.cs
@@ -1,0 +1,49 @@
+// <copyright file="CallbackMiddleware.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace TestApp.AspNetCore._6._0
+{
+    public class CallbackMiddleware
+    {
+        private readonly CallbackMiddlewareImpl impl;
+        private readonly RequestDelegate next;
+
+        public CallbackMiddleware(RequestDelegate next, CallbackMiddlewareImpl impl)
+        {
+            this.next = next;
+            this.impl = impl;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            if (this.impl == null || await this.impl.ProcessAsync(context))
+            {
+                await this.next(context);
+            }
+        }
+
+        public class CallbackMiddlewareImpl
+        {
+            public virtual async Task<bool> ProcessAsync(HttpContext context)
+            {
+                return await Task.FromResult(true);
+            }
+        }
+    }
+}

--- a/test/TestApp.AspNetCore.6.0/Controllers/ChildActivityController.cs
+++ b/test/TestApp.AspNetCore.6.0/Controllers/ChildActivityController.cs
@@ -1,0 +1,46 @@
+// <copyright file="ChildActivityController.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+using OpenTelemetry;
+
+namespace TestApp.AspNetCore._6._0.Controllers
+{
+    public class ChildActivityController : Controller
+    {
+        [Route("api/GetChildActivityTraceContext")]
+        public Dictionary<string, string> GetChildActivityTraceContext()
+        {
+            var result = new Dictionary<string, string>();
+            var activity = new Activity("ActivityInsideHttpRequest");
+            activity.Start();
+            result["TraceId"] = activity.Context.TraceId.ToString();
+            result["ParentSpanId"] = activity.ParentSpanId.ToString();
+            result["TraceState"] = activity.Context.TraceState;
+            activity.Stop();
+            return result;
+        }
+
+        [Route("api/GetChildActivityBaggageContext")]
+        public IReadOnlyDictionary<string, string> GetChildActivityBaggageContext()
+        {
+            var result = Baggage.Current.GetBaggage();
+            return result;
+        }
+    }
+}

--- a/test/TestApp.AspNetCore.6.0/Controllers/ForwardController.cs
+++ b/test/TestApp.AspNetCore.6.0/Controllers/ForwardController.cs
@@ -1,0 +1,72 @@
+// <copyright file="ForwardController.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+
+namespace TestApp.AspNetCore._6._0.Controllers
+{
+    [Route("api/[controller]")]
+    public class ForwardController : Controller
+    {
+        private readonly HttpClient httpClient;
+
+        public ForwardController(HttpClient httpClient)
+        {
+            this.httpClient = httpClient;
+        }
+
+        // POST api/test
+        [HttpPost]
+        public async Task<string> Post([FromBody] Data[] data)
+        {
+            var result = string.Empty;
+
+            if (data != null)
+            {
+                foreach (var argument in data)
+                {
+                    var request = new HttpRequestMessage(HttpMethod.Post, argument.Url)
+                    {
+                        Content = new StringContent(
+                            JsonConvert.SerializeObject(argument.Arguments),
+                            Encoding.UTF8,
+                            "application/json"),
+                    };
+                    await this.httpClient.SendAsync(request);
+                }
+            }
+            else
+            {
+                result = "done";
+            }
+
+            return result;
+        }
+
+        public class Data
+        {
+            [JsonProperty("url")]
+            public string Url { get; set; }
+
+            [JsonProperty("arguments")]
+            public Data[] Arguments { get; set; }
+        }
+    }
+}

--- a/test/TestApp.AspNetCore.6.0/Controllers/ValuesController.cs
+++ b/test/TestApp.AspNetCore.6.0/Controllers/ValuesController.cs
@@ -1,0 +1,56 @@
+// <copyright file="ValuesController.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
+
+namespace TestApp.AspNetCore._6._0.Controllers
+{
+    [Route("api/[controller]")]
+    public class ValuesController : Controller
+    {
+        // GET api/values
+        [HttpGet]
+        public IEnumerable<string> Get()
+        {
+            return new string[] { "value1", "value2" };
+        }
+
+        // GET api/values/5
+        [HttpGet("{id}")]
+        public string Get(int id)
+        {
+            return "value";
+        }
+
+        // POST api/values
+        [HttpPost]
+        public void Post([FromBody] string value)
+        {
+        }
+
+        // PUT api/values/5
+        [HttpPut("{id}")]
+        public void Put(int id, [FromBody] string value)
+        {
+        }
+
+        // DELETE api/values/5
+        [HttpDelete("{id}")]
+        public void Delete(int id)
+        {
+        }
+    }
+}

--- a/test/TestApp.AspNetCore.6.0/Program.cs
+++ b/test/TestApp.AspNetCore.6.0/Program.cs
@@ -1,0 +1,33 @@
+// <copyright file="Program.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+
+namespace TestApp.AspNetCore._6._0
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateWebHostBuilder(args).Build().Run();
+        }
+
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>();
+    }
+}

--- a/test/TestApp.AspNetCore.6.0/Startup.cs
+++ b/test/TestApp.AspNetCore.6.0/Startup.cs
@@ -1,0 +1,63 @@
+// <copyright file="Startup.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Net.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace TestApp.AspNetCore._6._0
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            this.Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddMvc();
+            services.AddSingleton<HttpClient>();
+            services.AddSingleton(
+                new CallbackMiddleware.CallbackMiddlewareImpl());
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseMiddleware<CallbackMiddleware>();
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
+        }
+    }
+}

--- a/test/TestApp.AspNetCore.6.0/TestApp.AspNetCore.6.0.csproj
+++ b/test/TestApp.AspNetCore.6.0/TestApp.AspNetCore.6.0.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="wwwroot\**" />
+    <Content Remove="wwwroot\**" />
+    <EmbeddedResource Remove="wwwroot\**" />
+    <None Remove="wwwroot\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.0-rc.2.21511.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Api\OpenTelemetry.Api.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.AspNetCore\OpenTelemetry.Instrumentation.AspNetCore.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Extensions.Hosting\OpenTelemetry.Extensions.Hosting.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry\OpenTelemetry.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/TestApp.AspNetCore.6.0/TestApp.AspNetCore.6.0.csproj
+++ b/test/TestApp.AspNetCore.6.0/TestApp.AspNetCore.6.0.csproj
@@ -13,6 +13,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.0-rc.2.21511.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="6.0.0-rc.2.21480.10" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Razor" Version="6.0.0-rc.2.21480.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0-rc.2.21480.5" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0-rc.2.21480.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/TestApp.AspNetCore.6.0/appsettings.Development.json
+++ b/test/TestApp.AspNetCore.6.0/appsettings.Development.json
@@ -1,0 +1,10 @@
+﻿{
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/test/TestApp.AspNetCore.6.0/appsettings.json
+++ b/test/TestApp.AspNetCore.6.0/appsettings.json
@@ -1,0 +1,15 @@
+﻿{
+  "Logging": {
+    "IncludeScopes": false,
+    "Debug": {
+      "LogLevel": {
+        "Default": "Warning"
+      }
+    },
+    "Console": {
+      "LogLevel": {
+        "Default": "Warning"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #.
[2064](https://github.com/open-telemetry/opentelemetry-dotnet/issues/2064)
## Changes

Please provide a brief description of the changes here.
1) Add .NET6.0 build
2) Add .NET6.0 target to test projects and aspnetcore instrumentation library

todos
1) Replace RC package version to GA versions once available.
2) Remove explicit install for .NET SDKs once 6.0 is available as pre-installed.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
