### PR TITLE
[SDK] More nullable annotations for logging API

### DIFF
--- a/src/OpenTelemetry/.publicApi/net462/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry/.publicApi/net462/PublicAPI.Shipped.txt
@@ -63,22 +63,22 @@ OpenTelemetry.Logs.LogRecord.FormattedMessage.get -> string?
 OpenTelemetry.Logs.LogRecord.LogLevel.get -> Microsoft.Extensions.Logging.LogLevel
 OpenTelemetry.Logs.LogRecord.SpanId.get -> System.Diagnostics.ActivitySpanId
 OpenTelemetry.Logs.LogRecord.State.get -> object?
-OpenTelemetry.Logs.LogRecord.StateValues.get -> System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string!, object!>>?
+OpenTelemetry.Logs.LogRecord.StateValues.get -> System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string!, object?>>?
 OpenTelemetry.Logs.LogRecord.Timestamp.get -> System.DateTime
 OpenTelemetry.Logs.LogRecord.TraceFlags.get -> System.Diagnostics.ActivityTraceFlags
 OpenTelemetry.Logs.LogRecord.TraceId.get -> System.Diagnostics.ActivityTraceId
 OpenTelemetry.Logs.LogRecord.TraceState.get -> string?
 OpenTelemetry.Logs.LogRecordScope
 OpenTelemetry.Logs.LogRecordScope.Enumerator
-~OpenTelemetry.Logs.LogRecordScope.Enumerator.Current.get -> System.Collections.Generic.KeyValuePair<string, object>
+OpenTelemetry.Logs.LogRecordScope.Enumerator.Current.get -> System.Collections.Generic.KeyValuePair<string!, object?>
 OpenTelemetry.Logs.LogRecordScope.Enumerator.Dispose() -> void
 OpenTelemetry.Logs.LogRecordScope.Enumerator.Enumerator() -> void
-~OpenTelemetry.Logs.LogRecordScope.Enumerator.Enumerator(object scope) -> void
+OpenTelemetry.Logs.LogRecordScope.Enumerator.Enumerator(object? scope) -> void
 OpenTelemetry.Logs.LogRecordScope.Enumerator.MoveNext() -> bool
 OpenTelemetry.Logs.LogRecordScope.Enumerator.Reset() -> void
 OpenTelemetry.Logs.LogRecordScope.GetEnumerator() -> OpenTelemetry.Logs.LogRecordScope.Enumerator
 OpenTelemetry.Logs.LogRecordScope.LogRecordScope() -> void
-~OpenTelemetry.Logs.LogRecordScope.Scope.get -> object
+OpenTelemetry.Logs.LogRecordScope.Scope.get -> object?
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions
 ~OpenTelemetry.Logs.OpenTelemetryLoggerOptions.AddProcessor(OpenTelemetry.BaseProcessor<OpenTelemetry.Logs.LogRecord> processor) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeFormattedMessage.get -> bool
@@ -90,8 +90,8 @@ OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.get -> bool
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.set -> void
 ~OpenTelemetry.Logs.OpenTelemetryLoggerOptions.SetResourceBuilder(OpenTelemetry.Resources.ResourceBuilder resourceBuilder) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions
 OpenTelemetry.Logs.OpenTelemetryLoggerProvider
-~OpenTelemetry.Logs.OpenTelemetryLoggerProvider.CreateLogger(string categoryName) -> Microsoft.Extensions.Logging.ILogger
-~OpenTelemetry.Logs.OpenTelemetryLoggerProvider.OpenTelemetryLoggerProvider(Microsoft.Extensions.Options.IOptionsMonitor<OpenTelemetry.Logs.OpenTelemetryLoggerOptions> options) -> void
+OpenTelemetry.Logs.OpenTelemetryLoggerProvider.CreateLogger(string! categoryName) -> Microsoft.Extensions.Logging.ILogger!
+OpenTelemetry.Logs.OpenTelemetryLoggerProvider.OpenTelemetryLoggerProvider(Microsoft.Extensions.Options.IOptionsMonitor<OpenTelemetry.Logs.OpenTelemetryLoggerOptions!>! options) -> void
 OpenTelemetry.Metrics.AggregationTemporality
 OpenTelemetry.Metrics.AggregationTemporality.Cumulative = 1 -> OpenTelemetry.Metrics.AggregationTemporality
 OpenTelemetry.Metrics.AggregationTemporality.Delta = 2 -> OpenTelemetry.Metrics.AggregationTemporality

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Shipped.txt
@@ -63,22 +63,22 @@ OpenTelemetry.Logs.LogRecord.FormattedMessage.get -> string?
 OpenTelemetry.Logs.LogRecord.LogLevel.get -> Microsoft.Extensions.Logging.LogLevel
 OpenTelemetry.Logs.LogRecord.SpanId.get -> System.Diagnostics.ActivitySpanId
 OpenTelemetry.Logs.LogRecord.State.get -> object?
-OpenTelemetry.Logs.LogRecord.StateValues.get -> System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string!, object!>>?
+OpenTelemetry.Logs.LogRecord.StateValues.get -> System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string!, object?>>?
 OpenTelemetry.Logs.LogRecord.Timestamp.get -> System.DateTime
 OpenTelemetry.Logs.LogRecord.TraceFlags.get -> System.Diagnostics.ActivityTraceFlags
 OpenTelemetry.Logs.LogRecord.TraceId.get -> System.Diagnostics.ActivityTraceId
 OpenTelemetry.Logs.LogRecord.TraceState.get -> string?
 OpenTelemetry.Logs.LogRecordScope
 OpenTelemetry.Logs.LogRecordScope.Enumerator
-~OpenTelemetry.Logs.LogRecordScope.Enumerator.Current.get -> System.Collections.Generic.KeyValuePair<string, object>
+OpenTelemetry.Logs.LogRecordScope.Enumerator.Current.get -> System.Collections.Generic.KeyValuePair<string!, object?>
 OpenTelemetry.Logs.LogRecordScope.Enumerator.Dispose() -> void
 OpenTelemetry.Logs.LogRecordScope.Enumerator.Enumerator() -> void
-~OpenTelemetry.Logs.LogRecordScope.Enumerator.Enumerator(object scope) -> void
+OpenTelemetry.Logs.LogRecordScope.Enumerator.Enumerator(object? scope) -> void
 OpenTelemetry.Logs.LogRecordScope.Enumerator.MoveNext() -> bool
 OpenTelemetry.Logs.LogRecordScope.Enumerator.Reset() -> void
 OpenTelemetry.Logs.LogRecordScope.GetEnumerator() -> OpenTelemetry.Logs.LogRecordScope.Enumerator
 OpenTelemetry.Logs.LogRecordScope.LogRecordScope() -> void
-~OpenTelemetry.Logs.LogRecordScope.Scope.get -> object
+OpenTelemetry.Logs.LogRecordScope.Scope.get -> object?
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions
 ~OpenTelemetry.Logs.OpenTelemetryLoggerOptions.AddProcessor(OpenTelemetry.BaseProcessor<OpenTelemetry.Logs.LogRecord> processor) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeFormattedMessage.get -> bool
@@ -90,8 +90,8 @@ OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.get -> bool
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.set -> void
 ~OpenTelemetry.Logs.OpenTelemetryLoggerOptions.SetResourceBuilder(OpenTelemetry.Resources.ResourceBuilder resourceBuilder) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions
 OpenTelemetry.Logs.OpenTelemetryLoggerProvider
-~OpenTelemetry.Logs.OpenTelemetryLoggerProvider.CreateLogger(string categoryName) -> Microsoft.Extensions.Logging.ILogger
-~OpenTelemetry.Logs.OpenTelemetryLoggerProvider.OpenTelemetryLoggerProvider(Microsoft.Extensions.Options.IOptionsMonitor<OpenTelemetry.Logs.OpenTelemetryLoggerOptions> options) -> void
+OpenTelemetry.Logs.OpenTelemetryLoggerProvider.CreateLogger(string! categoryName) -> Microsoft.Extensions.Logging.ILogger!
+OpenTelemetry.Logs.OpenTelemetryLoggerProvider.OpenTelemetryLoggerProvider(Microsoft.Extensions.Options.IOptionsMonitor<OpenTelemetry.Logs.OpenTelemetryLoggerOptions!>! options) -> void
 OpenTelemetry.Metrics.AggregationTemporality
 OpenTelemetry.Metrics.AggregationTemporality.Cumulative = 1 -> OpenTelemetry.Metrics.AggregationTemporality
 OpenTelemetry.Metrics.AggregationTemporality.Delta = 2 -> OpenTelemetry.Metrics.AggregationTemporality

--- a/src/OpenTelemetry/Logs/LogRecord.cs
+++ b/src/OpenTelemetry/Logs/LogRecord.cs
@@ -29,12 +29,12 @@ namespace OpenTelemetry.Logs
     /// </summary>
     public sealed class LogRecord
     {
-        private static readonly Action<object, List<object>> AddScopeToBufferedList = (object scope, List<object> state) =>
+        private static readonly Action<object?, List<object?>> AddScopeToBufferedList = (object? scope, List<object?> state) =>
         {
             state.Add(scope);
         };
 
-        private List<object>? bufferedScopes;
+        private List<object?>? bufferedScopes;
 
         internal LogRecord(
             IExternalScopeProvider? scopeProvider,
@@ -45,7 +45,7 @@ namespace OpenTelemetry.Logs
             string? formattedMessage,
             object? state,
             Exception? exception,
-            IReadOnlyList<KeyValuePair<string, object>>? stateValues)
+            IReadOnlyList<KeyValuePair<string, object?>>? stateValues)
         {
             this.ScopeProvider = scopeProvider;
 
@@ -98,7 +98,7 @@ namespace OpenTelemetry.Logs
         /// cref="OpenTelemetryLoggerOptions.ParseStateValues"/> is enabled
         /// otherwise <see langword="null"/>.
         /// </summary>
-        public IReadOnlyList<KeyValuePair<string, object>>? StateValues { get; set; }
+        public IReadOnlyList<KeyValuePair<string, object?>>? StateValues { get; set; }
 
         public Exception? Exception { get; }
 
@@ -127,7 +127,7 @@ namespace OpenTelemetry.Logs
 
             if (this.bufferedScopes != null)
             {
-                foreach (object scope in this.bufferedScopes)
+                foreach (object? scope in this.bufferedScopes)
                 {
                     ScopeForEachState<TState>.ForEachScope(scope, forEachScopeState);
                 }
@@ -149,7 +149,7 @@ namespace OpenTelemetry.Logs
                 return;
             }
 
-            List<object> scopes = new List<object>();
+            List<object?> scopes = new List<object?>();
 
             this.ScopeProvider?.ForEachScope(AddScopeToBufferedList, scopes);
 
@@ -158,7 +158,7 @@ namespace OpenTelemetry.Logs
 
         private readonly struct ScopeForEachState<TState>
         {
-            public static readonly Action<object, ScopeForEachState<TState>> ForEachScope = (object scope, ScopeForEachState<TState> state) =>
+            public static readonly Action<object?, ScopeForEachState<TState>> ForEachScope = (object? scope, ScopeForEachState<TState> state) =>
             {
                 LogRecordScope logRecordScope = new LogRecordScope(scope);
 

--- a/src/OpenTelemetry/Logs/LogRecordScope.cs
+++ b/src/OpenTelemetry/Logs/LogRecordScope.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -25,7 +27,7 @@ namespace OpenTelemetry.Logs
     /// </summary>
     public readonly struct LogRecordScope
     {
-        internal LogRecordScope(object scope)
+        internal LogRecordScope(object? scope)
         {
             this.Scope = scope;
         }
@@ -33,7 +35,7 @@ namespace OpenTelemetry.Logs
         /// <summary>
         /// Gets the raw scope value.
         /// </summary>
-        public object Scope { get; }
+        public object? Scope { get; }
 
         /// <summary>
         /// Gets an <see cref="IEnumerator"/> for looping over the inner values
@@ -45,26 +47,26 @@ namespace OpenTelemetry.Logs
         /// <summary>
         /// LogRecordScope enumerator.
         /// </summary>
-        public struct Enumerator : IEnumerator<KeyValuePair<string, object>>
+        public struct Enumerator : IEnumerator<KeyValuePair<string, object?>>
         {
-            private readonly IReadOnlyList<KeyValuePair<string, object>> scope;
+            private readonly IReadOnlyList<KeyValuePair<string, object?>> scope;
             private int position;
 
-            public Enumerator(object scope)
+            public Enumerator(object? scope)
             {
-                if (scope is IReadOnlyList<KeyValuePair<string, object>> scopeList)
+                if (scope is IReadOnlyList<KeyValuePair<string, object?>> scopeList)
                 {
                     this.scope = scopeList;
                 }
-                else if (scope is IEnumerable<KeyValuePair<string, object>> scopeEnumerable)
+                else if (scope is IEnumerable<KeyValuePair<string, object?>> scopeEnumerable)
                 {
-                    this.scope = new List<KeyValuePair<string, object>>(scopeEnumerable);
+                    this.scope = new List<KeyValuePair<string, object?>>(scopeEnumerable);
                 }
                 else
                 {
-                    this.scope = new List<KeyValuePair<string, object>>
+                    this.scope = new List<KeyValuePair<string, object?>>
                     {
-                        new KeyValuePair<string, object>(string.Empty, scope),
+                        new KeyValuePair<string, object?>(string.Empty, scope),
                     };
                 }
 
@@ -72,7 +74,7 @@ namespace OpenTelemetry.Logs
                 this.Current = default;
             }
 
-            public KeyValuePair<string, object> Current { get; private set; }
+            public KeyValuePair<string, object?> Current { get; private set; }
 
             object IEnumerator.Current => this.Current;
 


### PR DESCRIPTION
More nullable annotations for the SDK logging API. Fixed up some missing XML comments on `OpenTelemetryLoggerProvider`.

Follow-up to #3301 