### PR TITLE
Remove View public API to change aggregation as it is not supported

### DIFF
--- a/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -2,12 +2,6 @@ abstract OpenTelemetry.Metrics.MetricReader.ProcessMetrics(in OpenTelemetry.Batc
 OpenTelemetry.BaseExporter<T>.ForceFlush(int timeoutMilliseconds = -1) -> bool
 OpenTelemetry.Batch<T>.Batch(T[] items, int count) -> void
 OpenTelemetry.Batch<T>.Count.get -> long
-OpenTelemetry.Metrics.Aggregation
-OpenTelemetry.Metrics.Aggregation.Default = 0 -> OpenTelemetry.Metrics.Aggregation
-OpenTelemetry.Metrics.Aggregation.Drop = 1 -> OpenTelemetry.Metrics.Aggregation
-OpenTelemetry.Metrics.Aggregation.Histogram = 4 -> OpenTelemetry.Metrics.Aggregation
-OpenTelemetry.Metrics.Aggregation.LastValue = 3 -> OpenTelemetry.Metrics.Aggregation
-OpenTelemetry.Metrics.Aggregation.Sum = 2 -> OpenTelemetry.Metrics.Aggregation
 OpenTelemetry.Metrics.AggregationTemporality
 OpenTelemetry.Metrics.AggregationTemporality.Cumulative = 1 -> OpenTelemetry.Metrics.AggregationTemporality
 OpenTelemetry.Metrics.AggregationTemporality.Delta = 2 -> OpenTelemetry.Metrics.AggregationTemporality
@@ -107,8 +101,6 @@ override OpenTelemetry.Metrics.BaseExportingMetricReader.Dispose(bool disposing)
 override OpenTelemetry.Metrics.BaseExportingMetricReader.OnCollect(int timeoutMilliseconds) -> bool
 override OpenTelemetry.Metrics.BaseExportingMetricReader.OnShutdown(int timeoutMilliseconds) -> bool
 override OpenTelemetry.Metrics.BaseExportingMetricReader.ProcessMetrics(in OpenTelemetry.Batch<OpenTelemetry.Metrics.Metric> metrics, int timeoutMilliseconds) -> bool
-override OpenTelemetry.Metrics.ExplicitBucketHistogramConfiguration.Aggregation.get -> OpenTelemetry.Metrics.Aggregation
-override OpenTelemetry.Metrics.ExplicitBucketHistogramConfiguration.Aggregation.set -> void
 override OpenTelemetry.Metrics.MeterProviderBuilderBase.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation> instrumentationFactory) -> OpenTelemetry.Metrics.MeterProviderBuilder
 override OpenTelemetry.Metrics.MeterProviderBuilderBase.AddMeter(params string[] names) -> OpenTelemetry.Metrics.MeterProviderBuilder
 override OpenTelemetry.Metrics.PeriodicExportingMetricReader.Dispose(bool disposing) -> void
@@ -136,5 +128,3 @@ virtual OpenTelemetry.BaseExporter<T>.OnForceFlush(int timeoutMilliseconds) -> b
 virtual OpenTelemetry.Metrics.MetricReader.Dispose(bool disposing) -> void
 virtual OpenTelemetry.Metrics.MetricReader.OnCollect(int timeoutMilliseconds) -> bool
 virtual OpenTelemetry.Metrics.MetricReader.OnShutdown(int timeoutMilliseconds) -> bool
-virtual OpenTelemetry.Metrics.MetricStreamConfiguration.Aggregation.get -> OpenTelemetry.Metrics.Aggregation
-virtual OpenTelemetry.Metrics.MetricStreamConfiguration.Aggregation.set -> void

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -2,12 +2,6 @@ abstract OpenTelemetry.Metrics.MetricReader.ProcessMetrics(in OpenTelemetry.Batc
 OpenTelemetry.BaseExporter<T>.ForceFlush(int timeoutMilliseconds = -1) -> bool
 OpenTelemetry.Batch<T>.Batch(T[] items, int count) -> void
 OpenTelemetry.Batch<T>.Count.get -> long
-OpenTelemetry.Metrics.Aggregation
-OpenTelemetry.Metrics.Aggregation.Default = 0 -> OpenTelemetry.Metrics.Aggregation
-OpenTelemetry.Metrics.Aggregation.Drop = 1 -> OpenTelemetry.Metrics.Aggregation
-OpenTelemetry.Metrics.Aggregation.Histogram = 4 -> OpenTelemetry.Metrics.Aggregation
-OpenTelemetry.Metrics.Aggregation.LastValue = 3 -> OpenTelemetry.Metrics.Aggregation
-OpenTelemetry.Metrics.Aggregation.Sum = 2 -> OpenTelemetry.Metrics.Aggregation
 OpenTelemetry.Metrics.AggregationTemporality
 OpenTelemetry.Metrics.AggregationTemporality.Cumulative = 1 -> OpenTelemetry.Metrics.AggregationTemporality
 OpenTelemetry.Metrics.AggregationTemporality.Delta = 2 -> OpenTelemetry.Metrics.AggregationTemporality
@@ -107,8 +101,6 @@ override OpenTelemetry.Metrics.BaseExportingMetricReader.Dispose(bool disposing)
 override OpenTelemetry.Metrics.BaseExportingMetricReader.OnCollect(int timeoutMilliseconds) -> bool
 override OpenTelemetry.Metrics.BaseExportingMetricReader.OnShutdown(int timeoutMilliseconds) -> bool
 override OpenTelemetry.Metrics.BaseExportingMetricReader.ProcessMetrics(in OpenTelemetry.Batch<OpenTelemetry.Metrics.Metric> metrics, int timeoutMilliseconds) -> bool
-override OpenTelemetry.Metrics.ExplicitBucketHistogramConfiguration.Aggregation.get -> OpenTelemetry.Metrics.Aggregation
-override OpenTelemetry.Metrics.ExplicitBucketHistogramConfiguration.Aggregation.set -> void
 override OpenTelemetry.Metrics.MeterProviderBuilderBase.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation> instrumentationFactory) -> OpenTelemetry.Metrics.MeterProviderBuilder
 override OpenTelemetry.Metrics.MeterProviderBuilderBase.AddMeter(params string[] names) -> OpenTelemetry.Metrics.MeterProviderBuilder
 override OpenTelemetry.Metrics.PeriodicExportingMetricReader.Dispose(bool disposing) -> void
@@ -136,5 +128,3 @@ virtual OpenTelemetry.BaseExporter<T>.OnForceFlush(int timeoutMilliseconds) -> b
 virtual OpenTelemetry.Metrics.MetricReader.Dispose(bool disposing) -> void
 virtual OpenTelemetry.Metrics.MetricReader.OnCollect(int timeoutMilliseconds) -> bool
 virtual OpenTelemetry.Metrics.MetricReader.OnShutdown(int timeoutMilliseconds) -> bool
-virtual OpenTelemetry.Metrics.MetricStreamConfiguration.Aggregation.get -> OpenTelemetry.Metrics.Aggregation
-virtual OpenTelemetry.Metrics.MetricStreamConfiguration.Aggregation.set -> void

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -6,6 +6,10 @@
   `Keys`+`Values`
   ([#2642](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2642))
 
+* Remove MetricStreamConfiguration.Aggregation, as the feature to customize
+aggregation is not implemented yet.
+([#2660](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2660))
+
 ## 1.2.0-beta2
 
 Released 2021-Nov-19

--- a/src/OpenTelemetry/Metrics/ExplicitBucketHistogramConfiguration.cs
+++ b/src/OpenTelemetry/Metrics/ExplicitBucketHistogramConfiguration.cs
@@ -20,8 +20,6 @@ namespace OpenTelemetry.Metrics
 {
     public class ExplicitBucketHistogramConfiguration : MetricStreamConfiguration
     {
-        private Aggregation aggregation = Aggregation.Histogram;
-
         /// <summary>
         /// Gets or sets the values representing explicit histogram bucket
         /// boundary values.

--- a/src/OpenTelemetry/Metrics/ExplicitBucketHistogramConfiguration.cs
+++ b/src/OpenTelemetry/Metrics/ExplicitBucketHistogramConfiguration.cs
@@ -30,20 +30,5 @@ namespace OpenTelemetry.Metrics
         /// The array must be in ascending order with distinct values.
         /// </remarks>
         public double[] Boundaries { get; set; }
-
-        public override Aggregation Aggregation
-        {
-            get => this.aggregation;
-
-            set
-            {
-                if (value != Aggregation.Histogram)
-                {
-                    throw new ArgumentException($"Aggregation must be Histogram.");
-                }
-
-                this.aggregation = value;
-            }
-        }
     }
 }

--- a/src/OpenTelemetry/Metrics/ExplicitBucketHistogramConfiguration.cs
+++ b/src/OpenTelemetry/Metrics/ExplicitBucketHistogramConfiguration.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-
 namespace OpenTelemetry.Metrics
 {
     public class ExplicitBucketHistogramConfiguration : MetricStreamConfiguration

--- a/src/OpenTelemetry/Metrics/MetricStreamConfiguration.cs
+++ b/src/OpenTelemetry/Metrics/MetricStreamConfiguration.cs
@@ -38,13 +38,13 @@ namespace OpenTelemetry.Metrics
 
         public string[] TagKeys { get; set; }
 
-        public virtual Aggregation Aggregation { get; set; }
+        internal virtual Aggregation Aggregation { get; set; }
 
         // TODO: MetricPoints caps can be configured here
 
         private sealed class DropConfiguration : MetricStreamConfiguration
         {
-            public override Aggregation Aggregation
+            internal override Aggregation Aggregation
             {
                 get => Aggregation.Drop;
                 set { }

--- a/src/OpenTelemetry/Metrics/MetricStreamConfiguration.cs
+++ b/src/OpenTelemetry/Metrics/MetricStreamConfiguration.cs
@@ -17,7 +17,7 @@
 namespace OpenTelemetry.Metrics
 {
     // TODO: can be optimized like MetricType
-    public enum Aggregation
+    internal enum Aggregation
     {
 #pragma warning disable SA1602 // Enumeration items should be documented
         Default,


### PR DESCRIPTION
As https://github.com/open-telemetry/opentelemetry-dotnet/issues/2618 is not implemented yet, hiding the feature from public API itself. An alternate option was to throw NotImplementedException, but adding new public fields is not breaking, so can be introduced when #2618 is added.