### PR TITLE
Remove unused parameter timeoutMilliseconds from ProcessMetrics

### DIFF
--- a/src/OpenTelemetry/Metrics/BaseExportingMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/BaseExportingMetricReader.cs
@@ -78,7 +78,7 @@ namespace OpenTelemetry.Metrics
         }
 
         /// <inheritdoc/>
-        internal override bool ProcessMetrics(in Batch<Metric> metrics, int timeoutMilliseconds)
+        internal override bool ProcessMetrics(in Batch<Metric> metrics)
         {
             // TODO: Do we need to consider timeout here?
             try

--- a/src/OpenTelemetry/Metrics/CompositeMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/CompositeMetricReader.cs
@@ -70,7 +70,7 @@ namespace OpenTelemetry.Metrics
         public Enumerator GetEnumerator() => new Enumerator(this.head);
 
         /// <inheritdoc/>
-        internal override bool ProcessMetrics(in Batch<Metric> metrics, int timeoutMilliseconds)
+        internal override bool ProcessMetrics(in Batch<Metric> metrics)
         {
             // CompositeMetricReader delegates the work to its underlying readers,
             // so CompositeMetricReader.ProcessMetrics should never be called.

--- a/src/OpenTelemetry/Metrics/MetricReader.cs
+++ b/src/OpenTelemetry/Metrics/MetricReader.cs
@@ -183,15 +183,11 @@ namespace OpenTelemetry.Metrics
         /// Processes a batch of metrics.
         /// </summary>
         /// <param name="metrics">Batch of metrics to be processed.</param>
-        /// <param name="timeoutMilliseconds">
-        /// The number (non-negative) of milliseconds to wait, or
-        /// <c>Timeout.Infinite</c> to wait indefinitely.
-        /// </param>
         /// <returns>
         /// Returns <c>true</c> when metrics processing succeeded; otherwise,
         /// <c>false</c>.
         /// </returns>
-        internal virtual bool ProcessMetrics(in Batch<Metric> metrics, int timeoutMilliseconds)
+        internal virtual bool ProcessMetrics(in Batch<Metric> metrics)
         {
             return true;
         }
@@ -226,7 +222,7 @@ namespace OpenTelemetry.Metrics
 
             if (sw == null)
             {
-                return this.ProcessMetrics(metrics, Timeout.Infinite);
+                return this.ProcessMetrics(metrics);
             }
             else
             {
@@ -237,7 +233,7 @@ namespace OpenTelemetry.Metrics
                     return false;
                 }
 
-                return this.ProcessMetrics(metrics, (int)timeout);
+                return this.ProcessMetrics(metrics);
             }
         }
 


### PR DESCRIPTION
## Changes
- Remove unused parameter `timeoutMilliseconds` parameter from `ProcessMetrics`
