### PR TITLE
Traces: Speed up Activity enumerations by avoiding virtual calls

### DIFF
--- a/test/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks.csproj
@@ -8,6 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\ActivityHelperExtensions.cs" Link="Includes\ActivityHelperExtensions.cs" />
+    <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\EnumerationHelper.cs" Link="Includes\EnumerationHelper.cs" />
+    <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\IActivityEnumerator.cs" Link="Includes\IActivityEnumerator.cs" />
+    <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\StatusHelper.cs" Link="Includes\StatusHelper.cs" />
+    <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\SpanAttributeConstants.cs" Link="Includes\SpanAttributeConstants.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestHttpServer.cs" Link="Includes\TestHttpServer.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestExporter.cs" Link="TestExporter.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\Utils.cs" Link="Utils.cs" />

--- a/test/Benchmarks/Trace/ActivityEnumerationBenchmarks.cs
+++ b/test/Benchmarks/Trace/ActivityEnumerationBenchmarks.cs
@@ -1,0 +1,148 @@
+// <copyright file="ActivityEnumerationBenchmarks.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using BenchmarkDotNet.Attributes;
+using OpenTelemetry.Trace;
+
+namespace Benchmarks.Trace
+{
+    [MemoryDiagnoser]
+    public class ActivityEnumerationBenchmarks
+    {
+        private readonly ActivitySource source = new("Source");
+        private readonly Activity activity;
+
+        public ActivityEnumerationBenchmarks()
+        {
+            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+
+            ActivitySource.AddActivityListener(new ActivityListener
+            {
+                ActivityStarted = null,
+                ActivityStopped = null,
+                ShouldListenTo = (activitySource) => activitySource.Name == "Source",
+                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded,
+            });
+
+            ActivityTagsCollection tags = new ActivityTagsCollection
+            {
+                { "tag1", "value1" },
+                { "tag2", "value2" },
+                { "tag3", "value3" },
+                { "tag4", "value4" },
+                { "tag5", "value5" },
+            };
+
+            this.activity = this.source.StartActivity(
+                "test",
+                ActivityKind.Internal,
+                parentContext: default,
+                links: new ActivityLink[]
+                {
+                    new ActivityLink(default, tags),
+                    new ActivityLink(default, tags),
+                    new ActivityLink(default, tags),
+                    new ActivityLink(default, tags),
+                    new ActivityLink(default, tags),
+                });
+
+            this.activity.SetTag("tag1", "value1");
+            this.activity.SetTag("tag2", "value2");
+            this.activity.SetTag("tag3", "value3");
+            this.activity.SetTag("tag4", "value4");
+            this.activity.SetTag("tag5", "value5");
+
+            this.activity.AddEvent(new ActivityEvent("event1", tags: tags));
+            this.activity.AddEvent(new ActivityEvent("event2", tags: tags));
+            this.activity.AddEvent(new ActivityEvent("event3", tags: tags));
+            this.activity.AddEvent(new ActivityEvent("event4", tags: tags));
+            this.activity.AddEvent(new ActivityEvent("event5", tags: tags));
+
+            this.activity.Stop();
+        }
+
+        [Benchmark]
+        public void EnumerateTags()
+        {
+            TagEnumerationState state = default;
+
+            this.activity.EnumerateTags(ref state);
+        }
+
+        [Benchmark]
+        public void EnumerateLinks()
+        {
+            LinkEnumerationState state = default;
+
+            this.activity.EnumerateLinks(ref state);
+        }
+
+        [Benchmark]
+        public void EnumerateEvents()
+        {
+            EventEnumerationState state = default;
+
+            this.activity.EnumerateEvents(ref state);
+        }
+
+        private struct TagEnumerationState : IActivityEnumerator<KeyValuePair<string, object>>
+        {
+            public int Count;
+
+            public bool ForEach(KeyValuePair<string, object> activityTag)
+            {
+                this.Count++;
+                return true;
+            }
+        }
+
+        private struct LinkEnumerationState : IActivityEnumerator<ActivityLink>
+        {
+            public int LinkCount;
+            public int TagCount;
+
+            public bool ForEach(ActivityLink activityLink)
+            {
+                this.LinkCount++;
+
+                TagEnumerationState tags = default;
+                activityLink.EnumerateTags(ref tags);
+                this.TagCount += tags.Count;
+
+                return true;
+            }
+        }
+
+        private struct EventEnumerationState : IActivityEnumerator<ActivityEvent>
+        {
+            public int EventCount;
+            public int TagCount;
+
+            public bool ForEach(ActivityEvent activityEvent)
+            {
+                this.EventCount++;
+
+                TagEnumerationState tags = default;
+                activityEvent.EnumerateTags(ref tags);
+                this.TagCount += tags.Count;
+
+                return true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Changes

Avoid virtual calls in the IL generated by the allocation-free enumeration helper to speed up enumeration of `Activity` tags, links, & events.

I don't feel like this really needs to be mentioned in the `CHANGELOG` but if anyone feels like it should be there LMK.

## Benchmarks

### Before

|          Method |      Mean |    Error |   StdDev | Allocated |
|---------------- |----------:|---------:|---------:|----------:|
|   EnumerateTags |  30.67 ns | 0.398 ns | 0.458 ns |         - |
|  EnumerateLinks | 227.78 ns | 2.969 ns | 2.777 ns |         - |
| EnumerateEvents | 222.46 ns | 2.740 ns | 2.563 ns |         - |

### After

|          Method |      Mean |    Error |   StdDev | Allocated |
|---------------- |----------:|---------:|---------:|----------:|
|   EnumerateTags |  **28.53 ns** | 0.449 ns | 0.906 ns |         - |
|  EnumerateLinks | **203.03 ns** | 1.731 ns | 1.535 ns |         - |
| EnumerateEvents | **203.18 ns** | 3.395 ns | 3.176 ns |         - |