### PR TITLE
Prometheus HttpListenerPrefixes setter to accept wildcard hostname.

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterOptions.cs
@@ -54,19 +54,7 @@ namespace OpenTelemetry.Exporter
             get => this.httpListenerPrefixes;
             set
             {
-                Guard.ThrowIfNull(value, nameof(this.httpListenerPrefixes));
-
-                foreach (string inputUri in value)
-                {
-                    if (!(Uri.TryCreate(inputUri, UriKind.Absolute, out var uri) &&
-                        (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)))
-                    {
-                        throw new ArgumentException(
-                            "Prometheus server path should be a valid URI with http/https scheme.",
-                            nameof(this.httpListenerPrefixes));
-                    }
-                }
-
+                Guard.ThrowIfNull(value, nameof(this.HttpListenerPrefixes));
                 this.httpListenerPrefixes = value;
             }
         }

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterHttpServerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterHttpServerTests.cs
@@ -120,35 +120,5 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
                 })
                 .Build();
         }
-
-        [Theory]
-        [InlineData("")]
-        [InlineData(null)]
-        [InlineData("ftp://example.com")]
-        [InlineData("http://example.com", "https://example.com", "ftp://example.com")]
-        public void ServerEndpointSanityCheckNegativeTest(params string[] uris)
-        {
-            try
-            {
-                using MeterProvider meterProvider = Sdk.CreateMeterProviderBuilder()
-                    .AddPrometheusExporter(opt =>
-                    {
-                        opt.HttpListenerPrefixes = uris;
-                    })
-                    .Build();
-            }
-            catch (Exception ex)
-            {
-                if (ex is not ArgumentNullException)
-                {
-                    Assert.Equal("System.ArgumentException", ex.GetType().ToString());
-#if NET461
-                    Assert.Equal("Prometheus server path should be a valid URI with http/https scheme.\r\nParameter name: httpListenerPrefixes", ex.Message);
-#else
-                    Assert.Equal("Prometheus server path should be a valid URI with http/https scheme. (Parameter 'httpListenerPrefixes')", ex.Message);
-#endif
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-dotnet/issues/2881.

## Changes
Dropping the sanity check for PrometheusExporterOptions.HttpListenerPrefixes setter.
Currently, TryCreate [implementation](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.Uri/src/System/UriExt.cs#:~:text=private%20void%20InitializeUri(ParsingError%20err%2C%20UriKind%20uriKind%2C%20out%20UriFormatException%3F%20e)) in .NET runtime does not deem `https://+:8080/` and `http://*:8080/` as [valid](https://docs.microsoft.com/en-us/dotnet/api/system.net.httplistenerprefixcollection.add?view=netframework-4.6.1#:~:text=When%20a%20port,that%20include%20paths.) URI which were marked as valid cases for the item in `HttpListenerPrefixCollection`.

Are there ways to incorporate these cases: `https://+:8080/` and `http://*:8080/` without using ugly regexes?

