### PR TITLE
Stress test modified to have a reader to force sdk to do aggregation

### DIFF
--- a/test/OpenTelemetry.Tests.Stress.Metrics/OpenTelemetry.Tests.Stress.Metrics.csproj
+++ b/test/OpenTelemetry.Tests.Stress.Metrics/OpenTelemetry.Tests.Stress.Metrics.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests.Stress\Skeleton.cs" />
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry\OpenTelemetry.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.InMemory\OpenTelemetry.Exporter.InMemory.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Tests.Stress.Metrics/Program.cs
+++ b/test/OpenTelemetry.Tests.Stress.Metrics/Program.cs
@@ -15,15 +15,14 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using OpenTelemetry;
+using OpenTelemetry.Exporter;
 using OpenTelemetry.Metrics;
-using OpenTelemetry.Tests;
 
 namespace OpenTelemetry.Tests.Stress;
-
 public partial class Program
 {
     private const int ArraySize = 10;
@@ -39,8 +38,12 @@ public partial class Program
             DimensionValues[i] = $"DimValue{i}";
         }
 
+        var exportedItems = new List<Metric>();
+        var reader = new BaseExportingMetricReader(new InMemoryExporter<Metric>(exportedItems));
+
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
             .AddMeter(TestMeter.Name)
+            .AddReader(reader)
             .Build();
         Stress();
     }


### PR DESCRIPTION
Without adding a reader, we'll assume @utpilla did unbelievable magic in https://github.com/open-telemetry/opentelemetry-dotnet/pull/2596 and improved throughput from 7 M/sec to 70 M/sec. 😆 