### PR TITLE
Replace StringComparison.InvariantCultureIgnoreCase with OrdinalIgnoreCase

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/ExporterClientValidation.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/ExporterClientValidation.cs
@@ -30,7 +30,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClie
                 return;
             }
 
-            if (options.Endpoint.Scheme.Equals("http", StringComparison.InvariantCultureIgnoreCase))
+            if (options.Endpoint.Scheme.Equals("http", StringComparison.OrdinalIgnoreCase))
             {
                 if (AppContext.TryGetSwitch(
                         "System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", out var unencryptedIsSupported) == false

--- a/src/OpenTelemetry/DiagnosticSourceInstrumentation/PropertyFetcher.cs
+++ b/src/OpenTelemetry/DiagnosticSourceInstrumentation/PropertyFetcher.cs
@@ -84,7 +84,7 @@ namespace OpenTelemetry.Instrumentation
         {
             public static PropertyFetch Create(TypeInfo type, string propertyName)
             {
-                var property = type.DeclaredProperties.FirstOrDefault(p => string.Equals(p.Name, propertyName, StringComparison.InvariantCultureIgnoreCase));
+                var property = type.DeclaredProperties.FirstOrDefault(p => string.Equals(p.Name, propertyName, StringComparison.OrdinalIgnoreCase));
                 if (property == null)
                 {
                     property = type.GetProperty(propertyName);

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.netcore31.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.netcore31.cs
@@ -128,7 +128,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
 
             foreach (var kv in normalizedAttributesTestCase)
             {
-                Assert.Contains(activity.TagObjects, i => i.Key == kv.Key && i.Value.ToString().Equals(kv.Value, StringComparison.InvariantCultureIgnoreCase));
+                Assert.Contains(activity.TagObjects, i => i.Key == kv.Key && i.Value.ToString().Equals(kv.Value, StringComparison.OrdinalIgnoreCase));
             }
 
             if (tc.RecordException.HasValue && tc.RecordException.Value)


### PR DESCRIPTION
## Changes

Use `StringComparison.OrdinalIgnoreCase` instead of `InvariantCultureIgnoreCase` when it makes sense.