### PR TITLE
Logs: Performance and safety enhancements

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs/OtlpLogExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs/OtlpLogExporterHelperExtensions.cs
@@ -16,7 +16,9 @@
 
 using System;
 using OpenTelemetry.Exporter;
+using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Internal;
+using OtlpLogs = Opentelemetry.Proto.Logs.V1;
 
 namespace OpenTelemetry.Logs
 {
@@ -45,17 +47,19 @@ namespace OpenTelemetry.Logs
 
             if (exporterOptions.ExportProcessorType == ExportProcessorType.Simple)
             {
-                return loggerOptions.AddProcessor(new SimpleLogRecordExportProcessor(otlpExporter));
+                return loggerOptions.AddProcessor(
+                    LogRecordExtensions.ToOtlpLog,
+                    new SimpleExportProcessor<OtlpLogs.LogRecord>(otlpExporter));
             }
-            else
-            {
-                return loggerOptions.AddProcessor(new BatchLogRecordExportProcessor(
+
+            return loggerOptions.AddProcessor(
+                LogRecordExtensions.ToOtlpLog,
+                new BatchExportProcessor<OtlpLogs.LogRecord>(
                     otlpExporter,
                     exporterOptions.BatchExportProcessorOptions.MaxQueueSize,
                     exporterOptions.BatchExportProcessorOptions.ScheduledDelayMilliseconds,
                     exporterOptions.BatchExportProcessorOptions.ExporterTimeoutMilliseconds,
                     exporterOptions.BatchExportProcessorOptions.MaxExportBatchSize));
-            }
         }
     }
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
@@ -55,7 +55,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
             }
         }
 
-        internal static OtlpLogs.LogRecord ToOtlpLog(LogRecordStruct logRecord)
+        internal static OtlpLogs.LogRecord ToOtlpLog(in LogRecordStruct logRecord)
         {
             OtlpLogs.LogRecord otlpLogRecord = null;
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
@@ -33,16 +33,6 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
 {
     internal static class LogRecordExtensions
     {
-        private static readonly Action<KeyValuePair<string, object>, OtlpLogs.LogRecord> AddStateValueToLog =
-            (stateValue, logRecord) =>
-            {
-                var attribute = stateValue.ToOtlpAttribute();
-                if (attribute != null)
-                {
-                    logRecord.Attributes.Add(attribute);
-                }
-            };
-
         internal static void AddBatch(
             this OtlpCollector.ExportLogsServiceRequest request,
             OtlpResource.Resource processResource,
@@ -115,7 +105,14 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
                     otlpLogRecord.Flags = (uint)activityContext.TraceFlags;
                 }
 
-                logRecord.ForEachStateValue(AddStateValueToLog, otlpLogRecord);
+                foreach (KeyValuePair<string, object> stateValue in logRecord.State)
+                {
+                    var attribute = stateValue.ToOtlpAttribute();
+                    if (attribute != null)
+                    {
+                        otlpLogRecord.Attributes.Add(attribute);
+                    }
+                }
 
                 // TODO: Add additional attributes from scope
                 // Might make sense to take an approach similar to https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/897b734aa5ea9992538f04f6ea6871fe211fa903/src/OpenTelemetry.Contrib.Preview/Internal/DefaultLogStateConverter.cs

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
@@ -33,7 +33,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
         internal static void AddBatch(
             this OtlpCollector.ExportLogsServiceRequest request,
             OtlpResource.Resource processResource,
-            in Batch<LogRecord> logRecordBatch)
+            in Batch<OtlpLogs.LogRecord> logRecordBatch)
         {
             OtlpLogs.ResourceLogs resourceLogs = new OtlpLogs.ResourceLogs
             {
@@ -46,11 +46,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
 
             foreach (var logRecord in logRecordBatch)
             {
-                var otlpLogRecord = logRecord.ToOtlpLog();
-                if (otlpLogRecord != null)
-                {
-                    instrumentationLibraryLogs.Logs.Add(otlpLogRecord);
-                }
+                instrumentationLibraryLogs.Logs.Add(logRecord);
             }
         }
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
@@ -91,9 +91,11 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
                     otlpLogRecord.Attributes.AddStringAttribute(SemanticConventions.AttributeExceptionStacktrace, logRecord.Exception.ToInvariantString());
                 }
 
-                ActivityContext activityContext = Activity.Current?.Context ?? default;
-                if (activityContext.IsValid())
+                Activity activity = Activity.Current;
+                if (activity != null)
                 {
+                    ActivityContext activityContext = activity.Context;
+
                     byte[] traceIdBytes = new byte[16];
                     byte[] spanIdBytes = new byte[8];
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporter.cs
@@ -19,6 +19,7 @@ using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
 using OpenTelemetry.Logs;
 using OtlpCollector = Opentelemetry.Proto.Collector.Logs.V1;
+using OtlpLogs = Opentelemetry.Proto.Logs.V1;
 using OtlpResource = Opentelemetry.Proto.Resource.V1;
 
 namespace OpenTelemetry.Exporter
@@ -27,7 +28,7 @@ namespace OpenTelemetry.Exporter
     /// Exporter consuming <see cref="LogRecord"/> and exporting the data using
     /// the OpenTelemetry protocol (OTLP).
     /// </summary>
-    internal class OtlpLogExporter : BaseExporter<LogRecord>
+    internal class OtlpLogExporter : BaseExporter<OtlpLogs.LogRecord>
     {
         private readonly IExportClient<OtlpCollector.ExportLogsServiceRequest> exportClient;
 
@@ -63,7 +64,7 @@ namespace OpenTelemetry.Exporter
         internal OtlpResource.Resource ProcessResource => this.processResource ??= this.ParentProvider.GetResource().ToOtlpResource();
 
         /// <inheritdoc/>
-        public override ExportResult Export(in Batch<LogRecord> logRecordBatch)
+        public override ExportResult Export(in Batch<OtlpLogs.LogRecord> logRecordBatch)
         {
             // Prevents the exporter's gRPC and HTTP operations from being instrumented.
             using var scope = SuppressInstrumentationScope.Begin();

--- a/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net461/PublicAPI.Unshipped.txt
@@ -1,6 +1,28 @@
 OpenTelemetry.BaseExporter<T>.ForceFlush(int timeoutMilliseconds = -1) -> bool
 OpenTelemetry.Batch<T>.Batch(T[] items, int count) -> void
 OpenTelemetry.Batch<T>.Count.get -> long
+OpenTelemetry.Logs.LogConverter<T>
+OpenTelemetry.Logs.LogRecord.ForEachScope<TState>(OpenTelemetry.Logs.LogRecordScopeCallback<TState> callback, TState state) -> void
+OpenTelemetry.Logs.LogRecordScopeCallback<TState>
+OpenTelemetry.Logs.LogRecordState
+OpenTelemetry.Logs.LogRecordState.Enumerator
+OpenTelemetry.Logs.LogRecordState.Enumerator.Current.get -> System.Collections.Generic.KeyValuePair<string, object>
+OpenTelemetry.Logs.LogRecordState.Enumerator.Enumerator() -> void
+OpenTelemetry.Logs.LogRecordState.Enumerator.MoveNext() -> bool
+OpenTelemetry.Logs.LogRecordState.GetEnumerator() -> OpenTelemetry.Logs.LogRecordState.Enumerator
+OpenTelemetry.Logs.LogRecordState.LogRecordState() -> void
+OpenTelemetry.Logs.LogRecordState.State.get -> object
+OpenTelemetry.Logs.LogRecordStruct
+OpenTelemetry.Logs.LogRecordStruct.CategoryName.get -> string
+OpenTelemetry.Logs.LogRecordStruct.EventId.get -> Microsoft.Extensions.Logging.EventId
+OpenTelemetry.Logs.LogRecordStruct.Exception.get -> System.Exception
+OpenTelemetry.Logs.LogRecordStruct.ForEachScope<TState>(OpenTelemetry.Logs.LogRecordScopeCallback<TState> callback, TState state) -> void
+OpenTelemetry.Logs.LogRecordStruct.FormattedMessage.get -> string
+OpenTelemetry.Logs.LogRecordStruct.LogLevel.get -> Microsoft.Extensions.Logging.LogLevel
+OpenTelemetry.Logs.LogRecordStruct.LogRecordStruct() -> void
+OpenTelemetry.Logs.LogRecordStruct.State.get -> OpenTelemetry.Logs.LogRecordState
+OpenTelemetry.Logs.LogRecordStruct.Timestamp.get -> System.DateTime
+OpenTelemetry.Logs.OpenTelemetryLoggerOptions.AddProcessor<T>(OpenTelemetry.Logs.LogConverter<T> logConverter, OpenTelemetry.BaseProcessor<T> processor) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions
 OpenTelemetry.Metrics.MetricReaderOptions
 OpenTelemetry.Metrics.MetricReaderOptions.MetricReaderOptions() -> void
 OpenTelemetry.Metrics.MetricReaderOptions.MetricReaderType.get -> OpenTelemetry.Metrics.MetricReaderType
@@ -150,3 +172,7 @@ virtual OpenTelemetry.BaseExporter<T>.OnForceFlush(int timeoutMilliseconds) -> b
 virtual OpenTelemetry.Metrics.MetricReader.Dispose(bool disposing) -> void
 virtual OpenTelemetry.Metrics.MetricReader.OnCollect(int timeoutMilliseconds) -> bool
 virtual OpenTelemetry.Metrics.MetricReader.OnShutdown(int timeoutMilliseconds) -> bool
+*REMOVED*OpenTelemetry.Logs.LogRecord.ForEachScope<TState>(System.Action<OpenTelemetry.Logs.LogRecordScope, TState> callback, TState state) -> void
+*REMOVED*OpenTelemetry.Logs.LogRecordScope.Enumerator.Dispose() -> void
+*REMOVED*OpenTelemetry.Logs.LogRecordScope.Enumerator.Reset() -> void
+*REMOVED*OpenTelemetry.Logs.LogRecordScope.Enumerator.Enumerator(object scope) -> void

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,6 +1,28 @@
 OpenTelemetry.BaseExporter<T>.ForceFlush(int timeoutMilliseconds = -1) -> bool
 OpenTelemetry.Batch<T>.Batch(T[] items, int count) -> void
 OpenTelemetry.Batch<T>.Count.get -> long
+OpenTelemetry.Logs.LogConverter<T>
+OpenTelemetry.Logs.LogRecord.ForEachScope<TState>(OpenTelemetry.Logs.LogRecordScopeCallback<TState> callback, TState state) -> void
+OpenTelemetry.Logs.LogRecordScopeCallback<TState>
+OpenTelemetry.Logs.LogRecordState
+OpenTelemetry.Logs.LogRecordState.Enumerator
+OpenTelemetry.Logs.LogRecordState.Enumerator.Current.get -> System.Collections.Generic.KeyValuePair<string, object>
+OpenTelemetry.Logs.LogRecordState.Enumerator.Enumerator() -> void
+OpenTelemetry.Logs.LogRecordState.Enumerator.MoveNext() -> bool
+OpenTelemetry.Logs.LogRecordState.GetEnumerator() -> OpenTelemetry.Logs.LogRecordState.Enumerator
+OpenTelemetry.Logs.LogRecordState.LogRecordState() -> void
+OpenTelemetry.Logs.LogRecordState.State.get -> object
+OpenTelemetry.Logs.LogRecordStruct
+OpenTelemetry.Logs.LogRecordStruct.CategoryName.get -> string
+OpenTelemetry.Logs.LogRecordStruct.EventId.get -> Microsoft.Extensions.Logging.EventId
+OpenTelemetry.Logs.LogRecordStruct.Exception.get -> System.Exception
+OpenTelemetry.Logs.LogRecordStruct.ForEachScope<TState>(OpenTelemetry.Logs.LogRecordScopeCallback<TState> callback, TState state) -> void
+OpenTelemetry.Logs.LogRecordStruct.FormattedMessage.get -> string
+OpenTelemetry.Logs.LogRecordStruct.LogLevel.get -> Microsoft.Extensions.Logging.LogLevel
+OpenTelemetry.Logs.LogRecordStruct.LogRecordStruct() -> void
+OpenTelemetry.Logs.LogRecordStruct.State.get -> OpenTelemetry.Logs.LogRecordState
+OpenTelemetry.Logs.LogRecordStruct.Timestamp.get -> System.DateTime
+OpenTelemetry.Logs.OpenTelemetryLoggerOptions.AddProcessor<T>(OpenTelemetry.Logs.LogConverter<T> logConverter, OpenTelemetry.BaseProcessor<T> processor) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions
 OpenTelemetry.Metrics.MetricReaderOptions
 OpenTelemetry.Metrics.MetricReaderOptions.MetricReaderOptions() -> void
 OpenTelemetry.Metrics.MetricReaderOptions.MetricReaderType.get -> OpenTelemetry.Metrics.MetricReaderType
@@ -150,3 +172,7 @@ virtual OpenTelemetry.BaseExporter<T>.OnForceFlush(int timeoutMilliseconds) -> b
 virtual OpenTelemetry.Metrics.MetricReader.Dispose(bool disposing) -> void
 virtual OpenTelemetry.Metrics.MetricReader.OnCollect(int timeoutMilliseconds) -> bool
 virtual OpenTelemetry.Metrics.MetricReader.OnShutdown(int timeoutMilliseconds) -> bool
+*REMOVED*OpenTelemetry.Logs.LogRecord.ForEachScope<TState>(System.Action<OpenTelemetry.Logs.LogRecordScope, TState> callback, TState state) -> void
+*REMOVED*OpenTelemetry.Logs.LogRecordScope.Enumerator.Dispose() -> void
+*REMOVED*OpenTelemetry.Logs.LogRecordScope.Enumerator.Reset() -> void
+*REMOVED*OpenTelemetry.Logs.LogRecordScope.Enumerator.Enumerator(object scope) -> void

--- a/src/OpenTelemetry/BatchExportProcessor.cs
+++ b/src/OpenTelemetry/BatchExportProcessor.cs
@@ -25,7 +25,7 @@ namespace OpenTelemetry
     /// Implements processor that batches telemetry objects before calling exporter.
     /// </summary>
     /// <typeparam name="T">The type of telemetry object to be exported.</typeparam>
-    public abstract class BatchExportProcessor<T> : BaseExportProcessor<T>
+    public class BatchExportProcessor<T> : BaseExportProcessor<T>
         where T : class
     {
         internal const int DefaultMaxQueueSize = 2048;
@@ -53,7 +53,7 @@ namespace OpenTelemetry
         /// <param name="scheduledDelayMilliseconds">The delay interval in milliseconds between two consecutive exports. The default value is 5000.</param>
         /// <param name="exporterTimeoutMilliseconds">How long the export can run before it is cancelled. The default value is 30000.</param>
         /// <param name="maxExportBatchSize">The maximum batch size of every export. It must be smaller or equal to maxQueueSize. The default value is 512.</param>
-        protected BatchExportProcessor(
+        public BatchExportProcessor(
             BaseExporter<T> exporter,
             int maxQueueSize = DefaultMaxQueueSize,
             int scheduledDelayMilliseconds = DefaultScheduledDelayMilliseconds,

--- a/src/OpenTelemetry/Logs/BatchLogRecordExportProcessor.cs
+++ b/src/OpenTelemetry/Logs/BatchLogRecordExportProcessor.cs
@@ -14,10 +14,12 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using OpenTelemetry.Logs;
 
 namespace OpenTelemetry
 {
+    [Obsolete("LogRecord instances might contain data which is no longer valid at the time of export. Use LogConverter when batching is required to convert log messages into something safe to store in a batch.")]
     public class BatchLogRecordExportProcessor : BatchExportProcessor<LogRecord>
     {
         public BatchLogRecordExportProcessor(

--- a/src/OpenTelemetry/Logs/BatchLogRecordExportProcessor.cs
+++ b/src/OpenTelemetry/Logs/BatchLogRecordExportProcessor.cs
@@ -14,12 +14,10 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using OpenTelemetry.Logs;
 
 namespace OpenTelemetry
 {
-    [Obsolete("LogRecord instances might contain data which is no longer valid at the time of export. Use LogConverter when batching is required to convert log messages into something safe to store in a batch.")]
     public class BatchLogRecordExportProcessor : BatchExportProcessor<LogRecord>
     {
         public BatchLogRecordExportProcessor(
@@ -39,7 +37,7 @@ namespace OpenTelemetry
 
         public override void OnEnd(LogRecord data)
         {
-            data.BufferLogScopes();
+            data.Buffer();
 
             base.OnEnd(data);
         }

--- a/src/OpenTelemetry/Logs/CompositeLogProcessor.cs
+++ b/src/OpenTelemetry/Logs/CompositeLogProcessor.cs
@@ -1,0 +1,160 @@
+// <copyright file="CompositeLogProcessor.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Logs
+{
+    internal sealed class CompositeLogProcessor : ILogProcessor
+    {
+        private readonly DoublyLinkedListNode head;
+        private DoublyLinkedListNode tail;
+        private bool disposed;
+
+        public CompositeLogProcessor(IEnumerable<ILogProcessor> processors)
+        {
+            Guard.ThrowIfNull(processors);
+
+            using var iter = processors.GetEnumerator();
+            if (!iter.MoveNext())
+            {
+                throw new ArgumentException($"'{processors}' is null or empty", nameof(processors));
+            }
+
+            this.head = new DoublyLinkedListNode(iter.Current);
+            this.tail = this.head;
+
+            while (iter.MoveNext())
+            {
+                this.AddProcessor(iter.Current);
+            }
+        }
+
+        public CompositeLogProcessor AddProcessor(ILogProcessor processor)
+        {
+            Guard.ThrowIfNull(processor);
+
+            var node = new DoublyLinkedListNode(processor)
+            {
+                Previous = this.tail,
+            };
+            this.tail.Next = node;
+            this.tail = node;
+
+            return this;
+        }
+
+        public void OnEnd(in LogRecordStruct log)
+        {
+            for (var cur = this.head; cur != null; cur = cur.Next)
+            {
+                cur.Value.OnEnd(in log);
+            }
+        }
+
+        public bool ForceFlush(int timeoutMilliseconds = -1)
+        {
+            var result = true;
+            var sw = timeoutMilliseconds == Timeout.Infinite
+                ? null
+                : Stopwatch.StartNew();
+
+            for (var cur = this.head; cur != null; cur = cur.Next)
+            {
+                if (sw == null)
+                {
+                    result = cur.Value.ForceFlush(Timeout.Infinite) && result;
+                }
+                else
+                {
+                    var timeout = timeoutMilliseconds - sw.ElapsedMilliseconds;
+
+                    // notify all the processors, even if we run overtime
+                    result = cur.Value.ForceFlush((int)Math.Max(timeout, 0)) && result;
+                }
+            }
+
+            return result;
+        }
+
+        public bool Shutdown(int timeoutMilliseconds = -1)
+        {
+            var result = true;
+            var sw = timeoutMilliseconds == Timeout.Infinite
+                ? null
+                : Stopwatch.StartNew();
+
+            for (var cur = this.head; cur != null; cur = cur.Next)
+            {
+                if (sw == null)
+                {
+                    result = cur.Value.Shutdown(Timeout.Infinite) && result;
+                }
+                else
+                {
+                    var timeout = timeoutMilliseconds - sw.ElapsedMilliseconds;
+
+                    // notify all the processors, even if we run overtime
+                    result = cur.Value.Shutdown((int)Math.Max(timeout, 0)) && result;
+                }
+            }
+
+            return result;
+        }
+
+        public void Dispose()
+        {
+            if (!this.disposed)
+            {
+                for (var cur = this.head; cur != null; cur = cur.Next)
+                {
+                    try
+                    {
+                        cur.Value?.Dispose();
+                    }
+                    catch (Exception ex)
+                    {
+                        OpenTelemetrySdkEventSource.Log.SpanProcessorException(nameof(this.Dispose), ex);
+                    }
+                }
+
+                this.disposed = true;
+            }
+        }
+
+        void ILogProcessor.SetParentProvider(BaseProvider parentProvider)
+        {
+        }
+
+        private class DoublyLinkedListNode
+        {
+            public readonly ILogProcessor Value;
+
+            public DoublyLinkedListNode(ILogProcessor value)
+            {
+                this.Value = value;
+            }
+
+            public DoublyLinkedListNode Previous { get; set; }
+
+            public DoublyLinkedListNode Next { get; set; }
+        }
+    }
+}

--- a/src/OpenTelemetry/Logs/IInlineLogProcessor.cs
+++ b/src/OpenTelemetry/Logs/IInlineLogProcessor.cs
@@ -1,0 +1,41 @@
+// <copyright file="IInlineLogProcessor.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace OpenTelemetry.Logs
+{
+    internal interface IInlineLogProcessor : IDisposable
+    {
+        void SetParentProvider(BaseProvider parentProvider);
+
+        void Log(
+            string categoryName,
+            DateTime timestamp,
+            LogLevel logLevel,
+            EventId eventId,
+            object state,
+            IReadOnlyList<KeyValuePair<string, object>> parsedState,
+            IExternalScopeProvider scopeProvider,
+            Exception exception,
+            string formattedLogMessage);
+
+        bool Shutdown(int timeoutMilliseconds = Timeout.Infinite);
+    }
+}

--- a/src/OpenTelemetry/Logs/ILogProcessor.cs
+++ b/src/OpenTelemetry/Logs/ILogProcessor.cs
@@ -1,4 +1,4 @@
-// <copyright file="IInlineLogProcessor.cs" company="OpenTelemetry Authors">
+// <copyright file="ILogProcessor.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,26 +15,15 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
-using Microsoft.Extensions.Logging;
 
 namespace OpenTelemetry.Logs
 {
-    internal interface IInlineLogProcessor : IDisposable
+    internal interface ILogProcessor : IDisposable
     {
         void SetParentProvider(BaseProvider parentProvider);
 
-        void Log(
-            string categoryName,
-            DateTime timestamp,
-            LogLevel logLevel,
-            EventId eventId,
-            object state,
-            IReadOnlyList<KeyValuePair<string, object>> parsedState,
-            IExternalScopeProvider scopeProvider,
-            Exception exception,
-            string formattedLogMessage);
+        void OnEnd(LogRecordStruct log);
 
         bool Shutdown(int timeoutMilliseconds = Timeout.Infinite);
     }

--- a/src/OpenTelemetry/Logs/ILogProcessor.cs
+++ b/src/OpenTelemetry/Logs/ILogProcessor.cs
@@ -23,7 +23,9 @@ namespace OpenTelemetry.Logs
     {
         void SetParentProvider(BaseProvider parentProvider);
 
-        void OnEnd(LogRecordStruct log);
+        void OnEnd(in LogRecordStruct log);
+
+        bool ForceFlush(int timeoutMilliseconds = Timeout.Infinite);
 
         bool Shutdown(int timeoutMilliseconds = Timeout.Infinite);
     }

--- a/src/OpenTelemetry/Logs/InlineLogProcessor{T}.cs
+++ b/src/OpenTelemetry/Logs/InlineLogProcessor{T}.cs
@@ -1,0 +1,90 @@
+// <copyright file="InlineLogProcessor{T}.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace OpenTelemetry.Logs
+{
+    internal sealed class InlineLogProcessor<T> : IInlineLogProcessor
+        where T : class
+    {
+        private readonly LogConverter<T> logConverter;
+        private readonly BaseProcessor<T> innerProcessor;
+
+        public InlineLogProcessor(
+            LogConverter<T> logConverter,
+            BaseProcessor<T> innerProcessor)
+        {
+            this.logConverter = logConverter;
+            this.innerProcessor = innerProcessor;
+        }
+
+        public void SetParentProvider(BaseProvider parentProvider)
+        {
+            this.innerProcessor.SetParentProvider(parentProvider);
+        }
+
+        public void Log(
+            string categoryName,
+            DateTime timestamp,
+            LogLevel logLevel,
+            EventId eventId,
+            object state,
+            IReadOnlyList<KeyValuePair<string, object>> parsedState,
+            IExternalScopeProvider scopeProvider,
+            Exception exception,
+            string formattedLogMessage)
+        {
+            T record;
+            try
+            {
+                ActivityContext activityContext = Activity.Current?.Context ?? default;
+
+                record = this.logConverter(
+                    in activityContext,
+                    categoryName,
+                    timestamp,
+                    logLevel,
+                    eventId,
+                    state,
+                    parsedState,
+                    scopeProvider,
+                    exception,
+                    formattedLogMessage);
+            }
+            catch (Exception ex)
+            {
+                // TODO: Log event, exception thrown converting log.
+                return;
+            }
+
+            if (record != null)
+            {
+                this.innerProcessor.OnEnd(record);
+            }
+        }
+
+        public bool Shutdown(int timeoutMilliseconds = Timeout.Infinite)
+            => this.innerProcessor.Shutdown(timeoutMilliseconds);
+
+        public void Dispose()
+            => this.innerProcessor.Dispose();
+    }
+}

--- a/src/OpenTelemetry/Logs/LogConverter.cs
+++ b/src/OpenTelemetry/Logs/LogConverter.cs
@@ -1,0 +1,35 @@
+// <copyright file="LogConverter.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace OpenTelemetry.Logs
+{
+    public delegate T LogConverter<T>(
+        in ActivityContext activityContext,
+        string categoryName,
+        DateTime timestamp,
+        LogLevel logLevel,
+        EventId eventId,
+        object state,
+        IReadOnlyList<KeyValuePair<string, object>> parsedState,
+        IExternalScopeProvider scopeProvider,
+        Exception exception,
+        string formattedLogMessage);
+}

--- a/src/OpenTelemetry/Logs/LogConverter.cs
+++ b/src/OpenTelemetry/Logs/LogConverter.cs
@@ -16,5 +16,15 @@
 
 namespace OpenTelemetry.Logs
 {
+    /// <summary>
+    /// Represents a method that converts a <see cref="LogRecordStruct"/> log
+    /// message into another type.
+    /// </summary>
+    /// <typeparam name="T">The type the <see cref="LogRecordStruct"/> log
+    /// message is converted to.</typeparam>
+    /// <param name="log">The <see cref="LogRecordStruct"/> log message to
+    /// convert.</param>
+    /// <returns>The <typeparamref name="T"/> which represents the log
+    /// message.</returns>
     public delegate T LogConverter<T>(in LogRecordStruct log);
 }

--- a/src/OpenTelemetry/Logs/LogConverter.cs
+++ b/src/OpenTelemetry/Logs/LogConverter.cs
@@ -16,5 +16,5 @@
 
 namespace OpenTelemetry.Logs
 {
-    public delegate T LogConverter<T>(LogRecordStruct log);
+    public delegate T LogConverter<T>(in LogRecordStruct log);
 }

--- a/src/OpenTelemetry/Logs/LogConverter.cs
+++ b/src/OpenTelemetry/Logs/LogConverter.cs
@@ -14,22 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using Microsoft.Extensions.Logging;
-
 namespace OpenTelemetry.Logs
 {
-    public delegate T LogConverter<T>(
-        in ActivityContext activityContext,
-        string categoryName,
-        DateTime timestamp,
-        LogLevel logLevel,
-        EventId eventId,
-        object state,
-        IReadOnlyList<KeyValuePair<string, object>> parsedState,
-        IExternalScopeProvider scopeProvider,
-        Exception exception,
-        string formattedLogMessage);
+    public delegate T LogConverter<T>(LogRecordStruct log);
 }

--- a/src/OpenTelemetry/Logs/LogConvertingProcessor.cs
+++ b/src/OpenTelemetry/Logs/LogConvertingProcessor.cs
@@ -37,12 +37,12 @@ namespace OpenTelemetry.Logs
             this.innerProcessor.SetParentProvider(parentProvider);
         }
 
-        public void OnEnd(LogRecordStruct log)
+        public void OnEnd(in LogRecordStruct log)
         {
             T record;
             try
             {
-                record = this.logConverter(log);
+                record = this.logConverter(in log);
             }
             catch
             {
@@ -55,6 +55,9 @@ namespace OpenTelemetry.Logs
                 this.innerProcessor.OnEnd(record);
             }
         }
+
+        public bool ForceFlush(int timeoutMilliseconds = Timeout.Infinite)
+            => this.innerProcessor.ForceFlush(timeoutMilliseconds);
 
         public bool Shutdown(int timeoutMilliseconds = Timeout.Infinite)
             => this.innerProcessor.Shutdown(timeoutMilliseconds);

--- a/src/OpenTelemetry/Logs/LogConvertingProcessor.cs
+++ b/src/OpenTelemetry/Logs/LogConvertingProcessor.cs
@@ -18,6 +18,10 @@ using System.Threading;
 
 namespace OpenTelemetry.Logs
 {
+    // A special log processor which will call a conversion function and then
+    // pass the result to an inner processor. This is used to enable
+    // high-performance inline log processing without an intermediary storage
+    // class.
     internal sealed class LogConvertingProcessor<T> : ILogProcessor
         where T : class
     {

--- a/src/OpenTelemetry/Logs/LogRecord.cs
+++ b/src/OpenTelemetry/Logs/LogRecord.cs
@@ -116,7 +116,7 @@ namespace OpenTelemetry.Logs
         /// <typeparam name="TState">State.</typeparam>
         /// <param name="callback">The callback to be executed for every scope object.</param>
         /// <param name="state">The state object to be passed into the callback.</param>
-        public void ForEachScope<TState>(Action<LogRecordScope, TState> callback, TState state)
+        public void ForEachScope<TState>(LogRecordScopeCallback<TState> callback, TState state)
         {
             var forEachScopeState = new ScopeForEachState<TState>(callback, state);
 
@@ -160,11 +160,11 @@ namespace OpenTelemetry.Logs
                 state.Callback(logRecordScope, state.UserState);
             };
 
-            public readonly Action<LogRecordScope, TState> Callback;
+            public readonly LogRecordScopeCallback<TState> Callback;
 
             public readonly TState UserState;
 
-            public ScopeForEachState(Action<LogRecordScope, TState> callback, TState state)
+            public ScopeForEachState(LogRecordScopeCallback<TState> callback, TState state)
             {
                 this.Callback = callback;
                 this.UserState = state;

--- a/src/OpenTelemetry/Logs/LogRecord.cs
+++ b/src/OpenTelemetry/Logs/LogRecord.cs
@@ -34,7 +34,7 @@ namespace OpenTelemetry.Logs
         private List<object> bufferedScopes;
 
         internal LogRecord(
-            ActivityContext activityContext,
+            in ActivityContext activityContext,
             IExternalScopeProvider scopeProvider,
             DateTime timestamp,
             string categoryName,

--- a/src/OpenTelemetry/Logs/LogRecord.cs
+++ b/src/OpenTelemetry/Logs/LogRecord.cs
@@ -34,6 +34,7 @@ namespace OpenTelemetry.Logs
         private List<object> bufferedScopes;
 
         internal LogRecord(
+            in ActivityContext activityContext,
             IExternalScopeProvider scopeProvider,
             DateTime timestamp,
             string categoryName,
@@ -46,13 +47,12 @@ namespace OpenTelemetry.Logs
         {
             this.ScopeProvider = scopeProvider;
 
-            var activity = Activity.Current;
-            if (activity != null)
+            if (activityContext.IsValid())
             {
-                this.TraceId = activity.TraceId;
-                this.SpanId = activity.SpanId;
-                this.TraceState = activity.TraceStateString;
-                this.TraceFlags = activity.ActivityTraceFlags;
+                this.TraceId = activityContext.TraceId;
+                this.SpanId = activityContext.SpanId;
+                this.TraceState = activityContext.TraceState;
+                this.TraceFlags = activityContext.TraceFlags;
             }
 
             this.Timestamp = timestamp;

--- a/src/OpenTelemetry/Logs/LogRecord.cs
+++ b/src/OpenTelemetry/Logs/LogRecord.cs
@@ -140,7 +140,7 @@ namespace OpenTelemetry.Logs
         /// </summary>
         private void BufferLogState()
         {
-            if (this.bufferedStateValues != null)
+            if (this.bufferedStateValues != null || this.stateValues == null)
             {
                 return;
             }
@@ -149,7 +149,7 @@ namespace OpenTelemetry.Logs
 
             for (int i = 0; i < this.stateValues.Count; i++)
             {
-                bufferedStateValues[i] = this.stateValues[i];
+                bufferedStateValues.Add(this.stateValues[i]);
             }
 
             this.bufferedStateValues = bufferedStateValues;

--- a/src/OpenTelemetry/Logs/LogRecord.cs
+++ b/src/OpenTelemetry/Logs/LogRecord.cs
@@ -34,7 +34,7 @@ namespace OpenTelemetry.Logs
         private List<object> bufferedScopes;
 
         internal LogRecord(
-            in ActivityContext activityContext,
+            ActivityContext activityContext,
             IExternalScopeProvider scopeProvider,
             DateTime timestamp,
             string categoryName,
@@ -151,7 +151,7 @@ namespace OpenTelemetry.Logs
             this.bufferedScopes = scopes;
         }
 
-        private readonly struct ScopeForEachState<TState>
+        internal readonly struct ScopeForEachState<TState>
         {
             public static readonly Action<object, ScopeForEachState<TState>> ForEachScope = (object scope, ScopeForEachState<TState> state) =>
             {

--- a/src/OpenTelemetry/Logs/LogRecordProcessor.cs
+++ b/src/OpenTelemetry/Logs/LogRecordProcessor.cs
@@ -1,0 +1,54 @@
+// <copyright file="LogRecordProcessor.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Threading;
+
+namespace OpenTelemetry.Logs
+{
+    // A log processor for supporting the shipped LogRecord API.
+    internal sealed class LogRecordProcessor : ILogProcessor
+    {
+        private readonly BaseProcessor<LogRecord> innerProcessor;
+
+        public LogRecordProcessor(BaseProcessor<LogRecord> innerProcessor)
+        {
+            this.innerProcessor = innerProcessor;
+        }
+
+        public void SetParentProvider(BaseProvider parentProvider)
+        {
+            this.innerProcessor.SetParentProvider(parentProvider);
+        }
+
+        public void OnEnd(in LogRecordStruct log)
+        {
+            LogRecord logRecord = LogRecordStruct.ToLogRecord(in log);
+
+            this.innerProcessor.OnEnd(logRecord);
+
+            logRecord.ScopeProvider = null;
+        }
+
+        public bool ForceFlush(int timeoutMilliseconds = Timeout.Infinite)
+            => this.innerProcessor.ForceFlush(timeoutMilliseconds);
+
+        public bool Shutdown(int timeoutMilliseconds = Timeout.Infinite)
+            => this.innerProcessor.Shutdown(timeoutMilliseconds);
+
+        public void Dispose()
+            => this.innerProcessor.Dispose();
+    }
+}

--- a/src/OpenTelemetry/Logs/LogRecordScopeCallback.cs
+++ b/src/OpenTelemetry/Logs/LogRecordScopeCallback.cs
@@ -1,4 +1,4 @@
-// <copyright file="ILogProcessor.cs" company="OpenTelemetry Authors">
+// <copyright file="LogRecordScopeCallback.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,21 +14,14 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Threading;
-
 namespace OpenTelemetry.Logs
 {
-    // TODO: Investigate making this public so users can build simple
-    // allocation-free log exporters.
-    internal interface ILogProcessor : IDisposable
-    {
-        void SetParentProvider(BaseProvider parentProvider);
-
-        void OnEnd(in LogRecordStruct log);
-
-        bool ForceFlush(int timeoutMilliseconds = Timeout.Infinite);
-
-        bool Shutdown(int timeoutMilliseconds = Timeout.Infinite);
-    }
+    /// <summary>
+    /// Represents a callback action to process <see cref="LogRecordScope"/>s
+    /// attached to a log message.
+    /// </summary>
+    /// <typeparam name="TState">Type of state passed to the callback.</typeparam>
+    /// <param name="scope">The <see cref="LogRecordScope"/> being processed.</param>
+    /// <param name="state">State value.</param>
+    public delegate void LogRecordScopeCallback<TState>(LogRecordScope scope, TState state);
 }

--- a/src/OpenTelemetry/Logs/LogRecordStruct.cs
+++ b/src/OpenTelemetry/Logs/LogRecordStruct.cs
@@ -90,19 +90,19 @@ namespace OpenTelemetry.Logs
             }
         }
 
-        internal LogRecord ToLogRecord()
+        internal static LogRecord ToLogRecord(in LogRecordStruct logRecord)
         {
             return new LogRecord(
-                this.ActivityContext,
-                this.scopeProvider,
-                this.Timestamp,
-                this.CategoryName,
-                this.LogLevel,
-                this.EventId,
-                this.FormattedMessage,
-                this.state,
-                this.Exception,
-                this.stateValues);
+                logRecord.ActivityContext,
+                logRecord.scopeProvider,
+                logRecord.Timestamp,
+                logRecord.CategoryName,
+                logRecord.LogLevel,
+                logRecord.EventId,
+                logRecord.FormattedMessage,
+                logRecord.state,
+                logRecord.Exception,
+                logRecord.stateValues);
         }
     }
 }

--- a/src/OpenTelemetry/Logs/LogRecordStruct.cs
+++ b/src/OpenTelemetry/Logs/LogRecordStruct.cs
@@ -28,7 +28,6 @@ namespace OpenTelemetry.Logs
         private readonly IReadOnlyList<KeyValuePair<string, object>> stateValues;
 
         internal LogRecordStruct(
-            in ActivityContext activityContext,
             DateTime timestamp,
             string categoryName,
             LogLevel logLevel,
@@ -39,7 +38,6 @@ namespace OpenTelemetry.Logs
             object state,
             IReadOnlyList<KeyValuePair<string, object>> stateValues)
         {
-            this.ActivityContext = activityContext;
             this.Timestamp = timestamp;
             this.CategoryName = categoryName;
             this.LogLevel = logLevel;
@@ -50,8 +48,6 @@ namespace OpenTelemetry.Logs
             this.state = state;
             this.stateValues = stateValues;
         }
-
-        public ActivityContext ActivityContext { get; }
 
         public DateTime Timestamp { get; }
 
@@ -92,8 +88,10 @@ namespace OpenTelemetry.Logs
 
         internal static LogRecord ToLogRecord(in LogRecordStruct logRecord)
         {
+            var activityContext = Activity.Current?.Context ?? default;
+
             return new LogRecord(
-                logRecord.ActivityContext,
+                in activityContext,
                 logRecord.scopeProvider,
                 logRecord.Timestamp,
                 logRecord.CategoryName,

--- a/src/OpenTelemetry/Logs/LogRecordStruct.cs
+++ b/src/OpenTelemetry/Logs/LogRecordStruct.cs
@@ -87,7 +87,7 @@ namespace OpenTelemetry.Logs
         /// <summary>
         /// Gets the state for the log message.
         /// </summary>
-        public LogRecordState State => new LogRecordState(this.state, this.stateValues);
+        public LogRecordState State => new(this.state, this.stateValues);
 
         /// <summary>
         /// Executes callback for each currently active scope objects in order

--- a/src/OpenTelemetry/Logs/LogRecordStruct.cs
+++ b/src/OpenTelemetry/Logs/LogRecordStruct.cs
@@ -1,0 +1,108 @@
+// <copyright file="LogRecordStruct.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace OpenTelemetry.Logs
+{
+    public readonly ref struct LogRecordStruct
+    {
+        private readonly IExternalScopeProvider scopeProvider;
+        private readonly object state;
+        private readonly IReadOnlyList<KeyValuePair<string, object>> stateValues;
+
+        internal LogRecordStruct(
+            in ActivityContext activityContext,
+            DateTime timestamp,
+            string categoryName,
+            LogLevel logLevel,
+            EventId eventId,
+            string formattedMessage,
+            Exception exception,
+            IExternalScopeProvider scopeProvider,
+            object state,
+            IReadOnlyList<KeyValuePair<string, object>> stateValues)
+        {
+            this.ActivityContext = activityContext;
+            this.Timestamp = timestamp;
+            this.CategoryName = categoryName;
+            this.LogLevel = logLevel;
+            this.EventId = eventId;
+            this.FormattedMessage = formattedMessage;
+            this.Exception = exception;
+            this.scopeProvider = scopeProvider;
+            this.state = state;
+            this.stateValues = stateValues;
+        }
+
+        public ActivityContext ActivityContext { get; }
+
+        public DateTime Timestamp { get; }
+
+        public string CategoryName { get; }
+
+        public LogLevel LogLevel { get; }
+
+        public EventId EventId { get; }
+
+        public string FormattedMessage { get; }
+
+        public Exception Exception { get; }
+
+        public void ForEachScope<TState>(Action<LogRecordScope, TState> callback, TState state)
+        {
+            if (this.scopeProvider != null)
+            {
+                var forEachScopeState = new LogRecord.ScopeForEachState<TState>(callback, state);
+
+                this.scopeProvider.ForEachScope(LogRecord.ScopeForEachState<TState>.ForEachScope, forEachScopeState);
+            }
+        }
+
+        public void ForEachStateValue<TState>(Action<KeyValuePair<string, object>, TState> callback, TState state)
+        {
+            if (this.stateValues != null)
+            {
+                for (int i = 0; i < this.stateValues.Count; i++)
+                {
+                    callback(this.stateValues[i], state);
+                }
+            }
+            else if (this.state != null)
+            {
+                callback(new KeyValuePair<string, object>(string.Empty, this.state), state);
+            }
+        }
+
+        internal LogRecord ToLogRecord()
+        {
+            return new LogRecord(
+                this.ActivityContext,
+                this.scopeProvider,
+                this.Timestamp,
+                this.CategoryName,
+                this.LogLevel,
+                this.EventId,
+                this.FormattedMessage,
+                this.state,
+                this.Exception,
+                this.stateValues);
+        }
+    }
+}

--- a/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Internal;
@@ -51,16 +52,19 @@ namespace OpenTelemetry.Logs
             {
                 var options = this.provider.Options;
 
-                processor.Log(
-                    this.categoryName,
+                LogRecordStruct logRecordStruct = new(
+                    Activity.Current?.Context ?? default,
                     DateTime.UtcNow,
+                    this.categoryName,
                     logLevel,
                     eventId,
-                    options.ParseStateValues ? null : state,
-                    options.ParseStateValues ? this.ParseState(state) : null,
-                    options.IncludeScopes ? this.ScopeProvider : null,
+                    options.IncludeFormattedMessage ? formatter?.Invoke(state, exception) : null,
                     exception,
-                    options.IncludeFormattedMessage ? formatter?.Invoke(state, exception) : null);
+                    options.IncludeScopes ? this.ScopeProvider : null,
+                    options.ParseStateValues ? null : state,
+                    options.ParseStateValues ? this.ParseState(state) : null);
+
+                processor.OnEnd(logRecordStruct);
             }
         }
 

--- a/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
@@ -64,7 +64,7 @@ namespace OpenTelemetry.Logs
                     options.ParseStateValues ? null : state,
                     options.ParseStateValues ? this.ParseState(state) : null);
 
-                processor.OnEnd(logRecordStruct);
+                processor.OnEnd(in logRecordStruct);
             }
         }
 

--- a/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
@@ -51,20 +51,16 @@ namespace OpenTelemetry.Logs
             {
                 var options = this.provider.Options;
 
-                var record = new LogRecord(
-                    options.IncludeScopes ? this.ScopeProvider : null,
-                    DateTime.UtcNow,
+                processor.Log(
                     this.categoryName,
+                    DateTime.UtcNow,
                     logLevel,
                     eventId,
-                    options.IncludeFormattedMessage ? formatter?.Invoke(state, exception) : null,
                     options.ParseStateValues ? null : state,
+                    options.ParseStateValues ? this.ParseState(state) : null,
+                    options.IncludeScopes ? this.ScopeProvider : null,
                     exception,
-                    options.ParseStateValues ? this.ParseState(state) : null);
-
-                processor.OnEnd(record);
-
-                record.ScopeProvider = null;
+                    options.IncludeFormattedMessage ? formatter?.Invoke(state, exception) : null);
             }
         }
 

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggerOptions.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggerOptions.cs
@@ -52,7 +52,7 @@ namespace OpenTelemetry.Logs
         public bool ParseStateValues { get; set; }
 
         /// <summary>
-        /// Adds processor to the options.
+        /// Adds a <see cref="LogRecord"/> processor to the options.
         /// </summary>
         /// <param name="processor">Log processor to add.</param>
         /// <returns>Returns <see cref="OpenTelemetryLoggerOptions"/> for chaining.</returns>
@@ -66,12 +66,22 @@ namespace OpenTelemetry.Logs
         }
 
         /// <summary>
-        /// Adds processor to the options.
+        /// Adds a converter and processor to the options.
         /// </summary>
+        /// <remarks>
+        /// Note: A converting processor chain can achieve better performance
+        /// than a <see cref="LogRecord"/> processor by cutting out an
+        /// intermediary type. Use a converting processor chain when you want to
+        /// process or export log records in a format other than <see
+        /// cref="LogRecord"/>.
+        /// </remarks>
         /// <typeparam name="T">Log type.</typeparam>
-        /// <param name="logConverter">Log converter.</param>
-        /// <param name="processor">Log processor to add.</param>
-        /// <returns>Returns <see cref="OpenTelemetryLoggerOptions"/> for chaining.</returns>
+        /// <param name="logConverter"><see cref="LogConverter{T}"/> to convert
+        /// logs into instance of <typeparamref name="T"/>.</param>
+        /// <param name="processor">Log processor which receives <typeparamref
+        /// name="T"/> log message.</param>
+        /// <returns>Returns <see cref="OpenTelemetryLoggerOptions"/> for
+        /// chaining.</returns>
         public OpenTelemetryLoggerOptions AddProcessor<T>(LogConverter<T> logConverter, BaseProcessor<T> processor)
             where T : class
         {

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggerOptions.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggerOptions.cs
@@ -77,7 +77,7 @@ namespace OpenTelemetry.Logs
         {
             Guard.ThrowIfNull(processor);
 
-            this.Processors.Add(new InlineLogProcessor<T>(logConverter, processor));
+            this.Processors.Add(new LogConvertingProcessor<T>(logConverter, processor));
 
             return this;
         }

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggerOptions.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggerOptions.cs
@@ -22,7 +22,7 @@ namespace OpenTelemetry.Logs
 {
     public class OpenTelemetryLoggerOptions
     {
-        internal readonly List<BaseProcessor<LogRecord>> Processors = new List<BaseProcessor<LogRecord>>();
+        internal readonly List<object> Processors = new();
         internal ResourceBuilder ResourceBuilder = ResourceBuilder.CreateDefault();
 
         /// <summary>
@@ -61,6 +61,23 @@ namespace OpenTelemetry.Logs
             Guard.ThrowIfNull(processor);
 
             this.Processors.Add(processor);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds processor to the options.
+        /// </summary>
+        /// <typeparam name="T">Log type.</typeparam>
+        /// <param name="logConverter">Log converter.</param>
+        /// <param name="processor">Log processor to add.</param>
+        /// <returns>Returns <see cref="OpenTelemetryLoggerOptions"/> for chaining.</returns>
+        public OpenTelemetryLoggerOptions AddProcessor<T>(LogConverter<T> logConverter, BaseProcessor<T> processor)
+            where T : class
+        {
+            Guard.ThrowIfNull(processor);
+
+            this.Processors.Add(new InlineLogProcessor<T>(logConverter, processor));
 
             return this;
         }

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggerProvider.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggerProvider.cs
@@ -116,7 +116,7 @@ namespace OpenTelemetry.Logs
         {
             Guard.ThrowIfNull(processor);
 
-            return this.AddProcessor(new LogConvertingProcessor<LogRecord>(BuildLegacyLogRecord, processor));
+            return this.AddProcessor(new LogConvertingProcessor<LogRecord>(LogRecordStruct.ToLogRecord, processor));
         }
 
         internal OpenTelemetryLoggerProvider AddProcessor(ILogProcessor processor)
@@ -157,9 +157,6 @@ namespace OpenTelemetry.Logs
 
             base.Dispose(disposing);
         }
-
-        private static LogRecord BuildLegacyLogRecord(LogRecordStruct log)
-            => log.ToLogRecord();
 
         private void ShutdownProcessors(int timeoutMilliseconds)
         {

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggerProvider.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggerProvider.cs
@@ -111,7 +111,7 @@ namespace OpenTelemetry.Logs
         {
             Guard.ThrowIfNull(processor);
 
-            return this.AddProcessor(new LogConvertingProcessor<LogRecord>(LogRecordStruct.ToLogRecord, processor));
+            return this.AddProcessor(new LogRecordProcessor(processor));
         }
 
         internal OpenTelemetryLoggerProvider AddProcessor(ILogProcessor processor)

--- a/src/OpenTelemetry/SimpleExportProcessor.cs
+++ b/src/OpenTelemetry/SimpleExportProcessor.cs
@@ -23,16 +23,16 @@ namespace OpenTelemetry
     /// Implements processor that exports telemetry data at each OnEnd call.
     /// </summary>
     /// <typeparam name="T">The type of telemetry object to be exported.</typeparam>
-    public abstract class SimpleExportProcessor<T> : BaseExportProcessor<T>
+    public class SimpleExportProcessor<T> : BaseExportProcessor<T>
         where T : class
     {
-        private readonly object syncObject = new object();
+        private readonly object syncObject = new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleExportProcessor{T}"/> class.
         /// </summary>
         /// <param name="exporter">Exporter instance.</param>
-        protected SimpleExportProcessor(BaseExporter<T> exporter)
+        public SimpleExportProcessor(BaseExporter<T> exporter)
             : base(exporter)
         {
         }

--- a/test/Benchmarks/Exporter/OtlpGrpcLogExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/OtlpGrpcLogExporterBenchmarks.cs
@@ -1,0 +1,143 @@
+// <copyright file="OtlpGrpcLogExporterBenchmarks.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+extern alias OpenTelemetryProtocol;
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetryProtocol::OpenTelemetry.Exporter;
+using OpenTelemetryProtocol::OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
+using OtlpCollector = OpenTelemetryProtocol::Opentelemetry.Proto.Collector.Logs.V1;
+
+namespace Benchmarks.Exporter
+{
+    [MemoryDiagnoser]
+    public class OtlpGrpcLogExporterBenchmarks
+    {
+        private readonly Func<CustomReadOnlyListState, Exception, string> messageFormatter = (s, e) => s.ToString();
+        private BatchLogRecordExportProcessor batchLogRecordExportProcessor;
+        private ILoggerFactory loggerFactory;
+        private ILogger logger;
+
+        [Params(10, 50, 100)]
+        public int NumberOfLogs { get; set; }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            OtlpExporterOptions options = new();
+
+            this.loggerFactory = LoggerFactory.Create(configure => configure
+                .AddOpenTelemetry(builder =>
+                {
+                    builder.ParseStateValues = true;
+                    builder.IncludeScopes = true;
+
+                    this.batchLogRecordExportProcessor = new BatchLogRecordExportProcessor(
+                        new OtlpLogExporter(options, new NoopExportClient()),
+                        options.BatchExportProcessorOptions.MaxQueueSize,
+                        options.BatchExportProcessorOptions.ScheduledDelayMilliseconds,
+                        options.BatchExportProcessorOptions.ExporterTimeoutMilliseconds,
+                        options.BatchExportProcessorOptions.MaxExportBatchSize);
+
+                    builder.AddProcessor(this.batchLogRecordExportProcessor);
+                }));
+
+            this.logger = this.loggerFactory.CreateLogger<OtlpGrpcLogExporterBenchmarks>();
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            this.loggerFactory.Dispose();
+        }
+
+        [Benchmark]
+        public void OtlpLogExporterr_Batching()
+        {
+            for (int i = 0; i < this.NumberOfLogs; i++)
+            {
+                if (i % 10 == 1)
+                {
+                    this.logger.Log(LogLevel.Information, 0, new CustomReadOnlyListState(i), null, this.messageFormatter);
+                }
+                else if (i % 10 == 2)
+                {
+                    using IDisposable scope = this.logger.BeginScope("Scope {Index}", i);
+
+                    this.logger.LogInformation("Log scope message {Index}.", i);
+                }
+                else if (i % 10 == 3)
+                {
+                    using IDisposable scope = this.logger.BeginScope(new CustomReadOnlyListState(i));
+
+                    this.logger.Log(LogLevel.Information, 0, new CustomReadOnlyListState(i), null, this.messageFormatter);
+                }
+                else
+                {
+                    this.logger.LogInformation("Log message {Index}.", i);
+                }
+            }
+
+            this.batchLogRecordExportProcessor.ForceFlush();
+        }
+
+        private readonly struct CustomReadOnlyListState : IReadOnlyList<KeyValuePair<string, object>>
+        {
+            private readonly int index;
+
+            public CustomReadOnlyListState(int index)
+            {
+                this.index = index;
+            }
+
+            public int Count => 1;
+
+            public KeyValuePair<string, object> this[int index]
+                => new("Index", this.index);
+
+            public override string ToString() => $"Log message custom scope {this.index}";
+
+            public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+            {
+                for (var i = 0; i < this.Count; i++)
+                {
+                    yield return this[i];
+                }
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+        }
+
+        private sealed class NoopExportClient : IExportClient<OtlpCollector.ExportLogsServiceRequest>
+        {
+            public bool SendExportRequest(OtlpCollector.ExportLogsServiceRequest request, CancellationToken cancellationToken = default)
+            {
+                return true;
+            }
+
+            public bool Shutdown(int timeoutMilliseconds)
+            {
+                return true;
+            }
+        }
+    }
+}

--- a/test/Benchmarks/Logs/LogScopeBenchmarks.cs
+++ b/test/Benchmarks/Logs/LogScopeBenchmarks.cs
@@ -28,7 +28,7 @@ namespace Benchmarks.Logs
     {
         private readonly LoggerExternalScopeProvider scopeProvider = new();
 
-        private readonly Action<LogRecordScope, object> callback = (LogRecordScope scope, object state) =>
+        private readonly LogRecordScopeCallback<object> callback = (LogRecordScope scope, object state) =>
         {
             foreach (KeyValuePair<string, object> scopeItem in scope)
             {

--- a/test/Benchmarks/Logs/LogScopeBenchmarks.cs
+++ b/test/Benchmarks/Logs/LogScopeBenchmarks.cs
@@ -26,7 +26,7 @@ namespace Benchmarks.Logs
     [MemoryDiagnoser]
     public class LogScopeBenchmarks
     {
-        private readonly LoggerExternalScopeProvider scopeProvider = new LoggerExternalScopeProvider();
+        private readonly LoggerExternalScopeProvider scopeProvider = new();
 
         private readonly Action<LogRecordScope, object> callback = (LogRecordScope scope, object state) =>
         {
@@ -58,6 +58,7 @@ namespace Benchmarks.Logs
                 }));
 
             this.logRecord = new LogRecord(
+                default,
                 this.scopeProvider,
                 DateTime.UtcNow,
                 "Benchmark",

--- a/test/OpenTelemetry.Tests/Logs/LogRecordTest.cs
+++ b/test/OpenTelemetry.Tests/Logs/LogRecordTest.cs
@@ -32,7 +32,7 @@ namespace OpenTelemetry.Logs.Tests
     public sealed class LogRecordTest : IDisposable
     {
         private readonly ILogger logger;
-        private readonly List<LogRecord> exportedItems = new List<LogRecord>();
+        private readonly List<LogRecord> exportedItems = new();
         private readonly ILoggerFactory loggerFactory;
         private readonly BaseExportProcessor<LogRecord> processor;
         private readonly BaseExporter<LogRecord> exporter;
@@ -676,7 +676,7 @@ namespace OpenTelemetry.Logs.Tests
 
             public override void OnEnd(LogRecord data)
             {
-                data.BufferLogScopes();
+                data.Buffer();
 
                 base.OnEnd(data);
             }


### PR DESCRIPTION
Fixes #2905
Relates to #2932

## Goals

* SDK converts logs to into `OpenTelemetry.Logs.LogRecord` instances. During export `OtlpLogExporter` converts those instances into `Opentelemetry.Proto.Logs.V1.LogRecord` instances. In essence we are double buffering log data. It would be more efficient to convert the logs directly into `Opentelemetry.Proto.Logs.V1.LogRecord` instances for export.
* When SDK is converting logs into `OpenTelemetry.Logs.LogRecord` instances it doesn't know what the exporter will do with them. It has to be defensive. In the case of batching, it has to buffer data so it can be accessed safely later on. It has to buffer everything. It would be more efficient for SDK to only pay (cpu time, memory allocations) for what is needed.
* There is currently no way to make an allocation-free log exporter.

## Changes

SDK `OpenTelemetryLoggerProvider` now supports registration of a "converting processor chain" which is a conversion function + processor which accepts the results of the conversion (instead of `LogRecord`). This allows users to cut out the intermediary `LogRecord` type and only pay for what they need. Existing `LogRecord` processors will continue to work. Internally this is done with a non-generic `ILogProcessor` interface. In a follow-up we can also utilize this interface to support registration of zero-allocation log exporters.

## `OtlpLogExporter` Benchmarks

### Before

|                    Method | NumberOfLogs |      Mean |     Error |    StdDev |   Gen 0 | Allocated |
|-------------------------- |------------- |----------:|----------:|----------:|--------:|----------:|
| OtlpLogExporterr_Batching |           10 |  7.984 us | 0.1549 us | 0.1784 us |  3.7537 |     15 KB |
| OtlpLogExporterr_Batching |           50 | 40.955 us | 0.7468 us | 1.1178 us | 18.7378 |     77 KB |
| OtlpLogExporterr_Batching |          100 | 81.649 us | 1.5015 us | 1.4045 us | 37.4756 |    153 KB |

### After

|                    Method | NumberOfLogs |      Mean |     Error |    StdDev |   Gen 0 | Allocated |
|-------------------------- |------------- |----------:|----------:|----------:|--------:|----------:|
| OtlpLogExporterr_Batching |           10 |  **6.277 us** | 0.1231 us | 0.1264 us |  3.0060 |     **12 KB** |
| OtlpLogExporterr_Batching |           50 | **31.611 us** | 0.6162 us | 0.7096 us | 15.0146 |     **61 KB** |
| OtlpLogExporterr_Batching |          100 | **63.714 us** | 1.2296 us | 1.6415 us | 30.0293 |    **123 KB** |

## Example

```csharp
// Step 1: Define class to store log data.
public class MyExporterLogData
{
    public string Message { get; init; }

    // Step 2: Define conversion function to build storage class from log.
    internal static MyExporterLogData ToLogData(in LogRecordStruct log)
    {
        return new MyExporterLogData
        {
            Message = log.FormattedMessage,
        };
    }
}

// Step 3: Define exporter which accepts batch of storage class.
public class MyExporter : BaseExporter<MyExporterLogData>
{
    public override ExportResult Export(in Batch<MyExporterLogData> batch)
    {
        foreach (MyExporterLogData log in batch)
        {
            Console.WriteLine($"{log}");
        }

        return ExportResult.Success;
    }
}

// Step 4: Register converting processor chain.
public static class LoggerExtensions
{
    public static OpenTelemetryLoggerOptions AddMyExporter(this OpenTelemetryLoggerOptions options)
    {
        if (options == null)
        {
            throw new ArgumentNullException(nameof(options));
        }

        return options.AddProcessor(
            MyExporterLogData.ToLogData, // <- Conversion function.
            new BatchExportProcessor<MyExporterLogData>(new MyExporter())); // <- Processor.
    }
}
```

## Safety

* New struct to store log data `LogRecordStruct` which is `readonly ref struct`. Special type of struct (like `Span<T>`) which may not escape the stack. This is for safety. In the conversion functions users won't be allowed to copy log to heap. Or jump to another thread. This ensures the log data may only be accessed inline where it is valid. `LogRecordStruct` does not expose state `IReadOnlyList<KeyValuePair<string, object>>` only an enumerator to loop the values. This fixes the issue of deferred states being accessed when they have become invalid. Basically in the conversion function they must be looped inline so the values are captured and become safe to export later.

## Public API Changes

```csharp
// New. Conversion delegate. Must be public so it can be registered with log provider.
public delegate T LogConverter<T>(in LogRecordStruct log);

// New. Previously we used Action<LogRecordScope, TState> for looping scopes.
// Now LogRecordScope is a readonly ref struct which may not be used as
// a type parameter. To get around that, needed to define a delegate.
public delegate void LogRecordScopeCallback<TState>(LogRecordScope scope, TState state);

// New. Structure to expose state values enumerator.
public readonly ref struct LogRecordState
{
   public object State { get; }
   public Enumerator GetEnumerator();
}

// New. Structure to expose log data.
public readonly ref struct LogRecordStruct
{
   public DateTime Timestamp { get; }
   public string CategoryName { get; }
   public LogLevel LogLevel { get; }
   public EventId EventId { get; }
   public string FormattedMessage { get; }
   public Exception Exception { get; }
   public LogRecordState State { get; }
   public void ForEachScope<TState>(LogRecordScopeCallback<TState> callback, TState state);
}

// Existing
public class OpenTelemetryLoggerOptions
{
        // New. Entry point for registration of conversion function + processor.
        public OpenTelemetryLoggerOptions AddProcessor<T>(LogConverter<T> logConverter, BaseProcessor<T> processor)
            where T : class
}

// Dropped abstract from BatchExportProcessor<T>. So it can be used for whatever type the user wants to export. Made ctor public.
// Before
public abstract class BatchExportProcessor<T>
{
   protected BatchExportProcessor(...)
}
// After
public class BatchExportProcessor<T>
{
   public BatchExportProcessor(...)
}

// Dropped abstract from SimpleExportProcessor<T>. So it can be used for whatever type the user wants to export. Made ctor public.
// Before
public abstract class SimpleExportProcessor<T>
{
   protected SimpleExportProcessor(...)
}
// After
public class SimpleExportProcessor<T>
{
   public SimpleExportProcessor(...)
}
```

## Strategic Breaking Changes

I made some breaking changes. 😱 I know! I did this because it increases the safety of the solution. Impact should be very very low, if any. Only `LogExporter` authors would be impacted, and only under certain conditions. So I think it is worth doing. But not strictly necessary to achieve the goals. Looking for feedback on this.

* `readonly struct LogRecordScope` -> `readonly ref struct LogRecordScope`. Not breaking unless `LogExporter` author has copied the `LogRecordScope` to the heap, or jumped threads. That is what I'm seeking to prevent, because it is potentially unsafe. What we want to enforce/encourage is for values to be captured during the conversion, not the scope itself to be captured. Would also break if `LogExporter` author has used `LogRecordScope` as a type parameter (eg `List<LogRecordScope>`).

* `OpenTelemetry.Logs.LogRecord.ForEachScope<TState>(System.Action<OpenTelemetry.Logs.LogRecordScope, TState> callback, TState state)` became `OpenTelemetry.Logs.LogRecordStruct.ForEachScope<TState>(OpenTelemetry.Logs.LogRecordScopeCallback<TState> callback, TState state)`. Not breaking for users doing lambda ([example](https://github.com/open-telemetry/opentelemetry-dotnet/blob/d1c34ab235edc3816704c3a06fa8d3573efd9d9a/docs/logs/extending-the-sdk/MyExporter.cs#L49)). Breaking if using a strongly typed field ([example](https://github.com/open-telemetry/opentelemetry-dotnet/blob/d1c34ab235edc3816704c3a06fa8d3573efd9d9a/test/Benchmarks/Logs/LogScopeBenchmarks.cs#L31)). This had to be done due to the `readonly ref struct LogRecordScope` change above.

* Since `LogRecordScope` was being changed I removed `LogRecordScope.Enumerator` `Dispose` & `Reset` methods. They didn't do anything useful and removing `Dispose` allows the compiler to generate faster `foreach` code. Breaking only if `LogExporter` author is rolling their own `GetEnumerator`/`MoveNext`/`Current`/`Dispose` calls (not using `foreach`).

* Since `LogRecordScope` was being changed I made the ctor on `LogRecordScope` internal. Probably an oversight that it was exposed in the first place. Breaking if `LogExporter` author is newing `LogRecordScope.Enumerator` directly. No reason I can think of for why anyone would be doing that.

## TODOs

* [ ] Changes in public API reviewed
* [ ] `CHANGELOG` updates
* [ ] Unit tests
