### PR TITLE
Clean up test cases by using consistent variable name

### DIFF
--- a/examples/Console/TestConsoleExporter.cs
+++ b/examples/Console/TestConsoleExporter.cs
@@ -37,7 +37,7 @@ namespace Examples.Console
         {
             // Enable OpenTelemetry for the sources "Samples.SampleServer" and "Samples.SampleClient"
             // and use Console exporter.
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                     .AddSource("Samples.SampleClient", "Samples.SampleServer")
                     .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("console-test"))
                     .AddProcessor(new MyProcessor()) // This must be added before ConsoleExporter

--- a/examples/Console/TestGrpcNetClient.cs
+++ b/examples/Console/TestGrpcNetClient.cs
@@ -41,7 +41,7 @@ namespace Examples.Console
             //
             // dotnet run grpc
 
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddGrpcClientInstrumentation()
                 .AddSource("grpc-net-client-test")
                 .AddConsoleExporter()

--- a/examples/Console/TestHttpClient.cs
+++ b/examples/Console/TestHttpClient.cs
@@ -32,7 +32,7 @@ namespace Examples.Console
         {
             System.Console.WriteLine("Hello World!");
 
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddHttpClientInstrumentation()
                 .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("http-service-example"))
                 .AddSource("http-client-test")

--- a/examples/Console/TestInMemoryExporter.cs
+++ b/examples/Console/TestInMemoryExporter.cs
@@ -49,7 +49,7 @@ namespace Examples.Console
         {
             // Enable OpenTelemetry for the sources "Samples.SampleServer" and "Samples.SampleClient"
             // and use InMemory exporter.
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                     .AddSource("Samples.SampleClient", "Samples.SampleServer")
                     .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("inmemory-test"))
                     .AddInMemoryExporter(exportedItems)

--- a/examples/Console/TestJaegerExporter.cs
+++ b/examples/Console/TestJaegerExporter.cs
@@ -55,7 +55,7 @@ namespace Examples.Console
         {
             // Enable OpenTelemetry for the sources "Samples.SampleServer" and "Samples.SampleClient"
             // and use the Jaeger exporter.
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                     .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("jaeger-test"))
                     .AddSource("Samples.SampleClient", "Samples.SampleServer")
                     .AddJaegerExporter(o =>

--- a/examples/Console/TestOpenTracingShim.cs
+++ b/examples/Console/TestOpenTracingShim.cs
@@ -29,7 +29,7 @@ namespace Examples.Console
         {
             // Enable OpenTelemetry for the source "MyCompany.MyProduct.MyWebServer"
             // and use Console exporter.
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                     .AddSource("MyCompany.MyProduct.MyWebServer")
                     .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("MyServiceName"))
                     .AddConsoleExporter()

--- a/examples/Console/TestOtlpExporter.cs
+++ b/examples/Console/TestOtlpExporter.cs
@@ -69,7 +69,7 @@ namespace Examples.Console
 
             // Enable OpenTelemetry for the sources "Samples.SampleServer" and "Samples.SampleClient"
             // and use OTLP exporter.
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                     .AddSource("Samples.SampleClient", "Samples.SampleServer")
                     .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("otlp-test"))
                     .AddOtlpExporter(opt =>

--- a/examples/Console/TestRedis.cs
+++ b/examples/Console/TestRedis.cs
@@ -42,7 +42,7 @@ namespace Examples.Console
             var connection = ConnectionMultiplexer.Connect("localhost");
 
             // Configure exporter to export traces to Zipkin
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                     .AddZipkinExporter(o =>
                     {
                         o.Endpoint = new Uri(zipkinUri);

--- a/examples/Console/TestZPagesExporter.cs
+++ b/examples/Console/TestZPagesExporter.cs
@@ -33,7 +33,7 @@ namespace Examples.Console
             // Start the server
             httpServer.Start();
 
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                     .AddSource("zpages-test")
                     .AddZPagesExporter(o =>
                     {

--- a/examples/Console/TestZipkinExporter.cs
+++ b/examples/Console/TestZipkinExporter.cs
@@ -37,7 +37,7 @@ namespace Examples.Console
 
             // Enable OpenTelemetry for the sources "Samples.SampleServer" and "Samples.SampleClient"
             // and use the Zipkin exporter.
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                     .AddSource("Samples.SampleClient", "Samples.SampleServer")
                     .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("zipkin-test"))
                     .AddZipkinExporter(o =>

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
@@ -324,7 +324,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
                     endCalled = true;
                 };
 
-            var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+            var tracerProvider = Sdk.CreateTracerProviderBuilder()
                             .AddSource(ActivitySourceName)
                             .AddProcessor(testActivityProcessor)
                             .AddOtlpExporter()

--- a/test/OpenTelemetry.Exporter.ZPages.Tests/ZPagesExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.ZPages.Tests/ZPagesExporterTests.cs
@@ -75,7 +75,7 @@ namespace OpenTelemetry.Exporter.ZPages.Tests
                     endCalled = true;
                 };
 
-            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .AddProcessor(testActivityProcessor)
                 .AddZPagesExporter()

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
@@ -112,7 +112,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Tests
             var zipkinExporter = new ZipkinExporter(exporterOptions);
             var exportActivityProcessor = new BatchActivityExportProcessor(zipkinExporter);
 
-            var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+            var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .AddProcessor(testActivityProcessor)
                 .AddProcessor(exportActivityProcessor)

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -58,7 +58,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
             string filter = null,
             bool recordException = false)
         {
-            IDisposable openTelemetry = null;
+            IDisposable tracerProvider = null;
             RouteData routeData;
             switch (routeType)
             {

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -118,7 +118,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
             List<Activity> exportedItems = new List<Activity>(16);
 
             Sdk.SetDefaultTextMapPropagator(new TraceContextPropagator());
-            using (openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using (tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddAspNetInstrumentation((options) =>
                 {
                     options.Filter = httpContext =>
@@ -275,7 +275,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
             Sdk.SetDefaultTextMapPropagator(propagator.Object);
-            using (var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .SetSampler(new TestSampler(samplingDecision))
                 .AddAspNetInstrumentation()
                 .AddProcessor(activityProcessor.Object).Build())
@@ -312,7 +312,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
             bool isFilterCalled = false;
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
             Sdk.SetDefaultTextMapPropagator(propagator.Object);
-            using (var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddAspNetInstrumentation(options =>
                 {
                     options.Filter = context =>

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
@@ -50,7 +50,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
         : IClassFixture<WebApplicationFactory<Startup>>, IDisposable
     {
         private readonly WebApplicationFactory<Startup> factory;
-        private TracerProvider openTelemetrySdk = null;
+        private TracerProvider tracerProvider = null;
 
         public BasicTests(WebApplicationFactory<Startup> factory)
         {
@@ -70,7 +70,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
             void ConfigureTestServices(IServiceCollection services)
             {
-                this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+                this.tracerProvider = Sdk.CreateTracerProviderBuilder()
                     .AddAspNetCoreInstrumentation()
                     .AddProcessor(activityProcessor.Object)
                     .Build();
@@ -114,7 +114,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             activityProcessor.Setup(x => x.OnStart(It.IsAny<Activity>())).Callback<Activity>(c => c.SetTag("enriched", "no"));
             void ConfigureTestServices(IServiceCollection services)
             {
-                this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+                this.tracerProvider = Sdk.CreateTracerProviderBuilder()
                     .AddAspNetCoreInstrumentation(options =>
                     {
                         if (shouldEnrich)
@@ -163,7 +163,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
                 .WithWebHostBuilder(builder =>
                     builder.ConfigureTestServices(services =>
                     {
-                        this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder().AddAspNetCoreInstrumentation()
+                        this.tracerProvider = Sdk.CreateTracerProviderBuilder().AddAspNetCoreInstrumentation()
                         .AddProcessor(activityProcessor.Object)
                         .Build();
                     })))
@@ -225,7 +225,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
                         builder.ConfigureTestServices(services =>
                         {
                             Sdk.SetDefaultTextMapPropagator(propagator.Object);
-                            this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+                            this.tracerProvider = Sdk.CreateTracerProviderBuilder()
                                 .AddAspNetCoreInstrumentation()
                                 .AddProcessor(activityProcessor.Object)
                                 .Build();
@@ -286,7 +286,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
 
             void ConfigureTestServices(IServiceCollection services)
             {
-                this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+                this.tracerProvider = Sdk.CreateTracerProviderBuilder()
                     .AddAspNetCoreInstrumentation((opt) => opt.Filter = (ctx) => ctx.Request.Path != "/api/values/2")
                     .AddProcessor(activityProcessor.Object)
                     .Build();
@@ -330,7 +330,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
 
             void ConfigureTestServices(IServiceCollection services)
             {
-                this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+                this.tracerProvider = Sdk.CreateTracerProviderBuilder()
                     .AddAspNetCoreInstrumentation((opt) => opt.Filter = (ctx) =>
                     {
                         if (ctx.Request.Path == "/api/values/2")
@@ -403,7 +403,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
                     .WithWebHostBuilder(builder =>
                         builder.ConfigureTestServices(services =>
                         {
-                            this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+                            this.tracerProvider = Sdk.CreateTracerProviderBuilder()
                             .SetSampler(new TestSampler(samplingDecision))
                             .AddAspNetCoreInstrumentation()
                             .Build();
@@ -462,7 +462,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
                     .WithWebHostBuilder(builder =>
                         builder.ConfigureTestServices(services =>
                         {
-                            this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+                            this.tracerProvider = Sdk.CreateTracerProviderBuilder()
                             .AddAspNetCoreInstrumentation(options =>
                             {
                                 options.Filter = context =>
@@ -522,7 +522,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
 
             void ConfigureTestServices(IServiceCollection services)
             {
-                this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+                this.tracerProvider = Sdk.CreateTracerProviderBuilder()
                     .AddAspNetCoreInstrumentation(new AspNetCoreInstrumentation(
                         new TestHttpInListener(new AspNetCoreInstrumentationOptions())
                         {
@@ -572,7 +572,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             bool enrichCalled = false;
             void ConfigureTestServices(IServiceCollection services)
             {
-                this.openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+                this.tracerProvider = Sdk.CreateTracerProviderBuilder()
                     .SetSampler(new TestSampler(samplingDecision))
                     .AddAspNetCoreInstrumentation(options =>
                     {
@@ -605,7 +605,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
 
         public void Dispose()
         {
-            this.openTelemetrySdk?.Dispose();
+            this.tracerProvider?.Dispose();
         }
 
         private static void WaitForProcessorInvocations(Mock<BaseProcessor<Activity>> activityProcessor, int invocationCount)

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.Basic.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.Basic.netfx.cs
@@ -61,7 +61,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         public async Task HttpWebRequestInstrumentationInjectsHeadersAsync()
         {
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpClientInstrumentation()
                 .Build();
@@ -108,7 +108,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
                 });
 
             Sdk.SetDefaultTextMapPropagator(propagator.Object);
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpClientInstrumentation()
                 .Build();
@@ -155,7 +155,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
             Sdk.SetDefaultTextMapPropagator(propagator.Object);
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpClientInstrumentation()
                 .Build();
@@ -199,7 +199,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         public async Task HttpWebRequestInstrumentationBacksOffIfAlreadyInstrumented()
         {
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpClientInstrumentation()
                 .Build();
@@ -222,7 +222,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         public async Task RequestNotCollectedWhenInstrumentationFilterApplied()
         {
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpClientInstrumentation(
                     c => c.Filter = (req) => !req.RequestUri.OriginalString.Contains(this.url))
@@ -238,7 +238,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         public async Task RequestNotCollectedWhenInstrumentationFilterThrowsException()
         {
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpClientInstrumentation(
                     c => c.Filter = (req) => throw new Exception("From Instrumentation filter"))
@@ -256,7 +256,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         public void AddHttpClientInstrumentationUsesHttpWebRequestInstrumentationOptions()
         {
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var tracerProviderSdk = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpClientInstrumentation(options =>
                 {
@@ -273,7 +273,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
             await client.GetAsync(this.url).ConfigureAwait(false);
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpClientInstrumentation()
                 .Build();

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.netfx.cs
@@ -46,7 +46,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
                 out var port);
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .AddHttpClientInstrumentation(options =>
                 {

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
@@ -84,7 +84,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
             activityProcessor.Setup(x => x.OnStart(It.IsAny<Activity>())).Callback<Activity>(c => c.SetTag("enriched", "no"));
             var sampler = new TestSampler();
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddProcessor(activityProcessor.Object)
                 .SetSampler(sampler)
                 .AddSqlClientInstrumentation(options =>

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToActivityConverterTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToActivityConverterTests.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Implementation
     public class RedisProfilerEntryToActivityConverterTests : IDisposable
     {
         private readonly ConnectionMultiplexer connection;
-        private readonly IDisposable sdk;
+        private readonly IDisposable tracerProvider;
 
         public RedisProfilerEntryToActivityConverterTests()
         {
@@ -42,14 +42,14 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Implementation
 
             this.connection = ConnectionMultiplexer.Connect(connectionOptions);
 
-            this.sdk = Sdk.CreateTracerProviderBuilder()
+            this.tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddRedisInstrumentation(this.connection)
                 .Build();
         }
 
         public void Dispose()
         {
-            this.sdk.Dispose();
+            this.tracerProvider.Dispose();
             this.connection.Dispose();
         }
 

--- a/test/OpenTelemetry.Tests/Trace/ActivityExtensionsTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ActivityExtensionsTest.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void SetStatus()
         {
-            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .Build();
 
@@ -45,7 +45,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void SetStatusWithDescription()
         {
-            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .Build();
 
@@ -62,7 +62,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void SetStatusWithDescriptionTwice()
         {
-            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .Build();
 
@@ -80,7 +80,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void SetStatusWithIgnoredDescription()
         {
-            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .Build();
 
@@ -97,7 +97,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void SetCancelledStatus()
         {
-            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .Build();
 
@@ -112,7 +112,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void GetStatusWithNoStatusInActivity()
         {
-            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .Build();
 
@@ -126,7 +126,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void LastSetStatusWins()
         {
-            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .Build();
 
@@ -260,7 +260,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void EnumerateLinksNonempty()
         {
-            using var openTelemetrySdk = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .Build();
 

--- a/test/OpenTelemetry.Tests/Trace/ExportProcessorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/ExportProcessorTest.cs
@@ -33,7 +33,7 @@ namespace OpenTelemetry.Trace.Tests
             var exportedItems = new List<Activity>();
             var processor = new TestActivityExportProcessor(new InMemoryExporter<Activity>(exportedItems));
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var sdk = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .SetSampler(sampler)
                 .AddProcessor(processor)
@@ -55,7 +55,7 @@ namespace OpenTelemetry.Trace.Tests
             var exportedItems = new List<Activity>();
             var processor = new TestActivityExportProcessor(new InMemoryExporter<Activity>(exportedItems));
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var sdk = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .SetSampler(sampler)
                 .AddProcessor(processor)
@@ -77,7 +77,7 @@ namespace OpenTelemetry.Trace.Tests
             var exportedItems = new List<Activity>();
             var processor = new TestActivityExportProcessor(new InMemoryExporter<Activity>(exportedItems));
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var sdk = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .SetSampler(sampler)
                 .AddProcessor(processor)

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
@@ -39,7 +39,7 @@ namespace OpenTelemetry.Trace.Tests
         {
             var testSampler = new TestSampler();
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var sdk = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .SetSampler(testSampler)
                 .Build();
@@ -123,7 +123,7 @@ namespace OpenTelemetry.Trace.Tests
             };
 
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var sdk = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource(ActivitySourceName)
                 .SetSampler(testSampler)
                 .Build();
@@ -144,7 +144,7 @@ namespace OpenTelemetry.Trace.Tests
         {
             var testSampler = new TestSampler();
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var sdk = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                     .AddSource(ActivitySourceName)
                     .SetSampler(testSampler)
                     .Build();
@@ -204,7 +204,7 @@ namespace OpenTelemetry.Trace.Tests
 
             var testSampler = new TestSampler();
             using var activitySource = new ActivitySource(ActivitySourceName);
-            using var sdk = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                     .AddSource(ActivitySourceName)
                     .SetSampler(testSampler)
                     .Build();

--- a/test/OpenTelemetry.Tests/Trace/TracerTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerTest.cs
@@ -60,7 +60,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void Tracer_StartRootSpan_BadArgs_NullSpanName()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -77,7 +77,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void Tracer_StartSpan_BadArgs_NullSpanName()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -94,7 +94,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void Tracer_StartActiveSpan_BadArgs_NullSpanName()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -111,7 +111,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void Tracer_StartSpan_FromParent_BadArgs_NullSpanName()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -125,7 +125,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void Tracer_StartSpan_FromParentContext_BadArgs_NullSpanName()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -141,7 +141,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void Tracer_StartActiveSpan_FromParent_BadArgs_NullSpanName()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -155,7 +155,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void Tracer_StartActiveSpan_FromParentContext_BadArgs_NullSpanName()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -171,7 +171,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void Tracer_StartActiveSpan_CreatesActiveSpan()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -195,7 +195,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void GetCurrentSpanBlank()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
             Assert.False(Tracer.CurrentSpan.Context.IsValid);
@@ -204,7 +204,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void GetCurrentSpanBlankWontThrowOnEnd()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
             var current = Tracer.CurrentSpan;
@@ -214,7 +214,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void GetCurrentSpan()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
 
@@ -228,7 +228,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void CreateSpan_Sampled()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .Build();
             var span = this.tracer.StartSpan("foo");
@@ -238,7 +238,7 @@ namespace OpenTelemetry.Trace.Tests
         [Fact]
         public void CreateSpan_NotSampled()
         {
-            using var openTelemetry = Sdk.CreateTracerProviderBuilder()
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource("tracername")
                 .SetSampler(new AlwaysOffSampler())
                 .Build();


### PR DESCRIPTION
I noticed this while working on #2671.

This PR only changes one thing - for all the test cases, if they use `Sdk.CreateTracerProviderBuilder()`, the corresponding local variable name should be `tracerProvider` rather than `sdk`, `openTelemetry`, `openTelemetrySdk` or `shutdownSignal` (curious - why did we have this name).