### PR TITLE
Add Utkarsh as maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,13 @@ If you have trouble accessing the doc, please get in touch on
 * [Alan West](https://github.com/alanwest), New Relic
 * [Cijo Thomas](https://github.com/cijothomas), Microsoft
 * [Mikel Blanchard](https://github.com/CodeBlanch), Microsoft
+* [Utkarsh Umesan Pillai](https://github.com/utpilla), Microsoft
 
 [Approvers](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver)
 ([@open-telemetry/dotnet-approvers](https://github.com/orgs/open-telemetry/teams/dotnet-approvers)):
 
 * [Reiley Yang](https://github.com/reyang), Microsoft
 * [Robert Paj&#x105;k](https://github.com/pellared), Splunk
-* [Utkarsh Umesan Pillai](https://github.com/utpilla), Microsoft
 
 [Emeritus
 Maintainer/Approver/Triager](https://github.com/open-telemetry/community/blob/main/community-membership.md#emeritus-maintainerapprovertriager):


### PR DESCRIPTION
How time flies! It seems like just yesterday (May 2021 actually #2065) Utkarsh graciously agreed to join us in the role of an approver on the [opentelemetry-dotnet](https://github.com/open-telemetry/opentelemetry-dotnet) project. Since that time, Utkarsh has also assumed the role of maintainer for the [opentelemetry-dotnet-contrib](https://github.com/open-telemetry/opentelemetry-dotnet-contrib) project (https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/211).

Thank you @utpilla for:
* So much great work fine-tuning the performance of our metrics support. I mean just look at all the 👍, ❤️, 🎉, and 🚀 emojis on these PRs for example: https://github.com/open-telemetry/opentelemetry-dotnet/pull/2805 and https://github.com/open-telemetry/opentelemetry-dotnet/pull/2951.
* Your solid maintainership of the opentelemetry-dotnet-contrib project including:
  * Migrating numerous instrumentation projects from the core repo to the contrib repo.
  * Many important housekeeping efforts improving the CI and infrastructure.
  * Big :heart: to removing the word `contrib` outta the name of all those packages!
  * Sheparding the great work the community is delivering for runtime metrics, EventCounter instrumentation, and so many other things.
* As well as [so many helpful reviews](https://github.com/pulls?page=5&q=is%3Apr+commenter%3Autpilla+user%3Aopen-telemetry) across both projects. It's exciting to see the community grow, and you have played a big role in enabling that.

We now ask that you continue your great work in the role of maintainer for the opentelemetry-dotnet project!
