### PR TITLE
In-memory Exporter: Buffer log scopes

### DIFF
--- a/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Buffer scopes when exporting `LogRecord`
+* `InMemoryExporter` will now buffer scopes when exporting `LogRecord`
   ([#3360](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3360))
 
 ## 1.3.0

--- a/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Buffer scopes when exporting `LogRecord`
+  ([#3360](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3360))
+
 ## 1.3.0
 
 Released 2022-Jun-03

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporter.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporter.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Collections.Generic;
 
 namespace OpenTelemetry.Exporter
@@ -23,18 +22,20 @@ namespace OpenTelemetry.Exporter
         where T : class
     {
         private readonly ICollection<T> exportedItems;
-        private readonly Func<Batch<T>, ExportResult> onExport;
+        private readonly ExportFunc onExport;
 
         public InMemoryExporter(ICollection<T> exportedItems)
         {
             this.exportedItems = exportedItems;
-            this.onExport = (Batch<T> batch) => this.DefaultExport(batch);
+            this.onExport = (in Batch<T> batch) => this.DefaultExport(in batch);
         }
 
-        internal InMemoryExporter(Func<Batch<T>, ExportResult> exportFunc)
+        internal InMemoryExporter(ExportFunc exportFunc)
         {
             this.onExport = exportFunc;
         }
+
+        internal delegate ExportResult ExportFunc(in Batch<T> batch);
 
         public override ExportResult Export(in Batch<T> batch) => this.onExport(batch);
 

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporter.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporter.cs
@@ -27,7 +27,7 @@ namespace OpenTelemetry.Exporter
         public InMemoryExporter(ICollection<T> exportedItems)
         {
             this.exportedItems = exportedItems;
-            this.onExport = (in Batch<T> batch) => this.DefaultExport(in batch);
+            this.onExport = this.DefaultExport;
         }
 
         internal InMemoryExporter(ExportFunc exportFunc)

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterLoggingExtensions.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterLoggingExtensions.cs
@@ -27,7 +27,27 @@ namespace OpenTelemetry.Logs
             Guard.ThrowIfNull(loggerOptions);
             Guard.ThrowIfNull(exportedItems);
 
-            return loggerOptions.AddProcessor(new SimpleLogRecordExportProcessor(new InMemoryExporter<LogRecord>(exportedItems)));
+            var logExporter = new InMemoryExporter<LogRecord>(
+                exportFunc: (in Batch<LogRecord> batch) => ExportLogRecord(in batch, exportedItems));
+
+            return loggerOptions.AddProcessor(new SimpleLogRecordExportProcessor(logExporter));
+        }
+
+        private static ExportResult ExportLogRecord(in Batch<LogRecord> batch, ICollection<LogRecord> exportedItems)
+        {
+            if (exportedItems == null)
+            {
+                return ExportResult.Failure;
+            }
+
+            foreach (var log in batch)
+            {
+                log.BufferLogScopes();
+
+                exportedItems.Add(log);
+            }
+
+            return ExportResult.Success;
         }
     }
 }

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterMetricsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterMetricsExtensions.cs
@@ -145,7 +145,7 @@ namespace OpenTelemetry.Metrics
             configureMetricReader?.Invoke(metricReaderOptions);
 
             var metricExporter = new InMemoryExporter<Metric>(
-                exportFunc: metricBatch => ExportMetricSnapshot(metricBatch, exportedItems));
+                exportFunc: (in Batch<Metric> metricBatch) => ExportMetricSnapshot(in metricBatch, exportedItems));
 
             var metricReader = PeriodicExportingMetricReaderHelper.CreatePeriodicExportingMetricReader(
                 metricExporter,

--- a/test/OpenTelemetry.Tests/Logs/LogRecordTest.cs
+++ b/test/OpenTelemetry.Tests/Logs/LogRecordTest.cs
@@ -746,15 +746,14 @@ namespace OpenTelemetry.Logs.Tests
 
         private static ILoggerFactory InitializeLoggerFactory(out List<LogRecord> exportedItems, Action<OpenTelemetryLoggerOptions> configure = null)
         {
-            exportedItems = new List<LogRecord>();
-            var exporter = new InMemoryExporter<LogRecord>(exportedItems);
-            var processor = new TestLogRecordProcessor(exporter);
+            var items = exportedItems = new List<LogRecord>();
+
             return LoggerFactory.Create(builder =>
             {
                 builder.AddOpenTelemetry(options =>
                 {
                     configure?.Invoke(options);
-                    options.AddProcessor(processor);
+                    options.AddInMemoryExporter(items);
                 });
                 builder.AddFilter(typeof(LogRecordTest).FullName, LogLevel.Trace);
             });
@@ -840,21 +839,6 @@ namespace OpenTelemetry.Logs.Tests
         private class CustomState
         {
             public string Property { get; set; }
-        }
-
-        private class TestLogRecordProcessor : SimpleExportProcessor<LogRecord>
-        {
-            public TestLogRecordProcessor(BaseExporter<LogRecord> exporter)
-                : base(exporter)
-            {
-            }
-
-            public override void OnEnd(LogRecord data)
-            {
-                data.BufferLogScopes();
-
-                base.OnEnd(data);
-            }
         }
     }
 }


### PR DESCRIPTION
[Goal is to pare down the amount of changes on #3305]

## Changes

* Adds a delegate for the `Export` callback instead of using `Func`
* Buffer log scopes when using in-memory log exporter

* [X] Appropriate `CHANGELOG.md` updated for non-trivial changes
