### PR TITLE
Improvements to the OTLP trace example

### DIFF
--- a/examples/Console/Program.cs
+++ b/examples/Console/Program.cs
@@ -27,18 +27,21 @@ namespace Examples.Console
         /// Main method - invoke this using command line.
         /// For example:
         ///
-        /// dotnet run --project Examples.Console.csproj console
-        /// dotnet run --project Examples.Console.csproj inmemory
-        /// dotnet run --project Examples.Console.csproj zipkin -u http://localhost:9411/api/v2/spans
-        /// dotnet run --project Examples.Console.csproj jaeger -h localhost -p 6831
-        /// dotnet run --project Examples.Console.csproj prometheus -p 9464
-        /// dotnet run --project Examples.Console.csproj otlp -e "http://localhost:4317" -p "grpc"
-        /// dotnet run --project Examples.Console.csproj zpages
-        /// dotnet run --project Examples.Console.csproj metrics --help
+        /// dotnet run --project Examples.Console.csproj -- console
+        /// dotnet run --project Examples.Console.csproj -- inmemory
+        /// dotnet run --project Examples.Console.csproj -- zipkin -u http://localhost:9411/api/v2/spans
+        /// dotnet run --project Examples.Console.csproj -- jaeger -h localhost -p 6831
+        /// dotnet run --project Examples.Console.csproj -- prometheus -p 9464
+        /// dotnet run --project Examples.Console.csproj -- otlp -e "http://localhost:4317" -p "grpc"
+        /// dotnet run --project Examples.Console.csproj -- zpages
+        /// dotnet run --project Examples.Console.csproj -- metrics --help
+        ///
+        /// To see all available examples in the project run:
+        ///
+        /// dotnet run --project Examples.Console.csproj -- --help
         ///
         /// The above must be run from the project root folder
         /// (eg: C:\repos\opentelemetry-dotnet\examples\Console\).
-        /// </summary>
         /// <param name="args">Arguments from command line.</param>
         public static void Main(string[] args)
         {
@@ -153,7 +156,7 @@ namespace Examples.Console
     [Verb("otlp", HelpText = "Specify the options required to test OpenTelemetry Protocol (OTLP)")]
     internal class OtlpOptions
     {
-        [Option('e', "endpoint", HelpText = "Target to which the exporter is going to send traces or metrics", Default = "http://localhost:4317")]
+        [Option('e', "endpoint", HelpText = "Target to which the exporter is going to send traces or metrics (default value depends on protocol).", Default = null)]
         public string Endpoint { get; set; }
 
         [Option('p', "protocol", HelpText = "Transport protocol used by exporter. Supported values: grpc and http/protobuf.", Default = "grpc")]

--- a/examples/Console/Program.cs
+++ b/examples/Console/Program.cs
@@ -42,6 +42,7 @@ namespace Examples.Console
         ///
         /// The above must be run from the project root folder
         /// (eg: C:\repos\opentelemetry-dotnet\examples\Console\).
+        /// </summary>
         /// <param name="args">Arguments from command line.</param>
         public static void Main(string[] args)
         {

--- a/examples/Console/TestOtlpExporter.cs
+++ b/examples/Console/TestOtlpExporter.cs
@@ -34,10 +34,10 @@ namespace Examples.Console
              * launch the OpenTelemetry Collector with an OTLP receiver, by running:
              *
              *  - On Unix based systems use:
-             *     docker run --rm -it -p 4317:4317 -v $(pwd):/cfg otel/opentelemetry-collector:0.33.0 --config=/cfg/otlp-collector-example/config.yaml
+             *     docker run --rm -it -p 4317:4317 -p 4318:4318 -v $(pwd):/cfg otel/opentelemetry-collector:0.48.0 --config=/cfg/otlp-collector-example/config.yaml
              *
              *  - On Windows use:
-             *     docker run --rm -it -p 4317:4317 -v "%cd%":/cfg otel/opentelemetry-collector:0.33.0 --config=/cfg/otlp-collector-example/config.yaml
+             *     docker run --rm -it -p 4317:4317 -p 4318:4318 -v "%cd%":/cfg otel/opentelemetry-collector:0.48.0 --config=/cfg/otlp-collector-example/config.yaml
              *
              * Open another terminal window at the examples/Console/ directory and
              * launch the OTLP example by running:
@@ -74,7 +74,12 @@ namespace Examples.Console
                     .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("otlp-test"))
                     .AddOtlpExporter(opt =>
                     {
-                        opt.Endpoint = new Uri(endpoint);
+                        // If endpoint was not specified, the proper one will be selected according to the protocol.
+                        if (!string.IsNullOrEmpty(endpoint))
+                        {
+                            opt.Endpoint = new Uri(endpoint);
+                        }
+
                         opt.Protocol = otlpExportProtocol.Value;
                     })
                     .Build();

--- a/examples/Console/TestOtlpExporter.cs
+++ b/examples/Console/TestOtlpExporter.cs
@@ -81,6 +81,8 @@ namespace Examples.Console
                         }
 
                         opt.Protocol = otlpExportProtocol.Value;
+
+                        System.Console.WriteLine($"OTLP Exporter is using {opt.Protocol} protocol and endpoint {opt.Endpoint}");
                     })
                     .Build();
 

--- a/examples/Console/otlp-collector-example/config.yaml
+++ b/examples/Console/otlp-collector-example/config.yaml
@@ -8,6 +8,7 @@ receivers:
   otlp:
     protocols:
       grpc:
+      http:
 
 exporters:
   logging:


### PR DESCRIPTION
Follow up to https://github.com/open-telemetry/opentelemetry-dotnet/pull/3098#issuecomment-1088133032

- Better defaults for the OTLP trace example
- Add the http protocol to the collector config
- Make example CLI commands copy and paste ready

cc @cijothomas 