### PR TITLE
PropertyFetcher: Ignore payload type when expected property name does not exist

### DIFF
--- a/test/OpenTelemetry.Tests/Instrumentation/PropertyFetcherTest.cs
+++ b/test/OpenTelemetry.Tests/Instrumentation/PropertyFetcherTest.cs
@@ -67,6 +67,17 @@ namespace OpenTelemetry.Instrumentation.Tests
             Assert.False(fetch.TryFetch(null, out _));
         }
 
+        [Fact]
+        public void FetchPropertyMultiplePayloadTypes_IgnoreTypesWithoutExpectedPropertyName()
+        {
+            var fetch = new PropertyFetcher<string>("Property");
+
+            Assert.False(fetch.TryFetch(new PayloadTypeC(), out _));
+
+            Assert.True(fetch.TryFetch(new PayloadTypeA(), out string propertyValue));
+            Assert.Equal("A", propertyValue);
+        }
+
         private class PayloadTypeA
         {
             public string Property { get; set; } = "A";


### PR DESCRIPTION
Might fix the issue #3475