### PR TITLE
Do not export metrics description if it is empty

### DIFF
--- a/examples/Console/TestPrometheusExporter.cs
+++ b/examples/Console/TestPrometheusExporter.cs
@@ -29,7 +29,7 @@ namespace Examples.Console
     {
         private static readonly Meter MyMeter = new Meter("TestMeter");
         private static readonly Counter<double> Counter = MyMeter.CreateCounter<double>("myCounter", description: "A counter for demonstration purpose.");
-        private static readonly Histogram<long> MyHistogram = MyMeter.CreateHistogram<long>("myHistogram", description: "A histogram for demonstration purpose.");
+        private static readonly Histogram<long> MyHistogram = MyMeter.CreateHistogram<long>("myHistogram");
         private static readonly ThreadLocal<Random> ThreadLocalRandom = new ThreadLocal<Random>(() => new Random());
 
         internal static object Run(int port, int totalDurationInMins)

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterMetricsHttpServer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterMetricsHttpServer.cs
@@ -131,7 +131,8 @@ namespace OpenTelemetry.Exporter.Prometheus
                     try
                     {
                         ctx.Response.StatusCode = 200;
-                        ctx.Response.ContentType = PrometheusMetricsFormatHelper.ContentType;
+                        ctx.Response.Headers.Add("Server", string.Empty);
+                        ctx.Response.ContentType = "text/plain; charset=utf-8; version=0.0.4";
 
                         this.exporter.OnExport = (metrics) =>
                         {

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterMiddleware.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterMiddleware.cs
@@ -115,7 +115,7 @@ namespace OpenTelemetry.Exporter.Prometheus
         internal static async Task WriteMetricsToResponse(byte[] buffer, int count, HttpResponse response)
         {
             response.StatusCode = 200;
-            response.ContentType = PrometheusMetricsFormatHelper.ContentType;
+            response.ContentType = "text/plain; charset=utf-8; version=0.0.4";
 
             await response.Body.WriteAsync(buffer, 0, count).ConfigureAwait(false);
         }

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusMetricsFormatHelper.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusMetricsFormatHelper.cs
@@ -27,8 +27,6 @@ namespace OpenTelemetry.Exporter.Prometheus
 {
     internal static class PrometheusMetricsFormatHelper
     {
-        public const string ContentType = "text/plain; version = 0.0.4";
-
 #if NETCOREAPP3_1_OR_GREATER
         private static readonly SpanAction<char, (string, Func<char, bool, bool>)> CreateName
             = (Span<char> data, (string name, Func<char, bool, bool> isCharacterAllowedFunc) state) =>

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusSerializerExt.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusSerializerExt.cs
@@ -48,7 +48,7 @@ namespace OpenTelemetry.Exporter.Prometheus
 
         public static int WriteMetric(byte[] buffer, int cursor, Metric metric)
         {
-            if (metric.Description != null)
+            if (!string.IsNullOrWhiteSpace(metric.Description))
             {
                 cursor = WriteHelpText(buffer, cursor, metric.Name, metric.Unit, metric.Description);
             }

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterMetricsHttpServerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterMetricsHttpServerTests.cs
@@ -108,16 +108,12 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
             string[] lines = content.Split('\n');
 
             Assert.Equal(
-                $"# HELP counter_double",
-                lines[0]);
-
-            Assert.Equal(
                 $"# TYPE counter_double counter",
-                lines[1]);
+                lines[0]);
 
             Assert.Contains(
                 $"counter_double{{key1=\"value1\",key2=\"value2\"}} 101.17",
-                lines[2]);
+                lines[1]);
 
             var index = content.LastIndexOf(' ');
 

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterMiddlewareTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterMiddlewareTests.cs
@@ -69,16 +69,12 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
             string[] lines = content.Split('\n');
 
             Assert.Equal(
-                $"# HELP counter_double",
-                lines[0]);
-
-            Assert.Equal(
                 $"# TYPE counter_double counter",
-                lines[1]);
+                lines[0]);
 
             Assert.Contains(
                 $"counter_double{{key1=\"value1\",key2=\"value2\"}} 101.17",
-                lines[2]);
+                lines[1]);
 
             var index = content.LastIndexOf(' ');
 


### PR DESCRIPTION
Couple minor changes to PrometheusExporter:
1. When the metric description is empty/whitespace, do not send the `# HELP name description` line.
2. Hide the HTTP Server information.
3. Fix the Content-Type header.

With this change, the HTTP response looks clean:

```text
HTTP 200 OK

Transfer-Encoding: chunked
Content-Type: text/plain; charset=utf-8; version=0.0.4
Date: Wed, 10 Nov 2021 02:51:38 GMT


# HELP myCounter A counter for demonstration purpose.
# TYPE myCounter counter
myCounter{color="red",name="apple"} 2623.5000000000127 1636512698093
myCounter{color="yellow",name="lemon"} 26473.500000000106 1636512698093

# TYPE myHistogram histogram
myHistogram_bucket{tag1="value1",tag2="value2",le="0"} 0 1636512698093
myHistogram_bucket{tag1="value1",tag2="value2",le="5"} 2 1636512698093
myHistogram_bucket{tag1="value1",tag2="value2",le="10"} 4 1636512698093
myHistogram_bucket{tag1="value1",tag2="value2",le="25"} 7 1636512698093
myHistogram_bucket{tag1="value1",tag2="value2",le="50"} 15 1636512698093
myHistogram_bucket{tag1="value1",tag2="value2",le="75"} 21 1636512698093
myHistogram_bucket{tag1="value1",tag2="value2",le="100"} 26 1636512698093
myHistogram_bucket{tag1="value1",tag2="value2",le="250"} 50 1636512698093
myHistogram_bucket{tag1="value1",tag2="value2",le="500"} 95 1636512698093
myHistogram_bucket{tag1="value1",tag2="value2",le="1000"} 179 1636512698093
myHistogram_bucket{tag1="value1",tag2="value2",le="+Inf"} 265 1636512698093
myHistogram_sum{tag1="value1",tag2="value2"} 191192 1636512698093
myHistogram_count{tag1="value1",tag2="value2"} 265 1636512698093

# HELP myGauge A gauge for demonstration purpose.
# TYPE myGauge gauge
myGauge{tag1="value1",tag2="value2"} 794 1636512698093
myGauge{tag1="value1",tag2="value3"} 148 1636512698093

```