### PR TITLE
Bump minimum required version of Msft.Extensions.Logging to 3.1

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -33,9 +33,9 @@
     <MicrosoftCodeAnalysisAnalyzersPkgVer>[3.3.1]</MicrosoftCodeAnalysisAnalyzersPkgVer>
     <MicrosoftCodeCoveragePkgVer>[16.10.0]</MicrosoftCodeCoveragePkgVer>
     <MicrosoftExtensionsHostingAbstractionsPkgVer>[2.1.0,)</MicrosoftExtensionsHostingAbstractionsPkgVer>
-    <MicrosoftExtensionsLoggingPkgVer>[2.1.0,)</MicrosoftExtensionsLoggingPkgVer>
-    <MicrosoftExtensionsLoggingConfigurationPkgVer>[2.1.0,)</MicrosoftExtensionsLoggingConfigurationPkgVer>
-    <MicrosoftExtensionsOptionsPkgVer>[2.1.0,)</MicrosoftExtensionsOptionsPkgVer>
+    <MicrosoftExtensionsLoggingPkgVer>[3.1.0,)</MicrosoftExtensionsLoggingPkgVer>
+    <MicrosoftExtensionsLoggingConfigurationPkgVer>[3.1.0,)</MicrosoftExtensionsLoggingConfigurationPkgVer>
+    <MicrosoftExtensionsOptionsPkgVer>[3.1.0,)</MicrosoftExtensionsOptionsPkgVer>
     <MicrosoftNETFrameworkReferenceAssembliesPkgVer>[1.0.0,2.0)</MicrosoftNETFrameworkReferenceAssembliesPkgVer>
     <MicrosoftSourceLinkGitHubPkgVer>[1.0.0,2.0)</MicrosoftSourceLinkGitHubPkgVer>
     <OpenTracingPkgVer>[0.12.1,0.13)</OpenTracingPkgVer>

--- a/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.StackExchangeRedis/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Removes .NET Framework 4.6.1. The minimum .NET Framework
   version supported is .NET 4.6.2. ([#3190](https://github.com/open-telemetry/opentelemetry-dotnet/issues/3190))
 
+* Bumped minimum required version of `Microsoft.Extensions.Options`
+  to 3.1.0. ([#2582](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3196))
+
 ## 1.0.0-rc9.2
 
 Released 2022-Apr-12

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Removes .NET Framework 4.6.1. The minimum .NET Framework
   version supported is .NET 4.6.2. ([#3190](https://github.com/open-telemetry/opentelemetry-dotnet/issues/3190))
 
+* Bumped minimum required version of `Microsoft.Extensions.Logging`
+  and `Microsoft.Extensions.Logging.Configuration` to 3.1.0
+  ([#2582](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3196))
+
 ## 1.2.0
 
 Released 2022-Apr-15


### PR DESCRIPTION
2.1 has reached EOL last year...