### PR TITLE
Set PrometheusExporterMiddleware as public.

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus/.publicApi/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Prometheus/.publicApi/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -3,6 +3,8 @@ OpenTelemetry.Exporter.PrometheusExporter
 OpenTelemetry.Exporter.PrometheusExporter.Collect.get -> System.Func<int, bool>
 OpenTelemetry.Exporter.PrometheusExporter.Collect.set -> void
 OpenTelemetry.Exporter.PrometheusExporter.PrometheusExporter(OpenTelemetry.Exporter.PrometheusExporterOptions options) -> void
+OpenTelemetry.Exporter.PrometheusExporterMiddleware
+OpenTelemetry.Exporter.PrometheusExporterMiddleware.InvokeAsync(HttpContext httpContext) -> System.Threading.Tasks.Task
 OpenTelemetry.Exporter.PrometheusExporterOptions
 OpenTelemetry.Exporter.PrometheusExporterOptions.HttpListenerPrefixes.get -> System.Collections.Generic.IReadOnlyCollection<string>
 OpenTelemetry.Exporter.PrometheusExporterOptions.HttpListenerPrefixes.set -> void

--- a/src/OpenTelemetry.Exporter.Prometheus/.publicApi/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Prometheus/.publicApi/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -4,7 +4,8 @@ OpenTelemetry.Exporter.PrometheusExporter.Collect.get -> System.Func<int, bool>
 OpenTelemetry.Exporter.PrometheusExporter.Collect.set -> void
 OpenTelemetry.Exporter.PrometheusExporter.PrometheusExporter(OpenTelemetry.Exporter.PrometheusExporterOptions options) -> void
 OpenTelemetry.Exporter.PrometheusExporterMiddleware
-OpenTelemetry.Exporter.PrometheusExporterMiddleware.InvokeAsync(HttpContext httpContext) -> System.Threading.Tasks.Task
+OpenTelemetry.Exporter.PrometheusExporterMiddleware.InvokeAsync(Microsoft.AspNetCore.Http.HttpContext httpContext) -> System.Threading.Tasks.Task
+OpenTelemetry.Exporter.PrometheusExporterMiddleware.PrometheusExporterMiddleware(OpenTelemetry.Metrics.MeterProvider meterProvider, Microsoft.AspNetCore.Http.RequestDelegate next) -> void
 OpenTelemetry.Exporter.PrometheusExporterOptions
 OpenTelemetry.Exporter.PrometheusExporterOptions.HttpListenerPrefixes.get -> System.Collections.Generic.IReadOnlyCollection<string>
 OpenTelemetry.Exporter.PrometheusExporterOptions.HttpListenerPrefixes.set -> void

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterApplicationBuilderExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterApplicationBuilderExtensions.cs
@@ -20,7 +20,6 @@ using System;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Exporter;
-using OpenTelemetry.Exporter.Prometheus;
 using OpenTelemetry.Metrics;
 
 namespace Microsoft.AspNetCore.Builder

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterMiddleware.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterMiddleware.cs
@@ -27,7 +27,7 @@ namespace OpenTelemetry.Exporter.Prometheus
     /// <summary>
     /// ASP.NET Core middleware for exposing a Prometheus metrics scraping endpoint.
     /// </summary>
-    internal sealed class PrometheusExporterMiddleware
+    public sealed class PrometheusExporterMiddleware
     {
         private readonly PrometheusExporter exporter;
 

--- a/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterMiddleware.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterMiddleware.cs
@@ -19,10 +19,11 @@ using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using OpenTelemetry.Exporter.Prometheus;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Metrics;
 
-namespace OpenTelemetry.Exporter.Prometheus
+namespace OpenTelemetry.Exporter
 {
     /// <summary>
     /// ASP.NET Core middleware for exposing a Prometheus metrics scraping endpoint.


### PR DESCRIPTION
Fixes #2776.

## Changes

Updated `PrometheusExporterMiddleware` to be public rather than internal.

## Notes

While [the current `UseOpenTelemetryPrometheusScrapingEndpoint`](https://github.com/open-telemetry/opentelemetry-dotnet/blob/778052f67f58b945be7c046bb57a8f3dc3be57c1/src/OpenTelemetry.Exporter.Prometheus/PrometheusExporterApplicationBuilderExtensions.cs#L43) allows configuration of the Prometheus middleware based on options, it doesn't allow for more flexible options or more tailored handling of the Prometheus endpoint.

My specific use case is that I need to do `app.MapWhen` and include not only _path_ but also _port_.  I can't use the standalone listener on that port because I have _other_ management things like health checks also exposed on that port; but I can't put the `/metrics` endpoint right on the main API listener port, either.

Other options I considered before going with making `PrometheusExporterMiddleware` public:

- **Add port to `PrometheusExporterOptions`**: This seemed like it'd be confusing given there were already `HttpListenerPrefixes` in there. 
- **Create another `UseOpenTelemetryPrometheusScrapingEndpoint` overload that takes a predicate**: Something where you can pass the `Func<HttpContext, bool>` that you pass to `app.MapWhen`. However, that would end up bypassing the `PrometheusExporterOptions` entirely because the predicate would control the whole mapping. It'd be up to the consumer to resolve the options and build the predicate. This didn't seem intuitive.

In the end it seemed like the one thing that would solve all the problems for advanced users while still maintaining the nice, easy `UseOpenTelemetryPrometheusScrapingEndpoint` mechanism was to make `PrometheusExporterMiddleware` public. Advanced users will know that they'll need to manage the `UseMiddleware<T>` and parameter setup; folks looking for the one-liner will still have that ability.

Since the middleware got switched to public I also moved it into the main folder of the OpenTelemetry.Exporter.Prometheus project since it appeared everything in the "Implementation" folder was internal.