### PR TITLE
Bad View result in ignoring the View but not the instrument itself

### DIFF
--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -378,6 +378,12 @@ namespace OpenTelemetry.Internal
             this.WriteEvent(40, message);
         }
 
+        [Event(41, Message = "View Configuration ignored for Instrument '{0}', Meter '{1}'. Reason: '{2}'. Measurements from the instrument will use default configuration for Aggregation. Suggested action: '{3}'", Level = EventLevel.Warning)]
+        public void MetricViewIgnored(string instrumentName, string meterName, string reason, string fix)
+        {
+            this.WriteEvent(41, instrumentName, meterName, reason, fix);
+        }
+
 #if DEBUG
         public class OpenTelemetryEventListener : EventListener
         {

--- a/src/OpenTelemetry/Metrics/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderBuilderExtensions.cs
@@ -115,8 +115,8 @@ namespace OpenTelemetry.Metrics
         /// <remarks>
         /// <list type="bullet">
         /// <item>Note: An invalid <see cref="MetricStreamConfiguration"/>
-        /// returned from <paramref name="viewConfig"/> will cause a dropping
-        /// behavior for the instrument being configured, no error will be
+        /// returned from <paramref name="viewConfig"/> will cause the
+        /// view to be ignored, no error will be
         /// thrown at runtime.</item>
         /// <item>See View specification here : https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view.</item>
         /// </list>

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -165,10 +165,7 @@ namespace OpenTelemetry.Metrics
                             }
                             catch (Exception ex)
                             {
-                                // TODO: This allocates the string even if none listening,
-                                // could be improved with a separate dedicated method.
-                                OpenTelemetrySdkEventSource.Log.MetricInstrumentIgnored(instrument.Name, instrument.Meter.Name, "Applying View Configuration failed with error:" + ex.Message, "Fix the view configuration.");
-                                return;
+                                OpenTelemetrySdkEventSource.Log.MetricViewIgnored(instrument.Name, instrument.Meter.Name, ex.Message, "Fix the view configuration.");
                             }
 
                             if (metricStreamConfig != null)


### PR DESCRIPTION
Following from https://github.com/open-telemetry/opentelemetry-dotnet/pull/3119 and https://github.com/open-telemetry/opentelemetry-dotnet/pull/3117

This PR makes the following change:
If a View Config is invalid, and it was detected after the `MeterProvider` was built, we simply Ignore that particular View Config, and continue with the Instrument. If there are other Views, which matches the instrument, then it'll be applied. If there are none, a default configuration is applied (as required by the spec) In short, a "bad view results in *that* view being ignored. SDK proceeds as if this View did not even exist".

Added test to make the point clear. 


*NOTE* : This is different from a View which is invalid and is detected statically. In those cases, we simply throw, and fail to build the `MeterProvider` itself.

General idea with Views:
We validate and fail-fast whenever feasible.
If we missed the window to do fail-fast, then we would ignore the View (log that it is ignored), but continue with instrument as if **that** View did not exist.