### PR TITLE
[Discussion] [Logs] Circular logging

### DIFF
--- a/src/OpenTelemetry/Logs/LogEmitter.cs
+++ b/src/OpenTelemetry/Logs/LogEmitter.cs
@@ -44,10 +44,17 @@ namespace OpenTelemetry.Logs
         /// <param name="attributes"><see cref="LogRecordAttributeList"/>.</param>
         public void Emit(in LogRecordData data, in LogRecordAttributeList attributes = default)
         {
+            if (Sdk.SuppressInstrumentation)
+            {
+                return;
+            }
+
             var provider = this.loggerProvider;
             var processor = provider.Processor;
             if (processor != null)
             {
+                using var scope = SuppressInstrumentationScope.Begin();
+
                 var pool = provider.LogRecordPool;
 
                 var logRecord = pool.Rent();

--- a/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
@@ -53,6 +53,8 @@ namespace OpenTelemetry.Logs
             var processor = provider.Processor;
             if (processor != null)
             {
+                using var scope = SuppressInstrumentationScope.Begin();
+
                 var pool = provider.LogRecordPool;
 
                 var record = pool.Rent();


### PR DESCRIPTION
This came out of this comment: https://github.com/open-telemetry/opentelemetry-dotnet/pull/3454#discussion_r927064184

It is pretty easy to put logging into a bad state where it will stack overflow. On this PR I have a couple tests which show that.

It is also pretty easy to fix with `SuppressInstrumentationScope.Begin` however that is very expensive. The fix as-is on this PR will allocate an execution context for every log?

Not sure what to do here. If we consider extensions like what is on #3454 it becomes pretty unsafe to log at all in the logging pipeline without some kind of detection.

Thoughts? Ideas?

I'm thinking a special ThreadStatic might be cheaper to detect re-entrant logs and bail out in that case.
