### PR TITLE
Instrument ASP.NET Core after TraceProvider build

### DIFF
--- a/src/OpenTelemetry.Api/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+OpenTelemetry.Trace.TracerProvider.AddInstrumentation(object instrumentation) -> OpenTelemetry.Trace.TracerProvider

--- a/src/OpenTelemetry.Api/Trace/TracerProvider.cs
+++ b/src/OpenTelemetry.Api/Trace/TracerProvider.cs
@@ -14,7 +14,10 @@
 // limitations under the License.
 // </copyright>
 
+using System;
+using System.Collections.Concurrent;
 using System.Diagnostics;
+using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Trace
 {
@@ -23,6 +26,8 @@ namespace OpenTelemetry.Trace
     /// </summary>
     public class TracerProvider : BaseProvider
     {
+        private readonly ConcurrentBag<object> instrumentations = new();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TracerProvider"/> class.
         /// </summary>
@@ -34,6 +39,11 @@ namespace OpenTelemetry.Trace
         /// Gets the default Tracer.
         /// </summary>
         public static TracerProvider Default { get; } = new TracerProvider();
+
+        /// <summary>
+        /// Gets the registered instrumentation instances.
+        /// </summary>
+        internal ConcurrentBag<object> Instrumentations => this.instrumentations;
 
         /// <summary>
         /// Gets a tracer with given name and version.
@@ -49,6 +59,20 @@ namespace OpenTelemetry.Trace
             }
 
             return new Tracer(new ActivitySource(name, version));
+        }
+
+        /// <summary>
+        /// Tracks the instrumentation instance and disposes if is <see cref="IDisposable">IDisposable</see>.
+        /// </summary>
+        /// <param name="instrumentation">Instrumentation instance.</param>
+        /// <returns>TracerProvider instance.</returns>
+        public TracerProvider AddInstrumentation(object instrumentation)
+        {
+            Guard.ThrowIfNull(instrumentation);
+
+            this.instrumentations.Add(instrumentation);
+
+            return this;
         }
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -9,6 +9,9 @@ OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreInstrumentationOptions.Filter
 OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreInstrumentationOptions.RecordException.get -> bool
 OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreInstrumentationOptions.RecordException.set -> void
 OpenTelemetry.Metrics.MeterProviderBuilderExtensions
+OpenTelemetry.Trace.TraceProviderExtensions
 OpenTelemetry.Trace.TracerProviderBuilderExtensions
 static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.AddAspNetCoreInstrumentation(this OpenTelemetry.Metrics.MeterProviderBuilder builder) -> OpenTelemetry.Metrics.MeterProviderBuilder
+static OpenTelemetry.Trace.TraceProviderExtensions.AddAspNetCoreInstrumentation(this OpenTelemetry.Trace.TracerProvider provider, System.Action<OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreInstrumentationOptions> configureAspNetCoreInstrumentationOptions = null) -> OpenTelemetry.Trace.TracerProvider
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddAspNetCoreInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Instrumentation.AspNetCore.AspNetCoreInstrumentationOptions> configureAspNetCoreInstrumentationOptions = null) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddAspNetCoreSources(this OpenTelemetry.Trace.TracerProviderBuilder builder) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -18,7 +18,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Reflection;
 #if !NETSTANDARD2_0
 using System.Runtime.CompilerServices;
 #endif
@@ -34,11 +33,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
 {
     internal class HttpInListener : ListenerHandler
     {
-        internal const string ActivityOperationName = "Microsoft.AspNetCore.Hosting.HttpRequestIn";
-        internal static readonly AssemblyName AssemblyName = typeof(HttpInListener).Assembly.GetName();
-        internal static readonly string ActivitySourceName = AssemblyName.Name;
-        internal static readonly Version Version = AssemblyName.Version;
-        internal static readonly ActivitySource ActivitySource = new(ActivitySourceName, Version.ToString());
+        internal static readonly ActivitySource ActivitySource = new(InstrumentationInfo.ActivitySourceName, InstrumentationInfo.Version.ToString());
         private const string DiagnosticSourceName = "Microsoft.AspNetCore";
         private const string UnknownHostName = "UNKNOWN-HOST";
         private static readonly Func<HttpRequest, string, IEnumerable<string>> HttpRequestHeaderValuesGetter = (request, name) => request.Headers[name];
@@ -96,7 +91,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
                     // Create a new activity with its parent set from the extracted context.
                     // This makes the new activity as a "sibling" of the activity created by
                     // Asp.Net Core.
-                    Activity newOne = new Activity(ActivityOperationName);
+                    Activity newOne = new Activity(InstrumentationInfo.ActivityOperationName);
                     newOne.SetParentId(ctx.ActivityContext.TraceId, ctx.ActivityContext.SpanId, ctx.ActivityContext.TraceFlags);
                     newOne.TraceStateString = ctx.ActivityContext.TraceState;
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/InstrumentationInfo.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/InstrumentationInfo.cs
@@ -1,0 +1,29 @@
+// <copyright file="InstrumentationInfo.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Reflection;
+
+namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
+{
+    internal static class InstrumentationInfo
+    {
+        internal const string ActivityOperationName = "Microsoft.AspNetCore.Hosting.HttpRequestIn";
+        internal static readonly AssemblyName AssemblyName = typeof(HttpInListener).Assembly.GetName();
+        internal static readonly string ActivitySourceName = AssemblyName.Name;
+        internal static readonly Version Version = AssemblyName.Version;
+    }
+}

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/TraceProviderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/TraceProviderExtensions.cs
@@ -1,0 +1,62 @@
+// <copyright file="TraceProviderExtensions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using OpenTelemetry.Instrumentation.AspNetCore;
+using OpenTelemetry.Instrumentation.AspNetCore.Implementation;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Trace
+{
+    /// <summary>
+    /// Extension methods to simplify registering of ASP.NET Core request instrumentation.
+    /// </summary>
+    public static class TraceProviderExtensions
+    {
+        /// <summary>
+        /// Enables the incoming requests automatic data collection for ASP.NET Core.
+        /// </summary>
+        /// <param name="provider"><see cref="TracerProvider"/> being configured.</param>
+        /// <param name="configureAspNetCoreInstrumentationOptions">ASP.NET Core Request configuration options.</param>
+        /// <returns>The instance of <see cref="TracerProvider"/> to chain the calls.</returns>
+        public static TracerProvider AddAspNetCoreInstrumentation(
+            this TracerProvider provider,
+            Action<AspNetCoreInstrumentationOptions> configureAspNetCoreInstrumentationOptions = null)
+        {
+            Guard.ThrowIfNull(provider);
+
+            return AddAspNetCoreInstrumentation(provider, new AspNetCoreInstrumentationOptions(), configureAspNetCoreInstrumentationOptions);
+        }
+
+        internal static TracerProvider AddAspNetCoreInstrumentation(
+            this TracerProvider provider,
+            AspNetCoreInstrumentation instrumentation)
+        {
+            return provider.AddInstrumentation(() => instrumentation);
+        }
+
+        private static TracerProvider AddAspNetCoreInstrumentation(
+            TracerProvider provider,
+            AspNetCoreInstrumentationOptions options,
+            Action<AspNetCoreInstrumentationOptions> configure = null)
+        {
+            configure?.Invoke(options);
+            return AddAspNetCoreInstrumentation(
+                provider,
+                new AspNetCoreInstrumentation(new HttpInListener(options)));
+        }
+    }
+}

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/TracerProviderBuilderExtensions.cs
@@ -49,12 +49,25 @@ namespace OpenTelemetry.Trace
             return AddAspNetCoreInstrumentation(builder, new AspNetCoreInstrumentationOptions(), configureAspNetCoreInstrumentationOptions);
         }
 
+        /// <summary>
+        /// Adds ASP.NET Core sources to instrumentation list.
+        /// ASP.NET Core instrumentation must be added externally when ready to instrument.
+        /// </summary>
+        /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
+        /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
+        public static TracerProviderBuilder AddAspNetCoreSources(this TracerProviderBuilder builder)
+        {
+            builder.AddSource(InstrumentationInfo.ActivitySourceName);
+            builder.AddLegacySource(InstrumentationInfo.ActivityOperationName); // for the activities created by AspNetCore
+
+            return builder;
+        }
+
         internal static TracerProviderBuilder AddAspNetCoreInstrumentation(
             this TracerProviderBuilder builder,
             AspNetCoreInstrumentation instrumentation)
         {
-            builder.AddSource(HttpInListener.ActivitySourceName);
-            builder.AddLegacySource(HttpInListener.ActivityOperationName); // for the activities created by AspNetCore
+            builder.AddAspNetCoreSources();
             return builder.AddInstrumentation(() => instrumentation);
         }
 


### PR DESCRIPTION
## What

Autoinstrumentation requires subscribing to the sources when library loads, as we may hit a missing dll issue (eg when enabling all instrumentation by default for console app, ASP.NET references will break the app).

## Changes

* Moves tracking instrumentation objects from TraceProviderSdk to TraceProvider.
* Introduces new apis making possible to subscribe dynamically to ASP.NET Core instrumentation.
* Separates sources and instrumentation instances.
* Separates some metadata to a new type not to hit ASP.NET Core framework references.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
