### PR TITLE
Nit internal fixes for PrometheusExporter

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusExporterMeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusExporterMeterProviderBuilderExtensions.cs
@@ -50,7 +50,7 @@ namespace OpenTelemetry.Metrics
         {
             configure?.Invoke(options);
 
-            var exporter = new PrometheusExporter(scrapeEndpointPath: options.ScrapeEndpointPath, scrapeResponseCacheDurationMilliseconds: options.ScrapeResponseCacheDurationMilliseconds);
+            var exporter = new PrometheusExporter(scrapeResponseCacheDurationMilliseconds: options.ScrapeResponseCacheDurationMilliseconds);
             var reader = new BaseExportingMetricReader(exporter)
             {
                 TemporalityPreference = MetricReaderTemporalityPreference.Cumulative,

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusExporter.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusExporter.cs
@@ -33,15 +33,13 @@ namespace OpenTelemetry.Exporter.Prometheus
         /// <summary>
         /// Initializes a new instance of the <see cref="PrometheusExporter"/> class.
         /// </summary>
-        /// <param name="scrapeEndpointPath">Scraping endpoint.</param>
         /// <param name="scrapeResponseCacheDurationMilliseconds">
         /// The cache duration in milliseconds for scrape responses. Default value: 0.
         /// </param>
-        public PrometheusExporter(string scrapeEndpointPath = null, int scrapeResponseCacheDurationMilliseconds = 0)
+        public PrometheusExporter(int scrapeResponseCacheDurationMilliseconds = 0)
         {
             Guard.ThrowIfOutOfRange(scrapeResponseCacheDurationMilliseconds, min: 0);
 
-            this.ScrapeEndpointPath = scrapeEndpointPath ?? "/metrics";
             this.ScrapeResponseCacheDurationMilliseconds = scrapeResponseCacheDurationMilliseconds;
             this.CollectionManager = new PrometheusCollectionManager(this);
         }
@@ -66,8 +64,6 @@ namespace OpenTelemetry.Exporter.Prometheus
         internal PrometheusCollectionManager CollectionManager { get; }
 
         internal int ScrapeResponseCacheDurationMilliseconds { get; }
-
-        internal string ScrapeEndpointPath { get; }
 
         /// <inheritdoc/>
         public override ExportResult Export(in Batch<Metric> metrics)

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
@@ -43,7 +43,7 @@ namespace OpenTelemetry.Exporter.Prometheus
 
             this.exporter = exporter;
 
-            string path = this.exporter.ScrapeEndpointPath;
+            string path = options.ScrapeEndpointPath;
 
             if (!path.StartsWith("/"))
             {

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerMeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerMeterProviderBuilderExtensions.cs
@@ -55,7 +55,7 @@ namespace OpenTelemetry.Metrics
         {
             configure?.Invoke(options);
 
-            var exporter = new PrometheusExporter(scrapeEndpointPath: options.ScrapeEndpointPath);
+            var exporter = new PrometheusExporter();
 
             var reader = new BaseExportingMetricReader(exporter)
             {


### PR DESCRIPTION
Scrape path can be a pure hosting mechanism concept, no need to have it spilled into PrometheusExporter.
Might be able to do more cleanups in future PRs..