### PR TITLE
Mark LogRecord.CategoryName Obsolete

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
@@ -42,10 +42,12 @@ namespace OpenTelemetry.Exporter
                     this.WriteLine($"{"LogRecord.TraceFlags:",-RightPaddingLength}{logRecord.TraceFlags}");
                 }
 
+#pragma warning disable 618 // LogRecord.CategoryName is obsolete
                 if (logRecord.CategoryName != null)
                 {
                     this.WriteLine($"{"LogRecord.CategoryName:",-RightPaddingLength}{logRecord.CategoryName}");
                 }
+#pragma warning restore 618 // LogRecord.CategoryName is obsolete
 
                 this.WriteLine($"{"LogRecord.LogLevel:",-RightPaddingLength}{logRecord.LogLevel}");
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
@@ -75,16 +75,6 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
                     SeverityText = LogLevels[(int)logRecord.LogLevel],
                 };
 
-                if (!string.IsNullOrEmpty(logRecord.CategoryName))
-                {
-                    // TODO:
-                    // 1. Track the following issue, and map CategoryName to Name
-                    // if it makes it to log data model.
-                    // https://github.com/open-telemetry/opentelemetry-specification/issues/2398
-                    // 2. Confirm if this name for attribute is good.
-                    otlpLogRecord.Attributes.AddStringAttribute("dotnet.ilogger.category", logRecord.CategoryName);
-                }
-
                 bool bodyPopulatedFromFormattedMessage = false;
                 if (logRecord.FormattedMessage != null)
                 {

--- a/src/OpenTelemetry.Extensions.Serilog/OpenTelemetrySerilogSink.cs
+++ b/src/OpenTelemetry.Extensions.Serilog/OpenTelemetrySerilogSink.cs
@@ -71,7 +71,7 @@ namespace OpenTelemetry.Logs
                 if (property.Key == Constants.SourceContextPropertyName
                     && property.Value is ScalarValue sourceContextValue)
                 {
-                    data.CategoryName = sourceContextValue.Value as string;
+                    attributes.Add("serilog.source_context", sourceContextValue.Value as string);
                 }
                 else if (property.Value is ScalarValue scalarValue)
                 {

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -31,6 +31,9 @@
 * Fix exact match of activity source name when `wildcard` is used.
   ([#3446](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3446))
 
+* `LogRecord.CategoryName` has been marked obsolete.
+  ([#3493](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3493))
+
 ## 1.3.0
 
 Released 2022-Jun-03

--- a/src/OpenTelemetry/Logs/LogRecord.cs
+++ b/src/OpenTelemetry/Logs/LogRecord.cs
@@ -127,6 +127,7 @@ namespace OpenTelemetry.Logs
         /// <summary>
         /// Gets or sets the log category name.
         /// </summary>
+        [Obsolete("CategoryName may not be exported. Consider adding an attribute to the LogRecord.")]
         public string? CategoryName
         {
             get => this.Data.CategoryName;

--- a/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
@@ -64,13 +64,17 @@ namespace OpenTelemetry.Logs
                 ref LogRecordData data = ref record.Data;
 
                 data.TimestampBacking = DateTime.UtcNow;
-                data.CategoryName = this.categoryName;
                 data.LogLevel = logLevel;
                 data.EventId = eventId;
                 data.Message = provider.IncludeFormattedMessage ? formatter?.Invoke(state, exception) : null;
                 data.Exception = exception;
 
                 LogRecordData.SetActivityContext(ref data, Activity.Current);
+
+                LogRecordAttributeList attributes = default;
+
+                // TODO: Confirm if this name for attribute is good.
+                attributes.Add("dotnet.ilogger.category", this.categoryName);
 
                 processor.OnEnd(record);
 

--- a/test/OpenTelemetry.Extensions.EventSource.Tests/OpenTelemetryEventSourceLogEmitterTests.cs
+++ b/test/OpenTelemetry.Extensions.EventSource.Tests/OpenTelemetryEventSourceLogEmitterTests.cs
@@ -136,7 +136,11 @@ namespace OpenTelemetry.Extensions.EventSource.Tests
             Assert.Equal(TestEventSource.SimpleEventId, logRecord.EventId.Id);
             Assert.Equal(nameof(TestEventSource.SimpleEvent), logRecord.EventId.Name);
             Assert.Equal(LogLevel.Warning, logRecord.LogLevel);
+
+#pragma warning disable 618 // LogRecord.CategoryName is obsolete
             Assert.Null(logRecord.CategoryName);
+#pragma warning restore 618 // LogRecord.CategoryName is obsolete
+
             Assert.Null(logRecord.Exception);
 
             Assert.Equal(default, logRecord.TraceId);
@@ -222,7 +226,11 @@ namespace OpenTelemetry.Extensions.EventSource.Tests
             Assert.Equal(TestEventSource.ComplexEventId, logRecord.EventId.Id);
             Assert.Equal(nameof(TestEventSource.ComplexEvent), logRecord.EventId.Name);
             Assert.Equal(LogLevel.Information, logRecord.LogLevel);
+
+#pragma warning disable 618 // LogRecord.CategoryName is obsolete
             Assert.Null(logRecord.CategoryName);
+#pragma warning restore 618 // LogRecord.CategoryName is obsolete
+
             Assert.Null(logRecord.Exception);
 
             Assert.Equal(default, logRecord.TraceId);

--- a/test/OpenTelemetry.Extensions.Serilog.Tests/OpenTelemetrySerilogSinkTests.cs
+++ b/test/OpenTelemetry.Extensions.Serilog.Tests/OpenTelemetrySerilogSinkTests.cs
@@ -98,7 +98,10 @@ namespace OpenTelemetry.Extensions.Serilog.Tests
             Assert.NotEqual(DateTime.MinValue, logRecord.Timestamp);
             Assert.Equal(DateTimeKind.Utc, logRecord.Timestamp.Kind);
             Assert.Equal(LogLevel.Information, logRecord.LogLevel);
+
+#pragma warning disable 618 // LogRecord.CategoryName is obsolete
             Assert.Null(logRecord.CategoryName);
+#pragma warning restore 618 // LogRecord.CategoryName is obsolete
 
             Assert.NotNull(logRecord.StateValues);
             Assert.Single(logRecord.StateValues);
@@ -146,7 +149,7 @@ namespace OpenTelemetry.Extensions.Serilog.Tests
         }
 
         [Fact]
-        public void SerilogCategoryNameTest()
+        public void SerilogSourceContextTest()
         {
             List<LogRecord> exportedItems = new();
 
@@ -172,7 +175,11 @@ namespace OpenTelemetry.Extensions.Serilog.Tests
 
             LogRecord logRecord = exportedItems[0];
 
-            Assert.Equal("OpenTelemetry.Extensions.Serilog.Tests.OpenTelemetrySerilogSinkTests", logRecord.CategoryName);
+#pragma warning disable 618 // LogRecord.CategoryName is obsolete
+            Assert.Null(logRecord.CategoryName);
+#pragma warning restore 618 // LogRecord.CategoryName is obsolete
+
+            Assert.Contains(logRecord.StateValues, kvp => kvp.Key == "serilog.source_context" && (string?)kvp.Value == "OpenTelemetry.Extensions.Serilog.Tests.OpenTelemetrySerilogSinkTests");
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #3491

This PR proposes that option 3 from #3491 is a good idea 💡.

* `LogRecord.CategoryName` is marked obsolete
* Console log exporter still exports CategoryName if it's populated
* OTLP exporter ignores CategoryName
* Introduces an attribute name `serilog.source_context` for the Serilog sink
* The `OpenTelemetryLogger` now populates the `dotnet.ilogger.category` attribute instead of this being handled downstream