### PR TITLE
Metrics: Avoid defensive copies of MetricPoint struct

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -20,6 +20,10 @@
   to `-1`.
   ([#3038](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3038))
 
+* Marked members of the `MetricPoint` `struct` which do not mutate state as
+  `readonly`
+  ([#3065](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3065))
+
 ## 1.2.0-rc3
 
 Released 2022-Mar-04

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -74,7 +74,7 @@ namespace OpenTelemetry.Metrics
         /// <summary>
         /// Gets the tags associated with the metric point.
         /// </summary>
-        public ReadOnlyTagCollection Tags
+        public readonly ReadOnlyTagCollection Tags
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get;
@@ -86,7 +86,7 @@ namespace OpenTelemetry.Metrics
         public DateTimeOffset StartTime
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get;
+            readonly get;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             internal set;
@@ -98,7 +98,7 @@ namespace OpenTelemetry.Metrics
         public DateTimeOffset EndTime
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get;
+            readonly get;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             internal set;
@@ -107,7 +107,7 @@ namespace OpenTelemetry.Metrics
         internal MetricPointStatus MetricPointStatus
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get;
+            readonly get;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private set;
@@ -121,7 +121,7 @@ namespace OpenTelemetry.Metrics
         /// </remarks>
         /// <returns>Long sum value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public long GetSumLong()
+        public readonly long GetSumLong()
         {
             if (this.aggType != AggregationType.LongSumIncomingDelta && this.aggType != AggregationType.LongSumIncomingCumulative)
             {
@@ -139,7 +139,7 @@ namespace OpenTelemetry.Metrics
         /// </remarks>
         /// <returns>Double sum value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public double GetSumDouble()
+        public readonly double GetSumDouble()
         {
             if (this.aggType != AggregationType.DoubleSumIncomingDelta && this.aggType != AggregationType.DoubleSumIncomingCumulative)
             {
@@ -157,7 +157,7 @@ namespace OpenTelemetry.Metrics
         /// </remarks>
         /// <returns>Long gauge value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public long GetGaugeLastValueLong()
+        public readonly long GetGaugeLastValueLong()
         {
             if (this.aggType != AggregationType.LongGauge)
             {
@@ -175,7 +175,7 @@ namespace OpenTelemetry.Metrics
         /// </remarks>
         /// <returns>Double gauge value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public double GetGaugeLastValueDouble()
+        public readonly double GetGaugeLastValueDouble()
         {
             if (this.aggType != AggregationType.DoubleGauge)
             {
@@ -193,7 +193,7 @@ namespace OpenTelemetry.Metrics
         /// </remarks>
         /// <returns>Count value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public long GetHistogramCount()
+        public readonly long GetHistogramCount()
         {
             if (this.aggType != AggregationType.Histogram && this.aggType != AggregationType.HistogramSumCount)
             {
@@ -211,7 +211,7 @@ namespace OpenTelemetry.Metrics
         /// </remarks>
         /// <returns>Sum value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public double GetHistogramSum()
+        public readonly double GetHistogramSum()
         {
             if (this.aggType != AggregationType.Histogram && this.aggType != AggregationType.HistogramSumCount)
             {
@@ -229,7 +229,7 @@ namespace OpenTelemetry.Metrics
         /// </remarks>
         /// <returns><see cref="HistogramBuckets"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public HistogramBuckets GetHistogramBuckets()
+        public readonly HistogramBuckets GetHistogramBuckets()
         {
             if (this.aggType != AggregationType.Histogram && this.aggType != AggregationType.HistogramSumCount)
             {
@@ -542,7 +542,7 @@ namespace OpenTelemetry.Metrics
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private void ThrowNotSupportedMetricTypeException(string methodName)
+        private readonly void ThrowNotSupportedMetricTypeException(string methodName)
         {
             throw new NotSupportedException($"{methodName} is not supported for this metric type.");
         }


### PR DESCRIPTION
## Description

We have this pattern in our metric exporters where we do...

```csharp
foreach (ref readonly var metricPoint in metric.GetMetricPoints())
{
   long value = metricPoint.GetSumLong();
}
```

`MetricPoint` is a mutable struct:

https://github.com/open-telemetry/opentelemetry-dotnet/blob/a1e716716cd2c586119ea9a062e6cf88faccb63f/src/OpenTelemetry/Metrics/MetricPoint.cs#L27

When the compiler sees the `GetSumLong` invocation (for example) it doesn't know if that call is going to mutate the state of the local `metricPoint` so it will create a defensive copy. This can be avoided by declaring members which do not modify the state of the struct as `readonly`.

Here's a doc which goes over this in more detail: https://docs.microsoft.com/en-us/dotnet/csharp/write-safe-efficient-code#declare-readonly-members-for-mutable-structs

## Benchmarks

(I used `PrometheusSerializerBenchmarks` but this will be universal wherever `MetricPoint` is used as a `ref readonly`.)

### Before

|      Method | NumberOfSerializeCalls |          Mean |       Error |      StdDev | Allocated |
|------------ |----------------------- |--------------:|------------:|------------:|----------:|
| WriteMetric |                      1 |      5.324 us |   0.1063 us |   0.2781 us |         - |
| WriteMetric |                   1000 |  5,499.300 us | 109.2757 us | 112.2181 us |       6 B |
| WriteMetric |                  10000 | 54,968.431 us | 799.3971 us | 708.6447 us |     172 B |

### After

|      Method | NumberOfSerializeCalls |          Mean |       Error |      StdDev | Allocated |
|------------ |----------------------- |--------------:|------------:|------------:|----------:|
| WriteMetric |                      1 |      **4.427 us** |   0.0462 us |   0.0432 us |         - |
| WriteMetric |                   1000 |  **4,814.730 us** |  67.4480 us |  90.0411 us |      11 B |
| WriteMetric |                  10000 | **48,092.389 us** | 780.6455 us | 692.0219 us |      70 B |

## TODOs

* [X] Appropriate `CHANGELOG.md` updated for non-trivial changes
