### PR TITLE
Add links to dotnet runtime repo in docs

### DIFF
--- a/docs/metrics/getting-started/README.md
+++ b/docs/metrics/getting-started/README.md
@@ -87,9 +87,9 @@ the configuration for metrics like `Meter` names, readers, etc. and is highly
 ## OpenTelemetry .NET special note
 
 Metrics in OpenTelemetry .NET is a somewhat unique implementation of the
-OpenTelemetry project, as most of the Metrics API are incorporated directly
-into the .NET runtime itself. From a high level, what this means is that you
-can instrument your application by simply depending on
+OpenTelemetry project, as most of the Metrics API are made part of the [.NET
+runtime](https://github.com/dotnet/runtime) itself. From a high level, what this
+means is that you can instrument your application by simply depending on
 `System.Diagnostics.DiagnosticSource` package.
 
 ## Learn more

--- a/docs/metrics/getting-started/README.md
+++ b/docs/metrics/getting-started/README.md
@@ -87,7 +87,9 @@ the configuration for metrics like `Meter` names, readers, etc. and is highly
 ## OpenTelemetry .NET special note
 
 Metrics in OpenTelemetry .NET is a somewhat unique implementation of the
-OpenTelemetry project, as most of the Metrics API are made part of the [.NET
+OpenTelemetry project, as most of the
+[Metrics API](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md)
+is implemented by the [.NET
 runtime](https://github.com/dotnet/runtime) itself. From a high level, what this
 means is that you can instrument your application by simply depending on
 `System.Diagnostics.DiagnosticSource` package.

--- a/docs/trace/getting-started/README.md
+++ b/docs/trace/getting-started/README.md
@@ -71,10 +71,12 @@ the configuration for tracing like samplers, processors, etc. and is highly
 If you tried the above program, you may have already noticed that the terms
 `ActivitySource` and `Activity` were used instead of `Tracer` and `Span` from
 OpenTelemetry specification. This results from the fact that, OpenTelemetry .NET
-is a somewhat unique implementation of the OpenTelemetry project, as parts of
-the tracing API are incorporated directly into the .NET runtime itself. From a
-high level, what this means is that the `Activity` and `ActivitySource` classes
-from .NET runtime represent the OpenTelemetry concepts of
+is a somewhat unique implementation of the OpenTelemetry project, as most of the
+tracing API are made part of the [.NET
+runtime](https://github.com/dotnet/runtime) itself. From a high level, what this
+means is that the `Activity` and `ActivitySource` classes from
+[DiagnosticSource](https://www.nuget.org/packages/system.diagnostics.diagnosticsource)
+package represent the OpenTelemetry concepts of
 [Span](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#span)
 and
 [Tracer](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#tracer)

--- a/docs/trace/getting-started/README.md
+++ b/docs/trace/getting-started/README.md
@@ -70,13 +70,15 @@ the configuration for tracing like samplers, processors, etc. and is highly
 
 If you tried the above program, you may have already noticed that the terms
 `ActivitySource` and `Activity` were used instead of `Tracer` and `Span` from
-OpenTelemetry specification. This results from the fact that, OpenTelemetry .NET
-is a somewhat unique implementation of the OpenTelemetry project, as most of the
-tracing API are made part of the [.NET
-runtime](https://github.com/dotnet/runtime) itself. From a high level, what this
-means is that the `Activity` and `ActivitySource` classes from
-[DiagnosticSource](https://www.nuget.org/packages/system.diagnostics.diagnosticsource)
-package represent the OpenTelemetry concepts of
+OpenTelemetry specification. This results from the fact that, Traces in
+OpenTelemetry .NET is a somewhat unique implementation of the OpenTelemetry
+project, as most of the [Trace
+API](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md)
+is implemented by the [.NET runtime](https://github.com/dotnet/runtime) itself.
+From a high level, what this means is that you can instrument your application
+by simply depending on `System.Diagnostics.DiagnosticSource` package, which
+provides `Activity` and `ActivitySource` classes representing the OpenTelemetry
+concepts of
 [Span](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#span)
 and
 [Tracer](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#tracer)


### PR DESCRIPTION
We could use some improvements to make the messaging more consistent across all signals as a future improvement. This PR is just adding links to the runtime repo.