### PR TITLE
Use fetch-depth 0 to make minver work properly

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 # fetching all
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 # fetching all
 
     - name: Install dependencies
       run: dotnet restore


### PR DESCRIPTION
CI is failing on #3408 with the following:

> CSC : error CS1705: Assembly 'OpenTelemetry.Instrumentation.Runtime' with identity 'OpenTelemetry.Instrumentation.Runtime, Version=1.0.0.1, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c' uses 'OpenTelemetry.Api, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c' which has a higher version than referenced assembly 'OpenTelemetry.Api' with identity 'OpenTelemetry.Api, Version=0.0.0.0, Culture=neutral, PublicKeyToken=7bd6737fe5b67e3c' [/home/runner/work/opentelemetry-dotnet/opentelemetry-dotnet/examples/AspNetCore/Examples.AspNetCore.csproj]


This is because minver does not actually version our assemblies for PR builds and builds triggered for pushes to main. For minver to work, we need to set `fetch-depth=0`.

I suspect this may have some impact on build times... not sure what the overhead of fetching all commits is.