### PR TITLE
Simplify how to call `Guard` methods

### DIFF
--- a/src/OpenTelemetry.Api/Baggage.cs
+++ b/src/OpenTelemetry.Api/Baggage.cs
@@ -239,7 +239,7 @@ namespace OpenTelemetry
         /// <returns>Baggage item or <see langword="null"/> if nothing was found.</returns>
         public string GetBaggage(string name)
         {
-            Guard.ThrowIfNullOrEmpty(name, nameof(name));
+            Guard.ThrowIfNullOrEmpty(name);
 
             return this.baggage != null && this.baggage.TryGetValue(name, out string value)
                 ? value

--- a/src/OpenTelemetry.Api/Context/Propagation/CompositeTextMapPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/CompositeTextMapPropagator.cs
@@ -35,7 +35,7 @@ namespace OpenTelemetry.Context.Propagation
         /// <param name="propagators">List of <see cref="TextMapPropagator"/> wire context propagator.</param>
         public CompositeTextMapPropagator(IEnumerable<TextMapPropagator> propagators)
         {
-            Guard.ThrowIfNull(propagators, nameof(propagators));
+            Guard.ThrowIfNull(propagators);
 
             this.propagators = new List<TextMapPropagator>(propagators);
         }

--- a/src/OpenTelemetry.Api/Context/RuntimeContext.cs
+++ b/src/OpenTelemetry.Api/Context/RuntimeContext.cs
@@ -41,7 +41,7 @@ namespace OpenTelemetry.Context
         /// <returns>The slot registered.</returns>
         public static RuntimeContextSlot<T> RegisterSlot<T>(string slotName)
         {
-            Guard.ThrowIfNullOrEmpty(slotName, nameof(slotName));
+            Guard.ThrowIfNullOrEmpty(slotName);
 
             lock (Slots)
             {
@@ -66,7 +66,7 @@ namespace OpenTelemetry.Context
         /// <returns>The slot previously registered.</returns>
         public static RuntimeContextSlot<T> GetSlot<T>(string slotName)
         {
-            Guard.ThrowIfNullOrEmpty(slotName, nameof(slotName));
+            Guard.ThrowIfNullOrEmpty(slotName);
             var slot = GuardNotFound(slotName);
             var contextSlot = Guard.ThrowIfNotOfType<RuntimeContextSlot<T>>(slot, nameof(slot));
             return contextSlot;
@@ -127,7 +127,7 @@ namespace OpenTelemetry.Context
         /// <param name="value">The value to be set.</param>
         public static void SetValue(string slotName, object value)
         {
-            Guard.ThrowIfNullOrEmpty(slotName, nameof(slotName));
+            Guard.ThrowIfNullOrEmpty(slotName);
             var slot = GuardNotFound(slotName);
             var runtimeContextSlotValueAccessor = Guard.ThrowIfNotOfType<IRuntimeContextSlotValueAccessor>(slot, nameof(slot));
             runtimeContextSlotValueAccessor.Value = value;
@@ -140,7 +140,7 @@ namespace OpenTelemetry.Context
         /// <returns>The value retrieved from the context slot.</returns>
         public static object GetValue(string slotName)
         {
-            Guard.ThrowIfNullOrEmpty(slotName, nameof(slotName));
+            Guard.ThrowIfNullOrEmpty(slotName);
             var slot = GuardNotFound(slotName);
             var runtimeContextSlotValueAccessor = Guard.ThrowIfNotOfType<IRuntimeContextSlotValueAccessor>(slot, nameof(slot));
             return runtimeContextSlotValueAccessor.Value;

--- a/src/OpenTelemetry.Api/Context/RuntimeContext.cs
+++ b/src/OpenTelemetry.Api/Context/RuntimeContext.cs
@@ -68,7 +68,7 @@ namespace OpenTelemetry.Context
         {
             Guard.ThrowIfNullOrEmpty(slotName);
             var slot = GuardNotFound(slotName);
-            var contextSlot = Guard.ThrowIfNotOfType<RuntimeContextSlot<T>>(slot, nameof(slot));
+            var contextSlot = Guard.ThrowIfNotOfType<RuntimeContextSlot<T>>(slot);
             return contextSlot;
         }
 
@@ -129,7 +129,7 @@ namespace OpenTelemetry.Context
         {
             Guard.ThrowIfNullOrEmpty(slotName);
             var slot = GuardNotFound(slotName);
-            var runtimeContextSlotValueAccessor = Guard.ThrowIfNotOfType<IRuntimeContextSlotValueAccessor>(slot, nameof(slot));
+            var runtimeContextSlotValueAccessor = Guard.ThrowIfNotOfType<IRuntimeContextSlotValueAccessor>(slot);
             runtimeContextSlotValueAccessor.Value = value;
         }
 
@@ -142,7 +142,7 @@ namespace OpenTelemetry.Context
         {
             Guard.ThrowIfNullOrEmpty(slotName);
             var slot = GuardNotFound(slotName);
-            var runtimeContextSlotValueAccessor = Guard.ThrowIfNotOfType<IRuntimeContextSlotValueAccessor>(slot, nameof(slot));
+            var runtimeContextSlotValueAccessor = Guard.ThrowIfNotOfType<IRuntimeContextSlotValueAccessor>(slot);
             return runtimeContextSlotValueAccessor.Value;
         }
 

--- a/src/OpenTelemetry.Api/Internal/Guard.cs
+++ b/src/OpenTelemetry.Api/Internal/Guard.cs
@@ -82,7 +82,7 @@ namespace OpenTelemetry.Internal
         /// <param name="paramName">The parameter name to use in the thrown exception.</param>
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ThrowIfNullOrEmpty(string value, string paramName = DefaultParamName)
+        public static void ThrowIfNullOrEmpty(string value, [CallerArgumentExpression("value")] string paramName = DefaultParamName)
         {
             if (string.IsNullOrEmpty(value))
             {

--- a/src/OpenTelemetry.Api/Internal/Guard.cs
+++ b/src/OpenTelemetry.Api/Internal/Guard.cs
@@ -82,7 +82,7 @@ namespace OpenTelemetry.Internal
         /// <param name="paramName">The parameter name to use in the thrown exception.</param>
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ThrowIfNullOrEmpty(string value, [CallerArgumentExpression("value")] string paramName = DefaultParamName)
+        public static void ThrowIfNullOrEmpty(string value, [CallerArgumentExpression("value")] string paramName = null)
         {
             if (string.IsNullOrEmpty(value))
             {
@@ -97,7 +97,7 @@ namespace OpenTelemetry.Internal
         /// <param name="paramName">The parameter name to use in the thrown exception.</param>
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ThrowIfNullOrWhitespace(string value, string paramName = DefaultParamName)
+        public static void ThrowIfNullOrWhitespace(string value, [CallerArgumentExpression("value")] string paramName = null)
         {
             if (string.IsNullOrWhiteSpace(value))
             {

--- a/src/OpenTelemetry.Api/Internal/Guard.cs
+++ b/src/OpenTelemetry.Api/Internal/Guard.cs
@@ -19,7 +19,39 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
+#if !NETCOREAPP3_0_OR_GREATER
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Allows capturing of the expressions passed to a method.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+    internal sealed class CallerArgumentExpressionAttribute : Attribute
+#pragma warning restore SA1649 // File name should match first type name
+#pragma warning restore SA1402 // File may only contain a single type
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CallerArgumentExpressionAttribute"/> class.
+        /// </summary>
+        /// <param name="parameterName">The name of the targeted parameter.</param>
+        public CallerArgumentExpressionAttribute(string parameterName)
+        {
+            this.ParameterName = parameterName;
+        }
+
+        /// <summary>
+        /// Gets the target parameter name of the CallerArgumentExpression.
+        /// </summary>
+        public string ParameterName { get; }
+    }
+}
+#endif
+
+#pragma warning disable SA1403 // File may only contain a single namespace
 namespace OpenTelemetry.Internal
+#pragma warning restore SA1403 // File may only contain a single namespace
 {
     /// <summary>
     /// Methods for guarding against exception throwing values.

--- a/src/OpenTelemetry.Api/Internal/Guard.cs
+++ b/src/OpenTelemetry.Api/Internal/Guard.cs
@@ -35,7 +35,7 @@ namespace OpenTelemetry.Internal
         /// <param name="paramName">The parameter name to use in the thrown exception.</param>
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ThrowIfNull(object value, string paramName = DefaultParamName)
+        public static void ThrowIfNull(object value, [CallerArgumentExpression("value")] string paramName = null)
         {
             if (value is null)
             {

--- a/src/OpenTelemetry.Api/Internal/Guard.cs
+++ b/src/OpenTelemetry.Api/Internal/Guard.cs
@@ -58,8 +58,6 @@ namespace OpenTelemetry.Internal
     /// </summary>
     internal static class Guard
     {
-        private const string DefaultParamName = "N/A";
-
         /// <summary>
         /// Throw an exception if the value is null.
         /// </summary>
@@ -113,7 +111,7 @@ namespace OpenTelemetry.Internal
         /// <param name="paramName">The parameter name to use in the thrown exception.</param>
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ThrowIfZero(int value, string message = "Must not be zero", string paramName = DefaultParamName)
+        public static void ThrowIfZero(int value, string message = "Must not be zero", [CallerArgumentExpression("value")] string paramName = null)
         {
             if (value == 0)
             {
@@ -128,7 +126,7 @@ namespace OpenTelemetry.Internal
         /// <param name="paramName">The parameter name to use in the thrown exception.</param>
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ThrowIfInvalidTimeout(int value, string paramName = DefaultParamName)
+        public static void ThrowIfInvalidTimeout(int value, [CallerArgumentExpression("value")] string paramName = null)
         {
             ThrowIfOutOfRange(value, paramName, min: Timeout.Infinite, message: $"Must be non-negative or '{nameof(Timeout)}.{nameof(Timeout.Infinite)}'");
         }
@@ -145,7 +143,7 @@ namespace OpenTelemetry.Internal
         /// <param name="message">An optional custom message to use in the thrown exception.</param>
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ThrowIfOutOfRange(int value, string paramName = DefaultParamName, int min = int.MinValue, int max = int.MaxValue, string minName = null, string maxName = null, string message = null)
+        public static void ThrowIfOutOfRange(int value, [CallerArgumentExpression("value")] string paramName = null, int min = int.MinValue, int max = int.MaxValue, string minName = null, string maxName = null, string message = null)
         {
             Range(value, paramName, min, max, minName, maxName, message);
         }
@@ -162,7 +160,7 @@ namespace OpenTelemetry.Internal
         /// <param name="message">An optional custom message to use in the thrown exception.</param>
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void ThrowIfOutOfRange(double value, string paramName = DefaultParamName, double min = double.MinValue, double max = double.MaxValue, string minName = null, string maxName = null, string message = null)
+        public static void ThrowIfOutOfRange(double value, [CallerArgumentExpression("value")] string paramName = null, double min = double.MinValue, double max = double.MaxValue, string minName = null, string maxName = null, string message = null)
         {
             Range(value, paramName, min, max, minName, maxName, message);
         }
@@ -176,7 +174,7 @@ namespace OpenTelemetry.Internal
         /// <returns>The value casted to the specified type.</returns>
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static T ThrowIfNotOfType<T>(object value, string paramName = DefaultParamName)
+        public static T ThrowIfNotOfType<T>(object value, [CallerArgumentExpression("value")] string paramName = null)
         {
             if (value is not T result)
             {

--- a/src/OpenTelemetry.Api/Trace/SpanAttributes.cs
+++ b/src/OpenTelemetry.Api/Trace/SpanAttributes.cs
@@ -41,7 +41,7 @@ namespace OpenTelemetry.Trace
         public SpanAttributes(IEnumerable<KeyValuePair<string, object>> attributes)
             : this()
         {
-            Guard.ThrowIfNull(attributes, nameof(attributes));
+            Guard.ThrowIfNull(attributes);
 
             foreach (KeyValuePair<string, object> kvp in attributes)
             {
@@ -133,7 +133,7 @@ namespace OpenTelemetry.Trace
 
         private void AddInternal(string key, object value)
         {
-            Guard.ThrowIfNull(key, nameof(key));
+            Guard.ThrowIfNull(key);
 
             this.Attributes[key] = value;
         }

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterHelperExtensions.cs
@@ -31,7 +31,7 @@ namespace OpenTelemetry.Trace
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The objects should not be disposed.")]
         public static TracerProviderBuilder AddConsoleExporter(this TracerProviderBuilder builder, Action<ConsoleExporterOptions> configure = null)
         {
-            Guard.ThrowIfNull(builder, nameof(builder));
+            Guard.ThrowIfNull(builder);
 
             if (builder is IDeferredTracerProviderBuilder deferredTracerProviderBuilder)
             {

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterLoggingExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterLoggingExtensions.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Logs
         /// <returns>The instance of <see cref="OpenTelemetryLoggerOptions"/> to chain the calls.</returns>
         public static OpenTelemetryLoggerOptions AddConsoleExporter(this OpenTelemetryLoggerOptions loggerOptions, Action<ConsoleExporterOptions> configure = null)
         {
-            Guard.ThrowIfNull(loggerOptions, nameof(loggerOptions));
+            Guard.ThrowIfNull(loggerOptions);
 
             var options = new ConsoleExporterOptions();
             configure?.Invoke(options);

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterMetricsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterMetricsExtensions.cs
@@ -31,7 +31,7 @@ namespace OpenTelemetry.Metrics
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The objects should not be disposed.")]
         public static MeterProviderBuilder AddConsoleExporter(this MeterProviderBuilder builder, Action<ConsoleExporterOptions> configure = null)
         {
-            Guard.ThrowIfNull(builder, nameof(builder));
+            Guard.ThrowIfNull(builder);
 
             var options = new ConsoleExporterOptions();
             configure?.Invoke(options);

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterHelperExtensions.cs
@@ -32,8 +32,8 @@ namespace OpenTelemetry.Trace
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The objects should not be disposed.")]
         public static TracerProviderBuilder AddInMemoryExporter(this TracerProviderBuilder builder, ICollection<Activity> exportedItems)
         {
-            Guard.ThrowIfNull(builder, nameof(builder));
-            Guard.ThrowIfNull(exportedItems, nameof(exportedItems));
+            Guard.ThrowIfNull(builder);
+            Guard.ThrowIfNull(exportedItems);
 
             if (builder is IDeferredTracerProviderBuilder deferredTracerProviderBuilder)
             {

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterLoggingExtensions.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterLoggingExtensions.cs
@@ -24,8 +24,8 @@ namespace OpenTelemetry.Logs
     {
         public static OpenTelemetryLoggerOptions AddInMemoryExporter(this OpenTelemetryLoggerOptions loggerOptions, ICollection<LogRecord> exportedItems)
         {
-            Guard.ThrowIfNull(loggerOptions, nameof(loggerOptions));
-            Guard.ThrowIfNull(exportedItems, nameof(exportedItems));
+            Guard.ThrowIfNull(loggerOptions);
+            Guard.ThrowIfNull(exportedItems);
 
             return loggerOptions.AddProcessor(new SimpleLogRecordExportProcessor(new InMemoryExporter<LogRecord>(exportedItems)));
         }

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterMetricsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterMetricsExtensions.cs
@@ -30,8 +30,8 @@ namespace OpenTelemetry.Metrics
         /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
         public static MeterProviderBuilder AddInMemoryExporter(this MeterProviderBuilder builder, ICollection<Metric> exportedItems)
         {
-            Guard.ThrowIfNull(builder, nameof(builder));
-            Guard.ThrowIfNull(exportedItems, nameof(exportedItems));
+            Guard.ThrowIfNull(builder);
+            Guard.ThrowIfNull(exportedItems);
 
             return builder.AddReader(new BaseExportingMetricReader(new InMemoryExporter<Metric>(exportedItems)));
         }

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
@@ -50,7 +50,7 @@ namespace OpenTelemetry.Exporter
 
         internal JaegerExporter(JaegerExporterOptions options, TProtocolFactory protocolFactory = null, IJaegerClient client = null)
         {
-            Guard.ThrowIfNull(options, nameof(options));
+            Guard.ThrowIfNull(options);
 
             this.maxPayloadSizeInBytes = (!options.MaxPayloadSizeInBytes.HasValue || options.MaxPayloadSizeInBytes <= 0)
                 ? JaegerExporterOptions.DefaultMaxPayloadSizeInBytes
@@ -122,7 +122,7 @@ namespace OpenTelemetry.Exporter
 
         internal void SetResourceAndInitializeBatch(Resource resource)
         {
-            Guard.ThrowIfNull(resource, nameof(resource));
+            Guard.ThrowIfNull(resource);
 
             var process = this.Process;
 

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterHelperExtensions.cs
@@ -35,7 +35,7 @@ namespace OpenTelemetry.Trace
         /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
         public static TracerProviderBuilder AddJaegerExporter(this TracerProviderBuilder builder, Action<JaegerExporterOptions> configure = null)
         {
-            Guard.ThrowIfNull(builder, nameof(builder));
+            Guard.ThrowIfNull(builder);
 
             if (builder is IDeferredTracerProviderBuilder deferredTracerProviderBuilder)
             {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/BaseOtlpGrpcExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/BaseOtlpGrpcExportClient.cs
@@ -31,7 +31,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClie
         protected BaseOtlpGrpcExportClient(OtlpExporterOptions options)
         {
             Guard.ThrowIfNull(options);
-            Guard.ThrowIfInvalidTimeout(options.TimeoutMilliseconds, nameof(options.TimeoutMilliseconds));
+            Guard.ThrowIfInvalidTimeout(options.TimeoutMilliseconds);
 
             ExporterClientValidation.EnsureUnencryptedSupportIsEnabled(options);
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/BaseOtlpGrpcExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/BaseOtlpGrpcExportClient.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClie
     {
         protected BaseOtlpGrpcExportClient(OtlpExporterOptions options)
         {
-            Guard.ThrowIfNull(options, nameof(options));
+            Guard.ThrowIfNull(options);
             Guard.ThrowIfInvalidTimeout(options.TimeoutMilliseconds, nameof(options.TimeoutMilliseconds));
 
             ExporterClientValidation.EnsureUnencryptedSupportIsEnabled(options);

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/BaseOtlpHttpExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/BaseOtlpHttpExportClient.cs
@@ -27,8 +27,8 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClie
     {
         protected BaseOtlpHttpExportClient(OtlpExporterOptions options, HttpClient httpClient)
         {
-            Guard.ThrowIfNull(options, nameof(options));
-            Guard.ThrowIfNull(httpClient, nameof(httpClient));
+            Guard.ThrowIfNull(options);
+            Guard.ThrowIfNull(httpClient);
             Guard.ThrowIfInvalidTimeout(options.TimeoutMilliseconds, $"{nameof(options)}.{nameof(options.TimeoutMilliseconds)}");
 
             this.Options = options;

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/BaseOtlpHttpExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/BaseOtlpHttpExportClient.cs
@@ -29,7 +29,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClie
         {
             Guard.ThrowIfNull(options);
             Guard.ThrowIfNull(httpClient);
-            Guard.ThrowIfInvalidTimeout(options.TimeoutMilliseconds, $"{nameof(options)}.{nameof(options.TimeoutMilliseconds)}");
+            Guard.ThrowIfInvalidTimeout(options.TimeoutMilliseconds);
 
             this.Options = options;
             this.Headers = options.GetHeaders<Dictionary<string, string>>((d, k, v) => d.Add(k, v));

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
@@ -33,7 +33,7 @@ namespace OpenTelemetry.Metrics
         /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
         public static MeterProviderBuilder AddOtlpExporter(this MeterProviderBuilder builder, Action<OtlpExporterOptions> configure = null)
         {
-            Guard.ThrowIfNull(builder, nameof(builder));
+            Guard.ThrowIfNull(builder);
 
             if (builder is IDeferredMeterProviderBuilder deferredMeterProviderBuilder)
             {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
@@ -33,7 +33,7 @@ namespace OpenTelemetry.Trace
         /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
         public static TracerProviderBuilder AddOtlpExporter(this TracerProviderBuilder builder, Action<OtlpExporterOptions> configure = null)
         {
-            Guard.ThrowIfNull(builder, nameof(builder));
+            Guard.ThrowIfNull(builder);
 
             if (builder is IDeferredTracerProviderBuilder deferredTracerProviderBuilder)
             {

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterHttpServer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterHttpServer.cs
@@ -40,7 +40,7 @@ namespace OpenTelemetry.Exporter.Prometheus
         /// <param name="exporter">The <see cref="PrometheusExporter"/> instance.</param>
         public PrometheusExporterHttpServer(PrometheusExporter exporter)
         {
-            Guard.ThrowIfNull(exporter, nameof(exporter));
+            Guard.ThrowIfNull(exporter);
 
             this.exporter = exporter;
             if ((exporter.Options.HttpListenerPrefixes?.Count ?? 0) <= 0)

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterMiddleware.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterMiddleware.cs
@@ -38,7 +38,7 @@ namespace OpenTelemetry.Exporter.Prometheus
         /// <param name="next"><see cref="RequestDelegate"/>.</param>
         public PrometheusExporterMiddleware(MeterProvider meterProvider, RequestDelegate next)
         {
-            Guard.ThrowIfNull(meterProvider, nameof(meterProvider));
+            Guard.ThrowIfNull(meterProvider);
 
             if (!meterProvider.TryFindExporter(out PrometheusExporter exporter))
             {

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterMeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterMeterProviderBuilderExtensions.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Metrics
         /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
         public static MeterProviderBuilder AddPrometheusExporter(this MeterProviderBuilder builder, Action<PrometheusExporterOptions> configure = null)
         {
-            Guard.ThrowIfNull(builder, nameof(builder));
+            Guard.ThrowIfNull(builder);
 
             if (builder is IDeferredMeterProviderBuilder deferredMeterProviderBuilder)
             {

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterOptions.cs
@@ -87,7 +87,7 @@ namespace OpenTelemetry.Exporter
             get => this.scrapeResponseCacheDurationMilliseconds;
             set
             {
-                Guard.ThrowIfOutOfRange(value, nameof(value), min: 0);
+                Guard.ThrowIfOutOfRange(value, min: 0);
 
                 this.scrapeResponseCacheDurationMilliseconds = value;
             }

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterOptions.cs
@@ -54,7 +54,7 @@ namespace OpenTelemetry.Exporter
             get => this.httpListenerPrefixes;
             set
             {
-                Guard.ThrowIfNull(value, nameof(this.httpListenerPrefixes));
+                Guard.ThrowIfNull(value);
 
                 foreach (string inputUri in value)
                 {

--- a/src/OpenTelemetry.Exporter.ZPages/ZPagesExporter.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/ZPagesExporter.cs
@@ -37,7 +37,7 @@ namespace OpenTelemetry.Exporter.ZPages
         /// <param name="options">Options for the exporter.</param>
         public ZPagesExporter(ZPagesExporterOptions options)
         {
-            Guard.ThrowIfNull(options?.RetentionTime, $"{nameof(options)}?.{nameof(options.RetentionTime)}");
+            Guard.ThrowIfNull(options?.RetentionTime);
 
             ZPagesActivityTracker.RetentionTime = options.RetentionTime;
 

--- a/src/OpenTelemetry.Exporter.ZPages/ZPagesExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/ZPagesExporterHelperExtensions.cs
@@ -37,7 +37,7 @@ namespace OpenTelemetry.Trace
             this TracerProviderBuilder builder,
             Action<ZPagesExporterOptions> configure = null)
         {
-            Guard.ThrowIfNull(builder, nameof(builder));
+            Guard.ThrowIfNull(builder);
 
             var exporterOptions = new ZPagesExporterOptions();
             configure?.Invoke(exporterOptions);

--- a/src/OpenTelemetry.Exporter.ZPages/ZPagesExporterStatsHttpServer.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/ZPagesExporterStatsHttpServer.cs
@@ -42,7 +42,7 @@ namespace OpenTelemetry.Exporter.ZPages
         /// <param name="exporter">The <see cref="ZPagesExporterStatsHttpServer"/> instance.</param>
         public ZPagesExporterStatsHttpServer(ZPagesExporter exporter)
         {
-            Guard.ThrowIfNull(exporter?.Options?.Url, $"{nameof(exporter)}?.{nameof(exporter.Options)}?.{nameof(exporter.Options.Url)}");
+            Guard.ThrowIfNull(exporter?.Options?.Url);
 
             this.httpListener.Prefixes.Add(exporter.Options.Url);
         }

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinSpan.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinSpan.cs
@@ -41,8 +41,8 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
             bool? debug,
             bool? shared)
         {
-            Guard.ThrowIfNullOrWhitespace(traceId, nameof(traceId));
-            Guard.ThrowIfNullOrWhitespace(id, nameof(id));
+            Guard.ThrowIfNullOrWhitespace(traceId);
+            Guard.ThrowIfNullOrWhitespace(id);
 
             this.TraceId = traceId;
             this.ParentId = parentId;

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporter.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporter.cs
@@ -48,7 +48,7 @@ namespace OpenTelemetry.Exporter
         /// <param name="client">Http client to use to upload telemetry.</param>
         public ZipkinExporter(ZipkinExporterOptions options, HttpClient client = null)
         {
-            Guard.ThrowIfNull(options, nameof(options));
+            Guard.ThrowIfNull(options);
 
             this.options = options;
             this.maxPayloadSizeInBytes = (!options.MaxPayloadSizeInBytes.HasValue || options.MaxPayloadSizeInBytes <= 0) ? ZipkinExporterOptions.DefaultMaxPayloadSizeInBytes : options.MaxPayloadSizeInBytes.Value;

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporterHelperExtensions.cs
@@ -36,7 +36,7 @@ namespace OpenTelemetry.Trace
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The objects should not be disposed.")]
         public static TracerProviderBuilder AddZipkinExporter(this TracerProviderBuilder builder, Action<ZipkinExporterOptions> configure = null)
         {
-            Guard.ThrowIfNull(builder, nameof(builder));
+            Guard.ThrowIfNull(builder);
 
             if (builder is IDeferredTracerProviderBuilder deferredTracerProviderBuilder)
             {

--- a/src/OpenTelemetry.Extensions.Hosting/Implementation/MeterProviderBuilderHosting.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Implementation/MeterProviderBuilderHosting.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Metrics
 
         public MeterProviderBuilderHosting(IServiceCollection services)
         {
-            Guard.ThrowIfNull(services, nameof(services));
+            Guard.ThrowIfNull(services);
 
             this.Services = services;
         }
@@ -39,7 +39,7 @@ namespace OpenTelemetry.Metrics
 
         public MeterProviderBuilder Configure(Action<IServiceProvider, MeterProviderBuilder> configure)
         {
-            Guard.ThrowIfNull(configure, nameof(configure));
+            Guard.ThrowIfNull(configure);
 
             this.configurationActions.Add(configure);
             return this;
@@ -47,7 +47,7 @@ namespace OpenTelemetry.Metrics
 
         public MeterProvider Build(IServiceProvider serviceProvider)
         {
-            Guard.ThrowIfNull(serviceProvider, nameof(serviceProvider));
+            Guard.ThrowIfNull(serviceProvider);
 
             // Note: Not using a foreach loop because additional actions can be
             // added during each call.

--- a/src/OpenTelemetry.Extensions.Hosting/Implementation/TracerProviderBuilderHosting.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Implementation/TracerProviderBuilderHosting.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Trace
 
         public TracerProviderBuilderHosting(IServiceCollection services)
         {
-            Guard.ThrowIfNull(services, nameof(services));
+            Guard.ThrowIfNull(services);
 
             this.Services = services;
         }
@@ -39,7 +39,7 @@ namespace OpenTelemetry.Trace
 
         public TracerProviderBuilder Configure(Action<IServiceProvider, TracerProviderBuilder> configure)
         {
-            Guard.ThrowIfNull(configure, nameof(configure));
+            Guard.ThrowIfNull(configure);
 
             this.configurationActions.Add(configure);
             return this;
@@ -47,7 +47,7 @@ namespace OpenTelemetry.Trace
 
         public TracerProvider Build(IServiceProvider serviceProvider)
         {
-            Guard.ThrowIfNull(serviceProvider, nameof(serviceProvider));
+            Guard.ThrowIfNull(serviceProvider);
 
             // Note: Not using a foreach loop because additional actions can be
             // added during each call.

--- a/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryServicesExtensions.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryServicesExtensions.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
         public static IServiceCollection AddOpenTelemetryTracing(this IServiceCollection services, Action<TracerProviderBuilder> configure)
         {
-            Guard.ThrowIfNull(configure, nameof(configure));
+            Guard.ThrowIfNull(configure);
 
             var builder = new TracerProviderBuilderHosting(services);
             configure(builder);
@@ -73,7 +73,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
         public static IServiceCollection AddOpenTelemetryMetrics(this IServiceCollection services, Action<MeterProviderBuilder> configure)
         {
-            Guard.ThrowIfNull(configure, nameof(configure));
+            Guard.ThrowIfNull(configure);
 
             var builder = new MeterProviderBuilderHosting(services);
             configure(builder);
@@ -88,8 +88,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
         private static IServiceCollection AddOpenTelemetryTracing(this IServiceCollection services, Func<IServiceProvider, TracerProvider> createTracerProvider)
         {
-            Guard.ThrowIfNull(services, nameof(services));
-            Guard.ThrowIfNull(createTracerProvider, nameof(createTracerProvider));
+            Guard.ThrowIfNull(services);
+            Guard.ThrowIfNull(createTracerProvider);
 
             try
             {

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/TelemetryHttpModuleOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/TelemetryHttpModuleOptions.cs
@@ -42,7 +42,7 @@ namespace OpenTelemetry.Instrumentation.AspNet
             get => this.textMapPropagator;
             set
             {
-                Guard.ThrowIfNull(value, nameof(value));
+                Guard.ThrowIfNull(value);
 
                 this.textMapPropagator = value;
             }

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -32,7 +32,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
 
         public HttpInListener(AspNetInstrumentationOptions options)
         {
-            Guard.ThrowIfNull(options, nameof(options));
+            Guard.ThrowIfNull(options);
 
             this.options = options;
 

--- a/src/OpenTelemetry.Instrumentation.AspNet/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/TracerProviderBuilderExtensions.cs
@@ -35,7 +35,7 @@ namespace OpenTelemetry.Trace
             this TracerProviderBuilder builder,
             Action<AspNetInstrumentationOptions> configureAspNetInstrumentationOptions = null)
         {
-            Guard.ThrowIfNull(builder, nameof(builder));
+            Guard.ThrowIfNull(builder);
 
             var aspnetOptions = new AspNetInstrumentationOptions();
             configureAspNetInstrumentationOptions?.Invoke(aspnetOptions);

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -54,7 +54,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
         public HttpInListener(AspNetCoreInstrumentationOptions options)
             : base(DiagnosticSourceName)
         {
-            Guard.ThrowIfNull(options, nameof(options));
+            Guard.ThrowIfNull(options);
 
             this.options = options;
         }

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/MeterProviderBuilderExtensions.cs
@@ -32,7 +32,7 @@ namespace OpenTelemetry.Metrics
         public static MeterProviderBuilder AddAspNetCoreInstrumentation(
             this MeterProviderBuilder builder)
         {
-            Guard.ThrowIfNull(builder, nameof(builder));
+            Guard.ThrowIfNull(builder);
 
             // TODO: Implement an IDeferredMeterProviderBuilder
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/TracerProviderBuilderExtensions.cs
@@ -36,7 +36,7 @@ namespace OpenTelemetry.Trace
             this TracerProviderBuilder builder,
             Action<AspNetCoreInstrumentationOptions> configureAspNetCoreInstrumentationOptions = null)
         {
-            Guard.ThrowIfNull(builder, nameof(builder));
+            Guard.ThrowIfNull(builder);
 
             if (builder is IDeferredTracerProviderBuilder deferredTracerProviderBuilder)
             {

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/TracerProviderBuilderExtensions.cs
@@ -37,7 +37,7 @@ namespace OpenTelemetry.Trace
             this TracerProviderBuilder builder,
             Action<GrpcClientInstrumentationOptions> configure = null)
         {
-            Guard.ThrowIfNull(builder, nameof(builder));
+            Guard.ThrowIfNull(builder);
 
             var grpcOptions = new GrpcClientInstrumentationOptions();
             configure?.Invoke(grpcOptions);

--- a/src/OpenTelemetry.Instrumentation.Http/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/MeterProviderBuilderExtensions.cs
@@ -32,7 +32,7 @@ namespace OpenTelemetry.Metrics
         public static MeterProviderBuilder AddHttpClientInstrumentation(
             this MeterProviderBuilder builder)
         {
-            Guard.ThrowIfNull(builder, nameof(builder));
+            Guard.ThrowIfNull(builder);
 
             // TODO: Implement an IDeferredMeterProviderBuilder
 

--- a/src/OpenTelemetry.Instrumentation.Http/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/TracerProviderBuilderExtensions.cs
@@ -61,7 +61,7 @@ namespace OpenTelemetry.Trace
             this TracerProviderBuilder builder,
             Action<HttpClientInstrumentationOptions> configureHttpClientInstrumentationOptions = null)
         {
-            Guard.ThrowIfNull(builder, nameof(builder));
+            Guard.ThrowIfNull(builder);
 
             var httpClientOptions = new HttpClientInstrumentationOptions();
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/TracerProviderBuilderExtensions.cs
@@ -36,7 +36,7 @@ namespace OpenTelemetry.Trace
             this TracerProviderBuilder builder,
             Action<SqlClientInstrumentationOptions> configureSqlClientInstrumentationOptions = null)
         {
-            Guard.ThrowIfNull(builder, nameof(builder));
+            Guard.ThrowIfNull(builder);
 
             var sqlOptions = new SqlClientInstrumentationOptions();
             configureSqlClientInstrumentationOptions?.Invoke(sqlOptions);

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisCallsInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisCallsInstrumentation.cs
@@ -59,7 +59,7 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis
         /// <param name="options">Configuration options for redis instrumentation.</param>
         public StackExchangeRedisCallsInstrumentation(IConnectionMultiplexer connection, StackExchangeRedisCallsInstrumentationOptions options)
         {
-            Guard.ThrowIfNull(connection, nameof(connection));
+            Guard.ThrowIfNull(connection);
 
             this.options = options ?? new StackExchangeRedisCallsInstrumentationOptions();
 

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/TracerProviderBuilderExtensions.cs
@@ -43,7 +43,7 @@ namespace OpenTelemetry.Trace
             IConnectionMultiplexer connection = null,
             Action<StackExchangeRedisCallsInstrumentationOptions> configure = null)
         {
-            Guard.ThrowIfNull(builder, nameof(builder));
+            Guard.ThrowIfNull(builder);
 
             if (builder is not IDeferredTracerProviderBuilder deferredTracerProviderBuilder)
             {

--- a/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
@@ -69,7 +69,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public IScope Activate(ISpan span, bool finishSpanOnDispose)
         {
-            var shim = Guard.ThrowIfNotOfType<SpanShim>(span, nameof(span));
+            var shim = Guard.ThrowIfNotOfType<SpanShim>(span);
 
             var scope = Tracer.WithSpan(shim.Span);
 

--- a/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
@@ -37,7 +37,7 @@ namespace OpenTelemetry.Shims.OpenTracing
 
         public ScopeManagerShim(Tracer tracer)
         {
-            Guard.ThrowIfNull(tracer, nameof(tracer));
+            Guard.ThrowIfNull(tracer);
 
             this.tracer = tracer;
         }

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
@@ -81,8 +81,8 @@ namespace OpenTelemetry.Shims.OpenTracing
 
         public SpanBuilderShim(Tracer tracer, string spanName, IList<string> rootOperationNamesForActivityBasedAutoInstrumentations = null)
         {
-            Guard.ThrowIfNull(tracer, nameof(tracer));
-            Guard.ThrowIfNull(spanName, nameof(spanName));
+            Guard.ThrowIfNull(tracer);
+            Guard.ThrowIfNull(spanName);
 
             this.tracer = tracer;
             this.spanName = spanName;
@@ -130,7 +130,7 @@ namespace OpenTelemetry.Shims.OpenTracing
                 return this;
             }
 
-            Guard.ThrowIfNull(referenceType, nameof(referenceType));
+            Guard.ThrowIfNull(referenceType);
 
             // TODO There is no relation between OpenTracing.References (referenceType) and OpenTelemetry Link
             var actualContext = GetOpenTelemetrySpanContext(referencedContext);
@@ -279,7 +279,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public ISpanBuilder WithTag(global::OpenTracing.Tag.BooleanTag tag, bool value)
         {
-            Guard.ThrowIfNull(tag?.Key, $"{nameof(tag)}?.{nameof(tag.Key)}");
+            Guard.ThrowIfNull(tag?.Key);
 
             return this.WithTag(tag.Key, value);
         }
@@ -287,7 +287,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public ISpanBuilder WithTag(global::OpenTracing.Tag.IntOrStringTag tag, string value)
         {
-            Guard.ThrowIfNull(tag?.Key, $"{nameof(tag)}?.{nameof(tag.Key)}");
+            Guard.ThrowIfNull(tag?.Key);
 
             if (int.TryParse(value, out var result))
             {
@@ -300,7 +300,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public ISpanBuilder WithTag(global::OpenTracing.Tag.IntTag tag, int value)
         {
-            Guard.ThrowIfNull(tag?.Key, $"{nameof(tag)}?.{nameof(tag.Key)}");
+            Guard.ThrowIfNull(tag?.Key);
 
             return this.WithTag(tag.Key, value);
         }
@@ -308,7 +308,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public ISpanBuilder WithTag(global::OpenTracing.Tag.StringTag tag, string value)
         {
-            Guard.ThrowIfNull(tag?.Key, $"{nameof(tag)}?.{nameof(tag.Key)}");
+            Guard.ThrowIfNull(tag?.Key);
 
             return this.WithTag(tag.Key, value);
         }

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
@@ -321,7 +321,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <exception cref="ArgumentException">span is not a valid SpanShim object.</exception>
         private static TelemetrySpan GetOpenTelemetrySpan(ISpan span)
         {
-            var shim = Guard.ThrowIfNotOfType<SpanShim>(span, nameof(span));
+            var shim = Guard.ThrowIfNotOfType<SpanShim>(span);
 
             return shim.Span;
         }
@@ -334,7 +334,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <exception cref="ArgumentException">context is not a valid SpanContextShim object.</exception>
         private static SpanContext GetOpenTelemetrySpanContext(ISpanContext spanContext)
         {
-            var shim = Guard.ThrowIfNotOfType<SpanContextShim>(spanContext, nameof(spanContext));
+            var shim = Guard.ThrowIfNotOfType<SpanContextShim>(spanContext);
 
             return shim.SpanContext;
         }

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanShim.cs
@@ -46,7 +46,7 @@ namespace OpenTelemetry.Shims.OpenTracing
 
         public SpanShim(TelemetrySpan span)
         {
-            Guard.ThrowIfNull(span, nameof(span));
+            Guard.ThrowIfNull(span);
 
             if (!span.Context.IsValid)
             {
@@ -80,7 +80,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public ISpan Log(DateTimeOffset timestamp, IEnumerable<KeyValuePair<string, object>> fields)
         {
-            Guard.ThrowIfNull(fields, nameof(fields));
+            Guard.ThrowIfNull(fields);
 
             var payload = ConvertToEventPayload(fields);
             var eventName = payload.Item1;
@@ -141,7 +141,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public ISpan Log(string @event)
         {
-            Guard.ThrowIfNull(@event, nameof(@event));
+            Guard.ThrowIfNull(@event);
 
             this.Span.AddEvent(@event);
             return this;
@@ -150,7 +150,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public ISpan Log(DateTimeOffset timestamp, string @event)
         {
-            Guard.ThrowIfNull(@event, nameof(@event));
+            Guard.ThrowIfNull(@event);
 
             this.Span.AddEvent(@event, timestamp);
             return this;
@@ -166,7 +166,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public ISpan SetOperationName(string operationName)
         {
-            Guard.ThrowIfNull(operationName, nameof(operationName));
+            Guard.ThrowIfNull(operationName);
 
             this.Span.UpdateName(operationName);
             return this;
@@ -175,7 +175,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public ISpan SetTag(string key, string value)
         {
-            Guard.ThrowIfNull(key, nameof(key));
+            Guard.ThrowIfNull(key);
 
             this.Span.SetAttribute(key, value);
             return this;
@@ -184,7 +184,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public ISpan SetTag(string key, bool value)
         {
-            Guard.ThrowIfNull(key, nameof(key));
+            Guard.ThrowIfNull(key);
 
             // Special case the OpenTracing Error Tag
             // see https://opentracing.io/specification/conventions/
@@ -203,7 +203,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public ISpan SetTag(string key, int value)
         {
-            Guard.ThrowIfNull(key, nameof(key));
+            Guard.ThrowIfNull(key);
 
             this.Span.SetAttribute(key, value);
             return this;
@@ -212,7 +212,7 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public ISpan SetTag(string key, double value)
         {
-            Guard.ThrowIfNull(key, nameof(key));
+            Guard.ThrowIfNull(key);
 
             this.Span.SetAttribute(key, value);
             return this;

--- a/src/OpenTelemetry.Shims.OpenTracing/TracerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/TracerShim.cs
@@ -93,7 +93,7 @@ namespace OpenTelemetry.Shims.OpenTracing
             TCarrier carrier)
         {
             Guard.ThrowIfNull(spanContext);
-            var shim = Guard.ThrowIfNotOfType<SpanContextShim>(spanContext, nameof(spanContext));
+            var shim = Guard.ThrowIfNotOfType<SpanContextShim>(spanContext);
             Guard.ThrowIfNull(format);
             Guard.ThrowIfNull(carrier);
 

--- a/src/OpenTelemetry.Shims.OpenTracing/TracerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/TracerShim.cs
@@ -28,8 +28,8 @@ namespace OpenTelemetry.Shims.OpenTracing
 
         public TracerShim(Trace.Tracer tracer, TextMapPropagator textFormat)
         {
-            Guard.ThrowIfNull(tracer, nameof(tracer));
-            Guard.ThrowIfNull(textFormat, nameof(textFormat));
+            Guard.ThrowIfNull(tracer);
+            Guard.ThrowIfNull(textFormat);
 
             this.tracer = tracer;
             this.propagator = textFormat;
@@ -51,8 +51,8 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <inheritdoc/>
         public global::OpenTracing.ISpanContext Extract<TCarrier>(IFormat<TCarrier> format, TCarrier carrier)
         {
-            Guard.ThrowIfNull(format, nameof(format));
-            Guard.ThrowIfNull(carrier, nameof(carrier));
+            Guard.ThrowIfNull(format);
+            Guard.ThrowIfNull(carrier);
 
             PropagationContext propagationContext = default;
 
@@ -92,10 +92,10 @@ namespace OpenTelemetry.Shims.OpenTracing
             IFormat<TCarrier> format,
             TCarrier carrier)
         {
-            Guard.ThrowIfNull(spanContext, nameof(spanContext));
+            Guard.ThrowIfNull(spanContext);
             var shim = Guard.ThrowIfNotOfType<SpanContextShim>(spanContext, nameof(spanContext));
-            Guard.ThrowIfNull(format, nameof(format));
-            Guard.ThrowIfNull(carrier, nameof(carrier));
+            Guard.ThrowIfNull(format);
+            Guard.ThrowIfNull(carrier);
 
             if ((format == BuiltinFormats.TextMap || format == BuiltinFormats.HttpHeaders) && carrier is ITextMap textMapCarrier)
             {

--- a/src/OpenTelemetry/BaseExportProcessor.cs
+++ b/src/OpenTelemetry/BaseExportProcessor.cs
@@ -35,7 +35,7 @@ namespace OpenTelemetry
         /// <param name="exporter">Exporter instance.</param>
         protected BaseExportProcessor(BaseExporter<T> exporter)
         {
-            Guard.ThrowIfNull(exporter, nameof(exporter));
+            Guard.ThrowIfNull(exporter);
 
             this.exporter = exporter;
         }

--- a/src/OpenTelemetry/BaseExporter.cs
+++ b/src/OpenTelemetry/BaseExporter.cs
@@ -76,7 +76,7 @@ namespace OpenTelemetry
         /// </remarks>
         public bool ForceFlush(int timeoutMilliseconds = Timeout.Infinite)
         {
-            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
+            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds);
 
             try
             {
@@ -109,7 +109,7 @@ namespace OpenTelemetry
         /// </remarks>
         public bool Shutdown(int timeoutMilliseconds = Timeout.Infinite)
         {
-            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
+            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds);
 
             if (Interlocked.Increment(ref this.shutdownCount) > 1)
             {

--- a/src/OpenTelemetry/BaseProcessor.cs
+++ b/src/OpenTelemetry/BaseProcessor.cs
@@ -82,7 +82,7 @@ namespace OpenTelemetry
         /// </remarks>
         public bool ForceFlush(int timeoutMilliseconds = Timeout.Infinite)
         {
-            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
+            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds);
 
             try
             {
@@ -115,7 +115,7 @@ namespace OpenTelemetry
         /// </remarks>
         public bool Shutdown(int timeoutMilliseconds = Timeout.Infinite)
         {
-            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
+            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds);
 
             if (Interlocked.CompareExchange(ref this.shutdownCount, 1, 0) != 0)
             {

--- a/src/OpenTelemetry/Batch.cs
+++ b/src/OpenTelemetry/Batch.cs
@@ -42,7 +42,7 @@ namespace OpenTelemetry
         public Batch(T[] items, int count)
         {
             Guard.ThrowIfNull(items);
-            Guard.ThrowIfOutOfRange(count, nameof(count), 0, items.Length);
+            Guard.ThrowIfOutOfRange(count, min: 0, max: items.Length);
 
             this.item = null;
             this.circularBuffer = null;

--- a/src/OpenTelemetry/Batch.cs
+++ b/src/OpenTelemetry/Batch.cs
@@ -41,7 +41,7 @@ namespace OpenTelemetry
         /// <param name="count">The number of items in the batch.</param>
         public Batch(T[] items, int count)
         {
-            Guard.ThrowIfNull(items, nameof(items));
+            Guard.ThrowIfNull(items);
             Guard.ThrowIfOutOfRange(count, nameof(count), 0, items.Length);
 
             this.item = null;

--- a/src/OpenTelemetry/BatchExportProcessor.cs
+++ b/src/OpenTelemetry/BatchExportProcessor.cs
@@ -61,10 +61,10 @@ namespace OpenTelemetry
             int maxExportBatchSize = DefaultMaxExportBatchSize)
             : base(exporter)
         {
-            Guard.ThrowIfOutOfRange(maxQueueSize, nameof(maxQueueSize), min: 1);
-            Guard.ThrowIfOutOfRange(maxExportBatchSize, nameof(maxExportBatchSize), min: 1, max: maxQueueSize, maxName: nameof(maxQueueSize));
-            Guard.ThrowIfOutOfRange(scheduledDelayMilliseconds, nameof(scheduledDelayMilliseconds), min: 1);
-            Guard.ThrowIfOutOfRange(exporterTimeoutMilliseconds, nameof(exporterTimeoutMilliseconds), min: 0);
+            Guard.ThrowIfOutOfRange(maxQueueSize, min: 1);
+            Guard.ThrowIfOutOfRange(maxExportBatchSize, min: 1, max: maxQueueSize, maxName: nameof(maxQueueSize));
+            Guard.ThrowIfOutOfRange(scheduledDelayMilliseconds, min: 1);
+            Guard.ThrowIfOutOfRange(exporterTimeoutMilliseconds, min: 0);
 
             this.circularBuffer = new CircularBuffer<T>(maxQueueSize);
             this.scheduledDelayMilliseconds = scheduledDelayMilliseconds;

--- a/src/OpenTelemetry/CompositeProcessor.cs
+++ b/src/OpenTelemetry/CompositeProcessor.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry
 
         public CompositeProcessor(IEnumerable<BaseProcessor<T>> processors)
         {
-            Guard.ThrowIfNull(processors, nameof(processors));
+            Guard.ThrowIfNull(processors);
 
             using var iter = processors.GetEnumerator();
             if (!iter.MoveNext())
@@ -49,7 +49,7 @@ namespace OpenTelemetry
 
         public CompositeProcessor<T> AddProcessor(BaseProcessor<T> processor)
         {
-            Guard.ThrowIfNull(processor, nameof(processor));
+            Guard.ThrowIfNull(processor);
 
             var node = new DoublyLinkedListNode(processor)
             {

--- a/src/OpenTelemetry/DiagnosticSourceInstrumentation/DiagnosticSourceListener.cs
+++ b/src/OpenTelemetry/DiagnosticSourceInstrumentation/DiagnosticSourceListener.cs
@@ -27,7 +27,7 @@ namespace OpenTelemetry.Instrumentation
 
         public DiagnosticSourceListener(ListenerHandler handler)
         {
-            Guard.ThrowIfNull(handler, nameof(handler));
+            Guard.ThrowIfNull(handler);
 
             this.handler = handler;
         }

--- a/src/OpenTelemetry/DiagnosticSourceInstrumentation/DiagnosticSourceSubscriber.cs
+++ b/src/OpenTelemetry/DiagnosticSourceInstrumentation/DiagnosticSourceSubscriber.cs
@@ -42,7 +42,7 @@ namespace OpenTelemetry.Instrumentation
             Func<DiagnosticListener, bool> diagnosticSourceFilter,
             Func<string, object, object, bool> isEnabledFilter)
         {
-            Guard.ThrowIfNull(handlerFactory, nameof(handlerFactory));
+            Guard.ThrowIfNull(handlerFactory);
 
             this.listenerSubscriptions = new List<IDisposable>();
             this.handlerFactory = handlerFactory;

--- a/src/OpenTelemetry/DiagnosticSourceInstrumentation/PropertyFetcher.cs
+++ b/src/OpenTelemetry/DiagnosticSourceInstrumentation/PropertyFetcher.cs
@@ -46,7 +46,7 @@ namespace OpenTelemetry.Instrumentation
         /// <returns>Property fetched.</returns>
         public T Fetch(object obj)
         {
-            Guard.ThrowIfNull(obj, nameof(obj));
+            Guard.ThrowIfNull(obj);
 
             if (!this.TryFetch(obj, out T value, true))
             {

--- a/src/OpenTelemetry/Internal/CircularBuffer.cs
+++ b/src/OpenTelemetry/Internal/CircularBuffer.cs
@@ -79,7 +79,7 @@ namespace OpenTelemetry.Internal
         /// </returns>
         public bool Add(T value)
         {
-            Guard.ThrowIfNull(value, nameof(value));
+            Guard.ThrowIfNull(value);
 
             while (true)
             {
@@ -119,7 +119,7 @@ namespace OpenTelemetry.Internal
                 return this.Add(value);
             }
 
-            Guard.ThrowIfNull(value, nameof(value));
+            Guard.ThrowIfNull(value);
 
             var spinCountDown = maxSpinCount;
 

--- a/src/OpenTelemetry/Internal/CircularBuffer.cs
+++ b/src/OpenTelemetry/Internal/CircularBuffer.cs
@@ -36,7 +36,7 @@ namespace OpenTelemetry.Internal
         /// <param name="capacity">The capacity of the circular buffer, must be a positive integer.</param>
         public CircularBuffer(int capacity)
         {
-            Guard.ThrowIfOutOfRange(capacity, nameof(capacity), min: 1);
+            Guard.ThrowIfOutOfRange(capacity, min: 1);
 
             this.Capacity = capacity;
             this.trait = new T[capacity];

--- a/src/OpenTelemetry/Internal/PooledList.cs
+++ b/src/OpenTelemetry/Internal/PooledList.cs
@@ -52,7 +52,7 @@ namespace OpenTelemetry.Internal
 
         public static void Add(ref PooledList<T> list, T item)
         {
-            Guard.ThrowIfNull(list.buffer, $"{nameof(list)}.{nameof(list.buffer)}");
+            Guard.ThrowIfNull(list.buffer);
 
             var buffer = list.buffer;
 

--- a/src/OpenTelemetry/Internal/SelfDiagnosticsEventListener.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnosticsEventListener.cs
@@ -43,7 +43,7 @@ namespace OpenTelemetry.Internal
 
         public SelfDiagnosticsEventListener(EventLevel logLevel, SelfDiagnosticsConfigRefresher configRefresher)
         {
-            Guard.ThrowIfNull(configRefresher, nameof(configRefresher));
+            Guard.ThrowIfNull(configRefresher);
 
             this.logLevel = logLevel;
             this.configRefresher = configRefresher;

--- a/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
@@ -29,8 +29,8 @@ namespace OpenTelemetry.Logs
 
         internal OpenTelemetryLogger(string categoryName, OpenTelemetryLoggerProvider provider)
         {
-            Guard.ThrowIfNull(categoryName, nameof(categoryName));
-            Guard.ThrowIfNull(provider, nameof(provider));
+            Guard.ThrowIfNull(categoryName);
+            Guard.ThrowIfNull(provider);
 
             this.categoryName = categoryName;
             this.provider = provider;

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggerOptions.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggerOptions.cs
@@ -58,7 +58,7 @@ namespace OpenTelemetry.Logs
         /// <returns>Returns <see cref="OpenTelemetryLoggerOptions"/> for chaining.</returns>
         public OpenTelemetryLoggerOptions AddProcessor(BaseProcessor<LogRecord> processor)
         {
-            Guard.ThrowIfNull(processor, nameof(processor));
+            Guard.ThrowIfNull(processor);
 
             this.Processors.Add(processor);
 
@@ -73,7 +73,7 @@ namespace OpenTelemetry.Logs
         /// <returns>Returns <see cref="OpenTelemetryLoggerOptions"/> for chaining.</returns>
         public OpenTelemetryLoggerOptions SetResourceBuilder(ResourceBuilder resourceBuilder)
         {
-            Guard.ThrowIfNull(resourceBuilder, nameof(resourceBuilder));
+            Guard.ThrowIfNull(resourceBuilder);
 
             this.ResourceBuilder = resourceBuilder;
             return this;

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggerProvider.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggerProvider.cs
@@ -46,7 +46,7 @@ namespace OpenTelemetry.Logs
 
         internal OpenTelemetryLoggerProvider(OpenTelemetryLoggerOptions options)
         {
-            Guard.ThrowIfNull(options, nameof(options));
+            Guard.ThrowIfNull(options);
 
             this.Options = options;
             this.Resource = options.ResourceBuilder.Build();
@@ -97,7 +97,7 @@ namespace OpenTelemetry.Logs
 
         internal OpenTelemetryLoggerProvider AddProcessor(BaseProcessor<LogRecord> processor)
         {
-            Guard.ThrowIfNull(processor, nameof(processor));
+            Guard.ThrowIfNull(processor);
 
             processor.SetParentProvider(this);
 

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggingExtensions.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggingExtensions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Extensions.Logging
     {
         public static ILoggingBuilder AddOpenTelemetry(this ILoggingBuilder builder, Action<OpenTelemetryLoggerOptions> configure = null)
         {
-            Guard.ThrowIfNull(builder, nameof(builder));
+            Guard.ThrowIfNull(builder);
 
             builder.AddConfiguration();
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, OpenTelemetryLoggerProvider>());

--- a/src/OpenTelemetry/Metrics/BaseExportingMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/BaseExportingMetricReader.cs
@@ -29,7 +29,7 @@ namespace OpenTelemetry.Metrics
 
         public BaseExportingMetricReader(BaseExporter<Metric> exporter)
         {
-            Guard.ThrowIfNull(exporter, nameof(exporter));
+            Guard.ThrowIfNull(exporter);
 
             this.exporter = exporter;
 

--- a/src/OpenTelemetry/Metrics/CompositeMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/CompositeMetricReader.cs
@@ -34,7 +34,7 @@ namespace OpenTelemetry.Metrics
 
         public CompositeMetricReader(IEnumerable<MetricReader> readers)
         {
-            Guard.ThrowIfNull(readers, nameof(readers));
+            Guard.ThrowIfNull(readers);
 
             using var iter = readers.GetEnumerator();
             if (!iter.MoveNext())
@@ -54,7 +54,7 @@ namespace OpenTelemetry.Metrics
 
         public CompositeMetricReader AddReader(MetricReader reader)
         {
-            Guard.ThrowIfNull(reader, nameof(reader));
+            Guard.ThrowIfNull(reader);
 
             var node = new DoublyLinkedListNode(reader)
             {

--- a/src/OpenTelemetry/Metrics/MeterProviderBuilderBase.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderBuilderBase.cs
@@ -65,7 +65,7 @@ namespace OpenTelemetry.Metrics
 
             foreach (var name in names)
             {
-                Guard.ThrowIfNullOrWhitespace(name, nameof(name));
+                Guard.ThrowIfNullOrWhitespace(name);
 
                 this.meterSources.Add(name);
             }

--- a/src/OpenTelemetry/Metrics/MeterProviderBuilderBase.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderBuilderBase.cs
@@ -47,7 +47,7 @@ namespace OpenTelemetry.Metrics
         /// <inheritdoc />
         public override MeterProviderBuilder AddInstrumentation<TInstrumentation>(Func<TInstrumentation> instrumentationFactory)
         {
-            Guard.ThrowIfNull(instrumentationFactory, nameof(instrumentationFactory));
+            Guard.ThrowIfNull(instrumentationFactory);
 
             this.instrumentationFactories.Add(
                 new InstrumentationFactory(
@@ -61,7 +61,7 @@ namespace OpenTelemetry.Metrics
         /// <inheritdoc />
         public override MeterProviderBuilder AddMeter(params string[] names)
         {
-            Guard.ThrowIfNull(names, nameof(names));
+            Guard.ThrowIfNull(names);
 
             foreach (var name in names)
             {

--- a/src/OpenTelemetry/Metrics/MeterProviderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderExtensions.cs
@@ -43,7 +43,7 @@ namespace OpenTelemetry.Metrics
         public static bool ForceFlush(this MeterProvider provider, int timeoutMilliseconds = Timeout.Infinite)
         {
             Guard.ThrowIfNull(provider);
-            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
+            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds);
 
             if (provider is MeterProviderSdk meterProviderSdk)
             {
@@ -83,7 +83,7 @@ namespace OpenTelemetry.Metrics
         public static bool Shutdown(this MeterProvider provider, int timeoutMilliseconds = Timeout.Infinite)
         {
             Guard.ThrowIfNull(provider);
-            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
+            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds);
 
             if (provider is MeterProviderSdk meterProviderSdk)
             {

--- a/src/OpenTelemetry/Metrics/MeterProviderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderExtensions.cs
@@ -42,7 +42,7 @@ namespace OpenTelemetry.Metrics
         /// </remarks>
         public static bool ForceFlush(this MeterProvider provider, int timeoutMilliseconds = Timeout.Infinite)
         {
-            Guard.ThrowIfNull(provider, nameof(provider));
+            Guard.ThrowIfNull(provider);
             Guard.ThrowIfInvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
 
             if (provider is MeterProviderSdk meterProviderSdk)
@@ -82,7 +82,7 @@ namespace OpenTelemetry.Metrics
         /// </remarks>
         public static bool Shutdown(this MeterProvider provider, int timeoutMilliseconds = Timeout.Infinite)
         {
-            Guard.ThrowIfNull(provider, nameof(provider));
+            Guard.ThrowIfNull(provider);
             Guard.ThrowIfInvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
 
             if (provider is MeterProviderSdk meterProviderSdk)

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -49,7 +49,7 @@ namespace OpenTelemetry.Metrics
 
             foreach (var reader in readers)
             {
-                Guard.ThrowIfNull(reader, nameof(reader));
+                Guard.ThrowIfNull(reader);
 
                 reader.SetParentProvider(this);
                 reader.SetMaxMetricStreams(maxMetricStreams);

--- a/src/OpenTelemetry/Metrics/MetricPointsAccessor.cs
+++ b/src/OpenTelemetry/Metrics/MetricPointsAccessor.cs
@@ -33,7 +33,7 @@ namespace OpenTelemetry.Metrics
 
         internal MetricPointsAccessor(MetricPoint[] metricsPoints, int[] metricPointsToProcess, long targetCount, DateTimeOffset start, DateTimeOffset end)
         {
-            Guard.ThrowIfNull(metricsPoints, nameof(metricsPoints));
+            Guard.ThrowIfNull(metricsPoints);
 
             this.metricsPoints = metricsPoints;
             this.metricPointsToProcess = metricPointsToProcess;

--- a/src/OpenTelemetry/Metrics/MetricReader.cs
+++ b/src/OpenTelemetry/Metrics/MetricReader.cs
@@ -84,7 +84,7 @@ namespace OpenTelemetry.Metrics
         /// </remarks>
         public bool Collect(int timeoutMilliseconds = Timeout.Infinite)
         {
-            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
+            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds);
 
             var shouldRunCollect = false;
             var tcs = this.collectionTcs;
@@ -147,7 +147,7 @@ namespace OpenTelemetry.Metrics
         /// </remarks>
         public bool Shutdown(int timeoutMilliseconds = Timeout.Infinite)
         {
-            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
+            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds);
 
             if (Interlocked.CompareExchange(ref this.shutdownCount, 1, 0) != 0)
             {

--- a/src/OpenTelemetry/Metrics/PeriodicExportingMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/PeriodicExportingMetricReader.cs
@@ -39,8 +39,8 @@ namespace OpenTelemetry.Metrics
             int exportTimeoutMilliseconds = DefaultExportTimeoutMilliseconds)
             : base(exporter)
         {
-            Guard.ThrowIfOutOfRange(exportIntervalMilliseconds, nameof(exportIntervalMilliseconds), min: 1);
-            Guard.ThrowIfOutOfRange(exportTimeoutMilliseconds, nameof(exportTimeoutMilliseconds), min: 0);
+            Guard.ThrowIfOutOfRange(exportIntervalMilliseconds, min: 1);
+            Guard.ThrowIfOutOfRange(exportTimeoutMilliseconds, min: 0);
 
             if ((this.SupportedExportModes & ExportModes.Push) != ExportModes.Push)
             {

--- a/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
+++ b/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
@@ -52,7 +52,7 @@ namespace OpenTelemetry.Metrics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void SplitToKeysAndValues(ReadOnlySpan<KeyValuePair<string, object>> tags, int tagLength, out string[] tagKeys, out object[] tagValues)
         {
-            Guard.ThrowIfZero(tagLength, $"There must be at least one tag to use {nameof(ThreadStaticStorage)}", $"{nameof(tagLength)}");
+            Guard.ThrowIfZero(tagLength, $"There must be at least one tag to use {nameof(ThreadStaticStorage)}");
 
             if (tagLength <= MaxTagCacheSize)
             {

--- a/src/OpenTelemetry/Resources/Resource.cs
+++ b/src/OpenTelemetry/Resources/Resource.cs
@@ -109,7 +109,7 @@ namespace OpenTelemetry.Resources
 
         private static object SanitizeValue(object value, string keyName)
         {
-            Guard.ThrowIfNull(keyName, nameof(keyName));
+            Guard.ThrowIfNull(keyName);
 
             return value switch
             {

--- a/src/OpenTelemetry/Resources/ResourceBuilder.cs
+++ b/src/OpenTelemetry/Resources/ResourceBuilder.cs
@@ -90,7 +90,7 @@ namespace OpenTelemetry.Resources
         // https://github.com/open-telemetry/oteps/blob/master/text/0111-auto-resource-detection.md
         internal ResourceBuilder AddDetector(IResourceDetector resourceDetector)
         {
-            Guard.ThrowIfNull(resourceDetector, nameof(resourceDetector));
+            Guard.ThrowIfNull(resourceDetector);
 
             Resource resource = resourceDetector.Detect();
 
@@ -104,7 +104,7 @@ namespace OpenTelemetry.Resources
 
         internal ResourceBuilder AddResource(Resource resource)
         {
-            Guard.ThrowIfNull(resource, nameof(resource));
+            Guard.ThrowIfNull(resource);
 
             this.resources.Add(resource);
 

--- a/src/OpenTelemetry/Resources/ResourceBuilderExtensions.cs
+++ b/src/OpenTelemetry/Resources/ResourceBuilderExtensions.cs
@@ -56,7 +56,7 @@ namespace OpenTelemetry.Resources
         {
             Dictionary<string, object> resourceAttributes = new Dictionary<string, object>();
 
-            Guard.ThrowIfNullOrEmpty(serviceName, nameof(serviceName));
+            Guard.ThrowIfNullOrEmpty(serviceName);
 
             resourceAttributes.Add(ResourceSemanticConventions.AttributeServiceName, serviceName);
 

--- a/src/OpenTelemetry/Trace/ParentBasedSampler.cs
+++ b/src/OpenTelemetry/Trace/ParentBasedSampler.cs
@@ -43,7 +43,7 @@ namespace OpenTelemetry.Trace
         /// <param name="rootSampler">The <see cref="Sampler"/> to be called for root span/activity.</param>
         public ParentBasedSampler(Sampler rootSampler)
         {
-            Guard.ThrowIfNull(rootSampler, nameof(rootSampler));
+            Guard.ThrowIfNull(rootSampler);
 
             this.rootSampler = rootSampler;
             this.Description = $"ParentBased{{{rootSampler.Description}}}";

--- a/src/OpenTelemetry/Trace/TraceIdRatioBasedSampler.cs
+++ b/src/OpenTelemetry/Trace/TraceIdRatioBasedSampler.cs
@@ -37,7 +37,7 @@ namespace OpenTelemetry.Trace
         /// </param>
         public TraceIdRatioBasedSampler(double probability)
         {
-            Guard.ThrowIfOutOfRange(probability, nameof(probability), min: 0.0, max: 1.0);
+            Guard.ThrowIfOutOfRange(probability, min: 0.0, max: 1.0);
 
             this.probability = probability;
 

--- a/src/OpenTelemetry/Trace/TracerProviderBuilderBase.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderBuilderBase.cs
@@ -43,7 +43,7 @@ namespace OpenTelemetry.Trace
             Func<TInstrumentation> instrumentationFactory)
             where TInstrumentation : class
         {
-            Guard.ThrowIfNull(instrumentationFactory, nameof(instrumentationFactory));
+            Guard.ThrowIfNull(instrumentationFactory);
 
             this.instrumentationFactories.Add(
                 new InstrumentationFactory(
@@ -57,7 +57,7 @@ namespace OpenTelemetry.Trace
         /// <inheritdoc />
         public override TracerProviderBuilder AddSource(params string[] names)
         {
-            Guard.ThrowIfNull(names, nameof(names));
+            Guard.ThrowIfNull(names);
 
             foreach (var name in names)
             {
@@ -129,7 +129,7 @@ namespace OpenTelemetry.Trace
         /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
         internal TracerProviderBuilder SetSampler(Sampler sampler)
         {
-            Guard.ThrowIfNull(sampler, nameof(sampler));
+            Guard.ThrowIfNull(sampler);
 
             this.sampler = sampler;
             return this;
@@ -143,7 +143,7 @@ namespace OpenTelemetry.Trace
         /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
         internal TracerProviderBuilder SetResourceBuilder(ResourceBuilder resourceBuilder)
         {
-            Guard.ThrowIfNull(resourceBuilder, nameof(resourceBuilder));
+            Guard.ThrowIfNull(resourceBuilder);
 
             this.resourceBuilder = resourceBuilder;
             return this;
@@ -156,7 +156,7 @@ namespace OpenTelemetry.Trace
         /// <returns>Returns <see cref="TracerProviderBuilder"/> for chaining.</returns>
         internal TracerProviderBuilder AddProcessor(BaseProcessor<Activity> processor)
         {
-            Guard.ThrowIfNull(processor, nameof(processor));
+            Guard.ThrowIfNull(processor);
 
             this.processors.Add(processor);
 

--- a/src/OpenTelemetry/Trace/TracerProviderBuilderBase.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderBuilderBase.cs
@@ -61,7 +61,7 @@ namespace OpenTelemetry.Trace
 
             foreach (var name in names)
             {
-                Guard.ThrowIfNullOrWhitespace(name, nameof(name));
+                Guard.ThrowIfNullOrWhitespace(name);
 
                 // TODO: We need to fix the listening model.
                 // Today it ignores version.
@@ -74,7 +74,7 @@ namespace OpenTelemetry.Trace
         /// <inheritdoc />
         public override TracerProviderBuilder AddLegacySource(string operationName)
         {
-            Guard.ThrowIfNullOrWhitespace(operationName, nameof(operationName));
+            Guard.ThrowIfNullOrWhitespace(operationName);
 
             this.legacyActivityOperationNames.Add(operationName);
 

--- a/src/OpenTelemetry/Trace/TracerProviderExtensions.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderExtensions.cs
@@ -57,7 +57,7 @@ namespace OpenTelemetry.Trace
         public static bool ForceFlush(this TracerProvider provider, int timeoutMilliseconds = Timeout.Infinite)
         {
             Guard.ThrowIfNull(provider);
-            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
+            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds);
 
             if (provider is TracerProviderSdk tracerProviderSdk)
             {
@@ -97,7 +97,7 @@ namespace OpenTelemetry.Trace
         public static bool Shutdown(this TracerProvider provider, int timeoutMilliseconds = Timeout.Infinite)
         {
             Guard.ThrowIfNull(provider);
-            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
+            Guard.ThrowIfInvalidTimeout(timeoutMilliseconds);
 
             if (provider is TracerProviderSdk tracerProviderSdk)
             {

--- a/src/OpenTelemetry/Trace/TracerProviderExtensions.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderExtensions.cs
@@ -25,8 +25,8 @@ namespace OpenTelemetry.Trace
     {
         public static TracerProvider AddProcessor(this TracerProvider provider, BaseProcessor<Activity> processor)
         {
-            Guard.ThrowIfNull(provider, nameof(provider));
-            Guard.ThrowIfNull(processor, nameof(processor));
+            Guard.ThrowIfNull(provider);
+            Guard.ThrowIfNull(processor);
 
             if (provider is TracerProviderSdk tracerProviderSdk)
             {
@@ -56,7 +56,7 @@ namespace OpenTelemetry.Trace
         /// </remarks>
         public static bool ForceFlush(this TracerProvider provider, int timeoutMilliseconds = Timeout.Infinite)
         {
-            Guard.ThrowIfNull(provider, nameof(provider));
+            Guard.ThrowIfNull(provider);
             Guard.ThrowIfInvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
 
             if (provider is TracerProviderSdk tracerProviderSdk)
@@ -96,7 +96,7 @@ namespace OpenTelemetry.Trace
         /// </remarks>
         public static bool Shutdown(this TracerProvider provider, int timeoutMilliseconds = Timeout.Infinite)
         {
-            Guard.ThrowIfNull(provider, nameof(provider));
+            Guard.ThrowIfNull(provider);
             Guard.ThrowIfInvalidTimeout(timeoutMilliseconds, nameof(timeoutMilliseconds));
 
             if (provider is TracerProviderSdk tracerProviderSdk)

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -263,7 +263,7 @@ namespace OpenTelemetry.Trace
 
         internal TracerProviderSdk AddProcessor(BaseProcessor<Activity> processor)
         {
-            Guard.ThrowIfNull(processor, nameof(processor));
+            Guard.ThrowIfNull(processor);
 
             processor.SetParentProvider(this);
 

--- a/test/OpenTelemetry.Tests/Internal/GuardTest.cs
+++ b/test/OpenTelemetry.Tests/Internal/GuardTest.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using OpenTelemetry.Internal;
 using Xunit;
@@ -90,12 +89,15 @@ namespace OpenTelemetry.Tests.Internal
             // Invalid
             var ex1 = Assert.Throws<ArgumentException>(() => Guard.ThrowIfNullOrWhitespace(null));
             Assert.Contains("Must not be null or whitespace", ex1.Message);
+            Assert.Equal("null", ex1.ParamName);
 
             var ex2 = Assert.Throws<ArgumentException>(() => Guard.ThrowIfNullOrWhitespace(string.Empty));
             Assert.Contains("Must not be null or whitespace", ex2.Message);
+            Assert.Equal("string.Empty", ex2.ParamName);
 
             var ex3 = Assert.Throws<ArgumentException>(() => Guard.ThrowIfNullOrWhitespace(" \t\n\r"));
             Assert.Contains("Must not be null or whitespace", ex3.Message);
+            Assert.Equal("\" \\t\\n\\r\"", ex3.ParamName);
         }
 
         [Fact]
@@ -109,6 +111,7 @@ namespace OpenTelemetry.Tests.Internal
             // Invalid
             var ex1 = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.ThrowIfInvalidTimeout(-100));
             Assert.Contains("Must be non-negative or 'Timeout.Infinite'", ex1.Message);
+            Assert.Equal("-100", ex1.ParamName);
         }
 
         [Fact]
@@ -155,7 +158,7 @@ namespace OpenTelemetry.Tests.Internal
 
             // Invalid
             var ex1 = Assert.Throws<InvalidCastException>(() => Guard.ThrowIfNotOfType<double>(100));
-            Assert.Equal("Cannot cast 'N/A' from 'Int32' to 'Double'", ex1.Message);
+            Assert.Equal("Cannot cast '100' from 'Int32' to 'Double'", ex1.Message);
         }
 
         [Fact]
@@ -167,6 +170,7 @@ namespace OpenTelemetry.Tests.Internal
             // Invalid
             var ex1 = Assert.Throws<ArgumentException>(() => Guard.ThrowIfZero(0));
             Assert.Contains("Must not be zero", ex1.Message);
+            Assert.Equal("0", ex1.ParamName);
         }
     }
 }

--- a/test/OpenTelemetry.Tests/Internal/GuardTest.cs
+++ b/test/OpenTelemetry.Tests/Internal/GuardTest.cs
@@ -49,14 +49,14 @@ namespace OpenTelemetry.Tests.Internal
             Assert.Equal("potato", ex1.ParamName);
 
             object @event = null;
-            ex1 = Assert.Throws<ArgumentNullException>(() => Guard.ThrowIfNull(@event));
-            Assert.Contains("Must not be null", ex1.Message);
-            Assert.Equal("@event", ex1.ParamName);
+            var ex2 = Assert.Throws<ArgumentNullException>(() => Guard.ThrowIfNull(@event));
+            Assert.Contains("Must not be null", ex2.Message);
+            Assert.Equal("@event", ex2.ParamName);
 
             Thing thing = null;
-            ex1 = Assert.Throws<ArgumentNullException>(() => Guard.ThrowIfNull(thing?.Bar));
-            Assert.Contains("Must not be null", ex1.Message);
-            Assert.Equal("thing?.Bar", ex1.ParamName);
+            var ex3 = Assert.Throws<ArgumentNullException>(() => Guard.ThrowIfNull(thing?.Bar));
+            Assert.Contains("Must not be null", ex3.Message);
+            Assert.Equal("thing?.Bar", ex3.ParamName);
         }
 
         [Fact]
@@ -69,9 +69,16 @@ namespace OpenTelemetry.Tests.Internal
             // Invalid
             var ex1 = Assert.Throws<ArgumentException>(() => Guard.ThrowIfNullOrEmpty(null));
             Assert.Contains("Must not be null or empty", ex1.Message);
+            Assert.Equal("null", ex1.ParamName);
 
             var ex2 = Assert.Throws<ArgumentException>(() => Guard.ThrowIfNullOrEmpty(string.Empty));
             Assert.Contains("Must not be null or empty", ex2.Message);
+            Assert.Equal("string.Empty", ex2.ParamName);
+
+            var x = string.Empty;
+            var ex3 = Assert.Throws<ArgumentException>(() => Guard.ThrowIfNullOrEmpty(x));
+            Assert.Contains("Must not be null or empty", ex3.Message);
+            Assert.Equal("x", ex3.ParamName);
         }
 
         [Fact]

--- a/test/OpenTelemetry.Tests/Internal/GuardTest.cs
+++ b/test/OpenTelemetry.Tests/Internal/GuardTest.cs
@@ -15,12 +15,22 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using OpenTelemetry.Internal;
 using Xunit;
 
 namespace OpenTelemetry.Tests.Internal
 {
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+    public class Thing
+#pragma warning restore SA1649 // File name should match first type name
+#pragma warning restore SA1402 // File may only contain a single type
+    {
+        public string Bar { get; set; }
+    }
+
     public class GuardTest
     {
         [Fact]
@@ -33,8 +43,20 @@ namespace OpenTelemetry.Tests.Internal
             Guard.ThrowIfNull("hello");
 
             // Invalid
-            var ex1 = Assert.Throws<ArgumentNullException>(() => Guard.ThrowIfNull(null, "null"));
+            object potato = null;
+            var ex1 = Assert.Throws<ArgumentNullException>(() => Guard.ThrowIfNull(potato));
             Assert.Contains("Must not be null", ex1.Message);
+            Assert.Equal("potato", ex1.ParamName);
+
+            object @event = null;
+            ex1 = Assert.Throws<ArgumentNullException>(() => Guard.ThrowIfNull(@event));
+            Assert.Contains("Must not be null", ex1.Message);
+            Assert.Equal("@event", ex1.ParamName);
+
+            Thing thing = null;
+            ex1 = Assert.Throws<ArgumentNullException>(() => Guard.ThrowIfNull(thing?.Bar));
+            Assert.Contains("Must not be null", ex1.Message);
+            Assert.Equal("thing?.Bar", ex1.ParamName);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-dotnet/pull/2818#discussion_r793883737

Thanks for the suggestion @CodeBlanch and help with getting this working :)

## Changes

`paramName` will work without having to add the `nameof(myVar)` argument.

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
