### PR TITLE
[Do not merge] Refactoring OTLP exporter options

### DIFF
--- a/examples/Console/TestMetrics.cs
+++ b/examples/Console/TestMetrics.cs
@@ -68,9 +68,9 @@ namespace Examples.Console
                 providerBuilder
                     .AddOtlpExporter(o =>
                     {
-                        o.MetricReaderType = MetricReaderType.Periodic;
-                        o.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = options.DefaultCollectionPeriodMilliseconds;
-                        o.AggregationTemporality = options.IsDelta ? AggregationTemporality.Delta : AggregationTemporality.Cumulative;
+                        o.OtlpMetricExporterOptions.MetricReaderType = MetricReaderType.Periodic;
+                        o.OtlpMetricExporterOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = options.DefaultCollectionPeriodMilliseconds;
+                        o.OtlpMetricExporterOptions.AggregationTemporality = options.IsDelta ? AggregationTemporality.Delta : AggregationTemporality.Cumulative;
                     });
             }
             else

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/ICommonOtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/ICommonOtlpExporterOptions.cs
@@ -1,0 +1,46 @@
+// <copyright file="ICommonOtlpExporterOptions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+
+namespace OpenTelemetry.Exporter
+{
+    public interface ICommonOtlpExporterOptions
+    {
+        /// <summary>
+        /// Gets or sets the target to which the exporter is going to send telemetry.
+        /// Must be a valid Uri with scheme (http or https) and host, and
+        /// may contain a port and path. The default value is http://localhost:4317.
+        /// </summary>
+        public Uri Endpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets optional headers for the connection. Refer to the <a href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#specifying-headers-via-environment-variables">
+        /// specification</a> for information on the expected format for Headers.
+        /// </summary>
+        public string Headers { get; set; }
+
+        /// <summary>
+        /// Gets or sets the max waiting time (in milliseconds) for the backend to process each batch. The default value is 10000.
+        /// </summary>
+        public int TimeoutMilliseconds { get; set; }
+
+        /// <summary>
+        /// Gets or sets the the OTLP transport protocol. Supported values: Grpc and HttpProtobuf.
+        /// </summary>
+        public OtlpExportProtocol Protocol { get; set; }
+    }
+}

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/BaseOtlpGrpcExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/BaseOtlpGrpcExportClient.cs
@@ -28,7 +28,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClie
     /// <typeparam name="TRequest">Type of export request.</typeparam>
     internal abstract class BaseOtlpGrpcExportClient<TRequest> : IExportClient<TRequest>
     {
-        protected BaseOtlpGrpcExportClient(OtlpExporterOptions options)
+        protected BaseOtlpGrpcExportClient(ICommonOtlpExporterOptions options)
         {
             Guard.Null(options, nameof(options));
             Guard.InvalidTimeout(options.TimeoutMilliseconds, nameof(options.TimeoutMilliseconds));
@@ -37,7 +37,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClie
             this.Headers = options.GetMetadataFromHeaders();
         }
 
-        internal OtlpExporterOptions Options { get; }
+        internal ICommonOtlpExporterOptions Options { get; }
 
 #if NETSTANDARD2_1 || NET5_0_OR_GREATER
         internal GrpcChannel Channel { get; set; }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcMetricsExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcMetricsExportClient.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClie
     {
         private readonly OtlpCollector.MetricsService.IMetricsServiceClient metricsClient;
 
-        public OtlpGrpcMetricsExportClient(OtlpExporterOptions options, OtlpCollector.MetricsService.IMetricsServiceClient metricsServiceClient = null)
+        public OtlpGrpcMetricsExportClient(ICommonOtlpExporterOptions options, OtlpCollector.MetricsService.IMetricsServiceClient metricsServiceClient = null)
             : base(options)
         {
             if (metricsServiceClient != null)

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExportProtocol.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExportProtocol.cs
@@ -30,5 +30,7 @@ namespace OpenTelemetry.Exporter
         /// OTLP over HTTP with protobuf payloads (corresponds to 'http/protobuf' Protocol configuration option).
         /// </summary>
         HttpProtobuf = 1,
+
+        Unspecified = 10,
     }
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -18,7 +18,6 @@ using System;
 using System.Diagnostics;
 using System.Net.Http;
 using OpenTelemetry.Internal;
-using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Exporter
@@ -32,7 +31,7 @@ namespace OpenTelemetry.Exporter
     /// The constructor throws <see cref="FormatException"/> if it fails to parse
     /// any of the supported environment variables.
     /// </remarks>
-    public class OtlpExporterOptions
+    public class OtlpExporterOptions : ICommonOtlpExporterOptions
     {
         internal const string EndpointEnvVarName = "OTEL_EXPORTER_OTLP_ENDPOINT";
         internal const string HeadersEnvVarName = "OTEL_EXPORTER_OTLP_HEADERS";
@@ -84,56 +83,33 @@ namespace OpenTelemetry.Exporter
                     Timeout = TimeSpan.FromMilliseconds(this.TimeoutMilliseconds),
                 };
             };
+
+            this.OtlpMetricExporterOptions = new OtlpMetricExporterOptions(this);
         }
 
-        /// <summary>
-        /// Gets or sets the target to which the exporter is going to send telemetry.
-        /// Must be a valid Uri with scheme (http or https) and host, and
-        /// may contain a port and path. The default value is http://localhost:4317.
-        /// </summary>
+        /// <inheritdoc/>
         public Uri Endpoint { get; set; } = new Uri("http://localhost:4317");
 
-        /// <summary>
-        /// Gets or sets optional headers for the connection. Refer to the <a href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#specifying-headers-via-environment-variables">
-        /// specification</a> for information on the expected format for Headers.
-        /// </summary>
+        /// <inheritdoc/>
         public string Headers { get; set; }
 
-        /// <summary>
-        /// Gets or sets the max waiting time (in milliseconds) for the backend to process each batch. The default value is 10000.
-        /// </summary>
+        /// <inheritdoc/>
         public int TimeoutMilliseconds { get; set; } = 10000;
 
-        /// <summary>
-        /// Gets or sets the the OTLP transport protocol. Supported values: Grpc and HttpProtobuf.
-        /// </summary>
+        /// <inheritdoc/>
         public OtlpExportProtocol Protocol { get; set; } = OtlpExportProtocol.Grpc;
 
         /// <summary>
         /// Gets or sets the export processor type to be used with the OpenTelemetry Protocol Exporter. The default value is <see cref="ExportProcessorType.Batch"/>.
         /// </summary>
+        [Obsolete]
         public ExportProcessorType ExportProcessorType { get; set; } = ExportProcessorType.Batch;
 
         /// <summary>
         /// Gets or sets the BatchExportProcessor options. Ignored unless ExportProcessorType is Batch.
         /// </summary>
+        [Obsolete]
         public BatchExportProcessorOptions<Activity> BatchExportProcessorOptions { get; set; } = new BatchExportActivityProcessorOptions();
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetricReaderType" /> to use. Defaults to <c>MetricReaderType.Periodic</c>.
-        /// </summary>
-        public MetricReaderType MetricReaderType { get; set; } = MetricReaderType.Periodic;
-
-        /// <summary>
-        /// Gets or sets the <see cref="PeriodicExportingMetricReaderOptions" /> options. Ignored unless <c>MetricReaderType</c> is <c>Periodic</c>.
-        /// </summary>
-        public PeriodicExportingMetricReaderOptions PeriodicExportingMetricReaderOptions { get; set; } = new PeriodicExportingMetricReaderOptions();
-
-        /// <summary>
-        /// Gets or sets the AggregationTemporality used for Histogram
-        /// and Sum metrics.
-        /// </summary>
-        public AggregationTemporality AggregationTemporality { get; set; } = AggregationTemporality.Cumulative;
 
         /// <summary>
         /// Gets or sets the factory function called to create the <see
@@ -167,5 +143,9 @@ namespace OpenTelemetry.Exporter
         /// </list>
         /// </remarks>
         public Func<HttpClient> HttpClientFactory { get; set; }
+
+        public OtlpMetricExporterOptions OtlpMetricExporterOptions { get; }
+
+        public OtlpTraceExporterOptions OtlpTraceExporterOptions { get; }
     }
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
@@ -31,9 +31,9 @@ namespace OpenTelemetry.Exporter
     internal static class OtlpExporterOptionsExtensions
     {
 #if NETSTANDARD2_1 || NET5_0_OR_GREATER
-        public static GrpcChannel CreateChannel(this OtlpExporterOptions options)
+        public static GrpcChannel CreateChannel(this ICommonOtlpExporterOptions options)
 #else
-        public static Channel CreateChannel(this OtlpExporterOptions options)
+        public static Channel CreateChannel(this ICommonOtlpExporterOptions options)
 #endif
         {
             if (options.Endpoint.Scheme != Uri.UriSchemeHttp && options.Endpoint.Scheme != Uri.UriSchemeHttps)
@@ -58,12 +58,12 @@ namespace OpenTelemetry.Exporter
 #endif
         }
 
-        public static Metadata GetMetadataFromHeaders(this OtlpExporterOptions options)
+        public static Metadata GetMetadataFromHeaders(this ICommonOtlpExporterOptions options)
         {
             return options.GetHeaders<Metadata>((m, k, v) => m.Add(k, v));
         }
 
-        public static THeaders GetHeaders<THeaders>(this OtlpExporterOptions options, Action<THeaders, string, string> addHeader)
+        public static THeaders GetHeaders<THeaders>(this ICommonOtlpExporterOptions options, Action<THeaders, string, string> addHeader)
             where THeaders : new()
         {
             var optionHeaders = options.Headers;

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
@@ -52,7 +52,7 @@ namespace OpenTelemetry.Metrics
             Action<OtlpExporterOptions> configure,
             IServiceProvider serviceProvider)
         {
-            var initialEndpoint = options.Endpoint;
+            var initialEndpoint = options.OtlpMetricExporterOptions.Endpoint;
 
             configure?.Invoke(options);
 
@@ -62,11 +62,11 @@ namespace OpenTelemetry.Metrics
 
             var metricExporter = new OtlpMetricExporter(options);
 
-            var metricReader = options.MetricReaderType == MetricReaderType.Manual
+            var metricReader = options.OtlpMetricExporterOptions.MetricReaderType == MetricReaderType.Manual
                 ? new BaseExportingMetricReader(metricExporter)
-                : new PeriodicExportingMetricReader(metricExporter, options.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds);
+                : new PeriodicExportingMetricReader(metricExporter, options.OtlpMetricExporterOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds);
 
-            metricReader.Temporality = options.AggregationTemporality;
+            metricReader.Temporality = options.OtlpMetricExporterOptions.AggregationTemporality;
             return builder.AddReader(metricReader);
         }
     }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterOptions.cs
@@ -98,11 +98,6 @@ namespace OpenTelemetry.Exporter
         }
 
         /// <summary>
-        /// Gets or sets the metric export interval in milliseconds. The default value is 60000.
-        /// </summary>
-        public int MetricExportIntervalMilliseconds { get; set; } = 60000;
-
-        /// <summary>
         /// Gets or sets the <see cref="MetricReaderType" /> to use. Defaults to <c>MetricReaderType.Periodic</c>.
         /// </summary>
         public MetricReaderType MetricReaderType { get; set; } = MetricReaderType.Periodic;

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterOptions.cs
@@ -1,0 +1,121 @@
+// <copyright file="OtlpMetricExporterOptions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using OpenTelemetry.Internal;
+using OpenTelemetry.Metrics;
+
+namespace OpenTelemetry.Exporter
+{
+    public class OtlpMetricExporterOptions : ICommonOtlpExporterOptions
+    {
+        internal const string EndpointEnvVarName = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT";
+        internal const string HeadersEnvVarName = "OTEL_EXPORTER_OTLP_METRICS_HEADERS";
+        internal const string TimeoutEnvVarName = "OTEL_EXPORTER_OTLP_METRICS_TIMEOUT";
+        internal const string ProtocolEnvVarName = "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL";
+
+        private ICommonOtlpExporterOptions baseOptions;
+        private Uri endpoint = null;
+        private string headers = null;
+        private int timeoutMilliseconds = int.MinValue;
+        private OtlpExportProtocol protocol = OtlpExportProtocol.Unspecified;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OtlpMetricExporterOptions"/> class.
+        /// </summary>
+        internal OtlpMetricExporterOptions(ICommonOtlpExporterOptions baseOptions)
+        {
+            this.baseOptions = baseOptions;
+
+            if (EnvironmentVariableHelper.LoadUri(EndpointEnvVarName, out Uri endpoint))
+            {
+                this.Endpoint = endpoint;
+            }
+
+            if (EnvironmentVariableHelper.LoadString(HeadersEnvVarName, out string headersEnvVar))
+            {
+                this.Headers = headersEnvVar;
+            }
+
+            if (EnvironmentVariableHelper.LoadNumeric(TimeoutEnvVarName, out int timeout))
+            {
+                this.TimeoutMilliseconds = timeout;
+            }
+
+            if (EnvironmentVariableHelper.LoadString(ProtocolEnvVarName, out string protocolEnvVar))
+            {
+                var protocol = protocolEnvVar.ToOtlpExportProtocol();
+                if (protocol.HasValue)
+                {
+                    this.Protocol = protocol.Value;
+                }
+                else
+                {
+                    throw new FormatException($"{ProtocolEnvVarName} environment variable has an invalid value: '${protocolEnvVar}'");
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public Uri Endpoint
+        {
+            get => this.endpoint ?? this.baseOptions.Endpoint;
+            set => this.endpoint = value;
+        }
+
+        /// <inheritdoc/>
+        public string Headers
+        {
+            get => this.headers ?? this.baseOptions.Headers;
+            set => this.headers = value;
+        }
+
+        /// <inheritdoc/>
+        public int TimeoutMilliseconds
+        {
+            get => this.timeoutMilliseconds == int.MinValue ? this.baseOptions.TimeoutMilliseconds : this.timeoutMilliseconds;
+            set => this.timeoutMilliseconds = value;
+        }
+
+        /// <inheritdoc/>
+        public OtlpExportProtocol Protocol
+        {
+            get => this.protocol == OtlpExportProtocol.Unspecified ? this.baseOptions.Protocol : this.protocol;
+            set => this.protocol = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the metric export interval in milliseconds. The default value is 60000.
+        /// </summary>
+        public int MetricExportIntervalMilliseconds { get; set; } = 60000;
+
+        /// <summary>
+        /// Gets or sets the <see cref="MetricReaderType" /> to use. Defaults to <c>MetricReaderType.Periodic</c>.
+        /// </summary>
+        public MetricReaderType MetricReaderType { get; set; } = MetricReaderType.Periodic;
+
+        /// <summary>
+        /// Gets or sets the <see cref="PeriodicExportingMetricReaderOptions" /> options. Ignored unless <c>MetricReaderType</c> is <c>Periodic</c>.
+        /// </summary>
+        public PeriodicExportingMetricReaderOptions PeriodicExportingMetricReaderOptions { get; set; } = new PeriodicExportingMetricReaderOptions();
+
+        /// <summary>
+        /// Gets or sets the AggregationTemporality used for Histogram
+        /// and Sum metrics.
+        /// </summary>
+        public AggregationTemporality AggregationTemporality { get; set; } = AggregationTemporality.Cumulative;
+    }
+}

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
@@ -52,7 +52,7 @@ namespace OpenTelemetry.Trace
             Action<OtlpExporterOptions> configure,
             IServiceProvider serviceProvider)
         {
-            var originalEndpoint = exporterOptions.Endpoint;
+            var originalEndpoint = exporterOptions.OtlpTraceExporterOptions.Endpoint;
 
             configure?.Invoke(exporterOptions);
 
@@ -62,7 +62,7 @@ namespace OpenTelemetry.Trace
 
             var otlpExporter = new OtlpTraceExporter(exporterOptions);
 
-            if (exporterOptions.ExportProcessorType == ExportProcessorType.Simple)
+            if (exporterOptions.OtlpTraceExporterOptions.ExportProcessorType == ExportProcessorType.Simple)
             {
                 return builder.AddProcessor(new SimpleActivityExportProcessor(otlpExporter));
             }
@@ -70,10 +70,10 @@ namespace OpenTelemetry.Trace
             {
                 return builder.AddProcessor(new BatchActivityExportProcessor(
                     otlpExporter,
-                    exporterOptions.BatchExportProcessorOptions.MaxQueueSize,
-                    exporterOptions.BatchExportProcessorOptions.ScheduledDelayMilliseconds,
-                    exporterOptions.BatchExportProcessorOptions.ExporterTimeoutMilliseconds,
-                    exporterOptions.BatchExportProcessorOptions.MaxExportBatchSize));
+                    exporterOptions.OtlpTraceExporterOptions.BatchExportProcessorOptions.MaxQueueSize,
+                    exporterOptions.OtlpTraceExporterOptions.BatchExportProcessorOptions.ScheduledDelayMilliseconds,
+                    exporterOptions.OtlpTraceExporterOptions.BatchExportProcessorOptions.ExporterTimeoutMilliseconds,
+                    exporterOptions.OtlpTraceExporterOptions.BatchExportProcessorOptions.MaxExportBatchSize));
             }
         }
     }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterOptions.cs
@@ -1,0 +1,111 @@
+// <copyright file="OtlpTraceExporterOptions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using OpenTelemetry.Internal;
+using OpenTelemetry.Trace;
+
+namespace OpenTelemetry.Exporter
+{
+    public class OtlpTraceExporterOptions : ICommonOtlpExporterOptions
+    {
+        internal const string EndpointEnvVarName = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT";
+        internal const string HeadersEnvVarName = "OTEL_EXPORTER_OTLP_TRACES_HEADERS";
+        internal const string TimeoutEnvVarName = "OTEL_EXPORTER_OTLP_TRACES_TIMEOUT";
+        internal const string ProtocolEnvVarName = "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL";
+
+        private ICommonOtlpExporterOptions baseOptions;
+        private Uri endpoint = null;
+        private string headers = null;
+        private int timeoutMilliseconds = int.MinValue;
+        private OtlpExportProtocol protocol = OtlpExportProtocol.Unspecified;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OtlpTraceExporterOptions"/> class.
+        /// </summary>
+        internal OtlpTraceExporterOptions(ICommonOtlpExporterOptions baseOptions)
+        {
+            this.baseOptions = baseOptions;
+
+            if (EnvironmentVariableHelper.LoadUri(EndpointEnvVarName, out Uri endpoint))
+            {
+                this.Endpoint = endpoint;
+            }
+
+            if (EnvironmentVariableHelper.LoadString(HeadersEnvVarName, out string headersEnvVar))
+            {
+                this.Headers = headersEnvVar;
+            }
+
+            if (EnvironmentVariableHelper.LoadNumeric(TimeoutEnvVarName, out int timeout))
+            {
+                this.TimeoutMilliseconds = timeout;
+            }
+
+            if (EnvironmentVariableHelper.LoadString(ProtocolEnvVarName, out string protocolEnvVar))
+            {
+                var protocol = protocolEnvVar.ToOtlpExportProtocol();
+                if (protocol.HasValue)
+                {
+                    this.Protocol = protocol.Value;
+                }
+                else
+                {
+                    throw new FormatException($"{ProtocolEnvVarName} environment variable has an invalid value: '${protocolEnvVar}'");
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public Uri Endpoint
+        {
+            get => this.endpoint ?? this.baseOptions.Endpoint;
+            set => this.endpoint = value;
+        }
+
+        /// <inheritdoc/>
+        public string Headers
+        {
+            get => this.headers ?? this.baseOptions.Headers;
+            set => this.headers = value;
+        }
+
+        /// <inheritdoc/>
+        public int TimeoutMilliseconds
+        {
+            get => this.timeoutMilliseconds == int.MinValue ? this.baseOptions.TimeoutMilliseconds : this.timeoutMilliseconds;
+            set => this.timeoutMilliseconds = value;
+        }
+
+        /// <inheritdoc/>
+        public OtlpExportProtocol Protocol
+        {
+            get => this.protocol == OtlpExportProtocol.Unspecified ? this.baseOptions.Protocol : this.protocol;
+            set => this.protocol = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the export processor type to be used with the OpenTelemetry Protocol Exporter. The default value is <see cref="ExportProcessorType.Batch"/>.
+        /// </summary>
+        public ExportProcessorType ExportProcessorType { get; set; } = ExportProcessorType.Batch;
+
+        /// <summary>
+        /// Gets or sets the BatchExportProcessor options. Ignored unless ExportProcessorType is Batch.
+        /// </summary>
+        public BatchExportProcessorOptions<Activity> BatchExportProcessorOptions { get; set; } = new BatchExportActivityProcessorOptions();
+    }
+}


### PR DESCRIPTION
This is experimenting with an idea that makes the OTLP exporter options more hierarchical.

Few goals:

* Make the base `OtlpExporterOptions` class agnostic of whether it's for a trace, metric, or log exporter. This means some properties get marked obsolete.
* Demonstrate how we might handle the signal specific env var configs like `OTLP_EXPORTER_OTLP_METRICS_*` environment variables.