### PR TITLE
[Propagation] Improve the perf by passing structs by reference

### DIFF
--- a/src/OpenTelemetry.Api/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,13 @@
+override OpenTelemetry.Context.Propagation.B3Propagator.Extract<T>(ref OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> void
+override OpenTelemetry.Context.Propagation.B3Propagator.Inject<T>(in OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
+override OpenTelemetry.Context.Propagation.BaggagePropagator.Extract<T>(ref OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> void
+override OpenTelemetry.Context.Propagation.BaggagePropagator.Inject<T>(in OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
+override OpenTelemetry.Context.Propagation.CompositeTextMapPropagator.Extract<T>(ref OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> void
+override OpenTelemetry.Context.Propagation.CompositeTextMapPropagator.Inject<T>(in OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
+override OpenTelemetry.Context.Propagation.TraceContextPropagator.Extract<T>(ref OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> void
+override OpenTelemetry.Context.Propagation.TraceContextPropagator.Inject<T>(in OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
+static OpenTelemetry.ActivityContextExtensions.IsValid(this in System.Diagnostics.ActivityContext ctx) -> bool
+static OpenTelemetry.Context.Propagation.PropagationContext.CreateFromActivity(System.Diagnostics.Activity activity, OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> OpenTelemetry.Context.Propagation.PropagationContext
+static OpenTelemetry.Context.Propagation.PropagationContext.GetActivityContextRef(in OpenTelemetry.Context.Propagation.PropagationContext propagationContext) -> System.Diagnostics.ActivityContext
+virtual OpenTelemetry.Context.Propagation.TextMapPropagator.Extract<T>(ref OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> void
+virtual OpenTelemetry.Context.Propagation.TextMapPropagator.Inject<T>(in OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void

--- a/src/OpenTelemetry.Api/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,13 @@
+override OpenTelemetry.Context.Propagation.B3Propagator.Extract<T>(ref OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> void
+override OpenTelemetry.Context.Propagation.B3Propagator.Inject<T>(in OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
+override OpenTelemetry.Context.Propagation.BaggagePropagator.Extract<T>(ref OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> void
+override OpenTelemetry.Context.Propagation.BaggagePropagator.Inject<T>(in OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
+override OpenTelemetry.Context.Propagation.CompositeTextMapPropagator.Extract<T>(ref OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> void
+override OpenTelemetry.Context.Propagation.CompositeTextMapPropagator.Inject<T>(in OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
+override OpenTelemetry.Context.Propagation.TraceContextPropagator.Extract<T>(ref OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> void
+override OpenTelemetry.Context.Propagation.TraceContextPropagator.Inject<T>(in OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
+static OpenTelemetry.ActivityContextExtensions.IsValid(this in System.Diagnostics.ActivityContext ctx) -> bool
+static OpenTelemetry.Context.Propagation.PropagationContext.CreateFromActivity(System.Diagnostics.Activity activity, OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> OpenTelemetry.Context.Propagation.PropagationContext
+static OpenTelemetry.Context.Propagation.PropagationContext.GetActivityContextRef(in OpenTelemetry.Context.Propagation.PropagationContext propagationContext) -> System.Diagnostics.ActivityContext
+virtual OpenTelemetry.Context.Propagation.TextMapPropagator.Extract<T>(ref OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> void
+virtual OpenTelemetry.Context.Propagation.TextMapPropagator.Inject<T>(in OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void

--- a/src/OpenTelemetry.Api/ActivityContextExtensions.cs
+++ b/src/OpenTelemetry.Api/ActivityContextExtensions.cs
@@ -14,7 +14,9 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 // The ActivityContext class is in the System.Diagnostics namespace.
 // These extension methods on ActivityContext are intentionally not placed in the
@@ -29,13 +31,27 @@ namespace OpenTelemetry
     public static class ActivityContextExtensions
     {
         /// <summary>
-        /// Returns a bool indicating if a ActivityContext is valid or not.
+        /// Returns a value indicating whether or not a <see cref="ActivityContext"/> is valid.
         /// </summary>
-        /// <param name="ctx">ActivityContext.</param>
-        /// <returns>whether the context is a valid one or not.</returns>
+        /// <param name="ctx"><see cref="ActivityContext"/>.</param>
+        /// <returns><see langword="true"/> if the context is a valid otherwise <see langword="false"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [Obsolete("Use the IsValid method which accepts ActivityContext by reference for better performance.")]
         public static bool IsValid(this ActivityContext ctx)
         {
             return ctx != default;
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether or not a <see cref="ActivityContext"/> is valid.
+        /// </summary>
+        /// <param name="ctx"><see cref="ActivityContext"/>.</param>
+        /// <returns><see langword="true"/> if the context is a valid otherwise <see langword="false"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsValid(this in ActivityContext ctx)
+        {
+            return !ctx.SpanId.Equals(default)
+                && !ctx.TraceId.Equals(default);
         }
     }
 }

--- a/src/OpenTelemetry.Api/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Api/AssemblyInfo.cs
@@ -16,6 +16,7 @@
 
 using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("Benchmarks" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry.Tests" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry.Shims.OpenTracing.Tests" + AssemblyInfo.PublicKey)]

--- a/src/OpenTelemetry.Api/Context/Propagation/CompositeTextMapPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/CompositeTextMapPropagator.cs
@@ -55,11 +55,29 @@ namespace OpenTelemetry.Context.Propagation
         }
 
         /// <inheritdoc/>
+        public override void Extract<T>(ref PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter)
+        {
+            foreach (var propagator in this.propagators)
+            {
+                propagator.Extract(ref context, carrier, getter);
+            }
+        }
+
+        /// <inheritdoc/>
         public override void Inject<T>(PropagationContext context, T carrier, Action<T, string, string> setter)
         {
             foreach (var propagator in this.propagators)
             {
                 propagator.Inject(context, carrier, setter);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Inject<T>(in PropagationContext context, T carrier, Action<T, string, string> setter)
+        {
+            foreach (var propagator in this.propagators)
+            {
+                propagator.Inject(in context, carrier, setter);
             }
         }
     }

--- a/src/OpenTelemetry.Api/Context/Propagation/NoopTextMapPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/NoopTextMapPropagator.cs
@@ -30,7 +30,15 @@ namespace OpenTelemetry.Context.Propagation
             return DefaultPropagationContext;
         }
 
+        public override void Extract<T>(ref PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter)
+        {
+        }
+
         public override void Inject<T>(PropagationContext context, T carrier, Action<T, string, string> setter)
+        {
+        }
+
+        public override void Inject<T>(in PropagationContext context, T carrier, Action<T, string, string> setter)
         {
         }
     }

--- a/src/OpenTelemetry.Api/Context/Propagation/PropagationContext.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/PropagationContext.cs
@@ -24,24 +24,32 @@ namespace OpenTelemetry.Context.Propagation
     /// </summary>
     public readonly struct PropagationContext : IEquatable<PropagationContext>
     {
+        private readonly ActivityContext activityContext;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="PropagationContext"/> struct.
         /// </summary>
         /// <param name="activityContext"><see cref="System.Diagnostics.ActivityContext"/>.</param>
-        /// <param name="baggage"><see cref="Baggage"/>.</param>
+        /// <param name="baggage"><see cref="OpenTelemetry.Baggage"/>.</param>
         public PropagationContext(ActivityContext activityContext, Baggage baggage)
         {
-            this.ActivityContext = activityContext;
+            this.activityContext = activityContext;
+            this.Baggage = baggage;
+        }
+
+        private PropagationContext(Activity activity, Baggage baggage)
+        {
+            this.activityContext = activity?.Context ?? default;
             this.Baggage = baggage;
         }
 
         /// <summary>
         /// Gets <see cref="System.Diagnostics.ActivityContext"/>.
         /// </summary>
-        public ActivityContext ActivityContext { get; }
+        public ActivityContext ActivityContext => this.activityContext;
 
         /// <summary>
-        /// Gets <see cref="Baggage"/>.
+        /// Gets <see cref="OpenTelemetry.Baggage"/>.
         /// </summary>
         public Baggage Baggage { get; }
 
@@ -58,6 +66,29 @@ namespace OpenTelemetry.Context.Propagation
         /// <param name="left">First Entry to compare.</param>
         /// <param name="right">Second Entry to compare.</param>
         public static bool operator !=(PropagationContext left, PropagationContext right) => !(left == right);
+
+        /// <summary>
+        /// Create a <see cref="PropagationContext"/> from a <see cref="Activity"/>.
+        /// </summary>
+        /// <param name="activity"><see cref="Activity"/>.</param>
+        /// <param name="baggage"><see cref="OpenTelemetry.Baggage"/>.</param>
+        /// <returns><see cref="PropagationContext"/>.</returns>
+        public static PropagationContext CreateFromActivity(Activity activity, Baggage baggage = default)
+        {
+            return new PropagationContext(activity, baggage);
+        }
+
+        /// <summary>
+        /// Returns a reference to the <see
+        /// cref="System.Diagnostics.ActivityContext"/> contained within the
+        /// supplied <see cref="PropagationContext"/>.
+        /// </summary>
+        /// <param name="propagationContext"><see cref="PropagationContext"/>.</param>
+        /// <returns><see cref="System.Diagnostics.ActivityContext"/>.</returns>
+        public static ref readonly ActivityContext GetActivityContextRef(in PropagationContext propagationContext)
+        {
+            return ref propagationContext.activityContext;
+        }
 
         /// <inheritdoc/>
         public bool Equals(PropagationContext value)

--- a/src/OpenTelemetry.Api/Context/Propagation/PropagationContext.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/PropagationContext.cs
@@ -46,6 +46,7 @@ namespace OpenTelemetry.Context.Propagation
         /// <summary>
         /// Gets <see cref="System.Diagnostics.ActivityContext"/>.
         /// </summary>
+        [Obsolete("Use the GetActivityContextRef method to access ActivityContext by reference for better performance.")]
         public ActivityContext ActivityContext => this.activityContext;
 
         /// <summary>

--- a/src/OpenTelemetry.Api/Context/Propagation/TextMapPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TextMapPropagator.cs
@@ -43,6 +43,18 @@ namespace OpenTelemetry.Context.Propagation
         public abstract void Inject<T>(PropagationContext context, T carrier, Action<T, string, string> setter);
 
         /// <summary>
+        /// Injects <see cref="PropagationContext"/> into a carrier.
+        /// </summary>
+        /// <typeparam name="T">Type of an object to set context on. Typically HttpRequest or similar.</typeparam>
+        /// <param name="context">The default context to transmit over the wire.</param>
+        /// <param name="carrier">Object to set context on. Instance of this object will be passed to setter.</param>
+        /// <param name="setter">Action that will set name and value pair on the object.</param>
+        public virtual void Inject<T>(in PropagationContext context, T carrier, Action<T, string, string> setter)
+        {
+            this.Inject(context, carrier, setter);
+        }
+
+        /// <summary>
         /// Extracts the context from a carrier.
         /// </summary>
         /// <typeparam name="T">Type of object to extract context from. Typically HttpRequest or similar.</typeparam>
@@ -51,5 +63,17 @@ namespace OpenTelemetry.Context.Propagation
         /// <param name="getter">Function that will return string value of a key with the specified name.</param>
         /// <returns>Context from it's text representation.</returns>
         public abstract PropagationContext Extract<T>(PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter);
+
+        /// <summary>
+        /// Extracts <see cref="PropagationContext"/> from a carrier.
+        /// </summary>
+        /// <typeparam name="T">Type of an object to set context on. Typically HttpRequest or similar.</typeparam>
+        /// <param name="context">The extracted context.</param>
+        /// <param name="carrier">Object to set context on. Instance of this object will be passed to setter.</param>
+        /// <param name="getter">Function that will return string value of a key with the specified name.</param>
+        public virtual void Extract<T>(ref PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter)
+        {
+            context = this.Extract(context, carrier, getter);
+        }
     }
 }

--- a/src/OpenTelemetry.Extensions.Propagators/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions.Propagators/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+override OpenTelemetry.Extensions.Propagators.B3Propagator.Extract<T>(ref OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> void
+override OpenTelemetry.Extensions.Propagators.B3Propagator.Inject<T>(in OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void

--- a/src/OpenTelemetry.Extensions.Propagators/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions.Propagators/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+override OpenTelemetry.Extensions.Propagators.B3Propagator.Extract<T>(ref OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> void
+override OpenTelemetry.Extensions.Propagators.B3Propagator.Inject<T>(in OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void

--- a/src/OpenTelemetry.Extensions.Propagators/B3Propagator.cs
+++ b/src/OpenTelemetry.Extensions.Propagators/B3Propagator.cs
@@ -80,38 +80,55 @@ namespace OpenTelemetry.Extensions.Propagators
         /// <inheritdoc/>
         public override PropagationContext Extract<T>(PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter)
         {
-            if (context.ActivityContext.IsValid())
+            this.Extract(ref context, carrier, getter);
+            return context;
+        }
+
+        /// <inheritdoc/>
+        public override void Extract<T>(ref PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter)
+        {
+            ref readonly ActivityContext activityContext = ref PropagationContext.GetActivityContextRef(in context);
+
+            if (ActivityContextExtensions.IsValid(in activityContext))
             {
                 // If a valid context has already been extracted, perform a noop.
-                return context;
+                return;
             }
 
             if (carrier == null)
             {
                 OpenTelemetryApiEventSource.Log.FailedToExtractActivityContext(nameof(B3Propagator), "null carrier");
-                return context;
+                return;
             }
 
             if (getter == null)
             {
                 OpenTelemetryApiEventSource.Log.FailedToExtractActivityContext(nameof(B3Propagator), "null getter");
-                return context;
+                return;
             }
 
             if (this.singleHeader)
             {
-                return ExtractFromSingleHeader(context, carrier, getter);
+                ExtractFromSingleHeader(ref context, carrier, getter);
             }
             else
             {
-                return ExtractFromMultipleHeaders(context, carrier, getter);
+                ExtractFromMultipleHeaders(ref context, carrier, getter);
             }
         }
 
         /// <inheritdoc/>
         public override void Inject<T>(PropagationContext context, T carrier, Action<T, string, string> setter)
         {
-            if (context.ActivityContext.TraceId == default || context.ActivityContext.SpanId == default)
+            this.Inject(in context, carrier, setter);
+        }
+
+        /// <inheritdoc/>
+        public override void Inject<T>(in PropagationContext context, T carrier, Action<T, string, string> setter)
+        {
+            ref readonly ActivityContext activityContext = ref PropagationContext.GetActivityContextRef(in context);
+
+            if (!ActivityContextExtensions.IsValid(in activityContext))
             {
                 OpenTelemetryApiEventSource.Log.FailedToInjectActivityContext(nameof(B3Propagator), "invalid context");
                 return;
@@ -132,10 +149,10 @@ namespace OpenTelemetry.Extensions.Propagators
             if (this.singleHeader)
             {
                 var sb = new StringBuilder();
-                sb.Append(context.ActivityContext.TraceId.ToHexString());
+                sb.Append(activityContext.TraceId.ToHexString());
                 sb.Append(XB3CombinedDelimiter);
-                sb.Append(context.ActivityContext.SpanId.ToHexString());
-                if ((context.ActivityContext.TraceFlags & ActivityTraceFlags.Recorded) != 0)
+                sb.Append(activityContext.SpanId.ToHexString());
+                if ((activityContext.TraceFlags & ActivityTraceFlags.Recorded) != 0)
                 {
                     sb.Append(XB3CombinedDelimiter);
                     sb.Append(SampledValue);
@@ -145,16 +162,16 @@ namespace OpenTelemetry.Extensions.Propagators
             }
             else
             {
-                setter(carrier, XB3TraceId, context.ActivityContext.TraceId.ToHexString());
-                setter(carrier, XB3SpanId, context.ActivityContext.SpanId.ToHexString());
-                if ((context.ActivityContext.TraceFlags & ActivityTraceFlags.Recorded) != 0)
+                setter(carrier, XB3TraceId, activityContext.TraceId.ToHexString());
+                setter(carrier, XB3SpanId, activityContext.SpanId.ToHexString());
+                if ((activityContext.TraceFlags & ActivityTraceFlags.Recorded) != 0)
                 {
                     setter(carrier, XB3Sampled, SampledValue);
                 }
             }
         }
 
-        private static PropagationContext ExtractFromMultipleHeaders<T>(PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter)
+        private static void ExtractFromMultipleHeaders<T>(ref PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter)
         {
             try
             {
@@ -172,7 +189,7 @@ namespace OpenTelemetry.Extensions.Propagators
                 }
                 else
                 {
-                    return context;
+                    return;
                 }
 
                 ActivitySpanId spanId;
@@ -183,7 +200,7 @@ namespace OpenTelemetry.Extensions.Propagators
                 }
                 else
                 {
-                    return context;
+                    return;
                 }
 
                 var traceOptions = ActivityTraceFlags.None;
@@ -193,37 +210,36 @@ namespace OpenTelemetry.Extensions.Propagators
                     traceOptions |= ActivityTraceFlags.Recorded;
                 }
 
-                return new PropagationContext(
+                context = new PropagationContext(
                     new ActivityContext(traceId, spanId, traceOptions, isRemote: true),
                     context.Baggage);
             }
             catch (Exception e)
             {
                 OpenTelemetryApiEventSource.Log.ActivityContextExtractException(nameof(B3Propagator), e);
-                return context;
             }
         }
 
-        private static PropagationContext ExtractFromSingleHeader<T>(PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter)
+        private static void ExtractFromSingleHeader<T>(ref PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter)
         {
             try
             {
                 var header = getter(carrier, XB3Combined)?.FirstOrDefault();
                 if (string.IsNullOrWhiteSpace(header))
                 {
-                    return context;
+                    return;
                 }
 
                 var parts = header.Split(XB3CombinedDelimiter);
                 if (parts.Length < 2 || parts.Length > 4)
                 {
-                    return context;
+                    return;
                 }
 
                 var traceIdStr = parts[0];
                 if (string.IsNullOrWhiteSpace(traceIdStr))
                 {
-                    return context;
+                    return;
                 }
 
                 if (traceIdStr.Length == 16)
@@ -237,7 +253,7 @@ namespace OpenTelemetry.Extensions.Propagators
                 var spanIdStr = parts[1];
                 if (string.IsNullOrWhiteSpace(spanIdStr))
                 {
-                    return context;
+                    return;
                 }
 
                 var spanId = ActivitySpanId.CreateFromString(spanIdStr.AsSpan());
@@ -253,14 +269,13 @@ namespace OpenTelemetry.Extensions.Propagators
                     }
                 }
 
-                return new PropagationContext(
+                context = new PropagationContext(
                     new ActivityContext(traceId, spanId, traceOptions, isRemote: true),
                     context.Baggage);
             }
             catch (Exception e)
             {
                 OpenTelemetryApiEventSource.Log.ActivityContextExtractException(nameof(B3Propagator), e);
-                return context;
             }
         }
     }

--- a/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNet.TelemetryHttpModule/ActivityHelper.cs
@@ -76,7 +76,8 @@ namespace OpenTelemetry.Instrumentation.AspNet
         {
             Debug.Assert(context != null, "Context is null.");
 
-            PropagationContext propagationContext = textMapPropagator.Extract(default, context.Request, HttpRequestHeaderValuesGetter);
+            PropagationContext propagationContext = default;
+            textMapPropagator.Extract(ref propagationContext, context.Request, HttpRequestHeaderValuesGetter);
 
             Activity activity = AspNetSource.StartActivity(TelemetryHttpModule.AspNetActivityName, ActivityKind.Server, propagationContext.ActivityContext);
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -94,7 +94,10 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
                 ref readonly ActivityContext activityContext = ref PropagationContext.GetActivityContextRef(in ctx);
 
                 if (ActivityContextExtensions.IsValid(in activityContext)
-                    && activityContext != new ActivityContext(activity.TraceId, activity.ParentSpanId, activity.ActivityTraceFlags, activity.TraceStateString, true))
+                    && (!activityContext.TraceId.Equals(activity.TraceId)
+                    || !activityContext.SpanId.Equals(activity.ParentSpanId)
+                    || activityContext.TraceFlags != activity.ActivityTraceFlags
+                    || activityContext.TraceState != activity.TraceStateString))
                 {
                     // Create a new activity with its parent set from the extracted context.
                     // This makes the new activity as a "sibling" of the activity created by

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
@@ -88,8 +88,9 @@ namespace OpenTelemetry.Instrumentation.GrpcNetClient.Implementation
                 // propagator is used, as HttpClient by itself will only
                 // do TraceContext propagation.
                 var textMapPropagator = Propagators.DefaultTextMapPropagator;
+                var context = new PropagationContext(activity.Context, Baggage.Current);
                 textMapPropagator.Inject(
-                    new PropagationContext(activity.Context, Baggage.Current),
+                    in context,
                     request,
                     HttpRequestMessageContextPropagation.HeaderValueSetter);
             }

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
@@ -88,7 +88,7 @@ namespace OpenTelemetry.Instrumentation.GrpcNetClient.Implementation
                 // propagator is used, as HttpClient by itself will only
                 // do TraceContext propagation.
                 var textMapPropagator = Propagators.DefaultTextMapPropagator;
-                var context = new PropagationContext(activity.Context, Baggage.Current);
+                var context = PropagationContext.CreateFromActivity(activity, Baggage.Current);
                 textMapPropagator.Inject(
                     in context,
                     request,

--- a/test/Benchmarks/Context/PropagationBenchmarks.cs
+++ b/test/Benchmarks/Context/PropagationBenchmarks.cs
@@ -29,42 +29,42 @@ namespace Benchmarks.Context
         private static readonly Func<HttpRequest, string, IEnumerable<string>> CarrierGetter = (request, name) => request.Headers[name];
         private static readonly Action<object, string, string> CarrierSetter = (request, name, value) => { };
         private readonly TraceContextPropagator traceContextPropagator = new();
-        private readonly TextMapPropagator compositePropagator = new CompositeTextMapPropagator(new TextMapPropagator[] { new TraceContextPropagator(), new BaggagePropagator(), new B3Propagator() });
+        private readonly B3Propagator b3Propagator = new();
         private readonly object injectRequest = new();
+        private readonly HttpRequest emptyExtractRequest;
+        private readonly HttpRequest w3cExtractRequest;
+        private readonly HttpRequest b3ExtractRequest;
+
+        private readonly TextMapPropagator compositePropagator = new CompositeTextMapPropagator(
+            new TextMapPropagator[] { new TraceContextPropagator(), new BaggagePropagator(), new B3Propagator() });
+
         private readonly PropagationContext injectContext = new(
             new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
             default);
 
-        private HttpRequest extractRequest;
-
-        [Params("Empty", "W3C", "B3")]
-        public string Mode { get; set; }
-
-        [GlobalSetup]
-        public void GlobalSetup()
+        public PropagationBenchmarks()
         {
-            HttpContext context = new DefaultHttpContext();
+            HttpContext emptyContext = new DefaultHttpContext();
+            this.emptyExtractRequest = emptyContext.Request;
 
-            this.extractRequest = context.Request;
+            HttpContext w3cContext = new DefaultHttpContext();
+            this.w3cExtractRequest = w3cContext.Request;
+            this.w3cExtractRequest.Headers.Add(TraceContextPropagator.TraceParent, "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-00");
 
-            switch (this.Mode)
-            {
-                case "W3C":
-                    this.extractRequest.Headers.Add(TraceContextPropagator.TraceParent, "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-00");
-                    break;
-                case "B3":
-                    this.extractRequest.Headers.Add(B3Propagator.XB3TraceId, "ff000000000000000000000000000041");
-                    this.extractRequest.Headers.Add(B3Propagator.XB3SpanId, "ff00000000000041");
-                    this.extractRequest.Headers.Add(B3Propagator.XB3Sampled, "1");
-                    break;
-            }
+            HttpContext b3Context = new DefaultHttpContext();
+            this.b3ExtractRequest = b3Context.Request;
+            this.b3ExtractRequest.Headers.Add(B3Propagator.XB3TraceId, "ff000000000000000000000000000041");
+            this.b3ExtractRequest.Headers.Add(B3Propagator.XB3SpanId, "ff00000000000041");
+            this.b3ExtractRequest.Headers.Add(B3Propagator.XB3Sampled, "1");
         }
 
         [Benchmark]
-        public void TraceContextPropagator_ExtractBenchmark()
+        [Arguments("Empty")]
+        [Arguments("W3C")]
+        public void TraceContextPropagator_ExtractBenchmark(string mode)
         {
             PropagationContext context = default;
-            this.traceContextPropagator.Extract(ref context, this.extractRequest, CarrierGetter);
+            this.traceContextPropagator.Extract(ref context, mode == "Empty" ? this.emptyExtractRequest : this.w3cExtractRequest, CarrierGetter);
         }
 
         [Benchmark]
@@ -74,16 +74,41 @@ namespace Benchmarks.Context
         }
 
         [Benchmark]
-        public void CompositeTextMapPropagator_ExtractBenchmark()
+        [Arguments("Empty")]
+        [Arguments("B3")]
+        public void B3Propagator_ExtractBenchmark(string mode)
         {
             PropagationContext context = default;
-            this.compositePropagator.Extract(ref context, this.extractRequest, CarrierGetter);
+            this.b3Propagator.Extract(ref context, mode == "Empty" ? this.emptyExtractRequest : this.b3ExtractRequest, CarrierGetter);
+        }
+
+        [Benchmark]
+        public void B3Propagator_InjectBenchmark()
+        {
+            this.b3Propagator.Inject(in this.injectContext, this.injectRequest, CarrierSetter);
+        }
+
+        [Benchmark]
+        [Arguments("Empty")]
+        [Arguments("W3C")]
+        [Arguments("B3")]
+        public void CompositeTextMapPropagator_ExtractBenchmark(string mode)
+        {
+            var request = mode switch
+            {
+                "W3C" => this.w3cExtractRequest,
+                "B3" => this.b3ExtractRequest,
+                _ => this.emptyExtractRequest,
+            };
+
+            PropagationContext context = default;
+            this.compositePropagator.Extract(ref context, request, CarrierGetter);
         }
 
         [Benchmark]
         public void CompositeTextMapPropagator_InjectBenchmark()
         {
-            this.traceContextPropagator.Inject(in this.injectContext, this.injectRequest, CarrierSetter);
+            this.compositePropagator.Inject(in this.injectContext, this.injectRequest, CarrierSetter);
         }
     }
 }

--- a/test/Benchmarks/Context/PropagationBenchmarks.cs
+++ b/test/Benchmarks/Context/PropagationBenchmarks.cs
@@ -1,0 +1,90 @@
+// <copyright file="PropagationBenchmarks.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET6_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.Http;
+using OpenTelemetry.Context.Propagation;
+
+namespace Benchmarks.Context
+{
+    public class PropagationBenchmarks
+    {
+        private static readonly Func<HttpRequest, string, IEnumerable<string>> CarrierGetter = (request, name) => request.Headers[name];
+        private static readonly Action<object, string, string> CarrierSetter = (request, name, value) => { };
+        private readonly TraceContextPropagator traceContextPropagator = new();
+        private readonly TextMapPropagator compositePropagator = new CompositeTextMapPropagator(new TextMapPropagator[] { new TraceContextPropagator(), new BaggagePropagator(), new B3Propagator() });
+        private readonly object injectRequest = new();
+        private readonly PropagationContext injectContext = new(
+            new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded),
+            default);
+
+        private HttpRequest extractRequest;
+
+        [Params("Empty", "W3C", "B3")]
+        public string Mode { get; set; }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            HttpContext context = new DefaultHttpContext();
+
+            this.extractRequest = context.Request;
+
+            switch (this.Mode)
+            {
+                case "W3C":
+                    this.extractRequest.Headers.Add(TraceContextPropagator.TraceParent, "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-00");
+                    break;
+                case "B3":
+                    this.extractRequest.Headers.Add(B3Propagator.XB3TraceId, "ff000000000000000000000000000041");
+                    this.extractRequest.Headers.Add(B3Propagator.XB3SpanId, "ff00000000000041");
+                    this.extractRequest.Headers.Add(B3Propagator.XB3Sampled, "1");
+                    break;
+            }
+        }
+
+        [Benchmark]
+        public void TraceContextPropagator_ExtractBenchmark()
+        {
+            PropagationContext context = default;
+            this.traceContextPropagator.Extract(ref context, this.extractRequest, CarrierGetter);
+        }
+
+        [Benchmark]
+        public void TraceContextPropagator_InjectBenchmark()
+        {
+            this.traceContextPropagator.Inject(in this.injectContext, this.injectRequest, CarrierSetter);
+        }
+
+        [Benchmark]
+        public void CompositeTextMapPropagator_ExtractBenchmark()
+        {
+            PropagationContext context = default;
+            this.compositePropagator.Extract(ref context, this.extractRequest, CarrierGetter);
+        }
+
+        [Benchmark]
+        public void CompositeTextMapPropagator_InjectBenchmark()
+        {
+            this.traceContextPropagator.Inject(in this.injectContext, this.injectRequest, CarrierSetter);
+        }
+    }
+}
+#endif

--- a/test/Benchmarks/Instrumentation/AspNetCoreExtractionBenchmark.cs
+++ b/test/Benchmarks/Instrumentation/AspNetCoreExtractionBenchmark.cs
@@ -1,0 +1,83 @@
+// <copyright file="AspNetCoreExtractionBenchmark.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET6_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.Http;
+using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
+
+namespace Benchmarks.Instrumentation
+{
+    public class AspNetCoreExtractionBenchmark
+    {
+        private const string Traceparent = "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-00";
+        private static readonly Func<HttpRequest, string, IEnumerable<string>> CarrierGetter = (request, name) => request.Headers[name];
+        private static readonly ActivityContext RandomActivityContext = new(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded);
+        private static readonly ActivityContext MatchActivityContext = ActivityContext.Parse(Traceparent, traceState: null);
+        private static readonly TextMapPropagator Propagator = new CompositeTextMapPropagator(new TextMapPropagator[]
+        {
+            new TraceContextPropagator(),
+            new BaggagePropagator(),
+        });
+
+        private readonly HttpRequest w3cExtractRequest;
+
+        public AspNetCoreExtractionBenchmark()
+        {
+            HttpContext w3cContext = new DefaultHttpContext();
+            this.w3cExtractRequest = w3cContext.Request;
+            this.w3cExtractRequest.Headers.Add(TraceContextPropagator.TraceParent, Traceparent);
+        }
+
+        [Benchmark]
+        [Arguments(true)]
+        [Arguments(false)]
+        public Activity AspNetCoreExtractBenchmark(bool match)
+        {
+            ActivityContext compareContext = match ? MatchActivityContext : RandomActivityContext;
+            Activity createdActivity = null;
+
+            var textMapPropagator = Propagator;
+            if (textMapPropagator is not TraceContextPropagator)
+            {
+                PropagationContext ctx = default;
+                textMapPropagator.Extract(ref ctx, this.w3cExtractRequest, CarrierGetter);
+
+                ref readonly ActivityContext activityContext = ref PropagationContext.GetActivityContextRef(in ctx);
+
+                if (ActivityContextExtensions.IsValid(in activityContext)
+                    && (!activityContext.TraceId.Equals(compareContext.TraceId)
+                    || !activityContext.SpanId.Equals(compareContext.SpanId)
+                    || activityContext.TraceFlags != compareContext.TraceFlags
+                    || activityContext.TraceState != compareContext.TraceState))
+                {
+                    createdActivity = new Activity("InnerActivity");
+                    createdActivity.SetParentId(activityContext.TraceId, activityContext.SpanId, activityContext.TraceFlags);
+                    createdActivity.TraceStateString = activityContext.TraceState;
+                }
+
+                Baggage.Current = ctx.Baggage;
+            }
+
+            return createdActivity;
+        }
+    }
+}
+#endif

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/HttpInListenerTests.cs
@@ -24,6 +24,7 @@ using System.Web;
 using System.Web.Routing;
 using Moq;
 using OpenTelemetry.Context.Propagation;
+using OpenTelemetry.Context.Propagation.Tests;
 using OpenTelemetry.Instrumentation.AspNet.Implementation;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
@@ -258,16 +259,14 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
                 new HttpResponse(new StringWriter()));
 
             bool isPropagatorCalled = false;
-            var propagator = new Mock<TextMapPropagator>();
-            propagator.Setup(m => m.Extract(It.IsAny<PropagationContext>(), It.IsAny<HttpRequest>(), It.IsAny<Func<HttpRequest, string, IEnumerable<string>>>()))
-                .Returns(() =>
+            var propagator = new TestPropagator<HttpRequest>(
+                extractDelegate: (ref PropagationContext context, HttpRequest request, Func<HttpRequest, string, IEnumerable<string>> getter) =>
                 {
                     isPropagatorCalled = true;
-                    return default;
                 });
 
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            Sdk.SetDefaultTextMapPropagator(propagator.Object);
+            Sdk.SetDefaultTextMapPropagator(propagator);
             using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .SetSampler(new TestSampler(samplingDecision))
                 .AddAspNetInstrumentation()
@@ -294,17 +293,15 @@ namespace OpenTelemetry.Instrumentation.AspNet.Tests
                 new HttpResponse(new StringWriter()));
 
             bool isPropagatorCalled = false;
-            var propagator = new Mock<TextMapPropagator>();
-            propagator.Setup(m => m.Extract(It.IsAny<PropagationContext>(), It.IsAny<HttpRequest>(), It.IsAny<Func<HttpRequest, string, IEnumerable<string>>>()))
-                .Returns(() =>
+            var propagator = new TestPropagator<HttpRequest>(
+                extractDelegate: (ref PropagationContext context, HttpRequest request, Func<HttpRequest, string, IEnumerable<string>> getter) =>
                 {
                     isPropagatorCalled = true;
-                    return default;
                 });
 
             bool isFilterCalled = false;
             var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            Sdk.SetDefaultTextMapPropagator(propagator.Object);
+            Sdk.SetDefaultTextMapPropagator(propagator);
             using (var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddAspNetInstrumentation(options =>
                 {

--- a/test/OpenTelemetry.Instrumentation.AspNet.Tests/OpenTelemetry.Instrumentation.AspNet.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.AspNet.Tests/OpenTelemetry.Instrumentation.AspNet.Tests.csproj
@@ -30,5 +30,6 @@
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\EventSourceTestHelper.cs" Link="EventSourceTestHelper.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestEventListener.cs" Link="TestEventListener.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\InMemoryEventListener.cs" Link="InMemoryEventListener.cs" />
+    <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestPropagator{TCarrier}.cs" Link="TestPropagator{TCarrier}.cs" />
   </ItemGroup>
 </Project>

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/OpenTelemetry.Instrumentation.AspNetCore.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/OpenTelemetry.Instrumentation.AspNetCore.Tests.csproj
@@ -25,6 +25,7 @@
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\EventSourceTestHelper.cs" Link="EventSourceTestHelper.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\InMemoryEventListener.cs" Link="InMemoryEventListener.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestEventListener.cs" Link="TestEventListener.cs" />
+    <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestPropagator{TCarrier}.cs" Link="TestPropagator{TCarrier}.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/OpenTelemetry.Instrumentation.Grpc.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/OpenTelemetry.Instrumentation.Grpc.Tests.csproj
@@ -35,8 +35,12 @@
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.AspNetCore\OpenTelemetry.Instrumentation.AspNetCore.csproj" />
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.GrpcNetClient\OpenTelemetry.Instrumentation.GrpcNetClient.csproj" />
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.Http\OpenTelemetry.Instrumentation.Http.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\EventSourceTestHelper.cs" Link="EventSourceTestHelper.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestEventListener.cs" Link="TestEventListener.cs" />
+    <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestPropagator{TCarrier}.cs" Link="TestPropagator{TCarrier}.cs" />
   </ItemGroup>
 
 </Project>

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/OpenTelemetry.Instrumentation.Http.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/OpenTelemetry.Instrumentation.Http.Tests.csproj
@@ -12,6 +12,7 @@
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\EventSourceTestHelper.cs" Link="EventSourceTestHelper.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestEventListener.cs" Link="TestEventListener.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\InMemoryEventListener.cs" Link="InMemoryEventListener.cs" />
+    <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestPropagator{TCarrier}.cs" Link="TestPropagator{TCarrier}.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Tests/Shared/TestPropagator{TCarrier}.cs
+++ b/test/OpenTelemetry.Tests/Shared/TestPropagator{TCarrier}.cs
@@ -1,0 +1,69 @@
+// <copyright file="TestPropagator{TCarrier}.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+
+namespace OpenTelemetry.Context.Propagation.Tests
+{
+    internal sealed class TestPropagator<TCarrier> : TextMapPropagator
+    {
+        private static readonly ExtractDelegate NoopExtract = (ref PropagationContext context, TCarrier carrier, Func<TCarrier, string, IEnumerable<string>> getter) => { };
+        private static readonly InjectDelegate NoopInject = (in PropagationContext context, TCarrier carrier, Action<TCarrier, string, string> setter) => { };
+
+        private readonly ExtractDelegate extractDelegate;
+        private readonly InjectDelegate injectDelegate;
+
+        public TestPropagator(ExtractDelegate extractDelegate = null, InjectDelegate injectDelegate = null)
+        {
+            this.extractDelegate = extractDelegate ?? NoopExtract;
+            this.injectDelegate = injectDelegate ?? NoopInject;
+        }
+
+        public delegate void ExtractDelegate(ref PropagationContext context, TCarrier carrier, Func<TCarrier, string, IEnumerable<string>> getter);
+
+        public delegate void InjectDelegate(in PropagationContext context, TCarrier carrier, Action<TCarrier, string, string> setter);
+
+        public override ISet<string> Fields => null;
+
+        public override PropagationContext Extract<T>(PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter)
+        {
+            this.Extract(ref context, carrier, getter);
+            return context;
+        }
+
+        public override void Extract<T>(ref PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter)
+        {
+            if (carrier is TCarrier typedCarrier)
+            {
+                this.extractDelegate(ref context, typedCarrier, (Func<TCarrier, string, IEnumerable<string>>)(object)getter);
+            }
+        }
+
+        public override void Inject<T>(PropagationContext context, T carrier, Action<T, string, string> setter)
+        {
+            this.Inject(in context, carrier, setter);
+        }
+
+        public override void Inject<T>(in PropagationContext context, T carrier, Action<T, string, string> setter)
+        {
+            if (carrier is TCarrier typedCarrier)
+            {
+                this.injectDelegate(in context, typedCarrier, (Action<TCarrier, string, string>)(object)setter);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Changes

`ActivityContext` & `PropagationContext` are large structs. Passing them by value means they are copied. The [.NET guidance is to pass large struct by in/ref](https://docs.microsoft.com/en-us/dotnet/csharp/write-safe-efficient-code#use-in-parameters-for-large-structs). This is especially noticeable with the composite propagator which makes a lot of copies as it recurses. My goal with this PR was to pass by ref (`in` or `ref`) in a way that would be backwards compatible with existing propagators/instrumentation.

Before:
|                                      Method |  mode |      Mean |    Error |   StdDev |  Gen 0 | Allocated |
|-------------------------------------------- |------ |----------:|---------:|---------:|-------:|----------:|
|      TraceContextPropagator_InjectBenchmark |     ? |  42.52 ns | 0.659 ns | 0.809 ns | 0.0210 |     264 B |
|                B3Propagator_InjectBenchmark |     ? |  14.27 ns | 0.121 ns | 0.101 ns |      - |         - |
|  CompositeTextMapPropagator_InjectBenchmark |     ? |  76.72 ns | 0.662 ns | 0.553 ns | 0.0210 |     264 B |
|               B3Propagator_ExtractBenchmark |    B3 | 220.19 ns | 2.877 ns | 5.812 ns | 0.0172 |     216 B |
| CompositeTextMapPropagator_ExtractBenchmark |    B3 | 346.86 ns | 1.728 ns | 1.532 ns | 0.0210 |     264 B |
|     TraceContextPropagator_ExtractBenchmark | Empty |  34.67 ns | 0.703 ns | 0.623 ns | 0.0019 |      24 B |
|               B3Propagator_ExtractBenchmark | Empty |  39.79 ns | 0.129 ns | 0.107 ns | 0.0019 |      24 B |
| CompositeTextMapPropagator_ExtractBenchmark | Empty | 123.64 ns | 1.152 ns | 1.131 ns | 0.0057 |      72 B |
|     TraceContextPropagator_ExtractBenchmark |   W3C | 177.61 ns | 2.163 ns | 1.806 ns | 0.0153 |     192 B |
| CompositeTextMapPropagator_ExtractBenchmark |   W3C | 253.52 ns | 1.887 ns | 1.854 ns | 0.0172 |     216 B |

After:
|                                      Method |  mode |      Mean |    Error |   StdDev |  Gen 0 | Allocated |
|-------------------------------------------- |------ |----------:|---------:|---------:|-------:|----------:|
|      TraceContextPropagator_InjectBenchmark |     ? |  39.90 ns | 0.314 ns | 0.278 ns | 0.0210 |     264 B |
|                B3Propagator_InjectBenchmark |     ? |  12.46 ns | 0.189 ns | 0.177 ns |      - |         - |
|  CompositeTextMapPropagator_InjectBenchmark |     ? |  72.59 ns | 0.424 ns | 0.396 ns | 0.0210 |     264 B |
|               B3Propagator_ExtractBenchmark |    B3 | 206.05 ns | 0.503 ns | 0.470 ns | 0.0172 |     216 B |
| CompositeTextMapPropagator_ExtractBenchmark |    B3 | 317.80 ns | 0.824 ns | 0.688 ns | 0.0210 |     264 B |
|     TraceContextPropagator_ExtractBenchmark | Empty |  23.20 ns | 0.067 ns | 0.062 ns | 0.0019 |      24 B |
|               B3Propagator_ExtractBenchmark | Empty |  33.55 ns | 0.115 ns | 0.096 ns | 0.0019 |      24 B |
| CompositeTextMapPropagator_ExtractBenchmark | Empty | 100.98 ns | 0.253 ns | 0.225 ns | 0.0057 |      72 B |
|     TraceContextPropagator_ExtractBenchmark |   W3C | 164.99 ns | 0.414 ns | 0.387 ns | 0.0153 |     192 B |
| CompositeTextMapPropagator_ExtractBenchmark |   W3C | 232.80 ns | 0.501 ns | 0.391 ns | 0.0172 |     216 B |

TODOs:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Changes in public API reviewed
