### PR TITLE
Fix IDE0017: Use object initializers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -68,6 +68,7 @@ csharp_prefer_simple_using_statement = true:suggestion
 dotnet_style_readonly_field = true:suggestion
 csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
 dotnet_style_prefer_simplified_interpolation = true:suggestion
+dotnet_style_object_initializer = true:suggestion
 
 # Expression-level preferences
 dotnet_style_object_initializer = true:suggestion

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/MetricItemExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/MetricItemExtensions.cs
@@ -144,9 +144,11 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
             {
                 case MetricType.LongSum:
                     {
-                        var sum = new OtlpMetrics.Sum();
-                        sum.IsMonotonic = true;
-                        sum.AggregationTemporality = temporality;
+                        var sum = new OtlpMetrics.Sum
+                        {
+                            IsMonotonic = true,
+                            AggregationTemporality = temporality,
+                        };
 
                         foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                         {
@@ -168,9 +170,11 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
 
                 case MetricType.DoubleSum:
                     {
-                        var sum = new OtlpMetrics.Sum();
-                        sum.IsMonotonic = true;
-                        sum.AggregationTemporality = temporality;
+                        var sum = new OtlpMetrics.Sum
+                        {
+                            IsMonotonic = true,
+                            AggregationTemporality = temporality,
+                        };
 
                         foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                         {
@@ -234,8 +238,10 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
 
                 case MetricType.Histogram:
                     {
-                        var histogram = new OtlpMetrics.Histogram();
-                        histogram.AggregationTemporality = temporality;
+                        var histogram = new OtlpMetrics.Histogram
+                        {
+                            AggregationTemporality = temporality,
+                        };
 
                         foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                         {

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
@@ -33,8 +33,10 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
         [InlineData("key1=value1;key2=value2", new string[] { "key1" }, new string[] { "value1;key2=value2" })] // semicolon is not treated as a delimeter (https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#specifying-headers-via-environment-variables)
         public void GetMetadataFromHeadersWorksCorrectFormat(string headers, string[] keys, string[] values)
         {
-            var options = new OtlpExporterOptions();
-            options.Headers = headers;
+            var options = new OtlpExporterOptions
+            {
+                Headers = headers,
+            };
             var metadata = options.GetMetadataFromHeaders();
 
             Assert.Equal(keys.Length, metadata.Count);
@@ -52,8 +54,10 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
         {
             try
             {
-                var options = new OtlpExporterOptions();
-                options.Headers = headers;
+                var options = new OtlpExporterOptions
+                {
+                    Headers = headers,
+                };
                 var metadata = options.GetMetadataFromHeaders();
             }
             catch (Exception ex)

--- a/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorTest.cs
@@ -53,8 +53,10 @@ namespace OpenTelemetry.Trace.Tests
                 maxExportBatchSize: 1,
                 scheduledDelayMilliseconds: 100_000);
 
-            var activity = new Activity("start");
-            activity.ActivityTraceFlags = ActivityTraceFlags.Recorded;
+            var activity = new Activity("start")
+            {
+                ActivityTraceFlags = ActivityTraceFlags.Recorded,
+            };
 
             processor.OnEnd(activity);
 
@@ -93,11 +95,15 @@ namespace OpenTelemetry.Trace.Tests
                 maxExportBatchSize: 3,
                 exporterTimeoutMilliseconds: 30000);
 
-            var activity1 = new Activity("start1");
-            activity1.ActivityTraceFlags = ActivityTraceFlags.Recorded;
+            var activity1 = new Activity("start1")
+            {
+                ActivityTraceFlags = ActivityTraceFlags.Recorded,
+            };
 
-            var activity2 = new Activity("start2");
-            activity2.ActivityTraceFlags = ActivityTraceFlags.Recorded;
+            var activity2 = new Activity("start2")
+            {
+                ActivityTraceFlags = ActivityTraceFlags.Recorded,
+            };
 
             processor.OnEnd(activity1);
             processor.OnEnd(activity2);
@@ -138,8 +144,10 @@ namespace OpenTelemetry.Trace.Tests
                 maxExportBatchSize: 3,
                 exporterTimeoutMilliseconds: 30000);
 
-            var activity = new Activity("start");
-            activity.ActivityTraceFlags = ActivityTraceFlags.Recorded;
+            var activity = new Activity("start")
+            {
+                ActivityTraceFlags = ActivityTraceFlags.Recorded,
+            };
 
             processor.OnEnd(activity);
             processor.Shutdown(timeout);
@@ -167,8 +175,10 @@ namespace OpenTelemetry.Trace.Tests
                 maxQueueSize: 1,
                 maxExportBatchSize: 1);
 
-            var activity = new Activity("start");
-            activity.ActivityTraceFlags = ActivityTraceFlags.None;
+            var activity = new Activity("start")
+            {
+                ActivityTraceFlags = ActivityTraceFlags.None,
+            };
 
             processor.OnEnd(activity);
             processor.Shutdown();
@@ -186,8 +196,10 @@ namespace OpenTelemetry.Trace.Tests
                 maxQueueSize: 3,
                 maxExportBatchSize: 3);
 
-            var activity = new Activity("start");
-            activity.ActivityTraceFlags = ActivityTraceFlags.Recorded;
+            var activity = new Activity("start")
+            {
+                ActivityTraceFlags = ActivityTraceFlags.Recorded,
+            };
 
             processor.OnEnd(activity);
             processor.OnEnd(activity);

--- a/test/OpenTelemetry.Tests/Trace/SimpleExportActivityProcessorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/SimpleExportActivityProcessorTest.cs
@@ -38,14 +38,18 @@ namespace OpenTelemetry.Trace.Tests
             using var exporter = new InMemoryExporter<Activity>(exportedItems);
             using var processor = new SimpleActivityExportProcessor(exporter);
 
-            var activity1 = new Activity("start1");
-            activity1.ActivityTraceFlags = ActivityTraceFlags.Recorded;
+            var activity1 = new Activity("start1")
+            {
+                ActivityTraceFlags = ActivityTraceFlags.Recorded,
+            };
 
             processor.OnEnd(activity1);
             Assert.Single(exportedItems);
 
-            var activity2 = new Activity("start2");
-            activity2.ActivityTraceFlags = ActivityTraceFlags.Recorded;
+            var activity2 = new Activity("start2")
+            {
+                ActivityTraceFlags = ActivityTraceFlags.Recorded,
+            };
 
             processor.OnEnd(activity2);
             Assert.Equal(2, exportedItems.Count);
@@ -61,11 +65,15 @@ namespace OpenTelemetry.Trace.Tests
             using var exporter = new InMemoryExporter<Activity>(exportedItems);
             using var processor = new SimpleActivityExportProcessor(exporter);
 
-            var activity1 = new Activity("start1");
-            activity1.ActivityTraceFlags = ActivityTraceFlags.Recorded;
+            var activity1 = new Activity("start1")
+            {
+                ActivityTraceFlags = ActivityTraceFlags.Recorded,
+            };
 
-            var activity2 = new Activity("start2");
-            activity2.ActivityTraceFlags = ActivityTraceFlags.Recorded;
+            var activity2 = new Activity("start2")
+            {
+                ActivityTraceFlags = ActivityTraceFlags.Recorded,
+            };
 
             processor.OnEnd(activity1);
             processor.OnEnd(activity2);
@@ -88,8 +96,10 @@ namespace OpenTelemetry.Trace.Tests
             using var exporter = new InMemoryExporter<Activity>(exportedItems);
             using var processor = new SimpleActivityExportProcessor(exporter);
 
-            var activity = new Activity("start");
-            activity.ActivityTraceFlags = ActivityTraceFlags.Recorded;
+            var activity = new Activity("start")
+            {
+                ActivityTraceFlags = ActivityTraceFlags.Recorded,
+            };
 
             processor.OnEnd(activity);
 
@@ -107,8 +117,10 @@ namespace OpenTelemetry.Trace.Tests
             using var exporter = new InMemoryExporter<Activity>(exportedItems);
             using var processor = new SimpleActivityExportProcessor(exporter);
 
-            var activity = new Activity("start");
-            activity.ActivityTraceFlags = ActivityTraceFlags.None;
+            var activity = new Activity("start")
+            {
+                ActivityTraceFlags = ActivityTraceFlags.None,
+            };
 
             processor.OnEnd(activity);
             Assert.Empty(exportedItems);

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
@@ -195,12 +195,14 @@ namespace OpenTelemetry.Trace.Tests
         [InlineData(SamplingDecision.RecordAndSample)]
         public void TracerProviderSdkSamplerAttributesAreAppliedToActivity(SamplingDecision sampling)
         {
-            var testSampler = new TestSampler();
-            testSampler.SamplingAction = (samplingParams) =>
+            var testSampler = new TestSampler
             {
-                var attributes = new Dictionary<string, object>();
-                attributes.Add("tagkeybysampler", "tagvalueaddedbysampler");
-                return new SamplingResult(sampling, attributes);
+                SamplingAction = (samplingParams) =>
+                {
+                    var attributes = new Dictionary<string, object>();
+                    attributes.Add("tagkeybysampler", "tagvalueaddedbysampler");
+                    return new SamplingResult(sampling, attributes);
+                },
             };
 
             using var activitySource = new ActivitySource(ActivitySourceName);
@@ -937,9 +939,11 @@ namespace OpenTelemetry.Trace.Tests
         {
             // Create some parent activity.
             string tracestate = "a=b;c=d";
-            var activityLocalParent = new Activity("TestParent");
-            activityLocalParent.ActivityTraceFlags = traceFlags;
-            activityLocalParent.TraceStateString = tracestate;
+            var activityLocalParent = new Activity("TestParent")
+            {
+                ActivityTraceFlags = traceFlags,
+                TraceStateString = tracestate,
+            };
             activityLocalParent.Start();
 
             var operationNameForLegacyActivity = "TestOperationName";


### PR DESCRIPTION
Fixes #3001. The last in the series, though I may throw one more PR in with a few one-off analyzer warning fixes since there are still about 300 and they're pretty simple fixes. (And I triple-checked the title this time - it really is IDE0017!)

## Changes

- Set `dotnet_style_object_initializer` to `true:suggestion` in `.editorconfig` since that's the default behavior for the IDE if nothing is specified.
- Fixed all the info issues related to that rule.