### PR TITLE
Counter and Histogram to ignore negative measurements

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -12,7 +12,7 @@
   thread.
   ([2844](https://github.com/open-telemetry/opentelemetry-dotnet/issues/2844))
 
-* Bugfix - Histogram and Counter should not only allow non-negative
+* Bugfix - Histogram and Counter should only allow non-negative
   values.
   ([2846](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2846))
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -12,6 +12,10 @@
   thread.
   ([2844](https://github.com/open-telemetry/opentelemetry-dotnet/issues/2844))
 
+* Bugfix - Histogram and Counter should not only allow non-negative
+  values.
+  ([2846](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2846))
+
 ## 1.2.0-rc1
 
 Released 2021-Nov-29

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -139,7 +139,7 @@ namespace OpenTelemetry.Metrics
         {
             if (!this.allowNegativeMeasurement && value < 0)
             {
-                // do we log?
+                // TODO: do we log?
             }
             else
             {
@@ -151,7 +151,7 @@ namespace OpenTelemetry.Metrics
         {
             if (!this.allowNegativeMeasurement && value < 0)
             {
-                // do we log?
+                // TODO: do we log?
             }
             else
             {

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -398,6 +398,8 @@ namespace OpenTelemetry.Metrics.Tests
 
             counterLong.Add(10);
             counterLong.Add(10);
+
+            // -ve numbers are ignored.
             counterLong.Add(-5);
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
             long sumReceived = GetLongSum(exportedItems);
@@ -406,6 +408,8 @@ namespace OpenTelemetry.Metrics.Tests
             exportedItems.Clear();
             counterLong.Add(10);
             counterLong.Add(10);
+
+            // -ve numbers are ignored.
             counterLong.Add(-15);
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
             sumReceived = GetLongSum(exportedItems);

--- a/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
@@ -365,7 +365,7 @@ namespace OpenTelemetry.Metrics.Tests
                 .Build();
 
             var histogram = meter.CreateHistogram<long>("MyHistogram");
-            histogram.Record(-10);
+            histogram.Record(10);
             histogram.Record(0);
             histogram.Record(1);
             histogram.Record(9);
@@ -392,12 +392,12 @@ namespace OpenTelemetry.Metrics.Tests
             var count = histogramPoint.GetHistogramCount();
             var sum = histogramPoint.GetHistogramSum();
 
-            Assert.Equal(40, sum);
+            Assert.Equal(60, sum);
             Assert.Equal(7, count);
 
             int index = 0;
             int actualCount = 0;
-            var expectedBucketCounts = new long[] { 2, 1, 2, 2, 0, 0, 0, 0, 0, 0, 0 };
+            var expectedBucketCounts = new long[] { 1, 1, 3, 2, 0, 0, 0, 0, 0, 0, 0 };
             foreach (var histogramMeasurement in histogramPoint.GetHistogramBuckets())
             {
                 Assert.Equal(expectedBucketCounts[index], histogramMeasurement.BucketCount);
@@ -419,7 +419,7 @@ namespace OpenTelemetry.Metrics.Tests
             count = histogramPoint.GetHistogramCount();
             sum = histogramPoint.GetHistogramSum();
 
-            Assert.Equal(40, sum);
+            Assert.Equal(60, sum);
             Assert.Equal(7, count);
 
             index = 0;


### PR DESCRIPTION
[Counter](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#add) and [Histogram](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#record) API spec says the values must be non-negative.
This PR adds this validation, and ignores the measurement if negative.

Fixes https://github.com/open-telemetry/opentelemetry-dotnet/issues/2519