### PR TITLE
update stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,5 +15,7 @@ jobs:
           stale-pr-message: 'This PR was marked stale due to lack of activity. It will be closed in 7 days.'
           close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
           operations-per-run: 400
-          days-before-stale: 7
-          days-before-close: 7
+          days-before-pr-stale: 7
+          days-before-issue-stale: -1
+          days-before-pr-close: 7
+          days-before-issue-close: -1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,5 +14,6 @@ jobs:
         with:
           stale-pr-message: 'This PR was marked stale due to lack of activity. It will be closed in 7 days.'
           close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
+          operations-per-run: 400
           days-before-stale: 7
           days-before-close: 7


### PR DESCRIPTION
This is a follow up to #2769

Currently Issues are being marked as 'stale'. I'm sorry, this was not intended!

## Changes
- replace the generic `days-before-stale` with `days-before-pr-stale`
- replace the generic `days-before-close` with `days-before-pr-close`
- also set `days-before-issue-stale` to -1
- also set `days-before-issue-close` to -1


### Please provide a brief description of the changes here.

This change is to ensure that only PRs are affected by the Stale Bot.

Documentation: https://github.com/actions/stale
The documentation states that -1 is supported for the generic `days-before-stale` and `days-before-close`.
The documentation does not explicitly state if -1 is support for the "issue" specific values.

I propose these changes because I would prefer to be explicit with the config.
If this change fails, then we would set the "generic" to -1 and only configure the "pr" specific values.



For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
