### PR TITLE
Zipkin Exporter: README clarification for MaxPayloadSizeInBytes

### DIFF
--- a/src/OpenTelemetry.Exporter.Zipkin/README.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/README.md
@@ -40,8 +40,8 @@ take precedence over the environment variables.
   instance that will be used at runtime to transmit spans over HTTP. See
   [Configure HttpClient](#configure-httpclient) for more details.
 
-* `MaxPayloadSizeInBytes`: Maximum payload size - for .NET versions **other**
-   than 4.5.2 (default 4096).
+* `MaxPayloadSizeInBytes`: Maximum payload size of UTF8 JSON chunks sent to
+  Zipkin (default 4096).
 
 * `ServiceName`: Name of the service reporting telemetry. If the `Resource`
    associated with the telemetry has "service.name" defined, then it'll be


### PR DESCRIPTION
## Changes

The description of `MaxPayloadSizeInBytes` option in the Zipkin Exporter README has become misleading over time. Attempting to make it more clear 🧙 