### PR TITLE
Add OpenTelemetry.Proto project

### DIFF
--- a/OpenTelemetry.sln
+++ b/OpenTelemetry.sln
@@ -226,6 +226,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "source-generation", "docs\l
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "getting-started-prometheus-grafana", "docs\metrics\getting-started-prometheus-grafana\getting-started-prometheus-grafana.csproj", "{41B784AA-3301-4126-AF9F-1D59BD04B0BF}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.Proto", "src\OpenTelemetry.Proto\OpenTelemetry.Proto.csproj", "{9D84245C-E1FE-476E-8D3E-D40E547A4152}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -472,6 +474,10 @@ Global
 		{41B784AA-3301-4126-AF9F-1D59BD04B0BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{41B784AA-3301-4126-AF9F-1D59BD04B0BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{41B784AA-3301-4126-AF9F-1D59BD04B0BF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9D84245C-E1FE-476E-8D3E-D40E547A4152}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9D84245C-E1FE-476E-8D3E-D40E547A4152}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9D84245C-E1FE-476E-8D3E-D40E547A4152}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9D84245C-E1FE-476E-8D3E-D40E547A4152}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -6,7 +6,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="$(MicrosoftCodeAnalysisAnalyzersPkgVer)" Condition=" $(OS) == 'Windows_NT'">
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="$(MicrosoftCodeAnalysisAnalyzersPkgVer)" Condition="!($(ExcludeFromPublicApiAnalyzer) == 'true') And $(OS) == 'Windows_NT'">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>
@@ -74,7 +74,7 @@
   </PropertyGroup>
 
   <!--PublicApi Analyzer-->
-  <ItemGroup>
+  <ItemGroup Condition="!($(ExcludeFromPublicApiAnalyzer) == 'true')">
     <AdditionalFiles Include=".publicApi\$(TargetFramework)\PublicAPI.Shipped.txt" />
     <AdditionalFiles Include=".publicApi\$(TargetFramework)\PublicAPI.Unshipped.txt" />
     <None Include=".publicApi\*\PublicAPI.Shipped.txt" />

--- a/src/OpenTelemetry.Proto/.gitignore
+++ b/src/OpenTelemetry.Proto/.gitignore
@@ -1,2 +1,2 @@
-opentelemetry-proto-src
+opentelemetry-proto
 *.zip

--- a/src/OpenTelemetry.Proto/.gitignore
+++ b/src/OpenTelemetry.Proto/.gitignore
@@ -1,0 +1,2 @@
+opentelemetry-proto-src
+*.zip

--- a/src/OpenTelemetry.Proto/CHANGELOG.md
+++ b/src/OpenTelemetry.Proto/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.3.0
+
+Released 2022-Feb-TBD
+
+* Refer to
+  [opentelemetry-proto v0.3.0 release](https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v0.3.0).
+  ([#TBD](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TBD))

--- a/src/OpenTelemetry.Proto/OpenTelemetry.Proto.csproj
+++ b/src/OpenTelemetry.Proto/OpenTelemetry.Proto.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <OpenTelemetryProtoVersion>0.12.0</OpenTelemetryProtoVersion>
+    <OpenTelemetryProtoVersion>0.3.0</OpenTelemetryProtoVersion>
     <OpenTelemetryProtoUrl>https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v$(OpenTelemetryProtoVersion).zip</OpenTelemetryProtoUrl>
     <OpenTelemetryProtoZipFile>opentelemetry-proto-$(OpenTelemetryProtoVersion).zip</OpenTelemetryProtoZipFile>
     <OpenTelemetryProtoSourceRoot>opentelemetry-proto</OpenTelemetryProtoSourceRoot>
@@ -36,7 +36,5 @@
       SourceFiles="$(OpenTelemetryProtoZipFile)"
       DestinationFolder="$(OpenTelemetryProtoSourceRoot)"
       OverwriteReadOnlyFiles="true" />
-
-    <Delete Files="opentelemetry-proto-src\opentelemetry-proto-$(OpenTelemetryProtoVersion)\opentelemetry\proto\metrics\experimental\metrics_config_service.proto" />
   </Target>
 </Project>

--- a/src/OpenTelemetry.Proto/OpenTelemetry.Proto.csproj
+++ b/src/OpenTelemetry.Proto/OpenTelemetry.Proto.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <Description>OpenTelemetry protos for OpenTelemetry .NET</Description>
+    <MinVerTagPrefix>proto-</MinVerTagPrefix>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OpenTelemetryProtoVersion>0.12.0</OpenTelemetryProtoVersion>
+    <OpenTelemetryProtoUrl>https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v$(OpenTelemetryProtoVersion).zip</OpenTelemetryProtoUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Grpc" Version="$(GrpcPkgVer)" />
+    <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPkgVer)" />
+    <PackageReference Include="Grpc.Tools" Version="$(GrpcToolsPkgVer)" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="**/*.proto">
+      <ProtoRoot>opentelemetry-proto-src/opentelemetry-proto-$(OpenTelemetryProtoVersion)</ProtoRoot>
+    </Protobuf>
+  </ItemGroup>
+
+  <Target Name="DownloadOpenTelemetryProto" BeforeTargets="Build">
+    <RemoveDir Directories="opentelemetry-proto-src" />
+
+    <DownloadFile
+      SourceUrl="$(OpenTelemetryProtoUrl)"
+      DestinationFolder="$(MSBuildProjectDirectory)" />
+
+    <Unzip
+      SourceFiles="opentelemetry-proto-$(OpenTelemetryProtoVersion).zip"
+      DestinationFolder="$(MSBuildProjectDirectory)\opentelemetry-proto-src"
+      OverwriteReadOnlyFiles="true" />
+
+    <Delete Files="opentelemetry-proto-src\opentelemetry-proto-$(OpenTelemetryProtoVersion)\opentelemetry\proto\metrics\experimental\metrics_config_service.proto" />
+  </Target>
+</Project>

--- a/src/OpenTelemetry.Proto/OpenTelemetry.Proto.csproj
+++ b/src/OpenTelemetry.Proto/OpenTelemetry.Proto.csproj
@@ -10,6 +10,9 @@
   <PropertyGroup>
     <OpenTelemetryProtoVersion>0.12.0</OpenTelemetryProtoVersion>
     <OpenTelemetryProtoUrl>https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v$(OpenTelemetryProtoVersion).zip</OpenTelemetryProtoUrl>
+    <OpenTelemetryProtoZipFile>opentelemetry-proto-$(OpenTelemetryProtoVersion).zip</OpenTelemetryProtoZipFile>
+    <OpenTelemetryProtoSourceRoot>opentelemetry-proto</OpenTelemetryProtoSourceRoot>
+    <OpenTelemetryProtoSourceDir>$(OpenTelemetryProtoSourceRoot)\opentelemetry-proto-$(OpenTelemetryProtoVersion)</OpenTelemetryProtoSourceDir>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,20 +23,18 @@
 
   <ItemGroup>
     <Protobuf Include="**/*.proto">
-      <ProtoRoot>opentelemetry-proto-src/opentelemetry-proto-$(OpenTelemetryProtoVersion)</ProtoRoot>
+      <ProtoRoot>$(OpenTelemetryProtoSourceDir)</ProtoRoot>
     </Protobuf>
   </ItemGroup>
 
   <Target Name="DownloadOpenTelemetryProto" BeforeTargets="Build">
-    <RemoveDir Directories="opentelemetry-proto-src" />
-
-    <DownloadFile
+    <DownloadFile Condition="!Exists('$(OpenTelemetryProtoZipFile)')"
       SourceUrl="$(OpenTelemetryProtoUrl)"
       DestinationFolder="$(MSBuildProjectDirectory)" />
 
-    <Unzip
-      SourceFiles="opentelemetry-proto-$(OpenTelemetryProtoVersion).zip"
-      DestinationFolder="$(MSBuildProjectDirectory)\opentelemetry-proto-src"
+    <Unzip Condition="!Exists('$(OpenTelemetryProtoSourceDir)')"
+      SourceFiles="$(OpenTelemetryProtoZipFile)"
+      DestinationFolder="$(OpenTelemetryProtoSourceRoot)"
       OverwriteReadOnlyFiles="true" />
 
     <Delete Files="opentelemetry-proto-src\opentelemetry-proto-$(OpenTelemetryProtoVersion)\opentelemetry\proto\metrics\experimental\metrics_config_service.proto" />

--- a/src/OpenTelemetry.Proto/OpenTelemetry.Proto.csproj
+++ b/src/OpenTelemetry.Proto/OpenTelemetry.Proto.csproj
@@ -3,6 +3,8 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <Description>OpenTelemetry protos for OpenTelemetry .NET</Description>
     <MinVerTagPrefix>proto-</MinVerTagPrefix>
+
+    <ExcludeFromPublicApiAnalyzer>true</ExcludeFromPublicApiAnalyzer>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenTelemetry.Proto/OpenTelemetry.Proto.csproj
+++ b/src/OpenTelemetry.Proto/OpenTelemetry.Proto.csproj
@@ -27,7 +27,7 @@
     </Protobuf>
   </ItemGroup>
 
-  <Target Name="DownloadOpenTelemetryProto" BeforeTargets="Build">
+  <Target Name="DownloadOpenTelemetryProto" BeforeTargets="DispatchToInnerBuilds">
     <DownloadFile Condition="!Exists('$(OpenTelemetryProtoZipFile)')"
       SourceUrl="$(OpenTelemetryProtoUrl)"
       DestinationFolder="$(MSBuildProjectDirectory)" />

--- a/src/OpenTelemetry.Proto/README.md
+++ b/src/OpenTelemetry.Proto/README.md
@@ -1,0 +1,16 @@
+# OpenTelemetry Proto for OpenTelemetry .NET
+
+[![NuGet](https://img.shields.io/nuget/v/OpenTelemetry.Proto.svg)](https://www.nuget.org/packages/OpenTelemetry.Proto)
+[![NuGet](https://img.shields.io/nuget/dt/OpenTelemetry.Proto.svg)](https://www.nuget.org/packages/OpenTelemetry.Proto)
+
+Generated code for the OpenTelemetry protobuf data model.
+
+## Installation
+
+```shell
+dotnet add package OpenTelemetry.Proto
+```
+
+## References
+
+* [OpenTelemetry Proto](https://github.com/open-telemetry/opentelemetry-proto)


### PR DESCRIPTION
This PR introduces a new `OpenTelemetry.Proto` project that, when built, includes code generated from the OpenTelemetry protos.

The project currently targets version 0.3.0 of the opentelemetry-proto project. My thought is that we could land this initial PR and then add the `proto-0.3.0` tag to the repo. We could do follow up PRs incrementing the version up to the current 0.12.0 protos. This would allow us to retroactively publish prior versions.

I have not referenced OpenTelemetry.Proto by any other projects yet. I think it will be cool to reference OpenTelemetry.Proto from the OpenTelemetry.Exporter.OpenTelemetryProtocol project, but there some challenges to consider before doing so. Namely, when a user references the OTLP exporter package, they'd also pull down and expose the API of the OpenTelemetry.Proto project. OpenTelemetry.Proto has not reached 1.0, so there is a potential for breaking changes. If we do end up referencing OpenTelemetry.Proto from the OTLP exporter then we may want to do it in a way that does not expose the proto API to the consumer - ILRepack maybe?