### PR TITLE
Make MetricPoint access from MetricPointAccessor readonly

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -75,7 +75,7 @@ namespace OpenTelemetry.Exporter
 
                 Console.WriteLine(msg.ToString());
 
-                foreach (ref var metricPoint in metric.GetMetricPoints())
+                foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                 {
                     string valueDisplay = string.Empty;
                     StringBuilder tagsBuilder = new StringBuilder();

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/MetricItemExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/MetricItemExtensions.cs
@@ -148,7 +148,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
                         sum.IsMonotonic = true;
                         sum.AggregationTemporality = temporality;
 
-                        foreach (ref var metricPoint in metric.GetMetricPoints())
+                        foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                         {
                             var dataPoint = new OtlpMetrics.NumberDataPoint
                             {
@@ -172,7 +172,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
                         sum.IsMonotonic = true;
                         sum.AggregationTemporality = temporality;
 
-                        foreach (ref var metricPoint in metric.GetMetricPoints())
+                        foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                         {
                             var dataPoint = new OtlpMetrics.NumberDataPoint
                             {
@@ -193,7 +193,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
                 case MetricType.LongGauge:
                     {
                         var gauge = new OtlpMetrics.Gauge();
-                        foreach (ref var metricPoint in metric.GetMetricPoints())
+                        foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                         {
                             var dataPoint = new OtlpMetrics.NumberDataPoint
                             {
@@ -214,7 +214,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
                 case MetricType.DoubleGauge:
                     {
                         var gauge = new OtlpMetrics.Gauge();
-                        foreach (ref var metricPoint in metric.GetMetricPoints())
+                        foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                         {
                             var dataPoint = new OtlpMetrics.NumberDataPoint
                             {
@@ -237,7 +237,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
                         var histogram = new OtlpMetrics.Histogram();
                         histogram.AggregationTemporality = temporality;
 
-                        foreach (ref var metricPoint in metric.GetMetricPoints())
+                        foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                         {
                             var dataPoint = new OtlpMetrics.HistogramDataPoint
                             {

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusSerializerExt.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusSerializerExt.cs
@@ -40,7 +40,7 @@ namespace OpenTelemetry.Exporter.Prometheus
 
             if (!metric.MetricType.IsHistogram())
             {
-                foreach (ref var metricPoint in metric.GetMetricPoints())
+                foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                 {
                     var tags = metricPoint.Tags;
                     var timestamp = metricPoint.EndTime.ToUnixTimeMilliseconds();
@@ -103,7 +103,7 @@ namespace OpenTelemetry.Exporter.Prometheus
             }
             else
             {
-                foreach (ref var metricPoint in metric.GetMetricPoints())
+                foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                 {
                     var tags = metricPoint.Tags;
                     var timestamp = metricPoint.EndTime.ToUnixTimeMilliseconds();

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -125,7 +125,7 @@ namespace OpenTelemetry.Metrics
         {
             for (int i = 0; i <= indexSnapshot; i++)
             {
-                ref readonly var metricPoint = ref this.metricPoints[i];
+                ref var metricPoint = ref this.metricPoints[i];
                 if (metricPoint.MetricPointStatus == MetricPointStatus.NoCollectPending)
                 {
                     continue;
@@ -146,7 +146,7 @@ namespace OpenTelemetry.Metrics
         {
             for (int i = 0; i <= indexSnapshot; i++)
             {
-                ref readonly var metricPoint = ref this.metricPoints[i];
+                ref var metricPoint = ref this.metricPoints[i];
                 if (metricPoint.StartTime == default)
                 {
                     continue;

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -125,7 +125,7 @@ namespace OpenTelemetry.Metrics
         {
             for (int i = 0; i <= indexSnapshot; i++)
             {
-                ref var metricPoint = ref this.metricPoints[i];
+                ref readonly var metricPoint = ref this.metricPoints[i];
                 if (metricPoint.MetricPointStatus == MetricPointStatus.NoCollectPending)
                 {
                     continue;
@@ -146,7 +146,7 @@ namespace OpenTelemetry.Metrics
         {
             for (int i = 0; i <= indexSnapshot; i++)
             {
-                ref var metricPoint = ref this.metricPoints[i];
+                ref readonly var metricPoint = ref this.metricPoints[i];
                 if (metricPoint.StartTime == default)
                 {
                     continue;

--- a/src/OpenTelemetry/Metrics/MetricPointsAccessor.cs
+++ b/src/OpenTelemetry/Metrics/MetricPointsAccessor.cs
@@ -76,7 +76,7 @@ namespace OpenTelemetry.Metrics
             /// <summary>
             /// Gets the <see cref="MetricPoint"/> at the current position of the enumerator.
             /// </summary>
-            public ref MetricPoint Current
+            public ref readonly MetricPoint Current
             {
                 get
                 {

--- a/test/Benchmarks/Metrics/MetricCollectBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricCollectBenchmarks.cs
@@ -69,7 +69,7 @@ namespace Benchmarks.Metrics
                     if (this.UseWithRef)
                     {
                         // The performant way of iterating.
-                        foreach (ref var metricPoint in metric.GetMetricPoints())
+                        foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                         {
                             sum += metricPoint.GetSumDouble();
                         }

--- a/test/OpenTelemetry.Tests/Metrics/InMemoryExporterTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/InMemoryExporterTests.cs
@@ -48,7 +48,7 @@ namespace OpenTelemetry.Metrics.Tests
             var metric = exportedItems[0]; // Only one Metric object is added to the collection at this point
             var metricPointsEnumerator = metric.GetMetricPoints().GetEnumerator();
             Assert.True(metricPointsEnumerator.MoveNext()); // One MetricPoint is emitted for the Metric
-            ref var metricPointForFirstExport = ref metricPointsEnumerator.Current;
+            ref readonly var metricPointForFirstExport = ref metricPointsEnumerator.Current;
             Assert.Equal(10, metricPointForFirstExport.GetSumLong());
 
             // Emit 25 for the MetricPoint with a single key-vaue pair: ("tag1", "value1")

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -58,7 +58,7 @@ namespace OpenTelemetry.Metrics.Tests
             var metric = exportedItems[0];
             Assert.Equal("myGauge", metric.Name);
             List<MetricPoint> metricPoints = new List<MetricPoint>();
-            foreach (ref var mp in metric.GetMetricPoints())
+            foreach (ref readonly var mp in metric.GetMetricPoints())
             {
                 metricPoints.Add(mp);
             }
@@ -88,7 +88,7 @@ namespace OpenTelemetry.Metrics.Tests
             var metric = exportedItems[0];
             Assert.Equal("myGauge", metric.Name);
             List<MetricPoint> metricPoints = new List<MetricPoint>();
-            foreach (ref var mp in metric.GetMetricPoints())
+            foreach (ref readonly var mp in metric.GetMetricPoints())
             {
                 metricPoints.Add(mp);
             }
@@ -450,7 +450,7 @@ namespace OpenTelemetry.Metrics.Tests
 
                 foreach (var metric in exportedItems)
                 {
-                    foreach (ref var metricPoint in metric.GetMetricPoints())
+                    foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                     {
                         count++;
                     }
@@ -696,7 +696,7 @@ namespace OpenTelemetry.Metrics.Tests
             long sum = 0;
             foreach (var metric in metrics)
             {
-                foreach (ref var metricPoint in metric.GetMetricPoints())
+                foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                 {
                     if (metric.MetricType.IsSum())
                     {
@@ -717,7 +717,7 @@ namespace OpenTelemetry.Metrics.Tests
             double sum = 0;
             foreach (var metric in metrics)
             {
-                foreach (ref var metricPoint in metric.GetMetricPoints())
+                foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                 {
                     if (metric.MetricType.IsSum())
                     {

--- a/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
@@ -380,7 +380,7 @@ namespace OpenTelemetry.Metrics.Tests
             Assert.Equal("MyHistogram", metricCustom.Name);
 
             List<MetricPoint> metricPointsDefault = new List<MetricPoint>();
-            foreach (ref var mp in metricDefault.GetMetricPoints())
+            foreach (ref readonly var mp in metricDefault.GetMetricPoints())
             {
                 metricPointsDefault.Add(mp);
             }
@@ -407,7 +407,7 @@ namespace OpenTelemetry.Metrics.Tests
             Assert.Equal(Metric.DefaultHistogramBounds.Length + 1, actualCount);
 
             List<MetricPoint> metricPointsCustom = new List<MetricPoint>();
-            foreach (ref var mp in metricCustom.GetMetricPoints())
+            foreach (ref readonly var mp in metricCustom.GetMetricPoints())
             {
                 metricPointsCustom.Add(mp);
             }
@@ -465,7 +465,7 @@ namespace OpenTelemetry.Metrics.Tests
             var metric = exportedItems[0];
             Assert.Equal("NameOnly", metric.Name);
             List<MetricPoint> metricPoints = new List<MetricPoint>();
-            foreach (ref var mp in metric.GetMetricPoints())
+            foreach (ref readonly var mp in metric.GetMetricPoints())
             {
                 metricPoints.Add(mp);
             }
@@ -476,7 +476,7 @@ namespace OpenTelemetry.Metrics.Tests
             metric = exportedItems[1];
             Assert.Equal("SizeOnly", metric.Name);
             metricPoints.Clear();
-            foreach (ref var mp in metric.GetMetricPoints())
+            foreach (ref readonly var mp in metric.GetMetricPoints())
             {
                 metricPoints.Add(mp);
             }
@@ -487,7 +487,7 @@ namespace OpenTelemetry.Metrics.Tests
             metric = exportedItems[2];
             Assert.Equal("NoTags", metric.Name);
             metricPoints.Clear();
-            foreach (ref var mp in metric.GetMetricPoints())
+            foreach (ref readonly var mp in metric.GetMetricPoints())
             {
                 metricPoints.Add(mp);
             }

--- a/test/OpenTelemetry.Tests/Metrics/MultipleReadersTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MultipleReadersTests.cs
@@ -112,7 +112,7 @@ namespace OpenTelemetry.Metrics.Tests
             var metricPoints = metric.GetMetricPoints();
             var metricPointsEnumerator = metricPoints.GetEnumerator();
             Assert.True(metricPointsEnumerator.MoveNext()); // One MetricPoint is emitted for the Metric
-            ref var metricPointForFirstExport = ref metricPointsEnumerator.Current;
+            ref readonly var metricPointForFirstExport = ref metricPointsEnumerator.Current;
             if (metric.MetricType.IsSum())
             {
                 Assert.Equal(value, metricPointForFirstExport.GetSumLong());


### PR DESCRIPTION
Fixes the issue described in #2731 

## Changes
- Make MetricPoint access from MetricPointAccessor readonly

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
