### PR TITLE
Clean up github workflows

### DIFF
--- a/.github/workflows/apicompatibility.yml
+++ b/.github/workflows/apicompatibility.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0 # fetching all
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/setup-dotnet@v2
       with:
         dotnet-version: '7.0.x'
         include-prerelease: true

--- a/.github/workflows/apicompatibility.yml
+++ b/.github/workflows/apicompatibility.yml
@@ -2,7 +2,7 @@ name: API Compatibility
 
 on:
   pull_request:
-    branches: [ main, net7.0 ]
+    branches: [ main ]
     paths-ignore:
     - '**.md'
 

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0 # fetching all
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/setup-dotnet@v2
       with:
         dotnet-version: '7.0.x'
         include-prerelease: true

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -2,11 +2,11 @@ name: Code Coverage
 
 on:
   push:
-    branches: [ main, net7.0 ]
+    branches: [ main ]
     paths-ignore:
     - '**.md'
   pull_request:
-    branches: [ main, net7.0 ]
+    branches: [ main ]
     paths-ignore:
     - '**.md'
 

--- a/.github/workflows/docfx.yml
+++ b/.github/workflows/docfx.yml
@@ -2,9 +2,9 @@ name: docfx
 
 on:
   push:
-    branches: [ main, net7.0 ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, net7.0 ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/dotnet-format-md.yml
+++ b/.github/workflows/dotnet-format-md.yml
@@ -9,7 +9,7 @@ name: dotnet format
 
 on:
   pull_request:
-    branches: [ main, net7.0 ]
+    branches: [ main ]
     paths:
     - '**.md'
 

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -20,11 +20,6 @@ jobs:
     - name: check out code
       uses: actions/checkout@v3
 
-    - name: Setup .NET Core 6.0
-      uses: actions/setup-dotnet@v2
-      with:
-        dotnet-version: 6.0.x
-
     - name: Setup .NET Core 7.0
     - uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Setup .NET Core 7.0
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/setup-dotnet@v2
       with:
         dotnet-version: '7.0.x'
         include-prerelease: true

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -2,12 +2,12 @@ name: dotnet format
 
 on:
   push:
-    branches: [ main, net7.0 ]
+    branches: [ main ]
     paths:
     - '**.cs'
     - '.editorconfig'
   pull_request:
-    branches: [ main, net7.0 ]
+    branches: [ main ]
     paths:
     - '**.cs'
     - '.editorconfig'

--- a/.github/workflows/integration-md.yml
+++ b/.github/workflows/integration-md.yml
@@ -9,7 +9,7 @@ name: Integration Tests
 
 on:
   pull_request:
-    branches: [ main, net7.0 ]
+    branches: [ main ]
     paths:
     - '**.md'
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,11 +2,11 @@ name: Integration Tests
 
 on:
   push:
-    branches: [ main, net7.0 ]
+    branches: [ main ]
     paths-ignore:
     - '**.md'
   pull_request:
-    branches: [ main, net7.0 ]
+    branches: [ main ]
     paths-ignore:
     - '**.md'
 

--- a/.github/workflows/linux-ci-md.yml
+++ b/.github/workflows/linux-ci-md.yml
@@ -9,7 +9,7 @@ name: Linux
 
 on:
   pull_request:
-    branches: [ main, net7.0 ]
+    branches: [ main ]
     paths:
     - '**.md'
 

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -25,10 +25,6 @@ jobs:
 
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0.x'
-
-    - uses: actions/setup-dotnet@v1
-      with:
         dotnet-version: '7.0.x'
         include-prerelease: true
 

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -25,6 +25,10 @@ jobs:
 
     - uses: actions/setup-dotnet@v2
       with:
+        dotnet-version: '6.0.x'
+
+    - uses: actions/setup-dotnet@v2
+      with:
         dotnet-version: '7.0.x'
         include-prerelease: true
 

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -2,11 +2,11 @@ name: Linux
 
 on:
   push:
-    branches: [ main, net7.0 ]
+    branches: [ main ]
     paths-ignore:
     - '**.md'
   pull_request:
-    branches: [ main, net7.0 ]
+    branches: [ main ]
     paths-ignore:
     - '**.md'
 

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         fetch-depth: 0 # fetching all
 
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/setup-dotnet@v2
       with:
         dotnet-version: '7.0.x'
         include-prerelease: true

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -2,11 +2,11 @@ name: markdownlint
 
 on:
   push:
-    branches: [ main, net7.0 ]
+    branches: [ main ]
     paths:
     - '**.md'
   pull_request:
-    branches: [ main, net7.0 ]
+    branches: [ main ]
     paths:
     - '**.md'
 

--- a/.github/workflows/sanitycheck.yml
+++ b/.github/workflows/sanitycheck.yml
@@ -2,9 +2,9 @@ name: sanitycheck
 
 on:
   push:
-    branches: [ main, net7.0 ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, net7.0 ]
+    branches: [ main ]
 
 jobs:
   misspell:

--- a/.github/workflows/windows-ci-md.yml
+++ b/.github/workflows/windows-ci-md.yml
@@ -9,7 +9,7 @@ name: Windows
 
 on:
   pull_request:
-    branches: [ main, net7.0 ]
+    branches: [ main ]
     paths:
     - '**.md'
 

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         fetch-depth: 0 # fetching all
 
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/setup-dotnet@v2
       with:
         dotnet-version: '7.0.x'
         include-prerelease: true

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -2,11 +2,11 @@ name: Windows
 
 on:
   push:
-    branches: [ main, net7.0 ]
+    branches: [ main ]
     paths-ignore:
     - '**.md'
   pull_request:
-    branches: [ main, net7.0 ]
+    branches: [ main ]
     paths-ignore:
     - '**.md'
 


### PR DESCRIPTION
* Removes net7.0 branch trigger
* Removes .NET 6 SDK install - pretty sure it's not necessary?
* Use setup-dotnet@v2 - don't really think this enables anything for us, but it's what we were using before.