### PR TITLE
Renaming Guard Methods to make their action more explicit

### DIFF
--- a/src/OpenTelemetry.Api/Baggage.cs
+++ b/src/OpenTelemetry.Api/Baggage.cs
@@ -239,7 +239,7 @@ namespace OpenTelemetry
         /// <returns>Baggage item or <see langword="null"/> if nothing was found.</returns>
         public string GetBaggage(string name)
         {
-            Guard.NullOrEmpty(name, nameof(name));
+            Guard.ThrowIfNullOrEmpty(name, nameof(name));
 
             return this.baggage != null && this.baggage.TryGetValue(name, out string value)
                 ? value

--- a/src/OpenTelemetry.Api/Context/Propagation/CompositeTextMapPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/CompositeTextMapPropagator.cs
@@ -35,7 +35,7 @@ namespace OpenTelemetry.Context.Propagation
         /// <param name="propagators">List of <see cref="TextMapPropagator"/> wire context propagator.</param>
         public CompositeTextMapPropagator(IEnumerable<TextMapPropagator> propagators)
         {
-            Guard.Null(propagators, nameof(propagators));
+            Guard.ThrowIfNull(propagators, nameof(propagators));
 
             this.propagators = new List<TextMapPropagator>(propagators);
         }

--- a/src/OpenTelemetry.Api/Context/RuntimeContext.cs
+++ b/src/OpenTelemetry.Api/Context/RuntimeContext.cs
@@ -41,7 +41,7 @@ namespace OpenTelemetry.Context
         /// <returns>The slot registered.</returns>
         public static RuntimeContextSlot<T> RegisterSlot<T>(string slotName)
         {
-            Guard.NullOrEmpty(slotName, nameof(slotName));
+            Guard.ThrowIfNullOrEmpty(slotName, nameof(slotName));
 
             lock (Slots)
             {
@@ -66,9 +66,9 @@ namespace OpenTelemetry.Context
         /// <returns>The slot previously registered.</returns>
         public static RuntimeContextSlot<T> GetSlot<T>(string slotName)
         {
-            Guard.NullOrEmpty(slotName, nameof(slotName));
+            Guard.ThrowIfNullOrEmpty(slotName, nameof(slotName));
             var slot = GuardNotFound(slotName);
-            var contextSlot = Guard.Type<RuntimeContextSlot<T>>(slot, nameof(slot));
+            var contextSlot = Guard.ThrowIfNotOfType<RuntimeContextSlot<T>>(slot, nameof(slot));
             return contextSlot;
         }
 
@@ -127,9 +127,9 @@ namespace OpenTelemetry.Context
         /// <param name="value">The value to be set.</param>
         public static void SetValue(string slotName, object value)
         {
-            Guard.NullOrEmpty(slotName, nameof(slotName));
+            Guard.ThrowIfNullOrEmpty(slotName, nameof(slotName));
             var slot = GuardNotFound(slotName);
-            var runtimeContextSlotValueAccessor = Guard.Type<IRuntimeContextSlotValueAccessor>(slot, nameof(slot));
+            var runtimeContextSlotValueAccessor = Guard.ThrowIfNotOfType<IRuntimeContextSlotValueAccessor>(slot, nameof(slot));
             runtimeContextSlotValueAccessor.Value = value;
         }
 
@@ -140,9 +140,9 @@ namespace OpenTelemetry.Context
         /// <returns>The value retrieved from the context slot.</returns>
         public static object GetValue(string slotName)
         {
-            Guard.NullOrEmpty(slotName, nameof(slotName));
+            Guard.ThrowIfNullOrEmpty(slotName, nameof(slotName));
             var slot = GuardNotFound(slotName);
-            var runtimeContextSlotValueAccessor = Guard.Type<IRuntimeContextSlotValueAccessor>(slot, nameof(slot));
+            var runtimeContextSlotValueAccessor = Guard.ThrowIfNotOfType<IRuntimeContextSlotValueAccessor>(slot, nameof(slot));
             return runtimeContextSlotValueAccessor.Value;
         }
 

--- a/src/OpenTelemetry.Api/Internal/Guard.cs
+++ b/src/OpenTelemetry.Api/Internal/Guard.cs
@@ -35,7 +35,7 @@ namespace OpenTelemetry.Internal
         /// <param name="paramName">The parameter name to use in the thrown exception.</param>
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Null(object value, string paramName = DefaultParamName)
+        public static void ThrowIfNull(object value, string paramName = DefaultParamName)
         {
             if (value is null)
             {
@@ -50,7 +50,7 @@ namespace OpenTelemetry.Internal
         /// <param name="paramName">The parameter name to use in the thrown exception.</param>
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void NullOrEmpty(string value, string paramName = DefaultParamName)
+        public static void ThrowIfNullOrEmpty(string value, string paramName = DefaultParamName)
         {
             if (string.IsNullOrEmpty(value))
             {
@@ -65,7 +65,7 @@ namespace OpenTelemetry.Internal
         /// <param name="paramName">The parameter name to use in the thrown exception.</param>
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void NullOrWhitespace(string value, string paramName = DefaultParamName)
+        public static void ThrowIfNullOrWhitespace(string value, string paramName = DefaultParamName)
         {
             if (string.IsNullOrWhiteSpace(value))
             {
@@ -81,7 +81,7 @@ namespace OpenTelemetry.Internal
         /// <param name="paramName">The parameter name to use in the thrown exception.</param>
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Zero(int value, string message = "Must not be zero", string paramName = DefaultParamName)
+        public static void ThrowIfZero(int value, string message = "Must not be zero", string paramName = DefaultParamName)
         {
             if (value == 0)
             {
@@ -96,9 +96,9 @@ namespace OpenTelemetry.Internal
         /// <param name="paramName">The parameter name to use in the thrown exception.</param>
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void InvalidTimeout(int value, string paramName = DefaultParamName)
+        public static void ThrowIfInvalidTimeout(int value, string paramName = DefaultParamName)
         {
-            Range(value, paramName, min: Timeout.Infinite, message: $"Must be non-negative or '{nameof(Timeout)}.{nameof(Timeout.Infinite)}'");
+            ThrowIfOutOfRange(value, paramName, min: Timeout.Infinite, message: $"Must be non-negative or '{nameof(Timeout)}.{nameof(Timeout.Infinite)}'");
         }
 
         /// <summary>
@@ -113,9 +113,9 @@ namespace OpenTelemetry.Internal
         /// <param name="message">An optional custom message to use in the thrown exception.</param>
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Range(int value, string paramName = DefaultParamName, int min = int.MinValue, int max = int.MaxValue, string minName = null, string maxName = null, string message = null)
+        public static void ThrowIfOutOfRange(int value, string paramName = DefaultParamName, int min = int.MinValue, int max = int.MaxValue, string minName = null, string maxName = null, string message = null)
         {
-            Range<int>(value, paramName, min, max, minName, maxName, message);
+            Range(value, paramName, min, max, minName, maxName, message);
         }
 
         /// <summary>
@@ -130,9 +130,9 @@ namespace OpenTelemetry.Internal
         /// <param name="message">An optional custom message to use in the thrown exception.</param>
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Range(double value, string paramName = DefaultParamName, double min = double.MinValue, double max = double.MaxValue, string minName = null, string maxName = null, string message = null)
+        public static void ThrowIfOutOfRange(double value, string paramName = DefaultParamName, double min = double.MinValue, double max = double.MaxValue, string minName = null, string maxName = null, string message = null)
         {
-            Range<double>(value, paramName, min, max, minName, maxName, message);
+            Range(value, paramName, min, max, minName, maxName, message);
         }
 
         /// <summary>
@@ -144,7 +144,7 @@ namespace OpenTelemetry.Internal
         /// <returns>The value casted to the specified type.</returns>
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static T Type<T>(object value, string paramName = DefaultParamName)
+        public static T ThrowIfNotOfType<T>(object value, string paramName = DefaultParamName)
         {
             if (value is not T result)
             {

--- a/src/OpenTelemetry.Api/Trace/SpanAttributes.cs
+++ b/src/OpenTelemetry.Api/Trace/SpanAttributes.cs
@@ -41,7 +41,7 @@ namespace OpenTelemetry.Trace
         public SpanAttributes(IEnumerable<KeyValuePair<string, object>> attributes)
             : this()
         {
-            Guard.Null(attributes, nameof(attributes));
+            Guard.ThrowIfNull(attributes, nameof(attributes));
 
             foreach (KeyValuePair<string, object> kvp in attributes)
             {
@@ -133,7 +133,7 @@ namespace OpenTelemetry.Trace
 
         private void AddInternal(string key, object value)
         {
-            Guard.Null(key, nameof(key));
+            Guard.ThrowIfNull(key, nameof(key));
 
             this.Attributes[key] = value;
         }

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterHelperExtensions.cs
@@ -31,7 +31,7 @@ namespace OpenTelemetry.Trace
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The objects should not be disposed.")]
         public static TracerProviderBuilder AddConsoleExporter(this TracerProviderBuilder builder, Action<ConsoleExporterOptions> configure = null)
         {
-            Guard.Null(builder, nameof(builder));
+            Guard.ThrowIfNull(builder, nameof(builder));
 
             if (builder is IDeferredTracerProviderBuilder deferredTracerProviderBuilder)
             {

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterLoggingExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterLoggingExtensions.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Logs
         /// <returns>The instance of <see cref="OpenTelemetryLoggerOptions"/> to chain the calls.</returns>
         public static OpenTelemetryLoggerOptions AddConsoleExporter(this OpenTelemetryLoggerOptions loggerOptions, Action<ConsoleExporterOptions> configure = null)
         {
-            Guard.Null(loggerOptions, nameof(loggerOptions));
+            Guard.ThrowIfNull(loggerOptions, nameof(loggerOptions));
 
             var options = new ConsoleExporterOptions();
             configure?.Invoke(options);

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterMetricsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterMetricsExtensions.cs
@@ -31,7 +31,7 @@ namespace OpenTelemetry.Metrics
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The objects should not be disposed.")]
         public static MeterProviderBuilder AddConsoleExporter(this MeterProviderBuilder builder, Action<ConsoleExporterOptions> configure = null)
         {
-            Guard.Null(builder, nameof(builder));
+            Guard.ThrowIfNull(builder, nameof(builder));
 
             var options = new ConsoleExporterOptions();
             configure?.Invoke(options);

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterHelperExtensions.cs
@@ -32,8 +32,8 @@ namespace OpenTelemetry.Trace
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The objects should not be disposed.")]
         public static TracerProviderBuilder AddInMemoryExporter(this TracerProviderBuilder builder, ICollection<Activity> exportedItems)
         {
-            Guard.Null(builder, nameof(builder));
-            Guard.Null(exportedItems, nameof(exportedItems));
+            Guard.ThrowIfNull(builder, nameof(builder));
+            Guard.ThrowIfNull(exportedItems, nameof(exportedItems));
 
             if (builder is IDeferredTracerProviderBuilder deferredTracerProviderBuilder)
             {

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterLoggingExtensions.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterLoggingExtensions.cs
@@ -24,8 +24,8 @@ namespace OpenTelemetry.Logs
     {
         public static OpenTelemetryLoggerOptions AddInMemoryExporter(this OpenTelemetryLoggerOptions loggerOptions, ICollection<LogRecord> exportedItems)
         {
-            Guard.Null(loggerOptions, nameof(loggerOptions));
-            Guard.Null(exportedItems, nameof(exportedItems));
+            Guard.ThrowIfNull(loggerOptions, nameof(loggerOptions));
+            Guard.ThrowIfNull(exportedItems, nameof(exportedItems));
 
             return loggerOptions.AddProcessor(new SimpleLogRecordExportProcessor(new InMemoryExporter<LogRecord>(exportedItems)));
         }

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterMetricsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterMetricsExtensions.cs
@@ -30,8 +30,8 @@ namespace OpenTelemetry.Metrics
         /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
         public static MeterProviderBuilder AddInMemoryExporter(this MeterProviderBuilder builder, ICollection<Metric> exportedItems)
         {
-            Guard.Null(builder, nameof(builder));
-            Guard.Null(exportedItems, nameof(exportedItems));
+            Guard.ThrowIfNull(builder, nameof(builder));
+            Guard.ThrowIfNull(exportedItems, nameof(exportedItems));
 
             return builder.AddReader(new BaseExportingMetricReader(new InMemoryExporter<Metric>(exportedItems)));
         }

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
@@ -50,7 +50,7 @@ namespace OpenTelemetry.Exporter
 
         internal JaegerExporter(JaegerExporterOptions options, TProtocolFactory protocolFactory = null, IJaegerClient client = null)
         {
-            Guard.Null(options, nameof(options));
+            Guard.ThrowIfNull(options, nameof(options));
 
             this.maxPayloadSizeInBytes = (!options.MaxPayloadSizeInBytes.HasValue || options.MaxPayloadSizeInBytes <= 0)
                 ? JaegerExporterOptions.DefaultMaxPayloadSizeInBytes
@@ -122,7 +122,7 @@ namespace OpenTelemetry.Exporter
 
         internal void SetResourceAndInitializeBatch(Resource resource)
         {
-            Guard.Null(resource, nameof(resource));
+            Guard.ThrowIfNull(resource, nameof(resource));
 
             var process = this.Process;
 

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterHelperExtensions.cs
@@ -35,7 +35,7 @@ namespace OpenTelemetry.Trace
         /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
         public static TracerProviderBuilder AddJaegerExporter(this TracerProviderBuilder builder, Action<JaegerExporterOptions> configure = null)
         {
-            Guard.Null(builder, nameof(builder));
+            Guard.ThrowIfNull(builder, nameof(builder));
 
             if (builder is IDeferredTracerProviderBuilder deferredTracerProviderBuilder)
             {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs/OtlpLogExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs/OtlpLogExporterHelperExtensions.cs
@@ -33,7 +33,7 @@ namespace OpenTelemetry.Logs
         /// <returns>The instance of <see cref="OpenTelemetryLoggerOptions"/> to chain the calls.</returns>
         public static OpenTelemetryLoggerOptions AddOtlpExporter(this OpenTelemetryLoggerOptions loggerOptions, Action<OtlpExporterOptions> configure = null)
         {
-            Guard.Null(loggerOptions);
+            Guard.ThrowIfNull(loggerOptions);
 
             return AddOtlpExporter(loggerOptions, new OtlpExporterOptions(), configure);
         }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/BaseOtlpGrpcExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/BaseOtlpGrpcExportClient.cs
@@ -30,8 +30,8 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClie
     {
         protected BaseOtlpGrpcExportClient(OtlpExporterOptions options)
         {
-            Guard.Null(options, nameof(options));
-            Guard.InvalidTimeout(options.TimeoutMilliseconds, nameof(options.TimeoutMilliseconds));
+            Guard.ThrowIfNull(options, nameof(options));
+            Guard.ThrowIfInvalidTimeout(options.TimeoutMilliseconds, nameof(options.TimeoutMilliseconds));
 
             ExporterClientValidation.EnsureUnencryptedSupportIsEnabled(options);
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/BaseOtlpHttpExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/BaseOtlpHttpExportClient.cs
@@ -27,9 +27,9 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClie
     {
         protected BaseOtlpHttpExportClient(OtlpExporterOptions options, HttpClient httpClient)
         {
-            Guard.Null(options, nameof(options));
-            Guard.Null(httpClient, nameof(httpClient));
-            Guard.InvalidTimeout(options.TimeoutMilliseconds, $"{nameof(options)}.{nameof(options.TimeoutMilliseconds)}");
+            Guard.ThrowIfNull(options, nameof(options));
+            Guard.ThrowIfNull(httpClient, nameof(httpClient));
+            Guard.ThrowIfInvalidTimeout(options.TimeoutMilliseconds, $"{nameof(options)}.{nameof(options.TimeoutMilliseconds)}");
 
             this.Options = options;
             this.Headers = options.GetHeaders<Dictionary<string, string>>((d, k, v) => d.Add(k, v));

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
@@ -33,7 +33,7 @@ namespace OpenTelemetry.Metrics
         /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
         public static MeterProviderBuilder AddOtlpExporter(this MeterProviderBuilder builder, Action<OtlpExporterOptions> configure = null)
         {
-            Guard.Null(builder, nameof(builder));
+            Guard.ThrowIfNull(builder, nameof(builder));
 
             if (builder is IDeferredMeterProviderBuilder deferredMeterProviderBuilder)
             {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
@@ -33,7 +33,7 @@ namespace OpenTelemetry.Trace
         /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
         public static TracerProviderBuilder AddOtlpExporter(this TracerProviderBuilder builder, Action<OtlpExporterOptions> configure = null)
         {
-            Guard.Null(builder, nameof(builder));
+            Guard.ThrowIfNull(builder, nameof(builder));
 
             if (builder is IDeferredTracerProviderBuilder deferredTracerProviderBuilder)
             {

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterHttpServer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterHttpServer.cs
@@ -40,7 +40,7 @@ namespace OpenTelemetry.Exporter.Prometheus
         /// <param name="exporter">The <see cref="PrometheusExporter"/> instance.</param>
         public PrometheusExporterHttpServer(PrometheusExporter exporter)
         {
-            Guard.Null(exporter, nameof(exporter));
+            Guard.ThrowIfNull(exporter, nameof(exporter));
 
             this.exporter = exporter;
             if ((exporter.Options.HttpListenerPrefixes?.Count ?? 0) <= 0)

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterMiddleware.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterMiddleware.cs
@@ -38,7 +38,7 @@ namespace OpenTelemetry.Exporter.Prometheus
         /// <param name="next"><see cref="RequestDelegate"/>.</param>
         public PrometheusExporterMiddleware(MeterProvider meterProvider, RequestDelegate next)
         {
-            Guard.Null(meterProvider, nameof(meterProvider));
+            Guard.ThrowIfNull(meterProvider, nameof(meterProvider));
 
             if (!meterProvider.TryFindExporter(out PrometheusExporter exporter))
             {

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterMeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterMeterProviderBuilderExtensions.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Metrics
         /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
         public static MeterProviderBuilder AddPrometheusExporter(this MeterProviderBuilder builder, Action<PrometheusExporterOptions> configure = null)
         {
-            Guard.Null(builder, nameof(builder));
+            Guard.ThrowIfNull(builder, nameof(builder));
 
             if (builder is IDeferredMeterProviderBuilder deferredMeterProviderBuilder)
             {

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterOptions.cs
@@ -66,7 +66,7 @@ namespace OpenTelemetry.Exporter
             get => this.scrapeResponseCacheDurationMilliseconds;
             set
             {
-                Guard.Range(value, nameof(value), min: 0);
+                Guard.ThrowIfOutOfRange(value, nameof(value), min: 0);
 
                 this.scrapeResponseCacheDurationMilliseconds = value;
             }

--- a/src/OpenTelemetry.Exporter.ZPages/ZPagesExporter.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/ZPagesExporter.cs
@@ -37,7 +37,7 @@ namespace OpenTelemetry.Exporter.ZPages
         /// <param name="options">Options for the exporter.</param>
         public ZPagesExporter(ZPagesExporterOptions options)
         {
-            Guard.Null(options?.RetentionTime, $"{nameof(options)}?.{nameof(options.RetentionTime)}");
+            Guard.ThrowIfNull(options?.RetentionTime, $"{nameof(options)}?.{nameof(options.RetentionTime)}");
 
             ZPagesActivityTracker.RetentionTime = options.RetentionTime;
 

--- a/src/OpenTelemetry.Exporter.ZPages/ZPagesExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/ZPagesExporterHelperExtensions.cs
@@ -37,7 +37,7 @@ namespace OpenTelemetry.Trace
             this TracerProviderBuilder builder,
             Action<ZPagesExporterOptions> configure = null)
         {
-            Guard.Null(builder, nameof(builder));
+            Guard.ThrowIfNull(builder, nameof(builder));
 
             var exporterOptions = new ZPagesExporterOptions();
             configure?.Invoke(exporterOptions);

--- a/src/OpenTelemetry.Exporter.ZPages/ZPagesExporterStatsHttpServer.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/ZPagesExporterStatsHttpServer.cs
@@ -42,7 +42,7 @@ namespace OpenTelemetry.Exporter.ZPages
         /// <param name="exporter">The <see cref="ZPagesExporterStatsHttpServer"/> instance.</param>
         public ZPagesExporterStatsHttpServer(ZPagesExporter exporter)
         {
-            Guard.Null(exporter?.Options?.Url, $"{nameof(exporter)}?.{nameof(exporter.Options)}?.{nameof(exporter.Options.Url)}");
+            Guard.ThrowIfNull(exporter?.Options?.Url, $"{nameof(exporter)}?.{nameof(exporter.Options)}?.{nameof(exporter.Options.Url)}");
 
             this.httpListener.Prefixes.Add(exporter.Options.Url);
         }

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinSpan.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinSpan.cs
@@ -41,8 +41,8 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
             bool? debug,
             bool? shared)
         {
-            Guard.NullOrWhitespace(traceId, nameof(traceId));
-            Guard.NullOrWhitespace(id, nameof(id));
+            Guard.ThrowIfNullOrWhitespace(traceId, nameof(traceId));
+            Guard.ThrowIfNullOrWhitespace(id, nameof(id));
 
             this.TraceId = traceId;
             this.ParentId = parentId;

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporter.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporter.cs
@@ -48,7 +48,7 @@ namespace OpenTelemetry.Exporter
         /// <param name="client">Http client to use to upload telemetry.</param>
         public ZipkinExporter(ZipkinExporterOptions options, HttpClient client = null)
         {
-            Guard.Null(options, nameof(options));
+            Guard.ThrowIfNull(options, nameof(options));
 
             this.options = options;
             this.maxPayloadSizeInBytes = (!options.MaxPayloadSizeInBytes.HasValue || options.MaxPayloadSizeInBytes <= 0) ? ZipkinExporterOptions.DefaultMaxPayloadSizeInBytes : options.MaxPayloadSizeInBytes.Value;

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporterHelperExtensions.cs
@@ -36,7 +36,7 @@ namespace OpenTelemetry.Trace
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The objects should not be disposed.")]
         public static TracerProviderBuilder AddZipkinExporter(this TracerProviderBuilder builder, Action<ZipkinExporterOptions> configure = null)
         {
-            Guard.Null(builder, nameof(builder));
+            Guard.ThrowIfNull(builder, nameof(builder));
 
             if (builder is IDeferredTracerProviderBuilder deferredTracerProviderBuilder)
             {

--- a/src/OpenTelemetry.Extensions.Hosting/Implementation/MeterProviderBuilderHosting.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Implementation/MeterProviderBuilderHosting.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Metrics
 
         public MeterProviderBuilderHosting(IServiceCollection services)
         {
-            Guard.Null(services, nameof(services));
+            Guard.ThrowIfNull(services, nameof(services));
 
             this.Services = services;
         }
@@ -39,7 +39,7 @@ namespace OpenTelemetry.Metrics
 
         public MeterProviderBuilder Configure(Action<IServiceProvider, MeterProviderBuilder> configure)
         {
-            Guard.Null(configure, nameof(configure));
+            Guard.ThrowIfNull(configure, nameof(configure));
 
             this.configurationActions.Add(configure);
             return this;
@@ -47,7 +47,7 @@ namespace OpenTelemetry.Metrics
 
         public MeterProvider Build(IServiceProvider serviceProvider)
         {
-            Guard.Null(serviceProvider, nameof(serviceProvider));
+            Guard.ThrowIfNull(serviceProvider, nameof(serviceProvider));
 
             // Note: Not using a foreach loop because additional actions can be
             // added during each call.

--- a/src/OpenTelemetry.Extensions.Hosting/Implementation/TracerProviderBuilderHosting.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Implementation/TracerProviderBuilderHosting.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Trace
 
         public TracerProviderBuilderHosting(IServiceCollection services)
         {
-            Guard.Null(services, nameof(services));
+            Guard.ThrowIfNull(services, nameof(services));
 
             this.Services = services;
         }
@@ -39,7 +39,7 @@ namespace OpenTelemetry.Trace
 
         public TracerProviderBuilder Configure(Action<IServiceProvider, TracerProviderBuilder> configure)
         {
-            Guard.Null(configure, nameof(configure));
+            Guard.ThrowIfNull(configure, nameof(configure));
 
             this.configurationActions.Add(configure);
             return this;
@@ -47,7 +47,7 @@ namespace OpenTelemetry.Trace
 
         public TracerProvider Build(IServiceProvider serviceProvider)
         {
-            Guard.Null(serviceProvider, nameof(serviceProvider));
+            Guard.ThrowIfNull(serviceProvider, nameof(serviceProvider));
 
             // Note: Not using a foreach loop because additional actions can be
             // added during each call.

--- a/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryServicesExtensions.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryServicesExtensions.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
         public static IServiceCollection AddOpenTelemetryTracing(this IServiceCollection services, Action<TracerProviderBuilder> configure)
         {
-            Guard.Null(configure, nameof(configure));
+            Guard.ThrowIfNull(configure, nameof(configure));
 
             var builder = new TracerProviderBuilderHosting(services);
             configure(builder);
@@ -73,7 +73,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
         public static IServiceCollection AddOpenTelemetryMetrics(this IServiceCollection services, Action<MeterProviderBuilder> configure)
         {
-            Guard.Null(configure, nameof(configure));
+            Guard.ThrowIfNull(configure, nameof(configure));
 
             var builder = new MeterProviderBuilderHosting(services);
             configure(builder);
@@ -88,8 +88,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
         private static IServiceCollection AddOpenTelemetryTracing(this IServiceCollection services, Func<IServiceProvider, TracerProvider> createTracerProvider)
         {
-            Guard.Null(services, nameof(services));
-            Guard.Null(createTracerProvider, nameof(createTracerProvider));
+            Guard.ThrowIfNull(services, nameof(services));
+            Guard.ThrowIfNull(createTracerProvider, nameof(createTracerProvider));
 
             try
             {

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/TelemetryHttpModuleOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/TelemetryHttpModuleOptions.cs
@@ -42,7 +42,7 @@ namespace OpenTelemetry.Instrumentation.AspNet
             get => this.textMapPropagator;
             set
             {
-                Guard.Null(value, nameof(value));
+                Guard.ThrowIfNull(value, nameof(value));
 
                 this.textMapPropagator = value;
             }

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -32,7 +32,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
 
         public HttpInListener(AspNetInstrumentationOptions options)
         {
-            Guard.Null(options, nameof(options));
+            Guard.ThrowIfNull(options, nameof(options));
 
             this.options = options;
 

--- a/src/OpenTelemetry.Instrumentation.AspNet/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/TracerProviderBuilderExtensions.cs
@@ -35,7 +35,7 @@ namespace OpenTelemetry.Trace
             this TracerProviderBuilder builder,
             Action<AspNetInstrumentationOptions> configureAspNetInstrumentationOptions = null)
         {
-            Guard.Null(builder, nameof(builder));
+            Guard.ThrowIfNull(builder, nameof(builder));
 
             var aspnetOptions = new AspNetInstrumentationOptions();
             configureAspNetInstrumentationOptions?.Invoke(aspnetOptions);

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -54,7 +54,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
         public HttpInListener(AspNetCoreInstrumentationOptions options)
             : base(DiagnosticSourceName)
         {
-            Guard.Null(options, nameof(options));
+            Guard.ThrowIfNull(options, nameof(options));
 
             this.options = options;
         }

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/MeterProviderBuilderExtensions.cs
@@ -32,7 +32,7 @@ namespace OpenTelemetry.Metrics
         public static MeterProviderBuilder AddAspNetCoreInstrumentation(
             this MeterProviderBuilder builder)
         {
-            Guard.Null(builder, nameof(builder));
+            Guard.ThrowIfNull(builder, nameof(builder));
 
             // TODO: Implement an IDeferredMeterProviderBuilder
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/TracerProviderBuilderExtensions.cs
@@ -36,7 +36,7 @@ namespace OpenTelemetry.Trace
             this TracerProviderBuilder builder,
             Action<AspNetCoreInstrumentationOptions> configureAspNetCoreInstrumentationOptions = null)
         {
-            Guard.Null(builder, nameof(builder));
+            Guard.ThrowIfNull(builder, nameof(builder));
 
             if (builder is IDeferredTracerProviderBuilder deferredTracerProviderBuilder)
             {

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/TracerProviderBuilderExtensions.cs
@@ -37,7 +37,7 @@ namespace OpenTelemetry.Trace
             this TracerProviderBuilder builder,
             Action<GrpcClientInstrumentationOptions> configure = null)
         {
-            Guard.Null(builder, nameof(builder));
+            Guard.ThrowIfNull(builder, nameof(builder));
 
             var grpcOptions = new GrpcClientInstrumentationOptions();
             configure?.Invoke(grpcOptions);

--- a/src/OpenTelemetry.Instrumentation.Http/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/MeterProviderBuilderExtensions.cs
@@ -32,7 +32,7 @@ namespace OpenTelemetry.Metrics
         public static MeterProviderBuilder AddHttpClientInstrumentation(
             this MeterProviderBuilder builder)
         {
-            Guard.Null(builder, nameof(builder));
+            Guard.ThrowIfNull(builder, nameof(builder));
 
             // TODO: Implement an IDeferredMeterProviderBuilder
 

--- a/src/OpenTelemetry.Instrumentation.Http/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/TracerProviderBuilderExtensions.cs
@@ -61,7 +61,7 @@ namespace OpenTelemetry.Trace
             this TracerProviderBuilder builder,
             Action<HttpClientInstrumentationOptions> configureHttpClientInstrumentationOptions = null)
         {
-            Guard.Null(builder, nameof(builder));
+            Guard.ThrowIfNull(builder, nameof(builder));
 
             var httpClientOptions = new HttpClientInstrumentationOptions();
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/TracerProviderBuilderExtensions.cs
@@ -36,7 +36,7 @@ namespace OpenTelemetry.Trace
             this TracerProviderBuilder builder,
             Action<SqlClientInstrumentationOptions> configureSqlClientInstrumentationOptions = null)
         {
-            Guard.Null(builder, nameof(builder));
+            Guard.ThrowIfNull(builder, nameof(builder));
 
             var sqlOptions = new SqlClientInstrumentationOptions();
             configureSqlClientInstrumentationOptions?.Invoke(sqlOptions);

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisCallsInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisCallsInstrumentation.cs
@@ -59,7 +59,7 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis
         /// <param name="options">Configuration options for redis instrumentation.</param>
         public StackExchangeRedisCallsInstrumentation(IConnectionMultiplexer connection, StackExchangeRedisCallsInstrumentationOptions options)
         {
-            Guard.Null(connection, nameof(connection));
+            Guard.ThrowIfNull(connection, nameof(connection));
 
             this.options = options ?? new StackExchangeRedisCallsInstrumentationOptions();
 

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/TracerProviderBuilderExtensions.cs
@@ -43,7 +43,7 @@ namespace OpenTelemetry.Trace
             IConnectionMultiplexer connection = null,
             Action<StackExchangeRedisCallsInstrumentationOptions> configure = null)
         {
-            Guard.Null(builder, nameof(builder));
+            Guard.ThrowIfNull(builder, nameof(builder));
 
             if (builder is not IDeferredTracerProviderBuilder deferredTracerProviderBuilder)
             {

--- a/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
@@ -37,7 +37,7 @@ namespace OpenTelemetry.Shims.OpenTracing
 
         public ScopeManagerShim(Tracer tracer)
         {
-            Guard.Null(tracer, nameof(tracer));
+            Guard.ThrowIfNull(tracer, nameof(tracer));
 
             this.tracer = tracer;
         }
@@ -69,7 +69,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public IScope Activate(ISpan span, bool finishSpanOnDispose)
         {
-            var shim = Guard.Type<SpanShim>(span, nameof(span));
+            var shim = Guard.ThrowIfNotOfType<SpanShim>(span, nameof(span));
 
             var scope = Tracer.WithSpan(shim.Span);
 

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
@@ -81,8 +81,8 @@ namespace OpenTelemetry.Shims.OpenTracing
 
         public SpanBuilderShim(Tracer tracer, string spanName, IList<string> rootOperationNamesForActivityBasedAutoInstrumentations = null)
         {
-            Guard.Null(tracer, nameof(tracer));
-            Guard.Null(spanName, nameof(spanName));
+            Guard.ThrowIfNull(tracer, nameof(tracer));
+            Guard.ThrowIfNull(spanName, nameof(spanName));
 
             this.tracer = tracer;
             this.spanName = spanName;
@@ -130,7 +130,7 @@ namespace OpenTelemetry.Shims.OpenTracing
                 return this;
             }
 
-            Guard.Null(referenceType, nameof(referenceType));
+            Guard.ThrowIfNull(referenceType, nameof(referenceType));
 
             // TODO There is no relation between OpenTracing.References (referenceType) and OpenTelemetry Link
             var actualContext = GetOpenTelemetrySpanContext(referencedContext);
@@ -279,7 +279,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public ISpanBuilder WithTag(global::OpenTracing.Tag.BooleanTag tag, bool value)
         {
-            Guard.Null(tag?.Key, $"{nameof(tag)}?.{nameof(tag.Key)}");
+            Guard.ThrowIfNull(tag?.Key, $"{nameof(tag)}?.{nameof(tag.Key)}");
 
             return this.WithTag(tag.Key, value);
         }
@@ -287,7 +287,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public ISpanBuilder WithTag(global::OpenTracing.Tag.IntOrStringTag tag, string value)
         {
-            Guard.Null(tag?.Key, $"{nameof(tag)}?.{nameof(tag.Key)}");
+            Guard.ThrowIfNull(tag?.Key, $"{nameof(tag)}?.{nameof(tag.Key)}");
 
             if (int.TryParse(value, out var result))
             {
@@ -300,7 +300,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public ISpanBuilder WithTag(global::OpenTracing.Tag.IntTag tag, int value)
         {
-            Guard.Null(tag?.Key, $"{nameof(tag)}?.{nameof(tag.Key)}");
+            Guard.ThrowIfNull(tag?.Key, $"{nameof(tag)}?.{nameof(tag.Key)}");
 
             return this.WithTag(tag.Key, value);
         }
@@ -308,7 +308,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public ISpanBuilder WithTag(global::OpenTracing.Tag.StringTag tag, string value)
         {
-            Guard.Null(tag?.Key, $"{nameof(tag)}?.{nameof(tag.Key)}");
+            Guard.ThrowIfNull(tag?.Key, $"{nameof(tag)}?.{nameof(tag.Key)}");
 
             return this.WithTag(tag.Key, value);
         }
@@ -321,7 +321,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <exception cref="ArgumentException">span is not a valid SpanShim object.</exception>
         private static TelemetrySpan GetOpenTelemetrySpan(ISpan span)
         {
-            var shim = Guard.Type<SpanShim>(span, nameof(span));
+            var shim = Guard.ThrowIfNotOfType<SpanShim>(span, nameof(span));
 
             return shim.Span;
         }
@@ -334,7 +334,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <exception cref="ArgumentException">context is not a valid SpanContextShim object.</exception>
         private static SpanContext GetOpenTelemetrySpanContext(ISpanContext spanContext)
         {
-            var shim = Guard.Type<SpanContextShim>(spanContext, nameof(spanContext));
+            var shim = Guard.ThrowIfNotOfType<SpanContextShim>(spanContext, nameof(spanContext));
 
             return shim.SpanContext;
         }

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanShim.cs
@@ -46,7 +46,7 @@ namespace OpenTelemetry.Shims.OpenTracing
 
         public SpanShim(TelemetrySpan span)
         {
-            Guard.Null(span, nameof(span));
+            Guard.ThrowIfNull(span, nameof(span));
 
             if (!span.Context.IsValid)
             {
@@ -80,7 +80,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public ISpan Log(DateTimeOffset timestamp, IEnumerable<KeyValuePair<string, object>> fields)
         {
-            Guard.Null(fields, nameof(fields));
+            Guard.ThrowIfNull(fields, nameof(fields));
 
             var payload = ConvertToEventPayload(fields);
             var eventName = payload.Item1;
@@ -141,7 +141,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public ISpan Log(string @event)
         {
-            Guard.Null(@event, nameof(@event));
+            Guard.ThrowIfNull(@event, nameof(@event));
 
             this.Span.AddEvent(@event);
             return this;
@@ -150,7 +150,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public ISpan Log(DateTimeOffset timestamp, string @event)
         {
-            Guard.Null(@event, nameof(@event));
+            Guard.ThrowIfNull(@event, nameof(@event));
 
             this.Span.AddEvent(@event, timestamp);
             return this;
@@ -166,7 +166,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public ISpan SetOperationName(string operationName)
         {
-            Guard.Null(operationName, nameof(operationName));
+            Guard.ThrowIfNull(operationName, nameof(operationName));
 
             this.Span.UpdateName(operationName);
             return this;
@@ -175,7 +175,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public ISpan SetTag(string key, string value)
         {
-            Guard.Null(key, nameof(key));
+            Guard.ThrowIfNull(key, nameof(key));
 
             this.Span.SetAttribute(key, value);
             return this;
@@ -184,7 +184,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public ISpan SetTag(string key, bool value)
         {
-            Guard.Null(key, nameof(key));
+            Guard.ThrowIfNull(key, nameof(key));
 
             // Special case the OpenTracing Error Tag
             // see https://opentracing.io/specification/conventions/
@@ -203,7 +203,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public ISpan SetTag(string key, int value)
         {
-            Guard.Null(key, nameof(key));
+            Guard.ThrowIfNull(key, nameof(key));
 
             this.Span.SetAttribute(key, value);
             return this;
@@ -212,7 +212,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public ISpan SetTag(string key, double value)
         {
-            Guard.Null(key, nameof(key));
+            Guard.ThrowIfNull(key, nameof(key));
 
             this.Span.SetAttribute(key, value);
             return this;

--- a/src/OpenTelemetry.Shims.OpenTracing/TracerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/TracerShim.cs
@@ -28,8 +28,8 @@ namespace OpenTelemetry.Shims.OpenTracing
 
         public TracerShim(Trace.Tracer tracer, TextMapPropagator textFormat)
         {
-            Guard.Null(tracer, nameof(tracer));
-            Guard.Null(textFormat, nameof(textFormat));
+            Guard.ThrowIfNull(tracer, nameof(tracer));
+            Guard.ThrowIfNull(textFormat, nameof(textFormat));
 
             this.tracer = tracer;
             this.propagator = textFormat;
@@ -51,8 +51,8 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public global::OpenTracing.ISpanContext Extract<TCarrier>(IFormat<TCarrier> format, TCarrier carrier)
         {
-            Guard.Null(format, nameof(format));
-            Guard.Null(carrier, nameof(carrier));
+            Guard.ThrowIfNull(format, nameof(format));
+            Guard.ThrowIfNull(carrier, nameof(carrier));
 
             PropagationContext propagationContext = default;
 
@@ -92,10 +92,10 @@ namespace OpenTelemetry.Shims.OpenTracing
             IFormat<TCarrier> format,
             TCarrier carrier)
         {
-            Guard.Null(spanContext, nameof(spanContext));
-            var shim = Guard.Type<SpanContextShim>(spanContext, nameof(spanContext));
-            Guard.Null(format, nameof(format));
-            Guard.Null(carrier, nameof(carrier));
+            Guard.ThrowIfNull(spanContext, nameof(spanContext));
+            var shim = Guard.ThrowIfNotOfType<SpanContextShim>(spanContext, nameof(spanContext));
+            Guard.ThrowIfNull(format, nameof(format));
+            Guard.ThrowIfNull(carrier, nameof(carrier));
 
             if ((format == BuiltinFormats.TextMap || format == BuiltinFormats.HttpHeaders) && carrier is ITextMap textMapCarrier)
             {

--- a/src/OpenTelemetry/BaseExportProcessor.cs
+++ b/src/OpenTelemetry/BaseExportProcessor.cs
@@ -35,7 +35,7 @@ namespace OpenTelemetry
         /// <param name="exporter">Exporter instance.</param>
         protected BaseExportProcessor(BaseExporter<T> exporter)
         {
-            Guard.Null(exporter, nameof(exporter));
+            Guard.ThrowIfNull(exporter, nameof(exporter));
 
             this.exporter = exporter;
         }

--- a/src/OpenTelemetry/BaseExporter.cs
+++ b/src/OpenTelemetry/BaseExporter.cs
@@ -76,7 +76,7 @@ namespace OpenTelemetry
         /// </remarks>
         public bool ForceFlush(int timeoutMilliseconds = Timeout.Infinite)
         {
-            Guard.InvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
+            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
 
             try
             {
@@ -109,7 +109,7 @@ namespace OpenTelemetry
         /// </remarks>
         public bool Shutdown(int timeoutMilliseconds = Timeout.Infinite)
         {
-            Guard.InvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
+            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
 
             if (Interlocked.Increment(ref this.shutdownCount) > 1)
             {

--- a/src/OpenTelemetry/BaseProcessor.cs
+++ b/src/OpenTelemetry/BaseProcessor.cs
@@ -82,7 +82,7 @@ namespace OpenTelemetry
         /// </remarks>
         public bool ForceFlush(int timeoutMilliseconds = Timeout.Infinite)
         {
-            Guard.InvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
+            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
 
             try
             {
@@ -115,7 +115,7 @@ namespace OpenTelemetry
         /// </remarks>
         public bool Shutdown(int timeoutMilliseconds = Timeout.Infinite)
         {
-            Guard.InvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
+            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
 
             if (Interlocked.CompareExchange(ref this.shutdownCount, 1, 0) != 0)
             {

--- a/src/OpenTelemetry/Batch.cs
+++ b/src/OpenTelemetry/Batch.cs
@@ -41,8 +41,8 @@ namespace OpenTelemetry
         /// <param name="count">The number of items in the batch.</param>
         public Batch(T[] items, int count)
         {
-            Guard.Null(items, nameof(items));
-            Guard.Range(count, nameof(count), 0, items.Length);
+            Guard.ThrowIfNull(items, nameof(items));
+            Guard.ThrowIfOutOfRange(count, nameof(count), 0, items.Length);
 
             this.item = null;
             this.circularBuffer = null;

--- a/src/OpenTelemetry/BatchExportProcessor.cs
+++ b/src/OpenTelemetry/BatchExportProcessor.cs
@@ -61,10 +61,10 @@ namespace OpenTelemetry
             int maxExportBatchSize = DefaultMaxExportBatchSize)
             : base(exporter)
         {
-            Guard.Range(maxQueueSize, nameof(maxQueueSize), min: 1);
-            Guard.Range(maxExportBatchSize, nameof(maxExportBatchSize), min: 1, max: maxQueueSize, maxName: nameof(maxQueueSize));
-            Guard.Range(scheduledDelayMilliseconds, nameof(scheduledDelayMilliseconds), min: 1);
-            Guard.Range(exporterTimeoutMilliseconds, nameof(exporterTimeoutMilliseconds), min: 0);
+            Guard.ThrowIfOutOfRange(maxQueueSize, nameof(maxQueueSize), min: 1);
+            Guard.ThrowIfOutOfRange(maxExportBatchSize, nameof(maxExportBatchSize), min: 1, max: maxQueueSize, maxName: nameof(maxQueueSize));
+            Guard.ThrowIfOutOfRange(scheduledDelayMilliseconds, nameof(scheduledDelayMilliseconds), min: 1);
+            Guard.ThrowIfOutOfRange(exporterTimeoutMilliseconds, nameof(exporterTimeoutMilliseconds), min: 0);
 
             this.circularBuffer = new CircularBuffer<T>(maxQueueSize);
             this.scheduledDelayMilliseconds = scheduledDelayMilliseconds;

--- a/src/OpenTelemetry/CompositeProcessor.cs
+++ b/src/OpenTelemetry/CompositeProcessor.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry
 
         public CompositeProcessor(IEnumerable<BaseProcessor<T>> processors)
         {
-            Guard.Null(processors, nameof(processors));
+            Guard.ThrowIfNull(processors, nameof(processors));
 
             using var iter = processors.GetEnumerator();
             if (!iter.MoveNext())
@@ -49,7 +49,7 @@ namespace OpenTelemetry
 
         public CompositeProcessor<T> AddProcessor(BaseProcessor<T> processor)
         {
-            Guard.Null(processor, nameof(processor));
+            Guard.ThrowIfNull(processor, nameof(processor));
 
             var node = new DoublyLinkedListNode(processor)
             {

--- a/src/OpenTelemetry/DiagnosticSourceInstrumentation/DiagnosticSourceListener.cs
+++ b/src/OpenTelemetry/DiagnosticSourceInstrumentation/DiagnosticSourceListener.cs
@@ -27,7 +27,7 @@ namespace OpenTelemetry.Instrumentation
 
         public DiagnosticSourceListener(ListenerHandler handler)
         {
-            Guard.Null(handler, nameof(handler));
+            Guard.ThrowIfNull(handler, nameof(handler));
 
             this.handler = handler;
         }

--- a/src/OpenTelemetry/DiagnosticSourceInstrumentation/DiagnosticSourceSubscriber.cs
+++ b/src/OpenTelemetry/DiagnosticSourceInstrumentation/DiagnosticSourceSubscriber.cs
@@ -42,7 +42,7 @@ namespace OpenTelemetry.Instrumentation
             Func<DiagnosticListener, bool> diagnosticSourceFilter,
             Func<string, object, object, bool> isEnabledFilter)
         {
-            Guard.Null(handlerFactory, nameof(handlerFactory));
+            Guard.ThrowIfNull(handlerFactory, nameof(handlerFactory));
 
             this.listenerSubscriptions = new List<IDisposable>();
             this.handlerFactory = handlerFactory;

--- a/src/OpenTelemetry/DiagnosticSourceInstrumentation/PropertyFetcher.cs
+++ b/src/OpenTelemetry/DiagnosticSourceInstrumentation/PropertyFetcher.cs
@@ -46,7 +46,7 @@ namespace OpenTelemetry.Instrumentation
         /// <returns>Property fetched.</returns>
         public T Fetch(object obj)
         {
-            Guard.Null(obj, nameof(obj));
+            Guard.ThrowIfNull(obj, nameof(obj));
 
             if (!this.TryFetch(obj, out T value, true))
             {

--- a/src/OpenTelemetry/Internal/CircularBuffer.cs
+++ b/src/OpenTelemetry/Internal/CircularBuffer.cs
@@ -36,7 +36,7 @@ namespace OpenTelemetry.Internal
         /// <param name="capacity">The capacity of the circular buffer, must be a positive integer.</param>
         public CircularBuffer(int capacity)
         {
-            Guard.Range(capacity, nameof(capacity), min: 1);
+            Guard.ThrowIfOutOfRange(capacity, nameof(capacity), min: 1);
 
             this.Capacity = capacity;
             this.trait = new T[capacity];
@@ -79,7 +79,7 @@ namespace OpenTelemetry.Internal
         /// </returns>
         public bool Add(T value)
         {
-            Guard.Null(value, nameof(value));
+            Guard.ThrowIfNull(value, nameof(value));
 
             while (true)
             {
@@ -119,7 +119,7 @@ namespace OpenTelemetry.Internal
                 return this.Add(value);
             }
 
-            Guard.Null(value, nameof(value));
+            Guard.ThrowIfNull(value, nameof(value));
 
             var spinCountDown = maxSpinCount;
 

--- a/src/OpenTelemetry/Internal/PooledList.cs
+++ b/src/OpenTelemetry/Internal/PooledList.cs
@@ -52,7 +52,7 @@ namespace OpenTelemetry.Internal
 
         public static void Add(ref PooledList<T> list, T item)
         {
-            Guard.Null(list.buffer, $"{nameof(list)}.{nameof(list.buffer)}");
+            Guard.ThrowIfNull(list.buffer, $"{nameof(list)}.{nameof(list.buffer)}");
 
             var buffer = list.buffer;
 

--- a/src/OpenTelemetry/Internal/SelfDiagnosticsEventListener.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnosticsEventListener.cs
@@ -43,7 +43,7 @@ namespace OpenTelemetry.Internal
 
         public SelfDiagnosticsEventListener(EventLevel logLevel, SelfDiagnosticsConfigRefresher configRefresher)
         {
-            Guard.Null(configRefresher, nameof(configRefresher));
+            Guard.ThrowIfNull(configRefresher, nameof(configRefresher));
 
             this.logLevel = logLevel;
             this.configRefresher = configRefresher;

--- a/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
@@ -29,8 +29,8 @@ namespace OpenTelemetry.Logs
 
         internal OpenTelemetryLogger(string categoryName, OpenTelemetryLoggerProvider provider)
         {
-            Guard.Null(categoryName, nameof(categoryName));
-            Guard.Null(provider, nameof(provider));
+            Guard.ThrowIfNull(categoryName, nameof(categoryName));
+            Guard.ThrowIfNull(provider, nameof(provider));
 
             this.categoryName = categoryName;
             this.provider = provider;

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggerOptions.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggerOptions.cs
@@ -58,7 +58,7 @@ namespace OpenTelemetry.Logs
         /// <returns>Returns <see cref="OpenTelemetryLoggerOptions"/> for chaining.</returns>
         public OpenTelemetryLoggerOptions AddProcessor(BaseProcessor<LogRecord> processor)
         {
-            Guard.Null(processor, nameof(processor));
+            Guard.ThrowIfNull(processor, nameof(processor));
 
             this.Processors.Add(processor);
 
@@ -73,7 +73,7 @@ namespace OpenTelemetry.Logs
         /// <returns>Returns <see cref="OpenTelemetryLoggerOptions"/> for chaining.</returns>
         public OpenTelemetryLoggerOptions SetResourceBuilder(ResourceBuilder resourceBuilder)
         {
-            Guard.Null(resourceBuilder, nameof(resourceBuilder));
+            Guard.ThrowIfNull(resourceBuilder, nameof(resourceBuilder));
 
             this.ResourceBuilder = resourceBuilder;
             return this;

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggerProvider.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggerProvider.cs
@@ -46,7 +46,7 @@ namespace OpenTelemetry.Logs
 
         internal OpenTelemetryLoggerProvider(OpenTelemetryLoggerOptions options)
         {
-            Guard.Null(options, nameof(options));
+            Guard.ThrowIfNull(options, nameof(options));
 
             this.Options = options;
             this.Resource = options.ResourceBuilder.Build();
@@ -97,7 +97,7 @@ namespace OpenTelemetry.Logs
 
         internal OpenTelemetryLoggerProvider AddProcessor(BaseProcessor<LogRecord> processor)
         {
-            Guard.Null(processor, nameof(processor));
+            Guard.ThrowIfNull(processor, nameof(processor));
 
             processor.SetParentProvider(this);
 

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggingExtensions.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggingExtensions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Extensions.Logging
     {
         public static ILoggingBuilder AddOpenTelemetry(this ILoggingBuilder builder, Action<OpenTelemetryLoggerOptions> configure = null)
         {
-            Guard.Null(builder, nameof(builder));
+            Guard.ThrowIfNull(builder, nameof(builder));
 
             builder.AddConfiguration();
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, OpenTelemetryLoggerProvider>());

--- a/src/OpenTelemetry/Metrics/BaseExportingMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/BaseExportingMetricReader.cs
@@ -29,7 +29,7 @@ namespace OpenTelemetry.Metrics
 
         public BaseExportingMetricReader(BaseExporter<Metric> exporter)
         {
-            Guard.Null(exporter, nameof(exporter));
+            Guard.ThrowIfNull(exporter, nameof(exporter));
 
             this.exporter = exporter;
 

--- a/src/OpenTelemetry/Metrics/CompositeMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/CompositeMetricReader.cs
@@ -34,7 +34,7 @@ namespace OpenTelemetry.Metrics
 
         public CompositeMetricReader(IEnumerable<MetricReader> readers)
         {
-            Guard.Null(readers, nameof(readers));
+            Guard.ThrowIfNull(readers, nameof(readers));
 
             using var iter = readers.GetEnumerator();
             if (!iter.MoveNext())
@@ -54,7 +54,7 @@ namespace OpenTelemetry.Metrics
 
         public CompositeMetricReader AddReader(MetricReader reader)
         {
-            Guard.Null(reader, nameof(reader));
+            Guard.ThrowIfNull(reader, nameof(reader));
 
             var node = new DoublyLinkedListNode(reader)
             {

--- a/src/OpenTelemetry/Metrics/MeterProviderBuilderBase.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderBuilderBase.cs
@@ -47,7 +47,7 @@ namespace OpenTelemetry.Metrics
         /// <inheritdoc />
         public override MeterProviderBuilder AddInstrumentation<TInstrumentation>(Func<TInstrumentation> instrumentationFactory)
         {
-            Guard.Null(instrumentationFactory, nameof(instrumentationFactory));
+            Guard.ThrowIfNull(instrumentationFactory, nameof(instrumentationFactory));
 
             this.instrumentationFactories.Add(
                 new InstrumentationFactory(
@@ -61,11 +61,11 @@ namespace OpenTelemetry.Metrics
         /// <inheritdoc />
         public override MeterProviderBuilder AddMeter(params string[] names)
         {
-            Guard.Null(names, nameof(names));
+            Guard.ThrowIfNull(names, nameof(names));
 
             foreach (var name in names)
             {
-                Guard.NullOrWhitespace(name, nameof(name));
+                Guard.ThrowIfNullOrWhitespace(name, nameof(name));
 
                 this.meterSources.Add(name);
             }
@@ -106,7 +106,7 @@ namespace OpenTelemetry.Metrics
 
         internal MeterProviderBuilder SetMaxMetricStreams(int maxMetricStreams)
         {
-            Guard.Range(maxMetricStreams, min: 1);
+            Guard.ThrowIfOutOfRange(maxMetricStreams, min: 1);
 
             this.maxMetricStreams = maxMetricStreams;
             return this;
@@ -114,7 +114,7 @@ namespace OpenTelemetry.Metrics
 
         internal MeterProviderBuilder SetMaxMetricPointsPerMetricStream(int maxMetricPointsPerMetricStream)
         {
-            Guard.Range(maxMetricPointsPerMetricStream, min: 1);
+            Guard.ThrowIfOutOfRange(maxMetricPointsPerMetricStream, min: 1);
 
             this.maxMetricPointsPerMetricStream = maxMetricPointsPerMetricStream;
             return this;

--- a/src/OpenTelemetry/Metrics/MeterProviderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderExtensions.cs
@@ -42,8 +42,8 @@ namespace OpenTelemetry.Metrics
         /// </remarks>
         public static bool ForceFlush(this MeterProvider provider, int timeoutMilliseconds = Timeout.Infinite)
         {
-            Guard.Null(provider, nameof(provider));
-            Guard.InvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
+            Guard.ThrowIfNull(provider, nameof(provider));
+            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
 
             if (provider is MeterProviderSdk meterProviderSdk)
             {
@@ -82,8 +82,8 @@ namespace OpenTelemetry.Metrics
         /// </remarks>
         public static bool Shutdown(this MeterProvider provider, int timeoutMilliseconds = Timeout.Infinite)
         {
-            Guard.Null(provider, nameof(provider));
-            Guard.InvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
+            Guard.ThrowIfNull(provider, nameof(provider));
+            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
 
             if (provider is MeterProviderSdk meterProviderSdk)
             {

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -50,7 +50,7 @@ namespace OpenTelemetry.Metrics
 
             foreach (var reader in readers)
             {
-                Guard.Null(reader, nameof(reader));
+                Guard.ThrowIfNull(reader, nameof(reader));
 
                 reader.SetParentProvider(this);
                 reader.SetMaxMetricStreams(maxMetricStreams);

--- a/src/OpenTelemetry/Metrics/MetricPointsAccessor.cs
+++ b/src/OpenTelemetry/Metrics/MetricPointsAccessor.cs
@@ -33,7 +33,7 @@ namespace OpenTelemetry.Metrics
 
         internal MetricPointsAccessor(MetricPoint[] metricsPoints, int[] metricPointsToProcess, long targetCount, DateTimeOffset start, DateTimeOffset end)
         {
-            Guard.Null(metricsPoints, nameof(metricsPoints));
+            Guard.ThrowIfNull(metricsPoints, nameof(metricsPoints));
 
             this.metricsPoints = metricsPoints;
             this.metricPointsToProcess = metricPointsToProcess;

--- a/src/OpenTelemetry/Metrics/MetricReader.cs
+++ b/src/OpenTelemetry/Metrics/MetricReader.cs
@@ -83,7 +83,7 @@ namespace OpenTelemetry.Metrics
         /// </remarks>
         public bool Collect(int timeoutMilliseconds = Timeout.Infinite)
         {
-            Guard.InvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
+            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
 
             var shouldRunCollect = false;
             var tcs = this.collectionTcs;
@@ -146,7 +146,7 @@ namespace OpenTelemetry.Metrics
         /// </remarks>
         public bool Shutdown(int timeoutMilliseconds = Timeout.Infinite)
         {
-            Guard.InvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
+            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
 
             if (Interlocked.CompareExchange(ref this.shutdownCount, 1, 0) != 0)
             {

--- a/src/OpenTelemetry/Metrics/PeriodicExportingMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/PeriodicExportingMetricReader.cs
@@ -39,8 +39,8 @@ namespace OpenTelemetry.Metrics
             int exportTimeoutMilliseconds = DefaultExportTimeoutMilliseconds)
             : base(exporter)
         {
-            Guard.Range(exportIntervalMilliseconds, nameof(exportIntervalMilliseconds), min: 1);
-            Guard.Range(exportTimeoutMilliseconds, nameof(exportTimeoutMilliseconds), min: 0);
+            Guard.ThrowIfOutOfRange(exportIntervalMilliseconds, nameof(exportIntervalMilliseconds), min: 1);
+            Guard.ThrowIfOutOfRange(exportTimeoutMilliseconds, nameof(exportTimeoutMilliseconds), min: 0);
 
             if ((this.SupportedExportModes & ExportModes.Push) != ExportModes.Push)
             {

--- a/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
+++ b/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
@@ -52,7 +52,7 @@ namespace OpenTelemetry.Metrics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void SplitToKeysAndValues(ReadOnlySpan<KeyValuePair<string, object>> tags, int tagLength, out string[] tagKeys, out object[] tagValues)
         {
-            Guard.Zero(tagLength, $"There must be at least one tag to use {nameof(ThreadStaticStorage)}", $"{nameof(tagLength)}");
+            Guard.ThrowIfZero(tagLength, $"There must be at least one tag to use {nameof(ThreadStaticStorage)}", $"{nameof(tagLength)}");
 
             if (tagLength <= MaxTagCacheSize)
             {

--- a/src/OpenTelemetry/Resources/Resource.cs
+++ b/src/OpenTelemetry/Resources/Resource.cs
@@ -109,7 +109,7 @@ namespace OpenTelemetry.Resources
 
         private static object SanitizeValue(object value, string keyName)
         {
-            Guard.Null(keyName, nameof(keyName));
+            Guard.ThrowIfNull(keyName, nameof(keyName));
 
             return value switch
             {

--- a/src/OpenTelemetry/Resources/ResourceBuilder.cs
+++ b/src/OpenTelemetry/Resources/ResourceBuilder.cs
@@ -90,7 +90,7 @@ namespace OpenTelemetry.Resources
         // https://github.com/open-telemetry/oteps/blob/master/text/0111-auto-resource-detection.md
         internal ResourceBuilder AddDetector(IResourceDetector resourceDetector)
         {
-            Guard.Null(resourceDetector, nameof(resourceDetector));
+            Guard.ThrowIfNull(resourceDetector, nameof(resourceDetector));
 
             Resource resource = resourceDetector.Detect();
 
@@ -104,7 +104,7 @@ namespace OpenTelemetry.Resources
 
         internal ResourceBuilder AddResource(Resource resource)
         {
-            Guard.Null(resource, nameof(resource));
+            Guard.ThrowIfNull(resource, nameof(resource));
 
             this.resources.Add(resource);
 

--- a/src/OpenTelemetry/Resources/ResourceBuilderExtensions.cs
+++ b/src/OpenTelemetry/Resources/ResourceBuilderExtensions.cs
@@ -56,7 +56,7 @@ namespace OpenTelemetry.Resources
         {
             Dictionary<string, object> resourceAttributes = new Dictionary<string, object>();
 
-            Guard.NullOrEmpty(serviceName, nameof(serviceName));
+            Guard.ThrowIfNullOrEmpty(serviceName, nameof(serviceName));
 
             resourceAttributes.Add(ResourceSemanticConventions.AttributeServiceName, serviceName);
 

--- a/src/OpenTelemetry/Trace/ParentBasedSampler.cs
+++ b/src/OpenTelemetry/Trace/ParentBasedSampler.cs
@@ -43,7 +43,7 @@ namespace OpenTelemetry.Trace
         /// <param name="rootSampler">The <see cref="Sampler"/> to be called for root span/activity.</param>
         public ParentBasedSampler(Sampler rootSampler)
         {
-            Guard.Null(rootSampler, nameof(rootSampler));
+            Guard.ThrowIfNull(rootSampler, nameof(rootSampler));
 
             this.rootSampler = rootSampler;
             this.Description = $"ParentBased{{{rootSampler.Description}}}";

--- a/src/OpenTelemetry/Trace/TraceIdRatioBasedSampler.cs
+++ b/src/OpenTelemetry/Trace/TraceIdRatioBasedSampler.cs
@@ -37,7 +37,7 @@ namespace OpenTelemetry.Trace
         /// </param>
         public TraceIdRatioBasedSampler(double probability)
         {
-            Guard.Range(probability, nameof(probability), min: 0.0, max: 1.0);
+            Guard.ThrowIfOutOfRange(probability, nameof(probability), min: 0.0, max: 1.0);
 
             this.probability = probability;
 

--- a/src/OpenTelemetry/Trace/TracerProviderBuilderBase.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderBuilderBase.cs
@@ -43,7 +43,7 @@ namespace OpenTelemetry.Trace
             Func<TInstrumentation> instrumentationFactory)
             where TInstrumentation : class
         {
-            Guard.Null(instrumentationFactory, nameof(instrumentationFactory));
+            Guard.ThrowIfNull(instrumentationFactory, nameof(instrumentationFactory));
 
             this.instrumentationFactories.Add(
                 new InstrumentationFactory(
@@ -57,11 +57,11 @@ namespace OpenTelemetry.Trace
         /// <inheritdoc />
         public override TracerProviderBuilder AddSource(params string[] names)
         {
-            Guard.Null(names, nameof(names));
+            Guard.ThrowIfNull(names, nameof(names));
 
             foreach (var name in names)
             {
-                Guard.NullOrWhitespace(name, nameof(name));
+                Guard.ThrowIfNullOrWhitespace(name, nameof(name));
 
                 // TODO: We need to fix the listening model.
                 // Today it ignores version.
@@ -74,7 +74,7 @@ namespace OpenTelemetry.Trace
         /// <inheritdoc />
         public override TracerProviderBuilder AddLegacySource(string operationName)
         {
-            Guard.NullOrWhitespace(operationName, nameof(operationName));
+            Guard.ThrowIfNullOrWhitespace(operationName, nameof(operationName));
 
             this.legacyActivityOperationNames.Add(operationName);
 
@@ -129,7 +129,7 @@ namespace OpenTelemetry.Trace
         /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
         internal TracerProviderBuilder SetSampler(Sampler sampler)
         {
-            Guard.Null(sampler, nameof(sampler));
+            Guard.ThrowIfNull(sampler, nameof(sampler));
 
             this.sampler = sampler;
             return this;
@@ -143,7 +143,7 @@ namespace OpenTelemetry.Trace
         /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
         internal TracerProviderBuilder SetResourceBuilder(ResourceBuilder resourceBuilder)
         {
-            Guard.Null(resourceBuilder, nameof(resourceBuilder));
+            Guard.ThrowIfNull(resourceBuilder, nameof(resourceBuilder));
 
             this.resourceBuilder = resourceBuilder;
             return this;
@@ -156,7 +156,7 @@ namespace OpenTelemetry.Trace
         /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
         internal TracerProviderBuilder AddProcessor(BaseProcessor<Activity> processor)
         {
-            Guard.Null(processor, nameof(processor));
+            Guard.ThrowIfNull(processor, nameof(processor));
 
             this.processors.Add(processor);
 

--- a/src/OpenTelemetry/Trace/TracerProviderExtensions.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderExtensions.cs
@@ -25,8 +25,8 @@ namespace OpenTelemetry.Trace
     {
         public static TracerProvider AddProcessor(this TracerProvider provider, BaseProcessor<Activity> processor)
         {
-            Guard.Null(provider, nameof(provider));
-            Guard.Null(processor, nameof(processor));
+            Guard.ThrowIfNull(provider, nameof(provider));
+            Guard.ThrowIfNull(processor, nameof(processor));
 
             if (provider is TracerProviderSdk tracerProviderSdk)
             {
@@ -56,8 +56,8 @@ namespace OpenTelemetry.Trace
         /// </remarks>
         public static bool ForceFlush(this TracerProvider provider, int timeoutMilliseconds = Timeout.Infinite)
         {
-            Guard.Null(provider, nameof(provider));
-            Guard.InvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
+            Guard.ThrowIfNull(provider, nameof(provider));
+            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
 
             if (provider is TracerProviderSdk tracerProviderSdk)
             {
@@ -96,8 +96,8 @@ namespace OpenTelemetry.Trace
         /// </remarks>
         public static bool Shutdown(this TracerProvider provider, int timeoutMilliseconds = Timeout.Infinite)
         {
-            Guard.Null(provider, nameof(provider));
-            Guard.InvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
+            Guard.ThrowIfNull(provider, nameof(provider));
+            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
 
             if (provider is TracerProviderSdk tracerProviderSdk)
             {

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -282,7 +282,7 @@ namespace OpenTelemetry.Trace
 
         internal TracerProviderSdk AddProcessor(BaseProcessor<Activity> processor)
         {
-            Guard.Null(processor, nameof(processor));
+            Guard.ThrowIfNull(processor, nameof(processor));
 
             processor.SetParentProvider(this);
 

--- a/test/OpenTelemetry.Tests/Internal/GuardTest.cs
+++ b/test/OpenTelemetry.Tests/Internal/GuardTest.cs
@@ -27,13 +27,13 @@ namespace OpenTelemetry.Tests.Internal
         public void NullTest()
         {
             // Valid
-            Guard.Null(1);
-            Guard.Null(1.0);
-            Guard.Null(new object());
-            Guard.Null("hello");
+            Guard.ThrowIfNull(1);
+            Guard.ThrowIfNull(1.0);
+            Guard.ThrowIfNull(new object());
+            Guard.ThrowIfNull("hello");
 
             // Invalid
-            var ex1 = Assert.Throws<ArgumentNullException>(() => Guard.Null(null, "null"));
+            var ex1 = Assert.Throws<ArgumentNullException>(() => Guard.ThrowIfNull(null, "null"));
             Assert.Contains("Must not be null", ex1.Message);
         }
 
@@ -41,14 +41,14 @@ namespace OpenTelemetry.Tests.Internal
         public void NullOrEmptyTest()
         {
             // Valid
-            Guard.NullOrEmpty("a");
-            Guard.NullOrEmpty(" ");
+            Guard.ThrowIfNullOrEmpty("a");
+            Guard.ThrowIfNullOrEmpty(" ");
 
             // Invalid
-            var ex1 = Assert.Throws<ArgumentException>(() => Guard.NullOrEmpty(null));
+            var ex1 = Assert.Throws<ArgumentException>(() => Guard.ThrowIfNullOrEmpty(null));
             Assert.Contains("Must not be null or empty", ex1.Message);
 
-            var ex2 = Assert.Throws<ArgumentException>(() => Guard.NullOrEmpty(string.Empty));
+            var ex2 = Assert.Throws<ArgumentException>(() => Guard.ThrowIfNullOrEmpty(string.Empty));
             Assert.Contains("Must not be null or empty", ex2.Message);
         }
 
@@ -56,16 +56,16 @@ namespace OpenTelemetry.Tests.Internal
         public void NullOrWhitespaceTest()
         {
             // Valid
-            Guard.NullOrWhitespace("a");
+            Guard.ThrowIfNullOrWhitespace("a");
 
             // Invalid
-            var ex1 = Assert.Throws<ArgumentException>(() => Guard.NullOrWhitespace(null));
+            var ex1 = Assert.Throws<ArgumentException>(() => Guard.ThrowIfNullOrWhitespace(null));
             Assert.Contains("Must not be null or whitespace", ex1.Message);
 
-            var ex2 = Assert.Throws<ArgumentException>(() => Guard.NullOrWhitespace(string.Empty));
+            var ex2 = Assert.Throws<ArgumentException>(() => Guard.ThrowIfNullOrWhitespace(string.Empty));
             Assert.Contains("Must not be null or whitespace", ex2.Message);
 
-            var ex3 = Assert.Throws<ArgumentException>(() => Guard.NullOrWhitespace(" \t\n\r"));
+            var ex3 = Assert.Throws<ArgumentException>(() => Guard.ThrowIfNullOrWhitespace(" \t\n\r"));
             Assert.Contains("Must not be null or whitespace", ex3.Message);
         }
 
@@ -73,12 +73,12 @@ namespace OpenTelemetry.Tests.Internal
         public void InvalidTimeoutTest()
         {
             // Valid
-            Guard.InvalidTimeout(Timeout.Infinite);
-            Guard.InvalidTimeout(0);
-            Guard.InvalidTimeout(100);
+            Guard.ThrowIfInvalidTimeout(Timeout.Infinite);
+            Guard.ThrowIfInvalidTimeout(0);
+            Guard.ThrowIfInvalidTimeout(100);
 
             // Invalid
-            var ex1 = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.InvalidTimeout(-100));
+            var ex1 = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.ThrowIfInvalidTimeout(-100));
             Assert.Contains("Must be non-negative or 'Timeout.Infinite'", ex1.Message);
         }
 
@@ -86,17 +86,17 @@ namespace OpenTelemetry.Tests.Internal
         public void RangeIntTest()
         {
             // Valid
-            Guard.Range(0);
-            Guard.Range(0, min: 0, max: 0);
-            Guard.Range(5, min: -10, max: 10);
-            Guard.Range(int.MinValue, min: int.MinValue, max: 10);
-            Guard.Range(int.MaxValue, min: 10, max: int.MaxValue);
+            Guard.ThrowIfOutOfRange(0);
+            Guard.ThrowIfOutOfRange(0, min: 0, max: 0);
+            Guard.ThrowIfOutOfRange(5, min: -10, max: 10);
+            Guard.ThrowIfOutOfRange(int.MinValue, min: int.MinValue, max: 10);
+            Guard.ThrowIfOutOfRange(int.MaxValue, min: 10, max: int.MaxValue);
 
             // Invalid
-            var ex1 = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Range(-1, min: 0, max: 100, minName: "empty", maxName: "full"));
+            var ex1 = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.ThrowIfOutOfRange(-1, min: 0, max: 100, minName: "empty", maxName: "full"));
             Assert.Contains("Must be in the range: [0: empty, 100: full]", ex1.Message);
 
-            var ex2 = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Range(-1, min: 0, max: 100, message: "error"));
+            var ex2 = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.ThrowIfOutOfRange(-1, min: 0, max: 100, message: "error"));
             Assert.Contains("error", ex2.Message);
         }
 
@@ -104,15 +104,15 @@ namespace OpenTelemetry.Tests.Internal
         public void RangeDoubleTest()
         {
             // Valid
-            Guard.Range(1.0, min: 1.0, max: 1.0);
-            Guard.Range(double.MinValue, min: double.MinValue, max: 10.0);
-            Guard.Range(double.MaxValue, min: 10.0, max: double.MaxValue);
+            Guard.ThrowIfOutOfRange(1.0, min: 1.0, max: 1.0);
+            Guard.ThrowIfOutOfRange(double.MinValue, min: double.MinValue, max: 10.0);
+            Guard.ThrowIfOutOfRange(double.MaxValue, min: 10.0, max: double.MaxValue);
 
             // Invalid
-            var ex3 = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Range(-1.1, min: 0.1, max: 99.9, minName: "empty", maxName: "full"));
+            var ex3 = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.ThrowIfOutOfRange(-1.1, min: 0.1, max: 99.9, minName: "empty", maxName: "full"));
             Assert.Contains("Must be in the range: [0.1: empty, 99.9: full]", ex3.Message);
 
-            var ex4 = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Range(-1.1, min: 0.0, max: 100.0));
+            var ex4 = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.ThrowIfOutOfRange(-1.1, min: 0.0, max: 100.0));
             Assert.Contains("Must be in the range: [0, 100]", ex4.Message);
         }
 
@@ -120,12 +120,12 @@ namespace OpenTelemetry.Tests.Internal
         public void TypeTest()
         {
             // Valid
-            Guard.Type<int>(0);
-            Guard.Type<object>(new object());
-            Guard.Type<string>("hello");
+            Guard.ThrowIfNotOfType<int>(0);
+            Guard.ThrowIfNotOfType<object>(new object());
+            Guard.ThrowIfNotOfType<string>("hello");
 
             // Invalid
-            var ex1 = Assert.Throws<InvalidCastException>(() => Guard.Type<double>(100));
+            var ex1 = Assert.Throws<InvalidCastException>(() => Guard.ThrowIfNotOfType<double>(100));
             Assert.Equal("Cannot cast 'N/A' from 'Int32' to 'Double'", ex1.Message);
         }
 
@@ -133,10 +133,10 @@ namespace OpenTelemetry.Tests.Internal
         public void ZeroTest()
         {
             // Valid
-            Guard.Zero(1);
+            Guard.ThrowIfZero(1);
 
             // Invalid
-            var ex1 = Assert.Throws<ArgumentException>(() => Guard.Zero(0));
+            var ex1 = Assert.Throws<ArgumentException>(() => Guard.ThrowIfZero(0));
             Assert.Contains("Must not be zero", ex1.Message);
         }
     }


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-dotnet/pull/2501#issuecomment-952014130
Use more explicit method names for `Guard.cs`
Thanks @pellared and @reyang !

New Throw Method Names

- `ThrowIfNull`
- `ThrowIfNullOrEmpty`
- `ThrowIfNullOrWhitespace`
- `ThrowIfZero`
- `ThrowIfInvalidTimeout`
- `ThrowIfOutOfRange`

---

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
