### PR TITLE
Use the minimum version of dotnet in global json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "6.0.200"
+    "version": "6.0.100"
   }
 }


### PR DESCRIPTION
As rollforward is enabled, we'll work if user has any 6.0.*, so setting this to the **minimum** version.