### PR TITLE
Allow future addition of Histogram MinMax via View

### DIFF
--- a/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -20,6 +20,8 @@ OpenTelemetry.Metrics.HistogramBuckets.Enumerator.Current.get -> OpenTelemetry.M
 OpenTelemetry.Metrics.HistogramBuckets.Enumerator.Enumerator() -> void
 OpenTelemetry.Metrics.HistogramBuckets.Enumerator.MoveNext() -> bool
 OpenTelemetry.Metrics.HistogramBuckets.GetEnumerator() -> OpenTelemetry.Metrics.HistogramBuckets.Enumerator
+OpenTelemetry.Metrics.HistogramConfiguration
+OpenTelemetry.Metrics.HistogramConfiguration.HistogramConfiguration() -> void
 OpenTelemetry.Metrics.MetricPoint.GetSumDouble() -> double
 OpenTelemetry.Metrics.MetricPoint.GetSumLong() -> long
 OpenTelemetry.Metrics.MetricPoint.GetEndTime() -> System.DateTimeOffset

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -20,6 +20,8 @@ OpenTelemetry.Metrics.HistogramBuckets.Enumerator.Current.get -> OpenTelemetry.M
 OpenTelemetry.Metrics.HistogramBuckets.Enumerator.Enumerator() -> void
 OpenTelemetry.Metrics.HistogramBuckets.Enumerator.MoveNext() -> bool
 OpenTelemetry.Metrics.HistogramBuckets.GetEnumerator() -> OpenTelemetry.Metrics.HistogramBuckets.Enumerator
+OpenTelemetry.Metrics.HistogramConfiguration
+OpenTelemetry.Metrics.HistogramConfiguration.HistogramConfiguration() -> void
 OpenTelemetry.Metrics.MetricPoint.GetSumDouble() -> double
 OpenTelemetry.Metrics.MetricPoint.GetSumLong() -> long
 OpenTelemetry.Metrics.MetricPoint.GetEndTime() -> System.DateTimeOffset

--- a/src/OpenTelemetry/Metrics/HistogramConfiguration.cs
+++ b/src/OpenTelemetry/Metrics/HistogramConfiguration.cs
@@ -1,4 +1,4 @@
-// <copyright file="ExplicitBucketHistogramConfiguration.cs" company="OpenTelemetry Authors">
+// <copyright file="HistogramConfiguration.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,15 +16,12 @@
 
 namespace OpenTelemetry.Metrics
 {
-    public class ExplicitBucketHistogramConfiguration : HistogramConfiguration
+    public class HistogramConfiguration : MetricStreamConfiguration
     {
         /// <summary>
-        /// Gets or sets the values representing explicit histogram bucket
-        /// boundary values.
+        /// Gets or sets a value indicating whether Min, Max
+        /// should be collected.
         /// </summary>
-        /// <remarks>
-        /// The array must be in ascending order with distinct values.
-        /// </remarks>
-        public double[] Boundaries { get; set; }
+        internal bool RecordMinMax { get; set; } = true;
     }
 }


### PR DESCRIPTION
MinMax is not supported currently, so not exposing any setting for that publicly. But this introduces a base class `HistogramConfiguration` to hold `RecordMinMax` as it'll be applied to `ExplicitBucketHistogram` and `ExponentialHistogram`(when that feature is added). Alternate would be to add `RecordMinMax` to both `ExplicitBucketHistogram` and `ExponentialHistogram`