### PR TITLE
HTTP Instrumentation: CHANGELOG PR link fix

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Fixed an issue with `Filter` and `Enrich` callbacks not firing under certain
   conditions when gRPC is used
-  ([#2698](https://github.com/open-telemetry/opentelemetry-dotnet/issues/2698))
+  ([#2698](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2698))
 
 ## 1.0.0-rc8
 


### PR DESCRIPTION
## Changes

Fixed the link for https://github.com/open-telemetry/opentelemetry-dotnet/pull/2698 referenced in the HTTP Instrumentation CHANGELOG.
