### PR TITLE
[PoC] alternate approach for InMemoryExporter, adding selective copy to Metric (for discussion)

### DIFF
--- a/src/OpenTelemetry.Exporter.InMemory/OpenTelemetry.Exporter.InMemory.csproj
+++ b/src/OpenTelemetry.Exporter.InMemory/OpenTelemetry.Exporter.InMemory.csproj
@@ -17,8 +17,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\PeriodicExportingMetricReaderHelper.cs" Link="Includes\PeriodicExportingMetricReaderHelper.cs" />
-    <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\ServiceProviderExtensions.cs" Link="Includes\ServiceProviderExtensions.cs" />
+    <!--<Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\PeriodicExportingMetricReaderHelper.cs" Link="Includes\PeriodicExportingMetricReaderHelper.cs" />
+    <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\ServiceProviderExtensions.cs" Link="Includes\ServiceProviderExtensions.cs" />-->
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\Guard.cs" Link="Includes\Guard.cs" />
   </ItemGroup>
 

--- a/src/OpenTelemetry/AssemblyInfo.cs
+++ b/src/OpenTelemetry/AssemblyInfo.cs
@@ -17,6 +17,7 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("OpenTelemetry.Tests" + AssemblyInfo.PublicKey)]
+[assembly: InternalsVisibleTo("OpenTelemetry.Exporter.InMemory" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry.Exporter.Prometheus" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry.Exporter.Prometheus.Tests" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry.Extensions.Hosting.Tests" + AssemblyInfo.PublicKey)]

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -80,6 +80,14 @@ namespace OpenTelemetry.Metrics
             }
         }
 
+        private AggregatorStore(AggregatorStore other)
+        {
+            this.batchSize = other.batchSize;
+
+            this.currentMetricPointBatch = (int[])other.currentMetricPointBatch.Clone();
+            this.metricPoints = Array.ConvertAll(other.metricPoints, metricPoints => metricPoints.Copy());
+        }
+
         private delegate void UpdateLongDelegate(long value, ReadOnlySpan<KeyValuePair<string, object>> tags);
 
         private delegate void UpdateDoubleDelegate(double value, ReadOnlySpan<KeyValuePair<string, object>> tags);
@@ -154,6 +162,8 @@ namespace OpenTelemetry.Metrics
 
         internal MetricPointsAccessor GetMetricPoints()
             => new(this.metricPoints, this.currentMetricPointBatch, this.batchSize);
+
+        internal AggregatorStore Copy() => new(this);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void InitializeZeroTagPointIfNotInitialized()

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -82,6 +82,7 @@ namespace OpenTelemetry.Metrics
 
         private AggregatorStore(AggregatorStore other)
         {
+            this.name = other.name;
             this.batchSize = other.batchSize;
 
             this.currentMetricPointBatch = (int[])other.currentMetricPointBatch.Clone();

--- a/src/OpenTelemetry/Metrics/HistogramBuckets.cs
+++ b/src/OpenTelemetry/Metrics/HistogramBuckets.cs
@@ -52,6 +52,7 @@ namespace OpenTelemetry.Metrics
             HistogramBuckets copy = new HistogramBuckets(this.ExplicitBounds);
 
             Array.Copy(this.SnapshotBucketCounts, copy.SnapshotBucketCounts, this.SnapshotBucketCounts.Length);
+            Array.Copy(this.RunningBucketCounts, copy.RunningBucketCounts, this.RunningBucketCounts.Length);
             copy.SnapshotSum = this.SnapshotSum;
 
             return copy;

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -110,6 +110,13 @@ namespace OpenTelemetry.Metrics
             this.InstrumentDisposed = false;
         }
 
+        private Metric(Metric other)
+        {
+            this.MetricType = other.MetricType;
+            this.InstrumentIdentity = other.InstrumentIdentity;
+            this.aggStore = other.aggStore.Copy();
+        }
+
         public MetricType MetricType { get; private set; }
 
         public AggregationTemporality Temporality { get; private set; }
@@ -146,6 +153,11 @@ namespace OpenTelemetry.Metrics
         internal int Snapshot()
         {
             return this.aggStore.Snapshot();
+        }
+
+        internal Metric Copy()
+        {
+            return new Metric(this);
         }
     }
 }

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -115,6 +115,7 @@ namespace OpenTelemetry.Metrics
             this.MetricType = other.MetricType;
             this.InstrumentIdentity = other.InstrumentIdentity;
             this.aggStore = other.aggStore.Copy();
+            this.Temporality = other.Temporality;
         }
 
         public MetricType MetricType { get; private set; }


### PR DESCRIPTION
Alternate approach for #2361

## Changes
- Adds selective copy to `Metric` and `AggregatorStore`. 
- Updates `InMemoryExporter` to copy `Metric`.


## Discussion

This attempts to meet the initial ask of #2361 by providing a _selective_ deep-copy of `Metric`.
"Selective" meaning the minimum fields/properties that are required for current unit tests.
A SME might recommend additional minimum members.
With this draft, all unit tests pass locally. 

Ideally, we should deep-copy ALL members.
I would not recommend this approach without also investing in thorough unit tests to fully validate copying. 
I don't want to give the false impression this this is a true deep-copy when members could be missed!
This will likely require some extensive reflection-based comparisons and I want to test the waters before investing in this.

I've already evaluated one library ([FluentAssertions](https://fluentassertions.com/objectgraphs/)) to do this comparison, but this has some limitations.
FluentAssertions won't review private members and it depends on the Equals() method for structs.
I'm open to suggestions for other libraries!

## Open Questions
- Is this selective-copy approach appropriate?
  - This creates a maintenance tax that future developers are responsible for updating Copy() methods if needed.
  - Public customers may find scenarios not covered by our tests and be blocked in their own use-cases.
  - Could we mark certain members `public` to better communicate what is/isn't copied?
- Regarding full deep-copy, are there any ideas for better validating?


For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
