### PR TITLE
Rename GetCounterSum to GetSum

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -140,7 +140,7 @@ namespace OpenTelemetry.Exporter
                     {
                         if (metricType.IsSum())
                         {
-                            valueDisplay = metricPoint.GetCounterSumDouble().ToString(CultureInfo.InvariantCulture);
+                            valueDisplay = metricPoint.GetSumDouble().ToString(CultureInfo.InvariantCulture);
                         }
                         else
                         {
@@ -151,7 +151,7 @@ namespace OpenTelemetry.Exporter
                     {
                         if (metricType.IsSum())
                         {
-                            valueDisplay = metricPoint.GetCounterSumLong().ToString(CultureInfo.InvariantCulture);
+                            valueDisplay = metricPoint.GetSumLong().ToString(CultureInfo.InvariantCulture);
                         }
                         else
                         {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/MetricItemExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/MetricItemExtensions.cs
@@ -158,7 +158,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
 
                             AddAttributes(metricPoint.Tags, dataPoint.Attributes);
 
-                            dataPoint.AsInt = metricPoint.GetCounterSumLong();
+                            dataPoint.AsInt = metricPoint.GetSumLong();
                             sum.DataPoints.Add(dataPoint);
                         }
 
@@ -182,7 +182,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
 
                             AddAttributes(metricPoint.Tags, dataPoint.Attributes);
 
-                            dataPoint.AsDouble = metricPoint.GetCounterSumDouble();
+                            dataPoint.AsDouble = metricPoint.GetSumDouble();
                             sum.DataPoints.Add(dataPoint);
                         }
 

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusSerializerExt.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusSerializerExt.cs
@@ -75,7 +75,7 @@ namespace OpenTelemetry.Exporter.Prometheus
                     {
                         if (metric.MetricType.IsSum())
                         {
-                            cursor = WriteLong(buffer, cursor, metricPoint.GetCounterSumLong());
+                            cursor = WriteLong(buffer, cursor, metricPoint.GetSumLong());
                         }
                         else
                         {
@@ -86,7 +86,7 @@ namespace OpenTelemetry.Exporter.Prometheus
                     {
                         if (metric.MetricType.IsSum())
                         {
-                            cursor = WriteDouble(buffer, cursor, metricPoint.GetCounterSumDouble());
+                            cursor = WriteDouble(buffer, cursor, metricPoint.GetSumDouble());
                         }
                         else
                         {

--- a/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -20,8 +20,8 @@ OpenTelemetry.Metrics.HistogramBuckets.Enumerator.Current.get -> OpenTelemetry.M
 OpenTelemetry.Metrics.HistogramBuckets.Enumerator.Enumerator() -> void
 OpenTelemetry.Metrics.HistogramBuckets.Enumerator.MoveNext() -> bool
 OpenTelemetry.Metrics.HistogramBuckets.GetEnumerator() -> OpenTelemetry.Metrics.HistogramBuckets.Enumerator
-OpenTelemetry.Metrics.MetricPoint.GetCounterSumDouble() -> double
-OpenTelemetry.Metrics.MetricPoint.GetCounterSumLong() -> long
+OpenTelemetry.Metrics.MetricPoint.GetSumDouble() -> double
+OpenTelemetry.Metrics.MetricPoint.GetSumLong() -> long
 OpenTelemetry.Metrics.MetricPoint.GetEndTime() -> System.DateTimeOffset
 OpenTelemetry.Metrics.MetricPoint.GetGaugeLastValueDouble() -> double
 OpenTelemetry.Metrics.MetricPoint.GetGaugeLastValueLong() -> long

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -20,8 +20,8 @@ OpenTelemetry.Metrics.HistogramBuckets.Enumerator.Current.get -> OpenTelemetry.M
 OpenTelemetry.Metrics.HistogramBuckets.Enumerator.Enumerator() -> void
 OpenTelemetry.Metrics.HistogramBuckets.Enumerator.MoveNext() -> bool
 OpenTelemetry.Metrics.HistogramBuckets.GetEnumerator() -> OpenTelemetry.Metrics.HistogramBuckets.Enumerator
-OpenTelemetry.Metrics.MetricPoint.GetCounterSumDouble() -> double
-OpenTelemetry.Metrics.MetricPoint.GetCounterSumLong() -> long
+OpenTelemetry.Metrics.MetricPoint.GetSumDouble() -> double
+OpenTelemetry.Metrics.MetricPoint.GetSumLong() -> long
 OpenTelemetry.Metrics.MetricPoint.GetEndTime() -> System.DateTimeOffset
 OpenTelemetry.Metrics.MetricPoint.GetGaugeLastValueDouble() -> double
 OpenTelemetry.Metrics.MetricPoint.GetGaugeLastValueLong() -> long

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -29,8 +29,8 @@
   ([#2666](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2666))
 
 * Removed the public properties `LongValue`, `DoubleValue`, `StartTime`, and
-  `EndTime` in favor of their counterpart public methods `GetCounterSumLong`,
-  `GetCounterSumDouble`, `GetGaugeLastValueLong`, `GetGaugeLastValueDouble`,
+  `EndTime` in favor of their counterpart public methods `GetSumLong`,
+  `GetSumDouble`, `GetGaugeLastValueLong`, `GetGaugeLastValueDouble`,
   `GetStartTime`, and `GetEndTime`.
   ([#2667](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2667))
 

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -76,7 +76,7 @@ namespace OpenTelemetry.Metrics
 
         public DateTimeOffset GetEndTime() => this.EndTime;
 
-        public long GetCounterSumLong()
+        public long GetSumLong()
         {
             if (this.aggType == AggregationType.LongSumIncomingDelta || this.aggType == AggregationType.LongSumIncomingCumulative)
             {
@@ -84,11 +84,11 @@ namespace OpenTelemetry.Metrics
             }
             else
             {
-                throw new NotSupportedException($"{nameof(this.GetCounterSumLong)} is not supported for this metric type.");
+                throw new NotSupportedException($"{nameof(this.GetSumLong)} is not supported for this metric type.");
             }
         }
 
-        public double GetCounterSumDouble()
+        public double GetSumDouble()
         {
             if (this.aggType == AggregationType.DoubleSumIncomingDelta || this.aggType == AggregationType.DoubleSumIncomingCumulative)
             {
@@ -96,7 +96,7 @@ namespace OpenTelemetry.Metrics
             }
             else
             {
-                throw new NotSupportedException($"{nameof(this.GetCounterSumDouble)} is not supported for this metric type.");
+                throw new NotSupportedException($"{nameof(this.GetSumDouble)} is not supported for this metric type.");
             }
         }
 

--- a/test/Benchmarks/Metrics/MetricCollectBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricCollectBenchmarks.cs
@@ -71,7 +71,7 @@ namespace Benchmarks.Metrics
                         // The performant way of iterating.
                         foreach (ref var metricPoint in metric.GetMetricPoints())
                         {
-                            sum += metricPoint.GetCounterSumDouble();
+                            sum += metricPoint.GetSumDouble();
                         }
                     }
                     else
@@ -80,7 +80,7 @@ namespace Benchmarks.Metrics
                         // This is still "correct", but less performant.
                         foreach (var metricPoint in metric.GetMetricPoints())
                         {
-                            sum += metricPoint.GetCounterSumDouble();
+                            sum += metricPoint.GetSumDouble();
                         }
                     }
                 }

--- a/test/OpenTelemetry.Tests/Metrics/InMemoryExporterTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/InMemoryExporterTests.cs
@@ -49,7 +49,7 @@ namespace OpenTelemetry.Metrics.Tests
             var metricPointsEnumerator = metric.GetMetricPoints().GetEnumerator();
             Assert.True(metricPointsEnumerator.MoveNext()); // One MetricPoint is emitted for the Metric
             ref var metricPointForFirstExport = ref metricPointsEnumerator.Current;
-            Assert.Equal(10, metricPointForFirstExport.GetCounterSumLong());
+            Assert.Equal(10, metricPointForFirstExport.GetSumLong());
 
             // Emit 25 for the MetricPoint with a single key-vaue pair: ("tag1", "value1")
             counter.Add(25, new KeyValuePair<string, object>("tag1", "value1"));
@@ -60,10 +60,10 @@ namespace OpenTelemetry.Metrics.Tests
             metricPointsEnumerator = metric.GetMetricPoints().GetEnumerator();
             Assert.True(metricPointsEnumerator.MoveNext()); // One MetricPoint is emitted for the Metric
             var metricPointForSecondExport = metricPointsEnumerator.Current;
-            Assert.Equal(25, metricPointForSecondExport.GetCounterSumLong());
+            Assert.Equal(25, metricPointForSecondExport.GetSumLong());
 
             // MetricPoint.LongValue for the first exporter metric should still be 10
-            Assert.Equal(10, metricPointForFirstExport.GetCounterSumLong());
+            Assert.Equal(10, metricPointForFirstExport.GetSumLong());
         }
     }
 }

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -700,7 +700,7 @@ namespace OpenTelemetry.Metrics.Tests
                 {
                     if (metric.MetricType.IsSum())
                     {
-                        sum += metricPoint.GetCounterSumLong();
+                        sum += metricPoint.GetSumLong();
                     }
                     else
                     {
@@ -721,7 +721,7 @@ namespace OpenTelemetry.Metrics.Tests
                 {
                     if (metric.MetricType.IsSum())
                     {
-                        sum += metricPoint.GetCounterSumDouble();
+                        sum += metricPoint.GetSumDouble();
                     }
                     else
                     {

--- a/test/OpenTelemetry.Tests/Metrics/MultipleReadersTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MultipleReadersTests.cs
@@ -115,7 +115,7 @@ namespace OpenTelemetry.Metrics.Tests
             ref var metricPointForFirstExport = ref metricPointsEnumerator.Current;
             if (metric.MetricType.IsSum())
             {
-                Assert.Equal(value, metricPointForFirstExport.GetCounterSumLong());
+                Assert.Equal(value, metricPointForFirstExport.GetSumLong());
             }
             else
             {


### PR DESCRIPTION
Counter is the name of the instrument only and its not required to be part of the `MetricPoint` seen by the Exporters. The data model calls it simply "Sum" without "counter".
https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/datamodel.md#sums

For Gauge and Histogram instruments, the name of the point also has the instrument name in it. So we can keep current name as is.
https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/datamodel.md#gauge
https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/datamodel.md#histogram