### PR TITLE
SDK: Forward SetParentProvider to children of CompositeProcessor

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -11,6 +11,9 @@
   null-valued tag.
   ([#3325](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3325))
 
+* `CompositeProcessor` will now ensure `ParentProvider` is set on its children
+  ([#3368](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3368))
+
 ## 1.3.0
 
 Released 2022-Jun-03

--- a/src/OpenTelemetry/CompositeProcessor.cs
+++ b/src/OpenTelemetry/CompositeProcessor.cs
@@ -79,6 +79,16 @@ namespace OpenTelemetry
             }
         }
 
+        internal override void SetParentProvider(BaseProvider parentProvider)
+        {
+            base.SetParentProvider(parentProvider);
+
+            for (var cur = this.head; cur != null; cur = cur.Next)
+            {
+                cur.Value.SetParentProvider(parentProvider);
+            }
+        }
+
         /// <inheritdoc/>
         protected override bool OnForceFlush(int timeoutMilliseconds)
         {

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggerProvider.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggerProvider.cs
@@ -128,11 +128,13 @@ namespace OpenTelemetry.Logs
             }
             else
             {
-                this.Processor = new CompositeProcessor<LogRecord>(new[]
+                var newCompositeProcessor = new CompositeProcessor<LogRecord>(new[]
                 {
                     this.Processor,
-                    processor,
                 });
+                newCompositeProcessor.SetParentProvider(this);
+                newCompositeProcessor.AddProcessor(processor);
+                this.Processor = newCompositeProcessor;
             }
 
             return this;

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -277,11 +277,13 @@ namespace OpenTelemetry.Trace
             }
             else
             {
-                this.processor = new CompositeProcessor<Activity>(new[]
+                var newCompositeProcessor = new CompositeProcessor<Activity>(new[]
                 {
                     this.processor,
-                    processor,
                 });
+                newCompositeProcessor.SetParentProvider(this);
+                newCompositeProcessor.AddProcessor(processor);
+                this.processor = newCompositeProcessor;
             }
 
             return this;

--- a/test/OpenTelemetry.Tests/Trace/CompositeActivityProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/CompositeActivityProcessorTests.cs
@@ -99,5 +99,28 @@ namespace OpenTelemetry.Trace.Tests
             Assert.True(p1.ForceFlushCalled);
             Assert.True(p2.ForceFlushCalled);
         }
+
+        [Fact]
+        public void CompositeActivityProcessor_ForwardsParentProviderl()
+        {
+            using TracerProvider provider = new TestProvider();
+
+            using var p1 = new TestActivityProcessor(null, null);
+            using var p2 = new TestActivityProcessor(null, null);
+
+            using var processor = new CompositeProcessor<Activity>(new[] { p1, p2 });
+
+            Assert.Null(p1.ParentProvider);
+            Assert.Null(p2.ParentProvider);
+
+            processor.SetParentProvider(provider);
+
+            Assert.Equal(provider, p1.ParentProvider);
+            Assert.Equal(provider, p2.ParentProvider);
+        }
+
+        private sealed class TestProvider : TracerProvider
+        {
+        }
     }
 }

--- a/test/OpenTelemetry.Tests/Trace/CompositeActivityProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/CompositeActivityProcessorTests.cs
@@ -101,7 +101,7 @@ namespace OpenTelemetry.Trace.Tests
         }
 
         [Fact]
-        public void CompositeActivityProcessor_ForwardsParentProviderl()
+        public void CompositeActivityProcessor_ForwardsParentProvider()
         {
             using TracerProvider provider = new TestProvider();
 
@@ -110,11 +110,13 @@ namespace OpenTelemetry.Trace.Tests
 
             using var processor = new CompositeProcessor<Activity>(new[] { p1, p2 });
 
+            Assert.Null(processor.ParentProvider);
             Assert.Null(p1.ParentProvider);
             Assert.Null(p2.ParentProvider);
 
             processor.SetParentProvider(provider);
 
+            Assert.Equal(provider, processor.ParentProvider);
             Assert.Equal(provider, p1.ParentProvider);
             Assert.Equal(provider, p2.ParentProvider);
         }

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
@@ -700,9 +700,11 @@ namespace OpenTelemetry.Trace.Tests
 
             // AddLegacyOperationName chained to TracerProviderBuilder
             using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-                        .AddProcessor(testActivityProcessor)
-                        .AddLegacySource(operationNameForLegacyActivity)
-                        .Build();
+                .AddProcessor(testActivityProcessor)
+                .AddLegacySource(operationNameForLegacyActivity)
+                .Build();
+
+            Assert.Equal(tracerProvider, testActivityProcessor.ParentProvider);
 
             Activity activity = new Activity(operationNameForLegacyActivity);
             activity.Start();
@@ -735,6 +737,12 @@ namespace OpenTelemetry.Trace.Tests
                 };
 
             tracerProvider.AddProcessor(testActivityProcessorNew);
+
+            var sdkProvider = (TracerProviderSdk)tracerProvider;
+
+            Assert.True(sdkProvider.Processor is CompositeProcessor<Activity>);
+            Assert.Equal(tracerProvider, sdkProvider.Processor.ParentProvider);
+            Assert.Equal(tracerProvider, testActivityProcessorNew.ParentProvider);
 
             Activity activityNew = new Activity(operationNameForLegacyActivity); // Create a new Activity with the same operation name
             activityNew.Start();


### PR DESCRIPTION
## Changes

Forward `SetParentProvider` calls to child processors when using `CompositeProcessor`.

## TODOs

* [X] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [X] Tests
