### PR TITLE
Event logging type in format string

### DIFF
--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -330,7 +330,7 @@ namespace OpenTelemetry.Internal
             this.WriteEvent(32, exportProcessorName, exporterName, droppedCount);
         }
 
-        [Event(33, Message = "Measurements from Instrument '{0}', Meter '{1}' will be ignored. Reason: '{1}'. Suggested action: '{2}'", Level = EventLevel.Warning)]
+        [Event(33, Message = "Measurements from Instrument '{0}', Meter '{1}' will be ignored. Reason: '{2}'. Suggested action: '{3}'", Level = EventLevel.Warning)]
         public void MetricInstrumentIgnored(string instrumentName, string meterName, string reason, string fix)
         {
             this.WriteEvent(33, instrumentName, meterName, reason, fix);


### PR DESCRIPTION
Fixes Event 33 was outputting the `meterName` twice and not including the `fix` string.

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
