### PR TITLE
What should we do when a measurement has a null-valued tag?

### DIFF
--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -43,6 +43,23 @@ namespace OpenTelemetry.Metrics.Tests
         }
 
         [Fact]
+        public void MeasurementWithNullValuedTag_ShouldWeIgnoreItAndMaybeLog_Or_ShouldWeDropTheTagAndRecordTheMeasurementWithoutIt()
+        {
+            using var meter = new Meter(Utils.GetCurrentMethodName());
+            var exportedItems = new List<Metric>();
+            using var meterProvider = Sdk.CreateMeterProviderBuilder()
+                .AddMeter(meter.Name)
+                .AddInMemoryExporter(exportedItems)
+                .Build();
+
+            var counter = meter.CreateCounter<long>("myCounter");
+            counter.Add(100, new KeyValuePair<string, object>("tagWithNullValue", null));
+
+            meterProvider.ForceFlush(MaxTimeToAllowForFlush);
+            Assert.Empty(exportedItems);
+        }
+
+        [Fact]
         public void ObserverCallbackTest()
         {
             using var meter = new Meter(Utils.GetCurrentMethodName());


### PR DESCRIPTION
Added a test demonstrating status quo. One way or another I think we have a bug. Question is how should we handle it?

When recording a metric with a null-valued tag the following code throws a NullReferenceException. This code is invoked when locating the MetricPoint in the AggregationStore.

https://github.com/open-telemetry/opentelemetry-dotnet/blob/56d667759c252d1ca3b20e31a28577ee13a4aeae/src/OpenTelemetry/Metrics/Tags.cs#L87-L90

I think our options are:

1. Ignore the measurement. In this case, should we log?
2. Record the measurement without the null-valued tag. Maybe log in this case, too?