### PR TITLE
alternate workflow for "dotnet-format" to accommodate documentation-only PRs

### DIFF
--- a/.github/workflows/dotnet-format-md.yml
+++ b/.github/workflows/dotnet-format-md.yml
@@ -1,0 +1,21 @@
+# Syntax: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
+# See also: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+
+# Description: This workflow exists to unblock documentation-only PRs.
+
+# IMPORTANT: This workflow MUST use the same 'name' and 'matrix' as the non -md workflow.
+
+name: dotnet format
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+    - '**.md'
+
+jobs:
+  check-format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: 'echo "No build required"'


### PR DESCRIPTION
#3106.

## Changes
- new workflow "dotnet-format-md" for documentation-only PRs. same name as "dotnet-format".

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
