### PR TITLE
Revert "reword"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,7 +23,7 @@ A clear and concise description of what the bug is.
 
 **What is the expected behavior?**
 
-What do you expect to see?
+What did you expect to see?
 
 **What is the actual behavior?**
 


### PR DESCRIPTION
This reverts commit b03b18b48570d1de9eb30b23edf751f8324b422f.

I made a mistake while trying to [change the contrib issue templates](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/330), ended up performing a direct push to main branch in this repo (and surprisingly we allowed folks with admin access to do that). Now revert it.