### PR TITLE
Delta exporters will Export only those points which received new update

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Metrics SDK will not provide inactive Metrics to exporter.
+* Metrics SDK will not provide inactive Metrics to delta exporter.
   ([#2629](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2629))
 
 * Histogram bounds are validated when added to a View.

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Metrics SDK will not provide inactive Metrics to exporter.
+  ([#2629](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2629))
+
 * Histogram bounds are validated when added to a View.
   ([#2573](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2573))
 

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -37,11 +37,13 @@ namespace OpenTelemetry.Metrics
         private readonly AggregationTemporality temporality;
         private readonly bool outputDelta;
         private readonly MetricPoint[] metricPoints;
+        private readonly int[] currentMetricPointBatch;
         private readonly AggregationType aggType;
         private readonly double[] histogramBounds;
         private readonly UpdateLongDelegate updateLongCallback;
         private readonly UpdateDoubleDelegate updateDoubleCallback;
         private int metricPointIndex = 0;
+        private int batchSize = 0;
         private bool zeroTagMetricPointInitialized;
         private DateTimeOffset startTimeExclusive;
         private DateTimeOffset endTimeInclusive;
@@ -53,6 +55,7 @@ namespace OpenTelemetry.Metrics
             string[] tagKeysInteresting = null)
         {
             this.metricPoints = new MetricPoint[MaxMetricPoints];
+            this.currentMetricPointBatch = new int[MaxMetricPoints];
             this.aggType = aggType;
             this.temporality = temporality;
             this.outputDelta = temporality == AggregationTemporality.Delta ? true : false;
@@ -92,10 +95,47 @@ namespace OpenTelemetry.Metrics
             this.updateDoubleCallback(value, tags);
         }
 
-        internal void SnapShot()
+        internal int SnapShot()
         {
+            this.batchSize = 0;
             var indexSnapShot = Math.Min(this.metricPointIndex, MaxMetricPoints - 1);
+            if (this.temporality == AggregationTemporality.Delta)
+            {
+                this.SnapShotDelta(indexSnapShot);
+            }
+            else
+            {
+                this.SnapShotCumulative(indexSnapShot);
+            }
 
+            DateTimeOffset dt = DateTimeOffset.UtcNow;
+            this.endTimeInclusive = dt;
+            return this.batchSize;
+        }
+
+        internal void SnapShotDelta(int indexSnapShot)
+        {
+            for (int i = 0; i <= indexSnapShot; i++)
+            {
+                ref var metricPoint = ref this.metricPoints[i];
+                if (metricPoint.MetricPointStatus == MetricPointStatus.NoCollectPending)
+                {
+                    continue;
+                }
+
+                metricPoint.TakeSnapShot(this.outputDelta);
+                this.currentMetricPointBatch[this.batchSize] = i;
+                this.batchSize++;
+            }
+
+            if (this.endTimeInclusive != default)
+            {
+                this.startTimeExclusive = this.endTimeInclusive;
+            }
+        }
+
+        internal void SnapShotCumulative(int indexSnapShot)
+        {
             for (int i = 0; i <= indexSnapShot; i++)
             {
                 ref var metricPoint = ref this.metricPoints[i];
@@ -105,24 +145,14 @@ namespace OpenTelemetry.Metrics
                 }
 
                 metricPoint.TakeSnapShot(this.outputDelta);
+                this.currentMetricPointBatch[this.batchSize] = i;
+                this.batchSize++;
             }
-
-            if (this.temporality == AggregationTemporality.Delta)
-            {
-                if (this.endTimeInclusive != default)
-                {
-                    this.startTimeExclusive = this.endTimeInclusive;
-                }
-            }
-
-            DateTimeOffset dt = DateTimeOffset.UtcNow;
-            this.endTimeInclusive = dt;
         }
 
         internal BatchMetricPoint GetMetricPoints()
         {
-            var indexSnapShot = Math.Min(this.metricPointIndex, MaxMetricPoints - 1);
-            return new BatchMetricPoint(this.metricPoints, indexSnapShot + 1, this.startTimeExclusive, this.endTimeInclusive);
+            return new BatchMetricPoint(this.metricPoints, this.currentMetricPointBatch, this.batchSize, this.startTimeExclusive, this.endTimeInclusive);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -108,8 +108,7 @@ namespace OpenTelemetry.Metrics
                 this.SnapShotCumulative(indexSnapShot);
             }
 
-            DateTimeOffset dt = DateTimeOffset.UtcNow;
-            this.endTimeInclusive = dt;
+            this.endTimeInclusive = DateTimeOffset.UtcNow;
             return this.batchSize;
         }
 

--- a/src/OpenTelemetry/Metrics/BatchMetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/BatchMetricPoint.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Collections;
-using System.Diagnostics;
 using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Metrics
@@ -24,17 +23,18 @@ namespace OpenTelemetry.Metrics
     public readonly struct BatchMetricPoint : IDisposable
     {
         private readonly MetricPoint[] metricsPoints;
+        private readonly int[] metricPointsToProcess;
         private readonly long targetCount;
         private readonly DateTimeOffset start;
         private readonly DateTimeOffset end;
 
-        internal BatchMetricPoint(MetricPoint[] metricsPoints, int maxSize, DateTimeOffset start, DateTimeOffset end)
+        internal BatchMetricPoint(MetricPoint[] metricsPoints, int[] metricPointsToProcess, long targetCount, DateTimeOffset start, DateTimeOffset end)
         {
-            Debug.Assert(maxSize > 0, $"{nameof(maxSize)} should be a positive number.");
             Guard.Null(metricsPoints, nameof(metricsPoints));
 
             this.metricsPoints = metricsPoints;
-            this.targetCount = maxSize;
+            this.metricPointsToProcess = metricPointsToProcess;
+            this.targetCount = targetCount;
             this.start = start;
             this.end = end;
         }
@@ -50,7 +50,7 @@ namespace OpenTelemetry.Metrics
         /// <returns><see cref="Enumerator"/>.</returns>
         public Enumerator GetEnumerator()
         {
-            return new Enumerator(this.metricsPoints, this.targetCount, this.start, this.end);
+            return new Enumerator(this.metricsPoints, this.metricPointsToProcess, this.targetCount, this.start, this.end);
         }
 
         /// <summary>
@@ -59,14 +59,16 @@ namespace OpenTelemetry.Metrics
         public struct Enumerator : IEnumerator
         {
             private readonly MetricPoint[] metricsPoints;
+            private readonly int[] metricPointsToProcess;
             private readonly DateTimeOffset start;
             private readonly DateTimeOffset end;
             private long targetCount;
             private long index;
 
-            internal Enumerator(MetricPoint[] metricsPoints, long targetCount, DateTimeOffset start, DateTimeOffset end)
+            internal Enumerator(MetricPoint[] metricsPoints, int[] metricPointsToProcess, long targetCount, DateTimeOffset start, DateTimeOffset end)
             {
                 this.metricsPoints = metricsPoints;
+                this.metricPointsToProcess = metricPointsToProcess;
                 this.targetCount = targetCount;
                 this.index = -1;
                 this.start = start;
@@ -77,7 +79,7 @@ namespace OpenTelemetry.Metrics
             {
                 get
                 {
-                    return ref this.metricsPoints[this.index];
+                    return ref this.metricsPoints[this.metricPointsToProcess[this.index]];
                 }
             }
 
@@ -93,12 +95,7 @@ namespace OpenTelemetry.Metrics
             {
                 while (++this.index < this.targetCount)
                 {
-                    ref var metricPoint = ref this.metricsPoints[this.index];
-                    if (metricPoint.StartTime == default)
-                    {
-                        continue;
-                    }
-
+                    ref var metricPoint = ref this.metricsPoints[this.metricPointsToProcess[this.index]];
                     metricPoint.StartTime = this.start;
                     metricPoint.EndTime = this.end;
                     return true;

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -443,19 +443,23 @@ namespace OpenTelemetry.Metrics
                     for (int i = 0; i < target; i++)
                     {
                         var metric = this.metrics[i];
+                        int metricPointSize = 0;
                         if (metric != null)
                         {
                             if (metric.InstrumentDisposed)
                             {
-                                metric.SnapShot();
+                                metricPointSize = metric.SnapShot();
                                 this.metrics[i] = null;
                             }
                             else
                             {
-                                metric.SnapShot();
+                                metricPointSize = metric.SnapShot();
                             }
 
-                            this.metricsCurrentBatch[metricCountCurrentBatch++] = metric;
+                            if (metricPointSize > 0)
+                            {
+                                this.metricsCurrentBatch[metricCountCurrentBatch++] = metric;
+                            }
                         }
                     }
 

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -138,9 +138,9 @@ namespace OpenTelemetry.Metrics
             this.aggStore.Update(value, tags);
         }
 
-        internal void SnapShot()
+        internal int SnapShot()
         {
-            this.aggStore.SnapShot();
+            return this.aggStore.SnapShot();
         }
     }
 }

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -121,15 +121,17 @@ namespace OpenTelemetry.Metrics
                     }
             }
 
-            // There is a race with SnapShot:
-            // Update updates value
-            // SnapShot snapshots the value
-            // SnapShot sets status to NoCollectPending
-            // Update sets status to CollectPending -- this is not right as the SnapShot
+            // There is a race with Snapshot:
+            // Update() updates the value
+            // Snapshot snapshots the value
+            // Snapshot sets status to NoCollectPending
+            // Update sets status to CollectPending -- this is not right as the Snapshot
             // already included the updated value.
-            // In the absence of any new Update call until next SnapShot,
+            // In the absence of any new Update call until next Snapshot,
             // this results in exporting an Update even though
             // it had no update.
+            // TODO: For Delta, this can be mitigated
+            // by ignoring Zero points
             this.MetricPointStatus = MetricPointStatus.CollectPending;
         }
 
@@ -195,15 +197,17 @@ namespace OpenTelemetry.Metrics
                     }
             }
 
-            // There is a race with SnapShot:
-            // Update updates value
-            // SnapShot snapshots the value
-            // SnapShot sets status to NoCollectPending
-            // Update sets status to CollectPending -- this is not right as the SnapShot
+            // There is a race with Snapshot:
+            // Update() updates the value
+            // Snapshot snapshots the value
+            // Snapshot sets status to NoCollectPending
+            // Update sets status to CollectPending -- this is not right as the Snapshot
             // already included the updated value.
-            // In the absence of any new Update call until next SnapShot,
+            // In the absence of any new Update call until next Snapshot,
             // this results in exporting an Update even though
             // it had no update.
+            // TODO: For Delta, this can be mitigated
+            // by ignoring Zero points
             this.MetricPointStatus = MetricPointStatus.CollectPending;
         }
 

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -46,6 +46,7 @@ namespace OpenTelemetry.Metrics
             this.DoubleValue = default;
             this.doubleVal = default;
             this.lastDoubleSum = default;
+            this.MetricPointStatus = MetricPointStatus.NoCollectPending;
 
             if (this.AggType == AggregationType.Histogram)
             {
@@ -86,6 +87,8 @@ namespace OpenTelemetry.Metrics
 
         public double[] ExplicitBounds { get; internal set; }
 
+        internal MetricPointStatus MetricPointStatus { get; private set; }
+
         private readonly AggregationType AggType { get; }
 
         internal void Update(long number)
@@ -117,6 +120,17 @@ namespace OpenTelemetry.Metrics
                         break;
                     }
             }
+
+            // There is a race with SnapShot:
+            // Update updates value
+            // SnapShot snapshots the value
+            // SnapShot sets status to NoCollectPending
+            // Update sets status to CollectPending -- this is not right as the SnapShot
+            // already included the updated value.
+            // In the absence of any new Update call until next SnapShot,
+            // this results in exporting an Update even though
+            // it had no update.
+            this.MetricPointStatus = MetricPointStatus.CollectPending;
         }
 
         internal void Update(double number)
@@ -180,6 +194,17 @@ namespace OpenTelemetry.Metrics
                         break;
                     }
             }
+
+            // There is a race with SnapShot:
+            // Update updates value
+            // SnapShot snapshots the value
+            // SnapShot sets status to NoCollectPending
+            // Update sets status to CollectPending -- this is not right as the SnapShot
+            // already included the updated value.
+            // In the absence of any new Update call until next SnapShot,
+            // this results in exporting an Update even though
+            // it had no update.
+            this.MetricPointStatus = MetricPointStatus.CollectPending;
         }
 
         internal void TakeSnapShot(bool outputDelta)
@@ -194,6 +219,14 @@ namespace OpenTelemetry.Metrics
                             long initValue = Interlocked.Read(ref this.longVal);
                             this.LongValue = initValue - this.lastLongSum;
                             this.lastLongSum = initValue;
+                            this.MetricPointStatus = MetricPointStatus.NoCollectPending;
+
+                            // Check again if value got updated, if yes reset status.
+                            // This ensures no Updates get Lost.
+                            if (initValue != Interlocked.Read(ref this.longVal))
+                            {
+                                this.MetricPointStatus = MetricPointStatus.CollectPending;
+                            }
                         }
                         else
                         {
@@ -216,6 +249,14 @@ namespace OpenTelemetry.Metrics
                             double initValue = Interlocked.CompareExchange(ref this.doubleVal, 0.0, double.NegativeInfinity);
                             this.DoubleValue = initValue - this.lastDoubleSum;
                             this.lastDoubleSum = initValue;
+                            this.MetricPointStatus = MetricPointStatus.NoCollectPending;
+
+                            // Check again if value got updated, if yes reset status.
+                            // This ensures no Updates get Lost.
+                            if (initValue != Interlocked.CompareExchange(ref this.doubleVal, 0.0, double.NegativeInfinity))
+                            {
+                                this.MetricPointStatus = MetricPointStatus.CollectPending;
+                            }
                         }
                         else
                         {
@@ -233,6 +274,15 @@ namespace OpenTelemetry.Metrics
                 case AggregationType.LongGauge:
                     {
                         this.LongValue = Interlocked.Read(ref this.longVal);
+                        this.MetricPointStatus = MetricPointStatus.NoCollectPending;
+
+                        // Check again if value got updated, if yes reset status.
+                        // This ensures no Updates get Lost.
+                        if (this.LongValue != Interlocked.Read(ref this.longVal))
+                        {
+                            this.MetricPointStatus = MetricPointStatus.CollectPending;
+                        }
+
                         break;
                     }
 
@@ -244,6 +294,15 @@ namespace OpenTelemetry.Metrics
                         // the exchange (to 0.0) will never occur,
                         // but we get the original value atomically.
                         this.DoubleValue = Interlocked.CompareExchange(ref this.doubleVal, 0.0, double.NegativeInfinity);
+                        this.MetricPointStatus = MetricPointStatus.NoCollectPending;
+
+                        // Check again if value got updated, if yes reset status.
+                        // This ensures no Updates get Lost.
+                        if (this.DoubleValue != Interlocked.CompareExchange(ref this.doubleVal, 0.0, double.NegativeInfinity))
+                        {
+                            this.MetricPointStatus = MetricPointStatus.CollectPending;
+                        }
+
                         break;
                     }
 
@@ -267,6 +326,8 @@ namespace OpenTelemetry.Metrics
                                     this.bucketCounts[i] = 0;
                                 }
                             }
+
+                            this.MetricPointStatus = MetricPointStatus.NoCollectPending;
                         }
 
                         break;
@@ -283,6 +344,8 @@ namespace OpenTelemetry.Metrics
                                 this.longVal = 0;
                                 this.doubleVal = 0;
                             }
+
+                            this.MetricPointStatus = MetricPointStatus.NoCollectPending;
                         }
 
                         break;

--- a/src/OpenTelemetry/Metrics/MetricPointStatus.cs
+++ b/src/OpenTelemetry/Metrics/MetricPointStatus.cs
@@ -1,0 +1,33 @@
+// <copyright file="MetricPointStatus.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Metrics
+{
+    internal enum MetricPointStatus
+    {
+        /// <summary>
+        /// This status is applied to <see cref="MetricPoint"/>s with status <see cref="CollectPending"/> after a Collect.
+        /// If an update occurs, status will be moved to <see cref="CollectPending"/>.
+        /// </summary>
+        NoCollectPending,
+
+        /// <summary>
+        /// The <see cref="MetricPoint"/> has been updated since the previous Collect cycle.
+        /// Collect will move it to <see cref="NoCollectPending"/>.
+        /// </summary>
+        CollectPending,
+    }
+}

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.netcore31.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.netcore31.cs
@@ -180,14 +180,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
             }
             else
             {
-                Assert.Single(requestMetrics);
-                var metricPoints = new List<MetricPoint>();
-                foreach (var p in requestMetrics[0].GetMetricPoints())
-                {
-                    metricPoints.Add(p);
-                }
-
-                Assert.Empty(metricPoints);
+                Assert.Empty(requestMetrics);
             }
         }
 

--- a/test/OpenTelemetry.Tests/Metrics/MemoryEfficiencyTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MemoryEfficiencyTests.cs
@@ -24,7 +24,7 @@ namespace OpenTelemetry.Metrics.Tests
 {
     public class MemoryEfficiencyTests
     {
-        [Theory(Skip = "To be run after https://github.com/open-telemetry/opentelemetry-dotnet/issues/2524 is fixed")]
+        [Theory]
         [InlineData(AggregationTemporality.Cumulative)]
         [InlineData(AggregationTemporality.Delta)]
         public void ExportOnlyWhenPointChanged(AggregationTemporality temporality)
@@ -50,7 +50,14 @@ namespace OpenTelemetry.Metrics.Tests
 
             exportedItems.Clear();
             meterProvider.ForceFlush();
-            Assert.Empty(exportedItems);
+            if (temporality == AggregationTemporality.Cumulative)
+            {
+                Assert.Single(exportedItems);
+            }
+            else
+            {
+                Assert.Empty(exportedItems);
+            }
         }
     }
 }


### PR DESCRIPTION
Towards #2524 .
For delta, this only exports a point, if there is an update since last collection.
For cumulative, retains same behavior as before - once a point is updated, it'll be exported forever with same value. 

This PR *does not* reclaim an inactive point for using when we are running out of metric points.

Perf impact:

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19043.1288 (21H1/May2021Update)
Intel Xeon CPU E5-1650 v4 3.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET SDK=6.0.100
  [Host]     : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT
  DefaultJob : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT

Before:

|                    Method | AggregationTemporality |        Mean |     Error |    StdDev | Allocated |
|-------------------------- |----------------------- |------------:|----------:|----------:|----------:|
|            CounterHotPath |             Cumulative |    21.75 ns |  0.363 ns |  0.339 ns |         - |
| CounterWith1LabelsHotPath |             Cumulative |   100.80 ns |  1.198 ns |  1.120 ns |         - |
| CounterWith3LabelsHotPath |             Cumulative |   493.94 ns |  9.660 ns | 11.125 ns |         - |
| CounterWith5LabelsHotPath |             Cumulative |   743.28 ns | 12.839 ns | 20.363 ns |         - |
| CounterWith6LabelsHotPath |             Cumulative |   896.90 ns | 14.747 ns | 11.513 ns |         - |
| CounterWith7LabelsHotPath |             Cumulative | 1,010.37 ns | 18.028 ns | 15.054 ns |         - |
|            CounterHotPath |                  Delta |    19.32 ns |  0.170 ns |  0.133 ns |         - |
| CounterWith1LabelsHotPath |                  Delta |   102.44 ns |  0.920 ns |  0.768 ns |         - |
| CounterWith3LabelsHotPath |                  Delta |   500.14 ns |  9.894 ns | 11.778 ns |         - |
| CounterWith5LabelsHotPath |                  Delta |   751.90 ns | 11.629 ns | 11.942 ns |         - |
| CounterWith6LabelsHotPath |                  Delta |   870.99 ns | 16.727 ns | 17.897 ns |         - |
| CounterWith7LabelsHotPath |                  Delta |   995.99 ns | 18.730 ns | 23.003 ns |         - |

With this PR:

|                    Method | AggregationTemporality |        Mean |     Error |    StdDev | Allocated |
|-------------------------- |----------------------- |------------:|----------:|----------:|----------:|
|            CounterHotPath |             Cumulative |    20.44 ns |  0.395 ns |  0.422 ns |         - |
| CounterWith1LabelsHotPath |             Cumulative |   102.18 ns |  1.442 ns |  1.349 ns |         - |
| CounterWith3LabelsHotPath |             Cumulative |   515.90 ns |  9.947 ns |  9.305 ns |         - |
| CounterWith5LabelsHotPath |             Cumulative |   760.88 ns | 14.142 ns | 12.536 ns |         - |
| CounterWith6LabelsHotPath |             Cumulative |   891.03 ns | 10.911 ns |  9.111 ns |         - |
| CounterWith7LabelsHotPath |             Cumulative | 1,044.78 ns |  9.312 ns |  8.711 ns |         - |
|            CounterHotPath |                  Delta |    19.89 ns |  0.344 ns |  0.354 ns |         - |
| CounterWith1LabelsHotPath |                  Delta |   102.00 ns |  0.646 ns |  0.573 ns |         - |
| CounterWith3LabelsHotPath |                  Delta |   481.05 ns |  8.155 ns |  7.230 ns |         - |
| CounterWith5LabelsHotPath |                  Delta |   759.45 ns | 11.807 ns | 11.044 ns |         - |
| CounterWith6LabelsHotPath |                  Delta |   881.06 ns | 11.320 ns | 10.035 ns |         - |
| CounterWith7LabelsHotPath |                  Delta | 1,037.07 ns | 20.667 ns | 26.873 ns |         - |

(there is room for optimization to avoid the Delta vs Cumulative check on every Collect, as temporality is fixed at ctor itself. Good candidate for a small follow up PR)

Stress test:
Main:
Running (concurrency = 8), press <Esc> to stop...
Stopping the stress test...
* Total Loops: 216,780,099
* Average Loops/Second: 7,037,858
* Average CPU Cycles/Loop: 3,953

With this PR:
Stopping the stress test...
* Total Loops: 204,110,887
* Average Loops/Second: 6,808,235
* Average CPU Cycles/Loop: 3,942