### PR TITLE
Metrics: MetricPointValueStorage explicit layout struct

### DIFF
--- a/src/OpenTelemetry/Metrics/HistogramBuckets.cs
+++ b/src/OpenTelemetry/Metrics/HistogramBuckets.cs
@@ -26,14 +26,6 @@ namespace OpenTelemetry.Metrics
 
         internal readonly object LockObject;
 
-        internal long CountVal;
-
-        internal long Count;
-
-        internal double SumVal;
-
-        internal double Sum;
-
         internal HistogramBuckets(double[] histogramBounds)
         {
             this.ExplicitBounds = histogramBounds;

--- a/src/OpenTelemetry/Metrics/MetricPointValueStorage.cs
+++ b/src/OpenTelemetry/Metrics/MetricPointValueStorage.cs
@@ -1,0 +1,36 @@
+// <copyright file="MetricPointValueStorage.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Runtime.InteropServices;
+
+namespace OpenTelemetry.Metrics
+{
+    [StructLayout(LayoutKind.Explicit)]
+    internal struct MetricPointValueStorage
+    {
+        [FieldOffset(0)]
+        public long CurrentAsLong;
+
+        [FieldOffset(0)]
+        public double CurrentAsDouble;
+
+        [FieldOffset(8)]
+        public long SnapshotAsLong;
+
+        [FieldOffset(8)]
+        public double SnapshotAsDouble;
+    }
+}


### PR DESCRIPTION
## Changes

Added `MetricPointValueStorage` to store the values needed by `MetricPoint`. `MetricPointValueStorage` is basically a union where the same bytes are used for either `long` or `double` modes.

## Details

Before we had 3 `long`s & 3 `double`s (48 bytes) for all `MetricPoints` and then an additional 16 bytes (`long Count` + `double Sum`) for histograms. This should give us a fixed 32 bytes for all types of `MetricPoints`.

I also tried to improve the clarity of the code by renaming things from "val"/"value" style to "current"/"snapshot" style.