### PR TITLE
Minimal readthedocs addition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -342,3 +342,6 @@ ASALocalRun/
 /.sonarqube
 
 /src/LastMajorVersionBinaries
+
+# Sphinx Documentation
+/docs/public/_build

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# Read the Docs - OpenTelemetry .NET
+
+[Read the Docs Link](https://opentelemetry-dotnet.readthedocs.io)
+
+## Build
+
+1. `pip install -r requirements.txt`
+1. `sphinx-autobuild public public/_build/html`
+
+__Note:__ Sometimes its necessary to delete `/docs/public/_build/` and perform
+a fresh build.
+
+## Changes
+
+When changes are made to the example programs in the `/docs/` directory. Ensure
+that the documentation which includes their source code is updated if needed.

--- a/docs/public/GettingHelp.md
+++ b/docs/public/GettingHelp.md
@@ -1,0 +1,17 @@
+# Getting Help
+
+- Refer to [opentelemetry.io](https://opentelemetry.io/) for general
+  information about OpenTelemetry.
+- Refer to the
+  [OpenTelemetry .NET GitHub repository](https://github.com/open-telemetry/opentelemetry-dotnet)
+  for further information and resources related to OpenTelemetry .NET.
+- Ask questions about OpenTelemetry .NET in the
+  [Github Discussions](https://github.com/open-telemetry/opentelemetry-dotnet/discussions)
+- Feel free to join the
+  [CNCF OpenTelemetry .NET Slack channel](https://cloud-native.slack.com/archives/C01N3BC2W7Q).
+  If you are new, you can create a CNCF Slack account
+  [here](http://slack.cncf.io/). Ask any questions related to OpenTelemetry
+  .NET that are not covered by the existing documentation, in the
+  `otel-dotnet` channel.
+- For bugs and feature requests, write a
+  [GitHub issue](https://github.com/open-telemetry/opentelemetry-dotnet/issues).

--- a/docs/public/conf.py
+++ b/docs/public/conf.py
@@ -1,0 +1,35 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+
+project = 'OpenTelemetry .NET'
+author = 'OpenTelemetry authors'
+copyright = '2022, OpenTelemetry authors'
+version = '1.1'
+release = '1.1.0'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = ['myst_parser']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'furo'
+html_title = 'OpenTelemetry .NET'

--- a/docs/public/index.rst
+++ b/docs/public/index.rst
@@ -1,0 +1,9 @@
+OpenTelemetry .NET
+==================
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Further Reading
+
+   GettingHelp
+   Source Code <https://github.com/open-telemetry/opentelemetry-dotnet>

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+furo
+myst-parser
+sphinx-autobuild


### PR DESCRIPTION
Starts to fix #2333 

## Changes

Minimal project setup for a readthedocs webpage. Just to get things started and have things hosted on the public website. 
[A future PR](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2351) will move the existing README.md files in the `/docs/` directory to the readthedocs webpag.
Also, we need to add more maintainers to the project https://readthedocs.org/projects/opentelemetry-dotnet/ and change the admin. There's also a webhook to be setup so we can publish the docs automatically.

Files:

- Add to `.gitignore` the build directory that all the website code (HTML, CSS, etc.) gets produced to locally
- Add `README.md` with instructions on how to build the project
- Simple `GettingHelp.md` page with links for how to get help and ask questions
- `conf.py` is the configuration for sphinx which is the documentation builder used by readthedocs (similar to Jekyll and others), here mainly just setting project details, ability to use normal markdown, and a theme.
- `index.rst` is a table of contents of the site essentially, and has the sidebar elements
- `requirements.txt` has all the required python modules to build the project. need python3.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
