### PR TITLE
Add unit as metric name suffix in PrometheusExporter

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusSerializer.cs
@@ -178,7 +178,7 @@ namespace OpenTelemetry.Exporter.Prometheus
                     (ordinal >= (ushort)'a' && ordinal <= (ushort)'z') ||
                     (ordinal >= (ushort)'0' && ordinal <= (ushort)'9'))
                 {
-                    cursor = WriteUnicodeNoEscape(buffer, cursor, ordinal);
+                    buffer[cursor++] = unchecked((byte)ordinal);
                 }
                 else
                 {
@@ -235,7 +235,7 @@ namespace OpenTelemetry.Exporter.Prometheus
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int WriteMetricName(byte[] buffer, int cursor, string metricName)
+        public static int WriteMetricName(byte[] buffer, int cursor, string metricName, string metricUnit = null)
         {
             Debug.Assert(!string.IsNullOrEmpty(metricName), $"{nameof(metricName)} should not be null or empty.");
 
@@ -249,8 +249,29 @@ namespace OpenTelemetry.Exporter.Prometheus
                         buffer[cursor++] = unchecked((byte)'_');
                         break;
                     default:
-                        cursor = WriteUnicodeNoEscape(buffer, cursor, ordinal);
+                        buffer[cursor++] = unchecked((byte)ordinal);
                         break;
+                }
+            }
+
+            if (!string.IsNullOrEmpty(metricUnit))
+            {
+                buffer[cursor++] = unchecked((byte)'_');
+
+                for (int i = 0; i < metricUnit.Length; i++)
+                {
+                    var ordinal = (ushort)metricUnit[i];
+
+                    if ((ordinal >= (ushort)'A' && ordinal <= (ushort)'Z') ||
+                        (ordinal >= (ushort)'a' && ordinal <= (ushort)'z') ||
+                        (ordinal >= (ushort)'0' && ordinal <= (ushort)'9'))
+                    {
+                        buffer[cursor++] = unchecked((byte)ordinal);
+                    }
+                    else
+                    {
+                        buffer[cursor++] = unchecked((byte)'_');
+                    }
                 }
             }
 
@@ -258,10 +279,10 @@ namespace OpenTelemetry.Exporter.Prometheus
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int WriteHelpText(byte[] buffer, int cursor, string metricName, string metricDescription = null)
+        public static int WriteHelpText(byte[] buffer, int cursor, string metricName, string metricUnit = null, string metricDescription = null)
         {
             cursor = WriteAsciiStringNoEscape(buffer, cursor, "# HELP ");
-            cursor = WriteMetricName(buffer, cursor, metricName);
+            cursor = WriteMetricName(buffer, cursor, metricName, metricUnit);
 
             if (metricDescription != null)
             {
@@ -275,12 +296,12 @@ namespace OpenTelemetry.Exporter.Prometheus
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int WriteTypeInfo(byte[] buffer, int cursor, string metricName, string metricType)
+        public static int WriteTypeInfo(byte[] buffer, int cursor, string metricName, string metricUnit, string metricType)
         {
             Debug.Assert(!string.IsNullOrEmpty(metricType), $"{nameof(metricType)} should not be null or empty.");
 
             cursor = WriteAsciiStringNoEscape(buffer, cursor, "# TYPE ");
-            cursor = WriteMetricName(buffer, cursor, metricName);
+            cursor = WriteMetricName(buffer, cursor, metricName, metricUnit);
             buffer[cursor++] = unchecked((byte)' ');
             cursor = WriteAsciiStringNoEscape(buffer, cursor, metricType);
 

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusSerializer.cs
@@ -284,7 +284,7 @@ namespace OpenTelemetry.Exporter.Prometheus
             cursor = WriteAsciiStringNoEscape(buffer, cursor, "# HELP ");
             cursor = WriteMetricName(buffer, cursor, metricName, metricUnit);
 
-            if (metricDescription != null)
+            if (!string.IsNullOrEmpty(metricDescription))
             {
                 buffer[cursor++] = unchecked((byte)' ');
                 cursor = WriteUnicodeString(buffer, cursor, metricDescription);

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusSerializerExt.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusSerializerExt.cs
@@ -50,11 +50,11 @@ namespace OpenTelemetry.Exporter.Prometheus
         {
             if (metric.Description != null)
             {
-                cursor = WriteHelpText(buffer, cursor, metric.Name, metric.Description);
+                cursor = WriteHelpText(buffer, cursor, metric.Name, metric.Unit, metric.Description);
             }
 
             int metricType = (int)metric.MetricType >> 4;
-            cursor = WriteTypeInfo(buffer, cursor, metric.Name, MetricTypes[metricType]);
+            cursor = WriteTypeInfo(buffer, cursor, metric.Name, metric.Unit, MetricTypes[metricType]);
 
             if (metric.MetricType != MetricType.Histogram)
             {
@@ -65,7 +65,7 @@ namespace OpenTelemetry.Exporter.Prometheus
                     var timestamp = metricPoint.EndTime.ToUnixTimeMilliseconds();
 
                     // Counter and Gauge
-                    cursor = WriteMetricName(buffer, cursor, metric.Name);
+                    cursor = WriteMetricName(buffer, cursor, metric.Name, metric.Unit);
                     buffer[cursor++] = unchecked((byte)'{');
 
                     for (var i = 0; i < keys.Length; i++)
@@ -113,7 +113,7 @@ namespace OpenTelemetry.Exporter.Prometheus
                     {
                         totalCount += bucketCounts[idxBound];
 
-                        cursor = WriteMetricName(buffer, cursor, metric.Name);
+                        cursor = WriteMetricName(buffer, cursor, metric.Name, metric.Unit);
                         cursor = WriteAsciiStringNoEscape(buffer, cursor, "_bucket{");
 
                         for (var i = 0; i < keys.Length; i++)
@@ -144,7 +144,7 @@ namespace OpenTelemetry.Exporter.Prometheus
                     }
 
                     // Histogram sum
-                    cursor = WriteMetricName(buffer, cursor, metric.Name);
+                    cursor = WriteMetricName(buffer, cursor, metric.Name, metric.Unit);
                     cursor = WriteAsciiStringNoEscape(buffer, cursor, "_sum{");
 
                     for (var i = 0; i < keys.Length; i++)
@@ -168,7 +168,7 @@ namespace OpenTelemetry.Exporter.Prometheus
                     buffer[cursor++] = ASCII_LINEFEED;
 
                     // Histogram count
-                    cursor = WriteMetricName(buffer, cursor, metric.Name);
+                    cursor = WriteMetricName(buffer, cursor, metric.Name, metric.Unit);
                     cursor = WriteAsciiStringNoEscape(buffer, cursor, "_count{");
 
                     for (var i = 0; i < keys.Length; i++)


### PR DESCRIPTION
This is to prototype https://github.com/open-telemetry/opentelemetry-specification/pull/2017#discussion_r746103164 and https://github.com/open-telemetry/opentelemetry-specification/pull/2017#discussion_r746105004 so we can hammer out the OpenTelemetry->Prometheus data model spec.