### PR TITLE
[DO NOT MERGE] Exporter should not be allowed to update MetricPoint in the AggregatorStore

### DIFF
--- a/test/OpenTelemetry.Tests/Metrics/MetricExporterTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricExporterTests.cs
@@ -15,6 +15,10 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Tests;
 using Xunit;
 
 namespace OpenTelemetry.Metrics.Tests
@@ -65,6 +69,55 @@ namespace OpenTelemetry.Metrics.Tests
             }
         }
 
+        [Fact]
+        public void ExporterShouldNotUpdateMetricPoint()
+        {
+            var exportedItems = new List<Metric>();
+            var updateMetricPointExporter = new UpdateMetricPointExporter(exportedItems);
+            using var meter = new Meter(Utils.GetCurrentMethodName());
+            using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+            .AddReader(new BaseExportingMetricReader(updateMetricPointExporter) { Temporality = AggregationTemporality.Delta })
+            .Build();
+
+            var counter = meter.CreateCounter<long>("counter");
+            counter.Add(100, new KeyValuePair<string, object>("key", "value"));
+
+            meterProvider.ForceFlush();
+
+            Assert.Single(exportedItems);
+            var metricPoint = this.GetFirstMetricPointFromMetric(exportedItems[0]);
+            Assert.Equal(100, metricPoint.GetSumLong());
+            foreach (var tag in metricPoint.Tags)
+            {
+                Assert.Equal("key", tag.Key);
+                Assert.Equal("value", tag.Value);
+            }
+
+            exportedItems.Clear();
+
+            counter.Add(150, new KeyValuePair<string, object>("key", "value"));
+
+            meterProvider.ForceFlush();
+
+            Assert.Single(exportedItems);
+            metricPoint = this.GetFirstMetricPointFromMetric(exportedItems[0]);
+            Assert.Equal(150, metricPoint.GetSumLong());
+            foreach (var tag in metricPoint.Tags)
+            {
+                Assert.Equal("key", tag.Key);
+                Assert.Equal("value", tag.Value);
+            }
+        }
+
+        private ref MetricPoint GetFirstMetricPointFromMetric(Metric metric)
+        {
+            var metricPoints = metric.GetMetricPoints();
+            var metricPointsEnumerator = metricPoints.GetEnumerator();
+            Assert.True(metricPointsEnumerator.MoveNext()); // One MetricPoint is emitted for the Metric
+            return ref metricPointsEnumerator.Current;
+        }
+
         [ExportModes(ExportModes.Push)]
         private class PushOnlyMetricExporter : BaseExporter<Metric>
         {
@@ -96,6 +149,36 @@ namespace OpenTelemetry.Metrics.Tests
         {
             public override ExportResult Export(in Batch<Metric> batch)
             {
+                return ExportResult.Success;
+            }
+        }
+
+        private class UpdateMetricPointExporter : BaseExporter<Metric>
+        {
+            private static int invocationCount = 1;
+            private readonly List<Metric> exportedItems;
+
+            public UpdateMetricPointExporter(List<Metric> exportedItems)
+            {
+                this.exportedItems = exportedItems;
+            }
+
+            public override ExportResult Export(in Batch<Metric> batch)
+            {
+                foreach (var metric in batch)
+                {
+                    if (invocationCount > 1)
+                    {
+                        foreach (ref var metricPoint in metric.GetMetricPoints())
+                        {
+                            metricPoint = default;
+                        }
+                    }
+
+                    this.exportedItems.Add(metric);
+                }
+
+                invocationCount++;
                 return ExportResult.Success;
             }
         }


### PR DESCRIPTION
The enumerator of [Metric.GetMetricPoints()](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry/Metrics/MetricPointsAccessor.cs#L83) returns a reference to the `MetricPoint` in the `MetricPoint[]` used in the `AggregatorStore`. Since we return a reference to the `MetricPoint`, an exporter can set its value to `default` and thus change the original entry in the `MetricPoint[]`. This can clearly interfere with SDK's working.

## Changes
- Added a unit test to show that an exporter can update the `MetricPoint` of the `MetricPoint[]` of `AggregatorStore`
