### PR TITLE
Avoid redundant assignment of MetricPointStatus for Histogram updates

### DIFF
--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -264,7 +264,9 @@ namespace OpenTelemetry.Metrics
                 case AggregationType.HistogramSumCount:
                     {
                         this.Update((double)number);
-                        break;
+
+                        // At this point MetricPointStatus is already set to CollectPending so we can simply return.
+                        return;
                     }
             }
 


### PR DESCRIPTION
The method `Update(double number)` assigns `MetricPointStatus` to  `MetricPointStatus.CollectPending` so we need not repeat that for Histograms in the `Update(long number)` method.

## Changes
- Avoid redundant assignment of `MetricPointStatus` to `MetricPointStatus.CollectPending` for Histogram updates
