### PR TITLE
Fix view bugs where views create conflicting metric streams at runtime

### DIFF
--- a/src/OpenTelemetry/Metrics/InstrumentIdentity.cs
+++ b/src/OpenTelemetry/Metrics/InstrumentIdentity.cs
@@ -23,7 +23,7 @@ namespace OpenTelemetry.Metrics
     {
         private readonly int hashCode;
 
-        public InstrumentIdentity(Meter meter, string instrumentName, string unit, string description, Type instrumentType)
+        public InstrumentIdentity(Meter meter, string instrumentName, string unit, string description, Type instrumentType, bool derivedFromView)
         {
             this.MeterName = meter.Name;
             this.MeterVersion = meter.Version ?? string.Empty;
@@ -31,6 +31,7 @@ namespace OpenTelemetry.Metrics
             this.Unit = unit ?? string.Empty;
             this.Description = description ?? string.Empty;
             this.InstrumentType = instrumentType;
+            this.DerivedFromView = derivedFromView;
 
             unchecked
             {
@@ -41,6 +42,7 @@ namespace OpenTelemetry.Metrics
                 hash = (hash * 31) + this.InstrumentName.GetHashCode();
                 hash = this.Unit == null ? hash : (hash * 31) + this.Unit.GetHashCode();
                 hash = this.Description == null ? hash : (hash * 31) + this.Description.GetHashCode();
+                hash = (hash * 31) + this.DerivedFromView.GetHashCode();
                 this.hashCode = hash;
             }
         }
@@ -56,6 +58,8 @@ namespace OpenTelemetry.Metrics
         public readonly string Description { get; }
 
         public readonly Type InstrumentType { get; }
+
+        public readonly bool DerivedFromView { get; }
 
         public static bool operator ==(InstrumentIdentity metricIdentity1, InstrumentIdentity metricIdentity2) => metricIdentity1.Equals(metricIdentity2);
 
@@ -73,7 +77,8 @@ namespace OpenTelemetry.Metrics
                 && this.MeterVersion == other.MeterVersion
                 && this.InstrumentName == other.InstrumentName
                 && this.Unit == other.Unit
-                && this.Description == other.Description;
+                && this.Description == other.Description
+                && this.DerivedFromView == other.DerivedFromView;
         }
 
         public readonly override int GetHashCode() => this.hashCode;

--- a/src/OpenTelemetry/Metrics/MetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/MetricReaderExt.cs
@@ -156,6 +156,15 @@ namespace OpenTelemetry.Metrics
                         continue;
                     }
 
+                    if (this.metricStreamNames.Contains(metricStreamName))
+                    {
+                        OpenTelemetrySdkEventSource.Log.DuplicateMetricInstrument(
+                            metricName,
+                            meterName,
+                            "Metric instrument has the same name as an existing one but differs by description, unit, or instrument type. Measurements from this instrument will still be exported but may result in conflicts.",
+                            "Either change the name of the instrument or use MeterProviderBuilder.AddView to resolve the conflict.");
+                    }
+
                     var index = ++this.metricIndex;
                     if (index >= this.maxMetricStreams)
                     {

--- a/src/OpenTelemetry/Metrics/MetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/MetricReaderExt.cs
@@ -136,12 +136,6 @@ namespace OpenTelemetry.Metrics
                     {
                         if (metrics.Count == 0)
                         {
-                            OpenTelemetrySdkEventSource.Log.DuplicateMetricInstrument(
-                                metricName,
-                                meterName,
-                                "Metric instrument has the same name as an existing one but differs by description, unit, or instrument type. Measurements from this instrument will still be exported but may result in conflicts.",
-                                "Either change the name of the instrument or use MeterProviderBuilder.AddView to resolve the conflict.");
-
                             metrics.Add(existingMetric);
                         }
                         else

--- a/src/OpenTelemetry/Metrics/MetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/MetricReaderExt.cs
@@ -42,7 +42,7 @@ namespace OpenTelemetry.Metrics
             var meterVersion = instrument.Meter.Version;
             var metricName = instrument.Name;
             var metricStreamName = $"{meterName}.{meterVersion}.{metricName}";
-            var instrumentIdentity = new InstrumentIdentity(instrument.Meter, metricName, instrument.Unit, instrument.Description, instrument.GetType());
+            var instrumentIdentity = new InstrumentIdentity(instrument.Meter, metricName, instrument.Unit, instrument.Description, instrument.GetType(), false);
             lock (this.instrumentCreationLock)
             {
                 if (this.instrumentIdentityToMetric.TryGetValue(instrumentIdentity, out var existingMetric))
@@ -105,7 +105,7 @@ namespace OpenTelemetry.Metrics
                     var metricName = metricStreamConfig?.Name ?? instrument.Name;
                     var metricStreamName = $"{meterName}.{meterVersion}.{metricName}";
                     var metricDescription = metricStreamConfig?.Description ?? instrument.Description;
-                    var instrumentIdentity = new InstrumentIdentity(instrument.Meter, metricName, instrument.Unit, metricDescription, instrument.GetType());
+                    var instrumentIdentity = new InstrumentIdentity(instrument.Meter, metricName, instrument.Unit, metricDescription, instrument.GetType(), metricStreamConfig != null);
 
                     if (!MeterProviderBuilderSdk.IsValidInstrumentName(metricName))
                     {

--- a/src/OpenTelemetry/Metrics/MetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/MetricReaderExt.cs
@@ -120,19 +120,21 @@ namespace OpenTelemetry.Metrics
 
                     if (this.instrumentIdentityToMetric.TryGetValue(instrumentIdentity, out var existingMetric))
                     {
-                        metrics.Add(existingMetric);
-                        continue;
-                    }
-
-                    if (this.metricStreamNames.Contains(metricStreamName))
-                    {
                         OpenTelemetrySdkEventSource.Log.DuplicateMetricInstrument(
                             metricName,
                             meterName,
                             "Metric instrument has the same name as an existing one but differs by description, unit, or instrument type. Measurements from this instrument will still be exported but may result in conflicts.",
                             "Either change the name of the instrument or use MeterProviderBuilder.AddView to resolve the conflict.");
+
+                        if (metrics.Count == 0)
+                        {
+                            metrics.Add(existingMetric);
+                        }
+
+                        continue;
                     }
 
+                    // TODO: I think this check needs to be moved up...
                     if (metricStreamConfig?.Aggregation == Aggregation.Drop)
                     {
                         OpenTelemetrySdkEventSource.Log.MetricInstrumentIgnored(metricName, instrument.Meter.Name, "View configuration asks to drop this instrument.", "Modify view configuration to allow this instrument, if desired.");

--- a/src/OpenTelemetry/Metrics/MetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/MetricReaderExt.cs
@@ -42,7 +42,7 @@ namespace OpenTelemetry.Metrics
             var meterVersion = instrument.Meter.Version;
             var metricName = instrument.Name;
             var metricStreamName = $"{meterName}.{meterVersion}.{metricName}";
-            var instrumentIdentity = new InstrumentIdentity(instrument.Meter, metricName, instrument.Unit, instrument.Description, instrument.GetType(), false);
+            var instrumentIdentity = new InstrumentIdentity(instrument.Meter, metricName, instrument.Unit, instrument.Description, instrument.GetType(), derivedFromView: false);
             lock (this.instrumentCreationLock)
             {
                 if (this.instrumentIdentityToMetric.TryGetValue(instrumentIdentity, out var existingMetric))
@@ -119,7 +119,7 @@ namespace OpenTelemetry.Metrics
                     var metricName = metricStreamConfig?.Name ?? instrument.Name;
                     var metricStreamName = $"{meterName}.{meterVersion}.{metricName}";
                     var metricDescription = metricStreamConfig?.Description ?? instrument.Description;
-                    var instrumentIdentity = new InstrumentIdentity(instrument.Meter, metricName, instrument.Unit, metricDescription, instrument.GetType(), metricStreamConfig != null);
+                    var instrumentIdentity = new InstrumentIdentity(instrument.Meter, metricName, instrument.Unit, metricDescription, instrument.GetType(), derivedFromView: metricStreamConfig != null);
 
                     if (!MeterProviderBuilderSdk.IsValidInstrumentName(metricName))
                     {

--- a/src/OpenTelemetry/Metrics/MetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/MetricReaderExt.cs
@@ -134,15 +134,23 @@ namespace OpenTelemetry.Metrics
 
                     if (this.instrumentIdentityToMetric.TryGetValue(instrumentIdentity, out var existingMetric))
                     {
-                        OpenTelemetrySdkEventSource.Log.DuplicateMetricInstrument(
-                            metricName,
-                            meterName,
-                            "Metric instrument has the same name as an existing one but differs by description, unit, or instrument type. Measurements from this instrument will still be exported but may result in conflicts.",
-                            "Either change the name of the instrument or use MeterProviderBuilder.AddView to resolve the conflict.");
-
                         if (metrics.Count == 0)
                         {
+                            OpenTelemetrySdkEventSource.Log.DuplicateMetricInstrument(
+                                metricName,
+                                meterName,
+                                "Metric instrument has the same name as an existing one but differs by description, unit, or instrument type. Measurements from this instrument will still be exported but may result in conflicts.",
+                                "Either change the name of the instrument or use MeterProviderBuilder.AddView to resolve the conflict.");
+
                             metrics.Add(existingMetric);
+                        }
+                        else
+                        {
+                            OpenTelemetrySdkEventSource.Log.MetricViewIgnored(
+                                metricName,
+                                meterName,
+                                "A view applied to this instrument would result in a conflicting metric stream. The view will be ignored.",
+                                "Use MeterProviderBuilder.AddView to resolve the conflict.");
                         }
 
                         continue;

--- a/src/OpenTelemetry/Metrics/MetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/MetricReaderExt.cs
@@ -132,6 +132,12 @@ namespace OpenTelemetry.Metrics
                         continue;
                     }
 
+                    if (metricStreamConfig == MetricStreamConfiguration.Drop)
+                    {
+                        OpenTelemetrySdkEventSource.Log.MetricInstrumentIgnored(metricName, instrument.Meter.Name, "View configuration asks to drop this instrument.", "Modify view configuration to allow this instrument, if desired.");
+                        continue;
+                    }
+
                     if (this.instrumentIdentityToMetric.TryGetValue(instrumentIdentity, out var existingMetric))
                     {
                         if (metrics.Count == 0)
@@ -147,13 +153,6 @@ namespace OpenTelemetry.Metrics
                                 "Use MeterProviderBuilder.AddView to resolve the conflict.");
                         }
 
-                        continue;
-                    }
-
-                    // TODO: I think this check needs to be moved up...
-                    if (metricStreamConfig == MetricStreamConfiguration.Drop)
-                    {
-                        OpenTelemetrySdkEventSource.Log.MetricInstrumentIgnored(metricName, instrument.Meter.Name, "View configuration asks to drop this instrument.", "Modify view configuration to allow this instrument, if desired.");
                         continue;
                     }
 

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -489,11 +489,15 @@ namespace OpenTelemetry.Metrics.Tests
 
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
 
-            Assert.Single(exportedItems);
+            Assert.Equal(2, exportedItems.Count);
             var metric1 = new List<Metric>() { exportedItems[0] };
+            var metric2 = new List<Metric>() { exportedItems[1] };
 
             Assert.Equal("newname", exportedItems[0].Name);
+            Assert.Equal("newname", exportedItems[1].Name);
+
             Assert.Equal(20, GetLongSum(metric1));
+            Assert.Equal(20, GetLongSum(metric2));
         }
 
         [Fact]
@@ -578,13 +582,20 @@ namespace OpenTelemetry.Metrics.Tests
 
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
 
-            Assert.Single(exportedItems);
+            Assert.Equal(2, exportedItems.Count);
             var metric1 = new List<Metric>() { exportedItems[0] };
+            var metric2 = new List<Metric>() { exportedItems[1] };
+
             var tag1 = new List<KeyValuePair<string, object>> { tags[0] };
 
             Assert.Equal("name", exportedItems[0].Name);
+            Assert.Equal("name", exportedItems[1].Name);
+
             Assert.Equal(20, GetLongSum(metric1));
+            Assert.Equal(20, GetLongSum(metric2));
+
             CheckTagsForNthMetricPoint(metric1, tag1, 1);
+            CheckTagsForNthMetricPoint(metric2, tag1, 1);
         }
 
         [Fact]

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -477,8 +477,8 @@ namespace OpenTelemetry.Metrics.Tests
             using var meter = new Meter($"{Utils.GetCurrentMethodName()}");
             var meterProviderBuilder = Sdk.CreateMeterProviderBuilder()
                 .AddMeter(meter.Name)
-                .AddView("name", "newname")
-                .AddView("name", "newname")
+                .AddView((instrument) => new MetricStreamConfiguration { Name = "newname" })
+                .AddView((instrument) => new MetricStreamConfiguration { Name = "newname" })
                 .AddInMemoryExporter(exportedItems);
 
             using var meterProvider = meterProviderBuilder.Build();

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -468,6 +468,204 @@ namespace OpenTelemetry.Metrics.Tests
         }
 
         [Fact]
+        public void DuplicateInstrumentRegistration_WithViews_TwoIdenticalInstruments_TwoViews_SameRename()
+        {
+            var exportedItems = new List<Metric>();
+
+            using var meter = new Meter($"{Utils.GetCurrentMethodName()}");
+            var meterProviderBuilder = Sdk.CreateMeterProviderBuilder()
+                .AddMeter(meter.Name)
+                .AddView("name", "newname")
+                .AddView("name", "newname")
+                .AddInMemoryExporter(exportedItems);
+
+            using var meterProvider = meterProviderBuilder.Build();
+
+            var instrument1 = meter.CreateCounter<long>("name");
+            var instrument2 = meter.CreateCounter<long>("name");
+
+            instrument1.Add(10);
+            instrument2.Add(10);
+
+            meterProvider.ForceFlush(MaxTimeToAllowForFlush);
+
+            Assert.Single(exportedItems);
+            var metric1 = new List<Metric>() { exportedItems[0] };
+
+            Assert.Equal("newname", exportedItems[0].Name);
+            Assert.Equal(20, GetLongSum(metric1));
+        }
+
+        [Fact]
+        public void DuplicateInstrumentRegistration_WithViews_TwoIdenticalInstruments_TwoViews_DifferentTags()
+        {
+            var exportedItems = new List<Metric>();
+
+            using var meter = new Meter($"{Utils.GetCurrentMethodName()}");
+            var meterProviderBuilder = Sdk.CreateMeterProviderBuilder()
+                .AddMeter(meter.Name)
+                .AddView((instrument) =>
+                {
+                    return new MetricStreamConfiguration { TagKeys = new[] { "key1" } };
+                })
+                .AddView((instrument) =>
+                {
+                    return new MetricStreamConfiguration { TagKeys = new[] { "key2" } };
+                })
+                .AddInMemoryExporter(exportedItems);
+
+            using var meterProvider = meterProviderBuilder.Build();
+
+            var instrument1 = meter.CreateCounter<long>("name");
+            var instrument2 = meter.CreateCounter<long>("name");
+
+            var tags = new KeyValuePair<string, object>[]
+            {
+                new("key1", "value"),
+                new("key2", "value"),
+            };
+
+            instrument1.Add(10, tags);
+            instrument2.Add(10, tags);
+
+            meterProvider.ForceFlush(MaxTimeToAllowForFlush);
+
+            Assert.Equal(2, exportedItems.Count);
+            var metric1 = new List<Metric>() { exportedItems[0] };
+            var metric2 = new List<Metric>() { exportedItems[1] };
+            var tag1 = new List<KeyValuePair<string, object>> { tags[0] };
+            var tag2 = new List<KeyValuePair<string, object>> { tags[1] };
+
+            Assert.Equal("name", exportedItems[0].Name);
+            Assert.Equal("name", exportedItems[1].Name);
+            Assert.Equal(20, GetLongSum(metric1));
+            Assert.Equal(20, GetLongSum(metric2));
+            CheckTagsForNthMetricPoint(metric1, tag1, 1);
+            CheckTagsForNthMetricPoint(metric2, tag2, 1);
+        }
+
+        [Fact]
+        public void DuplicateInstrumentRegistration_WithViews_TwoIdenticalInstruments_TwoViews_SameTags()
+        {
+            var exportedItems = new List<Metric>();
+
+            using var meter = new Meter($"{Utils.GetCurrentMethodName()}");
+            var meterProviderBuilder = Sdk.CreateMeterProviderBuilder()
+                .AddMeter(meter.Name)
+                .AddView((instrument) =>
+                {
+                    return new MetricStreamConfiguration { TagKeys = new[] { "key1" } };
+                })
+                .AddView((instrument) =>
+                {
+                    return new MetricStreamConfiguration { TagKeys = new[] { "key1" } };
+                })
+                .AddInMemoryExporter(exportedItems);
+
+            using var meterProvider = meterProviderBuilder.Build();
+
+            var instrument1 = meter.CreateCounter<long>("name");
+            var instrument2 = meter.CreateCounter<long>("name");
+
+            var tags = new KeyValuePair<string, object>[]
+            {
+                new("key1", "value"),
+                new("key2", "value"),
+            };
+
+            instrument1.Add(10, tags);
+            instrument2.Add(10, tags);
+
+            meterProvider.ForceFlush(MaxTimeToAllowForFlush);
+
+            Assert.Single(exportedItems);
+            var metric1 = new List<Metric>() { exportedItems[0] };
+            var tag1 = new List<KeyValuePair<string, object>> { tags[0] };
+
+            Assert.Equal("name", exportedItems[0].Name);
+            Assert.Equal(20, GetLongSum(metric1));
+            CheckTagsForNthMetricPoint(metric1, tag1, 1);
+        }
+
+        [Fact]
+        public void DuplicateInstrumentRegistration_WithViews_TwoIdenticalInstruments_TwoViews_DifferentHistogramBounds()
+        {
+            var exportedItems = new List<Metric>();
+
+            using var meter = new Meter($"{Utils.GetCurrentMethodName()}");
+            var meterProviderBuilder = Sdk.CreateMeterProviderBuilder()
+                .AddMeter(meter.Name)
+                .AddView((instrument) =>
+                {
+                    return new ExplicitBucketHistogramConfiguration { Boundaries = new[] { 5.0, 10.0 } };
+                })
+                .AddView((instrument) =>
+                {
+                    return new ExplicitBucketHistogramConfiguration { Boundaries = new[] { 10.0, 20.0 } };
+                })
+                .AddInMemoryExporter(exportedItems);
+
+            using var meterProvider = meterProviderBuilder.Build();
+
+            var instrument1 = meter.CreateHistogram<long>("name");
+            var instrument2 = meter.CreateHistogram<long>("name");
+
+            instrument1.Record(15);
+            instrument2.Record(15);
+
+            meterProvider.ForceFlush(MaxTimeToAllowForFlush);
+
+            Assert.Equal(2, exportedItems.Count);
+            var metric1 = exportedItems[0];
+            var metric2 = exportedItems[1];
+
+            Assert.Equal("name", exportedItems[0].Name);
+            Assert.Equal("name", exportedItems[1].Name);
+
+            var metricPoints = new List<MetricPoint>();
+            foreach (ref readonly var mp in metric1.GetMetricPoints())
+            {
+                metricPoints.Add(mp);
+            }
+
+            Assert.Single(metricPoints);
+            var metricPoint = metricPoints[0];
+            Assert.Equal(2, metricPoint.GetHistogramCount());
+            Assert.Equal(30, metricPoint.GetHistogramSum());
+
+            var index = 0;
+            var actualCount = 0;
+            var expectedBucketCounts = new long[] { 0, 0, 2 };
+            foreach (var histogramMeasurement in metricPoint.GetHistogramBuckets())
+            {
+                Assert.Equal(expectedBucketCounts[index], histogramMeasurement.BucketCount);
+                index++;
+                actualCount++;
+            }
+
+            metricPoints = new List<MetricPoint>();
+            foreach (ref readonly var mp in metric2.GetMetricPoints())
+            {
+                metricPoints.Add(mp);
+            }
+
+            Assert.Single(metricPoints);
+            metricPoint = metricPoints[0];
+            Assert.Equal(2, metricPoint.GetHistogramCount());
+            Assert.Equal(30, metricPoint.GetHistogramSum());
+
+            index = 0;
+            actualCount = 0;
+            expectedBucketCounts = new long[] { 0, 2, 0 };
+            foreach (var histogramMeasurement in metricPoint.GetHistogramBuckets())
+            {
+                Assert.Equal(expectedBucketCounts[index], histogramMeasurement.BucketCount);
+                index++;
+                actualCount++;
+            }
+        }
+
+        [Fact]
         public void DuplicateInstrumentNamesFromDifferentMetersWithSameNameDifferentVersion()
         {
             var exportedItems = new List<Metric>();

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -490,7 +490,7 @@ namespace OpenTelemetry.Metrics.Tests
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
 
             // The second view results in a name conflict, so it is ignored
-            Assert.Equal(1, exportedItems.Count);
+            Assert.Single(exportedItems);
             var metric1 = new List<Metric>() { exportedItems[0] };
             Assert.Equal("newname", exportedItems[0].Name);
 
@@ -533,7 +533,7 @@ namespace OpenTelemetry.Metrics.Tests
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
 
             // The second view results in a name conflict, so it is ignored
-            Assert.Equal(1, exportedItems.Count);
+            Assert.Single(exportedItems);
             var metric1 = new List<Metric>() { exportedItems[0] };
             var tag1 = new List<KeyValuePair<string, object>> { tags[0] };
 
@@ -581,7 +581,7 @@ namespace OpenTelemetry.Metrics.Tests
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
 
             // The second view results in a name conflict, so it is ignored
-            Assert.Equal(1, exportedItems.Count);
+            Assert.Single(exportedItems);
             var metric1 = new List<Metric>() { exportedItems[0] };
 
             var tag1 = new List<KeyValuePair<string, object>> { tags[0] };
@@ -622,7 +622,7 @@ namespace OpenTelemetry.Metrics.Tests
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
 
             // The second view results in a name conflict, so it is ignored
-            Assert.Equal(1, exportedItems.Count);
+            Assert.Single(exportedItems);
             var metric1 = exportedItems[0];
 
             Assert.Equal("name", exportedItems[0].Name);
@@ -690,7 +690,7 @@ namespace OpenTelemetry.Metrics.Tests
 
             // The view only matches one instrument but renames it to the name
             // of the other instrument, so only one stream is produced
-            Assert.Equal(1, exportedItems.Count);
+            Assert.Single(exportedItems);
             var metric1 = new List<Metric>() { exportedItems[0] };
 
             var tag1 = new List<KeyValuePair<string, object>> { tags[0] };

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -697,9 +697,9 @@ namespace OpenTelemetry.Metrics.Tests
 
             Assert.Equal("name", exportedItems[0].Name);
 
-            // Both instruments record, tags get filtered even though second instrument
-            // did not match view
-            Assert.Equal(20, GetLongSum(metric1));
+            // Only the first instrument records. The second instrument registration
+            // is ignored as the view definition causes a conflict with it.
+            Assert.Equal(10, GetLongSum(metric1));
             CheckTagsForNthMetricPoint(metric1, tag1, 1);
         }
 

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -489,15 +489,13 @@ namespace OpenTelemetry.Metrics.Tests
 
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
 
-            Assert.Equal(2, exportedItems.Count);
+            // The second view results in a name conflict, so it is ignored
+            Assert.Equal(1, exportedItems.Count);
             var metric1 = new List<Metric>() { exportedItems[0] };
-            var metric2 = new List<Metric>() { exportedItems[1] };
-
             Assert.Equal("newname", exportedItems[0].Name);
-            Assert.Equal("newname", exportedItems[1].Name);
 
+            // Both instruments record
             Assert.Equal(20, GetLongSum(metric1));
-            Assert.Equal(20, GetLongSum(metric2));
         }
 
         [Fact]
@@ -534,18 +532,18 @@ namespace OpenTelemetry.Metrics.Tests
 
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
 
-            Assert.Equal(2, exportedItems.Count);
+            // The second view results in a name conflict, so it is ignored
+            Assert.Equal(1, exportedItems.Count);
             var metric1 = new List<Metric>() { exportedItems[0] };
-            var metric2 = new List<Metric>() { exportedItems[1] };
             var tag1 = new List<KeyValuePair<string, object>> { tags[0] };
-            var tag2 = new List<KeyValuePair<string, object>> { tags[1] };
 
             Assert.Equal("name", exportedItems[0].Name);
-            Assert.Equal("name", exportedItems[1].Name);
+
+            // Both instruments record
             Assert.Equal(20, GetLongSum(metric1));
-            Assert.Equal(20, GetLongSum(metric2));
+
+            // Only key1 is kept not key2
             CheckTagsForNthMetricPoint(metric1, tag1, 1);
-            CheckTagsForNthMetricPoint(metric2, tag2, 1);
         }
 
         [Fact]
@@ -582,20 +580,17 @@ namespace OpenTelemetry.Metrics.Tests
 
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
 
-            Assert.Equal(2, exportedItems.Count);
+            // The second view results in a name conflict, so it is ignored
+            Assert.Equal(1, exportedItems.Count);
             var metric1 = new List<Metric>() { exportedItems[0] };
-            var metric2 = new List<Metric>() { exportedItems[1] };
 
             var tag1 = new List<KeyValuePair<string, object>> { tags[0] };
 
             Assert.Equal("name", exportedItems[0].Name);
-            Assert.Equal("name", exportedItems[1].Name);
 
+            // Both instruments record
             Assert.Equal(20, GetLongSum(metric1));
-            Assert.Equal(20, GetLongSum(metric2));
-
             CheckTagsForNthMetricPoint(metric1, tag1, 1);
-            CheckTagsForNthMetricPoint(metric2, tag1, 1);
         }
 
         [Fact]
@@ -626,12 +621,11 @@ namespace OpenTelemetry.Metrics.Tests
 
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
 
-            Assert.Equal(2, exportedItems.Count);
+            // The second view results in a name conflict, so it is ignored
+            Assert.Equal(1, exportedItems.Count);
             var metric1 = exportedItems[0];
-            var metric2 = exportedItems[1];
 
             Assert.Equal("name", exportedItems[0].Name);
-            Assert.Equal("name", exportedItems[1].Name);
 
             var metricPoints = new List<MetricPoint>();
             foreach (ref readonly var mp in metric1.GetMetricPoints())
@@ -641,33 +635,14 @@ namespace OpenTelemetry.Metrics.Tests
 
             Assert.Single(metricPoints);
             var metricPoint = metricPoints[0];
+
+            // Both instruments record
             Assert.Equal(2, metricPoint.GetHistogramCount());
             Assert.Equal(30, metricPoint.GetHistogramSum());
 
             var index = 0;
             var actualCount = 0;
             var expectedBucketCounts = new long[] { 0, 0, 2 };
-            foreach (var histogramMeasurement in metricPoint.GetHistogramBuckets())
-            {
-                Assert.Equal(expectedBucketCounts[index], histogramMeasurement.BucketCount);
-                index++;
-                actualCount++;
-            }
-
-            metricPoints = new List<MetricPoint>();
-            foreach (ref readonly var mp in metric2.GetMetricPoints())
-            {
-                metricPoints.Add(mp);
-            }
-
-            Assert.Single(metricPoints);
-            metricPoint = metricPoints[0];
-            Assert.Equal(2, metricPoint.GetHistogramCount());
-            Assert.Equal(30, metricPoint.GetHistogramSum());
-
-            index = 0;
-            actualCount = 0;
-            expectedBucketCounts = new long[] { 0, 2, 0 };
             foreach (var histogramMeasurement in metricPoint.GetHistogramBuckets())
             {
                 Assert.Equal(expectedBucketCounts[index], histogramMeasurement.BucketCount);

--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -688,19 +688,21 @@ namespace OpenTelemetry.Metrics.Tests
 
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
 
-            // The view only matches one instrument but renames it to the name
-            // of the other instrument, so only one stream is produced
-            Assert.Single(exportedItems);
+            Assert.Equal(2, exportedItems.Count);
             var metric1 = new List<Metric>() { exportedItems[0] };
+            var metric2 = new List<Metric>() { exportedItems[1] };
 
-            var tag1 = new List<KeyValuePair<string, object>> { tags[0] };
+            var tags1 = new List<KeyValuePair<string, object>> { tags[0] };
+            var tags2 = new List<KeyValuePair<string, object>> { tags[0], tags[1] };
 
-            Assert.Equal("name", exportedItems[0].Name);
+            Assert.Equal("othername", exportedItems[0].Name);
+            Assert.Equal("othername", exportedItems[1].Name);
 
-            // Only the first instrument records. The second instrument registration
-            // is ignored as the view definition causes a conflict with it.
             Assert.Equal(10, GetLongSum(metric1));
-            CheckTagsForNthMetricPoint(metric1, tag1, 1);
+            Assert.Equal(10, GetLongSum(metric2));
+
+            CheckTagsForNthMetricPoint(metric1, tags1, 1);
+            CheckTagsForNthMetricPoint(metric2, tags2, 1);
         }
 
         [Fact]


### PR DESCRIPTION
This PR reopens #3074. It is an alternative to #3006.

In this one, views that create conflicts at runtime are ignored.