### PR TITLE
Add net7.0 target for aspnetcore

### DIFF
--- a/.github/workflows/apicompatibility.yml
+++ b/.github/workflows/apicompatibility.yml
@@ -11,8 +11,14 @@ jobs:
     runs-on: windows-latest
     env:
       CheckAPICompatibility: true
+      # https://github.com/actions/setup-dotnet/issues/122
+      DOTNET_MULTILEVEL_LOOKUP: 1
     steps:
     - uses: actions/checkout@v3
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '7.0.x'
+        include-prerelease: true
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -20,11 +20,17 @@ jobs:
         os: [windows-latest]
     env:
       OS: ${{ matrix.os }}
+      # https://github.com/actions/setup-dotnet/issues/122
+      DOTNET_MULTILEVEL_LOOKUP: 1
 
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0 # fetching all
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '7.0.x'
+        include-prerelease: true
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -25,6 +25,12 @@ jobs:
       with:
         dotnet-version: 6.0.x
 
+    - name: Setup .NET Core 7.0
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '7.0.x'
+        include-prerelease: true
+
     - name: Install format tool
       run: dotnet tool install -g dotnet-format
 

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -16,10 +16,20 @@ jobs:
 
     strategy:
       matrix:
-        version: [net6.0]
+        version: [net6.0, net7.0]
 
     steps:
     - uses: actions/checkout@v3
+
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0.x'
+
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '7.0.x'
+        include-prerelease: true
+
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -13,13 +13,21 @@ on:
 jobs:
   build-test:
     runs-on: windows-latest
+    env:
+      # https://github.com/actions/setup-dotnet/issues/122
+      DOTNET_MULTILEVEL_LOOKUP: 1
 
     strategy:
       matrix:
-        version: [net462,net6.0]
+        version: [net462,net6.0,net7.0]
 
     steps:
     - uses: actions/checkout@v3
+
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '7.0.x'
+        include-prerelease: true
 
     - name: Install dependencies
       run: dotnet restore

--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "6.0.100"
+    "version": "6.0.100",
+    "allowPrerelease": "true"
   }
 }

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/.publicApi/net7.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/.publicApi/net7.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,14 @@
+OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreInstrumentationOptions
+OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreInstrumentationOptions.AspNetCoreInstrumentationOptions() -> void
+OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreInstrumentationOptions.EnableGrpcAspNetCoreSupport.get -> bool
+OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreInstrumentationOptions.EnableGrpcAspNetCoreSupport.set -> void
+OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreInstrumentationOptions.Enrich.get -> System.Action<System.Diagnostics.Activity, string, object>
+OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreInstrumentationOptions.Enrich.set -> void
+OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreInstrumentationOptions.Filter.get -> System.Func<Microsoft.AspNetCore.Http.HttpContext, bool>
+OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreInstrumentationOptions.Filter.set -> void
+OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreInstrumentationOptions.RecordException.get -> bool
+OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreInstrumentationOptions.RecordException.set -> void
+OpenTelemetry.Metrics.MeterProviderBuilderExtensions
+OpenTelemetry.Trace.TracerProviderBuilderExtensions
+static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.AddAspNetCoreInstrumentation(this OpenTelemetry.Metrics.MeterProviderBuilder builder) -> OpenTelemetry.Metrics.MeterProviderBuilder
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddAspNetCoreInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreInstrumentationOptions> configureAspNetCoreInstrumentationOptions = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <Description>ASP.NET Core instrumentation for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);distributed-tracing;AspNetCore</PackageTags>
     <IncludeDiagnosticSourceInstrumentationHelpers>true</IncludeDiagnosticSourceInstrumentationHelpers>
@@ -29,6 +29,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
@@ -38,6 +38,9 @@ using TestApp.AspNetCore._3._1;
 #if NET6_0
 using TestApp.AspNetCore._6._0;
 #endif
+#if NET7_0
+using TestApp.AspNetCore._7._0;
+#endif
 using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AspNetCore.Tests

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/DependencyInjectionConfigTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/DependencyInjectionConfigTests.cs
@@ -24,6 +24,9 @@ using TestApp.AspNetCore._3._1;
 #if NET6_0
 using TestApp.AspNetCore._6._0;
 #endif
+#if NET7_0
+using TestApp.AspNetCore._7._0;
+#endif
 using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AspNetCore.Tests

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
@@ -31,6 +31,9 @@ using TestApp.AspNetCore._3._1;
 #if NET6_0
 using TestApp.AspNetCore._6._0;
 #endif
+#if NET7_0
+using TestApp.AspNetCore._7._0;
+#endif
 using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AspNetCore.Tests

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
@@ -27,6 +27,9 @@ using TestApp.AspNetCore._3._1;
 #if NET6_0
 using TestApp.AspNetCore._6._0;
 #endif
+#if NET7_0
+using TestApp.AspNetCore._7._0;
+#endif
 using Xunit;
 
 namespace OpenTelemetry.Instrumentation.AspNetCore.Tests

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/OpenTelemetry.Instrumentation.AspNetCore.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/OpenTelemetry.Instrumentation.AspNetCore.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Unit test project for OpenTelemetry ASP.NET Core instrumentation</Description>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,6 +25,11 @@
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\EventSourceTestHelper.cs" Link="EventSourceTestHelper.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\InMemoryEventListener.cs" Link="InMemoryEventListener.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestEventListener.cs" Link="TestEventListener.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <ProjectReference Include="$(RepoRoot)\test\TestApp.AspNetCore.7.0\TestApp.AspNetCore.7.0.csproj" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.0-preview.5.22303.8" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/Dockerfile
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/Dockerfile
@@ -2,16 +2,16 @@
 # This should be run from the root of the repo:
 # docker build --file test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/Dockerfile .
 
-ARG SDK_VERSION=6.0
+ARG SDK_VERSION=7.0
 FROM ubuntu AS w3c
 #Install git
 WORKDIR /w3c
 RUN apt-get update && apt-get install -y git
 RUN git clone https://github.com/w3c/trace-context.git
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 ARG PUBLISH_CONFIGURATION=Release
-ARG PUBLISH_FRAMEWORK=net6.0
+ARG PUBLISH_FRAMEWORK=net7.0
 WORKDIR /repo
 COPY . ./
 WORKDIR "/repo/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests"

--- a/test/TestApp.AspNetCore.7.0/AssemblyInfo.cs
+++ b/test/TestApp.AspNetCore.7.0/AssemblyInfo.cs
@@ -1,0 +1,24 @@
+// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage(
+    "StyleCop.CSharp.NamingRules",
+    "SA1300",
+    Justification = "Reviewed.",
+    Scope = "namespaceanddescendants",
+    Target = "TestApp.AspNetCore._6._0")]

--- a/test/TestApp.AspNetCore.7.0/CallbackMiddleware.cs
+++ b/test/TestApp.AspNetCore.7.0/CallbackMiddleware.cs
@@ -1,0 +1,51 @@
+// <copyright file="CallbackMiddleware.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+#pragma warning disable SA1300 // Element should begin with upper-case letter
+namespace TestApp.AspNetCore._7._0
+#pragma warning restore SA1300 // Element should begin with upper-case letter
+{
+    public class CallbackMiddleware
+    {
+        private readonly CallbackMiddlewareImpl impl;
+        private readonly RequestDelegate next;
+
+        public CallbackMiddleware(RequestDelegate next, CallbackMiddlewareImpl impl)
+        {
+            this.next = next;
+            this.impl = impl;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            if (this.impl == null || await this.impl.ProcessAsync(context))
+            {
+                await this.next(context);
+            }
+        }
+
+        public class CallbackMiddlewareImpl
+        {
+            public virtual async Task<bool> ProcessAsync(HttpContext context)
+            {
+                return await Task.FromResult(true);
+            }
+        }
+    }
+}

--- a/test/TestApp.AspNetCore.7.0/Controllers/ChildActivityController.cs
+++ b/test/TestApp.AspNetCore.7.0/Controllers/ChildActivityController.cs
@@ -1,0 +1,48 @@
+// <copyright file="ChildActivityController.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+using OpenTelemetry;
+
+#pragma warning disable SA1300 // Element should begin with upper-case letter
+namespace TestApp.AspNetCore._7._0.Controllers
+#pragma warning restore SA1300 // Element should begin with upper-case letter
+{
+    public class ChildActivityController : Controller
+    {
+        [Route("api/GetChildActivityTraceContext")]
+        public Dictionary<string, string> GetChildActivityTraceContext()
+        {
+            var result = new Dictionary<string, string>();
+            var activity = new Activity("ActivityInsideHttpRequest");
+            activity.Start();
+            result["TraceId"] = activity.Context.TraceId.ToString();
+            result["ParentSpanId"] = activity.ParentSpanId.ToString();
+            result["TraceState"] = activity.Context.TraceState;
+            activity.Stop();
+            return result;
+        }
+
+        [Route("api/GetChildActivityBaggageContext")]
+        public IReadOnlyDictionary<string, string> GetChildActivityBaggageContext()
+        {
+            var result = Baggage.Current.GetBaggage();
+            return result;
+        }
+    }
+}

--- a/test/TestApp.AspNetCore.7.0/Controllers/ForwardController.cs
+++ b/test/TestApp.AspNetCore.7.0/Controllers/ForwardController.cs
@@ -1,0 +1,74 @@
+// <copyright file="ForwardController.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+
+#pragma warning disable SA1300 // Element should begin with upper-case letter
+namespace TestApp.AspNetCore._7._0.Controllers
+#pragma warning restore SA1300 // Element should begin with upper-case letter
+{
+    [Route("api/[controller]")]
+    public class ForwardController : Controller
+    {
+        private readonly HttpClient httpClient;
+
+        public ForwardController(HttpClient httpClient)
+        {
+            this.httpClient = httpClient;
+        }
+
+        // POST api/test
+        [HttpPost]
+        public async Task<string> Post([FromBody] Data[] data)
+        {
+            var result = string.Empty;
+
+            if (data != null)
+            {
+                foreach (var argument in data)
+                {
+                    var request = new HttpRequestMessage(HttpMethod.Post, argument.Url)
+                    {
+                        Content = new StringContent(
+                            JsonConvert.SerializeObject(argument.Arguments),
+                            Encoding.UTF8,
+                            "application/json"),
+                    };
+                    await this.httpClient.SendAsync(request);
+                }
+            }
+            else
+            {
+                result = "done";
+            }
+
+            return result;
+        }
+
+        public class Data
+        {
+            [JsonProperty("url")]
+            public string Url { get; set; }
+
+            [JsonProperty("arguments")]
+            public Data[] Arguments { get; set; }
+        }
+    }
+}

--- a/test/TestApp.AspNetCore.7.0/Controllers/ValuesController.cs
+++ b/test/TestApp.AspNetCore.7.0/Controllers/ValuesController.cs
@@ -1,0 +1,58 @@
+// <copyright file="ValuesController.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
+
+#pragma warning disable SA1300 // Element should begin with upper-case letter
+namespace TestApp.AspNetCore._7._0.Controllers
+#pragma warning restore SA1300 // Element should begin with upper-case letter
+{
+    [Route("api/[controller]")]
+    public class ValuesController : Controller
+    {
+        // GET api/values
+        [HttpGet]
+        public IEnumerable<string> Get()
+        {
+            return new string[] { "value1", "value2" };
+        }
+
+        // GET api/values/5
+        [HttpGet("{id}")]
+        public string Get(int id)
+        {
+            return "value";
+        }
+
+        // POST api/values
+        [HttpPost]
+        public void Post([FromBody] string value)
+        {
+        }
+
+        // PUT api/values/5
+        [HttpPut("{id}")]
+        public void Put(int id, [FromBody] string value)
+        {
+        }
+
+        // DELETE api/values/5
+        [HttpDelete("{id}")]
+        public void Delete(int id)
+        {
+        }
+    }
+}

--- a/test/TestApp.AspNetCore.7.0/Program.cs
+++ b/test/TestApp.AspNetCore.7.0/Program.cs
@@ -1,0 +1,35 @@
+// <copyright file="Program.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+
+#pragma warning disable SA1300 // Element should begin with upper-case letter
+namespace TestApp.AspNetCore._7._0
+#pragma warning restore SA1300 // Element should begin with upper-case letter
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateWebHostBuilder(args).Build().Run();
+        }
+
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>();
+    }
+}

--- a/test/TestApp.AspNetCore.7.0/Startup.cs
+++ b/test/TestApp.AspNetCore.7.0/Startup.cs
@@ -1,0 +1,65 @@
+// <copyright file="Startup.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Net.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+#pragma warning disable SA1300 // Element should begin with upper-case letter
+namespace TestApp.AspNetCore._7._0
+#pragma warning restore SA1300 // Element should begin with upper-case letter
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            this.Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddMvc();
+            services.AddSingleton<HttpClient>();
+            services.AddSingleton(
+                new CallbackMiddleware.CallbackMiddlewareImpl());
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseMiddleware<CallbackMiddleware>();
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
+        }
+    }
+}

--- a/test/TestApp.AspNetCore.7.0/TestApp.AspNetCore.7.0.csproj
+++ b/test/TestApp.AspNetCore.7.0/TestApp.AspNetCore.7.0.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="wwwroot\**" />
+    <Content Remove="wwwroot\**" />
+    <EmbeddedResource Remove="wwwroot\**" />
+    <None Remove="wwwroot\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.0-preview.4.22259.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Api\OpenTelemetry.Api.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.AspNetCore\OpenTelemetry.Instrumentation.AspNetCore.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Extensions.Hosting\OpenTelemetry.Extensions.Hosting.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry\OpenTelemetry.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/TestApp.AspNetCore.7.0/appsettings.Development.json
+++ b/test/TestApp.AspNetCore.7.0/appsettings.Development.json
@@ -1,0 +1,10 @@
+﻿{
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/test/TestApp.AspNetCore.7.0/appsettings.json
+++ b/test/TestApp.AspNetCore.7.0/appsettings.json
@@ -1,0 +1,15 @@
+﻿{
+  "Logging": {
+    "IncludeScopes": false,
+    "Debug": {
+      "LogLevel": {
+        "Default": "Warning"
+      }
+    },
+    "Console": {
+      "LogLevel": {
+        "Default": "Warning"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #.

## Changes

Please provide a brief description of the changes here.

Adding .NET7.0 target for ASP.NET Core instrumentation library. Workflow changes are part of this PR as doing them separately causes the build to fail when no projects with .NET7.0 target are found. Will follow up with other .NET7.0 related changes in separate PR.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
