### PR TITLE
Invoke SDK initialization when using OpenTelemetry.Extensions.Hosting

### DIFF
--- a/examples/MicroserviceExample/Utils/Messaging/MessageReceiver.cs
+++ b/examples/MicroserviceExample/Utils/Messaging/MessageReceiver.cs
@@ -31,7 +31,7 @@ namespace Utils.Messaging
     public class MessageReceiver : IDisposable
     {
         private static readonly ActivitySource ActivitySource = new ActivitySource(nameof(MessageReceiver));
-        private static readonly TextMapPropagator Propagator = new TraceContextPropagator();
+        private static readonly TextMapPropagator Propagator = Propagators.DefaultTextMapPropagator;
 
         private readonly ILogger<MessageReceiver> logger;
         private readonly IConnection connection;

--- a/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+* Fixes an issue where the initialization of some aspects of the SDK can be
+  delayed when using the `AddOpenTelemetryTracing` and
+  `AddOpenTelemetryMetrics` methods. Namely, self-diagnostics and the default
+  context propagator responsible for propagating trace context and baggage.
+  ([#2901](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2901))
+
 ## 1.0.0-rc9
 
 Released 2022-Feb-02

--- a/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryServicesExtensions.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryServicesExtensions.cs
@@ -18,6 +18,7 @@ using System;
 using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using OpenTelemetry;
 using OpenTelemetry.Extensions.Hosting.Implementation;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Metrics;
@@ -91,6 +92,10 @@ namespace Microsoft.Extensions.DependencyInjection
             Guard.ThrowIfNull(services, nameof(services));
             Guard.ThrowIfNull(createTracerProvider, nameof(createTracerProvider));
 
+            // Accessing Sdk class is just to trigger its static ctor,
+            // which sets default Propagators and default Activity Id format
+            _ = Sdk.SuppressInstrumentation;
+
             try
             {
                 services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, TelemetryHostedService>());
@@ -114,6 +119,10 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             Debug.Assert(services != null, $"{nameof(services)} must not be null");
             Debug.Assert(createMeterProvider != null, $"{nameof(createMeterProvider)} must not be null");
+
+            // Accessing Sdk class is just to trigger its static ctor,
+            // which sets default Propagators and default Activity Id format
+            _ = Sdk.SuppressInstrumentation;
 
             try
             {


### PR DESCRIPTION
Fixes #2898

Using the microservice example to demonstrate that the SDK does not get initialized when expected.

The the static constructor on `OpenTelemtry.Sdk` does not get invoked until after the first message is sent and received in the microservice example:

https://github.com/open-telemetry/opentelemetry-dotnet/blob/aca7efc0f465786c0c307dae864a703a897a517f/src/OpenTelemetry/Sdk.cs#L30-L36

@utpilla 