### PR TITLE
Fix IDE0001: Name can be simplified.

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/ExporterClientValidation.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/ExporterClientValidation.cs
@@ -22,7 +22,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClie
     {
         internal static void EnsureUnencryptedSupportIsEnabled(OtlpExporterOptions options)
         {
-            var version = System.Environment.Version;
+            var version = Environment.Version;
 
             // This verification is only required for .NET Core 3.x
             if (version.Major != 3)

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTests.cs
@@ -45,7 +45,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
 
             var exporterOptions = new OtlpExporterOptions
             {
-                Endpoint = new System.Uri($"http://{CollectorHostname}{endpoint}"),
+                Endpoint = new Uri($"http://{CollectorHostname}{endpoint}"),
                 Protocol = protocol,
             };
 

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.client.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.client.cs
@@ -229,7 +229,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
                 using var source = new ActivitySource("test-source");
 
                 var propagator = new Mock<TextMapPropagator>();
-                propagator.Setup(m => m.Inject<HttpRequestMessage>(It.IsAny<PropagationContext>(), It.IsAny<HttpRequestMessage>(), It.IsAny<Action<HttpRequestMessage, string, string>>()))
+                propagator.Setup(m => m.Inject(It.IsAny<PropagationContext>(), It.IsAny<HttpRequestMessage>(), It.IsAny<Action<HttpRequestMessage, string, string>>()))
                     .Callback<PropagationContext, HttpRequestMessage, Action<HttpRequestMessage, string, string>>((context, message, action) =>
                     {
                         action(message, "customField", "customValue");
@@ -321,7 +321,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
 
                 bool isPropagatorCalled = false;
                 var propagator = new Mock<TextMapPropagator>();
-                propagator.Setup(m => m.Inject<HttpRequestMessage>(It.IsAny<PropagationContext>(), It.IsAny<HttpRequestMessage>(), It.IsAny<Action<HttpRequestMessage, string, string>>()))
+                propagator.Setup(m => m.Inject(It.IsAny<PropagationContext>(), It.IsAny<HttpRequestMessage>(), It.IsAny<Action<HttpRequestMessage, string, string>>()))
                     .Callback<PropagationContext, HttpRequestMessage, Action<HttpRequestMessage, string, string>>((context, message, action) =>
                     {
                         isPropagatorCalled = true;
@@ -383,7 +383,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
 
                 bool isPropagatorCalled = false;
                 var propagator = new Mock<TextMapPropagator>();
-                propagator.Setup(m => m.Inject<HttpRequestMessage>(It.IsAny<PropagationContext>(), It.IsAny<HttpRequestMessage>(), It.IsAny<Action<HttpRequestMessage, string, string>>()))
+                propagator.Setup(m => m.Inject(It.IsAny<PropagationContext>(), It.IsAny<HttpRequestMessage>(), It.IsAny<Action<HttpRequestMessage, string, string>>()))
                     .Callback<PropagationContext, HttpRequestMessage, Action<HttpRequestMessage, string, string>>((context, message, action) =>
                     {
                         isPropagatorCalled = true;

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.netcore31.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.netcore31.cs
@@ -18,10 +18,8 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
 using Moq;
-using OpenTelemetry.Context;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Instrumentation.Http.Implementation;
 using OpenTelemetry.Tests;
@@ -134,7 +132,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         public async Task HttpClientInstrumentationInjectsHeadersAsync_CustomFormat(bool shouldEnrich)
         {
             var propagator = new Mock<TextMapPropagator>();
-            propagator.Setup(m => m.Inject<HttpRequestMessage>(It.IsAny<PropagationContext>(), It.IsAny<HttpRequestMessage>(), It.IsAny<Action<HttpRequestMessage, string, string>>()))
+            propagator.Setup(m => m.Inject(It.IsAny<PropagationContext>(), It.IsAny<HttpRequestMessage>(), It.IsAny<Action<HttpRequestMessage, string, string>>()))
                 .Callback<PropagationContext, HttpRequestMessage, Action<HttpRequestMessage, string, string>>((context, message, action) =>
                 {
                     action(message, "custom_traceparent", $"00/{context.ActivityContext.TraceId}/{context.ActivityContext.SpanId}/01");
@@ -201,7 +199,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
             try
             {
                 var propagator = new Mock<TextMapPropagator>();
-                propagator.Setup(m => m.Inject<HttpRequestMessage>(It.IsAny<PropagationContext>(), It.IsAny<HttpRequestMessage>(), It.IsAny<Action<HttpRequestMessage, string, string>>()))
+                propagator.Setup(m => m.Inject(It.IsAny<PropagationContext>(), It.IsAny<HttpRequestMessage>(), It.IsAny<Action<HttpRequestMessage, string, string>>()))
                     .Callback<PropagationContext, HttpRequestMessage, Action<HttpRequestMessage, string, string>>((context, message, action) =>
                     {
                         action(message, "custom_traceparent", $"00/{context.ActivityContext.TraceId}/{context.ActivityContext.SpanId}/01");

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/TracerShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/TracerShimTests.cs
@@ -19,11 +19,11 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using global::OpenTracing;
-using global::OpenTracing.Propagation;
 using Moq;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Trace;
+using OpenTracing;
+using OpenTracing.Propagation;
 using Xunit;
 
 namespace OpenTelemetry.Shims.OpenTracing.Tests
@@ -42,7 +42,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
             Assert.Throws<ArgumentNullException>(() => new TracerShim(null, new TraceContextPropagator()));
 
             // null context format
-            var tracerMock = new Mock<Trace.Tracer>();
+            var tracerMock = new Mock<Tracer>();
             Assert.Throws<ArgumentNullException>(() => new TracerShim(TracerProvider.Default.GetTracer("test"), null));
         }
 


### PR DESCRIPTION
Continues work on #3001.

## Changes

Resolve all IDE0001 ("Name can be simplified") warnings. Also fixes two IDE0005 warnings ("Using directive is unnecessary") that happened to be in a file I was already modifying... and they were the only two IDE0005 I found, so it seemed reasonable to just include it.