### PR TITLE
Fix metric export interval to match spec

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterOptions.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System.Threading;
 using OpenTelemetry.Metrics;
 
 namespace OpenTelemetry.Exporter

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterOptions.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System.Threading;
 using OpenTelemetry.Metrics;
 
 namespace OpenTelemetry.Exporter
@@ -26,9 +27,9 @@ namespace OpenTelemetry.Exporter
         public ConsoleExporterOutputTargets Targets { get; set; } = ConsoleExporterOutputTargets.Console;
 
         /// <summary>
-        /// Gets or sets the metric export interval in milliseconds. The default value is 60000.
+        /// Gets or sets the metric export interval in milliseconds. The default value is <c>Timeout.Infinite</c>.
         /// </summary>
-        public int MetricExportIntervalMilliseconds { get; set; } = 60000;
+        public int MetricExportIntervalMilliseconds { get; set; } = Timeout.Infinite;
 
         /// <summary>
         /// Gets or sets the AggregationTemporality used for Histogram

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterOptions.cs
@@ -27,9 +27,9 @@ namespace OpenTelemetry.Exporter
         public ConsoleExporterOutputTargets Targets { get; set; } = ConsoleExporterOutputTargets.Console;
 
         /// <summary>
-        /// Gets or sets the metric export interval in milliseconds. The default value is <c>Timeout.Infinite</c>.
+        /// Gets or sets the metric export interval in milliseconds. The default value is 60000.
         /// </summary>
-        public int MetricExportIntervalMilliseconds { get; set; } = Timeout.Infinite;
+        public int MetricExportIntervalMilliseconds { get; set; } = 60000;
 
         /// <summary>
         /// Gets or sets the AggregationTemporality used for Histogram

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Changed `OtlpExporterOptions` constructor to throw
   `FormatException` if it fails to parse any of the supported environment
   variables.
+  
+* Changed `OtlpExporterOptions.MetricExportIntervalMilliseconds` to default
+  60000 milliseconds.
+  ([#2641](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2641))
 
 ## 1.2.0-beta1
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Changed `OtlpExporterOptions` constructor to throw
   `FormatException` if it fails to parse any of the supported environment
   variables.
-  
+
 * Changed `OtlpExporterOptions.MetricExportIntervalMilliseconds` to default
   60000 milliseconds.
   ([#2641](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2641))

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -109,9 +109,9 @@ namespace OpenTelemetry.Exporter
         public BatchExportProcessorOptions<Activity> BatchExportProcessorOptions { get; set; } = new BatchExportActivityProcessorOptions();
 
         /// <summary>
-        /// Gets or sets the metric export interval in milliseconds. The default value is 1000 milliseconds.
+        /// Gets or sets the metric export interval in milliseconds. The default value is 60000.
         /// </summary>
-        public int MetricExportIntervalMilliseconds { get; set; } = 1000;
+        public int MetricExportIntervalMilliseconds { get; set; } = 60000;
 
         /// <summary>
         /// Gets or sets the AggregationTemporality used for Histogram


### PR DESCRIPTION
The spec says export interval should be 60000 milliseconds and this pr fixes this for the otlp metric exporter. 

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
