### PR TITLE
[SDK] Final round of nullable annotations for the logging API

### DIFF
--- a/src/OpenTelemetry/.publicApi/net462/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry/.publicApi/net462/PublicAPI.Shipped.txt
@@ -44,7 +44,7 @@ OpenTelemetry.BatchExportProcessorOptions<T>.MaxQueueSize.set -> void
 OpenTelemetry.BatchExportProcessorOptions<T>.ScheduledDelayMilliseconds.get -> int
 OpenTelemetry.BatchExportProcessorOptions<T>.ScheduledDelayMilliseconds.set -> void
 OpenTelemetry.BatchLogRecordExportProcessor
-~OpenTelemetry.BatchLogRecordExportProcessor.BatchLogRecordExportProcessor(OpenTelemetry.BaseExporter<OpenTelemetry.Logs.LogRecord> exporter, int maxQueueSize = 2048, int scheduledDelayMilliseconds = 5000, int exporterTimeoutMilliseconds = 30000, int maxExportBatchSize = 512) -> void
+OpenTelemetry.BatchLogRecordExportProcessor.BatchLogRecordExportProcessor(OpenTelemetry.BaseExporter<OpenTelemetry.Logs.LogRecord!>! exporter, int maxQueueSize = 2048, int scheduledDelayMilliseconds = 5000, int exporterTimeoutMilliseconds = 30000, int maxExportBatchSize = 512) -> void
 OpenTelemetry.CompositeProcessor<T>
 ~OpenTelemetry.CompositeProcessor<T>.AddProcessor(OpenTelemetry.BaseProcessor<T> processor) -> OpenTelemetry.CompositeProcessor<T>
 ~OpenTelemetry.CompositeProcessor<T>.CompositeProcessor(System.Collections.Generic.IEnumerable<OpenTelemetry.BaseProcessor<T>> processors) -> void
@@ -80,7 +80,7 @@ OpenTelemetry.Logs.LogRecordScope.GetEnumerator() -> OpenTelemetry.Logs.LogRecor
 OpenTelemetry.Logs.LogRecordScope.LogRecordScope() -> void
 OpenTelemetry.Logs.LogRecordScope.Scope.get -> object?
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions
-~OpenTelemetry.Logs.OpenTelemetryLoggerOptions.AddProcessor(OpenTelemetry.BaseProcessor<OpenTelemetry.Logs.LogRecord> processor) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions
+OpenTelemetry.Logs.OpenTelemetryLoggerOptions.AddProcessor(OpenTelemetry.BaseProcessor<OpenTelemetry.Logs.LogRecord!>! processor) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeFormattedMessage.get -> bool
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeFormattedMessage.set -> void
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeScopes.get -> bool
@@ -88,7 +88,7 @@ OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeScopes.set -> void
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.OpenTelemetryLoggerOptions() -> void
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.get -> bool
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.set -> void
-~OpenTelemetry.Logs.OpenTelemetryLoggerOptions.SetResourceBuilder(OpenTelemetry.Resources.ResourceBuilder resourceBuilder) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions
+OpenTelemetry.Logs.OpenTelemetryLoggerOptions.SetResourceBuilder(OpenTelemetry.Resources.ResourceBuilder! resourceBuilder) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
 OpenTelemetry.Logs.OpenTelemetryLoggerProvider
 OpenTelemetry.Logs.OpenTelemetryLoggerProvider.CreateLogger(string! categoryName) -> Microsoft.Extensions.Logging.ILogger!
 OpenTelemetry.Logs.OpenTelemetryLoggerProvider.OpenTelemetryLoggerProvider(Microsoft.Extensions.Options.IOptionsMonitor<OpenTelemetry.Logs.OpenTelemetryLoggerOptions!>! options) -> void
@@ -219,7 +219,7 @@ OpenTelemetry.SimpleActivityExportProcessor
 ~OpenTelemetry.SimpleExportProcessor<T>
 ~OpenTelemetry.SimpleExportProcessor<T>.SimpleExportProcessor(OpenTelemetry.BaseExporter<T> exporter) -> void
 OpenTelemetry.SimpleLogRecordExportProcessor
-~OpenTelemetry.SimpleLogRecordExportProcessor.SimpleLogRecordExportProcessor(OpenTelemetry.BaseExporter<OpenTelemetry.Logs.LogRecord> exporter) -> void
+OpenTelemetry.SimpleLogRecordExportProcessor.SimpleLogRecordExportProcessor(OpenTelemetry.BaseExporter<OpenTelemetry.Logs.LogRecord!>! exporter) -> void
 OpenTelemetry.SuppressInstrumentationScope
 OpenTelemetry.SuppressInstrumentationScope.Dispose() -> void
 OpenTelemetry.Trace.AlwaysOffSampler
@@ -273,7 +273,7 @@ override OpenTelemetry.BatchExportProcessor<T>.Dispose(bool disposing) -> void
 ~override OpenTelemetry.BatchExportProcessor<T>.OnExport(T data) -> void
 override OpenTelemetry.BatchExportProcessor<T>.OnForceFlush(int timeoutMilliseconds) -> bool
 override OpenTelemetry.BatchExportProcessor<T>.OnShutdown(int timeoutMilliseconds) -> bool
-~override OpenTelemetry.BatchLogRecordExportProcessor.OnEnd(OpenTelemetry.Logs.LogRecord data) -> void
+override OpenTelemetry.BatchLogRecordExportProcessor.OnEnd(OpenTelemetry.Logs.LogRecord! data) -> void
 override OpenTelemetry.CompositeProcessor<T>.Dispose(bool disposing) -> void
 override OpenTelemetry.CompositeProcessor<T>.OnEnd(T data) -> void
 override OpenTelemetry.CompositeProcessor<T>.OnForceFlush(int timeoutMilliseconds) -> bool
@@ -301,7 +301,7 @@ override OpenTelemetry.Trace.TraceIdRatioBasedSampler.ShouldSample(in OpenTeleme
 ~override sealed OpenTelemetry.BaseExportProcessor<T>.OnStart(T data) -> void
 ~readonly OpenTelemetry.BaseExportProcessor<T>.exporter -> OpenTelemetry.BaseExporter<T>
 ~readonly OpenTelemetry.Metrics.BaseExportingMetricReader.exporter -> OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric>
-~static Microsoft.Extensions.Logging.OpenTelemetryLoggingExtensions.AddOpenTelemetry(this Microsoft.Extensions.Logging.ILoggingBuilder builder, System.Action<OpenTelemetry.Logs.OpenTelemetryLoggerOptions> configure = null) -> Microsoft.Extensions.Logging.ILoggingBuilder
+static Microsoft.Extensions.Logging.OpenTelemetryLoggingExtensions.AddOpenTelemetry(this Microsoft.Extensions.Logging.ILoggingBuilder! builder, System.Action<OpenTelemetry.Logs.OpenTelemetryLoggerOptions!>? configure = null) -> Microsoft.Extensions.Logging.ILoggingBuilder!
 ~static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.AddReader(this OpenTelemetry.Metrics.MeterProviderBuilder meterProviderBuilder, OpenTelemetry.Metrics.MetricReader reader) -> OpenTelemetry.Metrics.MeterProviderBuilder
 ~static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.AddView(this OpenTelemetry.Metrics.MeterProviderBuilder meterProviderBuilder, string instrumentName, OpenTelemetry.Metrics.MetricStreamConfiguration metricStreamConfiguration) -> OpenTelemetry.Metrics.MeterProviderBuilder
 ~static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.AddView(this OpenTelemetry.Metrics.MeterProviderBuilder meterProviderBuilder, string instrumentName, string name) -> OpenTelemetry.Metrics.MeterProviderBuilder

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Shipped.txt
@@ -44,7 +44,7 @@ OpenTelemetry.BatchExportProcessorOptions<T>.MaxQueueSize.set -> void
 OpenTelemetry.BatchExportProcessorOptions<T>.ScheduledDelayMilliseconds.get -> int
 OpenTelemetry.BatchExportProcessorOptions<T>.ScheduledDelayMilliseconds.set -> void
 OpenTelemetry.BatchLogRecordExportProcessor
-~OpenTelemetry.BatchLogRecordExportProcessor.BatchLogRecordExportProcessor(OpenTelemetry.BaseExporter<OpenTelemetry.Logs.LogRecord> exporter, int maxQueueSize = 2048, int scheduledDelayMilliseconds = 5000, int exporterTimeoutMilliseconds = 30000, int maxExportBatchSize = 512) -> void
+OpenTelemetry.BatchLogRecordExportProcessor.BatchLogRecordExportProcessor(OpenTelemetry.BaseExporter<OpenTelemetry.Logs.LogRecord!>! exporter, int maxQueueSize = 2048, int scheduledDelayMilliseconds = 5000, int exporterTimeoutMilliseconds = 30000, int maxExportBatchSize = 512) -> void
 OpenTelemetry.CompositeProcessor<T>
 ~OpenTelemetry.CompositeProcessor<T>.AddProcessor(OpenTelemetry.BaseProcessor<T> processor) -> OpenTelemetry.CompositeProcessor<T>
 ~OpenTelemetry.CompositeProcessor<T>.CompositeProcessor(System.Collections.Generic.IEnumerable<OpenTelemetry.BaseProcessor<T>> processors) -> void
@@ -80,7 +80,7 @@ OpenTelemetry.Logs.LogRecordScope.GetEnumerator() -> OpenTelemetry.Logs.LogRecor
 OpenTelemetry.Logs.LogRecordScope.LogRecordScope() -> void
 OpenTelemetry.Logs.LogRecordScope.Scope.get -> object?
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions
-~OpenTelemetry.Logs.OpenTelemetryLoggerOptions.AddProcessor(OpenTelemetry.BaseProcessor<OpenTelemetry.Logs.LogRecord> processor) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions
+OpenTelemetry.Logs.OpenTelemetryLoggerOptions.AddProcessor(OpenTelemetry.BaseProcessor<OpenTelemetry.Logs.LogRecord!>! processor) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeFormattedMessage.get -> bool
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeFormattedMessage.set -> void
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeScopes.get -> bool
@@ -88,7 +88,7 @@ OpenTelemetry.Logs.OpenTelemetryLoggerOptions.IncludeScopes.set -> void
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.OpenTelemetryLoggerOptions() -> void
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.get -> bool
 OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ParseStateValues.set -> void
-~OpenTelemetry.Logs.OpenTelemetryLoggerOptions.SetResourceBuilder(OpenTelemetry.Resources.ResourceBuilder resourceBuilder) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions
+OpenTelemetry.Logs.OpenTelemetryLoggerOptions.SetResourceBuilder(OpenTelemetry.Resources.ResourceBuilder! resourceBuilder) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
 OpenTelemetry.Logs.OpenTelemetryLoggerProvider
 OpenTelemetry.Logs.OpenTelemetryLoggerProvider.CreateLogger(string! categoryName) -> Microsoft.Extensions.Logging.ILogger!
 OpenTelemetry.Logs.OpenTelemetryLoggerProvider.OpenTelemetryLoggerProvider(Microsoft.Extensions.Options.IOptionsMonitor<OpenTelemetry.Logs.OpenTelemetryLoggerOptions!>! options) -> void
@@ -219,7 +219,7 @@ OpenTelemetry.SimpleActivityExportProcessor
 ~OpenTelemetry.SimpleExportProcessor<T>
 ~OpenTelemetry.SimpleExportProcessor<T>.SimpleExportProcessor(OpenTelemetry.BaseExporter<T> exporter) -> void
 OpenTelemetry.SimpleLogRecordExportProcessor
-~OpenTelemetry.SimpleLogRecordExportProcessor.SimpleLogRecordExportProcessor(OpenTelemetry.BaseExporter<OpenTelemetry.Logs.LogRecord> exporter) -> void
+OpenTelemetry.SimpleLogRecordExportProcessor.SimpleLogRecordExportProcessor(OpenTelemetry.BaseExporter<OpenTelemetry.Logs.LogRecord!>! exporter) -> void
 OpenTelemetry.SuppressInstrumentationScope
 OpenTelemetry.SuppressInstrumentationScope.Dispose() -> void
 OpenTelemetry.Trace.AlwaysOffSampler
@@ -273,7 +273,7 @@ override OpenTelemetry.BatchExportProcessor<T>.Dispose(bool disposing) -> void
 ~override OpenTelemetry.BatchExportProcessor<T>.OnExport(T data) -> void
 override OpenTelemetry.BatchExportProcessor<T>.OnForceFlush(int timeoutMilliseconds) -> bool
 override OpenTelemetry.BatchExportProcessor<T>.OnShutdown(int timeoutMilliseconds) -> bool
-~override OpenTelemetry.BatchLogRecordExportProcessor.OnEnd(OpenTelemetry.Logs.LogRecord data) -> void
+override OpenTelemetry.BatchLogRecordExportProcessor.OnEnd(OpenTelemetry.Logs.LogRecord! data) -> void
 override OpenTelemetry.CompositeProcessor<T>.Dispose(bool disposing) -> void
 override OpenTelemetry.CompositeProcessor<T>.OnEnd(T data) -> void
 override OpenTelemetry.CompositeProcessor<T>.OnForceFlush(int timeoutMilliseconds) -> bool
@@ -301,7 +301,7 @@ override OpenTelemetry.Trace.TraceIdRatioBasedSampler.ShouldSample(in OpenTeleme
 ~override sealed OpenTelemetry.BaseExportProcessor<T>.OnStart(T data) -> void
 ~readonly OpenTelemetry.BaseExportProcessor<T>.exporter -> OpenTelemetry.BaseExporter<T>
 ~readonly OpenTelemetry.Metrics.BaseExportingMetricReader.exporter -> OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric>
-~static Microsoft.Extensions.Logging.OpenTelemetryLoggingExtensions.AddOpenTelemetry(this Microsoft.Extensions.Logging.ILoggingBuilder builder, System.Action<OpenTelemetry.Logs.OpenTelemetryLoggerOptions> configure = null) -> Microsoft.Extensions.Logging.ILoggingBuilder
+static Microsoft.Extensions.Logging.OpenTelemetryLoggingExtensions.AddOpenTelemetry(this Microsoft.Extensions.Logging.ILoggingBuilder! builder, System.Action<OpenTelemetry.Logs.OpenTelemetryLoggerOptions!>? configure = null) -> Microsoft.Extensions.Logging.ILoggingBuilder!
 ~static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.AddReader(this OpenTelemetry.Metrics.MeterProviderBuilder meterProviderBuilder, OpenTelemetry.Metrics.MetricReader reader) -> OpenTelemetry.Metrics.MeterProviderBuilder
 ~static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.AddView(this OpenTelemetry.Metrics.MeterProviderBuilder meterProviderBuilder, string instrumentName, OpenTelemetry.Metrics.MetricStreamConfiguration metricStreamConfiguration) -> OpenTelemetry.Metrics.MeterProviderBuilder
 ~static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.AddView(this OpenTelemetry.Metrics.MeterProviderBuilder meterProviderBuilder, string instrumentName, string name) -> OpenTelemetry.Metrics.MeterProviderBuilder

--- a/src/OpenTelemetry/Logs/BatchLogRecordExportProcessor.cs
+++ b/src/OpenTelemetry/Logs/BatchLogRecordExportProcessor.cs
@@ -14,6 +14,9 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
+using OpenTelemetry.Internal;
 using OpenTelemetry.Logs;
 
 namespace OpenTelemetry
@@ -37,6 +40,8 @@ namespace OpenTelemetry
 
         public override void OnEnd(LogRecord data)
         {
+            Guard.ThrowIfNull(data);
+
             data.BufferLogScopes();
 
             base.OnEnd(data);

--- a/src/OpenTelemetry/Logs/BatchLogRecordExportProcessor.cs
+++ b/src/OpenTelemetry/Logs/BatchLogRecordExportProcessor.cs
@@ -16,13 +16,24 @@
 
 #nullable enable
 
-using OpenTelemetry.Internal;
+using System.Diagnostics;
 using OpenTelemetry.Logs;
 
 namespace OpenTelemetry
 {
+    /// <summary>
+    /// Implements a batch log record export processor.
+    /// </summary>
     public class BatchLogRecordExportProcessor : BatchExportProcessor<LogRecord>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BatchLogRecordExportProcessor"/> class.
+        /// </summary>
+        /// <param name="exporter">Log record exporter.</param>
+        /// <param name="maxQueueSize">The maximum queue size. After the size is reached data are dropped. The default value is 2048.</param>
+        /// <param name="scheduledDelayMilliseconds">The delay interval in milliseconds between two consecutive exports. The default value is 5000.</param>
+        /// <param name="exporterTimeoutMilliseconds">How long the export can run before it is cancelled. The default value is 30000.</param>
+        /// <param name="maxExportBatchSize">The maximum batch size of every export. It must be smaller or equal to maxQueueSize. The default value is 512.</param>
         public BatchLogRecordExportProcessor(
             BaseExporter<LogRecord> exporter,
             int maxQueueSize = DefaultMaxQueueSize,
@@ -38,11 +49,15 @@ namespace OpenTelemetry
         {
         }
 
+        /// <inheritdoc/>
         public override void OnEnd(LogRecord data)
         {
-            Guard.ThrowIfNull(data);
+            // Note: Intentionally doing a Debug.Assert here and not a
+            // Guard.ThrowIfNull to save prod cycles. Null should really never
+            // happen here.
+            Debug.Assert(data != null, "LogRecord was null.");
 
-            data.BufferLogScopes();
+            data!.BufferLogScopes();
 
             base.OnEnd(data);
         }

--- a/src/OpenTelemetry/Logs/LogRecord.cs
+++ b/src/OpenTelemetry/Logs/LogRecord.cs
@@ -68,22 +68,49 @@ namespace OpenTelemetry.Logs
             this.Exception = exception;
         }
 
+        /// <summary>
+        /// Gets the log timestamp.
+        /// </summary>
         public DateTime Timestamp { get; }
 
+        /// <summary>
+        /// Gets the log <see cref="ActivityTraceId"/>.
+        /// </summary>
         public ActivityTraceId TraceId { get; }
 
+        /// <summary>
+        /// Gets the log <see cref="ActivitySpanId"/>.
+        /// </summary>
         public ActivitySpanId SpanId { get; }
 
+        /// <summary>
+        /// Gets the log <see cref="ActivityTraceFlags"/>.
+        /// </summary>
         public ActivityTraceFlags TraceFlags { get; }
 
+        /// <summary>
+        /// Gets the log trace state.
+        /// </summary>
         public string? TraceState { get; }
 
+        /// <summary>
+        /// Gets the log category name.
+        /// </summary>
         public string CategoryName { get; }
 
+        /// <summary>
+        /// Gets the log <see cref="Microsoft.Extensions.Logging.LogLevel"/>.
+        /// </summary>
         public LogLevel LogLevel { get; }
 
+        /// <summary>
+        /// Gets the log <see cref="EventId"/>.
+        /// </summary>
         public EventId EventId { get; }
 
+        /// <summary>
+        /// Gets or sets the log formatted message.
+        /// </summary>
         public string? FormattedMessage { get; set; }
 
         /// <summary>
@@ -100,6 +127,9 @@ namespace OpenTelemetry.Logs
         /// </summary>
         public IReadOnlyList<KeyValuePair<string, object?>>? StateValues { get; set; }
 
+        /// <summary>
+        /// Gets the log <see cref="System.Exception"/>.
+        /// </summary>
         public Exception? Exception { get; }
 
         internal IExternalScopeProvider? ScopeProvider { get; set; }

--- a/src/OpenTelemetry/Logs/LogRecordScope.cs
+++ b/src/OpenTelemetry/Logs/LogRecordScope.cs
@@ -52,6 +52,10 @@ namespace OpenTelemetry.Logs
             private readonly IReadOnlyList<KeyValuePair<string, object?>> scope;
             private int position;
 
+            /// <summary>
+            /// Initializes a new instance of the <see cref="Enumerator"/> struct.
+            /// </summary>
+            /// <param name="scope">Scope.</param>
             public Enumerator(object? scope)
             {
                 if (scope is IReadOnlyList<KeyValuePair<string, object?>> scopeList)
@@ -74,10 +78,12 @@ namespace OpenTelemetry.Logs
                 this.Current = default;
             }
 
+            /// <inheritdoc/>
             public KeyValuePair<string, object?> Current { get; private set; }
 
             object IEnumerator.Current => this.Current;
 
+            /// <inheritdoc/>
             public bool MoveNext()
             {
                 if (this.position < this.scope.Count)
@@ -89,10 +95,12 @@ namespace OpenTelemetry.Logs
                 return false;
             }
 
+            /// <inheritdoc/>
             public void Dispose()
             {
             }
 
+            /// <inheritdoc/>
             public void Reset()
                 => throw new NotSupportedException();
         }

--- a/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
@@ -24,7 +24,7 @@ using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Logs
 {
-    internal class OpenTelemetryLogger : ILogger
+    internal sealed class OpenTelemetryLogger : ILogger
     {
         private readonly string categoryName;
         private readonly OpenTelemetryLoggerProvider provider;

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggerOptions.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggerOptions.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System.Collections.Generic;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Resources;

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggerOptions.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggerOptions.cs
@@ -22,6 +22,9 @@ using OpenTelemetry.Resources;
 
 namespace OpenTelemetry.Logs
 {
+    /// <summary>
+    /// Contains OpenTelemetry logging options.
+    /// </summary>
     public class OpenTelemetryLoggerOptions
     {
         internal readonly List<BaseProcessor<LogRecord>> Processors = new();

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggingExtensions.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggingExtensions.cs
@@ -26,8 +26,17 @@ using OpenTelemetry.Logs;
 
 namespace Microsoft.Extensions.Logging
 {
+    /// <summary>
+    /// Contains extension methods for registering <see cref="OpenTelemetryLoggerProvider"/> into a <see cref="ILoggingBuilder"/> instance.
+    /// </summary>
     public static class OpenTelemetryLoggingExtensions
     {
+        /// <summary>
+        /// Adds a OpenTelemetry logger named 'OpenTelemetry' to the factory.
+        /// </summary>
+        /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
+        /// <param name="configure">Optional configuration action.</param>
+        /// <returns>The supplied <see cref="ILoggingBuilder"/> for call chaining.</returns>
         public static ILoggingBuilder AddOpenTelemetry(this ILoggingBuilder builder, Action<OpenTelemetryLoggerOptions>? configure = null)
         {
             Guard.ThrowIfNull(builder);

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggingExtensions.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggingExtensions.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -26,7 +28,7 @@ namespace Microsoft.Extensions.Logging
 {
     public static class OpenTelemetryLoggingExtensions
     {
-        public static ILoggingBuilder AddOpenTelemetry(this ILoggingBuilder builder, Action<OpenTelemetryLoggerOptions> configure = null)
+        public static ILoggingBuilder AddOpenTelemetry(this ILoggingBuilder builder, Action<OpenTelemetryLoggerOptions>? configure = null)
         {
             Guard.ThrowIfNull(builder);
 

--- a/src/OpenTelemetry/Logs/SimpleLogRecordExportProcessor.cs
+++ b/src/OpenTelemetry/Logs/SimpleLogRecordExportProcessor.cs
@@ -20,8 +20,15 @@ using OpenTelemetry.Logs;
 
 namespace OpenTelemetry
 {
+    /// <summary>
+    /// Implements a simple log record export processor.
+    /// </summary>
     public class SimpleLogRecordExportProcessor : SimpleExportProcessor<LogRecord>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SimpleLogRecordExportProcessor"/> class.
+        /// </summary>
+        /// <param name="exporter">Log record exporter.</param>
         public SimpleLogRecordExportProcessor(BaseExporter<LogRecord> exporter)
             : base(exporter)
         {

--- a/src/OpenTelemetry/Logs/SimpleLogRecordExportProcessor.cs
+++ b/src/OpenTelemetry/Logs/SimpleLogRecordExportProcessor.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using OpenTelemetry.Logs;
 
 namespace OpenTelemetry


### PR DESCRIPTION
Completed nullable annotations for everything in /Logs/ folder (SDK logging API). Also fixed up the rest of the missing XML comments.

Follow-up to https://github.com/open-telemetry/opentelemetry-dotnet/pull/3302 & https://github.com/open-telemetry/opentelemetry-dotnet/pull/3301