### PR TITLE
Use ToOtlpAttribute method for traces

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -18,9 +18,8 @@ option
 * Fix handling of array-valued attributes for the OTLP trace exporter.
   ([#3238](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3238))
 
-* Improve the conversion and formatting of attribute values to the OTLP format
-  for resources, metrics, and logs. The list of data types that must be
-  supported per the
+* Improve the conversion and formatting of attribute values to the OTLP format.
+  The list of data types that must be supported per the
   [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/common#attribute)
   is more narrow than what the .NET OpenTelemetry SDK supports. Numeric
   [built-in value types](https://docs.microsoft.com/dotnet/csharp/language-reference/builtin-types/built-in-types)
@@ -30,6 +29,7 @@ option
   `char`, `bool` are supported. All other types are converted to a `string`.
   Array values are also supported.
   ([#3262](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3262))
+  ([#3274](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3274))
 
 ## 1.3.0-beta.1
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
@@ -360,14 +360,13 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
                 {
                     PooledList<OtlpCommon.KeyValue>.Add(ref this.Tags, attribute);
 
-                    switch (attribute.Value.ValueCase)
+                    if (attribute.Value.ValueCase == OtlpCommon.AnyValue.ValueOneofCase.StringValue)
                     {
-                        case OtlpCommon.AnyValue.ValueOneofCase.StringValue:
-                            PeerServiceResolver.InspectTag(ref this, key, attribute.Value.StringValue);
-                            break;
-                        case OtlpCommon.AnyValue.ValueOneofCase.IntValue:
-                            PeerServiceResolver.InspectTag(ref this, key, attribute.Value.IntValue);
-                            break;
+                        PeerServiceResolver.InspectTag(ref this, key, attribute.Value.StringValue);
+                    }
+                    else if (attribute.Value.ValueCase == OtlpCommon.AnyValue.ValueOneofCase.IntValue)
+                    {
+                        PeerServiceResolver.InspectTag(ref this, key, attribute.Value.IntValue);
                     }
                 }
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
@@ -359,16 +359,16 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
                 if (attribute != null)
                 {
                     PooledList<OtlpCommon.KeyValue>.Add(ref this.Tags, attribute);
-                }
 
-                switch (activityTag.Value)
-                {
-                    case string s:
-                        PeerServiceResolver.InspectTag(ref this, key, s);
-                        break;
-                    case int i:
-                        PeerServiceResolver.InspectTag(ref this, key, i);
-                        break;
+                    switch (attribute.Value.ValueCase)
+                    {
+                        case OtlpCommon.AnyValue.ValueOneofCase.StringValue:
+                            PeerServiceResolver.InspectTag(ref this, key, attribute.Value.StringValue);
+                            break;
+                        case OtlpCommon.AnyValue.ValueOneofCase.IntValue:
+                            PeerServiceResolver.InspectTag(ref this, key, attribute.Value.IntValue);
+                            break;
+                    }
                 }
 
                 return true;

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
@@ -310,12 +310,6 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
             return (Action<RepeatedField<OtlpTrace.Span>, int>)dynamicMethod.CreateDelegate(typeof(Action<RepeatedField<OtlpTrace.Span>, int>));
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static OtlpCommon.KeyValue CreateOtlpKeyValue(string key, OtlpCommon.AnyValue value)
-        {
-            return new OtlpCommon.KeyValue { Key = key, Value = value };
-        }
-
         private struct TagEnumerationState : IActivityEnumerator<KeyValuePair<string, object>>, PeerServiceResolver.IPeerServiceState
         {
             public bool Created;
@@ -361,74 +355,19 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
                     this.Created = true;
                 }
 
-                OtlpCommon.ArrayValue arrayValue;
+                var attribute = activityTag.ToOtlpAttribute();
+                if (attribute != null)
+                {
+                    PooledList<OtlpCommon.KeyValue>.Add(ref this.Tags, attribute);
+                }
 
                 switch (activityTag.Value)
                 {
                     case string s:
                         PeerServiceResolver.InspectTag(ref this, key, s);
-                        PooledList<OtlpCommon.KeyValue>.Add(ref this.Tags, CreateOtlpKeyValue(key, new OtlpCommon.AnyValue { StringValue = s }));
-                        break;
-                    case bool b:
-                        PooledList<OtlpCommon.KeyValue>.Add(ref this.Tags, CreateOtlpKeyValue(key, new OtlpCommon.AnyValue { BoolValue = b }));
                         break;
                     case int i:
                         PeerServiceResolver.InspectTag(ref this, key, i);
-                        PooledList<OtlpCommon.KeyValue>.Add(ref this.Tags, CreateOtlpKeyValue(key, new OtlpCommon.AnyValue { IntValue = i }));
-                        break;
-                    case long l:
-                        PooledList<OtlpCommon.KeyValue>.Add(ref this.Tags, CreateOtlpKeyValue(key, new OtlpCommon.AnyValue { IntValue = l }));
-                        break;
-                    case double d:
-                        PooledList<OtlpCommon.KeyValue>.Add(ref this.Tags, CreateOtlpKeyValue(key, new OtlpCommon.AnyValue { DoubleValue = d }));
-                        break;
-                    case int[] intArray:
-                        arrayValue = new OtlpCommon.ArrayValue();
-                        foreach (var item in intArray)
-                        {
-                            arrayValue.Values.Add(new OtlpCommon.AnyValue { IntValue = item });
-                        }
-
-                        PooledList<OtlpCommon.KeyValue>.Add(ref this.Tags, CreateOtlpKeyValue(key, new OtlpCommon.AnyValue { ArrayValue = arrayValue }));
-                        break;
-                    case double[] doubleArray:
-                        arrayValue = new OtlpCommon.ArrayValue();
-                        foreach (var item in doubleArray)
-                        {
-                            arrayValue.Values.Add(new OtlpCommon.AnyValue { DoubleValue = item });
-                        }
-
-                        PooledList<OtlpCommon.KeyValue>.Add(ref this.Tags, CreateOtlpKeyValue(key, new OtlpCommon.AnyValue { ArrayValue = arrayValue }));
-                        break;
-                    case bool[] boolArray:
-                        arrayValue = new OtlpCommon.ArrayValue();
-                        foreach (var item in boolArray)
-                        {
-                            arrayValue.Values.Add(new OtlpCommon.AnyValue { BoolValue = item });
-                        }
-
-                        PooledList<OtlpCommon.KeyValue>.Add(ref this.Tags, CreateOtlpKeyValue(key, new OtlpCommon.AnyValue { ArrayValue = arrayValue }));
-                        break;
-                    case string[] stringArray:
-                        arrayValue = new OtlpCommon.ArrayValue();
-                        foreach (var item in stringArray)
-                        {
-                            arrayValue.Values.Add(item == null ? new OtlpCommon.AnyValue() : new OtlpCommon.AnyValue { StringValue = item });
-                        }
-
-                        PooledList<OtlpCommon.KeyValue>.Add(ref this.Tags, CreateOtlpKeyValue(key, new OtlpCommon.AnyValue { ArrayValue = arrayValue }));
-                        break;
-                    case long[] longArray:
-                        arrayValue = new OtlpCommon.ArrayValue();
-                        foreach (var item in longArray)
-                        {
-                            arrayValue.Values.Add(new OtlpCommon.AnyValue { IntValue = item });
-                        }
-
-                        PooledList<OtlpCommon.KeyValue>.Add(ref this.Tags, CreateOtlpKeyValue(key, new OtlpCommon.AnyValue { ArrayValue = arrayValue }));
-                        break;
-                    default:
-                        PooledList<OtlpCommon.KeyValue>.Add(ref this.Tags, CreateOtlpKeyValue(key, new OtlpCommon.AnyValue { StringValue = activityTag.Value.ToString() }));
                         break;
                 }
 


### PR DESCRIPTION
`ToOtlpAttribute` method is now used for transforming attributes on all the things: traces, metrics, logs, resources.

There will be a failing test on this PR which will be resolved by merging #3273.