### PR TITLE
EnvironmentVariableHelper support for boolean

### DIFF
--- a/src/OpenTelemetry/Internal/EnvironmentVariableHelper.cs
+++ b/src/OpenTelemetry/Internal/EnvironmentVariableHelper.cs
@@ -111,5 +111,33 @@ namespace OpenTelemetry.Internal
 
             return true;
         }
+
+        /// <summary>
+        /// Reads an environment variable and parses it as a <see cref="bool" />.
+        /// </summary>
+        /// <param name="envVarKey">The name of the environment variable.</param>
+        /// <param name="result">The parsed value of the environment variable.</param>
+        /// <returns>
+        /// Returns <c>true</c> when a non-empty value was read; otherwise, <c>false</c>.
+        /// </returns>
+        /// <exception cref="FormatException">
+        /// Thrown when failed to parse the non-empty value.
+        /// </exception>
+        public static bool LoadBoolean(string envVarKey, out bool result)
+        {
+            result = default;
+
+            if (!LoadString(envVarKey, out string value))
+            {
+                return false;
+            }
+
+            if (!bool.TryParse(value, out result))
+            {
+                throw new FormatException($"{envVarKey} environment variable has an invalid value: '${value}'");
+            }
+
+            return true;
+        }
     }
 }

--- a/test/OpenTelemetry.Tests/Internal/EnvironmentVariableHelperTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/EnvironmentVariableHelperTests.cs
@@ -60,6 +60,8 @@ namespace OpenTelemetry.Internal.Tests
         [InlineData("TRUE", true)]
         [InlineData("false", false)]
         [InlineData("FALSE", false)]
+        [InlineData(" true ", true)]
+        [InlineData(" false ", false)]
         public void LoadBoolean(string value, bool expectedValue)
         {
             Environment.SetEnvironmentVariable(EnvVar, value);
@@ -82,6 +84,8 @@ namespace OpenTelemetry.Internal.Tests
         [Theory]
         [InlineData("something")] // non true/false
         [InlineData(" ")] // whitespaces
+        [InlineData("0")] // 0
+        [InlineData("1")] // 1
         public void LoadBoolean_Invalid(string value)
         {
             Environment.SetEnvironmentVariable(EnvVar, value);

--- a/test/OpenTelemetry.Tests/Internal/EnvironmentVariableHelperTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/EnvironmentVariableHelperTests.cs
@@ -56,6 +56,40 @@ namespace OpenTelemetry.Internal.Tests
         }
 
         [Theory]
+        [InlineData("true", true)]
+        [InlineData("TRUE", true)]
+        [InlineData("false", false)]
+        [InlineData("FALSE", false)]
+        public void LoadBoolean(string value, bool expectedValue)
+        {
+            Environment.SetEnvironmentVariable(EnvVar, value);
+
+            bool actualBool = EnvironmentVariableHelper.LoadBoolean(EnvVar, out bool actualValue);
+
+            Assert.True(actualBool);
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        [Fact]
+        public void LoadBoolean_NoValue()
+        {
+            bool actualBool = EnvironmentVariableHelper.LoadBoolean(EnvVar, out bool actualValue);
+
+            Assert.False(actualBool);
+            Assert.False(actualValue);
+        }
+
+        [Theory]
+        [InlineData("something")] // non true/false
+        [InlineData(" ")] // whitespaces
+        public void LoadBoolean_Invalid(string value)
+        {
+            Environment.SetEnvironmentVariable(EnvVar, value);
+
+            Assert.Throws<FormatException>(() => EnvironmentVariableHelper.LoadBoolean(EnvVar, out bool _));
+        }
+
+        [Theory]
         [InlineData("123", 123)]
         [InlineData("0", 0)]
         public void LoadNumeric(string value, int expectedValue)


### PR DESCRIPTION
Fixes: N/A

## Changes

Support for boolean values in `EnvironmentVariableHelper`.
Boolean is special type of Enum.

The plan is to copy this file also to contrib repo. The same approach was used for https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/d9cc2811c384943dc7aa5004af7c89dd0ed6bebc/src/OpenTelemetry.Internal/Guard.cs

In AutoIntrumentation we need to configure some env. variables for MySql.Data instrumentation. https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/519
