### PR TITLE
Use 10 sec export interval for console

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -7,6 +7,9 @@
   ([#2929](https://github.com/open-telemetry/opentelemetry-dotnet/pull/2929)
    [#3061](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3061))
 
+* `AddConsoleExporter` extension method by default sets up exporter
+   to export metrics every 10 seconds.
+
 ## 1.2.0-rc3
 
 Released 2022-Mar-04

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterMetricsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterMetricsExtensions.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Metrics
     /// </summary>
     public static class ConsoleExporterMetricsExtensions
     {
-        private const int DefaultExportIntervalMilliseconds = Timeout.Infinite;
+        private const int DefaultExportIntervalMilliseconds = 10000;
         private const int DefaultExportTimeoutMilliseconds = Timeout.Infinite;
 
         /// <summary>


### PR DESCRIPTION
From new spec default : https://github.com/open-telemetry/opentelemetry-specification/pull/2415 