### PR TITLE
Span attribute count and length limits

### DIFF
--- a/src/OpenTelemetry.Api/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,7 @@
+OpenTelemetry.Trace.SpanLimits
+OpenTelemetry.Trace.SpanLimits.AttributeCountLimit.get -> int?
+OpenTelemetry.Trace.SpanLimits.AttributeCountLimit.set -> void
+OpenTelemetry.Trace.SpanLimits.AttributeValueLengthLimit.get -> int?
+OpenTelemetry.Trace.SpanLimits.AttributeValueLengthLimit.set -> void
+OpenTelemetry.Trace.SpanLimits.SpanLimits() -> void
+static OpenTelemetry.Trace.TracerProvider.SetSpanLimits(OpenTelemetry.Trace.SpanLimits spanLimits) -> void

--- a/src/OpenTelemetry.Api/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,7 @@
+OpenTelemetry.Trace.SpanLimits
+OpenTelemetry.Trace.SpanLimits.AttributeCountLimit.get -> int?
+OpenTelemetry.Trace.SpanLimits.AttributeCountLimit.set -> void
+OpenTelemetry.Trace.SpanLimits.AttributeValueLengthLimit.get -> int?
+OpenTelemetry.Trace.SpanLimits.AttributeValueLengthLimit.set -> void
+OpenTelemetry.Trace.SpanLimits.SpanLimits() -> void
+static OpenTelemetry.Trace.TracerProvider.SetSpanLimits(OpenTelemetry.Trace.SpanLimits spanLimits) -> void

--- a/src/OpenTelemetry.Api/Trace/SpanAttributes.cs
+++ b/src/OpenTelemetry.Api/Trace/SpanAttributes.cs
@@ -139,6 +139,11 @@ namespace OpenTelemetry.Trace
         {
             Guard.ThrowIfNull(key);
 
+            if (this.Attributes.Count == TracerProvider.SpanAttributeCountLimit)
+            {
+                return;
+            }
+
             if (TracerProvider.SpanAttributeValueLengthLimit.HasValue)
             {
                 if (value is string[] strArr)

--- a/src/OpenTelemetry.Api/Trace/SpanAttributes.cs
+++ b/src/OpenTelemetry.Api/Trace/SpanAttributes.cs
@@ -147,7 +147,10 @@ namespace OpenTelemetry.Trace
                     strArr.CopyTo(newArr, 0);
                     for (var i = 0; i < strArr.Length; ++i)
                     {
-                        newArr[i] = newArr[i].Substring(0, TracerProvider.SpanAttributeValueLengthLimit.Value);
+                        var limit = TracerProvider.SpanAttributeValueLengthLimit.Value;
+                        newArr[i] = newArr[i].Length > limit
+                            ? newArr[i].Substring(0, limit)
+                            : newArr[i];
                     }
 
                     value = newArr;
@@ -155,7 +158,10 @@ namespace OpenTelemetry.Trace
 
                 if (value is string str)
                 {
-                    value = str.Substring(0, TracerProvider.SpanAttributeValueLengthLimit.Value);
+                    var limit = TracerProvider.SpanAttributeValueLengthLimit.Value;
+                    value = str.Length > limit
+                        ? str.Substring(0, limit)
+                        : str;
                 }
             }
 

--- a/src/OpenTelemetry.Api/Trace/SpanLimits.cs
+++ b/src/OpenTelemetry.Api/Trace/SpanLimits.cs
@@ -1,0 +1,44 @@
+// <copyright file="SpanLimits.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Trace;
+
+/// <summary>
+/// Defines the attribute count and length limits for spans.
+/// </summary>
+public class SpanLimits
+{
+    /// <summary>
+    /// Gets or sets the maximum allowed number of attributes on spans.
+    /// </summary>
+    public int? AttributeCountLimit { get; set; } = 128;
+
+    /// <summary>
+    /// Gets or sets the maximum length for string-valued attributes on spans.
+    /// </summary>
+    public int? AttributeValueLengthLimit { get; set; } = null;
+
+    // TODO: Implement span event and link limits.
+    // Open question:
+    // When SpanEventAttributeCountLimit or SpanLinkAttributeCountLimit are null
+    // should we fall back to use AttributeCountLimit?
+    // Or Should we allow these to be independently configurable?
+
+    // public int? SpanEventCountLimit { get;  set; } = 128;
+    // public int? SpanLinkCountLimit { get; set; } = 128;
+    // public int? SpanEventAttributeCountLimit { get; set; } = 128;
+    // public int? SpanLinkAttributeCountLimit { get; set; } = 128;
+}

--- a/src/OpenTelemetry.Api/Trace/TracerProvider.cs
+++ b/src/OpenTelemetry.Api/Trace/TracerProvider.cs
@@ -45,8 +45,13 @@ namespace OpenTelemetry.Trace
         /// <param name="spanLimits">The configured <see cref="SpanLimits" />.</param>
         public static void SetSpanLimits(SpanLimits spanLimits)
         {
-            SpanAttributeCountLimit = spanLimits.AttributeCountLimit;
-            SpanAttributeValueLengthLimit = spanLimits.AttributeValueLengthLimit;
+            SpanAttributeCountLimit = spanLimits.AttributeCountLimit.HasValue && spanLimits.AttributeCountLimit.Value >= 0
+                ? spanLimits.AttributeCountLimit.Value
+                : null;
+
+            SpanAttributeValueLengthLimit = spanLimits.AttributeValueLengthLimit.HasValue && spanLimits.AttributeCountLimit.Value >= 0
+                ? spanLimits.AttributeValueLengthLimit.Value
+                : null;
         }
 
         /// <summary>

--- a/src/OpenTelemetry.Api/Trace/TracerProvider.cs
+++ b/src/OpenTelemetry.Api/Trace/TracerProvider.cs
@@ -35,6 +35,20 @@ namespace OpenTelemetry.Trace
         /// </summary>
         public static TracerProvider Default { get; } = new TracerProvider();
 
+        internal static int? SpanAttributeCountLimit { get; set; }
+
+        internal static int? SpanAttributeValueLengthLimit { get; set; }
+
+        /// <summary>
+        /// Configures the <see cref="SpanLimits" /> for the default <see cref="TracerProvider" />.
+        /// </summary>
+        /// <param name="spanLimits">The configured <see cref="SpanLimits" />.</param>
+        public static void SetSpanLimits(SpanLimits spanLimits)
+        {
+            SpanAttributeCountLimit = spanLimits.AttributeCountLimit;
+            SpanAttributeValueLengthLimit = spanLimits.AttributeValueLengthLimit;
+        }
+
         /// <summary>
         /// Gets a tracer with given name and version.
         /// </summary>

--- a/test/OpenTelemetry.Tests/Trace/SpanAttributesTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/SpanAttributesTest.cs
@@ -81,5 +81,29 @@ namespace OpenTelemetry.Trace.Tests
         {
             Assert.Throws<ArgumentNullException>(() => new SpanAttributes(null));
         }
+
+        [Fact]
+        public void SpanLimits()
+        {
+            TracerProvider.SetSpanLimits(new SpanLimits
+            {
+                AttributeCountLimit = 3,
+                AttributeValueLengthLimit = 4,
+            });
+
+            var spanAttributes = new SpanAttributes(
+               new List<KeyValuePair<string, object>>()
+               {
+                    new KeyValuePair<string, object>("StringAttribute", "12345"),
+                    new KeyValuePair<string, object>("IntAttribute", 12345),
+                    new KeyValuePair<string, object>("StringArrayAttribute", new[] { "ABCDE", "FGHIJ", "KLMN" }),
+                    new KeyValuePair<string, object>("DoubleAttribute", 12345.6),
+               });
+
+            Assert.Equal(3, spanAttributes.Attributes.Count);
+            Assert.Equal("1234", spanAttributes.Attributes["StringAttribute"]);
+            Assert.Equal(12345, spanAttributes.Attributes["IntAttribute"]);
+            Assert.Equal(new[] { "ABCD", "FGHI", "KLMN" }, spanAttributes.Attributes["StringArrayAttribute"]);
+        }
     }
 }

--- a/test/OpenTelemetry.Tests/Trace/SpanAttributesTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/SpanAttributesTest.cs
@@ -89,7 +89,32 @@ namespace OpenTelemetry.Trace.Tests
         }
 
         [Fact]
-        public void SpanLimits()
+        public void SpanLimitsAddOneAtATime()
+        {
+            TracerProvider.SetSpanLimits(new SpanLimits
+            {
+                AttributeCountLimit = 4,
+                AttributeValueLengthLimit = 4,
+            });
+
+            var spanAttributes = new SpanAttributes();
+            spanAttributes.Add("TruncatedStringAttribute", "12345");
+            spanAttributes.Add("StringAttribute", "123");
+
+            // There is no Add overload that takes an int. This invokes the Add(string, long) overload.
+            spanAttributes.Add("IntAttribute", 12345);
+            spanAttributes.Add("StringArrayAttribute", new[] { "ABCDE", "FGHIJ", "KLMN", "OPQ" });
+            spanAttributes.Add("DoubleAttribute", 12345.6);
+
+            Assert.Equal(4, spanAttributes.Attributes.Count);
+            Assert.Equal("1234", spanAttributes.Attributes["TruncatedStringAttribute"]);
+            Assert.Equal("123", spanAttributes.Attributes["StringAttribute"]);
+            Assert.Equal(12345L, spanAttributes.Attributes["IntAttribute"]);
+            Assert.Equal(new[] { "ABCD", "FGHI", "KLMN", "OPQ" }, spanAttributes.Attributes["StringArrayAttribute"]);
+        }
+
+        [Fact]
+        public void SpanLimitsAddMultipleAtOnce()
         {
             TracerProvider.SetSpanLimits(new SpanLimits
             {

--- a/test/OpenTelemetry.Tests/Trace/SpanAttributesTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/SpanAttributesTest.cs
@@ -87,23 +87,79 @@ namespace OpenTelemetry.Trace.Tests
         {
             TracerProvider.SetSpanLimits(new SpanLimits
             {
-                AttributeCountLimit = 3,
+                AttributeCountLimit = 4,
                 AttributeValueLengthLimit = 4,
             });
 
             var spanAttributes = new SpanAttributes(
                new List<KeyValuePair<string, object>>()
                {
-                    new KeyValuePair<string, object>("StringAttribute", "12345"),
+                    new KeyValuePair<string, object>("TruncatedStringAttribute", "12345"),
+                    new KeyValuePair<string, object>("StringAttribute", "123"),
                     new KeyValuePair<string, object>("IntAttribute", 12345),
-                    new KeyValuePair<string, object>("StringArrayAttribute", new[] { "ABCDE", "FGHIJ", "KLMN" }),
+                    new KeyValuePair<string, object>("StringArrayAttribute", new[] { "ABCDE", "FGHIJ", "KLMN", "OPQ" }),
                     new KeyValuePair<string, object>("DoubleAttribute", 12345.6),
                });
 
-            Assert.Equal(3, spanAttributes.Attributes.Count);
-            Assert.Equal("1234", spanAttributes.Attributes["StringAttribute"]);
+            Assert.Equal(4, spanAttributes.Attributes.Count);
+            Assert.Equal("1234", spanAttributes.Attributes["TruncatedStringAttribute"]);
+            Assert.Equal("123", spanAttributes.Attributes["StringAttribute"]);
             Assert.Equal(12345, spanAttributes.Attributes["IntAttribute"]);
-            Assert.Equal(new[] { "ABCD", "FGHI", "KLMN" }, spanAttributes.Attributes["StringArrayAttribute"]);
+            Assert.Equal(new[] { "ABCD", "FGHI", "KLMN", "OPQ" }, spanAttributes.Attributes["StringArrayAttribute"]);
+        }
+
+        [Fact]
+        public void SpanLimitsUnset()
+        {
+            TracerProvider.SetSpanLimits(new SpanLimits
+            {
+                AttributeCountLimit = null,
+                AttributeValueLengthLimit = null,
+            });
+
+            var spanAttributes = new SpanAttributes(
+               new List<KeyValuePair<string, object>>()
+               {
+                    new KeyValuePair<string, object>("TruncatedStringAttribute", "12345"),
+                    new KeyValuePair<string, object>("StringAttribute", "123"),
+                    new KeyValuePair<string, object>("IntAttribute", 12345),
+                    new KeyValuePair<string, object>("StringArrayAttribute", new[] { "ABCDE", "FGHIJ", "KLMN", "OPQ" }),
+                    new KeyValuePair<string, object>("DoubleAttribute", 12345.6),
+               });
+
+            Assert.Equal(5, spanAttributes.Attributes.Count);
+            Assert.Equal("12345", spanAttributes.Attributes["TruncatedStringAttribute"]);
+            Assert.Equal("123", spanAttributes.Attributes["StringAttribute"]);
+            Assert.Equal(12345, spanAttributes.Attributes["IntAttribute"]);
+            Assert.Equal(new[] { "ABCDE", "FGHIJ", "KLMN", "OPQ" }, spanAttributes.Attributes["StringArrayAttribute"]);
+            Assert.Equal(12345.6, spanAttributes.Attributes["DoubleAttribute"]);
+        }
+
+        [Fact]
+        public void SpanLimitsIgnoredWhenSetToInvalidValue()
+        {
+            TracerProvider.SetSpanLimits(new SpanLimits
+            {
+                AttributeCountLimit = -5,
+                AttributeValueLengthLimit = -5,
+            });
+
+            var spanAttributes = new SpanAttributes(
+               new List<KeyValuePair<string, object>>()
+               {
+                    new KeyValuePair<string, object>("TruncatedStringAttribute", "12345"),
+                    new KeyValuePair<string, object>("StringAttribute", "123"),
+                    new KeyValuePair<string, object>("IntAttribute", 12345),
+                    new KeyValuePair<string, object>("StringArrayAttribute", new[] { "ABCDE", "FGHIJ", "KLMN", "OPQ" }),
+                    new KeyValuePair<string, object>("DoubleAttribute", 12345.6),
+               });
+
+            Assert.Equal(5, spanAttributes.Attributes.Count);
+            Assert.Equal("12345", spanAttributes.Attributes["TruncatedStringAttribute"]);
+            Assert.Equal("123", spanAttributes.Attributes["StringAttribute"]);
+            Assert.Equal(12345, spanAttributes.Attributes["IntAttribute"]);
+            Assert.Equal(new[] { "ABCDE", "FGHIJ", "KLMN", "OPQ" }, spanAttributes.Attributes["StringArrayAttribute"]);
+            Assert.Equal(12345.6, spanAttributes.Attributes["DoubleAttribute"]);
         }
     }
 }

--- a/test/OpenTelemetry.Tests/Trace/SpanAttributesTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/SpanAttributesTest.cs
@@ -20,8 +20,14 @@ using Xunit;
 
 namespace OpenTelemetry.Trace.Tests
 {
-    public class SpanAttributesTest
+    public class SpanAttributesTest : IDisposable
     {
+        public void Dispose()
+        {
+            TracerProvider.SpanAttributeCountLimit = null;
+            TracerProvider.SpanAttributeValueLengthLimit = null;
+        }
+
         [Fact]
         public void ValidateConstructor()
         {


### PR DESCRIPTION
Implements [attribute limits](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/README.md#attribute-limits) for span data when using the shim API.

Follow on PR will implement additional [span limits](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#span-limits) for events and links.

I've opened https://github.com/dotnet/runtime/issues/68528 to propose a similar API for `ActivitySource`.