### PR TITLE
Use HashSet constructor

### DIFF
--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -79,12 +79,7 @@ namespace OpenTelemetry.Metrics
             {
                 this.updateLongCallback = this.UpdateLongCustomTags;
                 this.updateDoubleCallback = this.UpdateDoubleCustomTags;
-                var hs = new HashSet<string>(StringComparer.Ordinal);
-                foreach (var key in tagKeysInteresting)
-                {
-                    hs.Add(key);
-                }
-
+                var hs = new HashSet<string>(tagKeysInteresting, StringComparer.Ordinal);
                 this.tagKeysInteresting = hs;
                 this.tagsKeysInterestingCount = hs.Count;
             }

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -89,12 +89,7 @@ namespace OpenTelemetry.Metrics
             }
             else if (meterSources.Any())
             {
-                var meterSourcesToSubscribe = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                foreach (var meterSource in meterSources)
-                {
-                    meterSourcesToSubscribe.Add(meterSource);
-                }
-
+                var meterSourcesToSubscribe = new HashSet<string>(meterSources, StringComparer.OrdinalIgnoreCase);
                 shouldListenTo = instrument => meterSourcesToSubscribe.Contains(instrument.Meter.Name);
             }
 

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -242,12 +242,7 @@ namespace OpenTelemetry.Trace
                 }
                 else
                 {
-                    var activitySources = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-                    foreach (var name in sources)
-                    {
-                        activitySources.Add(name);
-                    }
+                    var activitySources = new HashSet<string>(sources, StringComparer.OrdinalIgnoreCase);
 
                     if (this.supportLegacyActivity)
                     {


### PR DESCRIPTION
## Changes

Use the [HashSet constructor](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.hashset-1.-ctor?view=net-6.0#System_Collections_Generic_HashSet_1__ctor_System_Collections_Generic_IEnumerable__0__System_Collections_Generic_IEqualityComparer__0__) that takes an enumerable when doing a basic add all operation.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
