### PR TITLE
alternate workflow for "integration" to accommodate documentation-only PRs (2)

### DIFF
--- a/.github/workflows/integration-md.yml
+++ b/.github/workflows/integration-md.yml
@@ -1,0 +1,47 @@
+# Syntax: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
+# See also: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+
+# Description: This workflow exists to unblock documentation-only PRs.
+
+# IMPORTANT: This workflow MUST use the same 'name' and 'matrix' as the non -md workflow.
+
+name: Integration Tests
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+    - '**.md'
+
+jobs:
+  redis-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [netcoreapp3.1,net5.0,net6.0]
+    steps:
+      - run: 'echo "No build required"'
+
+  sql-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [netcoreapp3.1,net5.0,net6.0]
+    steps:
+      - run: 'echo "No build required"'
+
+  w3c-trace-context-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [netcoreapp3.1,net5.0,net6.0]
+    steps:
+      - run: 'echo "No build required"'
+
+  otlp-exporter-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [netcoreapp3.1,net5.0,net6.0]
+    steps:
+      - run: 'echo "No build required"'


### PR DESCRIPTION
#3106.
Supersedes #3130. (I broke the original branch while trying to clean up my forked repo)

## Changes
- new workflow "integration-md" for documentation-only PRs. same name as "integration".

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
