### PR TITLE
Should histogram sum be filled from negatives

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Bugfix - Histogram Sum should not be calculated from negative
+  values.
+  ([2736](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2736))
+
 * Make `MetricPoint` of `MetricPointAccessor` readonly.
   ([2736](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2736))
 

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -326,7 +326,11 @@ namespace OpenTelemetry.Metrics
                         lock (this.histogramBuckets.LockObject)
                         {
                             this.runningValue.AsLong++;
-                            this.histogramBuckets.RunningSum += number;
+                            if (number > 0)
+                            {
+                                this.histogramBuckets.RunningSum += number;
+                            }
+
                             this.histogramBuckets.RunningBucketCounts[i]++;
                         }
 
@@ -338,7 +342,10 @@ namespace OpenTelemetry.Metrics
                         lock (this.histogramBuckets.LockObject)
                         {
                             this.runningValue.AsLong++;
-                            this.histogramBuckets.RunningSum += number;
+                            if (number > 0)
+                            {
+                                this.histogramBuckets.RunningSum += number;
+                            }
                         }
 
                         break;

--- a/test/OpenTelemetry.Tests/Metrics/AggregatorTest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/AggregatorTest.cs
@@ -68,6 +68,8 @@ namespace OpenTelemetry.Metrics.Tests
             var histogramPoint = new MetricPoint(AggregationType.Histogram, DateTimeOffset.Now, null, null, boundaries);
 
             // 5 recordings <=10
+            // -ve numbers do not contribute to Sum,
+            // but contributes to Count and Buckets
             histogramPoint.Update(-10);
             histogramPoint.Update(0);
             histogramPoint.Update(1);
@@ -84,7 +86,7 @@ namespace OpenTelemetry.Metrics.Tests
             var sum = histogramPoint.GetHistogramSum();
 
             // Sum of all recordings
-            Assert.Equal(40, sum);
+            Assert.Equal(50, sum);
 
             // Count  = # of recordings
             Assert.Equal(7, count);
@@ -108,6 +110,8 @@ namespace OpenTelemetry.Metrics.Tests
             var boundaries = new double[] { };
             var histogramPoint = new MetricPoint(AggregationType.HistogramSumCount, DateTimeOffset.Now, null, null, boundaries);
 
+            // -ve numbers do not contribute to Sum,
+            // but contributes to Count and Buckets
             histogramPoint.Update(-10);
             histogramPoint.Update(0);
             histogramPoint.Update(1);
@@ -122,7 +126,7 @@ namespace OpenTelemetry.Metrics.Tests
             var sum = histogramPoint.GetHistogramSum();
 
             // Sum of all recordings
-            Assert.Equal(40, sum);
+            Assert.Equal(50, sum);
 
             // Count  = # of recordings
             Assert.Equal(7, count);

--- a/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
@@ -365,6 +365,8 @@ namespace OpenTelemetry.Metrics.Tests
                 .Build();
 
             var histogram = meter.CreateHistogram<long>("MyHistogram");
+            // -ve numbers do not contribute to Sum,
+            // but contributes to Count and Buckets
             histogram.Record(-10);
             histogram.Record(0);
             histogram.Record(1);
@@ -392,7 +394,7 @@ namespace OpenTelemetry.Metrics.Tests
             var count = histogramPoint.GetHistogramCount();
             var sum = histogramPoint.GetHistogramSum();
 
-            Assert.Equal(40, sum);
+            Assert.Equal(50, sum);
             Assert.Equal(7, count);
 
             int index = 0;
@@ -419,7 +421,7 @@ namespace OpenTelemetry.Metrics.Tests
             count = histogramPoint.GetHistogramCount();
             sum = histogramPoint.GetHistogramSum();
 
-            Assert.Equal(40, sum);
+            Assert.Equal(50, sum);
             Assert.Equal(7, count);
 
             index = 0;


### PR DESCRIPTION
Trying to get clarity on the expected behavior:
As per this (https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/metrics/v1/metrics.proto#L408-L409), SUM should not be filled when negative values are used.

Should we interpret it as
1. (This PR) - If -ve values are reported, then Histogram count, buckets are calculated as before. But the SUM should not include the -ve values.
2. If -ve values are reported, then SUM field *should not* be populated at all.
3. Block -ve values at Histogram.Record API itself. But what to do if user configured View to convert Gauge/UpDownCounter to a Histogram?