### PR TITLE
Update Newtonsoft.Json package version

### DIFF
--- a/build/Common.nonprod.props
+++ b/build/Common.nonprod.props
@@ -41,7 +41,7 @@
     <MicrosoftExtensionsLoggingPkgVer>[6.0.0,)</MicrosoftExtensionsLoggingPkgVer>
     <MicrosoftExtensionsLoggingAbstractionsPkgVer>[6.0.0,)</MicrosoftExtensionsLoggingAbstractionsPkgVer>
     <MicrosoftNETTestSdkPkgVer>[16.10.0]</MicrosoftNETTestSdkPkgVer>
-    <NewtonsoftJsonPkgVer>[12.0.2,13.0)</NewtonsoftJsonPkgVer>
+    <NewtonsoftJsonPkgVer>[13.0.1,14.0)</NewtonsoftJsonPkgVer>
     <MoqPkgVer>[4.14.5,5.0)</MoqPkgVer>
     <RabbitMQClientPkgVer>[6.1.0,7.0)</RabbitMQClientPkgVer>
     <RuntimeInstrumentationPkgVer>[1.0.0-rc.1,2.0)</RuntimeInstrumentationPkgVer>


### PR DESCRIPTION
## Changes
- Update Newtonsoft.Json package version to 13.0.1.

There is a [security vulnerability](https://github.com/advisories/GHSA-5crp-9r3c-p9vr) with the package versions < 13.0.1. It shouldn't affect us since we only use it in our test projects and we know our usage but regardless.
