### PR TITLE
Throw on invalid histogram bounds

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Histogram bounds are validated when added to a View.
+  ([#2573](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2573))
+
 * Changed `BatchExportActivityProcessorOptions` constructor to throw
   `FormatException` if it fails to parse any of the supported environment
   variables.

--- a/src/OpenTelemetry/Metrics/HistogramConfiguration.cs
+++ b/src/OpenTelemetry/Metrics/HistogramConfiguration.cs
@@ -22,6 +22,12 @@ namespace OpenTelemetry.Metrics
     {
         private Aggregation aggregation = Aggregation.Histogram;
 
+        /// <summary>
+        /// Gets or sets the custom histogram bounds.
+        /// </summary>
+        /// <remarks>
+        /// The array must be in ascending order with distinct values.
+        /// </remarks>
         public double[] BucketBounds { get; set; }
 
         public override Aggregation Aggregation

--- a/src/OpenTelemetry/Metrics/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderBuilderExtensions.cs
@@ -86,6 +86,15 @@ namespace OpenTelemetry.Metrics
                 throw new ArgumentException($"Custom view name {metricStreamConfiguration.Name} is invalid.", nameof(metricStreamConfiguration.Name));
             }
 
+            if (metricStreamConfiguration is HistogramConfiguration histogramConfiguration)
+            {
+                // Validate histogram bounds
+                if (histogramConfiguration.BucketBounds != null && !IsSortedAndDistinct(histogramConfiguration.BucketBounds))
+                {
+                    throw new ArgumentException($"Histogram bounds must be in ascending order with distinct values", nameof(histogramConfiguration.BucketBounds));
+                }
+            }
+
             if (meterProviderBuilder is MeterProviderBuilderBase meterProviderBuilderBase)
             {
                 return meterProviderBuilderBase.AddView(instrumentName, metricStreamConfiguration);
@@ -147,6 +156,19 @@ namespace OpenTelemetry.Metrics
             }
 
             return null;
+        }
+
+        private static bool IsSortedAndDistinct(double[] values)
+        {
+            for (int i = 1; i < values.Length; i++)
+            {
+                if (values[i] <= values[i - 1])
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
@@ -94,6 +94,16 @@ namespace OpenTelemetry.Metrics.Tests
         }
 
         [Theory]
+        [MemberData(nameof(MetricsTestData.InvalidHistogramBounds), MemberType = typeof(MetricsTestData))]
+        public void AddViewWithInvalidHistogramBoundsThrowsArgumentException(double[] bounds)
+        {
+            var ex = Assert.Throws<ArgumentException>(() => Sdk.CreateMeterProviderBuilder()
+                .AddView("name1", new HistogramConfiguration { BucketBounds = bounds }));
+
+            Assert.Contains("Histogram bounds must be in ascending order with distinct values", ex.Message);
+        }
+
+        [Theory]
         [MemberData(nameof(MetricsTestData.ValidInstrumentNames), MemberType = typeof(MetricsTestData))]
         public void ViewWithValidNameExported(string viewNewName)
         {

--- a/test/OpenTelemetry.Tests/Metrics/MetricsTestData.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricsTestData.cs
@@ -46,6 +46,8 @@ namespace OpenTelemetry.Metrics.Tests
            {
                     new object[] { new double[] { 0, 0 } },
                     new object[] { new double[] { 1, 0 } },
+                    new object[] { new double[] { 0, 1, 1, 2 } },
+                    new object[] { new double[] { 0, 1, 2, -1 } },
            };
     }
 }

--- a/test/OpenTelemetry.Tests/Metrics/MetricsTestData.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricsTestData.cs
@@ -40,5 +40,12 @@ namespace OpenTelemetry.Metrics.Tests
                     new object[] { "my_metric2" },
                     new object[] { new string('m', 63) },
            };
+
+        public static IEnumerable<object[]> InvalidHistogramBounds
+           => new List<object[]>
+           {
+                    new object[] { new double[] { 0, 0 } },
+                    new object[] { new double[] { 1, 0 } },
+           };
     }
 }


### PR DESCRIPTION
Fixes #2566

## Changes

Throws `ArgumentException` when invalid histogram bounds are provided.
The bounds must be in ascending order and contain distinct values.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed