### PR TITLE
Improve internal log message about exporter to include reader information

### DIFF
--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -76,15 +76,15 @@ namespace OpenTelemetry.Metrics
 
                 if (reader is PeriodicExportingMetricReader periodicExportingMetricReader)
                 {
-                    exportersAdded.Append(((PeriodicExportingMetricReader)reader).Exporter);
+                    exportersAdded.Append(periodicExportingMetricReader.Exporter);
                     exportersAdded.Append(" (Paired with PeriodicExportingMetricReader exporting at ");
-                    exportersAdded.Append(((PeriodicExportingMetricReader)reader).ExportIntervalMilliseconds);
+                    exportersAdded.Append(periodicExportingMetricReader.ExportIntervalMilliseconds);
                     exportersAdded.Append(" milliseconds intervals.)");
                     exportersAdded.Append(';');
                 }
                 else if (reader is BaseExportingMetricReader baseExportingMetricReader)
                 {
-                    exportersAdded.Append(((BaseExportingMetricReader)reader).Exporter);
+                    exportersAdded.Append(baseExportingMetricReader.Exporter);
                     exportersAdded.Append(" (Paired with a MetricReader requiring manual trigger to export.)");
                     exportersAdded.Append(';');
                 }

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -74,9 +74,18 @@ namespace OpenTelemetry.Metrics
                     this.reader = new CompositeMetricReader(new[] { this.reader, reader });
                 }
 
-                if (reader is BaseExportingMetricReader baseExportingMetricReader)
+                if (reader is PeriodicExportingMetricReader periodicExportingMetricReader)
+                {
+                    exportersAdded.Append(((PeriodicExportingMetricReader)reader).Exporter);
+                    exportersAdded.Append(" (Paired with PeriodicExportingMetricReader exporting at ");
+                    exportersAdded.Append(((PeriodicExportingMetricReader)reader).ExportIntervalMilliseconds);
+                    exportersAdded.Append(" milliseconds intervals.)");
+                    exportersAdded.Append(';');
+                }
+                else if (reader is BaseExportingMetricReader baseExportingMetricReader)
                 {
                     exportersAdded.Append(((BaseExportingMetricReader)reader).Exporter);
+                    exportersAdded.Append(" (Paired with a MetricReader requiring manual trigger to export.)");
                     exportersAdded.Append(';');
                 }
             }

--- a/src/OpenTelemetry/Metrics/PeriodicExportingMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/PeriodicExportingMetricReader.cs
@@ -31,7 +31,7 @@ namespace OpenTelemetry.Metrics
         internal const int DefaultExportIntervalMilliseconds = 60000;
         internal const int DefaultExportTimeoutMilliseconds = 30000;
 
-        private readonly int exportIntervalMilliseconds;
+        internal readonly int ExportIntervalMilliseconds;
         private readonly int exportTimeoutMilliseconds;
         private readonly Thread exporterThread;
         private readonly AutoResetEvent exportTrigger = new(false);
@@ -59,7 +59,7 @@ namespace OpenTelemetry.Metrics
                 throw new InvalidOperationException($"The '{nameof(exporter)}' does not support '{nameof(ExportModes)}.{nameof(ExportModes.Push)}'");
             }
 
-            this.exportIntervalMilliseconds = exportIntervalMilliseconds;
+            this.ExportIntervalMilliseconds = exportIntervalMilliseconds;
             this.exportTimeoutMilliseconds = exportTimeoutMilliseconds;
 
             this.exporterThread = new Thread(new ThreadStart(this.ExporterProc))
@@ -119,7 +119,7 @@ namespace OpenTelemetry.Metrics
 
             while (true)
             {
-                timeout = (int)(this.exportIntervalMilliseconds - (sw.ElapsedMilliseconds % this.exportIntervalMilliseconds));
+                timeout = (int)(this.ExportIntervalMilliseconds - (sw.ElapsedMilliseconds % this.ExportIntervalMilliseconds));
 
                 try
                 {

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
@@ -58,7 +58,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
             Assert.NotNull(metricReader);
 
             var exportIntervalMilliseconds = (int)typeof(PeriodicExportingMetricReader)
-                .GetField("exportIntervalMilliseconds", bindingFlags)
+                .GetField("ExportIntervalMilliseconds", bindingFlags)
                 .GetValue(metricReader);
 
             Assert.Equal(60000, exportIntervalMilliseconds);


### PR DESCRIPTION
Sample output
OpenTelemetry-Sdk - EventId: [39], EventName: [MeterProviderSdkEvent], Message: [MeterProviderSdk event: 'Exporters added = 
"OpenTelemetry.Exporter.ConsoleMetricExporter (Paired with PeriodicExportingMetricReader exporting at 10000 milliseconds intervals.);OpenTelemetry.Exporter.PrometheusExporter (Paired with a MetricReader requiring manual trigger to export.)".']
