### PR TITLE
Metrics: Improve perf by moving timestamps off of MetricPoint

### DIFF
--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -47,8 +47,6 @@ namespace OpenTelemetry.Metrics
         private int batchSize = 0;
         private int metricCapHitMessageLogged;
         private bool zeroTagMetricPointInitialized;
-        private DateTimeOffset startTimeExclusive;
-        private DateTimeOffset endTimeInclusive;
 
         internal AggregatorStore(
             string name,
@@ -66,7 +64,7 @@ namespace OpenTelemetry.Metrics
             this.aggType = aggType;
             this.outputDelta = temporality == AggregationTemporality.Delta;
             this.histogramBounds = histogramBounds;
-            this.startTimeExclusive = DateTimeOffset.UtcNow;
+            this.StartTimeExclusive = DateTimeOffset.UtcNow;
             if (tagKeysInteresting == null)
             {
                 this.updateLongCallback = this.UpdateLong;
@@ -85,6 +83,10 @@ namespace OpenTelemetry.Metrics
         private delegate void UpdateLongDelegate(long value, ReadOnlySpan<KeyValuePair<string, object>> tags);
 
         private delegate void UpdateDoubleDelegate(double value, ReadOnlySpan<KeyValuePair<string, object>> tags);
+
+        internal DateTimeOffset StartTimeExclusive { get; private set; }
+
+        internal DateTimeOffset EndTimeInclusive { get; private set; }
 
         internal void Update(long value, ReadOnlySpan<KeyValuePair<string, object>> tags)
         {
@@ -109,7 +111,7 @@ namespace OpenTelemetry.Metrics
                 this.SnapshotCumulative(indexSnapshot);
             }
 
-            this.endTimeInclusive = DateTimeOffset.UtcNow;
+            this.EndTimeInclusive = DateTimeOffset.UtcNow;
             return this.batchSize;
         }
 
@@ -128,9 +130,9 @@ namespace OpenTelemetry.Metrics
                 this.batchSize++;
             }
 
-            if (this.endTimeInclusive != default)
+            if (this.EndTimeInclusive != default)
             {
-                this.startTimeExclusive = this.endTimeInclusive;
+                this.StartTimeExclusive = this.EndTimeInclusive;
             }
         }
 
@@ -139,7 +141,7 @@ namespace OpenTelemetry.Metrics
             for (int i = 0; i <= indexSnapshot; i++)
             {
                 ref var metricPoint = ref this.metricPoints[i];
-                if (metricPoint.StartTime == default)
+                if (metricPoint.AggregatorStore == null)
                 {
                     continue;
                 }
@@ -151,9 +153,7 @@ namespace OpenTelemetry.Metrics
         }
 
         internal MetricPointsAccessor GetMetricPoints()
-        {
-            return new MetricPointsAccessor(this.metricPoints, this.currentMetricPointBatch, this.batchSize, this.startTimeExclusive, this.endTimeInclusive);
-        }
+            => new(this.metricPoints, this.currentMetricPointBatch, this.batchSize);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void InitializeZeroTagPointIfNotInitialized()
@@ -164,8 +164,7 @@ namespace OpenTelemetry.Metrics
                 {
                     if (!this.zeroTagMetricPointInitialized)
                     {
-                        var dt = DateTimeOffset.UtcNow;
-                        this.metricPoints[0] = new MetricPoint(this.aggType, dt, null, null, this.histogramBounds);
+                        this.metricPoints[0] = new MetricPoint(this, this.aggType, null, null, this.histogramBounds);
                         this.zeroTagMetricPointInitialized = true;
                     }
                 }
@@ -231,8 +230,7 @@ namespace OpenTelemetry.Metrics
                                 }
 
                                 ref var metricPoint = ref this.metricPoints[aggregatorIndex];
-                                var dt = DateTimeOffset.UtcNow;
-                                metricPoint = new MetricPoint(this.aggType, dt, sortedTags.Keys, sortedTags.Values, this.histogramBounds);
+                                metricPoint = new MetricPoint(this, this.aggType, sortedTags.Keys, sortedTags.Values, this.histogramBounds);
 
                                 // Add to dictionary *after* initializing MetricPoint
                                 // as other threads can start writing to the
@@ -282,8 +280,7 @@ namespace OpenTelemetry.Metrics
                             }
 
                             ref var metricPoint = ref this.metricPoints[aggregatorIndex];
-                            var dt = DateTimeOffset.UtcNow;
-                            metricPoint = new MetricPoint(this.aggType, dt, givenTags.Keys, givenTags.Values, this.histogramBounds);
+                            metricPoint = new MetricPoint(this, this.aggType, givenTags.Keys, givenTags.Values, this.histogramBounds);
 
                             // Add to dictionary *after* initializing MetricPoint
                             // as other threads can start writing to the

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -141,7 +141,7 @@ namespace OpenTelemetry.Metrics
             for (int i = 0; i <= indexSnapshot; i++)
             {
                 ref var metricPoint = ref this.metricPoints[i];
-                if (metricPoint.AggregatorStore == null)
+                if (!metricPoint.IsInitialized)
                 {
                     continue;
                 }

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -26,7 +26,7 @@ namespace OpenTelemetry.Metrics
     /// </summary>
     public struct MetricPoint
     {
-        internal readonly AggregatorStore AggregatorStore;
+        private readonly AggregatorStore aggregatorStore;
 
         private readonly AggregationType aggType;
 
@@ -72,7 +72,7 @@ namespace OpenTelemetry.Metrics
             }
 
             // Note: Intentionally set last because this is used to detect valid MetricPoints.
-            this.AggregatorStore = aggregatorStore;
+            this.aggregatorStore = aggregatorStore;
         }
 
         /// <summary>
@@ -87,12 +87,12 @@ namespace OpenTelemetry.Metrics
         /// <summary>
         /// Gets the start time associated with the metric point.
         /// </summary>
-        public readonly DateTimeOffset StartTime => this.AggregatorStore.StartTimeExclusive;
+        public readonly DateTimeOffset StartTime => this.aggregatorStore.StartTimeExclusive;
 
         /// <summary>
         /// Gets the end time associated with the metric point.
         /// </summary>
-        public readonly DateTimeOffset EndTime => this.AggregatorStore.EndTimeInclusive;
+        public readonly DateTimeOffset EndTime => this.aggregatorStore.EndTimeInclusive;
 
         internal MetricPointStatus MetricPointStatus
         {
@@ -102,6 +102,8 @@ namespace OpenTelemetry.Metrics
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private set;
         }
+
+        internal readonly bool IsInitialized => this.aggregatorStore != null;
 
         /// <summary>
         /// Gets the sum long value associated with the metric point.

--- a/src/OpenTelemetry/Metrics/MetricPointsAccessor.cs
+++ b/src/OpenTelemetry/Metrics/MetricPointsAccessor.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Metrics
@@ -28,18 +27,14 @@ namespace OpenTelemetry.Metrics
         private readonly MetricPoint[] metricsPoints;
         private readonly int[] metricPointsToProcess;
         private readonly long targetCount;
-        private readonly DateTimeOffset start;
-        private readonly DateTimeOffset end;
 
-        internal MetricPointsAccessor(MetricPoint[] metricsPoints, int[] metricPointsToProcess, long targetCount, DateTimeOffset start, DateTimeOffset end)
+        internal MetricPointsAccessor(MetricPoint[] metricsPoints, int[] metricPointsToProcess, long targetCount)
         {
             Guard.ThrowIfNull(metricsPoints);
 
             this.metricsPoints = metricsPoints;
             this.metricPointsToProcess = metricPointsToProcess;
             this.targetCount = targetCount;
-            this.start = start;
-            this.end = end;
         }
 
         /// <summary>
@@ -47,9 +42,7 @@ namespace OpenTelemetry.Metrics
         /// </summary>
         /// <returns><see cref="Enumerator"/>.</returns>
         public Enumerator GetEnumerator()
-        {
-            return new Enumerator(this.metricsPoints, this.metricPointsToProcess, this.targetCount, this.start, this.end);
-        }
+            => new(this.metricsPoints, this.metricPointsToProcess, this.targetCount);
 
         /// <summary>
         /// Enumerates the elements of a <see cref="MetricPointsAccessor"/>.
@@ -58,31 +51,22 @@ namespace OpenTelemetry.Metrics
         {
             private readonly MetricPoint[] metricsPoints;
             private readonly int[] metricPointsToProcess;
-            private readonly DateTimeOffset start;
-            private readonly DateTimeOffset end;
             private readonly long targetCount;
             private long index;
 
-            internal Enumerator(MetricPoint[] metricsPoints, int[] metricPointsToProcess, long targetCount, DateTimeOffset start, DateTimeOffset end)
+            internal Enumerator(MetricPoint[] metricsPoints, int[] metricPointsToProcess, long targetCount)
             {
                 this.metricsPoints = metricsPoints;
                 this.metricPointsToProcess = metricPointsToProcess;
                 this.targetCount = targetCount;
                 this.index = -1;
-                this.start = start;
-                this.end = end;
             }
 
             /// <summary>
             /// Gets the <see cref="MetricPoint"/> at the current position of the enumerator.
             /// </summary>
             public ref readonly MetricPoint Current
-            {
-                get
-                {
-                    return ref this.metricsPoints[this.metricPointsToProcess[this.index]];
-                }
-            }
+                => ref this.metricsPoints[this.metricPointsToProcess[this.index]];
 
             /// <summary>
             /// Advances the enumerator to the next element of the <see
@@ -93,17 +77,7 @@ namespace OpenTelemetry.Metrics
             /// langword="false"/> if the enumerator has passed the end of the
             /// collection.</returns>
             public bool MoveNext()
-            {
-                while (++this.index < this.targetCount)
-                {
-                    ref var metricPoint = ref this.metricsPoints[this.metricPointsToProcess[this.index]];
-                    metricPoint.StartTime = this.start;
-                    metricPoint.EndTime = this.end;
-                    return true;
-                }
-
-                return false;
-            }
+                => ++this.index < this.targetCount;
         }
     }
 }

--- a/test/OpenTelemetry.Tests/Metrics/AggregatorTest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/AggregatorTest.cs
@@ -21,10 +21,12 @@ namespace OpenTelemetry.Metrics.Tests
 {
     public class AggregatorTest
     {
+        private readonly AggregatorStore aggregatorStore = new("test", AggregationType.Histogram, AggregationTemporality.Cumulative, 1024, Metric.DefaultHistogramBounds);
+
         [Fact]
         public void HistogramDistributeToAllBucketsDefault()
         {
-            var histogramPoint = new MetricPoint(AggregationType.Histogram, DateTimeOffset.Now, null, null, Metric.DefaultHistogramBounds);
+            var histogramPoint = new MetricPoint(this.aggregatorStore, AggregationType.Histogram, null, null, Metric.DefaultHistogramBounds);
             histogramPoint.Update(-1);
             histogramPoint.Update(0);
             histogramPoint.Update(2);
@@ -65,7 +67,7 @@ namespace OpenTelemetry.Metrics.Tests
         public void HistogramDistributeToAllBucketsCustom()
         {
             var boundaries = new double[] { 10, 20 };
-            var histogramPoint = new MetricPoint(AggregationType.Histogram, DateTimeOffset.Now, null, null, boundaries);
+            var histogramPoint = new MetricPoint(this.aggregatorStore, AggregationType.Histogram, null, null, boundaries);
 
             // 5 recordings <=10
             histogramPoint.Update(-10);
@@ -105,8 +107,8 @@ namespace OpenTelemetry.Metrics.Tests
         [Fact]
         public void HistogramWithOnlySumCount()
         {
-            var boundaries = new double[] { };
-            var histogramPoint = new MetricPoint(AggregationType.HistogramSumCount, DateTimeOffset.Now, null, null, boundaries);
+            var boundaries = Array.Empty<double>();
+            var histogramPoint = new MetricPoint(this.aggregatorStore, AggregationType.HistogramSumCount, null, null, boundaries);
 
             histogramPoint.Update(-10);
             histogramPoint.Update(0);

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -623,6 +623,8 @@ namespace OpenTelemetry.Metrics.Tests
         [InlineData(false)]
         public void CounterAggregationTest(bool exportDelta)
         {
+            DateTime testStartTime = DateTime.UtcNow;
+
             var exportedItems = new List<Metric>();
 
             using var meter = new Meter($"{Utils.GetCurrentMethodName()}.{exportDelta}");
@@ -641,7 +643,20 @@ namespace OpenTelemetry.Metrics.Tests
             long sumReceived = GetLongSum(exportedItems);
             Assert.Equal(20, sumReceived);
 
+            var metricPoint = GetFirstMetricPoint(exportedItems);
+            Assert.NotNull(metricPoint);
+            Assert.True(metricPoint.Value.StartTime >= testStartTime);
+            Assert.True(metricPoint.Value.EndTime != default);
+
+            DateTimeOffset firstRunStartTime = metricPoint.Value.StartTime;
+            DateTimeOffset firstRunEndTime = metricPoint.Value.EndTime;
+
             exportedItems.Clear();
+
+#if NETFRAMEWORK
+            Thread.Sleep(5000); // Compensates for low resolution timing in netfx.
+#endif
+
             counterLong.Add(10);
             counterLong.Add(10);
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
@@ -654,6 +669,21 @@ namespace OpenTelemetry.Metrics.Tests
             {
                 Assert.Equal(40, sumReceived);
             }
+
+            metricPoint = GetFirstMetricPoint(exportedItems);
+            Assert.NotNull(metricPoint);
+            Assert.True(metricPoint.Value.StartTime >= testStartTime);
+            Assert.True(metricPoint.Value.EndTime != default);
+            if (exportDelta)
+            {
+                Assert.True(metricPoint.Value.StartTime > firstRunStartTime);
+            }
+            else
+            {
+                Assert.Equal(firstRunStartTime, metricPoint.Value.StartTime);
+            }
+
+            Assert.True(metricPoint.Value.EndTime > firstRunEndTime);
 
             exportedItems.Clear();
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
@@ -1373,6 +1403,19 @@ namespace OpenTelemetry.Metrics.Tests
             }
 
             return count;
+        }
+
+        private static MetricPoint? GetFirstMetricPoint(List<Metric> metrics)
+        {
+            foreach (var metric in metrics)
+            {
+                foreach (ref readonly var metricPoint in metric.GetMetricPoints())
+                {
+                    return metricPoint;
+                }
+            }
+
+            return null;
         }
 
         // Provide tags input sorted by Key

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -676,7 +676,7 @@ namespace OpenTelemetry.Metrics.Tests
             Assert.True(metricPoint.Value.EndTime != default);
             if (exportDelta)
             {
-                Assert.True(metricPoint.Value.StartTime > firstRunStartTime);
+                Assert.True(metricPoint.Value.StartTime == firstRunEndTime);
             }
             else
             {


### PR DESCRIPTION
## Changes

Instead of mirroring Start + End times on `MetricPoint`, store a reference back to `AggregatorStore`. This accomplishes two things:

* Reduces the size of `MetricPoint` from 104B to 80B. This lowers the overall memory footprint of the metrics pipeline.
* Speeds up export enumeration which previously was managing these values in `MoveNext`. Enumerator struct is also smaller which will slightly speed up creating the enumerator.

## Benchmarks

### Before

|  Method | UseWithRef |     Mean |    Error |   StdDev |   Median |  Gen 0 | Allocated |
|-------- |----------- |---------:|---------:|---------:|---------:|-------:|----------:|
| Collect |       True | 26.19 us | 0.534 us | 1.567 us | 26.69 us | 0.0305 |     160 B |

### After

|  Method | UseWithRef |     Mean |    Error |   StdDev |  Gen 0 | Allocated |
|-------- |----------- |---------:|---------:|---------:|-------:|----------:|
| Collect |       True | **18.01 us** | 0.529 us | 1.551 us | 0.0305 |     160 B |

## TODOs

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes