### PR TITLE
OTLP TraceExporter to not populate deprecated fields

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -17,6 +17,8 @@
   after instantiation by altering the original `OtlpExporterOptions` provided.
   ([#3066](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3066))
 
+* TraceExporter to stop populate DeprecatedCode in OTLP Status.
+
 ## 1.2.0-rc3
 
 Released 2022-Mar-04

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -17,7 +17,7 @@
   after instantiation by altering the original `OtlpExporterOptions` provided.
   ([#3066](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3066))
 
-* TraceExporter to stop populate DeprecatedCode in OTLP Status.
+* TraceExporter to stop populating `DeprecatedCode` in OTLP Status.
 
 ## 1.2.0-rc3
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
@@ -252,18 +252,6 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
                 Code = (OtlpTrace.Status.Types.StatusCode)(int)status,
             };
 
-            if (otlpStatus.Code != OtlpTrace.Status.Types.StatusCode.Error)
-            {
-#pragma warning disable CS0612 // Type or member is obsolete
-                otlpStatus.DeprecatedCode = OtlpTrace.Status.Types.DeprecatedStatusCode.Ok;
-#pragma warning restore CS0612 // Type or member is obsolete
-            }
-            else
-            {
-#pragma warning disable CS0612 // Type or member is obsolete
-                otlpStatus.DeprecatedCode = OtlpTrace.Status.Types.DeprecatedStatusCode.UnknownError;
-#pragma warning restore CS0612 // Type or member is obsolete
-            }
 
             if (!string.IsNullOrEmpty(otlpTags.StatusDescription))
             {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
@@ -252,7 +252,6 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
                 Code = (OtlpTrace.Status.Types.StatusCode)(int)status,
             };
 
-
             if (!string.IsNullOrEmpty(otlpTags.StatusDescription))
             {
                 otlpStatus.Message = otlpTags.StatusDescription;


### PR DESCRIPTION
To make https://github.com/open-telemetry/opentelemetry-dotnet/pull/3100/files simpler.