### PR TITLE
Make the SDK more forgiving for ObjectDisposedException

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * Fix null reference exception when a metric view does not match an instrument.
   ([#3285](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3285))
+* Swallow `ObjectDisposedException` in `BatchExportProcessor` and
+* `PeriodicExportingMetricReader`.
+  ([#TBD](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TBD))
 
 ## 1.3.0-beta.2
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -6,7 +6,7 @@
   ([#3285](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3285))
 * Swallow `ObjectDisposedException` in `BatchExportProcessor` and
 * `PeriodicExportingMetricReader`.
-  ([#TBD](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TBD))
+  ([#3291](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3291))
 
 ## 1.3.0-beta.2
 

--- a/src/OpenTelemetry/Metrics/PeriodicExportingMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/PeriodicExportingMetricReader.cs
@@ -75,7 +75,14 @@ namespace OpenTelemetry.Metrics
         {
             var result = true;
 
-            this.shutdownTrigger.Set();
+            try
+            {
+                this.shutdownTrigger.Set();
+            }
+            catch (ObjectDisposedException)
+            {
+                return false;
+            }
 
             if (timeoutMilliseconds == Timeout.Infinite)
             {


### PR DESCRIPTION
Fixes #3269.

I guess 99% of the cases it was due to the user's fault - e.g. LoggerProvider disposed before worker threads join, MeterProvider disposed while the Exporter is still busy. The rest 1% came from the underlying libraries/frameworks that the user has no control over (e.g. the framework doesn't have a proper shutdown mechanism).

Anyways I think the OpenTelemetry design principle encourages the SDK to be more forgiving after the initialization succeeded.