### PR TITLE
Fix IDE0090: 'new' expression can be simplified.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -65,6 +65,7 @@ csharp_prefer_braces = true:silent
 csharp_preserve_single_line_blocks = true
 csharp_preserve_single_line_statements = true
 dotnet_style_readonly_field = true:suggestion
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
 
 # Expression-level preferences
 dotnet_style_object_initializer = true:suggestion

--- a/docs/metrics/customizing-the-sdk/Program.cs
+++ b/docs/metrics/customizing-the-sdk/Program.cs
@@ -21,8 +21,8 @@ using OpenTelemetry.Metrics;
 
 public class Program
 {
-    private static readonly Meter Meter1 = new Meter("CompanyA.ProductA.Library1", "1.0");
-    private static readonly Meter Meter2 = new Meter("CompanyA.ProductB.Library2", "1.0");
+    private static readonly Meter Meter1 = new("CompanyA.ProductA.Library1", "1.0");
+    private static readonly Meter Meter2 = new("CompanyA.ProductB.Library2", "1.0");
 
     public static void Main(string[] args)
     {

--- a/docs/metrics/extending-the-sdk/Program.cs
+++ b/docs/metrics/extending-the-sdk/Program.cs
@@ -23,7 +23,7 @@ using OpenTelemetry.Metrics;
 
 public class Program
 {
-    private static readonly Meter MyMeter = new Meter("MyCompany.MyProduct.MyLibrary", "1.0");
+    private static readonly Meter MyMeter = new("MyCompany.MyProduct.MyLibrary", "1.0");
     private static readonly Counter<long> MyFruitCounter = MyMeter.CreateCounter<long>("MyFruitCounter");
 
     static Program()

--- a/docs/metrics/getting-started-prometheus-grafana/Program.cs
+++ b/docs/metrics/getting-started-prometheus-grafana/Program.cs
@@ -22,7 +22,7 @@ using OpenTelemetry.Metrics;
 
 public class Program
 {
-    private static readonly Meter MyMeter = new Meter("MyCompany.MyProduct.MyLibrary", "1.0");
+    private static readonly Meter MyMeter = new("MyCompany.MyProduct.MyLibrary", "1.0");
     private static readonly Counter<long> MyFruitCounter = MyMeter.CreateCounter<long>("MyFruitCounter");
 
     public static void Main(string[] args)

--- a/docs/metrics/getting-started/Program.cs
+++ b/docs/metrics/getting-started/Program.cs
@@ -20,7 +20,7 @@ using OpenTelemetry.Metrics;
 
 public class Program
 {
-    private static readonly Meter MyMeter = new Meter("MyCompany.MyProduct.MyLibrary", "1.0");
+    private static readonly Meter MyMeter = new("MyCompany.MyProduct.MyLibrary", "1.0");
     private static readonly Counter<long> MyFruitCounter = MyMeter.CreateCounter<long>("MyFruitCounter");
 
     public static void Main(string[] args)

--- a/docs/metrics/learning-more-instruments/Program.cs
+++ b/docs/metrics/learning-more-instruments/Program.cs
@@ -23,7 +23,7 @@ using OpenTelemetry.Metrics;
 
 public class Program
 {
-    private static readonly Meter MyMeter = new Meter("MyCompany.MyProduct.MyLibrary", "1.0");
+    private static readonly Meter MyMeter = new("MyCompany.MyProduct.MyLibrary", "1.0");
     private static readonly Histogram<long> MyHistogram = MyMeter.CreateHistogram<long>("MyHistogram");
 
     static Program()

--- a/docs/trace/customizing-the-sdk/Program.cs
+++ b/docs/trace/customizing-the-sdk/Program.cs
@@ -20,16 +20,16 @@ using OpenTelemetry.Trace;
 
 public class Program
 {
-    private static readonly ActivitySource MyLibraryActivitySource = new ActivitySource(
+    private static readonly ActivitySource MyLibraryActivitySource = new(
         "MyCompany.MyProduct.MyLibrary");
 
-    private static readonly ActivitySource ComponentAActivitySource = new ActivitySource(
+    private static readonly ActivitySource ComponentAActivitySource = new(
         "AbcCompany.XyzProduct.ComponentA");
 
-    private static readonly ActivitySource ComponentBActivitySource = new ActivitySource(
+    private static readonly ActivitySource ComponentBActivitySource = new(
         "AbcCompany.XyzProduct.ComponentB");
 
-    private static readonly ActivitySource SomeOtherActivitySource = new ActivitySource(
+    private static readonly ActivitySource SomeOtherActivitySource = new(
         "SomeCompany.SomeProduct.SomeComponent");
 
     public static void Main()

--- a/docs/trace/extending-the-sdk/Program.cs
+++ b/docs/trace/extending-the-sdk/Program.cs
@@ -21,7 +21,7 @@ using OpenTelemetry.Trace;
 
 public class Program
 {
-    private static readonly ActivitySource DemoSource = new ActivitySource("OTel.Demo");
+    private static readonly ActivitySource DemoSource = new("OTel.Demo");
 
     public static void Main()
     {

--- a/docs/trace/getting-started/Program.cs
+++ b/docs/trace/getting-started/Program.cs
@@ -20,7 +20,7 @@ using OpenTelemetry.Trace;
 
 public class Program
 {
-    private static readonly ActivitySource MyActivitySource = new ActivitySource(
+    private static readonly ActivitySource MyActivitySource = new(
         "MyCompany.MyProduct.MyLibrary");
 
     public static void Main()

--- a/docs/trace/reporting-exceptions/Program.cs
+++ b/docs/trace/reporting-exceptions/Program.cs
@@ -21,7 +21,7 @@ using OpenTelemetry.Trace;
 
 public class Program
 {
-    private static readonly ActivitySource MyActivitySource = new ActivitySource(
+    private static readonly ActivitySource MyActivitySource = new(
         "MyCompany.MyProduct.MyLibrary");
 
     public static void Main()

--- a/examples/AspNetCore/Controllers/WeatherForecastController.cs
+++ b/examples/AspNetCore/Controllers/WeatherForecastController.cs
@@ -33,7 +33,7 @@ namespace Examples.AspNetCore.Controllers
             "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching",
         };
 
-        private static readonly HttpClient HttpClient = new HttpClient();
+        private static readonly HttpClient HttpClient = new();
 
         private readonly ILogger<WeatherForecastController> logger;
 

--- a/examples/Console/InstrumentationWithActivitySource.cs
+++ b/examples/Console/InstrumentationWithActivitySource.cs
@@ -30,8 +30,8 @@ namespace Examples.Console
     internal class InstrumentationWithActivitySource : IDisposable
     {
         private const string RequestPath = "/api/request";
-        private readonly SampleServer server = new SampleServer();
-        private readonly SampleClient client = new SampleClient();
+        private readonly SampleServer server = new();
+        private readonly SampleClient client = new();
 
         public void Start(ushort port = 19999)
         {
@@ -48,7 +48,7 @@ namespace Examples.Console
 
         private class SampleServer : IDisposable
         {
-            private readonly HttpListener listener = new HttpListener();
+            private readonly HttpListener listener = new();
 
             public void Start(string url)
             {

--- a/examples/Console/TestPrometheusExporter.cs
+++ b/examples/Console/TestPrometheusExporter.cs
@@ -28,11 +28,11 @@ namespace Examples.Console;
 
 internal class TestPrometheusExporter
 {
-    private static readonly Meter MyMeter = new Meter("MyMeter");
-    private static readonly Meter MyMeter2 = new Meter("MyMeter2");
+    private static readonly Meter MyMeter = new("MyMeter");
+    private static readonly Meter MyMeter2 = new("MyMeter2");
     private static readonly Counter<double> Counter = MyMeter.CreateCounter<double>("myCounter", description: "A counter for demonstration purpose.");
     private static readonly Histogram<long> MyHistogram = MyMeter.CreateHistogram<long>("myHistogram");
-    private static readonly ThreadLocal<Random> ThreadLocalRandom = new ThreadLocal<Random>(() => new Random());
+    private static readonly ThreadLocal<Random> ThreadLocalRandom = new(() => new Random());
 
     internal static object Run(int port)
     {

--- a/examples/MicroserviceExample/Utils/Messaging/MessageReceiver.cs
+++ b/examples/MicroserviceExample/Utils/Messaging/MessageReceiver.cs
@@ -30,7 +30,7 @@ namespace Utils.Messaging
 {
     public class MessageReceiver : IDisposable
     {
-        private static readonly ActivitySource ActivitySource = new ActivitySource(nameof(MessageReceiver));
+        private static readonly ActivitySource ActivitySource = new(nameof(MessageReceiver));
         private static readonly TextMapPropagator Propagator = Propagators.DefaultTextMapPropagator;
 
         private readonly ILogger<MessageReceiver> logger;

--- a/examples/MicroserviceExample/Utils/Messaging/MessageSender.cs
+++ b/examples/MicroserviceExample/Utils/Messaging/MessageSender.cs
@@ -27,7 +27,7 @@ namespace Utils.Messaging
 {
     public class MessageSender : IDisposable
     {
-        private static readonly ActivitySource ActivitySource = new ActivitySource(nameof(MessageSender));
+        private static readonly ActivitySource ActivitySource = new(nameof(MessageSender));
         private static readonly TextMapPropagator Propagator = Propagators.DefaultTextMapPropagator;
 
         private readonly ILogger<MessageSender> logger;

--- a/src/OpenTelemetry.Api/Baggage.cs
+++ b/src/OpenTelemetry.Api/Baggage.cs
@@ -31,7 +31,7 @@ namespace OpenTelemetry
     public readonly struct Baggage : IEquatable<Baggage>
     {
         private static readonly RuntimeContextSlot<BaggageHolder> RuntimeContextSlot = RuntimeContext.RegisterSlot<BaggageHolder>("otel.baggage");
-        private static readonly Dictionary<string, string> EmptyBaggage = new Dictionary<string, string>();
+        private static readonly Dictionary<string, string> EmptyBaggage = new();
 
         private readonly Dictionary<string, string> baggage;
 

--- a/src/OpenTelemetry.Api/Context/Propagation/B3Propagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/B3Propagator.cs
@@ -49,9 +49,9 @@ namespace OpenTelemetry.Context.Propagation
         // "Debug" sampled value.
         internal const string FlagsValue = "1";
 
-        private static readonly HashSet<string> AllFields = new HashSet<string>() { XB3TraceId, XB3SpanId, XB3ParentSpanId, XB3Sampled, XB3Flags };
+        private static readonly HashSet<string> AllFields = new() { XB3TraceId, XB3SpanId, XB3ParentSpanId, XB3Sampled, XB3Flags };
 
-        private static readonly HashSet<string> SampledValues = new HashSet<string>(StringComparer.Ordinal) { SampledValue, LegacySampledValue };
+        private static readonly HashSet<string> SampledValues = new(StringComparer.Ordinal) { SampledValue, LegacySampledValue };
 
         private readonly bool singleHeader;
 

--- a/src/OpenTelemetry.Api/Context/RuntimeContext.cs
+++ b/src/OpenTelemetry.Api/Context/RuntimeContext.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Context
     /// </summary>
     public static class RuntimeContext
     {
-        private static readonly ConcurrentDictionary<string, object> Slots = new ConcurrentDictionary<string, object>();
+        private static readonly ConcurrentDictionary<string, object> Slots = new();
 
         /// <summary>
         /// Gets or sets the actual context carrier implementation.

--- a/src/OpenTelemetry.Api/Internal/OpenTelemetryApiEventSource.cs
+++ b/src/OpenTelemetry.Api/Internal/OpenTelemetryApiEventSource.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Internal
     [EventSource(Name = "OpenTelemetry-Api")]
     internal class OpenTelemetryApiEventSource : EventSource
     {
-        public static OpenTelemetryApiEventSource Log = new OpenTelemetryApiEventSource();
+        public static OpenTelemetryApiEventSource Log = new();
 
         [NonEvent]
         public void ActivityContextExtractException(string format, Exception ex)

--- a/src/OpenTelemetry.Api/Trace/Status.cs
+++ b/src/OpenTelemetry.Api/Trace/Status.cs
@@ -24,17 +24,17 @@ namespace OpenTelemetry.Trace
         /// <summary>
         /// The operation completed successfully.
         /// </summary>
-        public static readonly Status Ok = new Status(StatusCode.Ok);
+        public static readonly Status Ok = new(StatusCode.Ok);
 
         /// <summary>
         /// The default status.
         /// </summary>
-        public static readonly Status Unset = new Status(StatusCode.Unset);
+        public static readonly Status Unset = new(StatusCode.Unset);
 
         /// <summary>
         /// The operation contains an error.
         /// </summary>
-        public static readonly Status Error = new Status(StatusCode.Error);
+        public static readonly Status Error = new(StatusCode.Error);
 
         internal Status(StatusCode statusCode, string description = null)
         {

--- a/src/OpenTelemetry.Api/Trace/TelemetrySpan.cs
+++ b/src/OpenTelemetry.Api/Trace/TelemetrySpan.cs
@@ -27,7 +27,7 @@ namespace OpenTelemetry.Trace
     /// <remarks>TelemetrySpan is a wrapper around <see cref="Activity"/> class.</remarks>
     public class TelemetrySpan : IDisposable
     {
-        internal static readonly TelemetrySpan NoopInstance = new TelemetrySpan(null);
+        internal static readonly TelemetrySpan NoopInstance = new(null);
         internal readonly Activity Activity;
 
         internal TelemetrySpan(Activity activity)

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerExporterEventSource.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
     [EventSource(Name = "OpenTelemetry-Exporter-Jaeger")]
     internal class JaegerExporterEventSource : EventSource
     {
-        public static JaegerExporterEventSource Log = new JaegerExporterEventSource();
+        public static JaegerExporterEventSource Log = new();
 
         [NonEvent]
         public void FailedExport(Exception ex)

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerHttpClient.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerHttpClient.cs
@@ -23,7 +23,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
 {
     internal sealed class JaegerHttpClient : IJaegerClient
     {
-        private static readonly MediaTypeHeaderValue ContentTypeHeader = new MediaTypeHeaderValue("application/vnd.apache.thrift.binary");
+        private static readonly MediaTypeHeaderValue ContentTypeHeader = new("application/vnd.apache.thrift.binary");
 
         private readonly Uri endpoint;
         private readonly HttpClient httpClient;

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
@@ -35,7 +35,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
 {
     internal static class ActivityExtensions
     {
-        private static readonly ConcurrentBag<OtlpTrace.InstrumentationLibrarySpans> SpanListPool = new ConcurrentBag<OtlpTrace.InstrumentationLibrarySpans>();
+        private static readonly ConcurrentBag<OtlpTrace.InstrumentationLibrarySpans> SpanListPool = new();
         private static readonly Action<RepeatedField<OtlpTrace.Span>, int> RepeatedFieldOfSpanSetCountAction = CreateRepeatedFieldOfSpanSetCountAction();
 
         internal static void AddBatch(

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpHttpMetricsExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpHttpMetricsExportClient.cs
@@ -56,7 +56,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClie
 
         internal sealed class ExportRequestContent : HttpContent
         {
-            private static readonly MediaTypeHeaderValue ProtobufMediaTypeHeader = new MediaTypeHeaderValue(MediaContentType);
+            private static readonly MediaTypeHeaderValue ProtobufMediaTypeHeader = new(MediaContentType);
 
             private readonly OtlpCollector.ExportMetricsServiceRequest exportRequest;
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpHttpTraceExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpHttpTraceExportClient.cs
@@ -56,7 +56,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClie
 
         internal sealed class ExportRequestContent : HttpContent
         {
-            private static readonly MediaTypeHeaderValue ProtobufMediaTypeHeader = new MediaTypeHeaderValue(MediaContentType);
+            private static readonly MediaTypeHeaderValue ProtobufMediaTypeHeader = new(MediaContentType);
 
             private readonly OtlpCollector.ExportTraceServiceRequest exportRequest;
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/MetricItemExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/MetricItemExtensions.cs
@@ -32,7 +32,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
 {
     internal static class MetricItemExtensions
     {
-        private static readonly ConcurrentBag<OtlpMetrics.InstrumentationLibraryMetrics> MetricListPool = new ConcurrentBag<OtlpMetrics.InstrumentationLibraryMetrics>();
+        private static readonly ConcurrentBag<OtlpMetrics.InstrumentationLibraryMetrics> MetricListPool = new();
         private static readonly Action<RepeatedField<OtlpMetrics.Metric>, int> RepeatedFieldOfMetricSetCountAction = CreateRepeatedFieldOfMetricSetCountAction();
 
         internal static void AddMetrics(

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OpenTelemetryProtocolExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OpenTelemetryProtocolExporterEventSource.cs
@@ -23,7 +23,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
     [EventSource(Name = "OpenTelemetry-Exporter-OpenTelemetryProtocol")]
     internal class OpenTelemetryProtocolExporterEventSource : EventSource
     {
-        public static readonly OpenTelemetryProtocolExporterEventSource Log = new OpenTelemetryProtocolExporterEventSource();
+        public static readonly OpenTelemetryProtocolExporterEventSource Log = new();
 
         [NonEvent]
         public void FailedToReachCollector(Uri collectorUri, Exception ex)

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterEventSource.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Exporter.Prometheus
     [EventSource(Name = "OpenTelemetry-Exporter-Prometheus")]
     internal sealed class PrometheusExporterEventSource : EventSource
     {
-        public static PrometheusExporterEventSource Log = new PrometheusExporterEventSource();
+        public static PrometheusExporterEventSource Log = new();
 
         [NonEvent]
         public void FailedExport(Exception ex)

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterHttpServer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterHttpServer.cs
@@ -28,8 +28,8 @@ namespace OpenTelemetry.Exporter.Prometheus
     internal sealed class PrometheusExporterHttpServer : IDisposable
     {
         private readonly PrometheusExporter exporter;
-        private readonly HttpListener httpListener = new HttpListener();
-        private readonly object syncObject = new object();
+        private readonly HttpListener httpListener = new();
+        private readonly object syncObject = new();
 
         private CancellationTokenSource tokenSource;
         private Task workerThread;

--- a/src/OpenTelemetry.Exporter.ZPages/Implementation/ZPagesExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/Implementation/ZPagesExporterEventSource.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Exporter.ZPages.Implementation
     [EventSource(Name = "OpenTelemetry-Exporter-ZPages")]
     internal class ZPagesExporterEventSource : EventSource
     {
-        public static ZPagesExporterEventSource Log = new ZPagesExporterEventSource();
+        public static ZPagesExporterEventSource Log = new();
 
         [NonEvent]
         public void FailedExport(Exception ex)

--- a/src/OpenTelemetry.Exporter.ZPages/ZPagesExporterStatsHttpServer.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/ZPagesExporterStatsHttpServer.cs
@@ -30,8 +30,8 @@ namespace OpenTelemetry.Exporter.ZPages
     /// </summary>
     public class ZPagesExporterStatsHttpServer : IDisposable
     {
-        private readonly HttpListener httpListener = new HttpListener();
-        private readonly object syncObject = new object();
+        private readonly HttpListener httpListener = new();
+        private readonly object syncObject = new();
 
         private CancellationTokenSource tokenSource;
         private Task workerThread;

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinActivityConversionExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinActivityConversionExtensions.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
         private const long UnixEpochTicks = 621355968000000000L; // = DateTimeOffset.FromUnixTimeMilliseconds(0).Ticks
         private const long UnixEpochMicroseconds = UnixEpochTicks / TicksPerMicrosecond;
 
-        private static readonly ConcurrentDictionary<(string, int), ZipkinEndpoint> RemoteEndpointCache = new ConcurrentDictionary<(string, int), ZipkinEndpoint>();
+        private static readonly ConcurrentDictionary<(string, int), ZipkinEndpoint> RemoteEndpointCache = new();
 
         internal static ZipkinSpan ToZipkinSpan(this Activity activity, ZipkinEndpoint localEndpoint, bool useShortTraceIds = false)
         {

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinExporterEventSource.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
     [EventSource(Name = "OpenTelemetry-Exporter-Zipkin")]
     internal class ZipkinExporterEventSource : EventSource
     {
-        public static ZipkinExporterEventSource Log = new ZipkinExporterEventSource();
+        public static ZipkinExporterEventSource Log = new();
 
         [NonEvent]
         public void FailedExport(Exception ex)

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporter.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporter.cs
@@ -189,7 +189,7 @@ namespace OpenTelemetry.Exporter
 
         private sealed class JsonContent : HttpContent
         {
-            private static readonly MediaTypeHeaderValue JsonHeader = new MediaTypeHeaderValue("application/json")
+            private static readonly MediaTypeHeaderValue JsonHeader = new("application/json")
             {
                 CharSet = "utf-8",
             };

--- a/src/OpenTelemetry.Extensions.Hosting/Implementation/HostingExtensionsEventSource.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Implementation/HostingExtensionsEventSource.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Extensions.Hosting.Implementation
     [EventSource(Name = "OpenTelemetry-Extensions-Hosting")]
     internal class HostingExtensionsEventSource : EventSource
     {
-        public static HostingExtensionsEventSource Log = new HostingExtensionsEventSource();
+        public static HostingExtensionsEventSource Log = new();
 
         [NonEvent]
         public void FailedInitialize(Exception ex)

--- a/src/OpenTelemetry.Extensions.Hosting/Implementation/MeterProviderBuilderHosting.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Implementation/MeterProviderBuilderHosting.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Metrics
     /// </summary>
     internal sealed class MeterProviderBuilderHosting : MeterProviderBuilderBase, IDeferredMeterProviderBuilder
     {
-        private readonly List<Action<IServiceProvider, MeterProviderBuilder>> configurationActions = new List<Action<IServiceProvider, MeterProviderBuilder>>();
+        private readonly List<Action<IServiceProvider, MeterProviderBuilder>> configurationActions = new();
 
         public MeterProviderBuilderHosting(IServiceCollection services)
         {

--- a/src/OpenTelemetry.Extensions.Hosting/Implementation/TracerProviderBuilderHosting.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Implementation/TracerProviderBuilderHosting.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Trace
     /// </summary>
     internal sealed class TracerProviderBuilderHosting : TracerProviderBuilderBase, IDeferredTracerProviderBuilder
     {
-        private readonly List<Action<IServiceProvider, TracerProviderBuilder>> configurationActions = new List<Action<IServiceProvider, TracerProviderBuilder>>();
+        private readonly List<Action<IServiceProvider, TracerProviderBuilder>> configurationActions = new();
 
         public TracerProviderBuilderHosting(IServiceCollection services)
         {

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -33,11 +33,11 @@ namespace OpenTelemetry.Instrumentation.AspNet
         /// Key to store the state in HttpContext.
         /// </summary>
         internal const string ContextKey = "__AspnetInstrumentationContext__";
-        internal static readonly object StartedButNotSampledObj = new object();
+        internal static readonly object StartedButNotSampledObj = new();
 
         private const string BaggageSlotName = "otel.baggage";
         private static readonly Func<HttpRequest, string, IEnumerable<string>> HttpRequestHeaderValuesGetter = (request, name) => request.Headers.GetValues(name);
-        private static readonly ActivitySource AspNetSource = new ActivitySource(
+        private static readonly ActivitySource AspNetSource = new(
             TelemetryHttpModule.AspNetSourceName,
             typeof(ActivityHelper).Assembly.GetName().Version.ToString());
 

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/AspNetTelemetryEventSource.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/AspNetTelemetryEventSource.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Instrumentation.AspNet
         /// <summary>
         /// Instance of the PlatformEventSource class.
         /// </summary>
-        public static readonly AspNetTelemetryEventSource Log = new AspNetTelemetryEventSource();
+        public static readonly AspNetTelemetryEventSource Log = new();
 
         [NonEvent]
         public void ActivityStarted(Activity activity)

--- a/src/OpenTelemetry.Instrumentation.AspNet/Implementation/AspNetInstrumentationEventSource.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet/Implementation/AspNetInstrumentationEventSource.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Implementation
     [EventSource(Name = "OpenTelemetry-Instrumentation-AspNet")]
     internal sealed class AspNetInstrumentationEventSource : EventSource
     {
-        public static AspNetInstrumentationEventSource Log = new AspNetInstrumentationEventSource();
+        public static AspNetInstrumentationEventSource Log = new();
 
         [NonEvent]
         public void RequestFilterException(string operationName, Exception ex)

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/AspNetCoreInstrumentationEventSource.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/AspNetCoreInstrumentationEventSource.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
     [EventSource(Name = "OpenTelemetry-Instrumentation-AspNetCore")]
     internal class AspNetCoreInstrumentationEventSource : EventSource
     {
-        public static AspNetCoreInstrumentationEventSource Log = new AspNetCoreInstrumentationEventSource();
+        public static AspNetCoreInstrumentationEventSource Log = new();
 
         [NonEvent]
         public void RequestFilterException(Exception ex)

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -38,7 +38,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
         internal static readonly AssemblyName AssemblyName = typeof(HttpInListener).Assembly.GetName();
         internal static readonly string ActivitySourceName = AssemblyName.Name;
         internal static readonly Version Version = AssemblyName.Version;
-        internal static readonly ActivitySource ActivitySource = new ActivitySource(ActivitySourceName, Version.ToString());
+        internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, Version.ToString());
         private const string DiagnosticSourceName = "Microsoft.AspNetCore";
         private const string UnknownHostName = "UNKNOWN-HOST";
         private static readonly Func<HttpRequest, string, IEnumerable<string>> HttpRequestHeaderValuesGetter = (request, name) => request.Headers[name];

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInMetricsListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInMetricsListener.cs
@@ -23,7 +23,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
 {
     internal class HttpInMetricsListener : ListenerHandler
     {
-        private readonly PropertyFetcher<HttpContext> stopContextFetcher = new PropertyFetcher<HttpContext>("HttpContext");
+        private readonly PropertyFetcher<HttpContext> stopContextFetcher = new("HttpContext");
         private readonly Meter meter;
         private readonly Histogram<double> httpServerDuration;
 

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/GrpcTagHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/GrpcTagHelper.cs
@@ -29,7 +29,7 @@ namespace OpenTelemetry.Instrumentation.GrpcNetClient
         public const string GrpcMethodTagName = "grpc.method";
         public const string GrpcStatusCodeTagName = "grpc.status_code";
 
-        private static readonly Regex GrpcMethodRegex = new Regex(@"^/?(?<service>.*)/(?<method>.*)$", RegexOptions.Compiled);
+        private static readonly Regex GrpcMethodRegex = new(@"^/?(?<service>.*)/(?<method>.*)$", RegexOptions.Compiled);
 
         public static string GetGrpcMethodFromActivity(Activity activity)
         {

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
@@ -29,11 +29,11 @@ namespace OpenTelemetry.Instrumentation.GrpcNetClient.Implementation
         internal static readonly AssemblyName AssemblyName = typeof(GrpcClientDiagnosticListener).Assembly.GetName();
         internal static readonly string ActivitySourceName = AssemblyName.Name;
         internal static readonly Version Version = AssemblyName.Version;
-        internal static readonly ActivitySource ActivitySource = new ActivitySource(ActivitySourceName, Version.ToString());
+        internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, Version.ToString());
 
         private readonly GrpcClientInstrumentationOptions options;
-        private readonly PropertyFetcher<HttpRequestMessage> startRequestFetcher = new PropertyFetcher<HttpRequestMessage>("Request");
-        private readonly PropertyFetcher<HttpResponseMessage> stopRequestFetcher = new PropertyFetcher<HttpResponseMessage>("Response");
+        private readonly PropertyFetcher<HttpRequestMessage> startRequestFetcher = new("Request");
+        private readonly PropertyFetcher<HttpResponseMessage> stopRequestFetcher = new("Response");
 
         public GrpcClientDiagnosticListener(GrpcClientInstrumentationOptions options)
             : base("Grpc.Net.Client")

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcInstrumentationEventSource.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcInstrumentationEventSource.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Instrumentation.GrpcNetClient.Implementation
     [EventSource(Name = "OpenTelemetry-Instrumentation-Grpc")]
     internal class GrpcInstrumentationEventSource : EventSource
     {
-        public static GrpcInstrumentationEventSource Log = new GrpcInstrumentationEventSource();
+        public static GrpcInstrumentationEventSource Log = new();
 
         [Event(1, Message = "Payload is NULL in event '{1}' from handler '{0}', span will not be recorded.", Level = EventLevel.Warning)]
         public void NullPayload(string handlerName, string eventName)

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -33,14 +33,14 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
         internal static readonly AssemblyName AssemblyName = typeof(HttpHandlerDiagnosticListener).Assembly.GetName();
         internal static readonly string ActivitySourceName = AssemblyName.Name;
         internal static readonly Version Version = AssemblyName.Version;
-        internal static readonly ActivitySource ActivitySource = new ActivitySource(ActivitySourceName, Version.ToString());
+        internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, Version.ToString());
 
-        private static readonly Regex CoreAppMajorVersionCheckRegex = new Regex("^\\.NETCoreApp,Version=v(\\d+)\\.", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex CoreAppMajorVersionCheckRegex = new("^\\.NETCoreApp,Version=v(\\d+)\\.", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private readonly PropertyFetcher<HttpRequestMessage> startRequestFetcher = new PropertyFetcher<HttpRequestMessage>("Request");
-        private readonly PropertyFetcher<HttpResponseMessage> stopResponseFetcher = new PropertyFetcher<HttpResponseMessage>("Response");
-        private readonly PropertyFetcher<Exception> stopExceptionFetcher = new PropertyFetcher<Exception>("Exception");
-        private readonly PropertyFetcher<TaskStatus> stopRequestStatusFetcher = new PropertyFetcher<TaskStatus>("RequestTaskStatus");
+        private readonly PropertyFetcher<HttpRequestMessage> startRequestFetcher = new("Request");
+        private readonly PropertyFetcher<HttpResponseMessage> stopResponseFetcher = new("Response");
+        private readonly PropertyFetcher<Exception> stopExceptionFetcher = new("Exception");
+        private readonly PropertyFetcher<TaskStatus> stopRequestStatusFetcher = new("RequestTaskStatus");
         private readonly bool httpClientSupportsW3C;
         private readonly HttpClientInstrumentationOptions options;
 

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
@@ -24,7 +24,7 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
 {
     internal class HttpHandlerMetricsDiagnosticListener : ListenerHandler
     {
-        private readonly PropertyFetcher<HttpResponseMessage> stopResponseFetcher = new PropertyFetcher<HttpResponseMessage>("Response");
+        private readonly PropertyFetcher<HttpResponseMessage> stopResponseFetcher = new("Response");
         private readonly Histogram<double> httpClientDuration;
 
         public HttpHandlerMetricsDiagnosticListener(string name, Meter meter)

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpInstrumentationEventSource.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpInstrumentationEventSource.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
     [EventSource(Name = "OpenTelemetry-Instrumentation-Http")]
     internal class HttpInstrumentationEventSource : EventSource
     {
-        public static HttpInstrumentationEventSource Log = new HttpInstrumentationEventSource();
+        public static HttpInstrumentationEventSource Log = new();
 
         [NonEvent]
         public void FailedProcessResult(Exception ex)

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpTagHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpTagHelper.cs
@@ -24,11 +24,11 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
     /// </summary>
     internal static class HttpTagHelper
     {
-        private static readonly ConcurrentDictionary<string, string> MethodOperationNameCache = new ConcurrentDictionary<string, string>();
-        private static readonly ConcurrentDictionary<HttpMethod, string> HttpMethodOperationNameCache = new ConcurrentDictionary<HttpMethod, string>();
-        private static readonly ConcurrentDictionary<HttpMethod, string> HttpMethodNameCache = new ConcurrentDictionary<HttpMethod, string>();
-        private static readonly ConcurrentDictionary<string, ConcurrentDictionary<int, string>> HostAndPortToStringCache = new ConcurrentDictionary<string, ConcurrentDictionary<int, string>>();
-        private static readonly ConcurrentDictionary<Version, string> ProtocolVersionToStringCache = new ConcurrentDictionary<Version, string>();
+        private static readonly ConcurrentDictionary<string, string> MethodOperationNameCache = new();
+        private static readonly ConcurrentDictionary<HttpMethod, string> HttpMethodOperationNameCache = new();
+        private static readonly ConcurrentDictionary<HttpMethod, string> HttpMethodNameCache = new();
+        private static readonly ConcurrentDictionary<string, ConcurrentDictionary<int, string>> HostAndPortToStringCache = new();
+        private static readonly ConcurrentDictionary<Version, string> ProtocolVersionToStringCache = new();
 
         private static readonly Func<string, string> ConvertMethodToOperationNameRef = ConvertMethodToOperationName;
         private static readonly Func<HttpMethod, string> ConvertHttpMethodToOperationNameRef = ConvertHttpMethodToOperationName;

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
@@ -38,7 +38,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Implementation
 
         private static readonly Version Version = typeof(SqlActivitySourceHelper).Assembly.GetName().Version;
 #pragma warning disable SA1202 // Elements should be ordered by access <- In this case, Version MUST come before ActivitySource otherwise null ref exception is thrown.
-        internal static readonly ActivitySource ActivitySource = new ActivitySource(ActivitySourceName, Version.ToString());
+        internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, Version.ToString());
 #pragma warning restore SA1202 // Elements should be ordered by access
     }
 }

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
@@ -32,13 +32,13 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Implementation
         public const string SqlDataWriteCommandError = "System.Data.SqlClient.WriteCommandError";
         public const string SqlMicrosoftWriteCommandError = "Microsoft.Data.SqlClient.WriteCommandError";
 
-        private readonly PropertyFetcher<object> commandFetcher = new PropertyFetcher<object>("Command");
-        private readonly PropertyFetcher<object> connectionFetcher = new PropertyFetcher<object>("Connection");
-        private readonly PropertyFetcher<object> dataSourceFetcher = new PropertyFetcher<object>("DataSource");
-        private readonly PropertyFetcher<object> databaseFetcher = new PropertyFetcher<object>("Database");
-        private readonly PropertyFetcher<CommandType> commandTypeFetcher = new PropertyFetcher<CommandType>("CommandType");
-        private readonly PropertyFetcher<object> commandTextFetcher = new PropertyFetcher<object>("CommandText");
-        private readonly PropertyFetcher<Exception> exceptionFetcher = new PropertyFetcher<Exception>("Exception");
+        private readonly PropertyFetcher<object> commandFetcher = new("Command");
+        private readonly PropertyFetcher<object> connectionFetcher = new("Connection");
+        private readonly PropertyFetcher<object> dataSourceFetcher = new("DataSource");
+        private readonly PropertyFetcher<object> databaseFetcher = new("Database");
+        private readonly PropertyFetcher<CommandType> commandTypeFetcher = new("CommandType");
+        private readonly PropertyFetcher<object> commandTextFetcher = new("CommandText");
+        private readonly PropertyFetcher<Exception> exceptionFetcher = new("Exception");
         private readonly SqlClientInstrumentationOptions options;
 
         public SqlClientDiagnosticListener(string sourceName, SqlClientInstrumentationOptions options)

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientInstrumentationEventSource.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientInstrumentationEventSource.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Implementation
     [EventSource(Name = "OpenTelemetry-Instrumentation-SqlClient")]
     internal class SqlClientInstrumentationEventSource : EventSource
     {
-        public static SqlClientInstrumentationEventSource Log = new SqlClientInstrumentationEventSource();
+        public static SqlClientInstrumentationEventSource Log = new();
 
         [NonEvent]
         public void UnknownErrorProcessingEvent(string handlerName, string eventName, Exception ex)

--- a/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentationOptions.cs
@@ -48,7 +48,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient
          *  np:\\serverName\pipe\MSSQL$instanceName\pipeName - in this case a separate regex (see NamedPipeRegex below)
          *  is used to extract instanceName
          */
-        private static readonly Regex DataSourceRegex = new Regex("^(.*\\s*:\\s*\\\\{0,2})?(.*?)\\s*(?:[\\\\,]|$)\\s*(.*?)\\s*(?:,|$)\\s*(.*)$", RegexOptions.Compiled);
+        private static readonly Regex DataSourceRegex = new("^(.*\\s*:\\s*\\\\{0,2})?(.*?)\\s*(?:[\\\\,]|$)\\s*(.*?)\\s*(?:,|$)\\s*(.*)$", RegexOptions.Compiled);
 
         /// <summary>
         /// In a Data Source string like "np:\\serverName\pipe\MSSQL$instanceName\pipeName" match the
@@ -57,9 +57,9 @@ namespace OpenTelemetry.Instrumentation.SqlClient
         /// <see>
         /// <a href="https://docs.microsoft.com/previous-versions/sql/sql-server-2016/ms189307(v=sql.130)"/>
         /// </see>
-        private static readonly Regex NamedPipeRegex = new Regex("pipe\\\\MSSQL\\$(.*?)\\\\", RegexOptions.Compiled);
+        private static readonly Regex NamedPipeRegex = new("pipe\\\\MSSQL\\$(.*?)\\\\", RegexOptions.Compiled);
 
-        private static readonly ConcurrentDictionary<string, SqlConnectionDetails> ConnectionDetailCache = new ConcurrentDictionary<string, SqlConnectionDetails>(StringComparer.OrdinalIgnoreCase);
+        private static readonly ConcurrentDictionary<string, SqlConnectionDetails> ConnectionDetailCache = new(StringComparer.OrdinalIgnoreCase);
 
         // .NET Framework implementation uses SqlEventSource from which we can't reliably distinguish
         // StoredProcedures from regular Text sql commands.

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/Implementation/RedisProfilerEntryToActivityConverter.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Implementation
 {
     internal static class RedisProfilerEntryToActivityConverter
     {
-        private static readonly Lazy<Func<object, (string, string)>> MessageDataGetter = new Lazy<Func<object, (string, string)>>(() =>
+        private static readonly Lazy<Func<object, (string, string)>> MessageDataGetter = new(() =>
         {
             var redisAssembly = typeof(IProfiledCommand).Assembly;
             Type profiledCommandType = redisAssembly.GetType("StackExchange.Redis.Profiling.ProfiledCommand");

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisCallsInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisCallsInstrumentation.cs
@@ -37,20 +37,20 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis
         internal const string ActivitySourceName = "OpenTelemetry.StackExchange.Redis";
         internal const string ActivityName = ActivitySourceName + ".Execute";
         internal static readonly Version Version = typeof(StackExchangeRedisCallsInstrumentation).Assembly.GetName().Version;
-        internal static readonly ActivitySource ActivitySource = new ActivitySource(ActivitySourceName, Version.ToString());
+        internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, Version.ToString());
         internal static readonly IEnumerable<KeyValuePair<string, object>> CreationTags = new[]
         {
             new KeyValuePair<string, object>(SemanticConventions.AttributeDbSystem, "redis"),
         };
 
         internal readonly ConcurrentDictionary<(ActivityTraceId TraceId, ActivitySpanId SpanId), (Activity Activity, ProfilingSession Session)> Cache
-            = new ConcurrentDictionary<(ActivityTraceId, ActivitySpanId), (Activity, ProfilingSession)>();
+            = new();
 
         private readonly StackExchangeRedisCallsInstrumentationOptions options;
-        private readonly EventWaitHandle stopHandle = new EventWaitHandle(false, EventResetMode.ManualReset);
+        private readonly EventWaitHandle stopHandle = new(false, EventResetMode.ManualReset);
         private readonly Thread drainThread;
 
-        private readonly ProfilingSession defaultSession = new ProfilingSession();
+        private readonly ProfilingSession defaultSession = new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="StackExchangeRedisCallsInstrumentation"/> class.

--- a/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
@@ -27,7 +27,7 @@ namespace OpenTelemetry.Shims.OpenTracing
 {
     internal sealed class ScopeManagerShim : IScopeManager
     {
-        private static readonly ConditionalWeakTable<TelemetrySpan, IScope> SpanScopeTable = new ConditionalWeakTable<TelemetrySpan, IScope>();
+        private static readonly ConditionalWeakTable<TelemetrySpan, IScope> SpanScopeTable = new();
 
         private readonly Tracer tracer;
 

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
@@ -43,12 +43,12 @@ namespace OpenTelemetry.Shims.OpenTracing
         /// <summary>
         /// The OpenTelemetry links. These correspond loosely to OpenTracing references.
         /// </summary>
-        private readonly List<Link> links = new List<Link>();
+        private readonly List<Link> links = new();
 
         /// <summary>
         /// The OpenTelemetry attributes. These correspond to OpenTracing Tags.
         /// </summary>
-        private readonly List<KeyValuePair<string, object>> attributes = new List<KeyValuePair<string, object>>();
+        private readonly List<KeyValuePair<string, object>> attributes = new();
 
         /// <summary>
         /// The set of operation names for System.Diagnostics.Activity based automatic instrumentations that indicate a root span.

--- a/src/OpenTelemetry/BatchExportProcessor.cs
+++ b/src/OpenTelemetry/BatchExportProcessor.cs
@@ -38,9 +38,9 @@ namespace OpenTelemetry
         private readonly int exporterTimeoutMilliseconds;
         private readonly int maxExportBatchSize;
         private readonly Thread exporterThread;
-        private readonly AutoResetEvent exportTrigger = new AutoResetEvent(false);
-        private readonly ManualResetEvent dataExportedNotification = new ManualResetEvent(false);
-        private readonly ManualResetEvent shutdownTrigger = new ManualResetEvent(false);
+        private readonly AutoResetEvent exportTrigger = new(false);
+        private readonly ManualResetEvent dataExportedNotification = new(false);
+        private readonly ManualResetEvent shutdownTrigger = new(false);
         private long shutdownDrainTarget = long.MaxValue;
         private long droppedCount;
         private bool disposed;

--- a/src/OpenTelemetry/DiagnosticSourceInstrumentation/InstrumentationEventSource.cs
+++ b/src/OpenTelemetry/DiagnosticSourceInstrumentation/InstrumentationEventSource.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Instrumentation
     [EventSource(Name = "OpenTelemetry-Instrumentation")]
     internal class InstrumentationEventSource : EventSource
     {
-        public static InstrumentationEventSource Log = new InstrumentationEventSource();
+        public static InstrumentationEventSource Log = new();
 
         [Event(1, Message = "Current Activity is NULL in the '{0}' callback. Activity will not be recorded.", Level = EventLevel.Warning)]
         public void NullActivity(string eventName)

--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -31,9 +31,9 @@ namespace OpenTelemetry.Internal
     [EventSource(Name = "OpenTelemetry-Sdk")]
     internal class OpenTelemetrySdkEventSource : EventSource
     {
-        public static OpenTelemetrySdkEventSource Log = new OpenTelemetrySdkEventSource();
+        public static OpenTelemetrySdkEventSource Log = new();
 #if DEBUG
-        public static OpenTelemetryEventListener Listener = new OpenTelemetryEventListener();
+        public static OpenTelemetryEventListener Listener = new();
 #endif
 
         [NonEvent]
@@ -381,7 +381,7 @@ namespace OpenTelemetry.Internal
 #if DEBUG
         public class OpenTelemetryEventListener : EventListener
         {
-            private readonly List<EventSource> eventSources = new List<EventSource>();
+            private readonly List<EventSource> eventSources = new();
 
             public override void Dispose()
             {

--- a/src/OpenTelemetry/Internal/PeerServiceResolver.cs
+++ b/src/OpenTelemetry/Internal/PeerServiceResolver.cs
@@ -23,7 +23,7 @@ namespace OpenTelemetry.Exporter
 {
     internal static class PeerServiceResolver
     {
-        private static readonly Dictionary<string, int> PeerServiceKeyResolutionDictionary = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+        private static readonly Dictionary<string, int> PeerServiceKeyResolutionDictionary = new(StringComparer.OrdinalIgnoreCase)
         {
             [SemanticConventions.AttributePeerService] = 0, // priority 0 (highest).
             ["peer.hostname"] = 1,

--- a/src/OpenTelemetry/Internal/SelfDiagnostics.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnostics.cs
@@ -27,7 +27,7 @@ namespace OpenTelemetry.Internal
         /// <summary>
         /// Long-living object that hold relevant resources.
         /// </summary>
-        private static readonly SelfDiagnostics Instance = new SelfDiagnostics();
+        private static readonly SelfDiagnostics Instance = new();
         private readonly SelfDiagnosticsConfigRefresher configRefresher;
 
         static SelfDiagnostics()

--- a/src/OpenTelemetry/Internal/SelfDiagnosticsConfigParser.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnosticsConfigParser.cs
@@ -33,13 +33,13 @@ namespace OpenTelemetry.Internal
         /// </summary>
         private const int ConfigBufferSize = 4 * 1024;
 
-        private static readonly Regex LogDirectoryRegex = new Regex(
+        private static readonly Regex LogDirectoryRegex = new(
             @"""LogDirectory""\s*:\s*""(?<LogDirectory>.*?)""", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        private static readonly Regex FileSizeRegex = new Regex(
+        private static readonly Regex FileSizeRegex = new(
             @"""FileSize""\s*:\s*(?<FileSize>\d+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        private static readonly Regex LogLevelRegex = new Regex(
+        private static readonly Regex LogLevelRegex = new(
             @"""LogLevel""\s*:\s*""(?<LogLevel>.*?)""", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         // This class is called in SelfDiagnosticsConfigRefresher.UpdateMemoryMappedFileFromConfiguration

--- a/src/OpenTelemetry/Internal/SelfDiagnosticsConfigRefresher.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnosticsConfigRefresher.cs
@@ -46,8 +46,8 @@ namespace OpenTelemetry.Internal
         /// memoryMappedFileCache is a handle kept in thread-local storage as a cache to indicate whether the cached
         /// viewStream is created from the current m_memoryMappedFile.
         /// </summary>
-        private readonly ThreadLocal<MemoryMappedFile> memoryMappedFileCache = new ThreadLocal<MemoryMappedFile>(true);
-        private readonly ThreadLocal<MemoryMappedViewStream> viewStream = new ThreadLocal<MemoryMappedViewStream>(true);
+        private readonly ThreadLocal<MemoryMappedFile> memoryMappedFileCache = new(true);
+        private readonly ThreadLocal<MemoryMappedViewStream> viewStream = new(true);
         private bool disposedValue;
 
         // Once the configuration file is valid, an eventListener object will be created.

--- a/src/OpenTelemetry/Internal/SelfDiagnosticsEventListener.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnosticsEventListener.cs
@@ -33,11 +33,11 @@ namespace OpenTelemetry.Internal
         // Buffer size of the log line. A UTF-16 encoded character in C# can take up to 4 bytes if encoded in UTF-8.
         private const int BUFFERSIZE = 4 * 5120;
         private const string EventSourceNamePrefix = "OpenTelemetry-";
-        private readonly object lockObj = new object();
+        private readonly object lockObj = new();
         private readonly EventLevel logLevel;
         private readonly SelfDiagnosticsConfigRefresher configRefresher;
-        private readonly ThreadLocal<byte[]> writeBuffer = new ThreadLocal<byte[]>(() => null);
-        private readonly List<EventSource> eventSourcesBeforeConstructor = new List<EventSource>();
+        private readonly ThreadLocal<byte[]> writeBuffer = new(() => null);
+        private readonly List<EventSource> eventSourcesBeforeConstructor = new();
 
         private bool disposedValue = false;
 

--- a/src/OpenTelemetry/Logs/LogRecordScope.cs
+++ b/src/OpenTelemetry/Logs/LogRecordScope.cs
@@ -40,7 +40,7 @@ namespace OpenTelemetry.Logs
         /// of the scope.
         /// </summary>
         /// <returns><see cref="Enumerator"/>.</returns>
-        public Enumerator GetEnumerator() => new Enumerator(this.Scope);
+        public Enumerator GetEnumerator() => new(this.Scope);
 
         /// <summary>
         /// LogRecordScope enumerator.

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggerOptions.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggerOptions.cs
@@ -22,7 +22,7 @@ namespace OpenTelemetry.Logs
 {
     public class OpenTelemetryLoggerOptions
     {
-        internal readonly List<BaseProcessor<LogRecord>> Processors = new List<BaseProcessor<LogRecord>>();
+        internal readonly List<BaseProcessor<LogRecord>> Processors = new();
         internal ResourceBuilder ResourceBuilder = ResourceBuilder.CreateDefault();
 
         /// <summary>

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggerProvider.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggerProvider.cs
@@ -28,7 +28,7 @@ namespace OpenTelemetry.Logs
         internal readonly OpenTelemetryLoggerOptions Options;
         internal BaseProcessor<LogRecord> Processor;
         internal Resource Resource;
-        private readonly Hashtable loggers = new Hashtable();
+        private readonly Hashtable loggers = new();
         private bool disposed;
         private IExternalScopeProvider scopeProvider;
 

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -26,12 +26,12 @@ namespace OpenTelemetry.Metrics
     internal sealed class AggregatorStore
     {
         private static readonly string MetricPointCapHitFixMessage = "Modify instrumentation to reduce the number of unique key/value pair combinations. Or use Views to drop unwanted tags. Or use MeterProviderBuilder.SetMaxMetricPointsPerMetricStream to set higher limit.";
-        private readonly object lockZeroTags = new object();
+        private readonly object lockZeroTags = new();
         private readonly HashSet<string> tagKeysInteresting;
         private readonly int tagsKeysInterestingCount;
 
         private readonly ConcurrentDictionary<Tags, int> tagsToMetricPointIndexDictionary =
-            new ConcurrentDictionary<Tags, int>();
+            new();
 
         private readonly string name;
         private readonly string metricPointCapHitMessage;

--- a/src/OpenTelemetry/Metrics/CompositeMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/CompositeMetricReader.cs
@@ -67,7 +67,7 @@ namespace OpenTelemetry.Metrics
             return this;
         }
 
-        public Enumerator GetEnumerator() => new Enumerator(this.head);
+        public Enumerator GetEnumerator() => new(this.head);
 
         /// <inheritdoc/>
         internal override bool ProcessMetrics(in Batch<Metric> metrics, int timeoutMilliseconds)

--- a/src/OpenTelemetry/Metrics/MeterProviderBuilderBase.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderBuilderBase.cs
@@ -31,9 +31,9 @@ namespace OpenTelemetry.Metrics
     {
         internal const int MaxMetricsDefault = 1000;
         internal const int MaxMetricPointsPerMetricDefault = 2000;
-        private readonly List<InstrumentationFactory> instrumentationFactories = new List<InstrumentationFactory>();
-        private readonly List<string> meterSources = new List<string>();
-        private readonly List<Func<Instrument, MetricStreamConfiguration>> viewConfigs = new List<Func<Instrument, MetricStreamConfiguration>>();
+        private readonly List<InstrumentationFactory> instrumentationFactories = new();
+        private readonly List<string> meterSources = new();
+        private readonly List<Func<Instrument, MetricStreamConfiguration>> viewConfigs = new();
         private ResourceBuilder resourceBuilder = ResourceBuilder.CreateDefault();
         private int maxMetricStreams = MaxMetricsDefault;
         private int maxMetricPointsPerMetricStream = MaxMetricPointsPerMetricDefault;

--- a/src/OpenTelemetry/Metrics/MeterProviderBuilderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderBuilderSdk.cs
@@ -20,7 +20,7 @@ namespace OpenTelemetry.Metrics
 {
     internal class MeterProviderBuilderSdk : MeterProviderBuilderBase
     {
-        private static readonly Regex InstrumentNameRegex = new Regex(
+        private static readonly Regex InstrumentNameRegex = new(
             @"^[a-zA-Z][-.\w]{0,62}$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         /// <summary>

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -28,9 +28,9 @@ namespace OpenTelemetry.Metrics
     internal sealed class MeterProviderSdk : MeterProvider
     {
         internal int ShutdownCount;
-        private readonly List<object> instrumentations = new List<object>();
+        private readonly List<object> instrumentations = new();
         private readonly List<Func<Instrument, MetricStreamConfiguration>> viewConfigs;
-        private readonly object collectLock = new object();
+        private readonly object collectLock = new();
         private readonly MeterListener listener;
         private readonly MetricReader reader;
         private readonly CompositeMetricReader compositeMetricReader;

--- a/src/OpenTelemetry/Metrics/MetricReader.cs
+++ b/src/OpenTelemetry/Metrics/MetricReader.cs
@@ -28,9 +28,9 @@ namespace OpenTelemetry.Metrics
     public abstract partial class MetricReader : IDisposable
     {
         private const AggregationTemporality AggregationTemporalityUnspecified = (AggregationTemporality)0;
-        private readonly object newTaskLock = new object();
-        private readonly object onCollectLock = new object();
-        private readonly TaskCompletionSource<bool> shutdownTcs = new TaskCompletionSource<bool>();
+        private readonly object newTaskLock = new();
+        private readonly object onCollectLock = new();
+        private readonly TaskCompletionSource<bool> shutdownTcs = new();
         private AggregationTemporality temporality = AggregationTemporalityUnspecified;
         private int shutdownCount;
         private TaskCompletionSource<bool> collectionTcs;

--- a/src/OpenTelemetry/Metrics/MetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/MetricReaderExt.cs
@@ -27,9 +27,9 @@ namespace OpenTelemetry.Metrics
     /// </summary>
     public abstract partial class MetricReader
     {
-        private readonly HashSet<string> metricStreamNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        private readonly ConcurrentDictionary<InstrumentIdentity, Metric> instrumentIdentityToMetric = new ConcurrentDictionary<InstrumentIdentity, Metric>();
-        private readonly object instrumentCreationLock = new object();
+        private readonly HashSet<string> metricStreamNames = new(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<InstrumentIdentity, Metric> instrumentIdentityToMetric = new();
+        private readonly object instrumentCreationLock = new();
         private int maxMetricStreams;
         private int maxMetricPointsPerMetricStream;
         private Metric[] metrics;

--- a/src/OpenTelemetry/Metrics/PeriodicExportingMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/PeriodicExportingMetricReader.cs
@@ -34,8 +34,8 @@ namespace OpenTelemetry.Metrics
         private readonly int exportIntervalMilliseconds;
         private readonly int exportTimeoutMilliseconds;
         private readonly Thread exporterThread;
-        private readonly AutoResetEvent exportTrigger = new AutoResetEvent(false);
-        private readonly ManualResetEvent shutdownTrigger = new ManualResetEvent(false);
+        private readonly AutoResetEvent exportTrigger = new(false);
+        private readonly ManualResetEvent shutdownTrigger = new(false);
         private bool disposed;
 
         /// <summary>

--- a/src/OpenTelemetry/Resources/ResourceBuilder.cs
+++ b/src/OpenTelemetry/Resources/ResourceBuilder.cs
@@ -24,7 +24,7 @@ namespace OpenTelemetry.Resources
     /// </summary>
     public class ResourceBuilder
     {
-        private readonly List<Resource> resources = new List<Resource>();
+        private readonly List<Resource> resources = new();
 
         private ResourceBuilder()
         {
@@ -57,7 +57,7 @@ namespace OpenTelemetry.Resources
         /// </summary>
         /// <returns>Created <see cref="ResourceBuilder"/>.</returns>
         public static ResourceBuilder CreateEmpty()
-            => new ResourceBuilder();
+            => new();
 
         /// <summary>
         /// Clears the <see cref="Resource"/>s added to the builder.

--- a/src/OpenTelemetry/SimpleExportProcessor.cs
+++ b/src/OpenTelemetry/SimpleExportProcessor.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry
     public abstract class SimpleExportProcessor<T> : BaseExportProcessor<T>
         where T : class
     {
-        private readonly object syncObject = new object();
+        private readonly object syncObject = new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleExportProcessor{T}"/> class.

--- a/src/OpenTelemetry/Trace/TracerProviderBuilderBase.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderBuilderBase.cs
@@ -27,10 +27,10 @@ namespace OpenTelemetry.Trace
     /// </summary>
     public abstract class TracerProviderBuilderBase : TracerProviderBuilder
     {
-        private readonly List<InstrumentationFactory> instrumentationFactories = new List<InstrumentationFactory>();
-        private readonly List<BaseProcessor<Activity>> processors = new List<BaseProcessor<Activity>>();
-        private readonly List<string> sources = new List<string>();
-        private readonly HashSet<string> legacyActivityOperationNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private readonly List<InstrumentationFactory> instrumentationFactories = new();
+        private readonly List<BaseProcessor<Activity>> processors = new();
+        private readonly List<string> sources = new();
+        private readonly HashSet<string> legacyActivityOperationNames = new(StringComparer.OrdinalIgnoreCase);
         private ResourceBuilder resourceBuilder = ResourceBuilder.CreateDefault();
         private Sampler sampler = new ParentBasedSampler(new AlwaysOnSampler());
 

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -28,7 +28,7 @@ namespace OpenTelemetry.Trace
     {
         internal int ShutdownCount;
 
-        private readonly List<object> instrumentations = new List<object>();
+        private readonly List<object> instrumentations = new();
         private readonly ActivityListener listener;
         private readonly Sampler sampler;
         private readonly Action<Activity> getRequestedDataAction;

--- a/test/Benchmarks/Exporter/PrometheusSerializerBenchmarks.cs
+++ b/test/Benchmarks/Exporter/PrometheusSerializerBenchmarks.cs
@@ -31,7 +31,7 @@ namespace Benchmarks.Exporter
     {
         private Meter meter;
         private MeterProvider meterProvider;
-        private List<Metric> metrics = new List<Metric>();
+        private List<Metric> metrics = new();
         private byte[] buffer = new byte[85000];
 
         [Params(1, 1000, 10000)]

--- a/test/Benchmarks/Instrumentation/DiagnosticSourceSubscriberBenchmark.cs
+++ b/test/Benchmarks/Instrumentation/DiagnosticSourceSubscriberBenchmark.cs
@@ -34,8 +34,8 @@ namespace Benchmarks.Instrumentation
 
         private const string SourceName = "MySource";
 
-        private readonly DiagnosticListener listener = new DiagnosticListener(SourceName);
-        private readonly List<DiagnosticSourceSubscriber> subscribers = new List<DiagnosticSourceSubscriber>();
+        private readonly DiagnosticListener listener = new(SourceName);
+        private readonly List<DiagnosticSourceSubscriber> subscribers = new();
         private readonly Func<string, object, object, bool> isEnabledFilter = (name, arg1, arg2) => ((EventPayload)arg1).Data == "Data";
 
         [GlobalSetup]

--- a/test/Benchmarks/Logs/LogScopeBenchmarks.cs
+++ b/test/Benchmarks/Logs/LogScopeBenchmarks.cs
@@ -26,7 +26,7 @@ namespace Benchmarks.Logs
     [MemoryDiagnoser]
     public class LogScopeBenchmarks
     {
-        private readonly LoggerExternalScopeProvider scopeProvider = new LoggerExternalScopeProvider();
+        private readonly LoggerExternalScopeProvider scopeProvider = new();
 
         private readonly Action<LogRecordScope, object> callback = (LogRecordScope scope, object state) =>
         {

--- a/test/Benchmarks/Metrics/HistogramBenchmarks.cs
+++ b/test/Benchmarks/Metrics/HistogramBenchmarks.cs
@@ -61,7 +61,7 @@ namespace Benchmarks.Metrics
     public class HistogramBenchmarks
     {
         private const int MaxValue = 1000;
-        private Random random = new Random();
+        private Random random = new();
         private Histogram<long> histogram;
         private MeterProvider provider;
         private Meter meter;

--- a/test/Benchmarks/Metrics/MetricCollectBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricCollectBenchmarks.cs
@@ -52,7 +52,7 @@ namespace Benchmarks.Metrics
         private string[] dimensionValues = new string[] { "DimVal1", "DimVal2", "DimVal3", "DimVal4", "DimVal5", "DimVal6", "DimVal7", "DimVal8", "DimVal9", "DimVal10" };
 
         // TODO: Confirm if this needs to be thread-safe
-        private Random random = new Random();
+        private Random random = new();
 
         [Params(false, true)]
         public bool UseWithRef { get; set; }

--- a/test/Benchmarks/Metrics/MetricsBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricsBenchmarks.cs
@@ -58,7 +58,7 @@ namespace Benchmarks.Metrics
         private Counter<long> counter;
         private MeterProvider provider;
         private Meter meter;
-        private Random random = new Random();
+        private Random random = new();
         private string[] dimensionValues = new string[] { "DimVal1", "DimVal2", "DimVal3", "DimVal4", "DimVal5", "DimVal6", "DimVal7", "DimVal8", "DimVal9", "DimVal10" };
 
         [Params(AggregationTemporality.Cumulative, AggregationTemporality.Delta)]

--- a/test/Benchmarks/Metrics/MetricsViewBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricsViewBenchmarks.cs
@@ -43,7 +43,7 @@ namespace Benchmarks.Metrics
     [MemoryDiagnoser]
     public class MetricsViewBenchmarks
     {
-        private static readonly ThreadLocal<Random> ThreadLocalRandom = new ThreadLocal<Random>(() => new Random());
+        private static readonly ThreadLocal<Random> ThreadLocalRandom = new(() => new Random());
         private static readonly string[] DimensionValues = new string[] { "DimVal1", "DimVal2", "DimVal3", "DimVal4", "DimVal5", "DimVal6", "DimVal7", "DimVal8", "DimVal9", "DimVal10" };
         private static readonly int DimensionsValuesLength = DimensionValues.Length;
         private List<Metric> metrics;

--- a/test/Benchmarks/Trace/OpenTelemetrySdkBenchmarksActivity.cs
+++ b/test/Benchmarks/Trace/OpenTelemetrySdkBenchmarksActivity.cs
@@ -25,8 +25,8 @@ namespace Benchmarks.Trace
     [MemoryDiagnoser]
     public class OpenTelemetrySdkBenchmarksActivity
     {
-        private readonly ActivitySource benchmarkSource = new ActivitySource("Benchmark");
-        private readonly ActivityContext parentCtx = new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.None);
+        private readonly ActivitySource benchmarkSource = new("Benchmark");
+        private readonly ActivityContext parentCtx = new(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.None);
         private readonly string parentId = $"00-{ActivityTraceId.CreateRandom()}.{ActivitySpanId.CreateRandom()}.00";
         private TracerProvider tracerProvider;
 

--- a/test/Benchmarks/Trace/TraceBenchmarks.cs
+++ b/test/Benchmarks/Trace/TraceBenchmarks.cs
@@ -24,15 +24,15 @@ namespace Benchmarks.Trace
     [MemoryDiagnoser]
     public class TraceBenchmarks
     {
-        private readonly ActivitySource sourceWithNoListener = new ActivitySource("Benchmark.NoListener");
-        private readonly ActivitySource sourceWithPropagationDataListner = new ActivitySource("Benchmark.PropagationDataListner");
-        private readonly ActivitySource sourceWithAllDataListner = new ActivitySource("Benchmark.AllDataListner");
-        private readonly ActivitySource sourceWithAllDataAndRecordedListner = new ActivitySource("Benchmark.AllDataAndRecordedListner");
-        private readonly ActivitySource sourceWithOneProcessor = new ActivitySource("Benchmark.OneProcessor");
-        private readonly ActivitySource sourceWithTwoProcessors = new ActivitySource("Benchmark.TwoProcessors");
-        private readonly ActivitySource sourceWithThreeProcessors = new ActivitySource("Benchmark.ThreeProcessors");
-        private readonly ActivitySource sourceWithOneLegacyActivityOperationNameSubscription = new ActivitySource("Benchmark.OneInstrumentation");
-        private readonly ActivitySource sourceWithTwoLegacyActivityOperationNameSubscriptions = new ActivitySource("Benchmark.TwoInstrumentations");
+        private readonly ActivitySource sourceWithNoListener = new("Benchmark.NoListener");
+        private readonly ActivitySource sourceWithPropagationDataListner = new("Benchmark.PropagationDataListner");
+        private readonly ActivitySource sourceWithAllDataListner = new("Benchmark.AllDataListner");
+        private readonly ActivitySource sourceWithAllDataAndRecordedListner = new("Benchmark.AllDataAndRecordedListner");
+        private readonly ActivitySource sourceWithOneProcessor = new("Benchmark.OneProcessor");
+        private readonly ActivitySource sourceWithTwoProcessors = new("Benchmark.TwoProcessors");
+        private readonly ActivitySource sourceWithThreeProcessors = new("Benchmark.ThreeProcessors");
+        private readonly ActivitySource sourceWithOneLegacyActivityOperationNameSubscription = new("Benchmark.OneInstrumentation");
+        private readonly ActivitySource sourceWithTwoLegacyActivityOperationNameSubscriptions = new("Benchmark.TwoInstrumentations");
 
         public TraceBenchmarks()
         {

--- a/test/OpenTelemetry.Exporter.ZPages.Tests/ZPagesExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.ZPages.Tests/ZPagesExporterTests.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Exporter.ZPages.Tests
 {
     public class ZPagesExporterTests
     {
-        private static readonly HttpClient HttpClient = new HttpClient();
+        private static readonly HttpClient HttpClient = new();
 
         static ZPagesExporterTests()
         {

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionTest.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionTest.cs
@@ -25,7 +25,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation.Tests
     public class ZipkinActivityConversionTest
     {
         private const string ZipkinSpanName = "Name";
-        private static readonly ZipkinEndpoint DefaultZipkinEndpoint = new ZipkinEndpoint("TestService");
+        private static readonly ZipkinEndpoint DefaultZipkinEndpoint = new("TestService");
 
         [Fact]
         public void ToZipkinSpan_AllPropertiesSet()

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityExporterRemoteEndpointTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityExporterRemoteEndpointTests.cs
@@ -23,7 +23,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation.Tests
 {
     public class ZipkinActivityExporterRemoteEndpointTests
     {
-        private static readonly ZipkinEndpoint DefaultZipkinEndpoint = new ZipkinEndpoint("TestService");
+        private static readonly ZipkinEndpoint DefaultZipkinEndpoint = new("TestService");
 
         [Fact]
         public void GenerateActivity_RemoteEndpointOmittedByDefault()

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
@@ -35,7 +35,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Tests
     public class ZipkinExporterTests : IDisposable
     {
         private const string TraceId = "e8ea7e9ac72de94e91fabc613f9686b2";
-        private static readonly ConcurrentDictionary<Guid, string> Responses = new ConcurrentDictionary<Guid, string>();
+        private static readonly ConcurrentDictionary<Guid, string> Responses = new();
 
         private readonly IDisposable testServer;
         private readonly string testServerHost;

--- a/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/ActivityHelperTest.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule.Tests/ActivityHelperTest.cs
@@ -470,7 +470,7 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
 
         private class TestHttpRequest : HttpRequestBase
         {
-            private readonly NameValueCollection headers = new NameValueCollection();
+            private readonly NameValueCollection headers = new();
 
             public override NameValueCollection Headers => this.headers;
 

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcServer.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcServer.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
     public class GrpcServer<TService> : IDisposable
         where TService : class
     {
-        private static readonly Random GlobalRandom = new Random();
+        private static readonly Random GlobalRandom = new();
 
         private readonly IHost host;
 

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/TracerShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/TracerShimTests.cs
@@ -183,7 +183,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
         /// <seealso cref="OpenTracing.Propagation.ITextMap" />
         private class TextMapCarrier : ITextMap
         {
-            private readonly Dictionary<string, string> map = new Dictionary<string, string>();
+            private readonly Dictionary<string, string> map = new();
 
             public IDictionary<string, string> Map => this.map;
 
@@ -203,7 +203,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
         /// <seealso cref="OpenTracing.Propagation.IBinary" />
         private class BinaryCarrier : IBinary
         {
-            private readonly MemoryStream carrierStream = new MemoryStream();
+            private readonly MemoryStream carrierStream = new();
 
             public MemoryStream Get() => this.carrierStream;
 

--- a/test/OpenTelemetry.Tests.Stress.Metrics/Program.cs
+++ b/test/OpenTelemetry.Tests.Stress.Metrics/Program.cs
@@ -29,10 +29,10 @@ public partial class Program
     // Note: Uncomment the below line if you want to run Histogram stress test
     // private const int MaxHistogramMeasurement = 1000;
 
-    private static readonly Meter TestMeter = new Meter(Utils.GetCurrentMethodName());
+    private static readonly Meter TestMeter = new(Utils.GetCurrentMethodName());
     private static readonly Counter<long> TestCounter = TestMeter.CreateCounter<long>("TestCounter");
     private static readonly string[] DimensionValues = new string[ArraySize];
-    private static readonly ThreadLocal<Random> ThreadLocalRandom = new ThreadLocal<Random>(() => new Random());
+    private static readonly ThreadLocal<Random> ThreadLocalRandom = new(() => new Random());
 
     // Note: Uncomment the below line if you want to run Histogram stress test
     // private static readonly Histogram<long> TestHistogram = TestMeter.CreateHistogram<long>("TestHistogram");

--- a/test/OpenTelemetry.Tests.Stress/Skeleton.cs
+++ b/test/OpenTelemetry.Tests.Stress/Skeleton.cs
@@ -27,7 +27,7 @@ namespace OpenTelemetry.Tests.Stress;
 
 public partial class Program
 {
-    private static readonly Meter StressMeter = new Meter("OpenTelemetry.Tests.Stress");
+    private static readonly Meter StressMeter = new("OpenTelemetry.Tests.Stress");
     private static volatile bool bContinue = true;
     private static volatile string output = "Test results not available yet.";
 

--- a/test/OpenTelemetry.Tests/Logs/LogRecordTest.cs
+++ b/test/OpenTelemetry.Tests/Logs/LogRecordTest.cs
@@ -32,7 +32,7 @@ namespace OpenTelemetry.Logs.Tests
     public sealed class LogRecordTest : IDisposable
     {
         private readonly ILogger logger;
-        private readonly List<LogRecord> exportedItems = new List<LogRecord>();
+        private readonly List<LogRecord> exportedItems = new();
         private readonly ILoggerFactory loggerFactory;
         private readonly BaseExportProcessor<LogRecord> processor;
         private readonly BaseExporter<LogRecord> exporter;

--- a/test/OpenTelemetry.Tests/Shared/DelegatingTestExporter.cs
+++ b/test/OpenTelemetry.Tests/Shared/DelegatingTestExporter.cs
@@ -21,7 +21,7 @@ namespace OpenTelemetry.Tests
     public class DelegatingTestExporter<T> : BaseExporter<T>
         where T : class
     {
-        public List<ExportResult> ExportResults = new List<ExportResult>();
+        public List<ExportResult> ExportResults = new();
 
         private readonly BaseExporter<T> exporter;
 

--- a/test/OpenTelemetry.Tests/Shared/TestActivityExportProcessor.cs
+++ b/test/OpenTelemetry.Tests/Shared/TestActivityExportProcessor.cs
@@ -21,7 +21,7 @@ namespace OpenTelemetry.Tests
 {
     internal class TestActivityExportProcessor : SimpleActivityExportProcessor
     {
-        public List<Activity> ExportedItems = new List<Activity>();
+        public List<Activity> ExportedItems = new();
 
         public TestActivityExportProcessor(BaseExporter<Activity> exporter)
             : base(exporter)

--- a/test/OpenTelemetry.Tests/Shared/TestHttpServer.cs
+++ b/test/OpenTelemetry.Tests/Shared/TestHttpServer.cs
@@ -22,7 +22,7 @@ namespace OpenTelemetry.Tests
 {
     internal class TestHttpServer
     {
-        private static readonly Random GlobalRandom = new Random();
+        private static readonly Random GlobalRandom = new();
 
         public static IDisposable RunServer(Action<HttpListenerContext> action, out string host, out int port)
         {
@@ -53,7 +53,7 @@ namespace OpenTelemetry.Tests
         {
             private readonly Task httpListenerTask;
             private readonly HttpListener listener;
-            private readonly AutoResetEvent initialized = new AutoResetEvent(false);
+            private readonly AutoResetEvent initialized = new(false);
 
             public RunningServer(Action<HttpListenerContext> action, string host, int port)
             {

--- a/test/OpenTelemetry.Tests/Trace/ParentBasedSamplerTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/ParentBasedSamplerTests.cs
@@ -23,8 +23,8 @@ namespace OpenTelemetry.Trace.Tests
 {
     public class ParentBasedSamplerTests
     {
-        private readonly ParentBasedSampler parentBasedOnSampler = new ParentBasedSampler(new AlwaysOnSampler());
-        private readonly ParentBasedSampler parentBasedOffSampler = new ParentBasedSampler(new AlwaysOffSampler());
+        private readonly ParentBasedSampler parentBasedOnSampler = new(new AlwaysOnSampler());
+        private readonly ParentBasedSampler parentBasedOffSampler = new(new AlwaysOffSampler());
 
         [Fact]
         public void SampledParent()

--- a/test/OpenTelemetry.Tests/Trace/Propagation/B3PropagatorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/B3PropagatorTest.cs
@@ -42,8 +42,8 @@ namespace OpenTelemetry.Context.Propagation.Tests
                 return new string[] { v };
             };
 
-        private readonly B3Propagator b3propagator = new B3Propagator();
-        private readonly B3Propagator b3PropagatorSingleHeader = new B3Propagator(true);
+        private readonly B3Propagator b3propagator = new();
+        private readonly B3Propagator b3PropagatorSingleHeader = new(true);
 
         private readonly ITestOutputHelper output;
 

--- a/test/OpenTelemetry.Tests/Trace/Propagation/BaggagePropagatorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/BaggagePropagatorTest.cs
@@ -42,7 +42,7 @@ namespace OpenTelemetry.Context.Propagation.Tests
             carrier[name] = value;
         };
 
-        private readonly BaggagePropagator baggage = new BaggagePropagator();
+        private readonly BaggagePropagator baggage = new();
 
         [Fact]
         public void ValidateFieldsProperty()

--- a/test/OpenTelemetry.Tests/Trace/SpanContextTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/SpanContextTest.cs
@@ -28,13 +28,13 @@ namespace OpenTelemetry.Trace.Tests
         private static readonly byte[] SecondSpanIdBytes = { (byte)'0', 0, 0, 0, 0, 0, 0, 0 };
 
         private static readonly SpanContext First =
-          new SpanContext(
+          new(
               ActivityTraceId.CreateFromBytes(FirstTraceIdBytes),
               ActivitySpanId.CreateFromBytes(FirstSpanIdBytes),
               ActivityTraceFlags.None);
 
         private static readonly SpanContext Second =
-          new SpanContext(
+          new(
               ActivityTraceId.CreateFromBytes(SecondTraceIdBytes),
               ActivitySpanId.CreateFromBytes(SecondSpanIdBytes),
               ActivityTraceFlags.Recorded);


### PR DESCRIPTION
Continues work on #3001.

## Changes

Fixes all IDE0090 issues such that obvious object construction uses the `new()` syntax instead of `new T()`. Analyzer rule `csharp_style_implicit_object_creation_when_type_is_apparent` explicitly set to `true:suggestion` which is the default behavior, but calling it out helps indicate to folks that it's also the _desired_ value for the project and it's cool to fix those if you see them.

```c#
// var uses remain the same
var x = new Thing();

// explicit types like in class fields switch to new()
Thing x = new();
```