### PR TITLE
Minor improvements to Prometheus Exporter (ASP.NET Core)

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusExporterOptions.cs
@@ -25,7 +25,7 @@ namespace OpenTelemetry.Exporter.Prometheus
     {
         internal const string DefaultScrapeEndpointPath = "/metrics";
 
-        private int scrapeResponseCacheDurationMilliseconds = 10 * 1000;
+        private int scrapeResponseCacheDurationMilliseconds = 300;
 
         /// <summary>
         /// Gets or sets the path to use for the scraping endpoint. Default value: "/metrics".
@@ -33,7 +33,7 @@ namespace OpenTelemetry.Exporter.Prometheus
         public string ScrapeEndpointPath { get; set; } = DefaultScrapeEndpointPath;
 
         /// <summary>
-        /// Gets or sets the cache duration in milliseconds for scrape responses. Default value: 10,000 (10 seconds).
+        /// Gets or sets the cache duration in milliseconds for scrape responses. Default value: 300.
         /// </summary>
         /// <remarks>
         /// Note: Specify 0 to disable response caching.

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/README.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/README.md
@@ -15,15 +15,15 @@ to scrape.
 
 ### Step 1: Install Package
 
-Install
-
 ```shell
 dotnet add package OpenTelemetry.Exporter.Prometheus.AspNetCore
 ```
 
 ### Step 2: Configure OpenTelemetry MeterProvider
 
-* When using OpenTelemetry.Extensions.Hosting package on .NET Core 3.1+:
+* When using
+  [OpenTelemetry.Extensions.Hosting](../OpenTelemetry.Extensions.Hosting/README.md)
+  package on .NET Core 3.1+:
 
     ```csharp
     services.AddOpenTelemetryMetrics(builder =>
@@ -34,7 +34,7 @@ dotnet add package OpenTelemetry.Exporter.Prometheus.AspNetCore
 
 * Or configure directly:
 
-    Call the `AddPrometheusExporter` `MeterProviderBuilder` extension to
+    Call the `MeterProviderBuilder.AddPrometheusExporter` extension to
     register the Prometheus exporter.
 
     ```csharp
@@ -94,8 +94,7 @@ registered by
 
 Configures scrape endpoint response caching. Multiple scrape requests within the
 cache duration time period will receive the same previously generated response.
-The default value is `10000` (10 seconds). Set to `0` to disable response
-caching.
+The default value is `300`. Set to `0` to disable response caching.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Changes

* Changed the default cache duration from 10 seconds to 0.3 second (which is a good enough default for machine, and yet provide good interactive feedback to human).
* Improved the docs.

Given this is a fairly small change on the not-yet-released package, I didn't include a changelog entry.