### PR TITLE
SDK: Use Volatile.Read over Interlocked.Read

### DIFF
--- a/src/OpenTelemetry/DiagnosticSourceInstrumentation/DiagnosticSourceSubscriber.cs
+++ b/src/OpenTelemetry/DiagnosticSourceInstrumentation/DiagnosticSourceSubscriber.cs
@@ -60,7 +60,7 @@ namespace OpenTelemetry.Instrumentation
 
         public void OnNext(DiagnosticListener value)
         {
-            if ((Interlocked.Read(ref this.disposed) == 0) &&
+            if ((Volatile.Read(ref this.disposed) == 0) &&
                 this.diagnosticSourceFilter(value))
             {
                 var handler = this.handlerFactory(value.Name);

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -403,21 +403,21 @@ namespace OpenTelemetry.Metrics
                     {
                         if (outputDelta)
                         {
-                            long initValue = Interlocked.Read(ref this.runningValue.AsLong);
+                            long initValue = Volatile.Read(ref this.runningValue.AsLong);
                             this.snapshotValue.AsLong = initValue - this.deltaLastValue.AsLong;
                             this.deltaLastValue.AsLong = initValue;
                             this.MetricPointStatus = MetricPointStatus.NoCollectPending;
 
                             // Check again if value got updated, if yes reset status.
                             // This ensures no Updates get Lost.
-                            if (initValue != Interlocked.Read(ref this.runningValue.AsLong))
+                            if (initValue != Volatile.Read(ref this.runningValue.AsLong))
                             {
                                 this.MetricPointStatus = MetricPointStatus.CollectPending;
                             }
                         }
                         else
                         {
-                            this.snapshotValue.AsLong = Interlocked.Read(ref this.runningValue.AsLong);
+                            this.snapshotValue.AsLong = Volatile.Read(ref this.runningValue.AsLong);
                         }
 
                         break;
@@ -460,12 +460,12 @@ namespace OpenTelemetry.Metrics
 
                 case AggregationType.LongGauge:
                     {
-                        this.snapshotValue.AsLong = Interlocked.Read(ref this.runningValue.AsLong);
+                        this.snapshotValue.AsLong = Volatile.Read(ref this.runningValue.AsLong);
                         this.MetricPointStatus = MetricPointStatus.NoCollectPending;
 
                         // Check again if value got updated, if yes reset status.
                         // This ensures no Updates get Lost.
-                        if (this.snapshotValue.AsLong != Interlocked.Read(ref this.runningValue.AsLong))
+                        if (this.snapshotValue.AsLong != Volatile.Read(ref this.runningValue.AsLong))
                         {
                             this.MetricPointStatus = MetricPointStatus.CollectPending;
                         }


### PR DESCRIPTION
Noticed working on #3349 that [Volatile.Read](https://github.com/dotnet/runtime/blob/9d0fcb5c2030f2a394eb4d0e675ba0de6cac72d1/src/libraries/System.Private.CoreLib/src/System/Threading/Volatile.cs#L90-L96) has an optimization for 64bit systems that make it faster than [Interlocked.Read](https://github.com/dotnet/runtime/blob/9d0fcb5c2030f2a394eb4d0e675ba0de6cac72d1/src/libraries/System.Private.CoreLib/src/System/Threading/Interlocked.cs#L189-L190). This PR updates some of the other places where `Interlocked.Read` was being used.

Simple benchmark:

```csharp
    public class VolatileBenchmarks
    {
        private long value;

        [Benchmark]
        public long UsingInterlocked()
        {
            var v = Interlocked.Read(ref value);
            return v;
        }

        [Benchmark]
        public long UsingVolatile()
        {
            var v = Volatile.Read(ref value);
            return v;
        }
    }
```

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22000
12th Gen Intel Core i9-12900HK, 1 CPU, 20 logical and 14 physical cores
.NET SDK=6.0.400-preview.22301.10
  [Host]     : .NET 6.0.6 (6.0.622.26707), X64 RyuJIT
  DefaultJob : .NET 6.0.6 (6.0.622.26707), X64 RyuJIT


|           Method |      Mean |     Error |    StdDev |    Median |
|----------------- |----------:|----------:|----------:|----------:|
| UsingInterlocked | 5.6288 ns | 0.1398 ns | 0.4012 ns | 5.3640 ns |
|    UsingVolatile | 0.0021 ns | 0.0041 ns | 0.0038 ns | 0.0000 ns |