### PR TITLE
Fix the default endpoint for OTLP exporter when using http/protobuf protocol

### DIFF
--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(CheckAPICompatibility)' == 'true'">
-    <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="7.0.0-beta.22108.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="6.0.0-beta.21308.1" PrivateAssets="All" />
     <ResolvedMatchingContract Include="..\LastMajorVersionBinaries\$(AssemblyName)\$(OTelPreviousStableVer)\lib\$(TargetFramework)\$(AssemblyName).dll" />
   </ItemGroup>
 

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(CheckAPICompatibility)' == 'true'">
-    <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="6.0.0-beta.21308.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="7.0.0-beta.22108.2" PrivateAssets="All" />
     <ResolvedMatchingContract Include="..\LastMajorVersionBinaries\$(AssemblyName)\$(OTelPreviousStableVer)\lib\$(TargetFramework)\$(AssemblyName).dll" />
   </ItemGroup>
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/ApiCompatBaseline.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/ApiCompatBaseline.txt
@@ -1,0 +1,4 @@
+Compat issues with assembly OpenTelemetry.Exporter.OpenTelemetryProtocol:
+CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.CompilerGeneratedAttribute' exists on 'OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.get()' in the contract but not the implementation.
+CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.CompilerGeneratedAttribute' exists on 'OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.set(System.Uri)' in the contract but not the implementation.
+Total Issues: 2

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -6,6 +6,7 @@
   ([#2871](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2871))
 
 * Fixed the default endpoint for OTLP exporter over HTTP/Protobuf.
+  The default value is `http://localhost:4318`.
   ([#2868](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2868))
 
 ## 1.2.0-rc2

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## Unreleased
 
+* Fixed the default endpoint for OTLP exporter over HTTP/Protobuf.
+  ([#2686](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2868))
+
 ## 1.2.0-rc2
 
 Released 2022-Feb-02

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -6,7 +6,7 @@
   ([#2871](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2871))
 
 * Fixed the default endpoint for OTLP exporter over HTTP/Protobuf.
-  ([#2686](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2868))
+  ([#2868](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2868))
 
 ## 1.2.0-rc2
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -55,6 +55,11 @@ namespace OpenTelemetry.Exporter
         /// </summary>
         public OtlpExporterOptions()
         {
+            if (EnvironmentVariableHelper.LoadUri(EndpointEnvVarName, out Uri parsedEndpoint))
+            {
+                this.endpoint = parsedEndpoint;
+            }
+
             if (EnvironmentVariableHelper.LoadString(HeadersEnvVarName, out string headersEnvVar))
             {
                 this.Headers = headersEnvVar;
@@ -67,20 +72,15 @@ namespace OpenTelemetry.Exporter
 
             if (EnvironmentVariableHelper.LoadString(ProtocolEnvVarName, out string protocolEnvVar))
             {
-                var parsedProtocol = protocolEnvVar.ToOtlpExportProtocol();
-                if (parsedProtocol.HasValue)
+                var protocol = protocolEnvVar.ToOtlpExportProtocol();
+                if (protocol.HasValue)
                 {
-                    this.Protocol = parsedProtocol.Value;
+                    this.Protocol = protocol.Value;
                 }
                 else
                 {
                     throw new FormatException($"{ProtocolEnvVarName} environment variable has an invalid value: '${protocolEnvVar}'");
                 }
-            }
-
-            if (EnvironmentVariableHelper.LoadUri(EndpointEnvVarName, out Uri parsedEndpoint))
-            {
-                this.endpoint = parsedEndpoint;
             }
 
             this.HttpClientFactory = this.DefaultHttpClientFactory = () =>

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -196,7 +196,7 @@ namespace OpenTelemetry.Exporter
         public Func<HttpClient> HttpClientFactory { get; set; }
 
         /// <summary>
-        /// Gets a value indicating whether <see cref="Endpoint" /> was programmatically modified.
+        /// Gets a value indicating whether <see cref="Endpoint" /> was modified via its setter.
         /// </summary>
         internal bool ProgrammaticallyModifiedEndpoint { get; private set; }
     }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
@@ -155,12 +155,12 @@ namespace OpenTelemetry.Exporter
             }
         }
 
-        internal static void AppendExportPath(this OtlpExporterOptions options, Uri initialEndpoint, string exportRelativePath)
+        internal static void AppendExportPath(this OtlpExporterOptions options, string exportRelativePath)
         {
             // The exportRelativePath is only appended when the options.Endpoint property wasn't set by the user,
             // the protocol is HttpProtobuf and the OTEL_EXPORTER_OTLP_ENDPOINT environment variable
             // is present. If the user provides a custom value for options.Endpoint that value is taken as is.
-            if (ReferenceEquals(initialEndpoint, options.Endpoint))
+            if (!options.ProgrammaticallyModifiedEndpoint)
             {
                 if (options.Protocol == OtlpExportProtocol.HttpProtobuf)
                 {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
@@ -52,13 +52,11 @@ namespace OpenTelemetry.Metrics
             Action<OtlpExporterOptions> configure,
             IServiceProvider serviceProvider)
         {
-            var initialEndpoint = options.Endpoint;
-
             configure?.Invoke(options);
 
             options.TryEnableIHttpClientFactoryIntegration(serviceProvider, "OtlpMetricExporter");
 
-            options.AppendExportPath(initialEndpoint, OtlpExporterOptions.MetricsExportPath);
+            options.AppendExportPath(OtlpExporterOptions.MetricsExportPath);
 
             var metricExporter = new OtlpMetricExporter(options);
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
@@ -52,13 +52,11 @@ namespace OpenTelemetry.Trace
             Action<OtlpExporterOptions> configure,
             IServiceProvider serviceProvider)
         {
-            var originalEndpoint = exporterOptions.Endpoint;
-
             configure?.Invoke(exporterOptions);
 
             exporterOptions.TryEnableIHttpClientFactoryIntegration(serviceProvider, "OtlpTraceExporter");
 
-            exporterOptions.AppendExportPath(originalEndpoint, OtlpExporterOptions.TracesExportPath);
+            exporterOptions.AppendExportPath(OtlpExporterOptions.TracesExportPath);
 
             var otlpExporter = new OtlpTraceExporter(exporterOptions);
 

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
@@ -173,9 +173,9 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
 
             var options = new OtlpExporterOptions { Protocol = OtlpExportProtocol.HttpProtobuf };
 
-            options.AppendExportPath(options.Endpoint, "test/path");
+            options.AppendExportPath("test/path");
 
-            Assert.Equal("http://localhost:4317/", options.Endpoint.AbsoluteUri);
+            Assert.Equal("http://localhost:4318/", options.Endpoint.AbsoluteUri);
         }
 
         [Fact]
@@ -185,7 +185,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
 
             var options = new OtlpExporterOptions { Protocol = OtlpExportProtocol.HttpProtobuf };
 
-            options.AppendExportPath(options.Endpoint, "test/path");
+            options.AppendExportPath("test/path");
 
             Assert.Equal("http://test:8888/test/path", options.Endpoint.AbsoluteUri);
 
@@ -198,10 +198,9 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
             Environment.SetEnvironmentVariable(OtlpExporterOptions.EndpointEnvVarName, "http://test:8888");
 
             var options = new OtlpExporterOptions { Protocol = OtlpExportProtocol.HttpProtobuf };
-            var originalEndpoint = options.Endpoint;
             options.Endpoint = new Uri("http://test:8888");
 
-            options.AppendExportPath(originalEndpoint, "test/path");
+            options.AppendExportPath("test/path");
 
             Assert.Equal("http://test:8888/", options.Endpoint.AbsoluteUri);
 
@@ -219,7 +218,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
             var originalEndpoint = options.Endpoint;
             options.Endpoint = new Uri(endpoint);
 
-            options.AppendExportPath(originalEndpoint, "test/path");
+            options.AppendExportPath("test/path");
 
             Assert.Equal(endpoint, options.Endpoint.AbsoluteUri);
         }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsTests.cs
@@ -122,7 +122,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
         {
             Environment.SetEnvironmentVariable(OtlpExporterOptions.EndpointEnvVarName, "http://test:8888");
 
-            var options = new OtlpExporterOptions {Protocol = OtlpExportProtocol.Grpc};
+            var options = new OtlpExporterOptions { Protocol = OtlpExportProtocol.Grpc };
 
             Assert.Equal(new Uri("http://test:8888"), options.Endpoint);
             Assert.Equal(OtlpExportProtocol.Grpc, options.Protocol);
@@ -131,7 +131,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
         [Fact]
         public void OtlpExporterOptions_ProtocolSetterDoesNotOverrideCustomEndpointFromSetter()
         {
-            var options = new OtlpExporterOptions {Endpoint = new Uri("http://test:8888"), Protocol = OtlpExportProtocol.Grpc};
+            var options = new OtlpExporterOptions { Endpoint = new Uri("http://test:8888"), Protocol = OtlpExportProtocol.Grpc };
 
             Assert.Equal(new Uri("http://test:8888"), options.Endpoint);
             Assert.Equal(OtlpExportProtocol.Grpc, options.Protocol);

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsTests.cs
@@ -43,6 +43,19 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
         }
 
         [Fact]
+        public void OtlpExporterOptions_DefaultsForHttpProtobuf()
+        {
+            var options = new OtlpExporterOptions
+            {
+                Protocol = OtlpExportProtocol.HttpProtobuf,
+            };
+            Assert.Equal(new Uri("http://localhost:4318"), options.Endpoint);
+            Assert.Null(options.Headers);
+            Assert.Equal(10000, options.TimeoutMilliseconds);
+            Assert.Equal(OtlpExportProtocol.HttpProtobuf, options.Protocol);
+        }
+
+        [Fact]
         public void OtlpExporterOptions_EnvironmentVariableOverride()
         {
             Environment.SetEnvironmentVariable(OtlpExporterOptions.EndpointEnvVarName, "http://test:8888");
@@ -102,6 +115,26 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
             Assert.Equal("C=3", options.Headers);
             Assert.Equal(40000, options.TimeoutMilliseconds);
             Assert.Equal(OtlpExportProtocol.HttpProtobuf, options.Protocol);
+        }
+
+        [Fact]
+        public void OtlpExporterOptions_ProtocolSetterDoesNotOverrideCustomEndpointFromEnvVariables()
+        {
+            Environment.SetEnvironmentVariable(OtlpExporterOptions.EndpointEnvVarName, "http://test:8888");
+
+            var options = new OtlpExporterOptions {Protocol = OtlpExportProtocol.Grpc};
+
+            Assert.Equal(new Uri("http://test:8888"), options.Endpoint);
+            Assert.Equal(OtlpExportProtocol.Grpc, options.Protocol);
+        }
+
+        [Fact]
+        public void OtlpExporterOptions_ProtocolSetterDoesNotOverrideCustomEndpointFromSetter()
+        {
+            var options = new OtlpExporterOptions {Endpoint = new Uri("http://test:8888"), Protocol = OtlpExportProtocol.Grpc};
+
+            Assert.Equal(new Uri("http://test:8888"), options.Endpoint);
+            Assert.Equal(OtlpExportProtocol.Grpc, options.Protocol);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #2857.

## Changes

Default endpoint for OTLP exporter based on chosen protocol.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
~~* [ ] Design discussion issue #~~
~~* [ ] Changes in public API reviewed~~
