### PR TITLE
OTLPLogExporter to populate attributes from LogRecord.State

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -5,8 +5,12 @@
 * LogExporter to correctly map Severity to OTLP.
   ([#3177](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3177))
 
-* LogExporter to special case {OriginalFormat} to populate
+* LogExporter to special case `{OriginalFormat}` to populate
   Body. ([#3182](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3182))
+
+* LogExporter to populate attributes from `LogRecord.State`, if it
+  is of type `IReadOnlyList<KeyValuePair<string, object>>`
+  ([#3182](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3182))
 
 ## 1.2.0-rc5
 


### PR DESCRIPTION
Before this PR, OTLP exporter populated attributes only when `options.ParseStateValues = true;`., as it was relying on SDK to parse the `LogRecord.State` into KVPs.

This PR improves OTLPExporter, to populate attributes from `LogRecord.State`.
"State" can be really anything, so it checks if it is of type `IReadOnlyList<KeyValuePair<string, object>>`,
and if yes, populates attributes from it. Else state is ignored. (This _mostly_ matches the behavior of SDK itself when
`ParseStateValues` is true.)

Next PR:
If state is not `IReadOnlyList<KeyValuePair<string, object>>`, then check `IEnumerable<KeyValuePair<string, object>>`.

Next.Next:
Just give up.