### PR TITLE
Modify metric example to use console exporter defaults

### DIFF
--- a/examples/AspNet/Global.asax.cs
+++ b/examples/AspNet/Global.asax.cs
@@ -90,10 +90,6 @@ namespace Examples.AspNet
                     meterBuilder.AddConsoleExporter((exporterOptions, metricReaderOptions) =>
                     {
                         exporterOptions.Targets = ConsoleExporterOutputTargets.Debug;
-
-                        // The ConsoleMetricExporter defaults to a manual collect cycle.
-                        // This configuration causes metrics to be exported to stdout on a 10s interval.
-                        metricReaderOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = 10000;
                     });
                     break;
             }

--- a/examples/AspNetCore/Program.cs
+++ b/examples/AspNetCore/Program.cs
@@ -131,12 +131,7 @@ builder.Services.AddOpenTelemetryMetrics(options =>
             });
             break;
         default:
-            options.AddConsoleExporter((exporterOptions, metricReaderOptions) =>
-            {
-                // The ConsoleMetricExporter defaults to a manual collect cycle.
-                // This configuration causes metrics to be exported to stdout on a 10s interval.
-                metricReaderOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = 10000;
-            });
+            options.AddConsoleExporter();
             break;
     }
 });


### PR DESCRIPTION
Follow up from : https://github.com/open-telemetry/opentelemetry-dotnet/pull/3081/files
The default is now 10secs, so making examples leverage that.