### PR TITLE
csharp_namespace option in proto files

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ActivityExtensions.cs
@@ -26,10 +26,10 @@ using Google.Protobuf;
 using Google.Protobuf.Collections;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
-using OtlpCollector = Opentelemetry.Proto.Collector.Trace.V1;
-using OtlpCommon = Opentelemetry.Proto.Common.V1;
-using OtlpResource = Opentelemetry.Proto.Resource.V1;
-using OtlpTrace = Opentelemetry.Proto.Trace.V1;
+using OtlpCollector = OpenTelemetry.Proto.Collector.Trace.V1;
+using OtlpCommon = OpenTelemetry.Proto.Common.V1;
+using OtlpResource = OpenTelemetry.Proto.Resource.V1;
+using OtlpTrace = OpenTelemetry.Proto.Trace.V1;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
 {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcLogExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcLogExportClient.cs
@@ -17,7 +17,7 @@
 using System;
 using System.Threading;
 using Grpc.Core;
-using OtlpCollector = Opentelemetry.Proto.Collector.Logs.V1;
+using OtlpCollector = OpenTelemetry.Proto.Collector.Logs.V1;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient
 {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcMetricsExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcMetricsExportClient.cs
@@ -17,7 +17,7 @@
 using System;
 using System.Threading;
 using Grpc.Core;
-using OtlpCollector = Opentelemetry.Proto.Collector.Metrics.V1;
+using OtlpCollector = OpenTelemetry.Proto.Collector.Metrics.V1;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient
 {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcTraceExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcTraceExportClient.cs
@@ -17,7 +17,7 @@
 using System;
 using System.Threading;
 using Grpc.Core;
-using OtlpCollector = Opentelemetry.Proto.Collector.Trace.V1;
+using OtlpCollector = OpenTelemetry.Proto.Collector.Trace.V1;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient
 {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpHttpLogExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpHttpLogExportClient.cs
@@ -24,7 +24,7 @@ using System.Threading;
 #endif
 using System.Threading.Tasks;
 using Google.Protobuf;
-using OtlpCollector = Opentelemetry.Proto.Collector.Logs.V1;
+using OtlpCollector = OpenTelemetry.Proto.Collector.Logs.V1;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient
 {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpHttpMetricsExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpHttpMetricsExportClient.cs
@@ -24,7 +24,7 @@ using System.Threading;
 #endif
 using System.Threading.Tasks;
 using Google.Protobuf;
-using OtlpCollector = Opentelemetry.Proto.Collector.Metrics.V1;
+using OtlpCollector = OpenTelemetry.Proto.Collector.Metrics.V1;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient
 {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpHttpTraceExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpHttpTraceExportClient.cs
@@ -24,7 +24,7 @@ using System.Threading;
 #endif
 using System.Threading.Tasks;
 using Google.Protobuf;
-using OtlpCollector = Opentelemetry.Proto.Collector.Trace.V1;
+using OtlpCollector = OpenTelemetry.Proto.Collector.Trace.V1;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient
 {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
@@ -23,10 +23,10 @@ using Microsoft.Extensions.Logging;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Trace;
-using OtlpCollector = Opentelemetry.Proto.Collector.Logs.V1;
-using OtlpCommon = Opentelemetry.Proto.Common.V1;
-using OtlpLogs = Opentelemetry.Proto.Logs.V1;
-using OtlpResource = Opentelemetry.Proto.Resource.V1;
+using OtlpCollector = OpenTelemetry.Proto.Collector.Logs.V1;
+using OtlpCommon = OpenTelemetry.Proto.Common.V1;
+using OtlpLogs = OpenTelemetry.Proto.Logs.V1;
+using OtlpResource = OpenTelemetry.Proto.Resource.V1;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
 {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/MetricItemExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/MetricItemExtensions.cs
@@ -23,10 +23,10 @@ using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 using Google.Protobuf.Collections;
 using OpenTelemetry.Metrics;
-using OtlpCollector = Opentelemetry.Proto.Collector.Metrics.V1;
-using OtlpCommon = Opentelemetry.Proto.Common.V1;
-using OtlpMetrics = Opentelemetry.Proto.Metrics.V1;
-using OtlpResource = Opentelemetry.Proto.Resource.V1;
+using OtlpCollector = OpenTelemetry.Proto.Collector.Metrics.V1;
+using OtlpCommon = OpenTelemetry.Proto.Common.V1;
+using OtlpMetrics = OpenTelemetry.Proto.Metrics.V1;
+using OtlpResource = OpenTelemetry.Proto.Resource.V1;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
 {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpKeyValueTransformer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpKeyValueTransformer.cs
@@ -16,7 +16,7 @@
 
 using System;
 using OpenTelemetry.Internal;
-using OtlpCommon = Opentelemetry.Proto.Common.V1;
+using OtlpCommon = OpenTelemetry.Proto.Common.V1;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ResourceExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ResourceExtensions.cs
@@ -17,8 +17,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenTelemetry.Resources;
-using OtlpCommon = Opentelemetry.Proto.Common.V1;
-using OtlpResource = Opentelemetry.Proto.Resource.V1;
+using OtlpCommon = OpenTelemetry.Proto.Common.V1;
+using OtlpResource = OpenTelemetry.Proto.Resource.V1;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
 {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/collector/logs/v1/logs_service.proto
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/collector/logs/v1/logs_service.proto
@@ -21,6 +21,7 @@ package opentelemetry.proto.collector.logs.v1;
 
 import "opentelemetry/proto/logs/v1/logs.proto";
 
+option csharp_namespace = "OpenTelemetry.Proto.Collector.Logs.V1";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.collector.logs.v1";
 option java_outer_classname = "LogsServiceProto";

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
@@ -18,6 +18,7 @@ package opentelemetry.proto.collector.metrics.v1;
 
 import "opentelemetry/proto/metrics/v1/metrics.proto";
 
+option csharp_namespace = "OpenTelemetry.Proto.Collector.Metrics.V1";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.collector.metrics.v1";
 option java_outer_classname = "MetricsServiceProto";

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/collector/trace/v1/trace_service.proto
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/collector/trace/v1/trace_service.proto
@@ -18,6 +18,7 @@ package opentelemetry.proto.collector.trace.v1;
 
 import "opentelemetry/proto/trace/v1/trace.proto";
 
+option csharp_namespace = "OpenTelemetry.Proto.Collector.Trace.V1";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.collector.trace.v1";
 option java_outer_classname = "TraceServiceProto";

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/common/v1/common.proto
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/common/v1/common.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 package opentelemetry.proto.common.v1;
 
+option csharp_namespace = "OpenTelemetry.Proto.Common.V1";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.common.v1";
 option java_outer_classname = "CommonProto";

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/logs/v1/logs.proto
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/logs/v1/logs.proto
@@ -19,6 +19,7 @@ package opentelemetry.proto.logs.v1;
 import "opentelemetry/proto/common/v1/common.proto";
 import "opentelemetry/proto/resource/v1/resource.proto";
 
+option csharp_namespace = "OpenTelemetry.Proto.Logs.V1";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.logs.v1";
 option java_outer_classname = "LogsProto";

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/metrics/v1/metrics.proto
@@ -19,6 +19,7 @@ package opentelemetry.proto.metrics.v1;
 import "opentelemetry/proto/common/v1/common.proto";
 import "opentelemetry/proto/resource/v1/resource.proto";
 
+option csharp_namespace = "OpenTelemetry.Proto.Metrics.V1";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.metrics.v1";
 option java_outer_classname = "MetricsProto";

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/resource/v1/resource.proto
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/resource/v1/resource.proto
@@ -18,6 +18,7 @@ package opentelemetry.proto.resource.v1;
 
 import "opentelemetry/proto/common/v1/common.proto";
 
+option csharp_namespace = "OpenTelemetry.Proto.Resource.V1";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.resource.v1";
 option java_outer_classname = "ResourceProto";

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/trace/v1/trace.proto
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/trace/v1/trace.proto
@@ -19,6 +19,7 @@ package opentelemetry.proto.trace.v1;
 import "opentelemetry/proto/common/v1/common.proto";
 import "opentelemetry/proto/resource/v1/resource.proto";
 
+option csharp_namespace = "OpenTelemetry.Proto.Trace.V1";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.trace.v1";
 option java_outer_classname = "TraceProto";

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/trace/v1/trace_config.proto
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/trace/v1/trace_config.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 package opentelemetry.proto.trace.v1;
 
+option csharp_namespace = "OpenTelemetry.Proto.Collector.Trace.V1";
 option java_multiple_files = true;
 option java_package = "io.opentelemetry.proto.trace.v1";
 option java_outer_classname = "TraceConfigProto";

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
@@ -22,9 +22,9 @@ using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
 #if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using Grpc.Net.Client;
 #endif
-using LogOtlpCollector = Opentelemetry.Proto.Collector.Logs.V1;
-using MetricsOtlpCollector = Opentelemetry.Proto.Collector.Metrics.V1;
-using TraceOtlpCollector = Opentelemetry.Proto.Collector.Trace.V1;
+using LogOtlpCollector = OpenTelemetry.Proto.Collector.Logs.V1;
+using MetricsOtlpCollector = OpenTelemetry.Proto.Collector.Metrics.V1;
+using TraceOtlpCollector = OpenTelemetry.Proto.Collector.Trace.V1;
 
 namespace OpenTelemetry.Exporter
 {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporter.cs
@@ -18,8 +18,8 @@ using System;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
 using OpenTelemetry.Logs;
-using OtlpCollector = Opentelemetry.Proto.Collector.Logs.V1;
-using OtlpResource = Opentelemetry.Proto.Resource.V1;
+using OtlpCollector = OpenTelemetry.Proto.Collector.Logs.V1;
+using OtlpResource = OpenTelemetry.Proto.Resource.V1;
 
 namespace OpenTelemetry.Exporter
 {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporter.cs
@@ -18,8 +18,8 @@ using System;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
 using OpenTelemetry.Metrics;
-using OtlpCollector = Opentelemetry.Proto.Collector.Metrics.V1;
-using OtlpResource = Opentelemetry.Proto.Resource.V1;
+using OtlpCollector = OpenTelemetry.Proto.Collector.Metrics.V1;
+using OtlpResource = OpenTelemetry.Proto.Resource.V1;
 
 namespace OpenTelemetry.Exporter
 {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporter.cs
@@ -18,8 +18,8 @@ using System;
 using System.Diagnostics;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
-using OtlpCollector = Opentelemetry.Proto.Collector.Trace.V1;
-using OtlpResource = Opentelemetry.Proto.Resource.V1;
+using OtlpCollector = OpenTelemetry.Proto.Collector.Trace.V1;
+using OtlpResource = OpenTelemetry.Proto.Resource.V1;
 
 namespace OpenTelemetry.Exporter
 {

--- a/test/Benchmarks/Exporter/OtlpGrpcExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/OtlpGrpcExporterBenchmarks.cs
@@ -27,7 +27,7 @@ using OpenTelemetry;
 using OpenTelemetry.Internal;
 using OpenTelemetryProtocol::OpenTelemetry.Exporter;
 using OpenTelemetryProtocol::OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
-using OtlpCollector = OpenTelemetryProtocol::Opentelemetry.Proto.Collector.Trace.V1;
+using OtlpCollector = OpenTelemetryProtocol::OpenTelemetry.Proto.Collector.Trace.V1;
 
 namespace Benchmarks.Exporter
 {

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/ExportClient/OtlpHttpTraceExportClientTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/ExportClient/OtlpHttpTraceExportClientTests.cs
@@ -30,7 +30,7 @@ using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using Xunit;
-using OtlpCollector = Opentelemetry.Proto.Collector.Trace.V1;
+using OtlpCollector = OpenTelemetry.Proto.Collector.Trace.V1;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
 {

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpAttributeTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpAttributeTests.cs
@@ -19,7 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using Xunit;
-using OtlpCommon = Opentelemetry.Proto.Common.V1;
+using OtlpCommon = OpenTelemetry.Proto.Common.V1;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
 {

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
@@ -26,7 +26,7 @@ using OpenTelemetry.Logs;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
 using Xunit;
-using OtlpLogs = Opentelemetry.Proto.Logs.V1;
+using OtlpLogs = OpenTelemetry.Proto.Logs.V1;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
 {

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
@@ -25,8 +25,8 @@ using OpenTelemetry.Resources;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
 using Xunit;
-using OtlpCollector = Opentelemetry.Proto.Collector.Metrics.V1;
-using OtlpMetrics = Opentelemetry.Proto.Metrics.V1;
+using OtlpCollector = OpenTelemetry.Proto.Collector.Metrics.V1;
+using OtlpMetrics = OpenTelemetry.Proto.Metrics.V1;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
 {

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTestHelpers.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTestHelpers.cs
@@ -18,7 +18,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Google.Protobuf.Collections;
 using Xunit;
-using OtlpCommon = Opentelemetry.Proto.Common.V1;
+using OtlpCommon = OpenTelemetry.Proto.Common.V1;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
 {

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
@@ -26,9 +26,9 @@ using OpenTelemetry.Resources;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
 using Xunit;
-using OtlpCollector = Opentelemetry.Proto.Collector.Trace.V1;
-using OtlpCommon = Opentelemetry.Proto.Common.V1;
-using OtlpTrace = Opentelemetry.Proto.Trace.V1;
+using OtlpCollector = OpenTelemetry.Proto.Collector.Trace.V1;
+using OtlpCommon = OpenTelemetry.Proto.Common.V1;
+using OtlpTrace = OpenTelemetry.Proto.Trace.V1;
 using Status = OpenTelemetry.Trace.Status;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests


### PR DESCRIPTION
This is just a preview of what life would look like if the proto files defined the `csharp_namespace` option. I'm going to open a PR against the opentelemetry-proto project with these changes.