### PR TITLE
Improve log message for unsupported Instrument

### DIFF
--- a/docs/metrics/extending-the-sdk/README.md
+++ b/docs/metrics/extending-the-sdk/README.md
@@ -54,8 +54,8 @@ class MyExporter : BaseExporter<Metric>
 }
 ```
 
-A demo exporter which simply writes metric name and metric point start time
-, tags to the console is shown [here](./MyExporter.cs).
+A demo exporter which simply writes metric name, metric point start time
+and tags to the console is shown [here](./MyExporter.cs).
 
 Apart from the exporter itself, you should also provide extension methods as
 shown [here](./MyExporterExtensions.cs). This allows users to add the Exporter

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -207,7 +207,7 @@ namespace OpenTelemetry.Metrics
                             }
                         }
 
-                        OpenTelemetrySdkEventSource.Log.MeterProviderSdkEvent($"Succeeded publishing Instrument = \"{instrument.Name}\" of Meter = \"{instrument.Meter.Name}\".");
+                        OpenTelemetrySdkEventSource.Log.MeterProviderSdkEvent($"Completed publishing Instrument = \"{instrument.Name}\" of Meter = \"{instrument.Meter.Name}\".");
                     }
                     catch (Exception)
                     {
@@ -272,7 +272,7 @@ namespace OpenTelemetry.Metrics
                             }
                         }
 
-                        OpenTelemetrySdkEventSource.Log.MeterProviderSdkEvent($"Succeeded publishing Instrument = \"{instrument.Name}\" of Meter = \"{instrument.Meter.Name}\".");
+                        OpenTelemetrySdkEventSource.Log.MeterProviderSdkEvent($"Completed publishing Instrument = \"{instrument.Name}\" of Meter = \"{instrument.Meter.Name}\".");
                     }
                     catch (Exception)
                     {

--- a/src/OpenTelemetry/Metrics/MetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/MetricReaderExt.cs
@@ -67,7 +67,21 @@ namespace OpenTelemetry.Metrics
                 }
                 else
                 {
-                    var metric = new Metric(instrumentIdentity, this.Temporality, this.maxMetricPointsPerMetricStream);
+                    Metric metric = null;
+                    try
+                    {
+                        metric = new Metric(instrumentIdentity, this.Temporality, this.maxMetricPointsPerMetricStream);
+                    }
+                    catch (NotSupportedException nse)
+                    {
+                        // TODO: This allocates string even if none listening.
+                        // Could be improved with separate Event.
+                        // Also the message could call out what Instruments
+                        // and types (eg: int, long etc) are supported.
+                        OpenTelemetrySdkEventSource.Log.MetricInstrumentIgnored(metricName, instrument.Meter.Name, "Unsupported instrument. Details: " + nse.Message, "Switch to a supported instrument type.");
+                        return null;
+                    }
+
                     this.instrumentIdentityToMetric[instrumentIdentity] = metric;
                     this.metrics[index] = metric;
                     this.metricStreamNames.Add(metricStreamName);


### PR DESCRIPTION
With this PR, the following shows an example log message.
OpenTelemetry-Sdk - EventId: [33], EventName: [MetricInstrumentIgnored], Message: [Measurements from Instrument 'MyFruitCounter', Meter 'MyCompany.MyProduct.MyLibrary' will be ignored. Reason: 'Unsupported instrument. Details: Unsupported Instrument Type: System.Diagnostics.Metrics.Counter`1[[System.Decimal, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]'. Suggested action: 'Switch to a supported instrument type.']

Without this PR, user would see "Sdk internal error, contact Sdk owners".. I'd prefer not to be contacted for errors that can be fixed by users 😆 