### PR TITLE
Fix ability to run unit tests from VSCode

### DIFF
--- a/build/Common.nonprod.props
+++ b/build/Common.nonprod.props
@@ -17,7 +17,13 @@
     </Content>
     <!--Temp workaround to allow using daily dotnet 6 builds-->
     <!--<PackageReference Include="System.Runtime.CompilerServices.Unsafe" PrivateAssets="All" NoWarn="NU1605" Version="6.0.0-preview.4.21253.7" />-->
-</ItemGroup>
+  </ItemGroup>
+
+  <PropertyGroup>
+    <!-- Running unit tests from VSCode does not work with .NET SDK 6.0.200 without ProduceReferenceAssemblyInOutDir -->
+    <!-- Related breaking change: https://docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/write-reference-assemblies-to-obj -->
+    <ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>
+  </PropertyGroup>
 
   <PropertyGroup Label="Package versions used by test and example projects">
     <!--


### PR DESCRIPTION
Running unit tests from VSCode produces similar error found here https://github.com/microsoft/vscode-azurefunctions/issues/3051.

```text
/usr/local/share/dotnet/sdk/6.0.201/Microsoft.Common.CurrentVersion.targets(4650,5): error MSB3883: Unexpected exception:  [/Users/alan/github/open-telemetry/opentelemetry-dotnet/test/OpenTelemetry.Tests/OpenTelemetry.Tests.csproj]
/usr/local/share/dotnet/sdk/6.0.201/Microsoft.Common.CurrentVersion.targets(4650,5): error : DirectoryNotFoundException: Could not find a part of the path '/Users/alan/github/open-telemetry/opentelemetry-dotnet/test/OpenTelemetry.Tests/bin/Debug/net5.0/ref/OpenTelemetry.Tests.dll'. [/Users/alan/github/open-telemetry/opentelemetry-dotnet/test/OpenTelemetry.Tests/OpenTelemetry.Tests.csproj]
```