### PR TITLE
OTLP LogExporter to support ILogger Scopes

### DIFF
--- a/docs/logs/getting-started/Program.cs
+++ b/docs/logs/getting-started/Program.cs
@@ -25,11 +25,18 @@ public class Program
     {
         using var loggerFactory = LoggerFactory.Create(builder =>
         {
-            builder.AddOpenTelemetry(options => options
-                .AddConsoleExporter());
+            builder.AddOpenTelemetry(options =>
+            {
+                options.AddConsoleExporter();
+                options.IncludeScopes = true;
+            });
         });
 
         var logger = loggerFactory.CreateLogger<Program>();
-        logger.LogInformation("Hello from {name} {price}.", "tomato", 2.99);
+        using (logger.BeginScope("My scope 1 with {food} and {color}", "apple", "green"))
+        using (logger.BeginScope("My scope 2 with {food} and {color}", "apple", "green"))
+        {
+            logger.LogInformation("Hello from {name} {price}.", "tomato", 2.99);
+        }
     }
 }

--- a/docs/logs/getting-started/Program.cs
+++ b/docs/logs/getting-started/Program.cs
@@ -33,10 +33,6 @@ public class Program
         });
 
         var logger = loggerFactory.CreateLogger<Program>();
-        using (logger.BeginScope("My scope 1 with {food} and {color}", "apple", "green"))
-        using (logger.BeginScope("My scope 2 with {food} and {color}", "apple", "green"))
-        {
-            logger.LogInformation("Hello from {name} {price}.", "tomato", 2.99);
-        }
+        logger.LogInformation("Hello from {name} {price}.", "tomato", 2.99);
     }
 }

--- a/docs/logs/getting-started/Program.cs
+++ b/docs/logs/getting-started/Program.cs
@@ -28,7 +28,6 @@ public class Program
             builder.AddOpenTelemetry(options =>
             {
                 options.AddConsoleExporter();
-                options.IncludeScopes = true;
             });
         });
 

--- a/examples/Console/TestLogs.cs
+++ b/examples/Console/TestLogs.cs
@@ -29,6 +29,7 @@ namespace Examples.Console
                 builder.AddOpenTelemetry((opt) =>
                 {
                     opt.IncludeFormattedMessage = true;
+                    opt.IncludeScopes = true;
                     if (options.UseExporter.Equals("otlp", StringComparison.OrdinalIgnoreCase))
                     {
                         /*
@@ -68,7 +69,12 @@ namespace Examples.Console
             });
 
             var logger = loggerFactory.CreateLogger<Program>();
-            logger.LogInformation("Hello from {name} {price}.", "tomato", 2.99);
+            using (logger.BeginScope("My scope 1 with {food} and {color}", "apple", "green"))
+            using (logger.BeginScope("My scope 2 with {food} and {color}", "banana", "yellow"))
+            {
+                logger.LogInformation("Hello from {name} {price}.", "tomato", 2.99);
+            }
+
             return null;
         }
     }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* LogExporter to support Logging Scopes.
+  ([#3277](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3217))
+
+
 ## 1.3.0-beta.1
 
 Released 2022-Apr-15

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -5,7 +5,6 @@
 * LogExporter to support Logging Scopes.
   ([#3277](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3217))
 
-
 ## 1.3.0-beta.1
 
 Released 2022-Apr-15

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
@@ -142,7 +142,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
                     foreach (var scopeItem in scope)
                     {
                         var scopeItemWithDepthInfo = new KeyValuePair<string, object>($"[Scope.{scopeDepth}]:{scopeItem.Key}", scopeItem.Value);
-                        var otlpAttribute = scopeItem.ToOtlpAttribute();
+                        var otlpAttribute = scopeItemWithDepthInfo.ToOtlpAttribute();
                         otlpLog.Attributes.Add(otlpAttribute);
                     }
                 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Google.Protobuf;
 using Google.Protobuf.Collections;
@@ -132,8 +133,19 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
                     otlpLogRecord.Flags = (uint)logRecord.TraceFlags;
                 }
 
-                // TODO: Add additional attributes from scope and state
-                // Might make sense to take an approach similar to https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/897b734aa5ea9992538f04f6ea6871fe211fa903/src/OpenTelemetry.Contrib.Preview/Internal/DefaultLogStateConverter.cs
+                int scopeDepth = -1;
+                logRecord.ForEachScope(ProcessScope, otlpLogRecord);
+
+                void ProcessScope(LogRecordScope scope, OtlpLogs.LogRecord otlpLog)
+                {
+                    scopeDepth++;
+                    foreach (var scopeItem in scope)
+                    {
+                        var scopeItemWithDepthInfo = new KeyValuePair<string, object>($"[Scope.{scopeDepth}]:{scopeItem.Key}", scopeItem.Value);
+                        var otlpAttribute = scopeItem.ToOtlpAttribute();
+                        otlpLog.Attributes.Add(otlpAttribute);
+                    }
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Towards : https://github.com/open-telemetry/opentelemetry-dotnet/issues/2482
Focused on just getting the functionality and example usage.
Tests are not added, as the current test approach cannot be used for scopes, so this will be a separate PR.

Open qn:
For scopes, keys are prefixed with "[Scope.depth]:". This does require string allocated, but avoids collision when same keys are repeated in diff. scope depths... We can revisit this based on user feedback :)

For the code below:
```
            using (logger.BeginScope("My scope 1 with {food} and {color}", "apple", "green"))
            using (logger.BeginScope("My scope 2 with {food} and {color}", "banana", "yellow"))
            {
                logger.LogInformation("Hello from {name} {price}.", "tomato", 2.99);
            }
```
Sample output from OTLP collector 

```
LogRecord #0
Timestamp: 2022-04-21 18:52:28.8868154 +0000 UTC
Severity: Information
ShortName:
Body: Hello from tomato 2.99.
Attributes:
     -> name: STRING(tomato)
     -> price: DOUBLE(2.99)
     -> {OriginalFormat}: STRING(Hello from {name} {price}.)
     -> [Scope.0]:food: STRING(apple)
     -> [Scope.0]:color: STRING(green)
     -> [Scope.0]:{OriginalFormat}: STRING(My scope 1 with {food} and {color})
     -> [Scope.1]:food: STRING(banana)
     -> [Scope.1]:color: STRING(yellow)
     -> [Scope.1]:{OriginalFormat}: STRING(My scope 2 with {food} and {color})
```