### PR TITLE
Add unit test to validate Metric name description

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -51,13 +51,13 @@ namespace OpenTelemetry.Exporter
             {
                 var msg = new StringBuilder($"\nExport ");
                 msg.Append(metric.Name);
-                if (!string.IsNullOrEmpty(metric.Description))
+                if (metric.Description != string.Empty)
                 {
                     msg.Append(", ");
                     msg.Append(metric.Description);
                 }
 
-                if (!string.IsNullOrEmpty(metric.Unit))
+                if (metric.Unit != string.Empty)
                 {
                     msg.Append($", Unit: {metric.Unit}");
                 }

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -102,6 +102,52 @@ namespace OpenTelemetry.Metrics.Tests
         }
 
         [Theory]
+        [InlineData("unit")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void MetricUnitIsExportedCorrectly(string unit)
+        {
+            var exportedItems = new List<Metric>();
+
+            using var meter = new Meter($"{Utils.GetCurrentMethodName()}");
+            var meterProviderBuilder = Sdk.CreateMeterProviderBuilder()
+                .AddMeter(meter.Name)
+                .AddInMemoryExporter(exportedItems);
+
+            using var meterProvider = meterProviderBuilder.Build();
+
+            var counter = meter.CreateCounter<long>("name1", unit);
+            counter.Add(10);
+            meterProvider.ForceFlush(MaxTimeToAllowForFlush);
+            Assert.Single(exportedItems);
+            var metric = exportedItems[0];
+            Assert.Equal(unit ?? string.Empty, metric.Unit);
+        }
+
+        [Theory]
+        [InlineData("description")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void MetricDescriptionIsExportedCorrectly(string description)
+        {
+            var exportedItems = new List<Metric>();
+
+            using var meter = new Meter($"{Utils.GetCurrentMethodName()}");
+            var meterProviderBuilder = Sdk.CreateMeterProviderBuilder()
+                .AddMeter(meter.Name)
+                .AddInMemoryExporter(exportedItems);
+
+            using var meterProvider = meterProviderBuilder.Build();
+
+            var counter = meter.CreateCounter<long>("name1", null, description);
+            counter.Add(10);
+            meterProvider.ForceFlush(MaxTimeToAllowForFlush);
+            Assert.Single(exportedItems);
+            var metric = exportedItems[0];
+            Assert.Equal(description ?? string.Empty, metric.Description);
+        }
+
+        [Theory]
         [InlineData(AggregationTemporality.Cumulative, true)]
         [InlineData(AggregationTemporality.Cumulative, false)]
         [InlineData(AggregationTemporality.Delta, true)]


### PR DESCRIPTION
Minor addition to unit test to validate conformance to:
https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument

> If the unit is not provided or the unit is null, the API and SDK MUST make sure that the behavior is the same as an empty unit string.
