### PR TITLE
Minor test namespace adjustment

### DIFF
--- a/test/OpenTelemetry.Tests/Context/PropagatorsTest.cs
+++ b/test/OpenTelemetry.Tests/Context/PropagatorsTest.cs
@@ -15,11 +15,9 @@
 // </copyright>
 
 using System;
-using OpenTelemetry.Context.Propagation;
-using OpenTelemetry.Context.Propagation.Tests;
 using Xunit;
 
-namespace OpenTelemetry.Context.Tests
+namespace OpenTelemetry.Context.Propagation.Tests
 {
     public class PropagatorsTest : IDisposable
     {

--- a/test/OpenTelemetry.Tests/Internal/GuardTest.cs
+++ b/test/OpenTelemetry.Tests/Internal/GuardTest.cs
@@ -16,10 +16,9 @@
 
 using System;
 using System.Threading;
-using OpenTelemetry.Internal;
 using Xunit;
 
-namespace OpenTelemetry.Tests.Internal
+namespace OpenTelemetry.Internal.Tests
 {
     public class GuardTest
     {


### PR DESCRIPTION
Less cluttered Test Explorer :)

![image](https://user-images.githubusercontent.com/5232798/154183835-4890bef2-75b6-4d65-83ed-6ca90706fd9b.png)
Could use some more refactors to make it cleaner. Like moving Instrumentation.Tests elsewhere?