### PR TITLE
Adding conditional check for PublicApiAnalyzers.

### DIFF
--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -1,7 +1,7 @@
 <Project>
   <Import Project=".\Common.props" />
 
-  <ItemGroup Condition="'$(forRelease)' == 'true'">
+  <ItemGroup Condition="'$(ForRelease)' == 'true'">
     <PackageReference Include="MinVer" Version="$(MinVerPkgVer)" Condition="'$(IntegrationBuild)' != 'true'">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -1,7 +1,7 @@
 <Project>
   <Import Project=".\Common.props" />
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(forRelease)' == 'true'">
     <PackageReference Include="MinVer" Version="$(MinVerPkgVer)" Condition="'$(IntegrationBuild)' != 'true'">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -1,7 +1,7 @@
 <Project>
   <Import Project=".\Common.props" />
 
-  <ItemGroup Condition="'$(ForRelease)' == 'true'">
+  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Shared')) != 'true'">
     <PackageReference Include="MinVer" Version="$(MinVerPkgVer)" Condition="'$(IntegrationBuild)' != 'true'">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Changes
Not all projects under src/ are meant for releasing.
The `OpenTelemetry.Exporter.Prometheus.Shared` project in this PR https://github.com/open-telemetry/opentelemetry-dotnet/pull/3430/files is one example.

PublicApi documents are not required for projects not for release.
Thus, adding conditional check for PublicApiAnalyzers for the projects not meant for releasing to utilize it.
