### PR TITLE
code style compatible with dotnet new version

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -26,8 +26,8 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
 {
     internal sealed class HttpInListener : IDisposable
     {
-        private readonly PropertyFetcher<object> routeFetcher = new PropertyFetcher<object>("Route");
-        private readonly PropertyFetcher<string> routeTemplateFetcher = new PropertyFetcher<string>("RouteTemplate");
+        private readonly PropertyFetcher<object> routeFetcher = new("Route");
+        private readonly PropertyFetcher<string> routeTemplateFetcher = new("RouteTemplate");
         private readonly AspNetInstrumentationOptions options;
 
         public HttpInListener(AspNetInstrumentationOptions options)
@@ -57,12 +57,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
         /// <returns>Span uri value.</returns>
         private static string GetUriTagValueFromRequestUri(Uri uri)
         {
-            if (string.IsNullOrEmpty(uri.UserInfo))
-            {
-                return uri.ToString();
-            }
-
-            return string.Concat(uri.Scheme, Uri.SchemeDelimiter, uri.Authority, uri.PathAndQuery, uri.Fragment);
+            return string.IsNullOrEmpty(uri.UserInfo) ? uri.ToString() : string.Concat(uri.Scheme, Uri.SchemeDelimiter, uri.Authority, uri.PathAndQuery, uri.Fragment);
         }
 
         private void OnStartActivity(Activity activity, HttpContext context)

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -43,12 +43,12 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
         private const string DiagnosticSourceName = "Microsoft.AspNetCore";
         private const string UnknownHostName = "UNKNOWN-HOST";
         private static readonly Func<HttpRequest, string, IEnumerable<string>> HttpRequestHeaderValuesGetter = (request, name) => request.Headers[name];
-        private readonly PropertyFetcher<HttpContext> startContextFetcher = new PropertyFetcher<HttpContext>("HttpContext");
-        private readonly PropertyFetcher<HttpContext> stopContextFetcher = new PropertyFetcher<HttpContext>("HttpContext");
-        private readonly PropertyFetcher<Exception> stopExceptionFetcher = new PropertyFetcher<Exception>("Exception");
-        private readonly PropertyFetcher<object> beforeActionActionDescriptorFetcher = new PropertyFetcher<object>("actionDescriptor");
-        private readonly PropertyFetcher<object> beforeActionAttributeRouteInfoFetcher = new PropertyFetcher<object>("AttributeRouteInfo");
-        private readonly PropertyFetcher<string> beforeActionTemplateFetcher = new PropertyFetcher<string>("Template");
+        private readonly PropertyFetcher<HttpContext> startContextFetcher = new("HttpContext");
+        private readonly PropertyFetcher<HttpContext> stopContextFetcher = new("HttpContext");
+        private readonly PropertyFetcher<Exception> stopExceptionFetcher = new("Exception");
+        private readonly PropertyFetcher<object> beforeActionActionDescriptorFetcher = new("actionDescriptor");
+        private readonly PropertyFetcher<object> beforeActionAttributeRouteInfoFetcher = new("AttributeRouteInfo");
+        private readonly PropertyFetcher<string> beforeActionTemplateFetcher = new("Template");
         private readonly AspNetCoreInstrumentationOptions options;
 
         public HttpInListener(AspNetCoreInstrumentationOptions options)
@@ -87,7 +87,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
             // Ensure context extraction irrespective of sampling decision
             var request = context.Request;
             var textMapPropagator = Propagators.DefaultTextMapPropagator;
-            if (!(textMapPropagator is TraceContextPropagator))
+            if (textMapPropagator is not TraceContextPropagator)
             {
                 var ctx = textMapPropagator.Extract(default, request, HttpRequestHeaderValuesGetter);
 
@@ -144,7 +144,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
 
                 // see the spec https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md
 
-                if (request.Host.Port == null || request.Host.Port == 80 || request.Host.Port == 443)
+                if (request.Host.Port is null or 80 or 443)
                 {
                     activity.SetTag(SemanticConventions.AttributeHttpHost, request.Host.Host);
                 }
@@ -235,7 +235,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
             }
 
             var textMapPropagator = Propagators.DefaultTextMapPropagator;
-            if (!(textMapPropagator is TraceContextPropagator))
+            if (textMapPropagator is not TraceContextPropagator)
             {
                 Baggage.Current = default;
             }

--- a/src/OpenTelemetry/DiagnosticSourceInstrumentation/PropertyFetcher.cs
+++ b/src/OpenTelemetry/DiagnosticSourceInstrumentation/PropertyFetcher.cs
@@ -135,10 +135,7 @@ namespace OpenTelemetry.Instrumentation
                         return true;
                     }
 
-                    if (this.innerFetcher == null)
-                    {
-                        this.innerFetcher = Create(obj.GetType().GetTypeInfo(), this.propertyName);
-                    }
+                    this.innerFetcher ??= Create(obj.GetType().GetTypeInfo(), this.propertyName);
 
                     return this.innerFetcher.TryFetch(obj, out value);
                 }

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -137,14 +137,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
                         return httpContext.Request.Path != filter;
                     };
 
-                    if (setStatusToErrorInEnrich)
-                    {
-                        options.Enrich = GetEnrichmentAction(Status.Error);
-                    }
-                    else
-                    {
-                        options.Enrich = GetEnrichmentAction(default);
-                    }
+                    options.Enrich = GetEnrichmentAction(setStatusToErrorInEnrich ? Status.Error : default);
 
                     options.RecordException = recordException;
                 })
@@ -205,7 +198,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
             }
 
             // Host includes port if it isn't 80 or 443.
-            if (expectedUri.Port == 80 || expectedUri.Port == 443)
+            if (expectedUri.Port is 80 or 443)
             {
                 Assert.Equal(
                     expectedUri.Host,

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
@@ -399,40 +399,38 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
                 Sdk.SetDefaultTextMapPropagator(new ExtractOnlyPropagator(activityContext, expectedBaggage));
 
                 // Arrange
-                using (var testFactory = this.factory
+                using var testFactory = this.factory
                     .WithWebHostBuilder(builder =>
                         builder.ConfigureTestServices(services =>
                         {
                             this.tracerProvider = Sdk.CreateTracerProviderBuilder()
-                            .SetSampler(new TestSampler(samplingDecision))
-                            .AddAspNetCoreInstrumentation()
-                            .Build();
-                        })))
-                {
-                    using var client = testFactory.CreateClient();
+                                .SetSampler(new TestSampler(samplingDecision))
+                                .AddAspNetCoreInstrumentation()
+                                .Build();
+                        }));
+                using var client = testFactory.CreateClient();
 
-                    // Test TraceContext Propagation
-                    var request = new HttpRequestMessage(HttpMethod.Get, "/api/GetChildActivityTraceContext");
-                    var response = await client.SendAsync(request);
-                    var childActivityTraceContext = JsonConvert.DeserializeObject<Dictionary<string, string>>(response.Content.ReadAsStringAsync().Result);
+                // Test TraceContext Propagation
+                var request = new HttpRequestMessage(HttpMethod.Get, "/api/GetChildActivityTraceContext");
+                var response = await client.SendAsync(request);
+                var childActivityTraceContext = JsonConvert.DeserializeObject<Dictionary<string, string>>(response.Content.ReadAsStringAsync().Result);
 
-                    response.EnsureSuccessStatusCode();
+                response.EnsureSuccessStatusCode();
 
-                    Assert.Equal(expectedTraceId.ToString(), childActivityTraceContext["TraceId"]);
-                    Assert.Equal(expectedTraceState, childActivityTraceContext["TraceState"]);
-                    Assert.NotEqual(expectedParentSpanId.ToString(), childActivityTraceContext["ParentSpanId"]); // there is a new activity created in instrumentation therefore the ParentSpanId is different that what is provided in the headers
+                Assert.Equal(expectedTraceId.ToString(), childActivityTraceContext["TraceId"]);
+                Assert.Equal(expectedTraceState, childActivityTraceContext["TraceState"]);
+                Assert.NotEqual(expectedParentSpanId.ToString(), childActivityTraceContext["ParentSpanId"]); // there is a new activity created in instrumentation therefore the ParentSpanId is different that what is provided in the headers
 
-                    // Test Baggage Context Propagation
-                    request = new HttpRequestMessage(HttpMethod.Get, "/api/GetChildActivityBaggageContext");
+                // Test Baggage Context Propagation
+                request = new HttpRequestMessage(HttpMethod.Get, "/api/GetChildActivityBaggageContext");
 
-                    response = await client.SendAsync(request);
-                    var childActivityBaggageContext = JsonConvert.DeserializeObject<IReadOnlyDictionary<string, string>>(response.Content.ReadAsStringAsync().Result);
+                response = await client.SendAsync(request);
+                var childActivityBaggageContext = JsonConvert.DeserializeObject<IReadOnlyDictionary<string, string>>(response.Content.ReadAsStringAsync().Result);
 
-                    response.EnsureSuccessStatusCode();
+                response.EnsureSuccessStatusCode();
 
-                    Assert.Single(childActivityBaggageContext, item => item.Key == "key1" && item.Value == "value1");
-                    Assert.Single(childActivityBaggageContext, item => item.Key == "key2" && item.Value == "value2");
-                }
+                Assert.Single(childActivityBaggageContext, item => item.Key == "key1" && item.Value == "value1");
+                Assert.Single(childActivityBaggageContext, item => item.Key == "key2" && item.Value == "value2");
             }
             finally
             {
@@ -458,50 +456,48 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
 
                 // Arrange
                 bool isFilterCalled = false;
-                using (var testFactory = this.factory
+                using var testFactory = this.factory
                     .WithWebHostBuilder(builder =>
                         builder.ConfigureTestServices(services =>
                         {
                             this.tracerProvider = Sdk.CreateTracerProviderBuilder()
-                            .AddAspNetCoreInstrumentation(options =>
-                            {
-                                options.Filter = context =>
+                                .AddAspNetCoreInstrumentation(options =>
                                 {
-                                    isFilterCalled = true;
-                                    return false;
-                                };
-                            })
-                            .Build();
-                        })))
-                {
-                    using var client = testFactory.CreateClient();
+                                    options.Filter = context =>
+                                    {
+                                        isFilterCalled = true;
+                                        return false;
+                                    };
+                                })
+                                .Build();
+                        }));
+                using var client = testFactory.CreateClient();
 
-                    // Test TraceContext Propagation
-                    var request = new HttpRequestMessage(HttpMethod.Get, "/api/GetChildActivityTraceContext");
-                    var response = await client.SendAsync(request);
+                // Test TraceContext Propagation
+                var request = new HttpRequestMessage(HttpMethod.Get, "/api/GetChildActivityTraceContext");
+                var response = await client.SendAsync(request);
 
-                    // Ensure that filter was called
-                    Assert.True(isFilterCalled);
+                // Ensure that filter was called
+                Assert.True(isFilterCalled);
 
-                    var childActivityTraceContext = JsonConvert.DeserializeObject<Dictionary<string, string>>(response.Content.ReadAsStringAsync().Result);
+                var childActivityTraceContext = JsonConvert.DeserializeObject<Dictionary<string, string>>(response.Content.ReadAsStringAsync().Result);
 
-                    response.EnsureSuccessStatusCode();
+                response.EnsureSuccessStatusCode();
 
-                    Assert.Equal(expectedTraceId.ToString(), childActivityTraceContext["TraceId"]);
-                    Assert.Equal(expectedTraceState, childActivityTraceContext["TraceState"]);
-                    Assert.NotEqual(expectedParentSpanId.ToString(), childActivityTraceContext["ParentSpanId"]); // there is a new activity created in instrumentation therefore the ParentSpanId is different that what is provided in the headers
+                Assert.Equal(expectedTraceId.ToString(), childActivityTraceContext["TraceId"]);
+                Assert.Equal(expectedTraceState, childActivityTraceContext["TraceState"]);
+                Assert.NotEqual(expectedParentSpanId.ToString(), childActivityTraceContext["ParentSpanId"]); // there is a new activity created in instrumentation therefore the ParentSpanId is different that what is provided in the headers
 
-                    // Test Baggage Context Propagation
-                    request = new HttpRequestMessage(HttpMethod.Get, "/api/GetChildActivityBaggageContext");
+                // Test Baggage Context Propagation
+                request = new HttpRequestMessage(HttpMethod.Get, "/api/GetChildActivityBaggageContext");
 
-                    response = await client.SendAsync(request);
-                    var childActivityBaggageContext = JsonConvert.DeserializeObject<IReadOnlyDictionary<string, string>>(response.Content.ReadAsStringAsync().Result);
+                response = await client.SendAsync(request);
+                var childActivityBaggageContext = JsonConvert.DeserializeObject<IReadOnlyDictionary<string, string>>(response.Content.ReadAsStringAsync().Result);
 
-                    response.EnsureSuccessStatusCode();
+                response.EnsureSuccessStatusCode();
 
-                    Assert.Single(childActivityBaggageContext, item => item.Key == "key1" && item.Value == "value1");
-                    Assert.Single(childActivityBaggageContext, item => item.Key == "key2" && item.Value == "value2");
-                }
+                Assert.Single(childActivityBaggageContext, item => item.Key == "key1" && item.Value == "value1");
+                Assert.Single(childActivityBaggageContext, item => item.Key == "key2" && item.Value == "value2");
             }
             finally
             {

--- a/test/OpenTelemetry.Tests/Shared/InMemoryEventListener.cs
+++ b/test/OpenTelemetry.Tests/Shared/InMemoryEventListener.cs
@@ -21,7 +21,7 @@ namespace OpenTelemetry.Tests
 {
     internal class InMemoryEventListener : EventListener
     {
-        public ConcurrentQueue<EventWrittenEventArgs> Events = new ConcurrentQueue<EventWrittenEventArgs>();
+        public ConcurrentQueue<EventWrittenEventArgs> Events = new();
 
         public InMemoryEventListener(EventSource eventSource, EventLevel minLevel = EventLevel.Verbose)
         {

--- a/test/OpenTelemetry.Tests/Shared/TestEventListener.cs
+++ b/test/OpenTelemetry.Tests/Shared/TestEventListener.cs
@@ -92,10 +92,7 @@ namespace OpenTelemetry.Tests
         {
             // Check for null because this method is called by the base class constror before we can initialize it
             Action<EventSource> callback = this.OnOnEventSourceCreated;
-            if (callback != null)
-            {
-                callback(eventSource);
-            }
+            callback?.Invoke(eventSource);
         }
     }
 }


### PR DESCRIPTION
My changes include code style, I believe new changes related to newer versions of dotnet should be made in the code to make it compatible and more readable by new users

## Changes
Beginning with C# 9.0, constructor invocation expressions are target-typed. That is, if a target type of an expression is known, you can omit a type name
In C# 9 they added several new pattern matching operators that can be combined with the is operator
the null-coalescing assignment operator ??= assigns the value of its right-hand operand to its left-hand operand only if the left-hand operand evaluates to null and also new using declaration