### PR TITLE
Bumped grpc and protobuf packages

### DIFF
--- a/build/Common.nonprod.props
+++ b/build/Common.nonprod.props
@@ -27,10 +27,10 @@
     <BenchmarkDotNetPkgVer>[0.13.1,0.14)</BenchmarkDotNetPkgVer>
     <CommandLineParserPkgVer>[2.3.0,3.0)</CommandLineParserPkgVer>
     <DotNetXUnitCliVer>[2.3.1,3.0)</DotNetXUnitCliVer>
-    <GoogleProtobufPkgVer>[3.15.5,4.0)</GoogleProtobufPkgVer>
-    <GrpcAspNetCorePkgVer>[2.27.0,3.0)</GrpcAspNetCorePkgVer>
-    <GrpcAspNetCoreServerPkgVer>[2.30.0, 3.0)</GrpcAspNetCoreServerPkgVer>
-    <GrpcToolsPkgVer>[2.25.0,3.0)</GrpcToolsPkgVer>
+    <GoogleProtobufPkgVer>[3.19.4,4.0)</GoogleProtobufPkgVer>
+    <GrpcAspNetCorePkgVer>[2.43.0,3.0)</GrpcAspNetCorePkgVer>
+    <GrpcAspNetCoreServerPkgVer>[2.43.0, 3.0)</GrpcAspNetCoreServerPkgVer>
+    <GrpcToolsPkgVer>[2.44.0,3.0)</GrpcToolsPkgVer>
     <MicrosoftAspNetMvcPkgVer>[5.2.7,6.0)</MicrosoftAspNetMvcPkgVer>
     <MicrosoftAspNetWebApiWebHostPkgVer>[5.2.7,6.0)</MicrosoftAspNetWebApiWebHostPkgVer>
     <MicrosoftAspNetWebPagesPkgVer>[3.2.7,4.0)</MicrosoftAspNetWebPagesPkgVer>

--- a/build/Common.props
+++ b/build/Common.props
@@ -23,10 +23,10 @@
       Refer to https://docs.microsoft.com/nuget/concepts/package-versioning for semver syntax.
     -->
     <MinVerPkgVer>[2.3.0,3.0)</MinVerPkgVer>
-    <GoogleProtobufPkgVer>[3.15.5,4.0)</GoogleProtobufPkgVer>
-    <GrpcPkgVer>[2.23.0,3.0)</GrpcPkgVer>
-    <GrpcNetClientPkgVer>[2.32.0,3.0)</GrpcNetClientPkgVer>
-    <GrpcToolsPkgVer>[2.25.0,3.0)</GrpcToolsPkgVer>
+    <GoogleProtobufPkgVer>[3.19.4,4.0)</GoogleProtobufPkgVer>
+    <GrpcPkgVer>[2.44.0,3.0)</GrpcPkgVer>
+    <GrpcNetClientPkgVer>[2.43.0,3.0)</GrpcNetClientPkgVer>
+    <GrpcToolsPkgVer>[2.44.0,3.0)</GrpcToolsPkgVer>
     <MicrosoftAspNetCoreHttpAbstractionsPkgVer>[2.1.1,6.0)</MicrosoftAspNetCoreHttpAbstractionsPkgVer>
     <MicrosoftAspNetCoreHttpFeaturesPkgVer>[2.1.1,6.0)</MicrosoftAspNetCoreHttpFeaturesPkgVer>
     <MicrosoftCodeAnalysisAnalyzersPkgVer>[3.3.1]</MicrosoftCodeAnalysisAnalyzersPkgVer>


### PR DESCRIPTION
Fixes #2962

## Changes

Updated `Google.Protobuf`, `Grpc.AspNetCore`, `Grpc.AspNetCore.Server`, `Grpc.Tools`, `Grpc`, and `Grpc.Net.Client` package versions to latest versions

Tested by building and running unit tests.