### PR TITLE
Modify example asp.net core app to config prometheus options

### DIFF
--- a/examples/AspNetCore/Startup.cs
+++ b/examples/AspNetCore/Startup.cs
@@ -147,6 +147,8 @@ namespace Examples.AspNetCore
                         break;
                 }
             });
+
+            services.Configure<PrometheusExporterOptions>(this.Configuration.GetSection("Prometheus"));
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)

--- a/examples/AspNetCore/appsettings.json
+++ b/examples/AspNetCore/appsettings.json
@@ -17,6 +17,9 @@
     "Endpoint": "http://localhost:14268",
     "Protocol": "UdpCompactThrift"
   },
+  "Prometheus": {
+    "ScrapeResponseCacheDurationMilliseconds": 5000
+  },
   "Zipkin": {
     "ServiceName": "zipkin-test",
     "Endpoint": "http://localhost:9411/api/v2/spans"

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterHttpServer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterHttpServer.cs
@@ -66,7 +66,7 @@ namespace OpenTelemetry.Exporter.Prometheus
         }
 
         /// <summary>
-        /// Start exporter.
+        /// Start Http Server.
         /// </summary>
         /// <param name="token">An optional <see cref="CancellationToken"/> that can be used to stop the HTTP server.</param>
         public void Start(CancellationToken token = default)


### PR DESCRIPTION
Modify the example to show how to configure prometheus, similar to Jaeger, Zipkin etc.