### PR TITLE
OTLP Exporter: Integration test improvements

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
@@ -73,12 +73,14 @@ namespace OpenTelemetry.Trace
             }
             else
             {
+                var batchOptions = exporterOptions.BatchExportProcessorOptions ?? new();
+
                 return builder.AddProcessor(new BatchActivityExportProcessor(
                     otlpExporter,
-                    exporterOptions.BatchExportProcessorOptions.MaxQueueSize,
-                    exporterOptions.BatchExportProcessorOptions.ScheduledDelayMilliseconds,
-                    exporterOptions.BatchExportProcessorOptions.ExporterTimeoutMilliseconds,
-                    exporterOptions.BatchExportProcessorOptions.MaxExportBatchSize));
+                    batchOptions.MaxQueueSize,
+                    batchOptions.ScheduledDelayMilliseconds,
+                    batchOptions.ExporterTimeoutMilliseconds,
+                    batchOptions.MaxExportBatchSize));
             }
         }
     }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTests.cs
@@ -31,6 +31,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
     public sealed class IntegrationTests : IDisposable
     {
         private const string CollectorHostnameEnvVarName = "OTEL_COLLECTOR_HOSTNAME";
+        private const int ExportIntervalMilliseconds = 10000;
         private static readonly string CollectorHostname = SkipUnlessEnvVarFoundTheoryAttribute.GetEnvironmentVariable(CollectorHostnameEnvVarName);
         private readonly OpenTelemetryEventListener openTelemetryEventListener;
 
@@ -69,7 +70,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
                 Protocol = protocol,
                 BatchExportProcessorOptions = new()
                 {
-                    ScheduledDelayMilliseconds = 10000,
+                    ScheduledDelayMilliseconds = ExportIntervalMilliseconds,
                 },
             };
 
@@ -105,7 +106,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
             }
             else if (exporterOptions.ExportProcessorType == ExportProcessorType.Batch)
             {
-                handle.WaitOne(10000 * 2);
+                handle.WaitOne(ExportIntervalMilliseconds * 2);
             }
 
             Assert.Single(delegatingExporter.ExportResults);
@@ -145,7 +146,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
                 .AddMeter(meterName);
 
             var readerOptions = new MetricReaderOptions();
-            readerOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = 10000;
+            readerOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = ExportIntervalMilliseconds;
 
             OtlpMetricExporterExtensions.AddOtlpExporter(
                 builder,
@@ -176,7 +177,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
             }
             else
             {
-                handle.WaitOne(10000 * 2);
+                handle.WaitOne(ExportIntervalMilliseconds * 2);
             }
 
             Assert.Single(delegatingExporter.ExportResults);

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
@@ -429,6 +429,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
                 .AddOtlpExporter(
                     o =>
                     {
+                        o.Protocol = OtlpExportProtocol.HttpProtobuf;
                         o.ExportProcessorType = ExportProcessorType.Batch;
                         o.BatchExportProcessorOptions = null;
                     });

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
@@ -421,5 +421,17 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
 
             exportClientMock.Verify(m => m.Shutdown(It.IsAny<int>()), Times.Once());
         }
+
+        [Fact]
+        public void Null_BatchExportProcessorOptions_SupportedTest()
+        {
+            Sdk.CreateTracerProviderBuilder()
+                .AddOtlpExporter(
+                    o =>
+                    {
+                        o.ExportProcessorType = ExportProcessorType.Batch;
+                        o.BatchExportProcessorOptions = null;
+                    });
+        }
     }
 }

--- a/test/OpenTelemetry.Tests/Shared/DelegatingTestExporter.cs
+++ b/test/OpenTelemetry.Tests/Shared/DelegatingTestExporter.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 
 namespace OpenTelemetry.Tests
@@ -21,19 +22,24 @@ namespace OpenTelemetry.Tests
     public class DelegatingTestExporter<T> : BaseExporter<T>
         where T : class
     {
-        public List<ExportResult> ExportResults = new();
-
         private readonly BaseExporter<T> exporter;
+        private readonly Action onExportAction;
 
-        public DelegatingTestExporter(BaseExporter<T> exporter)
+        public DelegatingTestExporter(
+            BaseExporter<T> exporter,
+            Action onExportAction = null)
         {
             this.exporter = exporter;
+            this.onExportAction = onExportAction;
         }
+
+        public List<ExportResult> ExportResults { get; } = new();
 
         public override ExportResult Export(in Batch<T> batch)
         {
             var result = this.exporter.Export(batch);
             this.ExportResults.Add(result);
+            this.onExportAction?.Invoke();
             return result;
         }
     }


### PR DESCRIPTION
Related to #3092

Updated the OTLP integration tests to verify default batch/periodic modes in addition to force flush.

Also fixed a bug I noticed where `null` `BatchExportProcessorOptions` would blow up the OTLP tracing builder extension.