### PR TITLE
Update OpenTelemetry.Instrumentation.Runtime package version

### DIFF
--- a/build/Common.nonprod.props
+++ b/build/Common.nonprod.props
@@ -43,7 +43,7 @@
     <MicrosoftNETTestSdkPkgVer>[16.10.0]</MicrosoftNETTestSdkPkgVer>
     <MoqPkgVer>[4.14.5,5.0)</MoqPkgVer>
     <RabbitMQClientPkgVer>[6.1.0,7.0)</RabbitMQClientPkgVer>
-    <RuntimeInstrumentationPkgVer>[1.0.0-rc.2,2.0)</RuntimeInstrumentationPkgVer>
+    <RuntimeInstrumentationPkgVer>[1.0.0,2.0)</RuntimeInstrumentationPkgVer>
     <SwashbuckleAspNetCorePkgVer>[6.2.3]</SwashbuckleAspNetCorePkgVer>
     <SystemTextJsonPkgVer>6.0.5</SystemTextJsonPkgVer>
     <XUnitRunnerVisualStudioPkgVer>[2.4.3,3.0)</XUnitRunnerVisualStudioPkgVer>


### PR DESCRIPTION
## Changes
- Update OpenTelemetry.Instrumentation.Runtime package version to `1.0.0`
