### PR TITLE
[Do not merge] Benchmark hot path cumulative vs. delta

### DIFF
--- a/test/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry\OpenTelemetry.csproj" />
+    <ProjectReference Aliases="InMemory" Include="$(RepoRoot)\src\OpenTelemetry.Exporter.InMemory\OpenTelemetry.Exporter.InMemory.csproj" />
     <ProjectReference Aliases="Jaeger" Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Jaeger\OpenTelemetry.Exporter.Jaeger.csproj" />
     <ProjectReference Aliases="OpenTelemetryProtocol" Include="$(RepoRoot)\src\OpenTelemetry.Exporter.OpenTelemetryProtocol\OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj" />
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Prometheus\OpenTelemetry.Exporter.Prometheus.csproj" />


### PR DESCRIPTION
<details>
  <summary>
    Before `MetricPointStatus` #2466
  </summary>
<div>


|                                Method | WithSDK | AggregationTemporality |        Mean |     Error |    StdDev |  Gen 0 | Allocated |
|-------------------------------------- |-------- |----------------------- |------------:|----------:|----------:|-------:|----------:|
|                        CounterHotPath |    True |             Cumulative |    25.52 ns |  0.140 ns |  0.131 ns |      - |         - |
|             CounterWith1LabelsHotPath |    True |             Cumulative |   123.70 ns |  1.047 ns |  0.928 ns |      - |         - |
|             CounterWith3LabelsHotPath |    True |             Cumulative |   589.85 ns |  9.345 ns |  8.741 ns |      - |         - |
|             CounterWith5LabelsHotPath |    True |             Cumulative |   900.46 ns |  9.069 ns |  8.483 ns | 0.0038 |     104 B |
|             CounterWith6LabelsHotPath |    True |             Cumulative | 1,074.38 ns |  6.775 ns |  6.337 ns | 0.0057 |     120 B |
|             CounterWith7LabelsHotPath |    True |             Cumulative | 1,198.93 ns |  6.436 ns |  5.705 ns | 0.0057 |     136 B |
| CounterWith1LabelsHotPathUsingTagList |    True |             Cumulative |   147.23 ns |  2.084 ns |  2.140 ns |      - |         - |
| CounterWith3LabelsHotPathUsingTagList |    True |             Cumulative |   627.34 ns |  2.114 ns |  1.874 ns |      - |         - |
| CounterWith5LabelsHotPathUsingTagList |    True |             Cumulative |   907.89 ns |  6.057 ns |  5.666 ns |      - |         - |
| CounterWith6LabelsHotPathUsingTagList |    True |             Cumulative | 1,106.98 ns |  5.497 ns |  4.590 ns |      - |         - |
| CounterWith7LabelsHotPathUsingTagList |    True |             Cumulative | 1,280.64 ns | 13.937 ns | 10.881 ns |      - |         - |
|                        CounterHotPath |    True |                  Delta |    25.42 ns |  0.193 ns |  0.151 ns |      - |         - |
|             CounterWith1LabelsHotPath |    True |                  Delta |   128.70 ns |  0.816 ns |  0.723 ns |      - |         - |
|             CounterWith3LabelsHotPath |    True |                  Delta |   590.89 ns |  1.948 ns |  1.727 ns |      - |         - |
|             CounterWith5LabelsHotPath |    True |                  Delta |   888.35 ns |  4.590 ns |  4.069 ns | 0.0048 |     104 B |
|             CounterWith6LabelsHotPath |    True |                  Delta | 1,107.39 ns | 16.983 ns | 19.557 ns | 0.0057 |     120 B |
|             CounterWith7LabelsHotPath |    True |                  Delta | 1,209.62 ns |  5.101 ns |  4.259 ns | 0.0057 |     136 B |
| CounterWith1LabelsHotPathUsingTagList |    True |                  Delta |   146.88 ns |  0.717 ns |  0.599 ns |      - |         - |
| CounterWith3LabelsHotPathUsingTagList |    True |                  Delta |   634.54 ns | 11.313 ns | 10.028 ns |      - |         - |
| CounterWith5LabelsHotPathUsingTagList |    True |                  Delta |   926.57 ns |  8.426 ns |  7.470 ns |      - |         - |
| CounterWith6LabelsHotPathUsingTagList |    True |                  Delta | 1,111.70 ns |  6.484 ns |  6.066 ns |      - |         - |
| CounterWith7LabelsHotPathUsingTagList |    True |                  Delta | 1,225.91 ns | 10.298 ns |  9.633 ns |      - |         - |


</div>
</details>




<details>
  <summary>
    After `MetricPointStatus` #2466
  </summary>
  <div>

|                                Method | WithSDK | AggregationTemporality |        Mean |     Error |    StdDev |      Median |  Gen 0 | Allocated |
|-------------------------------------- |-------- |----------------------- |------------:|----------:|----------:|------------:|-------:|----------:|
|                        CounterHotPath |    True |             Cumulative |    74.00 ns |  0.343 ns |  0.304 ns |    73.96 ns |      - |         - |
|             CounterWith1LabelsHotPath |    True |             Cumulative |   185.45 ns |  1.107 ns |  1.036 ns |   185.54 ns |      - |         - |
|             CounterWith3LabelsHotPath |    True |             Cumulative |   638.07 ns |  4.617 ns |  3.604 ns |   638.62 ns |      - |         - |
|             CounterWith5LabelsHotPath |    True |             Cumulative |   958.28 ns |  5.287 ns |  4.687 ns |   958.99 ns | 0.0038 |     104 B |
|             CounterWith6LabelsHotPath |    True |             Cumulative | 1,129.27 ns |  7.470 ns |  6.988 ns | 1,128.16 ns | 0.0057 |     120 B |
|             CounterWith7LabelsHotPath |    True |             Cumulative | 1,286.25 ns | 11.697 ns | 10.942 ns | 1,282.93 ns | 0.0057 |     136 B |
| CounterWith1LabelsHotPathUsingTagList |    True |             Cumulative |   207.20 ns |  1.080 ns |  0.957 ns |   207.32 ns |      - |         - |
| CounterWith3LabelsHotPathUsingTagList |    True |             Cumulative |   688.24 ns |  5.806 ns |  5.147 ns |   688.88 ns |      - |         - |
| CounterWith5LabelsHotPathUsingTagList |    True |             Cumulative |   962.41 ns |  5.165 ns |  4.832 ns |   961.05 ns |      - |         - |
| CounterWith6LabelsHotPathUsingTagList |    True |             Cumulative | 1,203.48 ns | 23.884 ns | 65.383 ns | 1,171.13 ns |      - |         - |
| CounterWith7LabelsHotPathUsingTagList |    True |             Cumulative | 1,298.09 ns | 11.210 ns |  9.937 ns | 1,296.27 ns |      - |         - |
|                        CounterHotPath |    True |                  Delta |    76.79 ns |  0.365 ns |  0.341 ns |    76.77 ns |      - |         - |
|             CounterWith1LabelsHotPath |    True |                  Delta |   185.57 ns |  1.385 ns |  1.228 ns |   185.02 ns |      - |         - |
|             CounterWith3LabelsHotPath |    True |                  Delta |   651.88 ns | 10.908 ns | 13.795 ns |   647.63 ns |      - |         - |
|             CounterWith5LabelsHotPath |    True |                  Delta |   944.37 ns |  5.700 ns |  5.332 ns |   944.45 ns | 0.0038 |     104 B |
|             CounterWith6LabelsHotPath |    True |                  Delta | 1,098.92 ns |  5.127 ns |  4.545 ns | 1,098.76 ns | 0.0057 |     120 B |
|             CounterWith7LabelsHotPath |    True |                  Delta | 1,286.03 ns | 12.204 ns | 10.818 ns | 1,286.93 ns | 0.0057 |     136 B |
| CounterWith1LabelsHotPathUsingTagList |    True |                  Delta |   204.06 ns |  1.841 ns |  1.632 ns |   203.69 ns |      - |         - |
| CounterWith3LabelsHotPathUsingTagList |    True |                  Delta |   678.64 ns |  5.247 ns |  4.651 ns |   678.72 ns |      - |         - |
| CounterWith5LabelsHotPathUsingTagList |    True |                  Delta |   965.44 ns |  8.577 ns |  8.023 ns |   964.11 ns |      - |         - |
| CounterWith6LabelsHotPathUsingTagList |    True |                  Delta | 1,146.14 ns |  9.326 ns |  8.723 ns | 1,143.97 ns |      - |         - |
| CounterWith7LabelsHotPathUsingTagList |    True |                  Delta | 1,266.01 ns | 12.802 ns | 11.349 ns | 1,264.64 ns |      - |         - |

    
  </div>
</details>



