### PR TITLE
fix: http 400 status is not error on server

### DIFF
--- a/src/OpenTelemetry.Api/Internal/SpanHelper.cs
+++ b/src/OpenTelemetry.Api/Internal/SpanHelper.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+using System.Diagnostics;
+
 namespace OpenTelemetry.Trace
 {
     /// <summary>
@@ -25,11 +27,13 @@ namespace OpenTelemetry.Trace
         /// Helper method that populates span properties from http status code according
         /// to https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#status.
         /// </summary>
+        /// <param name="kind">The span kind.</param>
         /// <param name="httpStatusCode">Http status code.</param>
         /// <returns>Resolved span <see cref="Status"/> for the Http status code.</returns>
-        public static Status ResolveSpanStatusForHttpStatusCode(int httpStatusCode)
+        public static Status ResolveSpanStatusForHttpStatusCode(ActivityKind kind, int httpStatusCode)
         {
-            if (httpStatusCode >= 100 && httpStatusCode <= 399)
+            var upperBound = kind == ActivityKind.Client ? 399 : 499;
+            if (httpStatusCode >= 100 && httpStatusCode <= upperBound)
             {
                 return Status.Unset;
             }

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+* Fix: Http server span status is now unset for `400`-`499`.
+  ([#2904](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2904))
+
 ## Unreleased
 
 ## 1.0.0-rc9

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInListener.cs
@@ -135,7 +135,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
 
                 if (activity.GetStatus().StatusCode == StatusCode.Unset)
                 {
-                    activity.SetStatus(SpanHelper.ResolveSpanStatusForHttpStatusCode(response.StatusCode));
+                    activity.SetStatus(SpanHelper.ResolveSpanStatusForHttpStatusCode(activity.Kind, response.StatusCode));
                 }
 
                 var routeData = context.Request.RequestContext.RouteData;

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+* Fix: Http server span status is now unset for `400`-`499`.
+  ([#2789](https://github.com/open-telemetry/opentelemetry-js/pull/2789/files))
+
 ## Unreleased
 
 ## 1.0.0-rc9

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 * Fix: Http server span status is now unset for `400`-`499`.
-  ([#2789](https://github.com/open-telemetry/opentelemetry-js/pull/2789/files))
+  ([#2904](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2904))
 
 ## Unreleased
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -196,12 +196,12 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
                 }
                 else if (activity.GetStatus().StatusCode == StatusCode.Unset)
                 {
-                    activity.SetStatus(SpanHelper.ResolveSpanStatusForHttpStatusCode(response.StatusCode));
+                    activity.SetStatus(SpanHelper.ResolveSpanStatusForHttpStatusCode(activity.Kind, response.StatusCode));
                 }
 #else
                 if (activity.GetStatus().StatusCode == StatusCode.Unset)
                 {
-                    activity.SetStatus(SpanHelper.ResolveSpanStatusForHttpStatusCode(response.StatusCode));
+                    activity.SetStatus(SpanHelper.ResolveSpanStatusForHttpStatusCode(activity.Kind, response.StatusCode));
                 }
 #endif
 

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -183,7 +183,7 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
 
                     if (currentStatusCode == StatusCode.Unset)
                     {
-                        activity.SetStatus(SpanHelper.ResolveSpanStatusForHttpStatusCode((int)response.StatusCode));
+                        activity.SetStatus(SpanHelper.ResolveSpanStatusForHttpStatusCode(activity.Kind, (int)response.StatusCode));
                     }
 
                     try

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
@@ -122,7 +122,7 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
             {
                 activity.SetTag(SemanticConventions.AttributeHttpStatusCode, (int)response.StatusCode);
 
-                activity.SetStatus(SpanHelper.ResolveSpanStatusForHttpStatusCode((int)response.StatusCode));
+                activity.SetStatus(SpanHelper.ResolveSpanStatusForHttpStatusCode(activity.Kind, (int)response.StatusCode));
 
                 try
                 {
@@ -150,7 +150,7 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
                 {
                     activity.SetTag(SemanticConventions.AttributeHttpStatusCode, (int)response.StatusCode);
 
-                    status = SpanHelper.ResolveSpanStatusForHttpStatusCode((int)response.StatusCode);
+                    status = SpanHelper.ResolveSpanStatusForHttpStatusCode(activity.Kind, (int)response.StatusCode);
                 }
                 else
                 {


### PR DESCRIPTION
The specification here https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#status.

Says:
> For HTTP status codes in the 4xx range span status MUST be left unset in case of SpanKind.SERVER and MUST be set to Error in case of SpanKind.CLIENT

## Changes

For significant contributions please make sure you have completed the following items: