### PR TITLE
Swallow ObjectDisposedException

### DIFF
--- a/src/OpenTelemetry/BatchExportProcessor.cs
+++ b/src/OpenTelemetry/BatchExportProcessor.cs
@@ -240,7 +240,7 @@ namespace OpenTelemetry
                     }
                     catch (ObjectDisposedException)
                     {
-                        // the exporter is somehow disposed before the worker thread finishing its job
+                        // the exporter is somehow disposed before the worker thread could finish its job
                         return;
                     }
                 }
@@ -259,7 +259,7 @@ namespace OpenTelemetry
                     }
                     catch (ObjectDisposedException)
                     {
-                        // the exporter is somehow disposed before the worker thread finishing its job
+                        // the exporter is somehow disposed before the worker thread could finish its job
                         return;
                     }
                 }

--- a/src/OpenTelemetry/BatchExportProcessor.cs
+++ b/src/OpenTelemetry/BatchExportProcessor.cs
@@ -251,8 +251,15 @@ namespace OpenTelemetry
                         this.exporter.Export(batch);
                     }
 
-                    this.dataExportedNotification.Set();
-                    this.dataExportedNotification.Reset();
+                    try
+                    {
+                        this.dataExportedNotification.Set();
+                        this.dataExportedNotification.Reset();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        return;
+                    }
                 }
 
                 if (this.circularBuffer.RemovedCount >= this.shutdownDrainTarget)

--- a/src/OpenTelemetry/BatchExportProcessor.cs
+++ b/src/OpenTelemetry/BatchExportProcessor.cs
@@ -240,6 +240,7 @@ namespace OpenTelemetry
                     }
                     catch (ObjectDisposedException)
                     {
+                        // the exporter is somehow disposed before the worker thread finishing its job
                         return;
                     }
                 }
@@ -258,6 +259,7 @@ namespace OpenTelemetry
                     }
                     catch (ObjectDisposedException)
                     {
+                        // the exporter is somehow disposed before the worker thread finishing its job
                         return;
                     }
                 }

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -8,6 +8,10 @@
 * Fail-fast when using AddView with guaranteed conflict.
   ([2751](https://github.com/open-telemetry/opentelemetry-dotnet/issues/2751))
 
+* Swallow `ObjectDisposedException` from the `BatchExportProcessor` worker
+  thread.
+  ([2844](https://github.com/open-telemetry/opentelemetry-dotnet/issues/2844))
+
 ## 1.2.0-rc1
 
 Released 2021-Nov-29


### PR DESCRIPTION
Refer to the analysis here https://github.com/open-telemetry/opentelemetry-dotnet/pull/2831#issuecomment-1027421862.

I think it is a very rare case that the user might have disposed the `BatchExportingProcessor` while the exporter worker thread `Join()` timed out.

Here goes a self-contained repro simulating this situation:

```csharp

using System;
using System.Collections.Generic;
using System.Text;
using System.Threading;
using Microsoft.Extensions.Logging;
using OpenTelemetry;
using OpenTelemetry.Logs;

public class Program
{
    public static void Main()
    {
        var processor = new BatchLogRecordExportProcessor(
            exporter: new MyExporter("ExporterX"),
            scheduledDelayMilliseconds: 100,
            maxExportBatchSize: 1);
        using var loggerFactory = LoggerFactory.Create(builder =>
            builder.AddOpenTelemetry(options => options.AddProcessor(processor)));

        var logger = loggerFactory.CreateLogger<Program>();

        for (int i = 0; i < 100000; i++)
        {
            logger.LogInformation("Hello, World!");
        }

        processor.Dispose();
    }

    internal class MyExporter : BaseExporter<LogRecord>
    {
        private readonly string name;

        public MyExporter(string name = "MyExporter")
        {
            this.name = name;
        }

        public override ExportResult Export(in Batch<LogRecord> batch)
        {
            // SuppressInstrumentationScope should be used to prevent exporter
            // code from generating telemetry and causing live-loop.
            using var scope = SuppressInstrumentationScope.Begin();

            Console.WriteLine($"{this.name}.Export(...)");
            Thread.Sleep(1);
            return ExportResult.Success;
        }

        protected override bool OnShutdown(int timeoutMilliseconds)
        {
            Console.WriteLine($"{this.name}.OnShutdown(timeoutMilliseconds={timeoutMilliseconds})");
            return true;
        }

        protected override void Dispose(bool disposing)
        {
            Console.WriteLine($"{this.name}.Dispose({disposing})");
        }
    }
}
```