### PR TITLE
Update CONTRIBUTING.md with Visual Studio 2022

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ On all platforms, the minimum requirements are:
 
 ### Linux or MacOS
 
-* Visual Studio for Mac or Visual Studio Code
+* Visual Studio 2022+ for Mac or Visual Studio Code
 
 Mono might be required by your IDE but is not required by this project. This is
 because unit tests targeting .NET Framework (i.e: `net461`) are disabled outside
@@ -56,7 +56,7 @@ of Windows.
 
 ### Windows
 
-* Visual Studio 2017+ or Visual Studio Code
+* Visual Studio 2022+ or Visual Studio Code
 * .NET Framework 4.6.1+
 
 ### Public API


### PR DESCRIPTION

Fixes https://github.com/open-telemetry/opentelemetry-dotnet/issues/2729#issuecomment-988139167

## Changes

State that Visual Studio 2022 is required.
The minimum requirements on all platforms still looks good (git and ,NET Core 3.1+) but maybe we should also callout the other versions of .NET we target `net5.0` and `net6.0` so if they contributor wants to build and test all versions it's easier.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
