### PR TITLE
Appending "=" to "Service.Name" in Console.MetricExporter

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -41,7 +41,7 @@ namespace OpenTelemetry.Exporter
                     {
                         if (resourceAttribute.Key.Equals("service.name"))
                         {
-                            this.WriteLine("Service.Name" + resourceAttribute.Value);
+                            this.WriteLine("Service.Name=" + resourceAttribute.Value);
                         }
                     }
                 }


### PR DESCRIPTION
## Changes

> Currently the ConsoleMetricExporter prints the service name out in the following format:
> Service.NameMY_SERVICE_NAME, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
> Appending "=" when printing out the "Service.Name" key to match the other properties printed out in that line:
> Service.Name=MY_SERVICE_NAME, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
> This is a single line change and should have no impact on any other existing code.

Lifted from @greaterthanmost 's PR https://github.com/open-telemetry/opentelemetry-dotnet/pull/2889 that was closed due to staleness after having issues with the EasyCLA
