### PR TITLE
Fix Metric console exporter to respect Console and Debug flags

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+Fix MetricExporter to respect Console and Debug flags.
+
 ## 1.2.0-rc1
 
 Released 2021-Nov-29

--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -42,7 +42,7 @@ namespace OpenTelemetry.Exporter
                     {
                         if (resourceAttribute.Key.Equals("service.name"))
                         {
-                            Console.WriteLine("Service.Name" + resourceAttribute.Value);
+                            this.WriteLine("Service.Name" + resourceAttribute.Value);
                         }
                     }
                 }
@@ -73,7 +73,7 @@ namespace OpenTelemetry.Exporter
                     }
                 }
 
-                Console.WriteLine(msg.ToString());
+                this.WriteLine(msg.ToString());
 
                 foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                 {
@@ -174,7 +174,7 @@ namespace OpenTelemetry.Exporter
                     msg.Append(metric.MetricType);
                     msg.AppendLine();
                     msg.Append($"Value: {valueDisplay}");
-                    Console.WriteLine(msg);
+                    this.WriteLine(msg.ToString());
                 }
             }
 

--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Globalization;
 using System.Text;
 using OpenTelemetry.Metrics;


### PR DESCRIPTION
Without this Console Exporter was only writing to Console alone, and not respecting the `ConsoleExporterOutputTargets.Debug`