### PR TITLE
Add support for Activity Status and StatusDescription in Zipkin Exporter

### DIFF
--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added support for `Status` and `StatusDescription` properties on Activity
+  ([#2572](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2572))
+
 ## 1.2.0-beta1
 
 Released 2021-Oct-08

--- a/src/OpenTelemetry.Api/Internal/StatusHelper.cs
+++ b/src/OpenTelemetry.Api/Internal/StatusHelper.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using OpenTelemetry.Trace;
 
@@ -39,6 +40,23 @@ namespace OpenTelemetry.Internal
                 StatusCode.Unset => UnsetStatusCodeTagValue,
                 StatusCode.Error => ErrorStatusCodeTagValue,
                 StatusCode.Ok => OkStatusCodeTagValue,
+                _ => null,
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string GetTagValueForActivityStatusCode(ActivityStatusCode activityStatusCode)
+        {
+            return activityStatusCode switch
+            {
+                /*
+                 * Note: Order here does matter for perf. Unset is
+                 * first because assumption is most spans will be
+                 * Unset, then Error, then Ok.
+                 */
+                ActivityStatusCode.Unset => UnsetStatusCodeTagValue,
+                ActivityStatusCode.Error => ErrorStatusCodeTagValue,
+                ActivityStatusCode.Ok => OkStatusCodeTagValue,
                 _ => null,
             };
         }

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinActivityConversionExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinActivityConversionExtensions.cs
@@ -81,7 +81,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
                 ref tagState.Tags,
                 new KeyValuePair<string, object>(
                     SpanAttributeConstants.StatusCodeKey,
-                    activity.Status));
+                    StatusHelper.GetTagValueForActivityStatusCode(activity.Status)));
 
                 if (activity.Status == ActivityStatusCode.Error)
                 {

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionTest.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionTest.cs
@@ -149,7 +149,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation.Tests
             else
             {
                 Assert.Equal(
-                    expectedStatusCode,
+                    StatusHelper.GetTagValueForActivityStatusCode(expectedStatusCode),
                     zipkinSpan.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.StatusCodeKey).Value);
             }
 
@@ -179,7 +179,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation.Tests
 
             // Assert
             Assert.Equal(
-                    activityStatus,
+                    StatusHelper.GetTagValueForActivityStatusCode(activityStatus),
                     zipkinSpan.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.StatusCodeKey).Value);
 
             if (activityStatus == ActivityStatusCode.Error)

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionTest.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionTest.cs
@@ -142,9 +142,6 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation.Tests
             var zipkinSpan = activity.ToZipkinSpan(DefaultZipkinEndpoint);
 
             // Assert
-
-            Assert.Equal(expectedStatusCode, activity.Status);
-
             if (expectedStatusCode == ActivityStatusCode.Unset)
             {
                 Assert.DoesNotContain(zipkinSpan.Tags, t => t.Key == SpanAttributeConstants.StatusCodeKey);
@@ -169,7 +166,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation.Tests
         [Theory]
         [InlineData(ActivityStatusCode.Ok, "ERROR")]
         [InlineData(ActivityStatusCode.Error, "OK")]
-        public void ActivityStatusSetUsingTags_Takes_precedence_Over_Activity_Properties(ActivityStatusCode activityStatus, string statusCodeTagValue)
+        public void ActivityStatus_Takes_precedence_Over_Status_Tags(ActivityStatusCode activityStatus, string statusCodeTagValue)
         {
             // Arrange
             var activity = ZipkinExporterTests.CreateTestActivity();
@@ -182,21 +179,10 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation.Tests
 
             // Assert
             Assert.Equal(
-                    statusCodeTagValue,
+                    activityStatus,
                     zipkinSpan.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.StatusCodeKey).Value);
 
-            if (statusCodeTagValue == "unset")
-            {
-                Assert.DoesNotContain(zipkinSpan.Tags, t => t.Key == SpanAttributeConstants.StatusCodeKey);
-            }
-            else
-            {
-                Assert.Equal(
-                    statusCodeTagValue,
-                    zipkinSpan.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.StatusCodeKey).Value);
-            }
-
-            if (statusCodeTagValue == "ERROR")
+            if (activityStatus == ActivityStatusCode.Error)
             {
                 Assert.Contains(zipkinSpan.Tags, t => t.Key == "error" && (string)t.Value == string.Empty);
             }

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
@@ -275,13 +275,13 @@ namespace OpenTelemetry.Exporter.Zipkin.Tests
             switch (statusCode)
             {
                 case StatusCode.Ok:
-                    statusTag = $@"""{SpanAttributeConstants.StatusCodeKey}"":""OK"",";
+                    statusTag = $@",""{SpanAttributeConstants.StatusCodeKey}"":""OK""";
                     break;
                 case StatusCode.Unset:
                     statusTag = string.Empty;
                     break;
                 case StatusCode.Error:
-                    statusTag = $@"""{SpanAttributeConstants.StatusCodeKey}"":""ERROR"",";
+                    statusTag = $@",""{SpanAttributeConstants.StatusCodeKey}"":""ERROR""";
                     errorTag = $@",""{ZipkinActivityConversionExtensions.ZipkinErrorFlagTagName}"":""{statusDescription}""";
                     break;
                 default:
@@ -289,7 +289,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Tests
             }
 
             Assert.Equal(
-                $@"[{{""traceId"":""{traceId}"",""name"":""Name"",{parentId}""id"":""{ZipkinActivityConversionExtensions.EncodeSpanId(context.SpanId)}"",""kind"":""CLIENT"",""timestamp"":{timestamp},""duration"":60000000,""localEndpoint"":{{""serviceName"":""{serviceName}""{ipInformation}}},""remoteEndpoint"":{{""serviceName"":""http://localhost:44312/""}},""annotations"":[{{""timestamp"":{eventTimestamp},""value"":""Event1""}},{{""timestamp"":{eventTimestamp},""value"":""Event2""}}],""tags"":{{{resourceTags}""stringKey"":""value"",""longKey"":""1"",""longKey2"":""1"",""doubleKey"":""1"",""doubleKey2"":""1"",""longArrayKey"":""1,2"",""boolKey"":""true"",""boolArrayKey"":""true,false"",""http.host"":""http://localhost:44312/"",{statusTag}""otel.library.name"":""CreateTestActivity"",""peer.service"":""http://localhost:44312/""{errorTag}}}}}]",
+                $@"[{{""traceId"":""{traceId}"",""name"":""Name"",{parentId}""id"":""{ZipkinActivityConversionExtensions.EncodeSpanId(context.SpanId)}"",""kind"":""CLIENT"",""timestamp"":{timestamp},""duration"":60000000,""localEndpoint"":{{""serviceName"":""{serviceName}""{ipInformation}}},""remoteEndpoint"":{{""serviceName"":""http://localhost:44312/""}},""annotations"":[{{""timestamp"":{eventTimestamp},""value"":""Event1""}},{{""timestamp"":{eventTimestamp},""value"":""Event2""}}],""tags"":{{{resourceTags}""stringKey"":""value"",""longKey"":""1"",""longKey2"":""1"",""doubleKey"":""1"",""doubleKey2"":""1"",""longArrayKey"":""1,2"",""boolKey"":""true"",""boolArrayKey"":""true,false"",""http.host"":""http://localhost:44312/"",""otel.library.name"":""CreateTestActivity"",""peer.service"":""http://localhost:44312/""{statusTag}{errorTag}}}}}]",
                 Responses[requestId]);
         }
 

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
@@ -192,7 +192,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Tests
         [InlineData(false, false, false, StatusCode.Ok, null, true)]
         [InlineData(false, false, false, StatusCode.Error)]
         [InlineData(false, false, false, StatusCode.Error, "Error description")]
-        public void IntegrationTest(
+        public void IntegrationTest_With_Status_Tags(
             bool useShortTraceIds,
             bool useTestResource,
             bool isRootSpan,
@@ -281,6 +281,106 @@ namespace OpenTelemetry.Exporter.Zipkin.Tests
                     statusTag = string.Empty;
                     break;
                 case StatusCode.Error:
+                    statusTag = $@",""{SpanAttributeConstants.StatusCodeKey}"":""ERROR""";
+                    errorTag = $@",""{ZipkinActivityConversionExtensions.ZipkinErrorFlagTagName}"":""{statusDescription}""";
+                    break;
+                default:
+                    throw new NotSupportedException();
+            }
+
+            Assert.Equal(
+                $@"[{{""traceId"":""{traceId}"",""name"":""Name"",{parentId}""id"":""{ZipkinActivityConversionExtensions.EncodeSpanId(context.SpanId)}"",""kind"":""CLIENT"",""timestamp"":{timestamp},""duration"":60000000,""localEndpoint"":{{""serviceName"":""{serviceName}""{ipInformation}}},""remoteEndpoint"":{{""serviceName"":""http://localhost:44312/""}},""annotations"":[{{""timestamp"":{eventTimestamp},""value"":""Event1""}},{{""timestamp"":{eventTimestamp},""value"":""Event2""}}],""tags"":{{{resourceTags}""stringKey"":""value"",""longKey"":""1"",""longKey2"":""1"",""doubleKey"":""1"",""doubleKey2"":""1"",""longArrayKey"":""1,2"",""boolKey"":""true"",""boolArrayKey"":""true,false"",""http.host"":""http://localhost:44312/"",""otel.library.name"":""CreateTestActivity"",""peer.service"":""http://localhost:44312/""{statusTag}{errorTag}}}}}]",
+                Responses[requestId]);
+        }
+
+        [Theory]
+        [InlineData(true, false, false)]
+        [InlineData(false, false, false)]
+        [InlineData(false, true, false)]
+        [InlineData(false, false, true)]
+        [InlineData(false, false, false, ActivityStatusCode.Ok)]
+        [InlineData(false, false, false, ActivityStatusCode.Ok, null, true)]
+        [InlineData(false, false, false, ActivityStatusCode.Error)]
+        [InlineData(false, false, false, ActivityStatusCode.Error, "Error description")]
+        public void IntegrationTest_With_Activity_Status(
+            bool useShortTraceIds,
+            bool useTestResource,
+            bool isRootSpan,
+            ActivityStatusCode activityStatusCode = ActivityStatusCode.Unset,
+            string statusDescription = null,
+            bool addErrorTag = false)
+        {
+            Guid requestId = Guid.NewGuid();
+
+            ZipkinExporter exporter = new ZipkinExporter(
+                new ZipkinExporterOptions
+                {
+                    Endpoint = new Uri($"http://{this.testServerHost}:{this.testServerPort}/api/v2/spans?requestId={requestId}"),
+                    UseShortTraceIds = useShortTraceIds,
+                });
+
+            var serviceName = (string)exporter.ParentProvider.GetDefaultResource().Attributes
+                .Where(pair => pair.Key == ResourceSemanticConventions.AttributeServiceName).FirstOrDefault().Value;
+            var resourceTags = string.Empty;
+            var activity = CreateTestActivity(isRootSpan: isRootSpan);
+
+            activity.SetStatus(activityStatusCode, statusDescription);
+
+            if (useTestResource)
+            {
+                serviceName = "MyService";
+
+                exporter.SetLocalEndpointFromResource(ResourceBuilder.CreateEmpty().AddAttributes(new Dictionary<string, object>
+                {
+                    [ResourceSemanticConventions.AttributeServiceName] = serviceName,
+                    ["service.tag"] = "hello world",
+                }).Build());
+            }
+            else
+            {
+                exporter.SetLocalEndpointFromResource(Resource.Empty);
+            }
+
+            if (addErrorTag)
+            {
+                activity.SetTag(ZipkinActivityConversionExtensions.ZipkinErrorFlagTagName, "This should be removed.");
+            }
+
+            var processor = new SimpleActivityExportProcessor(exporter);
+
+            processor.OnEnd(activity);
+
+            var context = activity.Context;
+
+            var timestamp = activity.StartTimeUtc.ToEpochMicroseconds();
+            var eventTimestamp = activity.Events.First().Timestamp.ToEpochMicroseconds();
+
+            StringBuilder ipInformation = new StringBuilder();
+            if (!string.IsNullOrEmpty(exporter.LocalEndpoint.Ipv4))
+            {
+                ipInformation.Append($@",""ipv4"":""{exporter.LocalEndpoint.Ipv4}""");
+            }
+
+            if (!string.IsNullOrEmpty(exporter.LocalEndpoint.Ipv6))
+            {
+                ipInformation.Append($@",""ipv6"":""{exporter.LocalEndpoint.Ipv6}""");
+            }
+
+            var parentId = isRootSpan ? string.Empty : $@"""parentId"":""{ZipkinActivityConversionExtensions.EncodeSpanId(activity.ParentSpanId)}"",";
+
+            var traceId = useShortTraceIds ? TraceId.Substring(TraceId.Length - 16, 16) : TraceId;
+
+            string statusTag;
+            string errorTag = string.Empty;
+            switch (activityStatusCode)
+            {
+                case ActivityStatusCode.Ok:
+                    statusTag = $@",""{SpanAttributeConstants.StatusCodeKey}"":""OK""";
+                    break;
+                case ActivityStatusCode.Unset:
+                    statusTag = string.Empty;
+                    break;
+                case ActivityStatusCode.Error:
                     statusTag = $@",""{SpanAttributeConstants.StatusCodeKey}"":""ERROR""";
                     errorTag = $@",""{ZipkinActivityConversionExtensions.ZipkinErrorFlagTagName}"":""{statusDescription}""";
                     break;


### PR DESCRIPTION
Partially Fixes #.
#2569 
## Changes
If (_activity.Status != ActivityStatusCode.Unset)
then: Activity.Status and Activity.StatusDescription will be used to set `otel.status_code` and `error` tags in Zipkin.  
else custom tags (`otel.status_code` and `otel.status_description`) will be used (If set).

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
