### PR TITLE
Consolidate/cleanup SA1000

### DIFF
--- a/build/OpenTelemetry.prod.loose.ruleset
+++ b/build/OpenTelemetry.prod.loose.ruleset
@@ -5,7 +5,8 @@
     <Description Resource="OpenTelemetrySDKRules_Description" />
   </Localization>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-    <Rule Id="SA1000" Action="Warning" />
+    <!-- SA1000 KeywordsMustBeSpacedCorrectly https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3214 -->
+    <Rule Id="SA1000" Action="None" />
     <Rule Id="SA1001" Action="Warning" />
     <Rule Id="SA1002" Action="Warning" />
     <Rule Id="SA1003" Action="Warning" />

--- a/build/OpenTelemetry.prod.ruleset
+++ b/build/OpenTelemetry.prod.ruleset
@@ -5,6 +5,8 @@
     <Description Resource="OpenTelemetrySDKRules_Description" />
   </Localization>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <!-- SA1000 KeywordsMustBeSpacedCorrectly https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3214 -->
+    <Rule Id="SA1000" Action="None" />
     <Rule Id="SA1200" Action="None" />
     <Rule Id="SA1401" Action="None" />
     <Rule Id="SA1512" Action="None" />

--- a/build/OpenTelemetry.test.ruleset
+++ b/build/OpenTelemetry.test.ruleset
@@ -6,6 +6,8 @@
   </Localization>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="SA0001" Action="None" />
+    <!-- SA1000 KeywordsMustBeSpacedCorrectly https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3214 -->
+    <Rule Id="SA1000" Action="None" />
     <Rule Id="SA1200" Action="None" />
     <Rule Id="SA1401" Action="None" />
     <Rule Id="SA1512" Action="None" />

--- a/docs/Directory.Build.props
+++ b/docs/Directory.Build.props
@@ -2,7 +2,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.nonprod.props" />
 
   <PropertyGroup>
-    <NoWarn>$(NoWarn),SA1000</NoWarn>
     <OutputType>Exe</OutputType>
     <!-- https://dotnet.microsoft.com/download/dotnet-core -->
     <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>

--- a/examples/Console/TestPrometheusExporter.cs
+++ b/examples/Console/TestPrometheusExporter.cs
@@ -56,7 +56,6 @@ namespace Examples.Console
                 })
                 .Build();
 
-#pragma warning disable SA1000 // KeywordsMustBeSpacedCorrectly https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3214
             ObservableGauge<long> gauge = MyMeter.CreateObservableGauge(
             "myGauge",
             () =>
@@ -82,7 +81,6 @@ namespace Examples.Console
                 }
             });
             writeMetricTask.Start();
-#pragma warning restore SA1000 // KeywordsMustBeSpacedCorrectly
 
             token.CancelAfter(totalDurationInMins * 60 * 1000);
 

--- a/test/OpenTelemetry.Tests.Stress.Metrics/OpenTelemetry.Tests.Stress.Metrics.csproj
+++ b/test/OpenTelemetry.Tests.Stress.Metrics/OpenTelemetry.Tests.Stress.Metrics.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <NoWarn>$(NoWarn),SA1000</NoWarn>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net462</TargetFrameworks>
     <IsPackable>false</IsPackable>

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -26,7 +26,6 @@ using Xunit.Abstractions;
 
 namespace OpenTelemetry.Metrics.Tests
 {
-#pragma warning disable SA1000 // KeywordsMustBeSpacedCorrectly https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3214
     public class MetricApiTest
     {
         private const int MaxTimeToAllowForFlush = 10000;
@@ -655,5 +654,4 @@ namespace OpenTelemetry.Metrics.Tests
             public T DeltaValueUpdatedByEachCall;
         }
     }
-#pragma warning restore SA1000 // KeywordsMustBeSpacedCorrectly
 }

--- a/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
@@ -23,7 +23,6 @@ using Xunit.Abstractions;
 
 namespace OpenTelemetry.Metrics.Tests
 {
-#pragma warning disable SA1000 // KeywordsMustBeSpacedCorrectly https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3214
     public class MetricViewTests
     {
         private const int MaxTimeToAllowForFlush = 10000;
@@ -559,5 +558,4 @@ namespace OpenTelemetry.Metrics.Tests
             Assert.Equal(Aggregation.Drop, MetricStreamConfiguration.Drop.Aggregation);
         }
     }
-#pragma warning restore SA1000 // KeywordsMustBeSpacedCorrectly
 }


### PR DESCRIPTION
Given SA1000 has a [known problem](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3214), it makes more sense to disable it globally for now, so we don't have to keep adding `#pragma`s.