### PR TITLE
Modify aspnetcore example to allow otlp log exporter

### DIFF
--- a/examples/AspNetCore/Examples.AspNetCore.csproj
+++ b/examples/AspNetCore/Examples.AspNetCore.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -18,6 +18,7 @@
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Jaeger\OpenTelemetry.Exporter.Jaeger.csproj" />
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Zipkin\OpenTelemetry.Exporter.Zipkin.csproj" />
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.OpenTelemetryProtocol\OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs\OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs.csproj" />
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Prometheus\OpenTelemetry.Exporter.Prometheus.csproj" />
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.AspNetCore\OpenTelemetry.Instrumentation.AspNetCore.csproj" />
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.Http\OpenTelemetry.Instrumentation.Http.csproj" />

--- a/examples/AspNetCore/Program.cs
+++ b/examples/AspNetCore/Program.cs
@@ -69,7 +69,7 @@ namespace Examples.AspNetCore
                             break;
                     }
 
-                    builder.Services.Configure<OpenTelemetryLoggerOptions>( opt =>
+                    builder.Services.Configure<OpenTelemetryLoggerOptions>(opt =>
                     {
                         opt.IncludeScopes = true;
                         opt.ParseStateValues = true;

--- a/examples/AspNetCore/Program.cs
+++ b/examples/AspNetCore/Program.cs
@@ -17,6 +17,7 @@
 using System;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
@@ -52,9 +53,6 @@ namespace Examples.AspNetCore
                             AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
                             builder.AddOpenTelemetry(options =>
                             {
-                                options.IncludeScopes = true;
-                                options.ParseStateValues = true;
-                                options.IncludeFormattedMessage = true;
                                 options.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(context.Configuration.GetValue<string>("Otlp:ServiceName")));
                                 options.AddOtlpExporter(otlpOptions =>
                                  {
@@ -66,13 +64,17 @@ namespace Examples.AspNetCore
                         default:
                             builder.AddOpenTelemetry(options =>
                             {
-                                options.IncludeScopes = true;
-                                options.ParseStateValues = true;
-                                options.IncludeFormattedMessage = true;
                                 options.AddConsoleExporter();
                             });
                             break;
                     }
+
+                    builder.Services.Configure<OpenTelemetryLoggerOptions>( opt =>
+                    {
+                        opt.IncludeScopes = true;
+                        opt.ParseStateValues = true;
+                        opt.IncludeFormattedMessage = true;
+                    });
                 });
     }
 }

--- a/examples/AspNetCore/Program.cs
+++ b/examples/AspNetCore/Program.cs
@@ -14,11 +14,13 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
+using OpenTelemetry.Resources;
 
 namespace Examples.AspNetCore
 {
@@ -40,16 +42,36 @@ namespace Examples.AspNetCore
                     builder.ClearProviders();
                     builder.AddConsole();
 
-                    var useLogging = context.Configuration.GetValue<bool>("UseLogging");
-                    if (useLogging)
+                    var logExporter = context.Configuration.GetValue<string>("UseLogExporter").ToLowerInvariant();
+                    switch (logExporter)
                     {
-                        builder.AddOpenTelemetry(options =>
-                        {
-                            options.IncludeScopes = true;
-                            options.ParseStateValues = true;
-                            options.IncludeFormattedMessage = true;
-                            options.AddConsoleExporter();
-                        });
+                        case "otlp":
+                            // Adding the OtlpExporter creates a GrpcChannel.
+                            // This switch must be set before creating a GrpcChannel when calling an insecure gRPC service.
+                            // See: https://docs.microsoft.com/aspnet/core/grpc/troubleshoot#call-insecure-grpc-services-with-net-core-client
+                            AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+                            builder.AddOpenTelemetry(options =>
+                            {
+                                options.IncludeScopes = true;
+                                options.ParseStateValues = true;
+                                options.IncludeFormattedMessage = true;
+                                options.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(context.Configuration.GetValue<string>("Otlp:ServiceName")));
+                                options.AddOtlpExporter(otlpOptions =>
+                                 {
+                                     otlpOptions.Endpoint = new Uri(context.Configuration.GetValue<string>("Otlp:Endpoint"));
+                                 });
+                            });
+                            break;
+
+                        default:
+                            builder.AddOpenTelemetry(options =>
+                            {
+                                options.IncludeScopes = true;
+                                options.ParseStateValues = true;
+                                options.IncludeFormattedMessage = true;
+                                options.AddConsoleExporter();
+                            });
+                            break;
                     }
                 });
     }

--- a/examples/AspNetCore/appsettings.json
+++ b/examples/AspNetCore/appsettings.json
@@ -9,7 +9,7 @@
   "AllowedHosts": "*",
   "UseTracingExporter": "console",
   "UseMetricsExporter": "console",
-  "UseLogging": true,
+  "UseLogExporter": "console",
   "Jaeger": {
     "ServiceName": "jaeger-test",
     "AgentHost": "localhost",

--- a/examples/Console/Examples.Console.csproj
+++ b/examples/Console/Examples.Console.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn),CS0618</NoWarn>
   </PropertyGroup>

--- a/examples/GrpcService/Examples.GrpcService.csproj
+++ b/examples/GrpcService/Examples.GrpcService.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Asp.Net Core example - Log exporter made consistent with trace, metrics.
As a followup, can move the example to use .NET 6.0 template, which is a lot more concise.