### PR TITLE
Http Instrumentation: Fix gRPC causing issues retrieving request & response objects

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Fixed an issue with `Filter` and `Enrich` callbacks not firing under certain
+  conditions when gRPC is used
+  ([#2698](https://github.com/open-telemetry/opentelemetry-dotnet/issues/2698))
+
 ## 1.0.0-rc8
 
 Released 2021-Oct-08

--- a/test/OpenTelemetry.Tests/Instrumentation/PropertyFetcherTest.cs
+++ b/test/OpenTelemetry.Tests/Instrumentation/PropertyFetcherTest.cs
@@ -50,5 +50,35 @@ namespace OpenTelemetry.Instrumentation.Tests
             var fetch = new PropertyFetcher<string>("null");
             Assert.False(fetch.TryFetch(null, out _));
         }
+
+        [Fact]
+        public void FetchPropertyMultiplePayloadTypes()
+        {
+            var fetch = new PropertyFetcher<string>("Property");
+
+            Assert.True(fetch.TryFetch(new PayloadTypeA(), out string propertyValue));
+            Assert.Equal("A", propertyValue);
+
+            Assert.True(fetch.TryFetch(new PayloadTypeB(), out propertyValue));
+            Assert.Equal("B", propertyValue);
+
+            Assert.False(fetch.TryFetch(new PayloadTypeC(), out _));
+
+            Assert.False(fetch.TryFetch(null, out _));
+        }
+
+        private class PayloadTypeA
+        {
+            public string Property { get; set; } = "A";
+        }
+
+        private class PayloadTypeB
+        {
+            public string Property { get; set; } = "B";
+        }
+
+        private class PayloadTypeC
+        {
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-dotnet/issues/2652

## Changes

* If `PropertyFetcher` is given a different payload type than what was used during construction, it will now build an inner instance and defer to that. We could have also looked up the correct `PropertyFetcher` from some kind of dictionary (by payload type), but I went with this design to keep the common path (where only a single payload type is used) fast/lock-free.

## TODOs

* [X] `CHANGELOG.md` updated for non-trivial changes
* [X] Unit test
