### PR TITLE
Handle instrument disposal

### DIFF
--- a/docs/metrics/customizing-the-sdk/Program.cs
+++ b/docs/metrics/customizing-the-sdk/Program.cs
@@ -60,7 +60,7 @@ public class Program
             // turn off the above default. i.e any
             // instrument which does not match any views
             // gets dropped.
-            // .AddView(instrumentName: "*", new MetricStreamConfiguration() { Aggregation = Aggregation.Drop })
+            // .AddView(instrumentName: "*", MetricStreamConfiguration.Drop)
             .AddConsoleExporter()
             .Build();
 

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -106,6 +106,7 @@ namespace OpenTelemetry.Metrics
 
             this.aggStore = new AggregatorStore(aggType, temporality, histogramBounds ?? DefaultHistogramBounds, tagKeysInteresting);
             this.Temporality = temporality;
+            this.InstrumentDisposed = false;
         }
 
         public MetricType MetricType { get; private set; }
@@ -119,6 +120,8 @@ namespace OpenTelemetry.Metrics
         public string Unit { get; private set; }
 
         public Meter Meter { get; private set; }
+
+        internal bool InstrumentDisposed { get; set; }
 
         public BatchMetricPoint GetMetricPoints()
         {

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -364,6 +364,55 @@ namespace OpenTelemetry.Metrics.Tests
         [Theory]
         [InlineData(AggregationTemporality.Cumulative)]
         [InlineData(AggregationTemporality.Delta)]
+        public void TestInstrumentDisposal(AggregationTemporality temporality)
+        {
+            var metricItems = new List<Metric>();
+            var metricExporter = new InMemoryExporter<Metric>(metricItems);
+            var metricReader = new BaseExportingMetricReader(metricExporter)
+            {
+                PreferredAggregationTemporality = temporality,
+            };
+
+            var meter1 = new Meter($"{Utils.GetCurrentMethodName()}.{temporality}.1");
+            var meter2 = new Meter($"{Utils.GetCurrentMethodName()}.{temporality}.2");
+            var counter1 = meter1.CreateCounter<long>("counterFromMeter1");
+            var counter2 = meter2.CreateCounter<long>("counterFromMeter2");
+            using var meterProvider = Sdk.CreateMeterProviderBuilder()
+                .AddMeter(meter1.Name)
+                .AddMeter(meter2.Name)
+                .AddReader(metricReader)
+                .Build();
+
+            counter1.Add(10, new KeyValuePair<string, object>("key", "value"));
+            counter2.Add(10, new KeyValuePair<string, object>("key", "value"));
+
+            metricReader.Collect();
+            Assert.Equal(2, metricItems.Count);
+            metricItems.Clear();
+
+            meter1.Dispose();
+
+            metricReader.Collect();
+            Assert.Equal(2, metricItems.Count);
+            metricItems.Clear();
+
+            metricReader.Collect();
+            Assert.Single(metricItems);
+            metricItems.Clear();
+
+            meter2.Dispose();
+
+            metricReader.Collect();
+            Assert.Single(metricItems);
+            metricItems.Clear();
+
+            metricReader.Collect();
+            Assert.Empty(metricItems);
+        }
+
+        [Theory]
+        [InlineData(AggregationTemporality.Cumulative)]
+        [InlineData(AggregationTemporality.Delta)]
         public void TestMetricPointCap(AggregationTemporality temporality)
         {
             var metricItems = new List<Metric>();


### PR DESCRIPTION
Towards #2425 
This does not reclaim the position occupied by Metric in the Metric[], so the current hardcoded limit of 1000 remains even after disposing Meters (thereby instruments from it). This can be a follow up.

This will face similar challenges as https://github.com/open-telemetry/opentelemetry-dotnet/pull/2466 when reclaiming is incorporated, but likely a lot easier to fix as Instrument creation/disposal is not a hot path (instruments are typically created once and used throughout), and can afford to protect with plain lock statements.

This also does not re-allow the metric stream name even after the original instrument is disposed. There are some spec updates likely coming in this area, and this restriction might be going away. Hence not touching it in *this* PR.

