### PR TITLE
Try asp.net core tests with inproc server

### DIFF
--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/InProcServerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/InProcServerTests.cs
@@ -77,7 +77,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             Assert.Equal(200, activity.GetTagValue(SemanticConventions.AttributeHttpStatusCode));
         }
 
-        public async void DisposeAsync()
+        public async void Dispose()
         {
             this.tracerProvider.Dispose();
             this.client.Dispose();

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/InProcServerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/InProcServerTests.cs
@@ -77,11 +77,11 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             Assert.Equal(200, activity.GetTagValue(SemanticConventions.AttributeHttpStatusCode));
         }
 
-        public void Dispose()
+        public async void Dispose()
         {
             this.tracerProvider.Dispose();
             this.client.Dispose();
-            this.app.DisposeAsync();
+            await this.app.DisposeAsync();
         }
     }
 }

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/InProcServerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/InProcServerTests.cs
@@ -77,7 +77,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             Assert.Equal(200, activity.GetTagValue(SemanticConventions.AttributeHttpStatusCode));
         }
 
-        public async void Dispose()
+        public async void DisposeAsync()
         {
             this.tracerProvider.Dispose();
             this.client.Dispose();

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/InProcServerTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/InProcServerTests.cs
@@ -1,0 +1,88 @@
+// <copyright file="InProcServerTests.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET6_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using OpenTelemetry.Trace;
+using Xunit;
+
+namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
+{
+    public sealed class InProcServerTests : IDisposable
+    {
+        private TracerProvider tracerProvider;
+        private WebApplication app;
+        private HttpClient client;
+        private List<Activity> exportedItems;
+
+        public InProcServerTests()
+        {
+            this.exportedItems = new List<Activity>();
+            var builder = WebApplication.CreateBuilder();
+            var app = builder.Build();
+
+            this.tracerProvider = Sdk.CreateTracerProviderBuilder()
+                .AddAspNetCoreInstrumentation()
+                .AddInMemoryExporter(this.exportedItems).Build();
+            app.MapGet("/", () => "Hello World!");
+            app.RunAsync();
+
+            this.app = app;
+            this.client = new HttpClient();
+        }
+
+        [Fact]
+        public async void ExampleTest()
+        {
+            var res = await this.client.GetStringAsync("http://localhost:5000");
+            Assert.NotNull(res);
+
+            this.tracerProvider.ForceFlush();
+            for (var i = 0; i < 10; i++)
+            {
+                if (this.exportedItems.Count > 0)
+                {
+                    break;
+                }
+
+                // We need to let End callback execute as it is executed AFTER response was returned.
+                // In unit tests environment there may be a lot of parallel unit tests executed, so
+                // giving some breezing room for the End callback to complete
+                await Task.Delay(TimeSpan.FromSeconds(1));
+            }
+
+            var activity = this.exportedItems[0];
+            Assert.Equal(ActivityKind.Server, activity.Kind);
+            Assert.Equal("localhost:5000", activity.GetTagValue(SemanticConventions.AttributeHttpHost));
+            Assert.Equal("GET", activity.GetTagValue(SemanticConventions.AttributeHttpMethod));
+            Assert.Equal("1.1", activity.GetTagValue(SemanticConventions.AttributeHttpFlavor));
+            Assert.Equal(200, activity.GetTagValue(SemanticConventions.AttributeHttpStatusCode));
+        }
+
+        public void Dispose()
+        {
+            this.tracerProvider.Dispose();
+            this.client.Dispose();
+            this.app.DisposeAsync();
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Current asp.net core tests are based on the "Test Server" concept. This PR attempts to use a in-proc asp.net core server.
For testing certain aspects like http/3, (eg: https://github.com/open-telemetry/opentelemetry-dotnet/pull/3372), we might need to have a proper asp.net core server.

This is just an exploration of feasibility. No actual tests are moved. Need to evaluate this further, before using this as a the main test technique. Quite likely, we can use this only for very specific scenarios. The W3CIntegrationtests is already using this approach.