### PR TITLE
[Solution] Update preprocessor directives ahead of System.Diagnostics.DiagnosticSource .NET 7 update

### DIFF
--- a/src/OpenTelemetry.Api/Context/RemotingRuntimeContextSlot.cs
+++ b/src/OpenTelemetry.Api/Context/RemotingRuntimeContextSlot.cs
@@ -14,7 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-#if NET461
+#if NETFRAMEWORK
 using System.Collections;
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/Batch.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/Batch.cs
@@ -14,7 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-#if NETSTANDARD2_0 || NET461
+#if NETSTANDARD2_0 || NETFRAMEWORK
 using System;
 #endif
 using Thrift.Protocol;

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/EmitBatchArgs.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/EmitBatchArgs.cs
@@ -14,7 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-#if NETSTANDARD2_0 || NET461
+#if NETSTANDARD2_0 || NETFRAMEWORK
 using System;
 #endif
 using Thrift.Protocol;

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/ShimExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/ShimExtensions.cs
@@ -14,7 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-#if NETSTANDARD2_0 || NET461
+#if NETSTANDARD2_0 || NETFRAMEWORK
 namespace System
 {
     internal static class ShimExtensions

--- a/src/OpenTelemetry/Internal/ServiceProviderExtensions.cs
+++ b/src/OpenTelemetry/Internal/ServiceProviderExtensions.cs
@@ -14,7 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-#if NET461 || NETSTANDARD2_0 || NETSTANDARD2_1 || NETCOREAPP3_1_OR_GREATER
+#if NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER
 using Microsoft.Extensions.Options;
 #endif
 
@@ -34,7 +34,7 @@ namespace System
         public static T GetOptions<T>(this IServiceProvider serviceProvider)
             where T : class, new()
         {
-#if NET461 || NETSTANDARD2_0 || NETSTANDARD2_1 || NETCOREAPP3_1_OR_GREATER
+#if NETFRAMEWORK || NETSTANDARD2_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER
             IOptions<T> options = (IOptions<T>)serviceProvider.GetService(typeof(IOptions<T>));
 
             // Note: options could be null if user never invoked services.AddOptions().

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusCollectionManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusCollectionManagerTests.cs
@@ -16,7 +16,7 @@
 
 using System;
 using System.Diagnostics.Metrics;
-#if NET461
+#if NETFRAMEWORK
 using System.Linq;
 #endif
 using System.Threading;

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterHttpServerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterHttpServerTests.cs
@@ -48,7 +48,7 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
                         .AddMeter(meter.Name)
                         .AddPrometheusExporter(o =>
                         {
-#if NET461
+#if NETFRAMEWORK
                             bool expectedDefaultState = true;
 #else
                             bool expectedDefaultState = false;
@@ -142,7 +142,7 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
                 if (ex is not ArgumentNullException)
                 {
                     Assert.Equal("System.ArgumentException", ex.GetType().ToString());
-#if NET461
+#if NETFRAMEWORK
                     Assert.Equal("Prometheus server path should be a valid URI with http/https scheme.\r\nParameter name: httpListenerPrefixes", ex.Message);
 #else
                     Assert.Equal("Prometheus server path should be a valid URI with http/https scheme. (Parameter 'httpListenerPrefixes')", ex.Message);

--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterMiddlewareTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusExporterMiddlewareTests.cs
@@ -14,7 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-#if !NET461
+#if !NETFRAMEWORK
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;

--- a/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToActivityConverterTests.cs
+++ b/test/OpenTelemetry.Instrumentation.StackExchangeRedis.Tests/Implementation/RedisProfilerEntryToActivityConverterTests.cs
@@ -160,7 +160,7 @@ namespace OpenTelemetry.Instrumentation.StackExchangeRedis.Implementation
             Assert.Equal(dnsEndPoint.Port, result.GetTagValue(SemanticConventions.AttributeNetPeerPort));
         }
 
-#if !NET461
+#if !NETFRAMEWORK
         [Fact]
         public void ProfilerCommandToActivity_UsesOtherEndPointAsEndPoint()
         {

--- a/test/OpenTelemetry.Tests/Logs/LogRecordTest.cs
+++ b/test/OpenTelemetry.Tests/Logs/LogRecordTest.cs
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
-#if !NET461
+
+#if !NETFRAMEWORK
 using System;
 using System.Collections;
 using System.Collections.Generic;


### PR DESCRIPTION
## Changes

I needed to target a local .NET 7 build of System.Diagnostics.DiagnosticSource to benchmark some changes I am working on with the runtime team. There were some surprises/headaches getting that up and running! .NET 7 DiagnosticSource drops support for net461 (bumped to net462), net5.0, & netcoreapp3.1. Presumably because they will all be out of support by the time .NET 7 releases. We will need to update the targets in most (all?) of our csproj files in order to consume .NET 7. I'm not going to check that in because it will disrupt the 1.2 metrics effort, but I'm checking in the updates I made to preprocessor directives. Should be safe to do now and save a little bit of effort when it comes time to do that upgrade.