### PR TITLE
Add AspNet metrics instrumentation

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNet/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.AspNet/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -6,5 +6,7 @@ OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions.Filter.get -> 
 OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions.Filter.set -> void
 OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions.RecordException.get -> bool
 OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions.RecordException.set -> void
+OpenTelemetry.Metrics.MeterProviderBuilderExtensions
 OpenTelemetry.Trace.TracerProviderBuilderExtensions
+static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Metrics.MeterProviderBuilder builder) -> OpenTelemetry.Metrics.MeterProviderBuilder
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddAspNetInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Instrumentation.AspNet.AspNetInstrumentationOptions> configureAspNetInstrumentationOptions = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Instrumentation.AspNet/AspNetMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/AspNetMetrics.cs
@@ -1,0 +1,53 @@
+// <copyright file="AspNetMetrics.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Diagnostics.Metrics;
+using System.Reflection;
+using OpenTelemetry.Instrumentation.AspNet.Implementation;
+
+namespace OpenTelemetry.Instrumentation.AspNet
+{
+    /// <summary>
+    /// Asp.Net Requests instrumentation.
+    /// </summary>
+    internal class AspNetMetrics : IDisposable
+    {
+        internal static readonly AssemblyName AssemblyName = typeof(HttpInMetricsListener).Assembly.GetName();
+        internal static readonly string InstrumentationName = AssemblyName.Name;
+        internal static readonly string InstrumentationVersion = AssemblyName.Version.ToString();
+
+        private readonly Meter meter;
+
+        private readonly HttpInMetricsListener httpInMetricsListener;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AspNetMetrics"/> class.
+        /// </summary>
+        public AspNetMetrics()
+        {
+            this.meter = new Meter(InstrumentationName, InstrumentationVersion);
+            this.httpInMetricsListener = new HttpInMetricsListener(this.meter);
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            this.meter?.Dispose();
+            this.httpInMetricsListener?.Dispose();
+        }
+    }
+}

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* Added ASP.NET metrics instrumentation to collect `http.server.duration`.
+  ([2985](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2985))
 * Fix: Http server span status is now unset for `400`-`499`.
   ([#2904](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2904))
 

--- a/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNet/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 * Added ASP.NET metrics instrumentation to collect `http.server.duration`.
-  ([2985](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2985))
+  ([#2985](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2985))
 * Fix: Http server span status is now unset for `400`-`499`.
   ([#2904](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2904))
 

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInMetricsListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInMetricsListener.cs
@@ -1,0 +1,55 @@
+// <copyright file="HttpInMetricsListener.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Web;
+using OpenTelemetry.Trace;
+
+namespace OpenTelemetry.Instrumentation.AspNet.Implementation
+{
+    internal sealed class HttpInMetricsListener : IDisposable
+    {
+        private Histogram<double> httpServerDuration;
+
+        public HttpInMetricsListener(Meter meter)
+        {
+            this.httpServerDuration = meter.CreateHistogram<double>("http.server.duration", "ms", "measures the duration of the inbound HTTP request");
+            TelemetryHttpModule.Options.OnRequestStoppedCallback += this.OnStopActivity;
+        }
+
+        public void Dispose()
+        {
+            TelemetryHttpModule.Options.OnRequestStoppedCallback -= this.OnStopActivity;
+        }
+
+        private void OnStopActivity(Activity activity, HttpContext context)
+        {
+            // TODO: This is just a minimal set of attributes. See the spec for additional attributes:
+            // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md#http-server
+            var tags = new KeyValuePair<string, object>[]
+            {
+                new KeyValuePair<string, object>(SemanticConventions.AttributeHttpMethod, context.Request.HttpMethod),
+                new KeyValuePair<string, object>(SemanticConventions.AttributeHttpMethod, context.Request.Url.Scheme),
+                new KeyValuePair<string, object>(SemanticConventions.AttributeHttpStatusCode, context.Response.StatusCode),
+            };
+
+            this.httpServerDuration.Record(activity.Duration.TotalMilliseconds, tags);
+        }
+    }
+}

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInMetricsListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/HttpInMetricsListener.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Web;
@@ -25,7 +24,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
 {
     internal sealed class HttpInMetricsListener : IDisposable
     {
-        private Histogram<double> httpServerDuration;
+        private readonly Histogram<double> httpServerDuration;
 
         public HttpInMetricsListener(Meter meter)
         {
@@ -42,11 +41,11 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
         {
             // TODO: This is just a minimal set of attributes. See the spec for additional attributes:
             // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md#http-server
-            var tags = new KeyValuePair<string, object>[]
+            var tags = new TagList
             {
-                new KeyValuePair<string, object>(SemanticConventions.AttributeHttpMethod, context.Request.HttpMethod),
-                new KeyValuePair<string, object>(SemanticConventions.AttributeHttpMethod, context.Request.Url.Scheme),
-                new KeyValuePair<string, object>(SemanticConventions.AttributeHttpStatusCode, context.Response.StatusCode),
+                { SemanticConventions.AttributeHttpMethod, context.Request.HttpMethod },
+                { SemanticConventions.AttributeHttpScheme, context.Request.Url.Scheme },
+                { SemanticConventions.AttributeHttpStatusCode, context.Response.StatusCode },
             };
 
             this.httpServerDuration.Record(activity.Duration.TotalMilliseconds, tags);

--- a/src/OpenTelemetry.Instrumentation.AspNet/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/MeterProviderBuilderExtensions.cs
@@ -1,0 +1,42 @@
+// <copyright file="MeterProviderBuilderExtensions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using OpenTelemetry.Instrumentation.AspNet;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Metrics
+{
+    /// <summary>
+    /// Extension methods to simplify registering of ASP.NET request instrumentation.
+    /// </summary>
+    public static class MeterProviderBuilderExtensions
+    {
+        /// <summary>
+        /// Enables the incoming requests automatic data collection for ASP.NET.
+        /// </summary>
+        /// <param name="builder"><see cref="MeterProviderBuilder"/> being configured.</param>
+        /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
+        public static MeterProviderBuilder AddAspNetInstrumentation(
+            this MeterProviderBuilder builder)
+        {
+            Guard.ThrowIfNull(builder);
+
+            var instrumentation = new AspNetMetrics();
+            builder.AddMeter(AspNetMetrics.InstrumentationName);
+            return builder.AddInstrumentation(() => instrumentation);
+        }
+    }
+}

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInMetricsListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInMetricsListenerTests.cs
@@ -77,6 +77,36 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
             Assert.Equal("http.server.duration", exportedItems[0].Name);
             Assert.Equal(1L, count);
             Assert.Equal(duration, sum);
+
+            Assert.Equal(3, metricPoints[0].Tags.Count);
+            string httpMethod = null;
+            int httpStatusCode = 0;
+            string httpScheme = null;
+
+            foreach (var tag in metricPoints[0].Tags)
+            {
+                if (tag.Key == SemanticConventions.AttributeHttpMethod)
+                {
+                    httpMethod = (string)tag.Value;
+                    continue;
+                }
+
+                if (tag.Key == SemanticConventions.AttributeHttpStatusCode)
+                {
+                    httpStatusCode = (int)tag.Value;
+                    continue;
+                }
+
+                if (tag.Key == SemanticConventions.AttributeHttpScheme)
+                {
+                    httpScheme = (string)tag.Value;
+                    continue;
+                }
+            }
+
+            Assert.Equal("GET", httpMethod);
+            Assert.Equal(200, httpStatusCode);
+            Assert.Equal("http", httpScheme);
         }
     }
 }

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInMetricsListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInMetricsListenerTests.cs
@@ -1,0 +1,74 @@
+// <copyright file="HttpInMetricsListenerTests.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Collections.Generic;
+using System.IO;
+using System.Web;
+using OpenTelemetry.Context.Propagation;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+using Xunit;
+
+namespace OpenTelemetry.Instrumentation.AspNet.Tests
+{
+    public class HttpInMetricsListenerTests
+    {
+        [Fact]
+        public void HttpDurationMetricIsEmitted()
+        {
+            string url = "http://localhost/api/value";
+            HttpContext.Current = new HttpContext(
+                new HttpRequest(string.Empty, url, string.Empty),
+                new HttpResponse(new StringWriter()));
+
+            // This is to enable activity creation
+            // as it is created using activitysource inside TelemetryHttpModule
+            // TODO: This should not be needed once the dependency on activity is removed from metrics
+            using var traceprovider = Sdk.CreateTracerProviderBuilder()
+                .AddAspNetInstrumentation()
+                .Build();
+
+            var exportedItems = new List<Metric>();
+            using var meterprovider = Sdk.CreateMeterProviderBuilder()
+                .AddAspNetInstrumentation()
+                .AddInMemoryExporter(exportedItems)
+                .Build();
+
+            var activity = ActivityHelper.StartAspNetActivity(Propagators.DefaultTextMapPropagator, HttpContext.Current, TelemetryHttpModule.Options.OnRequestStartedCallback);
+            ActivityHelper.StopAspNetActivity(Propagators.DefaultTextMapPropagator, activity, HttpContext.Current, TelemetryHttpModule.Options.OnRequestStoppedCallback);
+
+            meterprovider.ForceFlush();
+
+            var metricPoints = new List<MetricPoint>();
+            foreach (var p in exportedItems[0].GetMetricPoints())
+            {
+                metricPoints.Add(p);
+            }
+
+            Assert.Single(metricPoints);
+
+            var metricPoint = metricPoints[0];
+
+            var count = metricPoint.GetHistogramCount();
+            var sum = metricPoint.GetHistogramSum();
+
+            Assert.Equal(MetricType.Histogram, exportedItems[0].MetricType);
+            Assert.Equal("http.server.duration", exportedItems[0].Name);
+            Assert.Equal(1L, count);
+            Assert.True(sum > 0);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2556 

## Changes

This change enables `http.server.duration` metric collection noted in [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md#http-server) for ASP.NET applications. It relies on activity to calculate the duration however, we need to update this at a later stage to make it independent of trace/activity creation. Opened #2994 

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
