### PR TITLE
Asp.Net Core trace instrumentation to populate http schema tag

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -5,10 +5,8 @@
 * Metrics instrumentation to correctly populate 'http.flavor' tag.
   (1.1 instead of HTTP/1.1 etc.)
   ([3379](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3379))
-
 * Tracing instrumentation to populate 'http.flavor' tag.
   ([3372](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3372))
-
 * Tracing instrumentation to populate 'http.schema' tag.
 ([3392](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3392))
 
@@ -18,7 +16,6 @@ Released 2022-Jun-03
 
 * Added additional metric dimensions.
   ([3247](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3247))
-
 * Removes net5.0 target as .NET 5.0 is going out
   of support. The package keeps netstandard2.1 target, so it
   can still be used with .NET5.0 apps.

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Tracing instrumentation to populate 'http.flavor' tag.
   ([3372](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3372))
 
+* Tracing instrumentation to populate 'http.schema' tag.
+([3392](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3392))
+
 ## 1.0.0-rc9.4
 
 Released 2022-Jun-03

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -153,6 +153,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
                 }
 
                 activity.SetTag(SemanticConventions.AttributeHttpMethod, request.Method);
+                activity.SetTag(SemanticConventions.AttributeHttpScheme, request.Scheme);
                 activity.SetTag(SemanticConventions.AttributeHttpTarget, path);
                 activity.SetTag(SemanticConventions.AttributeHttpUrl, GetUri(request));
                 activity.SetTag(SemanticConventions.AttributeHttpFlavor, HttpTagHelper.GetFlavorTagValueFromProtocol(request.Protocol));

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -143,14 +143,15 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
 
                 // see the spec https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md
 
-                if (request.Host.Port is null or 80 or 443)
-                {
-                    activity.SetTag(SemanticConventions.AttributeHttpHost, request.Host.Host);
-                }
-                else
-                {
-                    activity.SetTag(SemanticConventions.AttributeHttpHost, request.Host.Host + ":" + request.Host.Port);
-                }
+                activity.SetTag(SemanticConventions.AttributeHttpHost, request.Host.Value);
+                //if (request.Host.Port is null or 80 or 443)
+                //{
+                //    activity.SetTag(SemanticConventions.AttributeHttpHost, request.Host.Host);
+                //}
+                //else
+                //{
+                //    activity.SetTag(SemanticConventions.AttributeHttpHost, request.Host.Host + ":" + request.Host.Port);
+                //}
 
                 activity.SetTag(SemanticConventions.AttributeHttpMethod, request.Method);
                 activity.SetTag(SemanticConventions.AttributeHttpScheme, request.Scheme);

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -143,15 +143,14 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
 
                 // see the spec https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md
 
-                activity.SetTag(SemanticConventions.AttributeHttpHost, request.Host.Value);
-                //if (request.Host.Port is null or 80 or 443)
-                //{
-                //    activity.SetTag(SemanticConventions.AttributeHttpHost, request.Host.Host);
-                //}
-                //else
-                //{
-                //    activity.SetTag(SemanticConventions.AttributeHttpHost, request.Host.Host + ":" + request.Host.Port);
-                //}
+                if (request.Host.Port is null or 80 or 443)
+                {
+                    activity.SetTag(SemanticConventions.AttributeHttpHost, request.Host.Host);
+                }
+                else
+                {
+                    activity.SetTag(SemanticConventions.AttributeHttpHost, request.Host.Host + ":" + request.Host.Port);
+                }
 
                 activity.SetTag(SemanticConventions.AttributeHttpMethod, request.Method);
                 activity.SetTag(SemanticConventions.AttributeHttpScheme, request.Scheme);

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
@@ -113,6 +113,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             Assert.Equal("localhost", activity.GetTagValue(SemanticConventions.AttributeHttpHost));
             Assert.Equal("GET", activity.GetTagValue(SemanticConventions.AttributeHttpMethod));
             Assert.Equal("1.1", activity.GetTagValue(SemanticConventions.AttributeHttpFlavor));
+            Assert.Equal("http", activity.GetTagValue(SemanticConventions.AttributeHttpScheme));
             Assert.Equal(urlPath, activity.GetTagValue(SemanticConventions.AttributeHttpTarget));
             Assert.Equal($"http://localhost{urlPath}{query}", activity.GetTagValue(SemanticConventions.AttributeHttpUrl));
             Assert.Equal(statusCode, activity.GetTagValue(SemanticConventions.AttributeHttpStatusCode));

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/InProcessServer.cs
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/InProcessServer.cs
@@ -23,9 +23,6 @@ using OpenTelemetry.Trace;
 #if NETCOREAPP3_1
 using TestApp.AspNetCore._3._1;
 #endif
-#if NET5_0
-using TestApp.AspNetCore._5._0;
-#endif
 #if NET6_0
 using TestApp.AspNetCore._6._0;
 #endif


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-dotnet/issues/3373

Asp.Net Core was missing http.schema attribute, which is listed as a Recommended tag in the sem. conventions.
(the metrics instrumentation was already populating this)