### PR TITLE
Metric description and unit to be treated as empty string when not provided

### DIFF
--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -34,8 +34,8 @@ namespace OpenTelemetry.Metrics
             string[] tagKeysInteresting = null)
         {
             this.Name = metricName;
-            this.Description = metricDescription;
-            this.Unit = instrument.Unit;
+            this.Description = metricDescription ?? string.Empty;
+            this.Unit = instrument.Unit ?? string.Empty;
             this.Meter = instrument.Meter;
             AggregationType aggType = default;
             if (instrument.GetType() == typeof(ObservableCounter<long>)

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterMetricsHttpServerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterMetricsHttpServerTests.cs
@@ -105,11 +105,21 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
 
             string content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
-            var index = content.LastIndexOf(' ');
+            string[] lines = content.Split('\n');
 
             Assert.Equal(
-                $"# TYPE counter_double counter\ncounter_double{{key1=\"value1\",key2=\"value2\"}} 101.17",
-                content.Substring(0, index));
+                $"# HELP counter_double",
+                lines[0]);
+
+            Assert.Equal(
+                $"# TYPE counter_double counter",
+                lines[1]);
+
+            Assert.Contains(
+                $"counter_double{{key1=\"value1\",key2=\"value2\"}} 101.17",
+                lines[2]);
+
+            var index = content.LastIndexOf(' ');
 
             Assert.Equal('\n', content[content.Length - 1]);
 

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterMiddlewareTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterMiddlewareTests.cs
@@ -52,21 +52,41 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
 
             using var meter = new Meter(MeterName);
 
+            var beginTimestamp = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+
             var counter = meter.CreateCounter<double>("counter_double");
             counter.Add(100.18D, tags);
             counter.Add(0.99D, tags);
 
             using var response = await host.GetTestClient().GetAsync("/metrics").ConfigureAwait(false);
 
+            var endTimestamp = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             string content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
-            int index = content.LastIndexOf(' ');
+            string[] lines = content.Split('\n');
 
             Assert.Equal(
-                $"# TYPE counter_double counter\ncounter_double{{key1=\"value1\",key2=\"value2\"}} 101.17",
-                content.Substring(0, index));
+                $"# HELP counter_double",
+                lines[0]);
+
+            Assert.Equal(
+                $"# TYPE counter_double counter",
+                lines[1]);
+
+            Assert.Contains(
+                $"counter_double{{key1=\"value1\",key2=\"value2\"}} 101.17",
+                lines[2]);
+
+            var index = content.LastIndexOf(' ');
+
+            Assert.Equal('\n', content[content.Length - 1]);
+
+            var timestamp = long.Parse(content.Substring(index, content.Length - index - 1));
+
+            Assert.True(beginTimestamp <= timestamp && timestamp <= endTimestamp);
 
             await host.StopAsync().ConfigureAwait(false);
         }


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument

If the unit is not provided or the unit is null, the API and SDK MUST make sure that the behavior is the same as an empty unit string.

If the description is not provided or the description is null, the API and SDK MUST make sure that the behavior is the same as an empty description string.

