### PR TITLE
Examples: Fix ParentProvider not being set on MyFilteringProcessor

### DIFF
--- a/docs/trace/extending-the-sdk/MyFilteringProcessor.cs
+++ b/docs/trace/extending-the-sdk/MyFilteringProcessor.cs
@@ -17,8 +17,20 @@
 using System;
 using System.Diagnostics;
 using OpenTelemetry;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
 
-internal class MyFilteringProcessor : CompositeProcessor<Activity>
+/// <summary>
+/// A custom processor for filtering <see cref="Activity"/> instances.
+/// </summary>
+/// <remarks>
+/// Note: <see cref="CompositeProcessor{T}"/> is used as the base class because
+/// the SDK needs to understand that <c>MyFilteringProcessor</c> wraps an inner
+/// processor. Without that understanding some features such as <see
+/// cref="Resource"/> would unavailable because the SDK has to push state about
+/// the parent <see cref="TracerProvider"/> to all processors in the chain.
+/// </remarks>
+internal sealed class MyFilteringProcessor : CompositeProcessor<Activity>
 {
     private readonly Func<Activity, bool> filter;
 

--- a/docs/trace/extending-the-sdk/MyFilteringProcessor.cs
+++ b/docs/trace/extending-the-sdk/MyFilteringProcessor.cs
@@ -18,15 +18,14 @@ using System;
 using System.Diagnostics;
 using OpenTelemetry;
 
-internal class MyFilteringProcessor : BaseProcessor<Activity>
+internal class MyFilteringProcessor : CompositeProcessor<Activity>
 {
     private readonly Func<Activity, bool> filter;
-    private readonly BaseProcessor<Activity> processor;
 
     public MyFilteringProcessor(BaseProcessor<Activity> processor, Func<Activity, bool> filter)
+        : base(new[] { processor })
     {
         this.filter = filter ?? throw new ArgumentNullException(nameof(filter));
-        this.processor = processor ?? throw new ArgumentNullException(nameof(processor));
     }
 
     public override void OnEnd(Activity activity)
@@ -35,7 +34,7 @@ internal class MyFilteringProcessor : BaseProcessor<Activity>
         // only if the Filter returns true.
         if (this.filter(activity))
         {
-            this.processor.OnEnd(activity);
+            base.OnEnd(activity);
         }
     }
 }

--- a/docs/trace/extending-the-sdk/MyFilteringProcessor.cs
+++ b/docs/trace/extending-the-sdk/MyFilteringProcessor.cs
@@ -27,7 +27,7 @@ using OpenTelemetry.Trace;
 /// Note: <see cref="CompositeProcessor{T}"/> is used as the base class because
 /// the SDK needs to understand that <c>MyFilteringProcessor</c> wraps an inner
 /// processor. Without that understanding some features such as <see
-/// cref="Resource"/> would unavailable because the SDK needs to push state
+/// cref="Resource"/> would be unavailable because the SDK needs to push state
 /// about the parent <see cref="TracerProvider"/> to all processors in the
 /// chain.
 /// </remarks>

--- a/docs/trace/extending-the-sdk/MyFilteringProcessor.cs
+++ b/docs/trace/extending-the-sdk/MyFilteringProcessor.cs
@@ -27,8 +27,9 @@ using OpenTelemetry.Trace;
 /// Note: <see cref="CompositeProcessor{T}"/> is used as the base class because
 /// the SDK needs to understand that <c>MyFilteringProcessor</c> wraps an inner
 /// processor. Without that understanding some features such as <see
-/// cref="Resource"/> would unavailable because the SDK has to push state about
-/// the parent <see cref="TracerProvider"/> to all processors in the chain.
+/// cref="Resource"/> would unavailable because the SDK needs to push state
+/// about the parent <see cref="TracerProvider"/> to all processors in the
+/// chain.
 /// </remarks>
 internal sealed class MyFilteringProcessor : CompositeProcessor<Activity>
 {


### PR DESCRIPTION
Fixes #3241

## Changes

Uses `CompositeProcessor<Activity>` so that `ParentProvider` is correctly set on the inner processor for the filtering example.

Requires https://github.com/open-telemetry/opentelemetry-dotnet/pull/3368#issuecomment-1156984436 to fully work.