### PR TITLE
Make IResourceDetector public to allow custom implementations of resource detectors.

### DIFF
--- a/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -104,6 +104,8 @@ OpenTelemetry.ReadOnlyTagCollection.Enumerator.Enumerator() -> void
 OpenTelemetry.ReadOnlyTagCollection.Enumerator.MoveNext() -> bool
 OpenTelemetry.ReadOnlyTagCollection.GetEnumerator() -> OpenTelemetry.ReadOnlyTagCollection.Enumerator
 OpenTelemetry.ReadOnlyTagCollection.ReadOnlyTagCollection() -> void
+OpenTelemetry.Resources.IResourceDetector
+OpenTelemetry.Resources.IResourceDetector.Detect() -> OpenTelemetry.Resources.Resource
 OpenTelemetry.Trace.BatchExportActivityProcessorOptions
 OpenTelemetry.Trace.BatchExportActivityProcessorOptions.BatchExportActivityProcessorOptions() -> void
 override OpenTelemetry.BaseExportProcessor<T>.OnForceFlush(int timeoutMilliseconds) -> bool

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -104,6 +104,8 @@ OpenTelemetry.ReadOnlyTagCollection.Enumerator.Enumerator() -> void
 OpenTelemetry.ReadOnlyTagCollection.Enumerator.MoveNext() -> bool
 OpenTelemetry.ReadOnlyTagCollection.GetEnumerator() -> OpenTelemetry.ReadOnlyTagCollection.Enumerator
 OpenTelemetry.ReadOnlyTagCollection.ReadOnlyTagCollection() -> void
+OpenTelemetry.Resources.IResourceDetector
+OpenTelemetry.Resources.IResourceDetector.Detect() -> OpenTelemetry.Resources.Resource
 OpenTelemetry.Trace.BatchExportActivityProcessorOptions
 OpenTelemetry.Trace.BatchExportActivityProcessorOptions.BatchExportActivityProcessorOptions() -> void
 override OpenTelemetry.BaseExportProcessor<T>.OnForceFlush(int timeoutMilliseconds) -> bool

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Make `IResourceDetector` public to allow custom implementations of resource detectors.
+  ([2897](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2897))
+
 ## 1.2.0-rc2
 
 Released 2022-Feb-02

--- a/src/OpenTelemetry/Resources/IResourceDetector.cs
+++ b/src/OpenTelemetry/Resources/IResourceDetector.cs
@@ -19,7 +19,7 @@ namespace OpenTelemetry.Resources
     /// <summary>
     /// An interface for Resource detectors.
     /// </summary>
-    internal interface IResourceDetector
+    public interface IResourceDetector
     {
         /// <summary>
         /// Called to get a resource with attributes from detector.


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-dotnet/issues/2752.

## Changes

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
