### PR TITLE
Metrics hotpath benchmark updates

### DIFF
--- a/test/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry\OpenTelemetry.csproj" />
+    <ProjectReference Aliases="InMemory" Include="$(RepoRoot)\src\OpenTelemetry.Exporter.InMemory\OpenTelemetry.Exporter.InMemory.csproj" />
     <ProjectReference Aliases="Jaeger" Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Jaeger\OpenTelemetry.Exporter.Jaeger.csproj" />
     <ProjectReference Aliases="OpenTelemetryProtocol" Include="$(RepoRoot)\src\OpenTelemetry.Exporter.OpenTelemetryProtocol\OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj" />
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Prometheus\OpenTelemetry.Exporter.Prometheus.csproj" />

--- a/test/Benchmarks/Metrics/MetricsBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricsBenchmarks.cs
@@ -14,47 +14,42 @@
 // limitations under the License.
 // </copyright>
 
+extern alias InMemory;
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using BenchmarkDotNet.Attributes;
+using InMemory::OpenTelemetry.Exporter;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
 
 /*
-BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19043
-Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
-.NET Core SDK=6.0.100-rc.1.21458.32
-  [Host]     : .NET Core 3.1.19 (CoreCLR 4.700.21.41101, CoreFX 4.700.21.41603), X64 RyuJIT
-  DefaultJob : .NET Core 3.1.19 (CoreCLR 4.700.21.41101, CoreFX 4.700.21.41603), X64 RyuJIT
+// * Summary *
+
+BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19043.1288 (21H1/May2021Update)
+Intel Core i7-4790 CPU 3.60GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
+.NET SDK=6.0.100-rc.2.21505.57
+  [Host]     : .NET 5.0.11 (5.0.1121.47308), X64 RyuJIT
+  DefaultJob : .NET 5.0.11 (5.0.1121.47308), X64 RyuJIT
 
 
-|                                Method | WithSDK |      Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-|-------------------------------------- |-------- |----------:|---------:|---------:|-------:|------:|------:|----------:|
-|                        CounterHotPath |   False |  12.87 ns | 0.086 ns | 0.080 ns |      - |     - |     - |         - |
-|             CounterWith1LabelsHotPath |   False |  19.36 ns | 0.083 ns | 0.069 ns |      - |     - |     - |         - |
-|             CounterWith3LabelsHotPath |   False |  53.71 ns | 0.336 ns | 0.314 ns |      - |     - |     - |         - |
-|             CounterWith5LabelsHotPath |   False |  79.82 ns | 0.525 ns | 0.439 ns | 0.0166 |     - |     - |     104 B |
-|             CounterWith6LabelsHotPath |   False |  91.35 ns | 0.827 ns | 0.733 ns | 0.0191 |     - |     - |     120 B |
-|             CounterWith7LabelsHotPath |   False | 104.40 ns | 0.924 ns | 0.865 ns | 0.0216 |     - |     - |     136 B |
-| CounterWith1LabelsHotPathUsingTagList |   False |  50.43 ns | 0.415 ns | 0.388 ns |      - |     - |     - |         - |
-| CounterWith3LabelsHotPathUsingTagList |   False |  88.48 ns | 0.402 ns | 0.376 ns |      - |     - |     - |         - |
-| CounterWith5LabelsHotPathUsingTagList |   False | 121.61 ns | 0.472 ns | 0.418 ns |      - |     - |     - |         - |
-| CounterWith6LabelsHotPathUsingTagList |   False | 139.11 ns | 0.593 ns | 0.554 ns |      - |     - |     - |         - |
-| CounterWith7LabelsHotPathUsingTagList |   False | 154.07 ns | 0.773 ns | 0.685 ns |      - |     - |     - |         - |
-|                        CounterHotPath |    True |  38.23 ns | 0.235 ns | 0.220 ns |      - |     - |     - |         - |
-|             CounterWith1LabelsHotPath |    True | 102.48 ns | 0.942 ns | 0.881 ns |      - |     - |     - |         - |
-|             CounterWith3LabelsHotPath |    True | 417.00 ns | 2.904 ns | 2.716 ns |      - |     - |     - |         - |
-|             CounterWith5LabelsHotPath |    True | 578.45 ns | 5.287 ns | 4.946 ns | 0.0162 |     - |     - |     104 B |
-|             CounterWith6LabelsHotPath |    True | 665.56 ns | 3.716 ns | 3.476 ns | 0.0191 |     - |     - |     120 B |
-|             CounterWith7LabelsHotPath |    True | 778.88 ns | 5.482 ns | 4.578 ns | 0.0210 |     - |     - |     136 B |
-| CounterWith1LabelsHotPathUsingTagList |    True | 135.55 ns | 1.012 ns | 0.947 ns |      - |     - |     - |         - |
-| CounterWith3LabelsHotPathUsingTagList |    True | 457.96 ns | 4.242 ns | 3.968 ns |      - |     - |     - |         - |
-| CounterWith5LabelsHotPathUsingTagList |    True | 631.81 ns | 3.423 ns | 2.858 ns |      - |     - |     - |         - |
-| CounterWith6LabelsHotPathUsingTagList |    True | 719.81 ns | 4.704 ns | 4.400 ns |      - |     - |     - |         - |
-| CounterWith7LabelsHotPathUsingTagList |    True | 828.88 ns | 4.321 ns | 3.830 ns |      - |     - |     - |         - |
+|                    Method | AggregationTemporality |        Mean |     Error |    StdDev | Allocated |
+|-------------------------- |----------------------- |------------:|----------:|----------:|----------:|
+|            CounterHotPath |             Cumulative |    22.12 ns |  0.233 ns |  0.218 ns |         - |
+| CounterWith1LabelsHotPath |             Cumulative |   101.78 ns |  0.283 ns |  0.265 ns |         - |
+| CounterWith3LabelsHotPath |             Cumulative |   488.20 ns |  6.580 ns |  7.577 ns |         - |
+| CounterWith5LabelsHotPath |             Cumulative |   748.28 ns | 14.936 ns | 22.355 ns |         - |
+| CounterWith6LabelsHotPath |             Cumulative |   857.56 ns |  6.008 ns |  4.691 ns |         - |
+| CounterWith7LabelsHotPath |             Cumulative | 1,023.17 ns | 11.500 ns |  9.603 ns |         - |
+|            CounterHotPath |                  Delta |    20.93 ns |  0.244 ns |  0.216 ns |         - |
+| CounterWith1LabelsHotPath |                  Delta |   104.09 ns |  0.432 ns |  0.404 ns |         - |
+| CounterWith3LabelsHotPath |                  Delta |   477.48 ns |  2.646 ns |  2.066 ns |         - |
+| CounterWith5LabelsHotPath |                  Delta |   732.90 ns |  8.778 ns |  7.782 ns |         - |
+| CounterWith6LabelsHotPath |                  Delta |   868.00 ns |  4.503 ns |  3.760 ns |         - |
+| CounterWith7LabelsHotPath |                  Delta |   986.40 ns |  9.503 ns |  7.419 ns |         - |
 */
 
 namespace Benchmarks.Metrics
@@ -68,20 +63,21 @@ namespace Benchmarks.Metrics
         private Random random = new Random();
         private string[] dimensionValues = new string[] { "DimVal1", "DimVal2", "DimVal3", "DimVal4", "DimVal5", "DimVal6", "DimVal7", "DimVal8", "DimVal9", "DimVal10" };
 
-        [Params(false, true)]
-        public bool WithSDK { get; set; }
+        [Params(AggregationTemporality.Cumulative, AggregationTemporality.Delta)]
+        public AggregationTemporality AggregationTemporality { get; set; }
 
         [GlobalSetup]
         public void Setup()
         {
             this.meter = new Meter(Utils.GetCurrentMethodName());
 
-            if (this.WithSDK)
-            {
-                this.provider = Sdk.CreateMeterProviderBuilder()
-                    .AddMeter(this.meter.Name) // All instruments from this meter are enabled.
-                    .Build();
-            }
+            var exportedItems = new List<Metric>();
+            var reader = new PeriodicExportingMetricReader(new InMemoryExporter<Metric>(exportedItems), 1000);
+            reader.PreferredAggregationTemporality = this.AggregationTemporality;
+            this.provider = Sdk.CreateMeterProviderBuilder()
+                .AddMeter(this.meter.Name) // All instruments from this meter are enabled.
+                .AddReader(reader)
+                .Build();
 
             this.counter = this.meter.CreateCounter<long>("counter");
         }
@@ -118,64 +114,6 @@ namespace Benchmarks.Metrics
         [Benchmark]
         public void CounterWith5LabelsHotPath()
         {
-            var tag1 = new KeyValuePair<string, object>("DimName1", this.dimensionValues[this.random.Next(0, 2)]);
-            var tag2 = new KeyValuePair<string, object>("DimName2", this.dimensionValues[this.random.Next(0, 2)]);
-            var tag3 = new KeyValuePair<string, object>("DimName3", this.dimensionValues[this.random.Next(0, 5)]);
-            var tag4 = new KeyValuePair<string, object>("DimName4", this.dimensionValues[this.random.Next(0, 5)]);
-            var tag5 = new KeyValuePair<string, object>("DimName5", this.dimensionValues[this.random.Next(0, 10)]);
-            this.counter?.Add(100, tag1, tag2, tag3, tag4, tag5);
-        }
-
-        [Benchmark]
-        public void CounterWith6LabelsHotPath()
-        {
-            var tag1 = new KeyValuePair<string, object>("DimName1", this.dimensionValues[this.random.Next(0, 2)]);
-            var tag2 = new KeyValuePair<string, object>("DimName2", this.dimensionValues[this.random.Next(0, 2)]);
-            var tag3 = new KeyValuePair<string, object>("DimName3", this.dimensionValues[this.random.Next(0, 5)]);
-            var tag4 = new KeyValuePair<string, object>("DimName4", this.dimensionValues[this.random.Next(0, 5)]);
-            var tag5 = new KeyValuePair<string, object>("DimName5", this.dimensionValues[this.random.Next(0, 5)]);
-            var tag6 = new KeyValuePair<string, object>("DimName6", this.dimensionValues[this.random.Next(0, 2)]);
-            this.counter?.Add(100, tag1, tag2, tag3, tag4, tag5, tag6);
-        }
-
-        [Benchmark]
-        public void CounterWith7LabelsHotPath()
-        {
-            var tag1 = new KeyValuePair<string, object>("DimName1", this.dimensionValues[this.random.Next(0, 2)]);
-            var tag2 = new KeyValuePair<string, object>("DimName2", this.dimensionValues[this.random.Next(0, 2)]);
-            var tag3 = new KeyValuePair<string, object>("DimName3", this.dimensionValues[this.random.Next(0, 5)]);
-            var tag4 = new KeyValuePair<string, object>("DimName4", this.dimensionValues[this.random.Next(0, 5)]);
-            var tag5 = new KeyValuePair<string, object>("DimName5", this.dimensionValues[this.random.Next(0, 5)]);
-            var tag6 = new KeyValuePair<string, object>("DimName6", this.dimensionValues[this.random.Next(0, 2)]);
-            var tag7 = new KeyValuePair<string, object>("DimName7", this.dimensionValues[this.random.Next(0, 1)]);
-            this.counter?.Add(100, tag1, tag2, tag3, tag4, tag5, tag6, tag7);
-        }
-
-        [Benchmark]
-        public void CounterWith1LabelsHotPathUsingTagList()
-        {
-            var tags = new TagList
-            {
-                { "DimName1", this.dimensionValues[this.random.Next(0, 2)] },
-            };
-            this.counter?.Add(100, tags);
-        }
-
-        [Benchmark]
-        public void CounterWith3LabelsHotPathUsingTagList()
-        {
-            var tags = new TagList
-            {
-                { "DimName1", this.dimensionValues[this.random.Next(0, 10)] },
-                { "DimName2", this.dimensionValues[this.random.Next(0, 10)] },
-                { "DimName3", this.dimensionValues[this.random.Next(0, 10)] },
-            };
-            this.counter?.Add(100, tags);
-        }
-
-        [Benchmark]
-        public void CounterWith5LabelsHotPathUsingTagList()
-        {
             var tags = new TagList
             {
                 { "DimName1", this.dimensionValues[this.random.Next(0, 2)] },
@@ -188,7 +126,7 @@ namespace Benchmarks.Metrics
         }
 
         [Benchmark]
-        public void CounterWith6LabelsHotPathUsingTagList()
+        public void CounterWith6LabelsHotPath()
         {
             var tags = new TagList
             {
@@ -203,7 +141,7 @@ namespace Benchmarks.Metrics
         }
 
         [Benchmark]
-        public void CounterWith7LabelsHotPathUsingTagList()
+        public void CounterWith7LabelsHotPath()
         {
             var tags = new TagList
             {


### PR DESCRIPTION
Changes:

Added a InMemoryExporter with 1 second exports.

Removing the option of With/Without SDK. (Will make a separate benchmark to cover the incremental cost, i.e no listener, custom listener which is no op, opentelemetry listener, etc.)

Remove TagList vs No TagList - this can be added as a separate benchmark as needed, as from OTel SDK standpoint - both are same.