### PR TITLE
Fix analyzer issues in docs

### DIFF
--- a/docs/logs/extending-the-sdk/Program.cs
+++ b/docs/logs/extending-the-sdk/Program.cs
@@ -39,9 +39,6 @@ public class Program
         // unstructured log
         logger.LogInformation("Hello, World!");
 
-        // unstructured log with string interpolation
-        logger.LogInformation($"Hello from potato {0.99}.");
-
         // structured log with template
         logger.LogInformation("Hello from {name} {price}.", "tomato", 2.99);
 

--- a/docs/logs/extending-the-sdk/Program.cs
+++ b/docs/logs/extending-the-sdk/Program.cs
@@ -18,6 +18,8 @@ using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 
+namespace ExtendingTheSdk;
+
 public class Program
 {
     public static void Main()

--- a/docs/logs/extending-the-sdk/Program.cs
+++ b/docs/logs/extending-the-sdk/Program.cs
@@ -39,6 +39,9 @@ public class Program
         // unstructured log
         logger.LogInformation("Hello, World!");
 
+        // String interpolation, as in the below line, results in unstructured logging, and is not recommended
+        // logger.LogInformation($"Hello from potato {0.99}.");
+
         // structured log with template
         logger.LogInformation("Hello from {name} {price}.", "tomato", 2.99);
 

--- a/docs/logs/getting-started/Program.cs
+++ b/docs/logs/getting-started/Program.cs
@@ -17,6 +17,8 @@
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
 
+namespace GettingStarted;
+
 public class Program
 {
     public static void Main()

--- a/docs/logs/source-generation/FoodSupplyLogs.cs
+++ b/docs/logs/source-generation/FoodSupplyLogs.cs
@@ -16,6 +16,8 @@
 
 using Microsoft.Extensions.Logging;
 
+namespace SourceGeneration;
+
 public static partial class FoodSupplyLogs
 {
     [LoggerMessage(

--- a/docs/logs/source-generation/Program.cs
+++ b/docs/logs/source-generation/Program.cs
@@ -17,6 +17,8 @@
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
 
+namespace SourceGeneration;
+
 public class Program
 {
     public static void Main()

--- a/docs/metrics/customizing-the-sdk/Program.cs
+++ b/docs/metrics/customizing-the-sdk/Program.cs
@@ -19,12 +19,14 @@ using System.Diagnostics.Metrics;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 
+namespace CustomizingTheSdk;
+
 public class Program
 {
     private static readonly Meter Meter1 = new("CompanyA.ProductA.Library1", "1.0");
     private static readonly Meter Meter2 = new("CompanyA.ProductB.Library2", "1.0");
 
-    public static void Main(string[] args)
+    public static void Main()
     {
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
             .AddMeter(Meter1.Name)

--- a/docs/metrics/extending-the-sdk/Program.cs
+++ b/docs/metrics/extending-the-sdk/Program.cs
@@ -21,6 +21,8 @@ using System.Diagnostics.Metrics;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 
+namespace ExtendingTheSdk;
+
 public class Program
 {
     private static readonly Meter MyMeter = new("MyCompany.MyProduct.MyLibrary", "1.0");
@@ -38,7 +40,7 @@ public class Program
             });
     }
 
-    public static void Main(string[] args)
+    public static void Main()
     {
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
             .AddMeter("MyCompany.MyProduct.MyLibrary")

--- a/docs/metrics/getting-started-prometheus-grafana/Program.cs
+++ b/docs/metrics/getting-started-prometheus-grafana/Program.cs
@@ -20,12 +20,14 @@ using System.Threading;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 
+namespace GettingStartedPrometheusGrafana;
+
 public class Program
 {
     private static readonly Meter MyMeter = new("MyCompany.MyProduct.MyLibrary", "1.0");
     private static readonly Counter<long> MyFruitCounter = MyMeter.CreateCounter<long>("MyFruitCounter");
 
-    public static void Main(string[] args)
+    public static void Main()
     {
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
             .AddMeter("MyCompany.MyProduct.MyLibrary")

--- a/docs/metrics/getting-started/Program.cs
+++ b/docs/metrics/getting-started/Program.cs
@@ -18,12 +18,14 @@ using System.Diagnostics.Metrics;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 
+namespace GettingStarted;
+
 public class Program
 {
     private static readonly Meter MyMeter = new("MyCompany.MyProduct.MyLibrary", "1.0");
     private static readonly Counter<long> MyFruitCounter = MyMeter.CreateCounter<long>("MyFruitCounter");
 
-    public static void Main(string[] args)
+    public static void Main()
     {
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
             .AddMeter("MyCompany.MyProduct.MyLibrary")

--- a/docs/metrics/learning-more-instruments/Program.cs
+++ b/docs/metrics/learning-more-instruments/Program.cs
@@ -21,6 +21,8 @@ using System.Diagnostics.Metrics;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 
+namespace LearningMoreInstruments;
+
 public class Program
 {
     private static readonly Meter MyMeter = new("MyCompany.MyProduct.MyLibrary", "1.0");
@@ -35,7 +37,7 @@ public class Program
         MyMeter.CreateObservableGauge("Thread.State", () => GetThreadState(process));
     }
 
-    public static void Main(string[] args)
+    public static void Main()
     {
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
             .AddMeter("MyCompany.MyProduct.MyLibrary")

--- a/docs/trace/customizing-the-sdk/Program.cs
+++ b/docs/trace/customizing-the-sdk/Program.cs
@@ -18,6 +18,8 @@ using System.Diagnostics;
 using OpenTelemetry;
 using OpenTelemetry.Trace;
 
+namespace CustomizingTheSdk;
+
 public class Program
 {
     private static readonly ActivitySource MyLibraryActivitySource = new(

--- a/docs/trace/extending-the-sdk/MyFilteringProcessor.cs
+++ b/docs/trace/extending-the-sdk/MyFilteringProcessor.cs
@@ -25,18 +25,8 @@ internal class MyFilteringProcessor : BaseProcessor<Activity>
 
     public MyFilteringProcessor(BaseProcessor<Activity> processor, Func<Activity, bool> filter)
     {
-        if (filter == null)
-        {
-            throw new ArgumentNullException(nameof(filter));
-        }
-
-        if (processor == null)
-        {
-            throw new ArgumentNullException(nameof(processor));
-        }
-
-        this.filter = filter;
-        this.processor = processor;
+        this.filter = filter ?? throw new ArgumentNullException(nameof(filter));
+        this.processor = processor ?? throw new ArgumentNullException(nameof(processor));
     }
 
     public override void OnEnd(Activity activity)

--- a/docs/trace/extending-the-sdk/Program.cs
+++ b/docs/trace/extending-the-sdk/Program.cs
@@ -19,6 +19,8 @@ using OpenTelemetry;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
+namespace ExtendingTheSdk;
+
 public class Program
 {
     private static readonly ActivitySource DemoSource = new("OTel.Demo");

--- a/docs/trace/extending-the-sdk/README.md
+++ b/docs/trace/extending-the-sdk/README.md
@@ -197,7 +197,7 @@ client .NET Core](../../../src/OpenTelemetry.Instrumentation.Http/README.md) .
 Instrumentation libraries for these are already provided in this repo. The
 [OpenTelemetry .NET
 Contrib](https://github.com/open-telemetry/opentelemetry-dotnet-contrib)
-repostory also has instrumentations for libraries like
+repository also has instrumentations for libraries like
 [ElasticSearchClient](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Contrib.Instrumentation.ElasticsearchClient)
 etc. which fall in this category.
 

--- a/docs/trace/getting-started/Program.cs
+++ b/docs/trace/getting-started/Program.cs
@@ -18,6 +18,8 @@ using System.Diagnostics;
 using OpenTelemetry;
 using OpenTelemetry.Trace;
 
+namespace GettingStarted;
+
 public class Program
 {
     private static readonly ActivitySource MyActivitySource = new(

--- a/docs/trace/reporting-exceptions/Program.cs
+++ b/docs/trace/reporting-exceptions/Program.cs
@@ -19,6 +19,8 @@ using System.Diagnostics;
 using OpenTelemetry;
 using OpenTelemetry.Trace;
 
+namespace ReportingExceptions;
+
 public class Program
 {
     private static readonly ActivitySource MyActivitySource = new(

--- a/docs/trace/reporting-exceptions/README.md
+++ b/docs/trace/reporting-exceptions/README.md
@@ -136,7 +136,7 @@ will depend on the presence of a debugger:
 * If a debugger is attached, the debugger will be notified that an unhandled
   exception happened.
 * In case a postmortem debugger is configured, the postmortem debugger will be
-  activited and normally it will collect a crash dump.
+  activated and normally it will collect a crash dump.
 
 It might be useful to automatically capture the unhandled exceptions, travel
 through the unfinished activities and export them for troubleshooting. Here goes


### PR DESCRIPTION
Related to #3001.

## Changes

Updated items in the `docs/*` tree to resolve analyzer issues.

- Put all classes in file-scoped namespaces, which keeps the readability but handles the analyzer issue that classes should always be in namespaces. I used namespaces based on the name of the project it's in, so `getting-started` got the `GettingStarted` namespace.
- Simplified null checks.
- Removed unused parameters (`string[] args`) isn't required in `Main` and wasn't used).
- Removed one logger line causing CA2254. The line was showing the use of string interpolation in a log message template, which is not really that good. It seems like the docs shouldn't necessarily show "everything works" but maybe do both "show how it works" and "here's what you _should do_" so rather than suppress the issue I removed the line. If folks feel strongly, I can put it back with a suppression on it, but it'd be nice to not have the issue showing up in the VS Code "problems" window.
