### PR TITLE
Add integration test for OtlpMetricExporter

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
@@ -82,13 +82,14 @@ namespace OpenTelemetry.Metrics
             return AddOtlpExporter(builder, new OtlpExporterOptions(), new MetricReaderOptions(), null, configureExporterAndMetricReader, serviceProvider: null);
         }
 
-        private static MeterProviderBuilder AddOtlpExporter(
+        internal static MeterProviderBuilder AddOtlpExporter(
             MeterProviderBuilder builder,
             OtlpExporterOptions exporterOptions,
             MetricReaderOptions metricReaderOptions,
             Action<OtlpExporterOptions> configureExporter,
             Action<OtlpExporterOptions, MetricReaderOptions> configureExporterAndMetricReader,
-            IServiceProvider serviceProvider)
+            IServiceProvider serviceProvider,
+            Func<BaseExporter<Metric>, BaseExporter<Metric>> configureExporterInstance = null)
         {
             if (configureExporterAndMetricReader != null)
             {
@@ -103,7 +104,12 @@ namespace OpenTelemetry.Metrics
 
             exporterOptions.AppendExportPath(OtlpExporterOptions.MetricsExportPath);
 
-            var metricExporter = new OtlpMetricExporter(exporterOptions);
+            BaseExporter<Metric> metricExporter = new OtlpMetricExporter(exporterOptions);
+
+            if (configureExporterInstance != null)
+            {
+                metricExporter = configureExporterInstance(metricExporter);
+            }
 
             var metricReader = PeriodicExportingMetricReaderHelper.CreatePeriodicExportingMetricReader(
                 metricExporter,

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 using System;
+using System.Diagnostics;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Internal;
 
@@ -46,11 +47,12 @@ namespace OpenTelemetry.Trace
             return AddOtlpExporter(builder, new OtlpExporterOptions(), configure, serviceProvider: null);
         }
 
-        private static TracerProviderBuilder AddOtlpExporter(
+        internal static TracerProviderBuilder AddOtlpExporter(
             TracerProviderBuilder builder,
             OtlpExporterOptions exporterOptions,
             Action<OtlpExporterOptions> configure,
-            IServiceProvider serviceProvider)
+            IServiceProvider serviceProvider,
+            Func<BaseExporter<Activity>, BaseExporter<Activity>> configureExporterInstance = null)
         {
             configure?.Invoke(exporterOptions);
 
@@ -58,7 +60,12 @@ namespace OpenTelemetry.Trace
 
             exporterOptions.AppendExportPath(OtlpExporterOptions.TracesExportPath);
 
-            var otlpExporter = new OtlpTraceExporter(exporterOptions);
+            BaseExporter<Activity> otlpExporter = new OtlpTraceExporter(exporterOptions);
+
+            if (configureExporterInstance != null)
+            {
+                otlpExporter = configureExporterInstance(otlpExporter);
+            }
 
             if (exporterOptions.ExportProcessorType == ExportProcessorType.Simple)
             {

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Dockerfile
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Dockerfile
@@ -14,4 +14,4 @@ RUN dotnet publish "OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.csproj" -
 FROM mcr.microsoft.com/dotnet/sdk:${SDK_VERSION} AS final
 WORKDIR /test
 COPY --from=build /drop .
-ENTRYPOINT ["dotnet", "vstest", "OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.dll"]
+ENTRYPOINT ["dotnet", "vstest", "OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.dll", "--logger:console;verbosity=detailed"]

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTests.cs
@@ -16,22 +16,38 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
 {
-    public class IntegrationTests
+    public sealed class IntegrationTests : IDisposable
     {
         private const string CollectorHostnameEnvVarName = "OTEL_COLLECTOR_HOSTNAME";
         private static readonly string CollectorHostname = SkipUnlessEnvVarFoundTheoryAttribute.GetEnvironmentVariable(CollectorHostnameEnvVarName);
+        private readonly OpenTelemetryEventListener openTelemetryEventListener;
+
+        public IntegrationTests(ITestOutputHelper outputHelper)
+        {
+            this.openTelemetryEventListener = new(outputHelper);
+        }
+
+        public void Dispose()
+        {
+            this.openTelemetryEventListener.Dispose();
+        }
 
         [InlineData(OtlpExportProtocol.Grpc, ":4317")]
         [InlineData(OtlpExportProtocol.HttpProtobuf, ":4318/v1/traces")]
         [Trait("CategoryName", "CollectorIntegrationTests")]
         [SkipUnlessEnvVarFoundTheory(CollectorHostnameEnvVarName)]
-        public void ExportResultIsSuccess(OtlpExportProtocol protocol, string endpoint)
+        public void TraceExportResultIsSuccess(OtlpExportProtocol protocol, string endpoint)
         {
 #if NETCOREAPP3_1
             // Adding the OtlpExporter creates a GrpcChannel.
@@ -49,22 +65,88 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
                 Protocol = protocol,
             };
 
-            var otlpExporter = new OtlpTraceExporter(exporterOptions);
-            var delegatingExporter = new DelegatingTestExporter<Activity>(otlpExporter);
-            var exportActivityProcessor = new SimpleActivityExportProcessor(delegatingExporter);
+            DelegatingTestExporter<Activity> delegatingExporter = null;
 
             var activitySourceName = "otlp.collector.test";
 
             var builder = Sdk.CreateTracerProviderBuilder()
-                .AddSource(activitySourceName)
-                .AddProcessor(exportActivityProcessor);
+                .AddSource(activitySourceName);
+
+            OtlpTraceExporterHelperExtensions.AddOtlpExporter(
+                builder,
+                exporterOptions,
+                configure: null,
+                serviceProvider: null,
+                configureExporterInstance: otlpExporter =>
+                {
+                    delegatingExporter = new DelegatingTestExporter<Activity>(otlpExporter);
+                    return delegatingExporter;
+                });
 
             using var tracerProvider = builder.Build();
 
-            var source = new ActivitySource(activitySourceName);
+            using var source = new ActivitySource(activitySourceName);
             var activity = source.StartActivity($"{protocol} Test Activity");
             activity?.Stop();
 
+            Assert.NotNull(delegatingExporter);
+            Assert.True(tracerProvider.ForceFlush());
+            Assert.Single(delegatingExporter.ExportResults);
+            Assert.Equal(ExportResult.Success, delegatingExporter.ExportResults[0]);
+        }
+
+        [InlineData(OtlpExportProtocol.Grpc, ":4317")]
+        [InlineData(OtlpExportProtocol.HttpProtobuf, ":4318/v1/metrics")]
+        [Trait("CategoryName", "CollectorIntegrationTests")]
+        [SkipUnlessEnvVarFoundTheory(CollectorHostnameEnvVarName)]
+        public void MetricExportResultIsSuccess(OtlpExportProtocol protocol, string endpoint)
+        {
+#if NETCOREAPP3_1
+            // Adding the OtlpExporter creates a GrpcChannel.
+            // This switch must be set before creating a GrpcChannel when calling an insecure HTTP/2 endpoint.
+            // See: https://docs.microsoft.com/aspnet/core/grpc/troubleshoot#call-insecure-grpc-services-with-net-core-client
+            if (protocol == OtlpExportProtocol.Grpc)
+            {
+                AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+            }
+#endif
+
+            var exporterOptions = new OtlpExporterOptions
+            {
+                Endpoint = new Uri($"http://{CollectorHostname}{endpoint}"),
+                Protocol = protocol,
+            };
+
+            DelegatingTestExporter<Metric> delegatingExporter = null;
+
+            var meterName = "otlp.collector.test";
+
+            var builder = Sdk.CreateMeterProviderBuilder()
+                .AddMeter(meterName);
+
+            OtlpMetricExporterExtensions.AddOtlpExporter(
+                builder,
+                exporterOptions,
+                new MetricReaderOptions(),
+                configureExporter: null,
+                configureExporterAndMetricReader: null,
+                serviceProvider: null,
+                configureExporterInstance: otlpExporter =>
+                {
+                    delegatingExporter = new DelegatingTestExporter<Metric>(otlpExporter);
+                    return delegatingExporter;
+                });
+
+            using var meterProvider = builder.Build();
+
+            using var meter = new Meter(meterName);
+
+            var counter = meter.CreateCounter<int>("test_counter");
+
+            counter.Add(18);
+
+            Assert.NotNull(delegatingExporter);
+            Assert.True(meterProvider.ForceFlush());
             Assert.Single(delegatingExporter.ExportResults);
             Assert.Equal(ExportResult.Success, delegatingExporter.ExportResults[0]);
         }
@@ -93,6 +175,41 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
             else
             {
                 Assert.Null(exception);
+            }
+        }
+
+        private sealed class OpenTelemetryEventListener : EventListener
+        {
+            private readonly ITestOutputHelper outputHelper;
+
+            public OpenTelemetryEventListener(ITestOutputHelper outputHelper)
+            {
+                this.outputHelper = outputHelper;
+            }
+
+            protected override void OnEventSourceCreated(EventSource eventSource)
+            {
+                base.OnEventSourceCreated(eventSource);
+
+                if (eventSource.Name.StartsWith("OpenTelemetry", StringComparison.OrdinalIgnoreCase))
+                {
+                    this.EnableEvents(eventSource, EventLevel.Verbose, EventKeywords.All);
+                }
+            }
+
+            protected override void OnEventWritten(EventWrittenEventArgs eventData)
+            {
+                string message;
+                if (eventData.Message != null && (eventData.Payload?.Count ?? 0) > 0)
+                {
+                    message = string.Format(eventData.Message, eventData.Payload.ToArray());
+                }
+                else
+                {
+                    message = eventData.Message;
+                }
+
+                this.outputHelper.WriteLine(message);
             }
         }
     }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/config.yaml
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/config.yaml
@@ -21,3 +21,6 @@ service:
     traces:
       receivers: [otlp]
       exporters: [logging]
+    metrics:
+      receivers: [otlp]
+      exporters: [logging]


### PR DESCRIPTION
There was a break in OtlpMetricExporter for RC3 this is an effort to prevent that from happening in the future.