### PR TITLE
Histogram handle of `double.NaN` bounds and values

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Recording a `double.NaN` value on a histogram increases the count of the
+  greatest bucket and does not affect the sum.
+  ([#xxx](https://github.com/open-telemetry/opentelemetry-dotnet/pull/xxx))
+
 * Exposed public setters for `LogRecord.State`, `LogRecord.StateValues`,
   and `LogRecord.FormattedMessage`.
  ([#3217](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3217))

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Recording a `double.NaN` value on a histogram increases the count of the
   greatest bucket and does not affect the sum.
-  ([#xxx](https://github.com/open-telemetry/opentelemetry-dotnet/pull/xxx))
+  ([#3279](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3279))
 
 * Exposed public setters for `LogRecord.State`, `LogRecord.StateValues`,
   and `LogRecord.FormattedMessage`.

--- a/src/OpenTelemetry/Metrics/ExplicitBucketHistogramConfiguration.cs
+++ b/src/OpenTelemetry/Metrics/ExplicitBucketHistogramConfiguration.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Metrics
         /// Requirements:
         /// <list type="bullet">
         /// <item>The array must be in ascending order with distinct
-        /// values.</item>
+        /// values. double.NaN is not allowed</item>
         /// <item>An empty array would result in no histogram buckets being
         /// calculated.</item>
         /// <item>A null value would result in default bucket boundaries being
@@ -58,7 +58,7 @@ namespace OpenTelemetry.Metrics
                 {
                     if (!IsSortedAndDistinct(value))
                     {
-                        throw new ArgumentException($"Histogram boundaries are invalid. Histogram boundaries must be in ascending order with distinct values.", nameof(value));
+                        throw new ArgumentException($"Histogram boundaries are invalid. Histogram boundaries must be in ascending order with distinct values. double.NaN is not allowed.", nameof(value));
                     }
 
                     double[] copy = new double[value.Length];
@@ -76,9 +76,14 @@ namespace OpenTelemetry.Metrics
 
         private static bool IsSortedAndDistinct(double[] values)
         {
+            if (double.IsNaN(values[0]))
+            {
+                return false;
+            }
+
             for (int i = 1; i < values.Length; i++)
             {
-                if (values[i] <= values[i - 1])
+                if (double.IsNaN(values[i]) || values[i] <= values[i - 1])
                 {
                     return false;
                 }

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -324,13 +324,16 @@ namespace OpenTelemetry.Metrics
 
                 case AggregationType.Histogram:
                     {
-                        int i;
-                        for (i = 0; i < this.histogramBuckets.ExplicitBounds.Length; i++)
+                        int i = this.histogramBuckets.ExplicitBounds.Length;
+                        if (!double.IsNaN(number))
                         {
-                            // Upper bound is inclusive
-                            if (number <= this.histogramBuckets.ExplicitBounds[i])
+                            for (i = 0; i < this.histogramBuckets.ExplicitBounds.Length; i++)
                             {
-                                break;
+                                // Upper bound is inclusive
+                                if (number <= this.histogramBuckets.ExplicitBounds[i])
+                                {
+                                    break;
+                                }
                             }
                         }
 
@@ -342,8 +345,11 @@ namespace OpenTelemetry.Metrics
                                 unchecked
                                 {
                                     this.runningValue.AsLong++;
-                                    this.histogramBuckets.RunningSum += number;
                                     this.histogramBuckets.RunningBucketCounts[i]++;
+                                    if (!double.IsNaN(number))
+                                    {
+                                        this.histogramBuckets.RunningSum += number;
+                                    }
                                 }
 
                                 this.histogramBuckets.IsCriticalSectionOccupied = 0;
@@ -366,7 +372,10 @@ namespace OpenTelemetry.Metrics
                                 unchecked
                                 {
                                     this.runningValue.AsLong++;
-                                    this.histogramBuckets.RunningSum += number;
+                                    if (!double.IsNaN(number))
+                                    {
+                                        this.histogramBuckets.RunningSum += number;
+                                    }
                                 }
 
                                 this.histogramBuckets.IsCriticalSectionOccupied = 0;

--- a/test/OpenTelemetry.Tests/Metrics/MetricTestData.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricTestData.cs
@@ -44,6 +44,7 @@ namespace OpenTelemetry.Metrics.Tests
         public static IEnumerable<object[]> InvalidHistogramBoundaries
            => new List<object[]>
            {
+                    new object[] { new double[] { double.NaN } },
                     new object[] { new double[] { 0, 0 } },
                     new object[] { new double[] { 1, 0 } },
                     new object[] { new double[] { 0, 1, 1, 2 } },


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-dotnet/issues/3171

## Changes

- It will correctly place `double.NaN` values in the final histogram bucket
- Exception will be thrown if `double.NaN` is used as a histogram bound

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
