### PR TITLE
Improve View error messaging

### DIFF
--- a/src/OpenTelemetry/Metrics/ExplicitBucketHistogramConfiguration.cs
+++ b/src/OpenTelemetry/Metrics/ExplicitBucketHistogramConfiguration.cs
@@ -36,8 +36,7 @@ namespace OpenTelemetry.Metrics
         /// <item>A null value would result in default bucket boundaries being
         /// used.</item>
         /// </list>
-        /// Note: A copy is made of the provided array. Boundaries cannot be
-        /// modified after being set.
+        /// Note: A copy is made of the provided array.
         /// </remarks>
         public double[] Boundaries
         {

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -163,8 +163,10 @@ namespace OpenTelemetry.Metrics
                             {
                                 metricStreamConfig = viewConfig(instrument);
                             }
-                            catch (ArgumentException ex)
+                            catch (Exception ex)
                             {
+                                // TODO: This allocates the string even if none listening,
+                                // could be improved with a separate dedicated method.
                                 OpenTelemetrySdkEventSource.Log.MetricInstrumentIgnored(instrument.Name, instrument.Meter.Name, "Applying View Configuration failed with error:" + ex.Message, "Fix the view configuration.");
                                 return;
                             }

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -157,7 +157,18 @@ namespace OpenTelemetry.Metrics
                         var metricStreamConfigs = new List<MetricStreamConfiguration>(viewConfigCount);
                         foreach (var viewConfig in this.viewConfigs)
                         {
-                            var metricStreamConfig = viewConfig(instrument);
+                            MetricStreamConfiguration metricStreamConfig = null;
+
+                            try
+                            {
+                                metricStreamConfig = viewConfig(instrument);
+                            }
+                            catch (ArgumentException ex)
+                            {
+                                OpenTelemetrySdkEventSource.Log.MetricInstrumentIgnored(instrument.Name, instrument.Meter.Name, "Applying View Configuration failed with error:" + ex.Message, "Fix the view configuration.");
+                                return;
+                            }
+
                             if (metricStreamConfig != null)
                             {
                                 metricStreamConfigs.Add(metricStreamConfig);

--- a/src/OpenTelemetry/Metrics/MetricStreamConfiguration.cs
+++ b/src/OpenTelemetry/Metrics/MetricStreamConfiguration.cs
@@ -68,10 +68,12 @@ namespace OpenTelemetry.Metrics
         /// <remarks>
         /// Notes:
         /// <list type="bullet">
-        /// <item>If provided any metrics for the instrument which do not match
-        /// all the tag keys will be dropped (not collected).</item>
-        /// <item>A copy is made of the provided array. TagKeys cannot be
-        /// modified after being set.</item>
+        /// <item>If not provided, all the tags provided by the instrument
+        /// while reporting measurements will be used for aggregation.
+        /// If provided, only those tags in this list will be used
+        /// for aggregation.
+        /// </item>
+        /// <item>A copy is made of the provided array.</item>
         /// </list>
         /// </remarks>
         public string[] TagKeys


### PR DESCRIPTION
Follow up from https://github.com/open-telemetry/opentelemetry-dotnet/pull/3117 by @CodeBlanch 

If a View configuration was invalid, and we were able to detect it at runtime only, this PR improves the messaging.

Consider the following View configuration, which provides invalid Histogram boundaries.
```
.AddView((instrument) =>
                {
                    return instrument.Name == "myname"
                        ? new ExplicitBucketHistogramConfiguration() { Boundaries = invalidones }
                        : null;
                })
```

Without this PR:

OpenTelemetry-Sdk - EventId: [33], EventName: [MetricInstrumentIgnored], Message: [Measurements from Instrument 'counter1', Meter 'AddViewWithInvalidHistogramBoundsIgnored' will be ignored. Reason: 'SDK internal error occurred.'. Suggested action: 'Contact SDK owners..']

With this PR:

OpenTelemetry-Sdk - EventId: [33], EventName: [MetricInstrumentIgnored], Message: [Measurements from Instrument 'counter1', Meter 'AddViewWithInvalidHistogramBoundsIgnored' will be ignored. Reason: 'Applying View Configuration failed with error:Histogram boundaries are invalid. Histogram boundaries must be in ascending order with distinct values. (Parameter 'value')'. Suggested action: 'Fix the view configuration.']

The message could be improved, but this is better than blaming SDK Internal error.
