### PR TITLE
ConsoleExporter Log minor cosmetic improvement.

### DIFF
--- a/docs/logs/getting-started/Program.cs
+++ b/docs/logs/getting-started/Program.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
 

--- a/docs/logs/getting-started/Program.cs
+++ b/docs/logs/getting-started/Program.cs
@@ -28,8 +28,6 @@ public class Program
         {
             builder.AddOpenTelemetry(options => options
                 .AddConsoleExporter());
-
-            builder.Services.Configure<OpenTelemetryLoggerOptions>(opt => opt.ParseStateValues = true);
         });
 
         var logger = loggerFactory.CreateLogger<Program>();

--- a/docs/logs/getting-started/Program.cs
+++ b/docs/logs/getting-started/Program.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
 
@@ -27,6 +28,8 @@ public class Program
         {
             builder.AddOpenTelemetry(options => options
                 .AddConsoleExporter());
+
+            builder.Services.Configure<OpenTelemetryLoggerOptions>(opt => opt.ParseStateValues = true);
         });
 
         var logger = loggerFactory.CreateLogger<Program>();

--- a/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
@@ -22,7 +22,7 @@ namespace OpenTelemetry.Exporter
 {
     public class ConsoleLogRecordExporter : ConsoleExporter<LogRecord>
     {
-        private const int RightPaddingLength = 30;
+        private const int RightPaddingLength = 35;
 
         public ConsoleLogRecordExporter(ConsoleExporterOptions options)
             : base(options)
@@ -33,14 +33,17 @@ namespace OpenTelemetry.Exporter
         {
             foreach (var logRecord in batch)
             {
-                this.WriteLine($"{"LogRecord.TraceId:",-RightPaddingLength}{logRecord.TraceId}");
-                this.WriteLine($"{"LogRecord.SpanId:",-RightPaddingLength}{logRecord.SpanId}");
                 this.WriteLine($"{"LogRecord.Timestamp:",-RightPaddingLength}{logRecord.Timestamp:yyyy-MM-ddTHH:mm:ss.fffffffZ}");
-                this.WriteLine($"{"LogRecord.EventId:",-RightPaddingLength}{logRecord.EventId.Id}");
-                this.WriteLine($"{"LogRecord.EventName:",-RightPaddingLength}{logRecord.EventId.Name}");
+
+                if (logRecord.TraceId != default)
+                {
+                    this.WriteLine($"{"LogRecord.TraceId:",-RightPaddingLength}{logRecord.TraceId}");
+                    this.WriteLine($"{"LogRecord.SpanId:",-RightPaddingLength}{logRecord.SpanId}");
+                    this.WriteLine($"{"LogRecord.TraceFlags:",-RightPaddingLength}{logRecord.TraceFlags}");
+                }
+
                 this.WriteLine($"{"LogRecord.CategoryName:",-RightPaddingLength}{logRecord.CategoryName}");
                 this.WriteLine($"{"LogRecord.LogLevel:",-RightPaddingLength}{logRecord.LogLevel}");
-                this.WriteLine($"{"LogRecord.TraceFlags:",-RightPaddingLength}{logRecord.TraceFlags}");
                 if (logRecord.FormattedMessage != null)
                 {
                     this.WriteLine($"{"LogRecord.FormattedMessage:",-RightPaddingLength}{logRecord.FormattedMessage}");
@@ -56,6 +59,15 @@ namespace OpenTelemetry.Exporter
                     for (int i = 0; i < logRecord.StateValues.Count; i++)
                     {
                         this.WriteLine($"{logRecord.StateValues[i].Key,-RightPaddingLength}{logRecord.StateValues[i].Value}");
+                    }
+                }
+
+                if (logRecord.EventId != default)
+                {
+                    this.WriteLine($"{"LogRecord.EventId:",-RightPaddingLength}{logRecord.EventId.Id}");
+                    if (string.IsNullOrEmpty(logRecord.EventId.Name))
+                    {
+                        this.WriteLine($"{"LogRecord.EventName:",-RightPaddingLength}{logRecord.EventId.Name}");
                     }
                 }
 
@@ -84,7 +96,7 @@ namespace OpenTelemetry.Exporter
                 var resource = this.ParentProvider.GetResource();
                 if (resource != Resource.Empty)
                 {
-                    this.WriteLine("Resource associated with LogRecord:");
+                    this.WriteLine("\nResource associated with LogRecord:");
                     foreach (var resourceAttribute in resource.Attributes)
                     {
                         this.WriteLine($"    {resourceAttribute.Key}: {resourceAttribute.Value}");

--- a/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
@@ -99,7 +99,7 @@ namespace OpenTelemetry.Exporter
                     this.WriteLine("\nResource associated with LogRecord:");
                     foreach (var resourceAttribute in resource.Attributes)
                     {
-                        this.WriteLine($"    {resourceAttribute.Key}: {resourceAttribute.Value}");
+                        this.WriteLine($"{resourceAttribute.Key}: {resourceAttribute.Value}");
                     }
                 }
 


### PR DESCRIPTION
Better padding.
Print TraceContext only if non-default, same with Event.
Group TraceContext fields (traceid,spanid,traceflags) together.