### PR TITLE
Fix analyzers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -102,6 +102,8 @@ csharp_style_throw_expression = true:suggestion
 csharp_style_conditional_delegate_call = true:suggestion
 
 # Other features
+csharp_style_prefer_index_operator = false:none
+csharp_style_prefer_range_operator = false:none
 csharp_style_pattern_local_over_anonymous_function = true:suggestion
 csharp_style_deconstructed_variable_declaration = true:suggestion
 

--- a/docs/logs/customizing-the-sdk/Program.cs
+++ b/docs/logs/customizing-the-sdk/Program.cs
@@ -18,6 +18,8 @@ using Microsoft.Extensions.Logging;
 
 using OpenTelemetry.Logs;
 
+namespace CustomizingTheSdk;
+
 public class Program
 {
     public static void Main()

--- a/src/OpenTelemetry.Api/Trace/Status.cs
+++ b/src/OpenTelemetry.Api/Trace/Status.cs
@@ -91,7 +91,7 @@ namespace OpenTelemetry.Trace
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (!(obj is Status))
+            if (obj is not Status)
             {
                 return false;
             }

--- a/src/OpenTelemetry.Exporter.Console/ConsoleActivityExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleActivityExporter.cs
@@ -55,9 +55,7 @@ namespace OpenTelemetry.Exporter
                     this.WriteLine("Activity.Tags:");
                     foreach (var tag in activity.TagObjects)
                     {
-                        var array = tag.Value as Array;
-
-                        if (array == null)
+                        if (tag.Value is not Array array)
                         {
                             this.WriteLine($"    {tag.Key}: {tag.Value}");
                             continue;

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/Batch.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/Batch.cs
@@ -26,9 +26,9 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
     {
         public Batch(Process process, TProtocol protocol)
         {
-            this.BatchBeginMessage = this.GenerateBeginMessage(process, protocol, out int spanCountPosition);
+            this.BatchBeginMessage = GenerateBeginMessage(process, protocol, out int spanCountPosition);
             this.SpanCountPosition = spanCountPosition;
-            this.BatchEndMessage = this.GenerateEndMessage(protocol);
+            this.BatchEndMessage = GenerateEndMessage(protocol);
         }
 
         public byte[] BatchBeginMessage { get; }
@@ -40,7 +40,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
         public int MinimumMessageSize => this.BatchBeginMessage.Length
             + this.BatchEndMessage.Length;
 
-        private byte[] GenerateBeginMessage(Process process, TProtocol oprot, out int spanCountPosition)
+        private static byte[] GenerateBeginMessage(Process process, TProtocol oprot, out int spanCountPosition)
         {
             var struc = new TStruct("Batch");
 
@@ -70,7 +70,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
             return beginMessage;
         }
 
-        private byte[] GenerateEndMessage(TProtocol oprot)
+        private static byte[] GenerateEndMessage(TProtocol oprot)
         {
             oprot.WriteListEnd();
 

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/EmitBatchArgs.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/EmitBatchArgs.cs
@@ -26,9 +26,9 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
     {
         public EmitBatchArgs(TProtocol protocol)
         {
-            this.EmitBatchArgsBeginMessage = this.GenerateBeginMessage(protocol, out int seqIdPosition);
+            this.EmitBatchArgsBeginMessage = GenerateBeginMessage(protocol, out int seqIdPosition);
             this.SeqIdPosition = seqIdPosition;
-            this.EmitBatchArgsEndMessage = this.GenerateEndMessage(protocol);
+            this.EmitBatchArgsEndMessage = GenerateEndMessage(protocol);
         }
 
         public byte[] EmitBatchArgsBeginMessage { get; }
@@ -40,7 +40,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
         public int MinimumMessageSize => this.EmitBatchArgsBeginMessage.Length
             + this.EmitBatchArgsEndMessage.Length;
 
-        private byte[] GenerateBeginMessage(TProtocol oprot, out int seqIdPosition)
+        private static byte[] GenerateBeginMessage(TProtocol oprot, out int seqIdPosition)
         {
             oprot.WriteMessageBegin(new TMessage("emitBatch", TMessageType.Oneway, 0), out seqIdPosition);
 
@@ -61,7 +61,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
             return beginMessage;
         }
 
-        private byte[] GenerateEndMessage(TProtocol oprot)
+        private static byte[] GenerateEndMessage(TProtocol oprot)
         {
             oprot.WriteFieldEnd();
             oprot.WriteFieldStop();

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcLogExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcLogExportClient.cs
@@ -47,7 +47,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClie
 
             try
             {
-                this.logsClient.Export(request, headers: this.Headers, deadline: deadline);
+                this.logsClient.Export(request, headers: this.Headers, deadline: deadline, cancellationToken: cancellationToken);
             }
             catch (RpcException ex)
             {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcMetricsExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcMetricsExportClient.cs
@@ -47,7 +47,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClie
 
             try
             {
-                this.metricsClient.Export(request, headers: this.Headers, deadline: deadline);
+                this.metricsClient.Export(request, headers: this.Headers, deadline: deadline, cancellationToken: cancellationToken);
             }
             catch (RpcException ex)
             {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcTraceExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcTraceExportClient.cs
@@ -47,7 +47,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClie
 
             try
             {
-                this.traceClient.Export(request, headers: this.Headers, deadline: deadline);
+                this.traceClient.Export(request, headers: this.Headers, deadline: deadline, cancellationToken: cancellationToken);
             }
             catch (RpcException ex)
             {

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusSerializer.cs
@@ -242,16 +242,11 @@ namespace OpenTelemetry.Exporter.Prometheus
             for (int i = 0; i < metricName.Length; i++)
             {
                 var ordinal = (ushort)metricName[i];
-                switch (ordinal)
+                buffer[cursor++] = ordinal switch
                 {
-                    case ASCII_FULL_STOP:
-                    case ASCII_HYPHEN_MINUS:
-                        buffer[cursor++] = unchecked((byte)'_');
-                        break;
-                    default:
-                        buffer[cursor++] = unchecked((byte)ordinal);
-                        break;
-                }
+                    ASCII_FULL_STOP or ASCII_HYPHEN_MINUS => unchecked((byte)'_'),
+                    _ => unchecked((byte)ordinal),
+                };
             }
 
             if (!string.IsNullOrEmpty(metricUnit))

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -82,7 +82,7 @@ namespace OpenTelemetry.Instrumentation.AspNet
 
             if (activity != null)
             {
-                if (!(textMapPropagator is TraceContextPropagator))
+                if (textMapPropagator is not TraceContextPropagator)
                 {
                     Baggage.Current = propagationContext.Baggage;
 
@@ -152,7 +152,7 @@ namespace OpenTelemetry.Instrumentation.AspNet
 
             AspNetTelemetryEventSource.Log.ActivityStopped(currentActivity);
 
-            if (!(textMapPropagator is TraceContextPropagator))
+            if (textMapPropagator is not TraceContextPropagator)
             {
                 Baggage.Current = default;
             }

--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -391,6 +391,7 @@ namespace OpenTelemetry.Internal
                 }
 
                 base.Dispose();
+                GC.SuppressFinalize(this);
             }
 
             protected override void OnEventSourceCreated(EventSource eventSource)

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggerProvider.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggerProvider.cs
@@ -75,7 +75,7 @@ namespace OpenTelemetry.Logs
 
         public ILogger CreateLogger(string categoryName)
         {
-            if (!(this.loggers[categoryName] is OpenTelemetryLogger logger))
+            if (this.loggers[categoryName] is not OpenTelemetryLogger logger)
             {
                 lock (this.loggers)
                 {

--- a/src/OpenTelemetry/Metrics/AggregationTemporalityAttribute.cs
+++ b/src/OpenTelemetry/Metrics/AggregationTemporalityAttribute.cs
@@ -21,7 +21,7 @@ namespace OpenTelemetry.Metrics
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public sealed class AggregationTemporalityAttribute : Attribute
     {
-        private AggregationTemporality temporality;
+        private readonly AggregationTemporality temporality;
 
         public AggregationTemporalityAttribute(AggregationTemporality temporality)
         {

--- a/src/OpenTelemetry/Metrics/ExportModesAttribute.cs
+++ b/src/OpenTelemetry/Metrics/ExportModesAttribute.cs
@@ -21,7 +21,7 @@ namespace OpenTelemetry.Metrics
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public sealed class ExportModesAttribute : Attribute
     {
-        private ExportModes supportedExportModes;
+        private readonly ExportModes supportedExportModes;
 
         public ExportModesAttribute(ExportModes supported)
         {

--- a/src/OpenTelemetry/Metrics/InstrumentIdentity.cs
+++ b/src/OpenTelemetry/Metrics/InstrumentIdentity.cs
@@ -61,7 +61,7 @@ namespace OpenTelemetry.Metrics
 
         public static bool operator !=(InstrumentIdentity metricIdentity1, InstrumentIdentity metricIdentity2) => !metricIdentity1.Equals(metricIdentity2);
 
-        public readonly override bool Equals(object obj)
+        public override readonly bool Equals(object obj)
         {
             return obj is InstrumentIdentity other && this.Equals(other);
         }
@@ -76,6 +76,6 @@ namespace OpenTelemetry.Metrics
                 && this.Description == other.Description;
         }
 
-        public readonly override int GetHashCode() => this.hashCode;
+        public override readonly int GetHashCode() => this.hashCode;
     }
 }

--- a/src/OpenTelemetry/Metrics/MetricReader.cs
+++ b/src/OpenTelemetry/Metrics/MetricReader.cs
@@ -107,7 +107,7 @@ namespace OpenTelemetry.Metrics
 
             if (!shouldRunCollect)
             {
-                return Task.WaitAny(tcs.Task, this.shutdownTcs.Task, Task.Delay(timeoutMilliseconds)) == 0 ? tcs.Task.Result : false;
+                return Task.WaitAny(tcs.Task, this.shutdownTcs.Task, Task.Delay(timeoutMilliseconds)) == 0 && tcs.Task.Result;
             }
 
             var result = false;

--- a/src/OpenTelemetry/Metrics/Tags.cs
+++ b/src/OpenTelemetry/Metrics/Tags.cs
@@ -34,7 +34,7 @@ namespace OpenTelemetry.Metrics
 
         public static bool operator !=(Tags tag1, Tags tag2) => !tag1.Equals(tag2);
 
-        public readonly override bool Equals(object obj)
+        public override readonly bool Equals(object obj)
         {
             return obj is Tags other && this.Equals(other);
         }
@@ -78,7 +78,7 @@ namespace OpenTelemetry.Metrics
             return true;
         }
 
-        public readonly override int GetHashCode()
+        public override readonly int GetHashCode()
         {
             int hash = 17;
 

--- a/src/OpenTelemetry/Resources/Resource.cs
+++ b/src/OpenTelemetry/Resources/Resource.cs
@@ -72,7 +72,7 @@ namespace OpenTelemetry.Resources
             {
                 foreach (var attribute in other.Attributes)
                 {
-                    if (!newAttributes.TryGetValue(attribute.Key, out var value))
+                    if (!newAttributes.TryGetValue(attribute.Key, out _))
                     {
                         newAttributes[attribute.Key] = attribute.Value;
                     }
@@ -81,7 +81,7 @@ namespace OpenTelemetry.Resources
 
             foreach (var attribute in this.Attributes)
             {
-                if (!newAttributes.TryGetValue(attribute.Key, out var value))
+                if (!newAttributes.TryGetValue(attribute.Key, out _))
                 {
                     newAttributes[attribute.Key] = attribute.Value;
                 }

--- a/src/OpenTelemetry/Trace/SamplingResult.cs
+++ b/src/OpenTelemetry/Trace/SamplingResult.cs
@@ -87,7 +87,7 @@ namespace OpenTelemetry.Trace
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (!(obj is SamplingResult))
+            if (obj is not SamplingResult)
             {
                 return false;
             }

--- a/test/Benchmarks/Exporter/PrometheusSerializerBenchmarks.cs
+++ b/test/Benchmarks/Exporter/PrometheusSerializerBenchmarks.cs
@@ -29,10 +29,10 @@ namespace Benchmarks.Exporter
     [MemoryDiagnoser]
     public class PrometheusSerializerBenchmarks
     {
+        private readonly List<Metric> metrics = new();
+        private readonly byte[] buffer = new byte[85000];
         private Meter meter;
         private MeterProvider meterProvider;
-        private List<Metric> metrics = new();
-        private byte[] buffer = new byte[85000];
 
         [Params(1, 1000, 10000)]
         public int NumberOfSerializeCalls { get; set; }

--- a/test/Benchmarks/Helper/LocalServer.cs
+++ b/test/Benchmarks/Helper/LocalServer.cs
@@ -66,6 +66,8 @@ namespace Benchmarks.Helper
                 // ignored, see https://github.com/aspnet/KestrelHttpServer/issues/1513
                 // Kestrel 2.0.0 should have fix it, but it does not seem important for our tests
             }
+
+            GC.SuppressFinalize(this);
         }
 
         private class Startup

--- a/test/Benchmarks/Metrics/HistogramBenchmarks.cs
+++ b/test/Benchmarks/Metrics/HistogramBenchmarks.cs
@@ -61,12 +61,12 @@ namespace Benchmarks.Metrics
     public class HistogramBenchmarks
     {
         private const int MaxValue = 1000;
-        private Random random = new();
+        private readonly Random random = new();
+        private readonly string[] dimensionValues = new string[] { "DimVal1", "DimVal2", "DimVal3", "DimVal4", "DimVal5", "DimVal6", "DimVal7", "DimVal8", "DimVal9", "DimVal10" };
         private Histogram<long> histogram;
         private MeterProvider provider;
         private Meter meter;
         private double[] bounds;
-        private string[] dimensionValues = new string[] { "DimVal1", "DimVal2", "DimVal3", "DimVal4", "DimVal5", "DimVal6", "DimVal7", "DimVal8", "DimVal9", "DimVal10" };
 
         [Params(10, 20, 50, 100)]
         public int BoundCount { get; set; }

--- a/test/Benchmarks/Metrics/MetricCollectBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricCollectBenchmarks.cs
@@ -43,16 +43,16 @@ namespace Benchmarks.Metrics
     [MemoryDiagnoser]
     public class MetricCollectBenchmarks
     {
+        private readonly string[] dimensionValues = new string[] { "DimVal1", "DimVal2", "DimVal3", "DimVal4", "DimVal5", "DimVal6", "DimVal7", "DimVal8", "DimVal9", "DimVal10" };
+
+        // TODO: Confirm if this needs to be thread-safe
+        private readonly Random random = new();
         private Counter<double> counter;
         private MeterProvider provider;
         private Meter meter;
         private CancellationTokenSource token;
         private BaseExportingMetricReader reader;
         private Task writeMetricTask;
-        private string[] dimensionValues = new string[] { "DimVal1", "DimVal2", "DimVal3", "DimVal4", "DimVal5", "DimVal6", "DimVal7", "DimVal8", "DimVal9", "DimVal10" };
-
-        // TODO: Confirm if this needs to be thread-safe
-        private Random random = new();
 
         [Params(false, true)]
         public bool UseWithRef { get; set; }

--- a/test/Benchmarks/Metrics/MetricsBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricsBenchmarks.cs
@@ -55,11 +55,11 @@ namespace Benchmarks.Metrics
     [MemoryDiagnoser]
     public class MetricsBenchmarks
     {
+        private readonly Random random = new();
+        private readonly string[] dimensionValues = new string[] { "DimVal1", "DimVal2", "DimVal3", "DimVal4", "DimVal5", "DimVal6", "DimVal7", "DimVal8", "DimVal9", "DimVal10" };
         private Counter<long> counter;
         private MeterProvider provider;
         private Meter meter;
-        private Random random = new();
-        private string[] dimensionValues = new string[] { "DimVal1", "DimVal2", "DimVal3", "DimVal4", "DimVal5", "DimVal6", "DimVal7", "DimVal8", "DimVal9", "DimVal10" };
 
         [Params(AggregationTemporality.Cumulative, AggregationTemporality.Delta)]
         public AggregationTemporality AggregationTemporality { get; set; }

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerActivityConversionTest.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerActivityConversionTest.cs
@@ -318,13 +318,13 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation.Tests
             Assert.Equal("a", tag.VStr);
 
             // The second to last tag should be span.kind in this case
-            tag = tags[^2];
+            tag = tags[tags.Length - 2];
             Assert.Equal(JaegerTagType.STRING, tag.VType);
             Assert.Equal("span.kind", tag.Key);
             Assert.Equal("client", tag.VStr);
 
             // The last tag should be library.name in this case
-            tag = tags[^1];
+            tag = tags[tags.Length - 1];
             Assert.Equal(JaegerTagType.STRING, tag.VType);
             Assert.Equal("otel.library.name", tag.Key);
             Assert.Equal(nameof(CreateTestActivity), tag.VStr);

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerActivityConversionTest.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerActivityConversionTest.cs
@@ -71,7 +71,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation.Tests
             Assert.Equal(0x1, jaegerSpan.Flags);
 
             Assert.Equal(activity.StartTimeUtc.ToEpochMicroseconds(), jaegerSpan.StartTime);
-            Assert.Equal(this.TimeSpanToMicroseconds(activity.Duration), jaegerSpan.Duration);
+            Assert.Equal(TimeSpanToMicroseconds(activity.Duration), jaegerSpan.Duration);
 
             var tags = jaegerSpan.Tags.ToArray();
             var tag = tags[0];
@@ -159,7 +159,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation.Tests
             Assert.Equal(0x1, jaegerSpan.Flags);
 
             Assert.Equal(activity.StartTimeUtc.ToEpochMicroseconds(), jaegerSpan.StartTime);
-            Assert.Equal(this.TimeSpanToMicroseconds(activity.Duration), jaegerSpan.Duration);
+            Assert.Equal(TimeSpanToMicroseconds(activity.Duration), jaegerSpan.Duration);
 
             // 2 tags: span.kind & library.name.
             Assert.Equal(2, jaegerSpan.Tags.Count);
@@ -218,7 +218,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation.Tests
             Assert.Equal(0x1, jaegerSpan.Flags);
 
             Assert.Equal(activity.StartTimeUtc.ToEpochMicroseconds(), jaegerSpan.StartTime);
-            Assert.Equal(this.TimeSpanToMicroseconds(activity.Duration), jaegerSpan.Duration);
+            Assert.Equal(TimeSpanToMicroseconds(activity.Duration), jaegerSpan.Duration);
 
             var tags = jaegerSpan.Tags.ToArray();
             var tag = tags[0];
@@ -269,7 +269,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation.Tests
             Assert.Equal(0x1, jaegerSpan.Flags);
 
             Assert.Equal(activity.StartTimeUtc.ToEpochMicroseconds(), jaegerSpan.StartTime);
-            Assert.Equal(this.TimeSpanToMicroseconds(activity.Duration), jaegerSpan.Duration);
+            Assert.Equal(TimeSpanToMicroseconds(activity.Duration), jaegerSpan.Duration);
 
             var tags = jaegerSpan.Tags.ToArray();
             var tag = tags[0];
@@ -574,7 +574,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation.Tests
             return activity;
         }
 
-        private long TimeSpanToMicroseconds(TimeSpan timeSpan)
+        private static long TimeSpanToMicroseconds(TimeSpan timeSpan)
         {
             return timeSpan.Ticks / (TimeSpan.TicksPerMillisecond / 1000);
         }

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerActivityConversionTest.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerActivityConversionTest.cs
@@ -102,7 +102,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation.Tests
             var logs = jaegerSpan.Logs.ToArray();
             var jaegerLog = logs[0];
             Assert.Equal(activity.Events.First().Timestamp.ToEpochMicroseconds(), jaegerLog.Timestamp);
-            Assert.Equal(4, jaegerLog.Fields.Count());
+            Assert.Equal(4, jaegerLog.Fields.Count);
             var eventFields = jaegerLog.Fields.ToArray();
             var eventField = eventFields[0];
             Assert.Equal("key", eventField.Key);
@@ -120,7 +120,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation.Tests
             Assert.Equal(activity.Events.First().Timestamp.ToEpochMicroseconds(), jaegerLog.Timestamp);
 
             jaegerLog = logs[1];
-            Assert.Equal(2, jaegerLog.Fields.Count());
+            Assert.Equal(2, jaegerLog.Fields.Count);
             eventFields = jaegerLog.Fields.ToArray();
             eventField = eventFields[0];
             Assert.Equal("key", eventField.Key);
@@ -167,7 +167,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation.Tests
             var logs = jaegerSpan.Logs.ToArray();
             var jaegerLog = logs[0];
             Assert.Equal(activity.Events.First().Timestamp.ToEpochMicroseconds(), jaegerLog.Timestamp);
-            Assert.Equal(4, jaegerLog.Fields.Count());
+            Assert.Equal(4, jaegerLog.Fields.Count);
             var eventFields = jaegerLog.Fields.ToArray();
             var eventField = eventFields[0];
             Assert.Equal("key", eventField.Key);
@@ -179,7 +179,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation.Tests
             Assert.Equal(activity.Events.First().Timestamp.ToEpochMicroseconds(), jaegerLog.Timestamp);
 
             jaegerLog = logs[1];
-            Assert.Equal(2, jaegerLog.Fields.Count());
+            Assert.Equal(2, jaegerLog.Fields.Count);
             eventFields = jaegerLog.Fields.ToArray();
             eventField = eventFields[0];
             Assert.Equal("key", eventField.Key);
@@ -332,7 +332,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation.Tests
             var logs = jaegerSpan.Logs.ToArray();
             var jaegerLog = logs[0];
             Assert.Equal(activity.Events.First().Timestamp.ToEpochMicroseconds(), jaegerLog.Timestamp);
-            Assert.Equal(4, jaegerLog.Fields.Count());
+            Assert.Equal(4, jaegerLog.Fields.Count);
             var eventFields = jaegerLog.Fields.ToArray();
             var eventField = eventFields[0];
             Assert.Equal("key", eventField.Key);
@@ -343,7 +343,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation.Tests
             Assert.Equal(activity.Events.First().Timestamp.ToEpochMicroseconds(), jaegerLog.Timestamp);
 
             jaegerLog = logs[1];
-            Assert.Equal(2, jaegerLog.Fields.Count());
+            Assert.Equal(2, jaegerLog.Fields.Count);
             eventFields = jaegerLog.Fields.ToArray();
             eventField = eventFields[0];
             Assert.Equal("key", eventField.Key);

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerActivityConversionTest.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerActivityConversionTest.cs
@@ -318,13 +318,13 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation.Tests
             Assert.Equal("a", tag.VStr);
 
             // The second to last tag should be span.kind in this case
-            tag = tags[tags.Length - 2];
+            tag = tags[^2];
             Assert.Equal(JaegerTagType.STRING, tag.VType);
             Assert.Equal("span.kind", tag.Key);
             Assert.Equal("client", tag.VStr);
 
             // The last tag should be library.name in this case
-            tag = tags[tags.Length - 1];
+            tag = tags[^1];
             Assert.Equal(JaegerTagType.STRING, tag.VType);
             Assert.Equal("otel.library.name", tag.Key);
             Assert.Equal(nameof(CreateTestActivity), tag.VStr);

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterOptionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterOptionsTests.cs
@@ -29,6 +29,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests
         public void Dispose()
         {
             ClearEnvVars();
+            GC.SuppressFinalize(this);
         }
 
         [Fact]

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Http2UnencryptedSupportTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Http2UnencryptedSupportTests.cs
@@ -24,7 +24,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
 
         public Http2UnencryptedSupportTests()
         {
-            this.initialFlagStatus = this.DetermineInitialFlagStatus();
+            this.initialFlagStatus = DetermineInitialFlagStatus();
         }
 
         public void Dispose()
@@ -33,7 +33,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
             GC.SuppressFinalize(this);
         }
 
-        private bool DetermineInitialFlagStatus()
+        private static bool DetermineInitialFlagStatus()
         {
             if (AppContext.TryGetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", out var flag))
             {

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Http2UnencryptedSupportTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Http2UnencryptedSupportTests.cs
@@ -30,6 +30,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
         public void Dispose()
         {
             AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", this.initialFlagStatus);
+            GC.SuppressFinalize(this);
         }
 
         private bool DetermineInitialFlagStatus()

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/ExportClient/OtlpHttpTraceExportClientTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/ExportClient/OtlpHttpTraceExportClientTests.cs
@@ -109,7 +109,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
                     httpRequest = r;
 
                     // We have to capture content as it can't be accessed after request is disposed inside of SendExportRequest method
-                    httpRequestContent = r.Content.ReadAsByteArrayAsync()?.Result;
+                    httpRequestContent = r.Content.ReadAsByteArrayAsync(ct)?.Result;
                 })
 #else
                 .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
@@ -219,7 +219,6 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
             ClearEndpointEnvVar();
 
             var options = new OtlpExporterOptions { Protocol = OtlpExportProtocol.HttpProtobuf };
-            var originalEndpoint = options.Endpoint;
             options.Endpoint = new Uri(endpoint);
 
             options.AppendExportPath("test/path");

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsTests.cs
@@ -29,6 +29,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
         public void Dispose()
         {
             ClearEnvVars();
+            GC.SuppressFinalize(this);
         }
 
         [Fact]

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
@@ -342,7 +342,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
             var stringArray = otlpSpan.Attributes.Where(kvp => kvp.Key == "stringArray").ToList();
 
             Assert.NotNull(stringArray);
-            Assert.Equal(3, stringArray.Count());
+            Assert.Equal(3, stringArray.Count);
             Assert.Equal("test", stringArray[0].Value.StringValue);
             Assert.Equal(string.Empty, stringArray[1].Value.StringValue);
             Assert.Null(stringArray[2].Value);

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterMiddlewareTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterMiddlewareTests.cs
@@ -80,7 +80,7 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
 
             var index = content.LastIndexOf(' ');
 
-            Assert.Equal('\n', content[content.Length - 1]);
+            Assert.Equal('\n', content[^1]);
 
             var timestamp = long.Parse(content.Substring(index, content.Length - index - 1));
 

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterMiddlewareTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterMiddlewareTests.cs
@@ -80,7 +80,7 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
 
             var index = content.LastIndexOf(' ');
 
-            Assert.Equal('\n', content[^1]);
+            Assert.Equal('\n', content[content.Length - 1]);
 
             var timestamp = long.Parse(content.Substring(index, content.Length - index - 1));
 

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
@@ -81,6 +81,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Tests
         public void Dispose()
         {
             this.testServer.Dispose();
+            GC.SuppressFinalize(this);
         }
 
         [Fact]

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
@@ -145,13 +145,13 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
                 Assert.Equal("exception", activity.Events.First().Name);
             }
 
-            this.ValidateTagValue(activity, SemanticConventions.AttributeHttpUserAgent, userAgent);
+            ValidateTagValue(activity, SemanticConventions.AttributeHttpUserAgent, userAgent);
 
             activity.Dispose();
             processor.Object.Dispose();
         }
 
-        private void ValidateTagValue(Activity activity, string attribute, string expectedValue)
+        private static void ValidateTagValue(Activity activity, string attribute, string expectedValue)
         {
             if (string.IsNullOrEmpty(expectedValue))
             {

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
@@ -131,6 +131,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
         public void Dispose()
         {
             this.meterProvider?.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcServer.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcServer.cs
@@ -62,6 +62,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
         {
             this.host.StopAsync(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult();
             this.host.Dispose();
+            GC.SuppressFinalize(this);
         }
 
         private IHost CreateServer()

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.server.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.server.cs
@@ -204,6 +204,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
         public void Dispose()
         {
             this.server.Dispose();
+            GC.SuppressFinalize(this);
         }
 
         private static void WaitForProcessorInvocations(Mock<BaseProcessor<Activity>> spanProcessor, int invocationCount)

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.server.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.server.cs
@@ -150,11 +150,13 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
 
                 using var channel = GrpcChannel.ForAddress(uri);
                 var client = new Greeter.GreeterClient(channel);
-                var headers = new Metadata();
-                headers.Add("traceparent", "00-120dc44db5b736468afb112197b0dbd3-5dfbdf27ec544544-01");
-                headers.Add("x-b3-traceid", "120dc44db5b736468afb112197b0dbd3");
-                headers.Add("x-b3-spanid", "b0966f651b9e0126");
-                headers.Add("x-b3-sampled", "1");
+                var headers = new Metadata
+                {
+                    { "traceparent", "00-120dc44db5b736468afb112197b0dbd3-5dfbdf27ec544544-01" },
+                    { "x-b3-traceid", "120dc44db5b736468afb112197b0dbd3" },
+                    { "x-b3-spanid", "b0966f651b9e0126" },
+                    { "x-b3-sampled", "1" },
+                };
                 client.SayHello(new HelloRequest(), headers);
 
                 WaitForProcessorInvocations(processor, 4);

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/Services/GreeterService.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/Services/GreeterService.cs
@@ -31,7 +31,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Services.Tests
 
         public override Task<HelloReply> SayHello(HelloRequest request, ServerCallContext context)
         {
-            this.logger.LogInformation($"Sending hello to {request.Name}");
+            this.logger.LogInformation("Sending hello to {Name}", request.Name);
             return Task.FromResult(new HelloReply { Message = "Hello " + request.Name });
         }
 
@@ -41,7 +41,7 @@ namespace OpenTelemetry.Instrumentation.Grpc.Services.Tests
             while (!context.CancellationToken.IsCancellationRequested)
             {
                 var message = $"How are you {request.Name}? {++i}";
-                this.logger.LogInformation($"Sending greeting {message}.");
+                this.logger.LogInformation("Sending greeting {Message}.", message);
 
                 await responseStream.WriteAsync(new HelloReply { Message = message });
 

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.netcore31.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.netcore31.cs
@@ -406,6 +406,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         {
             this.serverLifeTime?.Dispose();
             Activity.Current = null;
+            GC.SuppressFinalize(this);
         }
 
         private static void ActivityEnrichmentSetTag(Activity activity, string method, object obj)

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.netcore31.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.netcore31.cs
@@ -34,7 +34,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
 {
     public partial class HttpClientTests
     {
-        public static int Counter;
+        private static int counter;
 
         public static IEnumerable<object[]> TestData => HttpTestData.ReadTestCases();
 
@@ -221,7 +221,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
 
         private static async Task CheckEnrichment(Sampler sampler, int expect, string url)
         {
-            Counter = 0;
+            counter = 0;
             var processor = new Mock<BaseProcessor<Activity>>();
             using (Sdk.CreateTracerProviderBuilder()
                 .SetSampler(sampler)
@@ -233,12 +233,12 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
                 using var r = await c.GetAsync(url).ConfigureAwait(false);
             }
 
-            Assert.Equal(expect, Counter);
+            Assert.Equal(expect, counter);
         }
 
         private static void ActivityEnrichmentCounter(Activity activity, string method, object obj)
         {
-            Counter++;
+            counter++;
         }
     }
 }

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.netcore31.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.netcore31.cs
@@ -68,7 +68,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
                                {
                                    opt.SetHttpFlavor = tc.SetHttpFlavor;
                                    opt.Enrich = ActivityEnrichment;
-                                   opt.RecordException = tc.RecordException.HasValue ? tc.RecordException.Value : false;
+                                   opt.RecordException = tc.RecordException ?? false;
                                })
                                .AddProcessor(processor.Object)
                                .Build())

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
@@ -52,6 +52,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests
         public void Dispose()
         {
             this.fakeSqlClientDiagnosticSource.Dispose();
+            GC.SuppressFinalize(this);
         }
 
         [Fact]

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToActivityConverterTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToActivityConverterTests.cs
@@ -51,6 +51,7 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Implementation
         {
             this.tracerProvider.Dispose();
             this.connection.Dispose();
+            GC.SuppressFinalize(this);
         }
 
         [Fact]

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/InProcessServer.cs
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/InProcessServer.cs
@@ -52,6 +52,7 @@ namespace OpenTelemetry.Instrumentation.W3cTraceContext.Tests
         public void Dispose()
         {
             this.DisposeServer();
+            GC.SuppressFinalize(this);
         }
 
         private static string GetTimestamp()

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/W3CTraceContextTests.cs
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/W3CTraceContextTests.cs
@@ -93,7 +93,7 @@ namespace OpenTelemetry.Instrumentation.W3cTraceContext.Tests
 
             // The output ends with '\n', which should be ignored.
             var lastNewLineCharacterPos = output.LastIndexOf('\n', output.Length - 2);
-            return output.Substring(lastNewLineCharacterPos + 1);
+            return output[(lastNewLineCharacterPos + 1)..];
         }
     }
 }

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/W3CTraceContextTests.cs
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/W3CTraceContextTests.cs
@@ -93,7 +93,7 @@ namespace OpenTelemetry.Instrumentation.W3cTraceContext.Tests
 
             // The output ends with '\n', which should be ignored.
             var lastNewLineCharacterPos = output.LastIndexOf('\n', output.Length - 2);
-            return output[(lastNewLineCharacterPos + 1)..];
+            return output.Substring(lastNewLineCharacterPos + 1);
         }
     }
 }

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanBuilderShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanBuilderShimTests.cs
@@ -121,7 +121,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
         public void Start_ActivityOperationRootSpanChecks()
         {
             // Create an activity
-            var activity = new Activity("foo")
+            _ = new Activity("foo")
                 .SetIdFormat(ActivityIdFormat.W3C)
                 .Start();
 
@@ -185,7 +185,7 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
 
             // Add a parent
             var spanContext = SpanContextShimTests.GetSpanContextShim();
-            var test = shim.AsChildOf(spanContext);
+            _ = shim.AsChildOf(spanContext);
 
             // build
             var spanShim = (SpanShim)shim.Start();
@@ -211,7 +211,6 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
 
             // build
             var spanShim = (SpanShim)shim.Start();
-            var linkContext = spanShim.Span.Activity.Links.First().Context;
 
             Assert.Equal("foo", spanShim.Span.Activity.OperationName);
             Assert.Contains(spanContext1.TraceId, spanShim.Span.Activity.ParentId);

--- a/test/OpenTelemetry.Tests/Context/PropagatorsTest.cs
+++ b/test/OpenTelemetry.Tests/Context/PropagatorsTest.cs
@@ -44,6 +44,7 @@ namespace OpenTelemetry.Context.Propagation.Tests
         public void Dispose()
         {
             Propagators.Reset();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/test/OpenTelemetry.Tests/Context/RuntimeContextTest.cs
+++ b/test/OpenTelemetry.Tests/Context/RuntimeContextTest.cs
@@ -102,6 +102,7 @@ namespace OpenTelemetry.Context.Tests
         public void Dispose()
         {
             RuntimeContext.Clear();
+            GC.SuppressFinalize(this);
         }
 
 #if NETFRAMEWORK

--- a/test/OpenTelemetry.Tests/Internal/EnvironmentVariableHelperTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/EnvironmentVariableHelperTests.cs
@@ -31,6 +31,7 @@ namespace OpenTelemetry.Internal.Tests
         public void Dispose()
         {
             Environment.SetEnvironmentVariable(EnvVar, null);
+            GC.SuppressFinalize(this);
         }
 
         [Fact]

--- a/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsConfigParserTest.cs
+++ b/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsConfigParserTest.cs
@@ -38,7 +38,7 @@ namespace OpenTelemetry.Internal.Tests
                     ""path"": ""Diagnostics"",
                     ""FileSize"": 1024
                     }";
-            Assert.False(SelfDiagnosticsConfigParser.TryParseLogDirectory(configJson, out string logDirectory));
+            Assert.False(SelfDiagnosticsConfigParser.TryParseLogDirectory(configJson, out _));
         }
 
         [Fact]
@@ -71,7 +71,7 @@ namespace OpenTelemetry.Internal.Tests
                     ""LogDirectory"": ""Diagnostics"",
                     ""size"": 1024
                     }";
-            Assert.False(SelfDiagnosticsConfigParser.TryParseFileSize(configJson, out int fileSize));
+            Assert.False(SelfDiagnosticsConfigParser.TryParseFileSize(configJson, out _));
         }
 
         [Fact]

--- a/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsConfigRefresherTest.cs
+++ b/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsConfigRefresherTest.cs
@@ -78,7 +78,7 @@ namespace OpenTelemetry.Internal.Tests
                 Assert.StartsWith(MessageOnNewFileString, logText);
 
                 // The event was captured
-                string logLine = logText.Substring(MessageOnNewFileString.Length);
+                string logLine = logText[MessageOnNewFileString.Length..];
                 string logMessage = ParseLogMessage(logLine);
                 string expectedMessage = "Unknown error in SpanProcessor event '{0}': '{1}'.{Event string sample}{Exception string sample}";
                 Assert.StartsWith(expectedMessage, logMessage);
@@ -92,8 +92,8 @@ namespace OpenTelemetry.Internal.Tests
         private static string ParseLogMessage(string logLine)
         {
             int timestampPrefixLength = "2020-08-14T20:33:24.4788109Z:".Length;
-            Assert.Matches(@"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}Z:", logLine.Substring(0, timestampPrefixLength));
-            return logLine.Substring(timestampPrefixLength);
+            Assert.Matches(@"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}Z:", logLine[..timestampPrefixLength]);
+            return logLine[timestampPrefixLength..];
         }
 
         private static byte[] ReadFile(int byteCount)

--- a/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsConfigRefresherTest.cs
+++ b/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsConfigRefresherTest.cs
@@ -78,7 +78,7 @@ namespace OpenTelemetry.Internal.Tests
                 Assert.StartsWith(MessageOnNewFileString, logText);
 
                 // The event was captured
-                string logLine = logText[MessageOnNewFileString.Length..];
+                string logLine = logText.Substring(MessageOnNewFileString.Length);
                 string logMessage = ParseLogMessage(logLine);
                 string expectedMessage = "Unknown error in SpanProcessor event '{0}': '{1}'.{Event string sample}{Exception string sample}";
                 Assert.StartsWith(expectedMessage, logMessage);
@@ -92,8 +92,8 @@ namespace OpenTelemetry.Internal.Tests
         private static string ParseLogMessage(string logLine)
         {
             int timestampPrefixLength = "2020-08-14T20:33:24.4788109Z:".Length;
-            Assert.Matches(@"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}Z:", logLine[..timestampPrefixLength]);
-            return logLine[timestampPrefixLength..];
+            Assert.Matches(@"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}Z:", logLine.Substring(0, timestampPrefixLength));
+            return logLine.Substring(timestampPrefixLength);
         }
 
         private static byte[] ReadFile(int byteCount)

--- a/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsEventListenerTest.cs
+++ b/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsEventListenerTest.cs
@@ -291,8 +291,8 @@ namespace OpenTelemetry.Internal.Tests
         private static string ParseLogMessage(string logLine)
         {
             int timestampPrefixLength = "2020-08-14T20:33:24.4788109Z:".Length;
-            Assert.Matches(@"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}Z:", logLine.Substring(0, timestampPrefixLength));
-            return logLine.Substring(timestampPrefixLength);
+            Assert.Matches(@"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}Z:", logLine[..timestampPrefixLength]);
+            return logLine[timestampPrefixLength..];
         }
 
         private static void AssertBufferOutput(byte[] expected, byte[] buffer, int startPos, int endPos)

--- a/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsEventListenerTest.cs
+++ b/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsEventListenerTest.cs
@@ -291,8 +291,8 @@ namespace OpenTelemetry.Internal.Tests
         private static string ParseLogMessage(string logLine)
         {
             int timestampPrefixLength = "2020-08-14T20:33:24.4788109Z:".Length;
-            Assert.Matches(@"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}Z:", logLine[..timestampPrefixLength]);
-            return logLine[timestampPrefixLength..];
+            Assert.Matches(@"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{7}Z:", logLine.Substring(0, timestampPrefixLength));
+            return logLine.Substring(timestampPrefixLength);
         }
 
         private static void AssertBufferOutput(byte[] expected, byte[] buffer, int startPos, int endPos)

--- a/test/OpenTelemetry.Tests/Logs/LogRecordTest.cs
+++ b/test/OpenTelemetry.Tests/Logs/LogRecordTest.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using Microsoft.Extensions.Logging;
@@ -74,9 +75,7 @@ namespace OpenTelemetry.Logs.Tests
         [InlineData(LogLevel.Critical)]
         public void CheckLogLevel(LogLevel logLevel)
         {
-            var message = $"Log {logLevel}";
-            this.logger.Log(logLevel, message);
-
+            this.logger.Log(logLevel, "Log {logLevel}", logLevel);
             var logLevelRecorded = this.exportedItems[0].LogLevel;
             Assert.Equal(logLevel, logLevelRecorded);
         }
@@ -84,17 +83,18 @@ namespace OpenTelemetry.Logs.Tests
         [Fact]
         public void CheckStateForUnstructuredLog()
         {
-            var message = "Hello, World!";
+            const string message = "Hello, World!";
             this.logger.LogInformation(message);
             var state = this.exportedItems[0].State as IReadOnlyList<KeyValuePair<string, object>>;
 
             // state only has {OriginalFormat}
             Assert.Equal(1, state.Count);
 
-            Assert.Equal(message.ToString(), state.ToString());
+            Assert.Equal(message, state.ToString());
         }
 
         [Fact]
+        [SuppressMessage("CA2254", "CA2254", Justification = "While you shouldn't use interpolation in a log message, this test verifies things work with it anyway.")]
         public void CheckStateForUnstructuredLogWithStringInterpolation()
         {
             var message = $"Hello from potato {0.99}.";
@@ -104,13 +104,13 @@ namespace OpenTelemetry.Logs.Tests
             // state only has {OriginalFormat}
             Assert.Equal(1, state.Count);
 
-            Assert.Equal(message.ToString(), state.ToString());
+            Assert.Equal(message, state.ToString());
         }
 
         [Fact]
         public void CheckStateForStructuredLogWithTemplate()
         {
-            var message = "Hello from {name} {price}.";
+            const string message = "Hello from {name} {price}.";
             this.logger.LogInformation(message, "tomato", 2.99);
             var state = this.exportedItems[0].State as IReadOnlyList<KeyValuePair<string, object>>;
 
@@ -221,7 +221,7 @@ namespace OpenTelemetry.Logs.Tests
         {
             var exceptionMessage = "Exception Message";
             var exception = new Exception(exceptionMessage);
-            var message = "Exception Occurred";
+            const string message = "Exception Occurred";
             this.logger.LogInformation(exception, message);
 
             var state = this.exportedItems[0].State;
@@ -234,7 +234,7 @@ namespace OpenTelemetry.Logs.Tests
             Assert.NotNull(loggedException);
             Assert.Equal(exceptionMessage, loggedException.Message);
 
-            Assert.Equal(message.ToString(), state.ToString());
+            Assert.Equal(message, state.ToString());
         }
 
         [Fact]

--- a/test/OpenTelemetry.Tests/Metrics/AggregatorTest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/AggregatorTest.cs
@@ -105,7 +105,7 @@ namespace OpenTelemetry.Metrics.Tests
         [Fact]
         public void HistogramWithOnlySumCount()
         {
-            var boundaries = new double[] { };
+            var boundaries = Array.Empty<double>();
             var histogramPoint = new MetricPoint(AggregationType.HistogramSumCount, DateTimeOffset.Now, null, null, boundaries);
 
             histogramPoint.Update(-10);

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -28,10 +28,10 @@ namespace OpenTelemetry.Metrics.Tests
     public class MetricApiTest
     {
         private const int MaxTimeToAllowForFlush = 10000;
-        private static int numberOfThreads = Environment.ProcessorCount;
-        private static long deltaLongValueUpdatedByEachCall = 10;
-        private static double deltaDoubleValueUpdatedByEachCall = 11.987;
-        private static int numberOfMetricUpdateByEachThread = 100000;
+        private static readonly int NumberOfThreads = Environment.ProcessorCount;
+        private static readonly long DeltaLongValueUpdatedByEachCall = 10;
+        private static readonly double DeltaDoubleValueUpdatedByEachCall = 11.987;
+        private static readonly int NumberOfMetricUpdateByEachThread = 100000;
         private readonly ITestOutputHelper output;
 
         public MetricApiTest(ITestOutputHelper output)
@@ -1212,13 +1212,13 @@ namespace OpenTelemetry.Metrics.Tests
         [Fact]
         public void MultithreadedLongCounterTest()
         {
-            this.MultithreadedCounterTest(deltaLongValueUpdatedByEachCall);
+            this.MultithreadedCounterTest(DeltaLongValueUpdatedByEachCall);
         }
 
         [Fact]
         public void MultithreadedDoubleCounterTest()
         {
-            this.MultithreadedCounterTest(deltaDoubleValueUpdatedByEachCall);
+            this.MultithreadedCounterTest(DeltaDoubleValueUpdatedByEachCall);
         }
 
         [Fact]
@@ -1227,7 +1227,7 @@ namespace OpenTelemetry.Metrics.Tests
             var expected = new long[11];
             for (var i = 0; i < expected.Length; i++)
             {
-                expected[i] = numberOfThreads * numberOfMetricUpdateByEachThread;
+                expected[i] = NumberOfThreads * NumberOfMetricUpdateByEachThread;
             }
 
             // Metric.DefaultHistogramBounds: 0, 5, 10, 25, 50, 75, 100, 250, 500, 1000
@@ -1242,7 +1242,7 @@ namespace OpenTelemetry.Metrics.Tests
             var expected = new long[11];
             for (var i = 0; i < expected.Length; i++)
             {
-                expected[i] = numberOfThreads * numberOfMetricUpdateByEachThread;
+                expected[i] = NumberOfThreads * NumberOfMetricUpdateByEachThread;
             }
 
             // Metric.DefaultHistogramBounds: 0, 5, 10, 25, 50, 75, 100, 250, 500, 1000
@@ -1420,7 +1420,7 @@ namespace OpenTelemetry.Metrics.Tests
             var mreToEnsureAllThreadsStart = arguments.MreToEnsureAllThreadsStart;
             var counter = arguments.Instrument as Counter<T>;
             var valueToUpdate = arguments.ValuesToRecord[0];
-            if (Interlocked.Increment(ref arguments.ThreadsStartedCount) == numberOfThreads)
+            if (Interlocked.Increment(ref arguments.ThreadsStartedCount) == NumberOfThreads)
             {
                 mreToEnsureAllThreadsStart.Set();
             }
@@ -1428,7 +1428,7 @@ namespace OpenTelemetry.Metrics.Tests
             // Wait until signalled to start calling update on aggregator
             mre.WaitOne();
 
-            for (int i = 0; i < numberOfMetricUpdateByEachThread; i++)
+            for (int i = 0; i < NumberOfMetricUpdateByEachThread; i++)
             {
                 counter.Add(valueToUpdate, new KeyValuePair<string, object>("verb", "GET"));
             }
@@ -1446,7 +1446,7 @@ namespace OpenTelemetry.Metrics.Tests
             var mreToEnsureAllThreadsStart = arguments.MreToEnsureAllThreadsStart;
             var histogram = arguments.Instrument as Histogram<T>;
 
-            if (Interlocked.Increment(ref arguments.ThreadsStartedCount) == numberOfThreads)
+            if (Interlocked.Increment(ref arguments.ThreadsStartedCount) == NumberOfThreads)
             {
                 mreToEnsureAllThreadsStart.Set();
             }
@@ -1454,7 +1454,7 @@ namespace OpenTelemetry.Metrics.Tests
             // Wait until signalled to start calling update on aggregator
             mre.WaitOne();
 
-            for (int i = 0; i < numberOfMetricUpdateByEachThread; i++)
+            for (int i = 0; i < NumberOfMetricUpdateByEachThread; i++)
             {
                 for (int j = 0; j < arguments.ValuesToRecord.Length; j++)
                 {
@@ -1482,8 +1482,8 @@ namespace OpenTelemetry.Metrics.Tests
                 MreToEnsureAllThreadsStart = new ManualResetEvent(false),
             };
 
-            Thread[] t = new Thread[numberOfThreads];
-            for (int i = 0; i < numberOfThreads; i++)
+            Thread[] t = new Thread[NumberOfThreads];
+            for (int i = 0; i < NumberOfThreads; i++)
             {
                 t[i] = new Thread(CounterUpdateThread<T>);
                 t[i].Start(argToThread);
@@ -1493,25 +1493,25 @@ namespace OpenTelemetry.Metrics.Tests
             Stopwatch sw = Stopwatch.StartNew();
             argToThread.MreToBlockUpdateThread.Set();
 
-            for (int i = 0; i < numberOfThreads; i++)
+            for (int i = 0; i < NumberOfThreads; i++)
             {
                 t[i].Join();
             }
 
-            this.output.WriteLine($"Took {sw.ElapsedMilliseconds} msecs. Total threads: {numberOfThreads}, each thread doing {numberOfMetricUpdateByEachThread} recordings.");
+            this.output.WriteLine($"Took {sw.ElapsedMilliseconds} msecs. Total threads: {NumberOfThreads}, each thread doing {NumberOfMetricUpdateByEachThread} recordings.");
 
             meterProvider.ForceFlush();
 
             if (typeof(T) == typeof(long))
             {
                 var sumReceived = GetLongSum(metricItems);
-                var expectedSum = deltaLongValueUpdatedByEachCall * numberOfMetricUpdateByEachThread * numberOfThreads;
+                var expectedSum = DeltaLongValueUpdatedByEachCall * NumberOfMetricUpdateByEachThread * NumberOfThreads;
                 Assert.Equal(expectedSum, sumReceived);
             }
             else if (typeof(T) == typeof(double))
             {
                 var sumReceived = GetDoubleSum(metricItems);
-                var expectedSum = deltaDoubleValueUpdatedByEachCall * numberOfMetricUpdateByEachThread * numberOfThreads;
+                var expectedSum = DeltaDoubleValueUpdatedByEachCall * NumberOfMetricUpdateByEachThread * NumberOfThreads;
                 Assert.Equal(expectedSum, sumReceived, 2);
             }
         }
@@ -1545,8 +1545,8 @@ namespace OpenTelemetry.Metrics.Tests
                 ValuesToRecord = values,
             };
 
-            Thread[] t = new Thread[numberOfThreads];
-            for (int i = 0; i < numberOfThreads; i++)
+            Thread[] t = new Thread[NumberOfThreads];
+            for (int i = 0; i < NumberOfThreads; i++)
             {
                 t[i] = new Thread(HistogramUpdateThread<T>);
                 t[i].Start(argsToThread);
@@ -1556,12 +1556,12 @@ namespace OpenTelemetry.Metrics.Tests
             Stopwatch sw = Stopwatch.StartNew();
             argsToThread.MreToBlockUpdateThread.Set();
 
-            for (int i = 0; i < numberOfThreads; i++)
+            for (int i = 0; i < NumberOfThreads; i++)
             {
                 t[i].Join();
             }
 
-            this.output.WriteLine($"Took {sw.ElapsedMilliseconds} msecs. Total threads: {numberOfThreads}, each thread doing {numberOfMetricUpdateByEachThread * values.Length} recordings.");
+            this.output.WriteLine($"Took {sw.ElapsedMilliseconds} msecs. Total threads: {NumberOfThreads}, each thread doing {NumberOfMetricUpdateByEachThread * values.Length} recordings.");
 
             metricReader.Collect();
 

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -878,7 +878,7 @@ namespace OpenTelemetry.Metrics.Tests
                 {
                     metricReaderOptions.Temporality = exportDelta ? AggregationTemporality.Delta : AggregationTemporality.Cumulative;
                 })
-                .AddView("requestCount", new MetricStreamConfiguration() { TagKeys = new string[] { } })
+                .AddView("requestCount", new MetricStreamConfiguration() { TagKeys = Array.Empty<string>() })
                 .Build();
 
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -744,17 +744,23 @@ namespace OpenTelemetry.Metrics.Tests
         public void ObservableCounterWithTagsAggregationTest(bool exportDelta)
         {
             var exportedItems = new List<Metric>();
-            var tags1 = new List<KeyValuePair<string, object>>();
-            tags1.Add(new("statusCode", 200));
-            tags1.Add(new("verb", "get"));
+            var tags1 = new List<KeyValuePair<string, object>>
+            {
+                new("statusCode", 200),
+                new("verb", "get"),
+            };
 
-            var tags2 = new List<KeyValuePair<string, object>>();
-            tags2.Add(new("statusCode", 200));
-            tags2.Add(new("verb", "post"));
+            var tags2 = new List<KeyValuePair<string, object>>
+            {
+                new("statusCode", 200),
+                new("verb", "post"),
+            };
 
-            var tags3 = new List<KeyValuePair<string, object>>();
-            tags3.Add(new("statusCode", 500));
-            tags3.Add(new("verb", "get"));
+            var tags3 = new List<KeyValuePair<string, object>>
+            {
+                new("statusCode", 500),
+                new("verb", "get"),
+            };
 
             using var meter = new Meter($"{Utils.GetCurrentMethodName()}.{exportDelta}");
             var counterLong = meter.CreateObservableCounter(
@@ -835,17 +841,23 @@ namespace OpenTelemetry.Metrics.Tests
         public void ObservableCounterSpatialAggregationTest(bool exportDelta)
         {
             var exportedItems = new List<Metric>();
-            var tags1 = new List<KeyValuePair<string, object>>();
-            tags1.Add(new("statusCode", 200));
-            tags1.Add(new("verb", "get"));
+            var tags1 = new List<KeyValuePair<string, object>>
+            {
+                new("statusCode", 200),
+                new("verb", "get"),
+            };
 
-            var tags2 = new List<KeyValuePair<string, object>>();
-            tags2.Add(new("statusCode", 200));
-            tags2.Add(new("verb", "post"));
+            var tags2 = new List<KeyValuePair<string, object>>
+            {
+                new("statusCode", 200),
+                new("verb", "post"),
+            };
 
-            var tags3 = new List<KeyValuePair<string, object>>();
-            tags3.Add(new("statusCode", 500));
-            tags3.Add(new("verb", "get"));
+            var tags3 = new List<KeyValuePair<string, object>>
+            {
+                new("statusCode", 500),
+                new("verb", "get"),
+            };
 
             using var meter = new Meter($"{Utils.GetCurrentMethodName()}.{exportDelta}");
             var counterLong = meter.CreateObservableCounter(

--- a/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
@@ -447,7 +447,7 @@ namespace OpenTelemetry.Metrics.Tests
                 .AddView("FruitCounter", new MetricStreamConfiguration()
                 { TagKeys = new string[] { "size" }, Name = "SizeOnly" })
                 .AddView("FruitCounter", new MetricStreamConfiguration()
-                { TagKeys = new string[] { }, Name = "NoTags" })
+                { TagKeys = Array.Empty<string>(), Name = "NoTags" })
                 .AddInMemoryExporter(exportedItems)
                 .Build();
 

--- a/test/OpenTelemetry.Tests/Metrics/MultipleReadersTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MultipleReadersTests.cs
@@ -98,22 +98,22 @@ namespace OpenTelemetry.Metrics.Tests
             }
 
             // Check value exported for Counter
-            this.AssertLongSumValueForMetric(exportedItems1[0], 10);
-            this.AssertLongSumValueForMetric(exportedItems2[0], 10);
+            AssertLongSumValueForMetric(exportedItems1[0], 10);
+            AssertLongSumValueForMetric(exportedItems2[0], 10);
 
             // Check value exported for Gauge
-            this.AssertLongSumValueForMetric(exportedItems1[1], 100);
-            this.AssertLongSumValueForMetric(exportedItems2[1], 200);
+            AssertLongSumValueForMetric(exportedItems1[1], 100);
+            AssertLongSumValueForMetric(exportedItems2[1], 200);
 
             // Check value exported for ObservableCounter
-            this.AssertLongSumValueForMetric(exportedItems1[2], 1000);
+            AssertLongSumValueForMetric(exportedItems1[2], 1000);
             if (aggregationTemporality == AggregationTemporality.Delta)
             {
-                this.AssertLongSumValueForMetric(exportedItems2[2], 1200);
+                AssertLongSumValueForMetric(exportedItems2[2], 1200);
             }
             else
             {
-                this.AssertLongSumValueForMetric(exportedItems2[2], 1200);
+                AssertLongSumValueForMetric(exportedItems2[2], 1200);
             }
 
             exportedItems1.Clear();
@@ -127,29 +127,29 @@ namespace OpenTelemetry.Metrics.Tests
             Assert.Equal(3, exportedItems2.Count);
 
             // Check value exported for Counter
-            this.AssertLongSumValueForMetric(exportedItems1[0], 15);
+            AssertLongSumValueForMetric(exportedItems1[0], 15);
             if (aggregationTemporality == AggregationTemporality.Delta)
             {
-                this.AssertLongSumValueForMetric(exportedItems2[0], 15);
+                AssertLongSumValueForMetric(exportedItems2[0], 15);
             }
             else
             {
-                this.AssertLongSumValueForMetric(exportedItems2[0], 25);
+                AssertLongSumValueForMetric(exportedItems2[0], 25);
             }
 
             // Check value exported for Gauge
-            this.AssertLongSumValueForMetric(exportedItems1[1], 300);
-            this.AssertLongSumValueForMetric(exportedItems2[1], 400);
+            AssertLongSumValueForMetric(exportedItems1[1], 300);
+            AssertLongSumValueForMetric(exportedItems2[1], 400);
 
             // Check value exported for ObservableCounter
-            this.AssertLongSumValueForMetric(exportedItems1[2], 300);
+            AssertLongSumValueForMetric(exportedItems1[2], 300);
             if (aggregationTemporality == AggregationTemporality.Delta)
             {
-                this.AssertLongSumValueForMetric(exportedItems2[2], 200);
+                AssertLongSumValueForMetric(exportedItems2[2], 200);
             }
             else
             {
-                this.AssertLongSumValueForMetric(exportedItems2[2], 1400);
+                AssertLongSumValueForMetric(exportedItems2[2], 1400);
             }
         }
 
@@ -198,7 +198,7 @@ namespace OpenTelemetry.Metrics.Tests
             }
         }
 
-        private void AssertLongSumValueForMetric(Metric metric, long value)
+        private static void AssertLongSumValueForMetric(Metric metric, long value)
         {
             var metricPoints = metric.GetMetricPoints();
             var metricPointsEnumerator = metricPoints.GetEnumerator();

--- a/test/OpenTelemetry.Tests/Resources/OtelEnvResourceDetectorTest.cs
+++ b/test/OpenTelemetry.Tests/Resources/OtelEnvResourceDetectorTest.cs
@@ -36,10 +36,6 @@ namespace OpenTelemetry.Resources.Tests
         [Fact]
         public void OtelEnvResource_EnvVarKey()
         {
-            // Act
-            var resource = new OtelServiceNameEnvVarDetector().Detect();
-
-            // Assert
             Assert.Equal("OTEL_RESOURCE_ATTRIBUTES", OtelEnvResourceDetector.EnvVarKey);
         }
 

--- a/test/OpenTelemetry.Tests/Resources/OtelEnvResourceDetectorTest.cs
+++ b/test/OpenTelemetry.Tests/Resources/OtelEnvResourceDetectorTest.cs
@@ -30,6 +30,7 @@ namespace OpenTelemetry.Resources.Tests
         public void Dispose()
         {
             Environment.SetEnvironmentVariable(OtelEnvResourceDetector.EnvVarKey, null);
+            GC.SuppressFinalize(this);
         }
 
         [Fact]

--- a/test/OpenTelemetry.Tests/Resources/OtelServiceNameEnvVarDetectorTests.cs
+++ b/test/OpenTelemetry.Tests/Resources/OtelServiceNameEnvVarDetectorTests.cs
@@ -30,6 +30,7 @@ namespace OpenTelemetry.Resources.Tests
         public void Dispose()
         {
             Environment.SetEnvironmentVariable(OtelServiceNameEnvVarDetector.EnvVarKey, null);
+            GC.SuppressFinalize(this);
         }
 
         [Fact]

--- a/test/OpenTelemetry.Tests/Resources/OtelServiceNameEnvVarDetectorTests.cs
+++ b/test/OpenTelemetry.Tests/Resources/OtelServiceNameEnvVarDetectorTests.cs
@@ -36,10 +36,6 @@ namespace OpenTelemetry.Resources.Tests
         [Fact]
         public void OtelServiceNameEnvVar_EnvVarKey()
         {
-            // Act
-            var resource = new OtelServiceNameEnvVarDetector().Detect();
-
-            // Assert
             Assert.Equal("OTEL_SERVICE_NAME", OtelServiceNameEnvVarDetector.EnvVarKey);
         }
 

--- a/test/OpenTelemetry.Tests/Resources/ResourceTest.cs
+++ b/test/OpenTelemetry.Tests/Resources/ResourceTest.cs
@@ -90,14 +90,14 @@ namespace OpenTelemetry.Resources.Tests
         public void CreateResource_EmptyArray()
         {
             // Arrange
-            var attributes = new Dictionary<string, object> { { "EmptyArray", new string[0] } };
+            var attributes = new Dictionary<string, object> { { "EmptyArray", Array.Empty<string>() } };
 
             // does not throw
             var resource = new Resource(attributes);
 
             // Assert
             Assert.Single(resource.Attributes);
-            Assert.Equal(new string[0], resource.Attributes.Where(x => x.Key == "EmptyArray").FirstOrDefault().Value);
+            Assert.Equal(Array.Empty<string>(), resource.Attributes.Where(x => x.Key == "EmptyArray").FirstOrDefault().Value);
         }
 
         [Fact]

--- a/test/OpenTelemetry.Tests/Resources/ResourceTest.cs
+++ b/test/OpenTelemetry.Tests/Resources/ResourceTest.cs
@@ -105,7 +105,7 @@ namespace OpenTelemetry.Resources.Tests
         {
             // Arrange
             var attributeCount = 0;
-            var attributes = this.CreateAttributes(attributeCount);
+            var attributes = CreateAttributes(attributeCount);
 
             // Act
             var resource = new Resource(attributes);
@@ -119,7 +119,7 @@ namespace OpenTelemetry.Resources.Tests
         {
             // Arrange
             var attributeCount = 1;
-            var attributes = this.CreateAttributes(attributeCount);
+            var attributes = CreateAttributes(attributeCount);
 
             // Act
             var resource = new Resource(attributes);
@@ -133,7 +133,7 @@ namespace OpenTelemetry.Resources.Tests
         {
             // Arrange
             var attributeCount = 5;
-            var attributes = this.CreateAttributes(attributeCount);
+            var attributes = CreateAttributes(attributeCount);
 
             // Act
             var resource = new Resource(attributes);
@@ -229,11 +229,11 @@ namespace OpenTelemetry.Resources.Tests
         {
             // Arrange
             var sourceAttributeCount = 0;
-            var sourceAttributes = this.CreateAttributes(sourceAttributeCount);
+            var sourceAttributes = CreateAttributes(sourceAttributeCount);
             var sourceResource = new Resource(sourceAttributes);
 
             var otherAttributeCount = 3;
-            var otherAttributes = this.CreateAttributes(otherAttributeCount);
+            var otherAttributes = CreateAttributes(otherAttributeCount);
             var otherResource = new Resource(otherAttributes);
 
             // Act
@@ -251,11 +251,11 @@ namespace OpenTelemetry.Resources.Tests
         {
             // Arrange
             var sourceAttributeCount = 3;
-            var sourceAttributes = this.CreateAttributes(sourceAttributeCount);
+            var sourceAttributes = CreateAttributes(sourceAttributeCount);
             var sourceResource = new Resource(sourceAttributes);
 
             var otherAttributeCount = 0;
-            var otherAttributes = this.CreateAttributes(otherAttributeCount);
+            var otherAttributes = CreateAttributes(otherAttributeCount);
             var otherResource = new Resource(otherAttributes);
 
             // Act
@@ -272,11 +272,11 @@ namespace OpenTelemetry.Resources.Tests
         {
             // Arrange
             var sourceAttributeCount = 3;
-            var sourceAttributes = this.CreateAttributes(sourceAttributeCount);
+            var sourceAttributes = CreateAttributes(sourceAttributeCount);
             var sourceResource = new Resource(sourceAttributes);
 
             var otherAttributeCount = 3;
-            var otherAttributes = this.CreateAttributes(otherAttributeCount, sourceAttributeCount);
+            var otherAttributes = CreateAttributes(otherAttributeCount, sourceAttributeCount);
             var otherResource = new Resource(otherAttributes);
 
             // Act
@@ -293,11 +293,11 @@ namespace OpenTelemetry.Resources.Tests
         {
             // Arrange
             var sourceAttributeCount = 3;
-            var sourceAttributes = this.CreateAttributes(sourceAttributeCount);
+            var sourceAttributes = CreateAttributes(sourceAttributeCount);
             var sourceResource = new Resource(sourceAttributes);
 
             var otherAttributeCount = 3;
-            var otherAttributes = this.CreateAttributes(otherAttributeCount, sourceAttributeCount - 1);
+            var otherAttributes = CreateAttributes(otherAttributeCount, sourceAttributeCount - 1);
             var otherResource = new Resource(otherAttributes);
 
             // Act
@@ -320,11 +320,11 @@ namespace OpenTelemetry.Resources.Tests
         {
             // Arrange
             var sourceAttributeCount = 3;
-            var sourceAttributes = this.CreateAttributes(sourceAttributeCount);
+            var sourceAttributes = CreateAttributes(sourceAttributeCount);
             var sourceResource = new Resource(sourceAttributes);
 
             var otherAttributeCount = 3;
-            var otherAttributes = this.CreateAttributes(otherAttributeCount);
+            var otherAttributes = CreateAttributes(otherAttributeCount);
             var otherResource = new Resource(otherAttributes);
 
             // Act
@@ -416,7 +416,7 @@ namespace OpenTelemetry.Resources.Tests
         public void GetResourceWithDefaultAttributes_ResourceWithAttrs()
         {
             // Arrange
-            var resource = ResourceBuilder.CreateDefault().AddAttributes(this.CreateAttributes(2)).Build();
+            var resource = ResourceBuilder.CreateDefault().AddAttributes(CreateAttributes(2)).Build();
 
             // Assert
             var attributes = resource.Attributes;
@@ -430,7 +430,7 @@ namespace OpenTelemetry.Resources.Tests
         {
             // Arrange
             Environment.SetEnvironmentVariable(OtelEnvResourceDetector.EnvVarKey, "EVKey1=EVVal1,EVKey2=EVVal2");
-            var resource = ResourceBuilder.CreateDefault().AddAttributes(this.CreateAttributes(2)).Build();
+            var resource = ResourceBuilder.CreateDefault().AddAttributes(CreateAttributes(2)).Build();
 
             // Assert
             var attributes = resource.Attributes;
@@ -460,7 +460,7 @@ namespace OpenTelemetry.Resources.Tests
         {
             // Arrange
             Environment.SetEnvironmentVariable(OtelServiceNameEnvVarDetector.EnvVarKey, "some-service");
-            var resource = ResourceBuilder.CreateDefault().AddAttributes(this.CreateAttributes(2)).Build();
+            var resource = ResourceBuilder.CreateDefault().AddAttributes(CreateAttributes(2)).Build();
 
             // Assert
             var attributes = resource.Attributes;
@@ -475,7 +475,7 @@ namespace OpenTelemetry.Resources.Tests
             // Arrange
             Environment.SetEnvironmentVariable(OtelEnvResourceDetector.EnvVarKey, "service.name=from-resource-attr");
             Environment.SetEnvironmentVariable(OtelServiceNameEnvVarDetector.EnvVarKey, "from-service-name");
-            var resource = ResourceBuilder.CreateDefault().AddAttributes(this.CreateAttributes(2)).Build();
+            var resource = ResourceBuilder.CreateDefault().AddAttributes(CreateAttributes(2)).Build();
 
             // Assert
             var attributes = resource.Attributes;
@@ -490,7 +490,7 @@ namespace OpenTelemetry.Resources.Tests
             // Arrange
             Environment.SetEnvironmentVariable(OtelEnvResourceDetector.EnvVarKey, "service.name=from-resource-attr");
             Environment.SetEnvironmentVariable(OtelServiceNameEnvVarDetector.EnvVarKey, "from-service-name");
-            var resource = ResourceBuilder.CreateDefault().AddService("from-code").AddAttributes(this.CreateAttributes(2)).Build();
+            var resource = ResourceBuilder.CreateDefault().AddService("from-code").AddAttributes(CreateAttributes(2)).Build();
 
             // Assert
             var attributes = resource.Attributes;
@@ -546,7 +546,7 @@ namespace OpenTelemetry.Resources.Tests
             Assert.Contains("unknown_service", serviceName.FirstOrDefault().Value as string);
         }
 
-        private Dictionary<string, object> CreateAttributes(int attributeCount, int startIndex = 0)
+        private static Dictionary<string, object> CreateAttributes(int attributeCount, int startIndex = 0)
         {
             var attributes = new Dictionary<string, object>();
             AddAttributes(attributes, attributeCount, startIndex);

--- a/test/OpenTelemetry.Tests/Resources/ResourceTest.cs
+++ b/test/OpenTelemetry.Tests/Resources/ResourceTest.cs
@@ -34,6 +34,7 @@ namespace OpenTelemetry.Resources.Tests
         public void Dispose()
         {
             ClearEnvVars();
+            GC.SuppressFinalize(this);
         }
 
         [Fact]

--- a/test/OpenTelemetry.Tests/Shared/TestPropagator.cs
+++ b/test/OpenTelemetry.Tests/Shared/TestPropagator.cs
@@ -44,7 +44,7 @@ namespace OpenTelemetry.Context.Propagation.Tests
             }
 
             IEnumerable<string> id = getter(carrier, this.idHeaderName);
-            if (id.Count() <= 0)
+            if (!id.Any())
             {
                 return context;
             }

--- a/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorOptionsTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorOptionsTest.cs
@@ -23,12 +23,12 @@ namespace OpenTelemetry.Trace.Tests
     {
         public BatchExportActivityProcessorOptionsTest()
         {
-            this.ClearEnvVars();
+            ClearEnvVars();
         }
 
         public void Dispose()
         {
-            this.ClearEnvVars();
+            ClearEnvVars();
             GC.SuppressFinalize(this);
         }
 
@@ -89,7 +89,7 @@ namespace OpenTelemetry.Trace.Tests
             Assert.Equal("OTEL_BSP_SCHEDULE_DELAY", BatchExportActivityProcessorOptions.ScheduledDelayEnvVarKey);
         }
 
-        private void ClearEnvVars()
+        private static void ClearEnvVars()
         {
             Environment.SetEnvironmentVariable(BatchExportActivityProcessorOptions.ExporterTimeoutEnvVarKey, null);
             Environment.SetEnvironmentVariable(BatchExportActivityProcessorOptions.MaxExportBatchSizeEnvVarKey, null);

--- a/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorOptionsTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorOptionsTest.cs
@@ -29,6 +29,7 @@ namespace OpenTelemetry.Trace.Tests
         public void Dispose()
         {
             this.ClearEnvVars();
+            GC.SuppressFinalize(this);
         }
 
         [Fact]

--- a/test/OpenTelemetry.Tests/Trace/BatchTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/BatchTest.cs
@@ -87,13 +87,13 @@ namespace OpenTelemetry.Trace.Tests
             var value = "a";
             var batch = new Batch<string>(value);
             var enumerator = batch.GetEnumerator();
-            this.ValidateEnumerator(enumerator, value);
+            ValidateEnumerator(enumerator, value);
 
             var circularBuffer = new CircularBuffer<string>(1);
             circularBuffer.Add(value);
             batch = new Batch<string>(circularBuffer, 1);
             enumerator = batch.GetEnumerator();
-            this.ValidateEnumerator(enumerator, value);
+            ValidateEnumerator(enumerator, value);
         }
 
         [Fact]
@@ -157,10 +157,10 @@ namespace OpenTelemetry.Trace.Tests
 
             Assert.Equal(1, batch.Count);
 
-            this.ValidateEnumerator(batch.GetEnumerator(), "b");
+            ValidateEnumerator(batch.GetEnumerator(), "b");
         }
 
-        private void ValidateEnumerator(Batch<string>.Enumerator enumerator, string expected)
+        private static void ValidateEnumerator(Batch<string>.Enumerator enumerator, string expected)
         {
             if (enumerator.Current != null)
             {

--- a/test/OpenTelemetry.Tests/Trace/CompositeActivityProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/CompositeActivityProcessorTests.cs
@@ -28,7 +28,7 @@ namespace OpenTelemetry.Trace.Tests
         public void CompositeActivityProcessor_BadArgs()
         {
             Assert.Throws<ArgumentNullException>(() => new CompositeProcessor<Activity>(null));
-            Assert.Throws<ArgumentException>(() => new CompositeProcessor<Activity>(new BaseProcessor<Activity>[0]));
+            Assert.Throws<ArgumentException>(() => new CompositeProcessor<Activity>(Array.Empty<BaseProcessor<Activity>>()));
 
             using var p1 = new TestActivityProcessor(null, null);
             using var processor = new CompositeProcessor<Activity>(new[] { p1 });

--- a/test/OpenTelemetry.Tests/Trace/CurrentSpanTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/CurrentSpanTests.cs
@@ -48,6 +48,7 @@ namespace OpenTelemetry.Trace.Tests
         public void Dispose()
         {
             Activity.Current = null;
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/test/OpenTelemetry.Tests/Trace/LinkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/LinkTest.cs
@@ -127,6 +127,7 @@ namespace OpenTelemetry.Trace.Tests
         public void Dispose()
         {
             Activity.Current = null;
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/test/OpenTelemetry.Tests/Trace/ParentBasedSamplerTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/ParentBasedSamplerTests.cs
@@ -119,7 +119,7 @@ namespace OpenTelemetry.Trace.Tests
                 localParentSampled.Object,
                 localParentNotSampled.Object);
 
-            var samplingParams = this.MakeTestParameters(parentIsRemote, parentIsSampled);
+            var samplingParams = MakeTestParameters(parentIsRemote, parentIsSampled);
 
             Mock<Sampler> invokedSampler;
             if (parentIsRemote && parentIsSampled)
@@ -155,7 +155,7 @@ namespace OpenTelemetry.Trace.Tests
             Assert.Throws<ArgumentNullException>(() => new ParentBasedSampler(null));
         }
 
-        private SamplingParameters MakeTestParameters(bool parentIsRemote, bool parentIsSampled)
+        private static SamplingParameters MakeTestParameters(bool parentIsRemote, bool parentIsSampled)
         {
             return new SamplingParameters(
                 parentContext: new ActivityContext(

--- a/test/OpenTelemetry.Tests/Trace/Propagation/B3PropagatorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/B3PropagatorTest.cs
@@ -367,12 +367,12 @@ namespace OpenTelemetry.Context.Propagation.Tests
         [Fact]
         public void Fields_list()
         {
-            this.ContainsExactly(
+            ContainsExactly(
                 this.b3propagator.Fields,
                 new List<string> { B3Propagator.XB3TraceId, B3Propagator.XB3SpanId, B3Propagator.XB3ParentSpanId, B3Propagator.XB3Sampled, B3Propagator.XB3Flags });
         }
 
-        private void ContainsExactly(ISet<string> list, List<string> items)
+        private static void ContainsExactly(ISet<string> list, List<string> items)
         {
             Assert.Equal(items.Count, list.Count);
             foreach (var item in items)

--- a/test/OpenTelemetry.Tests/Trace/Propagation/CompositePropagatorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/CompositePropagatorTest.cs
@@ -24,7 +24,7 @@ namespace OpenTelemetry.Context.Propagation.Tests
 {
     public class CompositePropagatorTest
     {
-        private static readonly string[] Empty = new string[0];
+        private static readonly string[] Empty = Array.Empty<string>();
         private static readonly Func<IDictionary<string, string>, string, IEnumerable<string>> Getter = (headers, name) =>
         {
             count++;

--- a/test/OpenTelemetry.Tests/Trace/Propagation/TraceContextPropagatorTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/Propagation/TraceContextPropagatorTest.cs
@@ -27,7 +27,7 @@ namespace OpenTelemetry.Context.Propagation.Tests
         private const string TraceId = "0af7651916cd43dd8448eb211c80319c";
         private const string SpanId = "b9c7c989f97918e1";
 
-        private static readonly string[] Empty = new string[0];
+        private static readonly string[] Empty = Array.Empty<string>();
         private static readonly Func<IDictionary<string, string>, string, IEnumerable<string>> Getter = (headers, name) =>
         {
             if (headers.TryGetValue(name, out var value))
@@ -45,7 +45,7 @@ namespace OpenTelemetry.Context.Propagation.Tests
                 return value;
             }
 
-            return new string[] { };
+            return Array.Empty<string>();
         };
 
         private static readonly Action<IDictionary<string, string>, string, string> Setter = (carrier, name, value) =>

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
@@ -998,7 +998,6 @@ namespace OpenTelemetry.Trace.Tests
         {
             var tracerProvider = Sdk.CreateTracerProviderBuilder().Build();
             var resource = tracerProvider.GetResource();
-            var attributes = resource.Attributes;
 
             Assert.NotNull(resource);
             Assert.NotEqual(Resource.Empty, resource);

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
@@ -186,7 +186,7 @@ namespace OpenTelemetry.Trace.Tests
 
             // OpenTelemetry ActivityContext does not support non W3C Ids.
             Assert.Null(fromInvalidW3CIdParent.ParentId);
-            Assert.Equal(default(ActivitySpanId), fromInvalidW3CIdParent.ParentSpanId);
+            Assert.Equal(default, fromInvalidW3CIdParent.ParentSpanId);
         }
 
         [Theory]

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
@@ -199,8 +199,10 @@ namespace OpenTelemetry.Trace.Tests
             {
                 SamplingAction = (samplingParams) =>
                 {
-                    var attributes = new Dictionary<string, object>();
-                    attributes.Add("tagkeybysampler", "tagvalueaddedbysampler");
+                    var attributes = new Dictionary<string, object>
+                    {
+                        { "tagkeybysampler", "tagvalueaddedbysampler" },
+                    };
                     return new SamplingResult(sampling, attributes);
                 },
             };

--- a/test/OpenTelemetry.Tests/Trace/TracerTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerTest.cs
@@ -106,11 +106,11 @@ namespace OpenTelemetry.Trace.Tests
             var rootSpan1 = exportedItems[1];
             Assert.Equal("RootSpan2", rootSpan2.DisplayName);
             Assert.Equal("RootSpan1", rootSpan1.DisplayName);
-            Assert.Equal(default(ActivitySpanId), rootSpan1.ParentSpanId);
+            Assert.Equal(default, rootSpan1.ParentSpanId);
 
             // This is where this test currently fails
             // rootSpan2 should be a root span of a new trace and not a child of rootSpan1
-            Assert.Equal(default(ActivitySpanId), rootSpan2.ParentSpanId);
+            Assert.Equal(default, rootSpan2.ParentSpanId);
             Assert.NotEqual(rootSpan2.TraceId, rootSpan1.TraceId);
             Assert.NotEqual(rootSpan2.ParentSpanId, rootSpan1.SpanId);
         }


### PR DESCRIPTION
Associated with #3001.

## Changes

Fixes ~120 analyzer issues:

- Put types in namespaces
- Forward cancellation tokens to child operations
- Use `.Count` instead of `.Count()` for performance.
- Modifiers are not ordered.
- Use `switch` expression.
- `Dispose()` should call `GC.SuppressFinalize(this)`.
- Use pattern matching (`!(foo is object)` should be `foo is not object`).
- `default` expression can be simplified.
- Non-constant fields should not be visible outside the class.
- Collection initialization can be simplified.
- Log message templates should not change between calls (use constants, no string interpolation).
- Avoid 0-length array allocations, use `Array.Empty` instead.
- Use `Any()` instead of `Count() > 0`
- Make fields readonly where possible.
- Member doesn't access instance data and can be marked static.
- Unnecessary value assignment to variable (use discard `_` or remove the assignment if it isn't used).
- Conditional can be simplified (use `??` null coalescing op)
- Turned off the analyzers that talk about simplifying range (`[1..3]`) and indexing (`[^2]`) since those are not supported by .NET 4.6.1.

Admittedly, this is a lot for one PR so I get it if folks might want to break it up. On the other hand, there's not any real functionality change and it continues on the path of making work in VS Code waaaaay less noisy. It also saves time on reviewing, I think, given it's one PR instead of one for every commit I made (19).