### PR TITLE
OTLPLogExporter bug fix to handle null EventName

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -1,10 +1,9 @@
 # Changelog
 
-* Changed `OtlpLogExporter` to convert `ILogger` structured log inputs to
-  `Attributes` in OpenTelemetry (only active when `ParseStateValues` is `true`
-  on `OpenTelemetryLoggerOptions`)
-
 ## Unreleased
+
+* LogExporter bug fix to handle null EventName.
+  ([#2870](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2871))
 
 ## 1.2.0-rc2
 
@@ -13,6 +12,10 @@ Released 2022-Feb-02
 * Added validation that insecure channel is configured correctly when using
   .NET Core 3.x for gRPC-based exporting.
   ([#2691](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2691))
+
+* Changed `OtlpLogExporter` to convert `ILogger` structured log inputs to
+  `Attributes` in OpenTelemetry (only active when `ParseStateValues` is `true`
+  on `OpenTelemetryLoggerOptions`)
 
 ## 1.2.0-rc1
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
@@ -85,9 +85,13 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
                 }
             }
 
-            if (logRecord.EventId != default)
+            if (logRecord.EventId.Id != default)
             {
                 otlpLogRecord.Attributes.AddIntAttribute(nameof(logRecord.EventId.Id), logRecord.EventId.Id);
+            }
+
+            if (!string.IsNullOrEmpty(logRecord.EventId.Name))
+            {
                 otlpLogRecord.Attributes.AddStringAttribute(nameof(logRecord.EventId.Name), logRecord.EventId.Name);
             }
 

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
@@ -1,0 +1,101 @@
+// <copyright file="OtlpLogExporterTests.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
+using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Tests;
+using OpenTelemetry.Trace;
+using Xunit;
+using OtlpCollector = Opentelemetry.Proto.Collector.Trace.V1;
+using OtlpCommon = Opentelemetry.Proto.Common.V1;
+using OtlpTrace = Opentelemetry.Proto.Trace.V1;
+using Status = OpenTelemetry.Trace.Status;
+
+namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
+{
+    public class OtlpLogExporterTests : Http2UnencryptedSupportTests
+    {
+        static OtlpLogExporterTests()
+        {
+            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+            Activity.ForceDefaultIdFormat = true;
+
+            var listener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
+            };
+
+            ActivitySource.AddActivityListener(listener);
+        }
+
+        [Fact]
+        public void ToOtlpLogRecordTest()
+        {
+            // Just a basic test to demonstrate an
+            // approach useful for testing.
+            // This needs to be expanded to
+            // actually test the conversion.
+            List<LogRecord> logRecords = new List<LogRecord>();
+
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddOpenTelemetry(options =>
+                {
+                    options.IncludeFormattedMessage = true;
+                    options.ParseStateValues = true;
+                    options.AddInMemoryExporter(logRecords);
+                });
+            });
+
+            // TODO:
+            // Validate attributes, severity, traceid,spanid etc.
+
+            var logger = loggerFactory.CreateLogger("log-category");
+            logger.LogInformation("Hello from {name} {price}.", "tomato", 2.99);
+            Assert.Single(logRecords);
+            var logRecord = logRecords[0];
+            var otlpLogRecord = logRecord.ToOtlpLog();
+            Assert.NotNull(otlpLogRecord);
+            Assert.Equal("Hello from tomato 2.99.", otlpLogRecord.Body.StringValue);
+            logRecords.Clear();
+
+            logger.LogInformation(new EventId(10, null), "Hello from {name} {price}.", "tomato", 2.99);
+            Assert.Single(logRecords);
+            logRecord = logRecords[0];
+            otlpLogRecord = logRecord.ToOtlpLog();
+            Assert.NotNull(otlpLogRecord);
+            Assert.Equal("Hello from tomato 2.99.", otlpLogRecord.Body.StringValue);
+            logRecords.Clear();
+
+            logger.LogInformation(new EventId(10, "MyEvent10"), "Hello from {name} {price}.", "tomato", 2.99);
+            Assert.Single(logRecords);
+            logRecord = logRecords[0];
+            otlpLogRecord = logRecord.ToOtlpLog();
+            Assert.NotNull(otlpLogRecord);
+            Assert.Equal("Hello from tomato 2.99.", otlpLogRecord.Body.StringValue);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2870

## Changes

Apart from null exception fix, this also adds a very basic test for OTLP LogRecord. This is very basic, and a step1 towards adding proper tests (currently there are no tests for OTLP Logs)
