### PR TITLE
AddHttpClientInstrumentation uses Options<T>.

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Updated `TracerProviderBuilderExtensions.AddHttpClientInstrumentation` to support
+  `IDeferredTracerProviderBuilder` and `IOptions<HttpClientInstrumentationOptions>`
+  ([#3051](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3051))
+
 ## 1.0.0-rc10
 
 Released 2022-Mar-04
@@ -92,7 +96,7 @@ Released 2020-Nov-5
   `HttpWebRequest` in Activity.CustomProperty. To enrich activity, use the
   Enrich action on the instrumentation.
   ([#1407](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1407))
-* Renamed TextMapPropagator to TraceContextPropagator, CompositePropapagor to
+* Renamed TextMapPropagator to TraceContextPropagator, CompositePropagator to
   CompositeTextMapPropagator. IPropagator is renamed to TextMapPropagator and
   changed from interface to abstract class.
   ([#1427](https://github.com/open-telemetry/opentelemetry-dotnet/pull/1427))

--- a/src/OpenTelemetry.Instrumentation.Http/OpenTelemetry.Instrumentation.Http.csproj
+++ b/src/OpenTelemetry.Instrumentation.Http/OpenTelemetry.Instrumentation.Http.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\ServiceProviderExtensions.cs" Link="Includes\ServiceProviderExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\Guard.cs" Link="Includes\Guard.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #3050.

## Changes

Copied the pattern from [`AddAspNetCoreInstrumentation`](https://github.com/open-telemetry/opentelemetry-dotnet/blob/a709cfd2a993fef5dedf8beb73b128ff2d03b896/src/OpenTelemetry.Instrumentation.AspNetCore/TracerProviderBuilderExtensions.cs#L41) to support `IDeferredTracerProviderBuilder` when in `netstandard`. I did notice there's a different options structure for `net461` but I didn't modify that code path. I guessed that the full framework folks weren't using `Options<T>` and, even if they are, I'm on a Mac in VS Code so I can't really exercise that code path myself.
