### PR TITLE
Add Prometheus Exporter to ASPNET Example

### DIFF
--- a/examples/AspNet/Examples.AspNet.csproj
+++ b/examples/AspNet/Examples.AspNet.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
@@ -110,9 +110,13 @@
       <Project>{7edae7fa-b44e-42ca-80fa-7df2faa2c5dd}</Project>
       <Name>OpenTelemetry.Exporter.Zipkin</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\OpenTelemetry.Exporter.OpenTelemetryProtocol\OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj">
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.OpenTelemetryProtocol\OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj">
       <Project>{a38ac295-2745-4b85-8b6b-dca864cedd5b}</Project>
       <Name>OpenTelemetry.Exporter.OpenTelemetryProtocol</Name>
+    </ProjectReference>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Prometheus\OpenTelemetry.Exporter.Prometheus.csproj">
+      <Project>{52158a12-e7ef-45a1-859f-06f9b17410cb}</Project>
+      <Name>OpenTelemetry.Exporter.Prometheus</Name>
     </ProjectReference>
   </ItemGroup>
   <PropertyGroup>

--- a/examples/AspNet/Global.asax.cs
+++ b/examples/AspNet/Global.asax.cs
@@ -73,8 +73,7 @@ namespace Examples.AspNet
             // https://github.com/open-telemetry/opentelemetry-dotnet/issues/2994
 
             var meterBuilder = Sdk.CreateMeterProviderBuilder()
-                 .AddAspNetInstrumentation()
-                 .AddHttpClientInstrumentation();
+                 .AddAspNetInstrumentation();
 
             switch (ConfigurationManager.AppSettings["UseMetricsExporter"].ToLowerInvariant())
             {
@@ -83,6 +82,9 @@ namespace Examples.AspNet
                     {
                         otlpOptions.Endpoint = new Uri(ConfigurationManager.AppSettings["OtlpEndpoint"]);
                     });
+                    break;
+                case "prometheus":
+                    meterBuilder.AddPrometheusExporter();
                     break;
                 default:
                     meterBuilder.AddConsoleExporter((exporterOptions, metricReaderOptions) =>


### PR DESCRIPTION
Continue from https://github.com/open-telemetry/opentelemetry-dotnet/pull/3033
Just default Prometheus (http://localhost:9464/metrics), without any customization. Good enough for demonstrating recently added metrics from ASP.NET instrumentation.

Also removed AddHttpClientInstrumentation() as it does not produce any metrics in .NET Framework.