### PR TITLE
Prometheus exporter returns 204 No Content and logs warning on no metrics.

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added `IApplicationBuilder` extension methods to help with Prometheus
   middleware configuration on ASP.NET Core
   ([#3029](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3029))
+
 * Changed Prometheus exporter to return 204 No Content and log a warning event
   if there are no metrics to collect.
 

--- a/src/OpenTelemetry.Exporter.Prometheus/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Added `IApplicationBuilder` extension methods to help with Prometheus
   middleware configuration on ASP.NET Core
   ([#3029](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3029))
+* Changed Prometheus exporter to return 204 No Content and log a warning event
+  if there are no metrics to collect.
 
 ## 1.2.0-rc5
 

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterEventSource.cs
@@ -76,10 +76,7 @@ namespace OpenTelemetry.Exporter.Prometheus
         [Event(4, Message = "No metrics are available for export.", Level = EventLevel.Warning)]
         public void NoMetrics()
         {
-            if (this.IsEnabled(EventLevel.Warning, EventKeywords.All))
-            {
-                this.WriteEvent(4);
-            }
+            this.WriteEvent(4);
         }
     }
 }

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterEventSource.cs
@@ -72,5 +72,14 @@ namespace OpenTelemetry.Exporter.Prometheus
         {
             this.WriteEvent(3, exception);
         }
+
+        [Event(4, Message = "No metrics are available for export.", Level = EventLevel.Warning)]
+        public void NoMetrics()
+        {
+            if (this.IsEnabled(EventLevel.Warning, EventKeywords.All))
+            {
+                this.WriteEvent(4);
+            }
+        }
     }
 }

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterHttpServer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterHttpServer.cs
@@ -156,10 +156,10 @@ namespace OpenTelemetry.Exporter.Prometheus
                 var collectionResponse = await this.exporter.CollectionManager.EnterCollect().ConfigureAwait(false);
                 try
                 {
+                    context.Response.Headers.Add("Server", string.Empty);
                     if (collectionResponse.View.Count > 0)
                     {
                         context.Response.StatusCode = 200;
-                        context.Response.Headers.Add("Server", string.Empty);
                         context.Response.Headers.Add("Last-Modified", collectionResponse.GeneratedAtUtc.ToString("R"));
                         context.Response.ContentType = "text/plain; charset=utf-8; version=0.0.4";
 
@@ -167,7 +167,9 @@ namespace OpenTelemetry.Exporter.Prometheus
                     }
                     else
                     {
-                        throw new InvalidOperationException("Collection failure.");
+                        // It's not expected to have no metrics to collect, but it's not necessarily a failure, either.
+                        context.Response.StatusCode = 204;
+                        PrometheusExporterEventSource.Log.NoMetrics();
                     }
                 }
                 finally

--- a/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterMiddleware.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus/Implementation/PrometheusExporterMiddleware.cs
@@ -79,7 +79,9 @@ namespace OpenTelemetry.Exporter.Prometheus
                     }
                     else
                     {
-                        throw new InvalidOperationException("Collection failure.");
+                        // It's not expected to have no metrics to collect, but it's not necessarily a failure, either.
+                        response.StatusCode = 204;
+                        PrometheusExporterEventSource.Log.NoMetrics();
                     }
                 }
                 finally


### PR DESCRIPTION
Fixes #2970.

## Changes

Instead of throwing when there are no metrics to collect, have the Prometheus middleware log a warning and issue 204 No Content. This allows Prometheus metrics to be scraped early in the application lifecycle without causing Prometheus to show an error about the scrape endpoint connectivity.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [x] Design discussion issue #2970
* [ ] Changes in public API reviewed
