### PR TITLE
Start ZPages HttpListener sooner

### DIFF
--- a/src/OpenTelemetry.Exporter.ZPages/ZPagesExporterStatsHttpServer.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/ZPagesExporterStatsHttpServer.cs
@@ -65,6 +65,8 @@ namespace OpenTelemetry.Exporter.ZPages
                     new CancellationTokenSource() :
                     CancellationTokenSource.CreateLinkedTokenSource(token);
 
+                this.httpListener.Start();
+
                 this.workerThread = Task.Factory.StartNew(this.WorkerThread, default, TaskCreationOptions.LongRunning, TaskScheduler.Default);
             }
         }
@@ -110,8 +112,6 @@ namespace OpenTelemetry.Exporter.ZPages
 
         private void WorkerThread()
         {
-            this.httpListener.Start();
-
             try
             {
                 while (!this.tokenSource.IsCancellationRequested)


### PR DESCRIPTION
I think this will fix the flicker we've seen here https://github.com/open-telemetry/opentelemetry-dotnet/runs/7433955618.

The following test starts the ZPages server, but the underlying HttpListener may not yet be started before `Start()` returns

https://github.com/open-telemetry/opentelemetry-dotnet/blob/d93606ea71d0d124592b3fc60f0388b5701591de/test/OpenTelemetry.Exporter.ZPages.Tests/ZPagesExporterTests.cs#L164-L168