### PR TITLE
Minor improvement to observable counter test

### DIFF
--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -15,9 +15,7 @@
 // </copyright>
 
 using System;
-using System.Buffers;
 using System.Collections.Generic;
-using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Threading;
@@ -469,6 +467,7 @@ namespace OpenTelemetry.Metrics.Tests
                 })
                 .Build();
 
+            // Export 1
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
             Assert.Single(exportedItems);
             var metric = exportedItems[0];
@@ -491,6 +490,32 @@ namespace OpenTelemetry.Metrics.Tests
 
             var metricPoint3 = metricPoints[2];
             Assert.Equal(10, metricPoint3.GetSumLong());
+            ValidateMetricPointTags(tags3, metricPoint3.Tags);
+
+            // Export 2
+            exportedItems.Clear();
+            meterProvider.ForceFlush(MaxTimeToAllowForFlush);
+            Assert.Single(exportedItems);
+            metric = exportedItems[0];
+            Assert.Equal("observable-counter", metric.Name);
+            metricPoints.Clear();
+            foreach (ref readonly var mp in metric.GetMetricPoints())
+            {
+                metricPoints.Add(mp);
+            }
+
+            Assert.Equal(3, metricPoints.Count);
+
+            metricPoint1 = metricPoints[0];
+            Assert.Equal(exportDelta ? 0 : 10, metricPoint1.GetSumLong());
+            ValidateMetricPointTags(tags1, metricPoint1.Tags);
+
+            metricPoint2 = metricPoints[1];
+            Assert.Equal(exportDelta ? 0 : 10, metricPoint2.GetSumLong());
+            ValidateMetricPointTags(tags2, metricPoint2.Tags);
+
+            metricPoint3 = metricPoints[2];
+            Assert.Equal(exportDelta ? 0 : 10, metricPoint3.GetSumLong());
             ValidateMetricPointTags(tags3, metricPoint3.Tags);
         }
 


### PR DESCRIPTION
The distinction between delta export vs cumulative really come into picture from the 2nd export cycle only, where cumulative->delta conversion occurs. Test is modified to test this scenario of cumulative -> delta case,