### PR TITLE
Move OTLP metric-specific options to its own class

### DIFF
--- a/examples/Console/TestMetrics.cs
+++ b/examples/Console/TestMetrics.cs
@@ -68,9 +68,9 @@ namespace Examples.Console
                 providerBuilder
                     .AddOtlpExporter(o =>
                     {
-                        o.MetricReaderType = MetricReaderType.Periodic;
-                        o.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = options.DefaultCollectionPeriodMilliseconds;
-                        o.AggregationTemporality = options.IsDelta ? AggregationTemporality.Delta : AggregationTemporality.Cumulative;
+                        o.MetricOptions.MetricReaderType = MetricReaderType.Periodic;
+                        o.MetricOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = options.DefaultCollectionPeriodMilliseconds;
+                        o.MetricOptions.AggregationTemporality = options.IsDelta ? AggregationTemporality.Delta : AggregationTemporality.Cumulative;
                     });
             }
             else

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -8,8 +8,6 @@ OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Protocol.set -> void
 OpenTelemetry.Exporter.ICommonOtlpExporterOptions.TimeoutMilliseconds.get -> int
 OpenTelemetry.Exporter.ICommonOtlpExporterOptions.TimeoutMilliseconds.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions
-OpenTelemetry.Exporter.OtlpExporterOptions.AggregationTemporality.get -> OpenTelemetry.Metrics.AggregationTemporality
-OpenTelemetry.Exporter.OtlpExporterOptions.AggregationTemporality.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
 OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.get -> System.Uri
@@ -18,10 +16,7 @@ OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.get -> OpenTeleme
 OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.Headers.get -> string
 OpenTelemetry.Exporter.OtlpExporterOptions.Headers.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.MetricReaderType.get -> OpenTelemetry.Metrics.MetricReaderType
-OpenTelemetry.Exporter.OtlpExporterOptions.MetricReaderType.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.PeriodicExportingMetricReaderOptions.get -> OpenTelemetry.Metrics.PeriodicExportingMetricReaderOptions
-OpenTelemetry.Exporter.OtlpExporterOptions.PeriodicExportingMetricReaderOptions.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.MetricOptions.get -> OpenTelemetry.Exporter.OtlpMetricExporterOptions
 OpenTelemetry.Exporter.OtlpExporterOptions.HttpClientFactory.get -> System.Func<System.Net.Http.HttpClient>
 OpenTelemetry.Exporter.OtlpExporterOptions.HttpClientFactory.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.OtlpExporterOptions() -> void

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -1,3 +1,12 @@
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Endpoint.get -> System.Uri
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Endpoint.set -> void
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Headers.get -> string
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Headers.set -> void
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Protocol.get -> OpenTelemetry.Exporter.OtlpExportProtocol
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Protocol.set -> void
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.TimeoutMilliseconds.get -> int
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.TimeoutMilliseconds.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions
 OpenTelemetry.Exporter.OtlpExporterOptions.AggregationTemporality.get -> OpenTelemetry.Metrics.AggregationTemporality
 OpenTelemetry.Exporter.OtlpExporterOptions.AggregationTemporality.set -> void

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -30,8 +30,9 @@ OpenTelemetry.Exporter.OtlpExporterOptions.Protocol.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.TimeoutMilliseconds.get -> int
 OpenTelemetry.Exporter.OtlpExporterOptions.TimeoutMilliseconds.set -> void
 OpenTelemetry.Exporter.OtlpExportProtocol
-OpenTelemetry.Exporter.OtlpExportProtocol.Grpc = 0 -> OpenTelemetry.Exporter.OtlpExportProtocol
-OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf = 1 -> OpenTelemetry.Exporter.OtlpExportProtocol
+OpenTelemetry.Exporter.OtlpExportProtocol.Grpc = 1 -> OpenTelemetry.Exporter.OtlpExportProtocol
+OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf = 2 -> OpenTelemetry.Exporter.OtlpExportProtocol
+OpenTelemetry.Exporter.OtlpExportProtocol.Unspecified = 0 -> OpenTelemetry.Exporter.OtlpExportProtocol
 OpenTelemetry.Exporter.OtlpMetricExporter
 OpenTelemetry.Exporter.OtlpMetricExporter.OtlpMetricExporter(OpenTelemetry.Exporter.OtlpExporterOptions options) -> void
 OpenTelemetry.Exporter.OtlpTraceExporter

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -35,6 +35,21 @@ OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf = 2 -> OpenTelemetry.Expo
 OpenTelemetry.Exporter.OtlpExportProtocol.Unspecified = 0 -> OpenTelemetry.Exporter.OtlpExportProtocol
 OpenTelemetry.Exporter.OtlpMetricExporter
 OpenTelemetry.Exporter.OtlpMetricExporter.OtlpMetricExporter(OpenTelemetry.Exporter.OtlpExporterOptions options) -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.AggregationTemporality.get -> OpenTelemetry.Metrics.AggregationTemporality
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.AggregationTemporality.set -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.Endpoint.get -> System.Uri
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.Endpoint.set -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.Headers.get -> string
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.Headers.set -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.MetricReaderType.get -> OpenTelemetry.Metrics.MetricReaderType
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.MetricReaderType.set -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.PeriodicExportingMetricReaderOptions.get -> OpenTelemetry.Metrics.PeriodicExportingMetricReaderOptions
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.PeriodicExportingMetricReaderOptions.set -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.Protocol.get -> OpenTelemetry.Exporter.OtlpExportProtocol
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.Protocol.set -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.TimeoutMilliseconds.get -> int
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.TimeoutMilliseconds.set -> void
 OpenTelemetry.Exporter.OtlpTraceExporter
 OpenTelemetry.Exporter.OtlpTraceExporter.OtlpTraceExporter(OpenTelemetry.Exporter.OtlpExporterOptions options) -> void
 OpenTelemetry.Metrics.OtlpMetricExporterExtensions

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net5.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net5.0/PublicAPI.Unshipped.txt
@@ -7,12 +7,7 @@ OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Protocol.get -> OpenTelemetry.
 OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Protocol.set -> void
 OpenTelemetry.Exporter.ICommonOtlpExporterOptions.TimeoutMilliseconds.get -> int
 OpenTelemetry.Exporter.ICommonOtlpExporterOptions.TimeoutMilliseconds.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.AggregationTemporality.get -> OpenTelemetry.Metrics.AggregationTemporality
-OpenTelemetry.Exporter.OtlpExporterOptions.AggregationTemporality.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.MetricReaderType.get -> OpenTelemetry.Metrics.MetricReaderType
-OpenTelemetry.Exporter.OtlpExporterOptions.MetricReaderType.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.PeriodicExportingMetricReaderOptions.get -> OpenTelemetry.Metrics.PeriodicExportingMetricReaderOptions
-OpenTelemetry.Exporter.OtlpExporterOptions.PeriodicExportingMetricReaderOptions.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.MetricOptions.get -> OpenTelemetry.Exporter.OtlpMetricExporterOptions
 OpenTelemetry.Exporter.OtlpExporterOptions.HttpClientFactory.get -> System.Func<System.Net.Http.HttpClient>
 OpenTelemetry.Exporter.OtlpExporterOptions.HttpClientFactory.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.Protocol.get -> OpenTelemetry.Exporter.OtlpExportProtocol

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net5.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net5.0/PublicAPI.Unshipped.txt
@@ -18,8 +18,9 @@ OpenTelemetry.Exporter.OtlpExporterOptions.HttpClientFactory.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.Protocol.get -> OpenTelemetry.Exporter.OtlpExportProtocol
 OpenTelemetry.Exporter.OtlpExporterOptions.Protocol.set -> void
 OpenTelemetry.Exporter.OtlpExportProtocol
-OpenTelemetry.Exporter.OtlpExportProtocol.Grpc = 0 -> OpenTelemetry.Exporter.OtlpExportProtocol
-OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf = 1 -> OpenTelemetry.Exporter.OtlpExportProtocol
+OpenTelemetry.Exporter.OtlpExportProtocol.Grpc = 1 -> OpenTelemetry.Exporter.OtlpExportProtocol
+OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf = 2 -> OpenTelemetry.Exporter.OtlpExportProtocol
+OpenTelemetry.Exporter.OtlpExportProtocol.Unspecified = 0 -> OpenTelemetry.Exporter.OtlpExportProtocol
 OpenTelemetry.Exporter.OtlpMetricExporter
 OpenTelemetry.Exporter.OtlpMetricExporter.OtlpMetricExporter(OpenTelemetry.Exporter.OtlpExporterOptions options) -> void
 OpenTelemetry.Metrics.OtlpMetricExporterExtensions

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net5.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net5.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,12 @@
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Endpoint.get -> System.Uri
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Endpoint.set -> void
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Headers.get -> string
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Headers.set -> void
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Protocol.get -> OpenTelemetry.Exporter.OtlpExportProtocol
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Protocol.set -> void
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.TimeoutMilliseconds.get -> int
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.TimeoutMilliseconds.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.AggregationTemporality.get -> OpenTelemetry.Metrics.AggregationTemporality
 OpenTelemetry.Exporter.OtlpExporterOptions.AggregationTemporality.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.MetricReaderType.get -> OpenTelemetry.Metrics.MetricReaderType

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net5.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net5.0/PublicAPI.Unshipped.txt
@@ -23,6 +23,21 @@ OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf = 2 -> OpenTelemetry.Expo
 OpenTelemetry.Exporter.OtlpExportProtocol.Unspecified = 0 -> OpenTelemetry.Exporter.OtlpExportProtocol
 OpenTelemetry.Exporter.OtlpMetricExporter
 OpenTelemetry.Exporter.OtlpMetricExporter.OtlpMetricExporter(OpenTelemetry.Exporter.OtlpExporterOptions options) -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.AggregationTemporality.get -> OpenTelemetry.Metrics.AggregationTemporality
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.AggregationTemporality.set -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.Endpoint.get -> System.Uri
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.Endpoint.set -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.Headers.get -> string
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.Headers.set -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.MetricReaderType.get -> OpenTelemetry.Metrics.MetricReaderType
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.MetricReaderType.set -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.PeriodicExportingMetricReaderOptions.get -> OpenTelemetry.Metrics.PeriodicExportingMetricReaderOptions
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.PeriodicExportingMetricReaderOptions.set -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.Protocol.get -> OpenTelemetry.Exporter.OtlpExportProtocol
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.Protocol.set -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.TimeoutMilliseconds.get -> int
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.TimeoutMilliseconds.set -> void
 OpenTelemetry.Metrics.OtlpMetricExporterExtensions
 override OpenTelemetry.Exporter.OtlpMetricExporter.Export(in OpenTelemetry.Batch<OpenTelemetry.Metrics.Metric> metrics) -> OpenTelemetry.ExportResult
 override OpenTelemetry.Exporter.OtlpMetricExporter.OnShutdown(int timeoutMilliseconds) -> bool

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -7,12 +7,7 @@ OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Protocol.get -> OpenTelemetry.
 OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Protocol.set -> void
 OpenTelemetry.Exporter.ICommonOtlpExporterOptions.TimeoutMilliseconds.get -> int
 OpenTelemetry.Exporter.ICommonOtlpExporterOptions.TimeoutMilliseconds.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.AggregationTemporality.get -> OpenTelemetry.Metrics.AggregationTemporality
-OpenTelemetry.Exporter.OtlpExporterOptions.AggregationTemporality.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.MetricReaderType.get -> OpenTelemetry.Metrics.MetricReaderType
-OpenTelemetry.Exporter.OtlpExporterOptions.MetricReaderType.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.PeriodicExportingMetricReaderOptions.get -> OpenTelemetry.Metrics.PeriodicExportingMetricReaderOptions
-OpenTelemetry.Exporter.OtlpExporterOptions.PeriodicExportingMetricReaderOptions.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.MetricOptions.get -> OpenTelemetry.Exporter.OtlpMetricExporterOptions
 OpenTelemetry.Exporter.OtlpExporterOptions.HttpClientFactory.get -> System.Func<System.Net.Http.HttpClient>
 OpenTelemetry.Exporter.OtlpExporterOptions.HttpClientFactory.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.Protocol.get -> OpenTelemetry.Exporter.OtlpExportProtocol

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -18,8 +18,9 @@ OpenTelemetry.Exporter.OtlpExporterOptions.HttpClientFactory.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.Protocol.get -> OpenTelemetry.Exporter.OtlpExportProtocol
 OpenTelemetry.Exporter.OtlpExporterOptions.Protocol.set -> void
 OpenTelemetry.Exporter.OtlpExportProtocol
-OpenTelemetry.Exporter.OtlpExportProtocol.Grpc = 0 -> OpenTelemetry.Exporter.OtlpExportProtocol
-OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf = 1 -> OpenTelemetry.Exporter.OtlpExportProtocol
+OpenTelemetry.Exporter.OtlpExportProtocol.Grpc = 1 -> OpenTelemetry.Exporter.OtlpExportProtocol
+OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf = 2 -> OpenTelemetry.Exporter.OtlpExportProtocol
+OpenTelemetry.Exporter.OtlpExportProtocol.Unspecified = 0 -> OpenTelemetry.Exporter.OtlpExportProtocol
 OpenTelemetry.Exporter.OtlpMetricExporter
 OpenTelemetry.Exporter.OtlpMetricExporter.OtlpMetricExporter(OpenTelemetry.Exporter.OtlpExporterOptions options) -> void
 OpenTelemetry.Metrics.OtlpMetricExporterExtensions

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,12 @@
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Endpoint.get -> System.Uri
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Endpoint.set -> void
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Headers.get -> string
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Headers.set -> void
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Protocol.get -> OpenTelemetry.Exporter.OtlpExportProtocol
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Protocol.set -> void
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.TimeoutMilliseconds.get -> int
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.TimeoutMilliseconds.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.AggregationTemporality.get -> OpenTelemetry.Metrics.AggregationTemporality
 OpenTelemetry.Exporter.OtlpExporterOptions.AggregationTemporality.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.MetricReaderType.get -> OpenTelemetry.Metrics.MetricReaderType

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -23,6 +23,21 @@ OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf = 2 -> OpenTelemetry.Expo
 OpenTelemetry.Exporter.OtlpExportProtocol.Unspecified = 0 -> OpenTelemetry.Exporter.OtlpExportProtocol
 OpenTelemetry.Exporter.OtlpMetricExporter
 OpenTelemetry.Exporter.OtlpMetricExporter.OtlpMetricExporter(OpenTelemetry.Exporter.OtlpExporterOptions options) -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.AggregationTemporality.get -> OpenTelemetry.Metrics.AggregationTemporality
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.AggregationTemporality.set -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.Endpoint.get -> System.Uri
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.Endpoint.set -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.Headers.get -> string
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.Headers.set -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.MetricReaderType.get -> OpenTelemetry.Metrics.MetricReaderType
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.MetricReaderType.set -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.PeriodicExportingMetricReaderOptions.get -> OpenTelemetry.Metrics.PeriodicExportingMetricReaderOptions
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.PeriodicExportingMetricReaderOptions.set -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.Protocol.get -> OpenTelemetry.Exporter.OtlpExportProtocol
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.Protocol.set -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.TimeoutMilliseconds.get -> int
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.TimeoutMilliseconds.set -> void
 OpenTelemetry.Metrics.OtlpMetricExporterExtensions
 override OpenTelemetry.Exporter.OtlpMetricExporter.Export(in OpenTelemetry.Batch<OpenTelemetry.Metrics.Metric> metrics) -> OpenTelemetry.ExportResult
 override OpenTelemetry.Exporter.OtlpMetricExporter.OnShutdown(int timeoutMilliseconds) -> bool

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
@@ -7,12 +7,7 @@ OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Protocol.get -> OpenTelemetry.
 OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Protocol.set -> void
 OpenTelemetry.Exporter.ICommonOtlpExporterOptions.TimeoutMilliseconds.get -> int
 OpenTelemetry.Exporter.ICommonOtlpExporterOptions.TimeoutMilliseconds.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.AggregationTemporality.get -> OpenTelemetry.Metrics.AggregationTemporality
-OpenTelemetry.Exporter.OtlpExporterOptions.AggregationTemporality.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.MetricReaderType.get -> OpenTelemetry.Metrics.MetricReaderType
-OpenTelemetry.Exporter.OtlpExporterOptions.MetricReaderType.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.PeriodicExportingMetricReaderOptions.get -> OpenTelemetry.Metrics.PeriodicExportingMetricReaderOptions
-OpenTelemetry.Exporter.OtlpExporterOptions.PeriodicExportingMetricReaderOptions.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.MetricOptions.get -> OpenTelemetry.Exporter.OtlpMetricExporterOptions
 OpenTelemetry.Exporter.OtlpExporterOptions.HttpClientFactory.get -> System.Func<System.Net.Http.HttpClient>
 OpenTelemetry.Exporter.OtlpExporterOptions.HttpClientFactory.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.Protocol.get -> OpenTelemetry.Exporter.OtlpExportProtocol

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
@@ -18,8 +18,9 @@ OpenTelemetry.Exporter.OtlpExporterOptions.HttpClientFactory.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.Protocol.get -> OpenTelemetry.Exporter.OtlpExportProtocol
 OpenTelemetry.Exporter.OtlpExporterOptions.Protocol.set -> void
 OpenTelemetry.Exporter.OtlpExportProtocol
-OpenTelemetry.Exporter.OtlpExportProtocol.Grpc = 0 -> OpenTelemetry.Exporter.OtlpExportProtocol
-OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf = 1 -> OpenTelemetry.Exporter.OtlpExportProtocol
+OpenTelemetry.Exporter.OtlpExportProtocol.Grpc = 1 -> OpenTelemetry.Exporter.OtlpExportProtocol
+OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf = 2 -> OpenTelemetry.Exporter.OtlpExportProtocol
+OpenTelemetry.Exporter.OtlpExportProtocol.Unspecified = 0 -> OpenTelemetry.Exporter.OtlpExportProtocol
 OpenTelemetry.Exporter.OtlpMetricExporter
 OpenTelemetry.Exporter.OtlpMetricExporter.OtlpMetricExporter(OpenTelemetry.Exporter.OtlpExporterOptions options) -> void
 OpenTelemetry.Metrics.OtlpMetricExporterExtensions

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,3 +1,12 @@
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Endpoint.get -> System.Uri
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Endpoint.set -> void
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Headers.get -> string
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Headers.set -> void
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Protocol.get -> OpenTelemetry.Exporter.OtlpExportProtocol
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.Protocol.set -> void
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.TimeoutMilliseconds.get -> int
+OpenTelemetry.Exporter.ICommonOtlpExporterOptions.TimeoutMilliseconds.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.AggregationTemporality.get -> OpenTelemetry.Metrics.AggregationTemporality
 OpenTelemetry.Exporter.OtlpExporterOptions.AggregationTemporality.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.MetricReaderType.get -> OpenTelemetry.Metrics.MetricReaderType

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
@@ -23,6 +23,21 @@ OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf = 2 -> OpenTelemetry.Expo
 OpenTelemetry.Exporter.OtlpExportProtocol.Unspecified = 0 -> OpenTelemetry.Exporter.OtlpExportProtocol
 OpenTelemetry.Exporter.OtlpMetricExporter
 OpenTelemetry.Exporter.OtlpMetricExporter.OtlpMetricExporter(OpenTelemetry.Exporter.OtlpExporterOptions options) -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.AggregationTemporality.get -> OpenTelemetry.Metrics.AggregationTemporality
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.AggregationTemporality.set -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.Endpoint.get -> System.Uri
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.Endpoint.set -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.Headers.get -> string
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.Headers.set -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.MetricReaderType.get -> OpenTelemetry.Metrics.MetricReaderType
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.MetricReaderType.set -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.PeriodicExportingMetricReaderOptions.get -> OpenTelemetry.Metrics.PeriodicExportingMetricReaderOptions
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.PeriodicExportingMetricReaderOptions.set -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.Protocol.get -> OpenTelemetry.Exporter.OtlpExportProtocol
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.Protocol.set -> void
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.TimeoutMilliseconds.get -> int
+OpenTelemetry.Exporter.OtlpMetricExporterOptions.TimeoutMilliseconds.set -> void
 OpenTelemetry.Metrics.OtlpMetricExporterExtensions
 override OpenTelemetry.Exporter.OtlpMetricExporter.Export(in OpenTelemetry.Batch<OpenTelemetry.Metrics.Metric> metrics) -> OpenTelemetry.ExportResult
 override OpenTelemetry.Exporter.OtlpMetricExporter.OnShutdown(int timeoutMilliseconds) -> bool

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/ICommonOtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/ICommonOtlpExporterOptions.cs
@@ -38,7 +38,7 @@ public interface ICommonOtlpExporterOptions
     public string Headers { get; set; }
 
     /// <summary>
-    /// Gets or sets the max waiting time (in milliseconds) for the backend to process each batch. The default value is 10000.
+    /// Gets or sets the maximum waiting time (in milliseconds) for the backend to process each batch. The default value is 10000.
     /// </summary>
     public int TimeoutMilliseconds { get; set; }
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/ICommonOtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/ICommonOtlpExporterOptions.cs
@@ -1,0 +1,49 @@
+// <copyright file="ICommonOtlpExporterOptions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+
+namespace OpenTelemetry.Exporter;
+
+/// <summary>
+/// Interface representing the OTLP exporter configuration options common for all signal types (i.e., logs, metrics, and traces).
+/// See: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options.
+/// </summary>
+public interface ICommonOtlpExporterOptions
+{
+    /// <summary>
+    /// Gets or sets the target to which the exporter is going to send telemetry.
+    /// Must be a valid Uri with scheme (http or https) and host, and
+    /// may contain a port and path. The default value is http://localhost:4317.
+    /// </summary>
+    public Uri Endpoint { get; set; }
+
+    /// <summary>
+    /// Gets or sets optional headers for the connection. Refer to the <a href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#specifying-headers-via-environment-variables">
+    /// specification</a> for information on the expected format for Headers.
+    /// </summary>
+    public string Headers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the max waiting time (in milliseconds) for the backend to process each batch. The default value is 10000.
+    /// </summary>
+    public int TimeoutMilliseconds { get; set; }
+
+    /// <summary>
+    /// Gets or sets the the OTLP transport protocol. Supported values: Grpc and HttpProtobuf.
+    /// </summary>
+    public OtlpExportProtocol Protocol { get; set; }
+}

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/BaseOtlpGrpcExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/BaseOtlpGrpcExportClient.cs
@@ -28,7 +28,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClie
     /// <typeparam name="TRequest">Type of export request.</typeparam>
     internal abstract class BaseOtlpGrpcExportClient<TRequest> : IExportClient<TRequest>
     {
-        protected BaseOtlpGrpcExportClient(OtlpExporterOptions options)
+        protected BaseOtlpGrpcExportClient(ICommonOtlpExporterOptions options)
         {
             Guard.Null(options, nameof(options));
             Guard.InvalidTimeout(options.TimeoutMilliseconds, nameof(options.TimeoutMilliseconds));
@@ -37,7 +37,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClie
             this.Headers = options.GetMetadataFromHeaders();
         }
 
-        internal OtlpExporterOptions Options { get; }
+        internal ICommonOtlpExporterOptions Options { get; }
 
 #if NETSTANDARD2_1 || NET5_0_OR_GREATER
         internal GrpcChannel Channel { get; set; }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/BaseOtlpHttpExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/BaseOtlpHttpExportClient.cs
@@ -25,7 +25,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClie
     /// <typeparam name="TRequest">Type of export request.</typeparam>
     internal abstract class BaseOtlpHttpExportClient<TRequest> : IExportClient<TRequest>
     {
-        protected BaseOtlpHttpExportClient(OtlpExporterOptions options, HttpClient httpClient)
+        protected BaseOtlpHttpExportClient(ICommonOtlpExporterOptions options, HttpClient httpClient)
         {
             Guard.Null(options, nameof(options));
             Guard.Null(httpClient, nameof(httpClient));
@@ -36,7 +36,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClie
             this.HttpClient = httpClient;
         }
 
-        internal OtlpExporterOptions Options { get; }
+        internal ICommonOtlpExporterOptions Options { get; }
 
         internal HttpClient HttpClient { get; }
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcMetricsExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcMetricsExportClient.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClie
     {
         private readonly OtlpCollector.MetricsService.IMetricsServiceClient metricsClient;
 
-        public OtlpGrpcMetricsExportClient(OtlpExporterOptions options, OtlpCollector.MetricsService.IMetricsServiceClient metricsServiceClient = null)
+        public OtlpGrpcMetricsExportClient(ICommonOtlpExporterOptions options, OtlpCollector.MetricsService.IMetricsServiceClient metricsServiceClient = null)
             : base(options)
         {
             if (metricsServiceClient != null)

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpHttpMetricsExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpHttpMetricsExportClient.cs
@@ -35,7 +35,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClie
         internal const string MediaContentType = "application/x-protobuf";
         private readonly Uri exportMetricsUri;
 
-        public OtlpHttpMetricsExportClient(OtlpExporterOptions options, HttpClient httpClient)
+        public OtlpHttpMetricsExportClient(ICommonOtlpExporterOptions options, HttpClient httpClient)
             : base(options, httpClient)
         {
             this.exportMetricsUri = this.Options.Endpoint;

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExportProtocol.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExportProtocol.cs
@@ -22,13 +22,18 @@ namespace OpenTelemetry.Exporter
     public enum OtlpExportProtocol : byte
     {
         /// <summary>
+        /// OTLP protocol has not been specified.
+        /// </summary>
+        Unspecified = 0,
+
+        /// <summary>
         /// OTLP over gRPC (corresponds to 'grpc' Protocol configuration option). Used as default.
         /// </summary>
-        Grpc = 0,
+        Grpc = 1,
 
         /// <summary>
         /// OTLP over HTTP with protobuf payloads (corresponds to 'http/protobuf' Protocol configuration option).
         /// </summary>
-        HttpProtobuf = 1,
+        HttpProtobuf = 2,
     }
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -32,7 +32,7 @@ namespace OpenTelemetry.Exporter
     /// The constructor throws <see cref="FormatException"/> if it fails to parse
     /// any of the supported environment variables.
     /// </remarks>
-    public class OtlpExporterOptions
+    public class OtlpExporterOptions : ICommonOtlpExporterOptions
     {
         internal const string EndpointEnvVarName = "OTEL_EXPORTER_OTLP_ENDPOINT";
         internal const string HeadersEnvVarName = "OTEL_EXPORTER_OTLP_HEADERS";

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -84,6 +84,8 @@ namespace OpenTelemetry.Exporter
                     Timeout = TimeSpan.FromMilliseconds(this.TimeoutMilliseconds),
                 };
             };
+
+            this.MetricOptions = new OtlpMetricExporterOptions(this);
         }
 
         /// <summary>
@@ -110,6 +112,11 @@ namespace OpenTelemetry.Exporter
         public OtlpExportProtocol Protocol { get; set; } = OtlpExportProtocol.Grpc;
 
         /// <summary>
+        /// Gets metric-specific OTLP exporter options.
+        /// </summary>
+        public OtlpMetricExporterOptions MetricOptions { get; }
+
+        /// <summary>
         /// Gets or sets the export processor type to be used with the OpenTelemetry Protocol Exporter. The default value is <see cref="ExportProcessorType.Batch"/>.
         /// </summary>
         public ExportProcessorType ExportProcessorType { get; set; } = ExportProcessorType.Batch;
@@ -118,22 +125,6 @@ namespace OpenTelemetry.Exporter
         /// Gets or sets the BatchExportProcessor options. Ignored unless ExportProcessorType is Batch.
         /// </summary>
         public BatchExportProcessorOptions<Activity> BatchExportProcessorOptions { get; set; } = new BatchExportActivityProcessorOptions();
-
-        /// <summary>
-        /// Gets or sets the <see cref="MetricReaderType" /> to use. Defaults to <c>MetricReaderType.Periodic</c>.
-        /// </summary>
-        public MetricReaderType MetricReaderType { get; set; } = MetricReaderType.Periodic;
-
-        /// <summary>
-        /// Gets or sets the <see cref="PeriodicExportingMetricReaderOptions" /> options. Ignored unless <c>MetricReaderType</c> is <c>Periodic</c>.
-        /// </summary>
-        public PeriodicExportingMetricReaderOptions PeriodicExportingMetricReaderOptions { get; set; } = new PeriodicExportingMetricReaderOptions();
-
-        /// <summary>
-        /// Gets or sets the AggregationTemporality used for Histogram
-        /// and Sum metrics.
-        /// </summary>
-        public AggregationTemporality AggregationTemporality { get; set; } = AggregationTemporality.Cumulative;
 
         /// <summary>
         /// Gets or sets the factory function called to create the <see

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
@@ -31,9 +31,9 @@ namespace OpenTelemetry.Exporter
     internal static class OtlpExporterOptionsExtensions
     {
 #if NETSTANDARD2_1 || NET5_0_OR_GREATER
-        public static GrpcChannel CreateChannel(this OtlpExporterOptions options)
+        public static GrpcChannel CreateChannel(this ICommonOtlpExporterOptions options)
 #else
-        public static Channel CreateChannel(this OtlpExporterOptions options)
+        public static Channel CreateChannel(this ICommonOtlpExporterOptions options)
 #endif
         {
             if (options.Endpoint.Scheme != Uri.UriSchemeHttp && options.Endpoint.Scheme != Uri.UriSchemeHttps)
@@ -58,12 +58,12 @@ namespace OpenTelemetry.Exporter
 #endif
         }
 
-        public static Metadata GetMetadataFromHeaders(this OtlpExporterOptions options)
+        public static Metadata GetMetadataFromHeaders(this ICommonOtlpExporterOptions options)
         {
             return options.GetHeaders<Metadata>((m, k, v) => m.Add(k, v));
         }
 
-        public static THeaders GetHeaders<THeaders>(this OtlpExporterOptions options, Action<THeaders, string, string> addHeader)
+        public static THeaders GetHeaders<THeaders>(this ICommonOtlpExporterOptions options, Action<THeaders, string, string> addHeader)
             where THeaders : new()
         {
             var optionHeaders = options.Headers;
@@ -104,9 +104,9 @@ namespace OpenTelemetry.Exporter
         public static IExportClient<MetricsOtlpCollector.ExportMetricsServiceRequest> GetMetricsExportClient(this OtlpExporterOptions options) =>
             options.Protocol switch
             {
-                OtlpExportProtocol.Grpc => new OtlpGrpcMetricsExportClient(options),
+                OtlpExportProtocol.Grpc => new OtlpGrpcMetricsExportClient(options.MetricOptions),
                 OtlpExportProtocol.HttpProtobuf => new OtlpHttpMetricsExportClient(
-                    options,
+                    options.MetricOptions,
                     options.HttpClientFactory?.Invoke() ?? throw new InvalidOperationException("OtlpExporterOptions was missing HttpClientFactory or it returned null.")),
                 _ => throw new NotSupportedException($"Protocol {options.Protocol} is not supported."),
             };

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
@@ -52,7 +52,7 @@ namespace OpenTelemetry.Metrics
             Action<OtlpExporterOptions> configure,
             IServiceProvider serviceProvider)
         {
-            var initialEndpoint = options.Endpoint;
+            var initialEndpoint = options.MetricOptions.Endpoint;
 
             configure?.Invoke(options);
 
@@ -62,11 +62,11 @@ namespace OpenTelemetry.Metrics
 
             var metricExporter = new OtlpMetricExporter(options);
 
-            var metricReader = options.MetricReaderType == MetricReaderType.Manual
+            var metricReader = options.MetricOptions.MetricReaderType == MetricReaderType.Manual
                 ? new BaseExportingMetricReader(metricExporter)
-                : new PeriodicExportingMetricReader(metricExporter, options.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds);
+                : new PeriodicExportingMetricReader(metricExporter, options.MetricOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds);
 
-            metricReader.Temporality = options.AggregationTemporality;
+            metricReader.Temporality = options.MetricOptions.AggregationTemporality;
             return builder.AddReader(metricReader);
         }
     }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterOptions.cs
@@ -1,0 +1,121 @@
+// <copyright file="OtlpMetricExporterOptions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using OpenTelemetry.Internal;
+using OpenTelemetry.Metrics;
+
+namespace OpenTelemetry.Exporter;
+
+/// <summary>
+/// OpenTelemetry Protocol (OTLP) exporter options for metric specific OTLP exporter configuration.
+/// OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, OTEL_EXPORTER_OTLP_METRICS_HEADERS, OTEL_EXPORTER_OTLP_METRICS_TIMEOUT, OTEL_EXPORTER_OTLP_METRICS_PROTOCOL
+/// environment variables are parsed during object construction.
+/// </summary>
+/// <remarks>
+/// The constructor throws <see cref="FormatException"/> if it fails to parse
+/// any of the supported environment variables.
+/// </remarks>
+public class OtlpMetricExporterOptions : ICommonOtlpExporterOptions
+{
+    internal const string EndpointEnvVarName = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT";
+    internal const string HeadersEnvVarName = "OTEL_EXPORTER_OTLP_METRICS_HEADERS";
+    internal const string TimeoutEnvVarName = "OTEL_EXPORTER_OTLP_METRICS_TIMEOUT";
+    internal const string ProtocolEnvVarName = "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL";
+
+    private ICommonOtlpExporterOptions baseOptions;
+    private Uri endpoint = null;
+    private string headers = null;
+    private int timeoutMilliseconds = int.MinValue;
+    private OtlpExportProtocol protocol = OtlpExportProtocol.Unspecified;
+
+    internal OtlpMetricExporterOptions(ICommonOtlpExporterOptions baseOptions)
+    {
+        this.baseOptions = baseOptions;
+
+        if (EnvironmentVariableHelper.LoadUri(EndpointEnvVarName, out Uri endpoint))
+        {
+            this.Endpoint = endpoint;
+        }
+
+        if (EnvironmentVariableHelper.LoadString(HeadersEnvVarName, out string headersEnvVar))
+        {
+            this.Headers = headersEnvVar;
+        }
+
+        if (EnvironmentVariableHelper.LoadNumeric(TimeoutEnvVarName, out int timeout))
+        {
+            this.TimeoutMilliseconds = timeout;
+        }
+
+        if (EnvironmentVariableHelper.LoadString(ProtocolEnvVarName, out string protocolEnvVar))
+        {
+            var protocol = protocolEnvVar.ToOtlpExportProtocol();
+            if (protocol.HasValue)
+            {
+                this.Protocol = protocol.Value;
+            }
+            else
+            {
+                throw new FormatException($"{ProtocolEnvVarName} environment variable has an invalid value: '${protocolEnvVar}'");
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public Uri Endpoint
+    {
+        get => this.endpoint ?? this.baseOptions.Endpoint;
+        set => this.endpoint = value;
+    }
+
+    /// <inheritdoc/>
+    public string Headers
+    {
+        get => this.headers ?? this.baseOptions.Headers;
+        set => this.headers = value;
+    }
+
+    /// <inheritdoc/>
+    public int TimeoutMilliseconds
+    {
+        get => this.timeoutMilliseconds == int.MinValue ? this.baseOptions.TimeoutMilliseconds : this.timeoutMilliseconds;
+        set => this.timeoutMilliseconds = value;
+    }
+
+    /// <inheritdoc/>
+    public OtlpExportProtocol Protocol
+    {
+        get => this.protocol == OtlpExportProtocol.Unspecified ? this.baseOptions.Protocol : this.protocol;
+        set => this.protocol = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="MetricReaderType" /> to use. Defaults to <c>MetricReaderType.Periodic</c>.
+    /// </summary>
+    public MetricReaderType MetricReaderType { get; set; } = MetricReaderType.Periodic;
+
+    /// <summary>
+    /// Gets or sets the <see cref="PeriodicExportingMetricReaderOptions" /> options. Ignored unless <c>MetricReaderType</c> is <c>Periodic</c>.
+    /// </summary>
+    public PeriodicExportingMetricReaderOptions PeriodicExportingMetricReaderOptions { get; set; } = new PeriodicExportingMetricReaderOptions();
+
+    /// <summary>
+    /// Gets or sets the AggregationTemporality used for Histogram
+    /// and Sum metrics.
+    /// </summary>
+    public AggregationTemporality AggregationTemporality { get; set; } = AggregationTemporality.Cumulative;
+}


### PR DESCRIPTION
This is a proposal to move signal-specific exporter options to their own class. This PR just moves the metric-specific options for now to get input. If folks like this approach, then my plan would be to make a trace-specific options class and move `ExportProcessorType` and `BatchExporterProcessorOptions` and then mark these options obsolete on the `OtlpExporterOptions` class.

I thought about making `OtlpExporterOptions` a base class, but instead made an interface `ICommonOtlpExporterOptions` since we have `AddOtlpExporter` extensions methods like

```csharp
public static TracerProviderBuilder AddOtlpExporter(this TracerProviderBuilder builder, Action<OtlpExporterOptions> configure)
```

so we could not then add another extension method like... unless this wouldn't be considered a breaking change 🤔.

```csharp
public static TracerProviderBuilder AddOtlpExporter(this TracerProviderBuilder builder, Action<TraceOtlpExporterOptions> configure)
```

This PR also implements support for the `OTEL_EXPORTER_OTLP_METRICS_*` environment variables.

---

@CodeBlanch had another idea which is to leave `OtlpExporterOptions` as is with all the metric, trace, and ultimately log specific settings on this class. Then provide an API using a builder pattern to allow people to more easily build up an appropriate options instance.