### PR TITLE
Add logs when exception occurs in critical paths

### DIFF
--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -74,6 +74,15 @@ namespace OpenTelemetry.Internal
         }
 
         [NonEvent]
+        public void MetricReaderException(string evnt, Exception ex)
+        {
+            if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
+            {
+                this.MetricReaderException(evnt, ex.ToInvariantString());
+            }
+        }
+
+        [NonEvent]
         public void TracestateKeyIsInvalid(ReadOnlySpan<char> key)
         {
             if (this.IsEnabled(EventLevel.Warning, EventKeywords.All))
@@ -140,6 +149,15 @@ namespace OpenTelemetry.Internal
             if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
             {
                 this.TracerProviderException(evnt, ex.ToInvariantString());
+            }
+        }
+
+        [NonEvent]
+        public void MeterProviderException(string evnt, Exception ex)
+        {
+            if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
+            {
+                this.MeterProviderException(evnt, ex.ToInvariantString());
             }
         }
 
@@ -355,6 +373,18 @@ namespace OpenTelemetry.Internal
         public void MetricInstrumentIgnored(string instrumentName, string meterName, string reason, string fix)
         {
             this.WriteEvent(33, instrumentName, meterName, reason, fix);
+        }
+
+        [Event(34, Message = "Unknown error in MetricReader event '{0}': '{1}'.", Level = EventLevel.Error)]
+        public void MetricReaderException(string evnt, string ex)
+        {
+            this.WriteEvent(34, evnt, ex);
+        }
+
+        [Event(35, Message = "Unknown error in MeterProvider '{0}': '{1}'.", Level = EventLevel.Error)]
+        public void MeterProviderException(string evnt, string ex)
+        {
+            this.WriteEvent(35, evnt, ex);
         }
 
 #if DEBUG

--- a/src/OpenTelemetry/Metrics/BaseExportingMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/BaseExportingMetricReader.cs
@@ -81,7 +81,15 @@ namespace OpenTelemetry.Metrics
         internal override bool ProcessMetrics(in Batch<Metric> metrics, int timeoutMilliseconds)
         {
             // TODO: Do we need to consider timeout here?
-            return this.exporter.Export(metrics) == ExportResult.Success;
+            try
+            {
+                return this.exporter.Export(metrics) == ExportResult.Success;
+            }
+            catch (Exception ex)
+            {
+                OpenTelemetrySdkEventSource.Log.MetricReaderException(nameof(this.ProcessMetrics), ex);
+                return false;
+            }
         }
 
         /// <inheritdoc />
@@ -138,9 +146,9 @@ namespace OpenTelemetry.Metrics
 
                         this.exporter.Dispose();
                     }
-                    catch (Exception)
+                    catch (Exception ex)
                     {
-                        // TODO: Log
+                        OpenTelemetrySdkEventSource.Log.MetricReaderException(nameof(this.Dispose), ex);
                     }
                 }
 

--- a/src/OpenTelemetry/Metrics/MeterProviderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderExtensions.cs
@@ -51,10 +51,9 @@ namespace OpenTelemetry.Metrics
                 {
                     return meterProviderSdk.OnForceFlush(timeoutMilliseconds);
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
-                    // TODO: what event source do we use?
-                    // OpenTelemetrySdkEventSource.Log.MeterProviderException(nameof(meterProviderSdk.OnForceFlush), ex);
+                    OpenTelemetrySdkEventSource.Log.MeterProviderException(nameof(meterProviderSdk.OnForceFlush), ex);
                     return false;
                 }
             }
@@ -97,10 +96,9 @@ namespace OpenTelemetry.Metrics
                 {
                     return meterProviderSdk.OnShutdown(timeoutMilliseconds);
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
-                    // TODO: what event source do we use?
-                    // OpenTelemetrySdkEventSource.Log.MeterProviderException(nameof(meterProviderSdk.OnShutdown), ex);
+                    OpenTelemetrySdkEventSource.Log.MeterProviderException(nameof(meterProviderSdk.OnShutdown), ex);
                     return false;
                 }
             }

--- a/src/OpenTelemetry/Metrics/MetricReader.cs
+++ b/src/OpenTelemetry/Metrics/MetricReader.cs
@@ -117,9 +117,9 @@ namespace OpenTelemetry.Metrics
                     result = this.OnCollect(timeoutMilliseconds);
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                // TODO: OpenTelemetrySdkEventSource.Log.SpanProcessorException(nameof(this.Shutdown), ex);
+                OpenTelemetrySdkEventSource.Log.MetricReaderException(nameof(this.Collect), ex);
             }
 
             tcs.TrySetResult(result);
@@ -158,9 +158,9 @@ namespace OpenTelemetry.Metrics
             {
                 result = this.OnShutdown(timeoutMilliseconds);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                // TODO: OpenTelemetrySdkEventSource.Log.SpanProcessorException(nameof(this.Shutdown), ex);
+                OpenTelemetrySdkEventSource.Log.MetricReaderException(nameof(this.Shutdown), ex);
             }
 
             this.shutdownTcs.TrySetResult(result);
@@ -220,7 +220,7 @@ namespace OpenTelemetry.Metrics
                 : Stopwatch.StartNew();
 
             var collectObservableInstruments = this.ParentProvider.GetObservableInstrumentCollectCallback();
-            collectObservableInstruments();
+            collectObservableInstruments?.Invoke();
 
             var metrics = this.GetMetricsBatch();
 

--- a/src/OpenTelemetry/Metrics/MetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/MetricReaderExt.cs
@@ -236,9 +236,9 @@ namespace OpenTelemetry.Metrics
 
                 return (metricCountCurrentBatch > 0) ? new Batch<Metric>(this.metricsCurrentBatch, metricCountCurrentBatch) : default;
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                // TODO: Log
+                OpenTelemetrySdkEventSource.Log.MetricReaderException(nameof(this.GetMetricsBatch), ex);
                 return default;
             }
         }


### PR DESCRIPTION
Metrics SDK is blind if an exception occurs today. This PR adds logging on critical `MetricReader` and `MeterProvider` paths (i.e anything which can result in not metrics being exported) and includes exception.ToString() in the log message.

We have this issue https://github.com/open-telemetry/opentelemetry-dotnet/issues/2543 to be addressed. Its a bigger undertaking, so this PR is just a temporary fix to avoid being totally blind if Metric SDK fails.

There'll be couple more follow ups before Metric stable release, to do some cleanups, and add logs in the recording paths as well.