### PR TITLE
add internal method ToCollection() to Batch

### DIFF
--- a/src/OpenTelemetry/Batch.cs
+++ b/src/OpenTelemetry/Batch.cs
@@ -110,16 +110,7 @@ namespace OpenTelemetry
         /// Creates a <see cref="ICollection{T}"/> containing the times of the <see cref="Batch{T}"/>.
         /// </summary>
         /// <returns>A collection containing the items of the <see cref="Batch{T}"/>.</returns>
-        public ICollection<T> ToCollection()
-        {
-            var collection = new List<T>();
-            foreach (var item in this.items)
-            {
-                collection.Add(item);
-            }
-
-            return collection;
-        }
+        public ICollection<T> ToCollection() => new List<T>(this.items);
 
         /// <summary>
         /// Enumerates the elements of a <see cref="Batch{T}"/>.

--- a/src/OpenTelemetry/Batch.cs
+++ b/src/OpenTelemetry/Batch.cs
@@ -107,7 +107,7 @@ namespace OpenTelemetry
         }
 
         /// <summary>
-        /// Creates a <see cref="ICollection{T}"/> containing the times of the <see cref="Batch{T}"/>.
+        /// Creates a <see cref="ICollection{T}"/> containing the items of the <see cref="Batch{T}"/>.
         /// </summary>
         /// <returns>A collection containing the items of the <see cref="Batch{T}"/>.</returns>
         public ICollection<T> ToCollection() => new List<T>(this.items);

--- a/src/OpenTelemetry/Batch.cs
+++ b/src/OpenTelemetry/Batch.cs
@@ -107,6 +107,21 @@ namespace OpenTelemetry
         }
 
         /// <summary>
+        /// Creates a <see cref="ICollection{T}"/> containing the times of the <see cref="Batch{T}"/>.
+        /// </summary>
+        /// <returns>A collection containing the items of the <see cref="Batch{T}"/>.</returns>
+        public ICollection<T> ToCollection()
+        {
+            var collection = new List<T>();
+            foreach (var item in this.items)
+            {
+                collection.Add(item);
+            }
+
+            return collection;
+        }
+
+        /// <summary>
         /// Enumerates the elements of a <see cref="Batch{T}"/>.
         /// </summary>
         public struct Enumerator : IEnumerator<T>

--- a/src/OpenTelemetry/Batch.cs
+++ b/src/OpenTelemetry/Batch.cs
@@ -110,7 +110,7 @@ namespace OpenTelemetry
         /// Creates a <see cref="ICollection{T}"/> containing the items of the <see cref="Batch{T}"/>.
         /// </summary>
         /// <returns>A collection containing the items of the <see cref="Batch{T}"/>.</returns>
-        public ICollection<T> ToCollection() => new List<T>(this.items);
+        internal ICollection<T> ToCollection() => new List<T>(this.items);
 
         /// <summary>
         /// Enumerates the elements of a <see cref="Batch{T}"/>.

--- a/test/OpenTelemetry.Tests/Trace/BatchTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/BatchTest.cs
@@ -15,6 +15,8 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
+
 using OpenTelemetry.Internal;
 using Xunit;
 
@@ -158,6 +160,20 @@ namespace OpenTelemetry.Trace.Tests
             Assert.Equal(1, batch.Count);
 
             ValidateEnumerator(batch.GetEnumerator(), "b");
+        }
+
+        [Fact]
+        public void VerifyToCollection()
+        {
+            var batch = new Batch<string>(items: new string[] { "0", "1", "2", "3" }, count: 4);
+
+            var list = (List<string>)batch.ToCollection();
+
+            Assert.Equal(4, list.Count);
+            for (int i = 0; i < list.Count; i++)
+            {
+                Assert.Equal(i.ToString(), list[i]);
+            }
         }
 
         private static void ValidateEnumerator(Batch<string>.Enumerator enumerator, string expected)


### PR DESCRIPTION
related to #2361.
pulling a minor change out of #3198.

## Changes
- Add internal method `ToCollection` to `Batch`

## Please provide a brief description of the changes here.

This change is to eliminate the `foreach` boilerplate code: 
  ```
  foreach (var data in batch)
  {
      someCollection.Add(data);
  }
  ```



## For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed

## Other options considered

1. do nothing
    this will cause unit tests to have a lot of `foreach` statements.

2. `ToCollection(ICollection<T> someCollection)`
    I considered this but decided to imitate [Enumerable.ToList](https://docs.microsoft.com/dotnet/api/system.linq.enumerable.tolist?view=net-6.0) which returns the collection.

3. `ToList()`
    I don't have a strong opinion about the return type. I chose to return `ICollection` because I see this used more often in this repo.

4. add extension method/class to OpenTelemetry.Tests.Shared
    this would work, but is an extra file that would need to be imported into test projects.
    having this method in the Batch class allows it to access private fields.