### PR TITLE
Add null check when a view does not match an instrument

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fix null reference exception when a metric view does not match an instrument.
+  ([#3285](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3285))
+
 ## 1.3.0-beta.2
 
 Released 2022-May-16

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -167,7 +167,7 @@ namespace OpenTelemetry.Metrics
                                 // The SDK provides some static MetricStreamConfigurations.
                                 // For example, the Drop configuration. The static ViewId
                                 // should not be changed for these configurations.
-                                if (!metricStreamConfig.ViewId.HasValue)
+                                if (metricStreamConfig != null && !metricStreamConfig.ViewId.HasValue)
                                 {
                                     metricStreamConfig.ViewId = i;
                                 }


### PR DESCRIPTION
Fixes #3283

Bug was causing superfluous warnings in diagnostic logs when an instrument didn't match a view config. For example:

```text
2022-05-17T19:29:28.8189110Z:View Configuration ignored for Instrument '{0}', Meter '{1}'. Reason: '{2}'. Measurements from the instrument will use default configuration for Aggregation. Suggested action: '{3}'{http.client.duration}{OpenTelemetry.Instrumentation.Http}{Object reference not set to an instance of an object.}{Fix the view configuration.}
```