### PR TITLE
Adjust changelog to reflect actual date and package

### DIFF
--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-## 1.3.0-rc.1
+## 1.3.0-rc.2
 
-Released 2022-May-31
+Released 2022-June-1
 
 * `B3Propagator` class from `OpenTelemetry.Extensions.Propagators` namespace has
   been deprecated and moved as is to a new `OpenTelemetry.Extensions.Propagators`

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-## 1.3.0-rc.1
+## 1.3.0-rc.2
 
-Released 2022-May-31
+Released 2022-June-1
 
 * Improve the conversion and formatting of attribute values.
   The list of data types that must be supported per the

--- a/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-## 1.3.0-rc.1
+## 1.3.0-rc.2
 
-Released 2022-May-31
+Released 2022-June-1
 
 * Adds new `AddInMemoryExporter` extension method to export `Metric` as new
   type `MetricSnapshot`.

--- a/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-## 1.3.0-rc.1
+## 1.3.0-rc.2
 
-Released 2022-May-31
+Released 2022-June-1
 
 * Improve the conversion and formatting of attribute values.
   The list of data types that must be supported per the

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-## 1.3.0-rc.1
+## 1.3.0-rc.2
 
-Released 2022-May-31
+Released 2022-June-1
 
 ## 1.0.0-rc9.3
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-## 1.3.0-rc.1
+## 1.3.0-rc.2
 
-Released 2022-May-31
+Released 2022-June-1
 
 ## 1.3.0-beta.2
 

--- a/src/OpenTelemetry.Exporter.Prometheus/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-## 1.3.0-rc.1
+## 1.3.0-rc.2
 
-Released 2022-May-31
+Released 2022-June-1
 
 ## 1.3.0-beta.2
 

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-## 1.3.0-rc.1
+## 1.3.0-rc.2
 
-Released 2022-May-31
+Released 2022-June-1
 
 * Improve the conversion and formatting of attribute values.
   The list of data types that must be supported per the

--- a/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-## 1.3.0-rc.1
+## 1.3.0-rc.2
 
-Released 2022-May-31
+Released 2022-June-1
 
 * Initial release. This has been ported as is from
 [OpenTelemetry.Api](../OpenTelemetry.Api/README.md) package.

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-## 1.3.0-rc.1
+## 1.3.0-rc.2
 
-Released 2022-May-31
+Released 2022-June-1
 
 * Fix null reference exception when a metric view does not match an instrument.
   ([#3285](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3285))


### PR DESCRIPTION
Release pipeline had issues (unknown) with 1.3.0-rc.1 tag. For unknown reasons, it was simply not picking up the rc.1 tag. rc.2 worked, so that was the actual package that got released.

Fixing changelog to reflect the actual version and date.