### PR TITLE
stale automation

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,6 +14,5 @@ jobs:
         with:
           stale-pr-message: 'This PR was marked stale due to lack of activity. It will be closed in 7 days.'
           close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
-          exempt-pr-labels: 'release:after-ga'
           days-before-stale: 7
           days-before-close: 7

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,19 @@
+# Syntax: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
+# Github Actions Stale: https://github.com/actions/stale
+
+name: "Close stale pull requests"
+on:
+  schedule:
+    - cron: "12 3 * * *"  # arbitrary time not to DDOS GitHub
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-pr-message: 'This PR was marked stale due to lack of activity. It will be closed in 7 days.'
+          close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
+          exempt-pr-labels: 'release:after-ga'
+          days-before-stale: 7
+          days-before-close: 7


### PR DESCRIPTION
Fixes #2363 

## Changes
- adding new Stale workflow to automatically close PRs
  - Issues are ignored
  - PRs older that 7 days will be tagged as `stale`
  - `stale` PRs will be closed after 7 additional days (14 total).

Adding automation to close stale PRs.
This workflow was copied from https://github.com/open-telemetry/opentelemetry-specification/blob/main/.github/workflows/stale-pr.yaml


## Outstanding Questions
- **Does this repo require extra permissions for automation to make changes?**
Specification repo uses `repo-token: ${{ secrets.GITHUB_TOKEN }}` to provide someone's Personal Access Token to the stale automation. May not know if this is needed until we merge this and see it fail  :)
- The specification repo is using 7 days to mark PRs as stale, **is this too aggressive for this repo?** 
For context, this repo has 53 open PRs. With this setting, 46 would be identified as stale.
- **Should any PRs be exempt from stale?**
The specification repo exempts any PRs marked as `release:after-ga`. I don't see many PRs labeled here, but this is an option.
- **Should Issues be reviewed for stale?**
Specification repo proposed 1 year but was unable to agree on a policy. If this is wanted, labels can be used to exempt specific issues.



For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
