### PR TITLE
Add failing test for StartRootSpan

### DIFF
--- a/test/OpenTelemetry.Tests/Trace/TracerTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerTest.cs
@@ -89,8 +89,7 @@ namespace OpenTelemetry.Trace.Tests
             async Task DoSomeAsyncWork()
             {
                 await Task.Delay(10);
-                var newRootSpan = TracerProvider.Default.GetTracer("tracername").StartRootSpan("RootSpan2");
-                using (Tracer.WithSpan(newRootSpan))
+                using (tracer.GetTracer("tracername").StartRootSpan("RootSpan2"))
                 {
                     await Task.Delay(10);
                 }
@@ -102,7 +101,18 @@ namespace OpenTelemetry.Trace.Tests
             }
 
             Assert.Equal(2, exportedItems.Count);
-            Assert.NotEqual(exportedItems[0].TraceId, exportedItems[1].TraceId);
+
+            var rootSpan2 = exportedItems[0];
+            var rootSpan1 = exportedItems[1];
+            Assert.Equal("RootSpan2", rootSpan2.DisplayName);
+            Assert.Equal("RootSpan1", rootSpan1.DisplayName);
+            Assert.Equal(default(ActivitySpanId), rootSpan1.ParentSpanId);
+
+            // This is where this test currently fails
+            // rootSpan2 should be a root span of a new trace and not a child of rootSpan1
+            Assert.Equal(default(ActivitySpanId), rootSpan2.ParentSpanId);
+            Assert.NotEqual(rootSpan2.TraceId, rootSpan1.TraceId);
+            Assert.NotEqual(rootSpan2.ParentSpanId, rootSpan1.SpanId);
         }
 
         [Fact]


### PR DESCRIPTION
Relates to #2803 

Just adding a test for now for discussion and to determine whether there's something we can do at the moment.

It appears the `StartActivity` method starts a new span parented from `Activity.Current` even when you pass in a new `ParentContext`. I imagine this might be by design since `Activity.Current` is tracked via `AsyncLocal` and maybe `StartActivity` doesn't want to clobber that state.

https://github.com/open-telemetry/opentelemetry-dotnet/blob/6b7f2dd77cf9d37260a853fcc95f7b77e296065d/src/OpenTelemetry.Api/Trace/Tracer.cs#L79-L82

https://github.com/open-telemetry/opentelemetry-dotnet/blob/6b7f2dd77cf9d37260a853fcc95f7b77e296065d/src/OpenTelemetry.Api/Trace/Tracer.cs#L167-L195

In a scenario where a thread hop has occurred - as in this test - maybe it would be more intuitive to wipe out `Activity.Current`... though, not sure there's a way for us to detect we're on a new thread.

---

Confirmed that `StartActivity` uses `Activity.Current` when the parent's `ActivityContext == default`

https://github.com/dotnet/runtime/blob/3ae87395f638a533f37b8e3385f6d3f199a72f4f/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivitySource.cs#L252-L253