### PR TITLE
Update OTEL_EXPORTER_JAEGER_PROTOCOL parsing

### DIFF
--- a/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Change supported values for `OTEL_EXPORTER_JAEGER_PROTOCOL`
+  Supported values: `udp/thrift.compact` and `http/thrift.binary` defined
+  in the [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/9a0a3300c6269c2837a1d7c9c5232ec816f63222/specification/sdk-environment-variables.md?plain=1#L129).
+  ([#2914](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2914))
+
 ## 1.2.0-rc2
 
 Released 2022-Feb-02

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptions.cs
@@ -35,7 +35,7 @@ namespace OpenTelemetry.Exporter
     {
         internal const int DefaultMaxPayloadSizeInBytes = 4096;
 
-        internal const string OtelProtocolEnvVarKey = "OTEL_EXPORTER_JAEGER_PROTOCOL";
+        internal const string OTelProtocolEnvVarKey = "OTEL_EXPORTER_JAEGER_PROTOCOL";
         internal const string OTelAgentHostEnvVarKey = "OTEL_EXPORTER_JAEGER_AGENT_HOST";
         internal const string OTelAgentPortEnvVarKey = "OTEL_EXPORTER_JAEGER_AGENT_PORT";
         internal const string OTelEndpointEnvVarKey = "OTEL_EXPORTER_JAEGER_ENDPOINT";
@@ -44,7 +44,7 @@ namespace OpenTelemetry.Exporter
 
         public JaegerExporterOptions()
         {
-            if (EnvironmentVariableHelper.LoadString(OtelProtocolEnvVarKey, out string protocolEnvVar)
+            if (EnvironmentVariableHelper.LoadString(OTelProtocolEnvVarKey, out string protocolEnvVar)
                 && Enum.TryParse(protocolEnvVar, ignoreCase: true, out JaegerExportProtocol protocol))
             {
                 this.Protocol = protocol;

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptions.cs
@@ -44,10 +44,18 @@ namespace OpenTelemetry.Exporter
 
         public JaegerExporterOptions()
         {
-            if (EnvironmentVariableHelper.LoadString(OTelProtocolEnvVarKey, out string protocolEnvVar)
-                && Enum.TryParse(protocolEnvVar, ignoreCase: true, out JaegerExportProtocol protocol))
+            if (EnvironmentVariableHelper.LoadString(OTelProtocolEnvVarKey, out string protocolEnvVar))
             {
-                this.Protocol = protocol;
+                var protocol = protocolEnvVar.ToJaegerExportProtocol();
+
+                if (protocol.HasValue)
+                {
+                    this.Protocol = protocol.Value;
+                }
+                else
+                {
+                    throw new FormatException($"{OTelProtocolEnvVarKey} environment variable has an invalid value: '{protocolEnvVar}'");
+                }
             }
 
             if (EnvironmentVariableHelper.LoadString(OTelAgentHostEnvVarKey, out string agentHostEnvVar))

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptionsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptionsExtensions.cs
@@ -19,7 +19,7 @@ namespace OpenTelemetry.Exporter;
 internal static class JaegerExporterOptionsExtensions
 {
     public static JaegerExportProtocol? ToJaegerExportProtocol(this string protocol) =>
-        protocol.Trim() switch
+        protocol?.Trim() switch
         {
             "udp/thrift.compact" => JaegerExportProtocol.UdpCompactThrift,
             "http/thrift.binary" => JaegerExportProtocol.HttpBinaryThrift,

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptionsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptionsExtensions.cs
@@ -1,0 +1,28 @@
+// <copyright file="JaegerExporterOptionsExtensions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Exporter;
+
+internal static class JaegerExporterOptionsExtensions
+{
+    public static JaegerExportProtocol? ToJaegerExportProtocol(this string protocol) =>
+        protocol.Trim() switch
+        {
+            "udp/thrift.compact" => JaegerExportProtocol.UdpCompactThrift,
+            "http/thrift.binary" => JaegerExportProtocol.HttpBinaryThrift,
+            _ => null,
+        };
+}

--- a/src/OpenTelemetry.Exporter.Jaeger/README.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/README.md
@@ -66,8 +66,8 @@ properties:
 
   | Protocol       | Description                                           |
   |----------------|-------------------------------------------------------|
-  |UdpCompactThrift| Apache Thrift compact over UDP to a Jaeger Agent.     |
-  |HttpBinaryThrift| Apache Thrift binary over HTTP to a Jaeger Collector. |
+  |`udp/thrift.compact`| Apache Thrift compact over UDP to a Jaeger Agent.     |
+  |`http/thrift.binary`| Apache Thrift binary over HTTP to a Jaeger Collector. |
 
 See the [`TestJaegerExporter.cs`](../../examples/Console/TestJaegerExporter.cs)
 for an example of how to use the exporter.

--- a/src/OpenTelemetry.Exporter.Jaeger/README.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/README.md
@@ -78,12 +78,14 @@ The following environment variables can be used to override the default
 values of the `JaegerExporterOptions`
 (following the [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#jaeger-exporter)).
 
-| Environment variable               | `JaegerExporterOptions` property                         |
-| ---------------------------------- | -------------------------------------------------------- |
-| `OTEL_EXPORTER_JAEGER_AGENT_HOST`  | `AgentHost`                                              |
-| `OTEL_EXPORTER_JAEGER_AGENT_PORT`  | `AgentPort`                                              |
-| `OTEL_EXPORTER_JAEGER_ENDPOINT`    | `Endpoint`                                               |
-| `OTEL_EXPORTER_JAEGER_PROTOCOL`    | `Protocol` (`udp/thrift.compact` or `http/thrift.binary`)|
+  <!-- markdownlint-disable MD013 -->
+| Environment variable              | `JaegerExporterOptions` property                          |
+|-----------------------------------|-----------------------------------------------------------|
+| `OTEL_EXPORTER_JAEGER_AGENT_HOST` | `AgentHost`                                               |
+| `OTEL_EXPORTER_JAEGER_AGENT_PORT` | `AgentPort`                                               |
+| `OTEL_EXPORTER_JAEGER_ENDPOINT`   | `Endpoint`                                                |
+| `OTEL_EXPORTER_JAEGER_PROTOCOL`   | `Protocol` (`udp/thrift.compact` or `http/thrift.binary`) |
+  <!-- markdownlint-enable MD013 -->
 
 `FormatException` is thrown in case of an invalid value for any of the
 supported environment variables.

--- a/src/OpenTelemetry.Exporter.Jaeger/README.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/README.md
@@ -64,10 +64,10 @@ properties:
 
 * `Protocol`: The protocol to use. The default value is `UdpCompactThrift`.
 
-  | Protocol       | Description                                           |
-  |----------------|-------------------------------------------------------|
-  |`udp/thrift.compact`| Apache Thrift compact over UDP to a Jaeger Agent.     |
-  |`http/thrift.binary`| Apache Thrift binary over HTTP to a Jaeger Collector. |
+  | Protocol         | Description                                           |
+  |------------------|-------------------------------------------------------|
+  |`UdpCompactThrift`| Apache Thrift compact over UDP to a Jaeger Agent.     |
+  |`HttpBinaryThrift`| Apache Thrift binary over HTTP to a Jaeger Collector. |
 
 See the [`TestJaegerExporter.cs`](../../examples/Console/TestJaegerExporter.cs)
 for an example of how to use the exporter.
@@ -75,14 +75,15 @@ for an example of how to use the exporter.
 ## Environment Variables
 
 The following environment variables can be used to override the default
-values of the `JaegerExporterOptions`.
+values of the `JaegerExporterOptions`
+(following the [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#jaeger-exporter)).
 
-| Environment variable               | `JaegerExporterOptions` property |
-| ---------------------------------- | -------------------------------- |
-| `OTEL_EXPORTER_JAEGER_AGENT_HOST`  | `AgentHost`                      |
-| `OTEL_EXPORTER_JAEGER_AGENT_PORT`  | `AgentPort`                      |
-| `OTEL_EXPORTER_JAEGER_ENDPOINT`    | `Endpoint`                       |
-| `OTEL_EXPORTER_JAEGER_PROTOCOL`    | `Protocol`                       |
+| Environment variable               | `JaegerExporterOptions` property                         |
+| ---------------------------------- | -------------------------------------------------------- |
+| `OTEL_EXPORTER_JAEGER_AGENT_HOST`  | `AgentHost`                                              |
+| `OTEL_EXPORTER_JAEGER_AGENT_PORT`  | `AgentPort`                                              |
+| `OTEL_EXPORTER_JAEGER_ENDPOINT`    | `Endpoint`                                               |
+| `OTEL_EXPORTER_JAEGER_PROTOCOL`    | `Protocol` (`udp/thrift.compact` or `http/thrift.binary`)|
 
 `FormatException` is thrown in case of an invalid value for any of the
 supported environment variables.

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -79,7 +79,7 @@ namespace OpenTelemetry.Exporter
                 }
                 else
                 {
-                    throw new FormatException($"{ProtocolEnvVarName} environment variable has an invalid value: '${protocolEnvVar}'");
+                    throw new FormatException($"{ProtocolEnvVarName} environment variable has an invalid value: '{protocolEnvVar}'");
                 }
             }
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
@@ -56,12 +56,12 @@ The following environment variables can be used to override the default
 values of the `OtlpExporterOptions`
 (following the [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md)).
 
-| Environment variable          | `OtlpExporterOptions` property    |
-| ------------------------------| ----------------------------------|
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | `Endpoint`                        |
-| `OTEL_EXPORTER_OTLP_HEADERS`  | `Headers`                         |
-| `OTEL_EXPORTER_OTLP_TIMEOUT`  | `TimeoutMilliseconds`             |
-| `OTEL_EXPORTER_OTLP_PROTOCOL` | `Protocol` (grpc or http/protobuf)|
+| Environment variable          | `OtlpExporterOptions` property        |
+| ------------------------------| --------------------------------------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `Endpoint`                            |
+| `OTEL_EXPORTER_OTLP_HEADERS`  | `Headers`                             |
+| `OTEL_EXPORTER_OTLP_TIMEOUT`  | `TimeoutMilliseconds`                 |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `Protocol` (`grpc` or `http/protobuf`)|
 
 `FormatException` is thrown in case of an invalid value for any of the
 supported environment variables.

--- a/src/OpenTelemetry/Internal/EnvironmentVariableHelper.cs
+++ b/src/OpenTelemetry/Internal/EnvironmentVariableHelper.cs
@@ -78,7 +78,7 @@ namespace OpenTelemetry.Internal
 
             if (!int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out result))
             {
-                throw new FormatException($"{envVarKey} environment variable has an invalid value: '${value}'");
+                throw new FormatException($"{envVarKey} environment variable has an invalid value: '{value}'");
             }
 
             return true;

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterOptionsExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterOptionsExtensionsTests.cs
@@ -1,0 +1,33 @@
+// <copyright file="JaegerExporterOptionsExtensionsTests.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using Xunit;
+
+namespace OpenTelemetry.Exporter.Jaeger.Tests;
+
+public class JaegerExporterOptionsExtensionsTests
+{
+    [Theory]
+    [InlineData("udp/thrift.compact", JaegerExportProtocol.UdpCompactThrift)]
+    [InlineData("http/thrift.binary", JaegerExportProtocol.HttpBinaryThrift)]
+    [InlineData("unsupported", null)]
+    public void ToJaegerExportProtocol_Protocol_MapsToCorrectValue(string protocol, JaegerExportProtocol? expectedExportProtocol)
+    {
+        var exportProtocol = protocol.ToJaegerExportProtocol();
+
+        Assert.Equal(expectedExportProtocol, exportProtocol);
+    }
+}

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterOptionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterOptionsTests.cs
@@ -23,12 +23,12 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests
     {
         public JaegerExporterOptionsTests()
         {
-            this.ClearEnvVars();
+            ClearEnvVars();
         }
 
         public void Dispose()
         {
-            this.ClearEnvVars();
+            ClearEnvVars();
         }
 
         [Fact]
@@ -84,10 +84,11 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests
             Assert.Equal("OTEL_EXPORTER_JAEGER_ENDPOINT", JaegerExporterOptions.OTelEndpointEnvVarKey);
         }
 
-        private void ClearEnvVars()
+        private static void ClearEnvVars()
         {
             Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelAgentHostEnvVarKey, null);
             Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelAgentPortEnvVarKey, null);
+            Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelProtocolEnvVarKey, null);
         }
     }
 }

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterOptionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterOptionsTests.cs
@@ -40,6 +40,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests
             Assert.Equal(6831, options.AgentPort);
             Assert.Equal(4096, options.MaxPayloadSizeInBytes);
             Assert.Equal(ExportProcessorType.Batch, options.ExportProcessorType);
+            Assert.Equal(JaegerExportProtocol.UdpCompactThrift, options.Protocol);
         }
 
         [Fact]

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterOptionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterOptionsTests.cs
@@ -78,8 +78,10 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests
         [Fact]
         public void JaegerExporterOptions_EnvironmentVariableNames()
         {
+            Assert.Equal("OTEL_EXPORTER_JAEGER_PROTOCOL", JaegerExporterOptions.OTelProtocolEnvVarKey);
             Assert.Equal("OTEL_EXPORTER_JAEGER_AGENT_HOST", JaegerExporterOptions.OTelAgentHostEnvVarKey);
             Assert.Equal("OTEL_EXPORTER_JAEGER_AGENT_PORT", JaegerExporterOptions.OTelAgentPortEnvVarKey);
+            Assert.Equal("OTEL_EXPORTER_JAEGER_ENDPOINT", JaegerExporterOptions.OTelEndpointEnvVarKey);
         }
 
         private void ClearEnvVars()

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterOptionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterOptionsTests.cs
@@ -48,17 +48,21 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests
         {
             Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelAgentHostEnvVarKey, "jeager-host");
             Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelAgentPortEnvVarKey, "123");
+            Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelProtocolEnvVarKey, "http/thrift.binary");
 
             var options = new JaegerExporterOptions();
 
             Assert.Equal("jeager-host", options.AgentHost);
             Assert.Equal(123, options.AgentPort);
+            Assert.Equal(JaegerExportProtocol.HttpBinaryThrift, options.Protocol);
         }
 
-        [Fact]
-        public void JaegerExporterOptions_InvalidPortEnvironmentVariableOverride()
+        [Theory]
+        [InlineData(JaegerExporterOptions.OTelAgentPortEnvVarKey)]
+        [InlineData(JaegerExporterOptions.OTelProtocolEnvVarKey)]
+        public void JaegerExporterOptions_InvalidEnvironmentVariableOverride(string envVar)
         {
-            Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelAgentPortEnvVarKey, "invalid");
+            Environment.SetEnvironmentVariable(envVar, "invalid");
 
             Assert.Throws<FormatException>(() => new JaegerExporterOptions());
         }

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterOptionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterOptionsTests.cs
@@ -41,6 +41,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests
             Assert.Equal(4096, options.MaxPayloadSizeInBytes);
             Assert.Equal(ExportProcessorType.Batch, options.ExportProcessorType);
             Assert.Equal(JaegerExportProtocol.UdpCompactThrift, options.Protocol);
+            Assert.Equal(new Uri("http://localhost:14268"), options.Endpoint);
         }
 
         [Fact]
@@ -49,12 +50,14 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests
             Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelAgentHostEnvVarKey, "jeager-host");
             Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelAgentPortEnvVarKey, "123");
             Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelProtocolEnvVarKey, "http/thrift.binary");
+            Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelEndpointEnvVarKey, "http://custom-endpoint:12345");
 
             var options = new JaegerExporterOptions();
 
             Assert.Equal("jeager-host", options.AgentHost);
             Assert.Equal(123, options.AgentPort);
             Assert.Equal(JaegerExportProtocol.HttpBinaryThrift, options.Protocol);
+            Assert.Equal(new Uri("http://custom-endpoint:12345"), options.Endpoint);
         }
 
         [Theory]
@@ -91,9 +94,10 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests
 
         private static void ClearEnvVars()
         {
+            Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelProtocolEnvVarKey, null);
             Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelAgentHostEnvVarKey, null);
             Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelAgentPortEnvVarKey, null);
-            Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelProtocolEnvVarKey, null);
+            Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelEndpointEnvVarKey, null);
         }
     }
 }


### PR DESCRIPTION
Fixes #2910.

## Changes

Align the `OTEL_EXPORTER_JAEGER_PROTOCOL` parsing with the [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#jaeger-exporter)

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes

