### PR TITLE
Update default httpListenerPrefixes for PrometheusExporter to be http://localhost:9184/

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterOptions.cs
@@ -29,7 +29,7 @@ namespace OpenTelemetry.Exporter
         internal Func<DateTimeOffset> GetUtcNowDateTimeOffset = () => DateTimeOffset.UtcNow;
 
         private int scrapeResponseCacheDurationMilliseconds = 10 * 1000;
-        private IReadOnlyCollection<string> httpListenerPrefixes = new string[] { "http://*:80/" };
+        private IReadOnlyCollection<string> httpListenerPrefixes = new string[] { "http://localhost:9184/" };
 
 #if NETCOREAPP3_1_OR_GREATER
         /// <summary>
@@ -47,7 +47,7 @@ namespace OpenTelemetry.Exporter
 
         /// <summary>
         /// Gets or sets the prefixes to use for the http listener. Default
-        /// value: http://*:80/.
+        /// value: http://localhost:9184/.
         /// </summary>
         public IReadOnlyCollection<string> HttpListenerPrefixes
         {

--- a/src/OpenTelemetry.Exporter.Prometheus/README.md
+++ b/src/OpenTelemetry.Exporter.Prometheus/README.md
@@ -83,7 +83,7 @@ properties:
 
 * `HttpListenerPrefixes`: Defines the prefixes which will be used by the
   listener when `StartHttpListener` is `true`. The default value is
-  `["http://*:80/"]`. You may specify multiple endpoints.
+  `["http://localhost:9184/"]`. You may specify multiple endpoints.
 
   For details see:
   [HttpListenerPrefixCollection.Add(String)](https://docs.microsoft.com/dotnet/api/system.net.httplistenerprefixcollection.add)

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+* Update default httpListenerPrefixes for PrometheusExporter to be <http://localhost:9184/>.
+([2782](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2782))
 
 * Make `MetricPoint` of `MetricPointAccessor` readonly.
   ([2736](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2736))


### PR DESCRIPTION
Dependency:
Wait for merge of https://github.com/open-telemetry/opentelemetry-dotnet/pull/2771

Fixes #.
https://github.com/open-telemetry/opentelemetry-dotnet/issues/2780

## Changes
Update default httpListenerPrefixes for PrometheusExporter to be http://localhost:9184/

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Changes in public API reviewed
