### PR TITLE
Minor additions to Extending Metric SDK docs

### DIFF
--- a/docs/metrics/extending-the-sdk/MyExporterExtensions.cs
+++ b/docs/metrics/extending-the-sdk/MyExporterExtensions.cs
@@ -15,17 +15,27 @@
 // </copyright>
 
 using System;
+using System.Threading;
 using OpenTelemetry.Metrics;
 
 internal static class MyExporterExtensions
 {
-    public static MeterProviderBuilder AddMyExporter(this MeterProviderBuilder builder)
+    public static MeterProviderBuilder AddMyExporter(this MeterProviderBuilder builder, int exportIntervalMilliSeconds = Timeout.Infinite)
     {
         if (builder == null)
         {
             throw new ArgumentNullException(nameof(builder));
         }
 
-        return builder.AddReader(new BaseExportingMetricReader(new MyExporter()));
+        if (exportIntervalMilliSeconds == Timeout.Infinite)
+        {
+            // Export triggered manually only.
+            return builder.AddReader(new BaseExportingMetricReader(new MyExporter()));
+        }
+        else
+        {
+            // Export is triggered periodically.
+            return builder.AddReader(new PeriodicExportingMetricReader(new MyExporter(), exportIntervalMilliSeconds));
+        }
     }
 }

--- a/docs/metrics/extending-the-sdk/README.md
+++ b/docs/metrics/extending-the-sdk/README.md
@@ -29,8 +29,6 @@ not covered by the built-in exporters:
   done via `OpenTelemetry.SuppressInstrumentationScope`.
 * Exporters receives a batch of `Metric`, and each `Metric`
   can contain 1 or more `MetricPoint`s.
-* Exporters should use `Activity.TagObjects` collection instead of
-  `Activity.Tags` to obtain the full set of attributes (tags).
 * Exporters should use `ParentProvider.GetResource()` to get the `Resource`
   associated with the provider.
 


### PR DESCRIPTION
Removed unrelated statement about TagObjects.
Modified AddExporter() Extension method to demonstrate both type of MetricReaders.