### PR TITLE
Add Extensions.Propagators to core

### DIFF
--- a/src/OpenTelemetry.Extensions.Propagators/OpenTelemetry.Extensions.Propagators.csproj
+++ b/src/OpenTelemetry.Extensions.Propagators/OpenTelemetry.Extensions.Propagators.csproj
@@ -12,9 +12,8 @@
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\OpenTelemetryApiEventSource.cs" Link="Includes\OpenTelemetryApiEventSource.cs" />
   </ItemGroup>
 
-  <!--Do not run ApiCompat for net462/net6.0 as this is newly added. There is no existing contract for net462 against which we could compare the implementation.
-  Remove this property once we have released a stable net462/net6.0 version.-->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'net6.0'">
+  <!--Do not run ApiCompat as this package is newly added.-->
+  <PropertyGroup>
     <RunApiCompat>false</RunApiCompat>
   </PropertyGroup>
 

--- a/src/OpenTelemetry.Extensions.Propagators/OpenTelemetry.Extensions.Propagators.csproj
+++ b/src/OpenTelemetry.Extensions.Propagators/OpenTelemetry.Extensions.Propagators.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <Description>OpenTelemetry Extensions Propagators</Description>
     <PackageTags>$(PackageTags);distributed-tracing;AspNet;AspNetCore;B3</PackageTags>
+    <MinVerTagPrefix>core-</MinVerTagPrefix>
     <IncludeInstrumentationHelpers>true</IncludeInstrumentationHelpers>
   </PropertyGroup>
 


### PR DESCRIPTION
As per today SIG discussion, this package will be stable released, as 1.3.0 along with rest of core packages. The only component in this is the lift-and-shifted B3Propagator which was already part of stable release.