### PR TITLE
Use lock for Histogram

### DIFF
--- a/src/OpenTelemetry/Metrics/HistogramBuckets.cs
+++ b/src/OpenTelemetry/Metrics/HistogramBuckets.cs
@@ -34,8 +34,6 @@ namespace OpenTelemetry.Metrics
 
         internal double SnapshotSum;
 
-        internal int IsCriticalSectionOccupied = 0;
-
         internal HistogramBuckets(double[] explicitBounds)
         {
             this.ExplicitBounds = explicitBounds;

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -336,23 +336,14 @@ namespace OpenTelemetry.Metrics
                             }
                         }
 
-                        var sw = default(SpinWait);
-                        while (true)
+                        lock (this.histogramBuckets.LockObject)
                         {
-                            if (Interlocked.Exchange(ref this.histogramBuckets.IsCriticalSectionOccupied, 1) == 0)
+                            unchecked
                             {
-                                unchecked
-                                {
-                                    this.runningValue.AsLong++;
-                                    this.histogramBuckets.RunningSum += number;
-                                    this.histogramBuckets.RunningBucketCounts[i]++;
-                                }
-
-                                this.histogramBuckets.IsCriticalSectionOccupied = 0;
-                                break;
+                                this.runningValue.AsLong++;
+                                this.histogramBuckets.RunningSum += number;
+                                this.histogramBuckets.RunningBucketCounts[i]++;
                             }
-
-                            sw.SpinOnce();
                         }
 
                         break;
@@ -360,22 +351,13 @@ namespace OpenTelemetry.Metrics
 
                 case AggregationType.HistogramSumCount:
                     {
-                        var sw = default(SpinWait);
-                        while (true)
+                        lock (this.histogramBuckets.LockObject)
                         {
-                            if (Interlocked.Exchange(ref this.histogramBuckets.IsCriticalSectionOccupied, 1) == 0)
+                            unchecked
                             {
-                                unchecked
-                                {
-                                    this.runningValue.AsLong++;
-                                    this.histogramBuckets.RunningSum += number;
-                                }
-
-                                this.histogramBuckets.IsCriticalSectionOccupied = 0;
-                                break;
+                                this.runningValue.AsLong++;
+                                this.histogramBuckets.RunningSum += number;
                             }
-
-                            sw.SpinOnce();
                         }
 
                         break;

--- a/test/Benchmarks/Metrics/TestBenchmarks.cs
+++ b/test/Benchmarks/Metrics/TestBenchmarks.cs
@@ -1,0 +1,39 @@
+// <copyright file="TestBenchmarks.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Threading;
+using BenchmarkDotNet.Attributes;
+
+namespace Benchmarks.Metrics
+{
+    [MemoryDiagnoser]
+    public class TestBenchmarks
+    {
+        private int isLocked = 1;
+
+        [Benchmark]
+        public void Exchange()
+        {
+            var temp = Interlocked.Exchange(ref this.isLocked, 1) == 0;
+        }
+
+        [Benchmark]
+        public void CompareExchange()
+        {
+            var temp = Interlocked.CompareExchange(ref this.isLocked, 1, 0) == 0;
+        }
+    }
+}


### PR DESCRIPTION
Use lock for Histogram updates

### Stress Test Results (high contention) with Prometheus Exporter scraping interval = 10s
Multiple threads updating the **same** Histogram MetricPoint in parallel
```
C:\opentelemetry-dotnet\test\OpenTelemetry.Tests.Stress.Metrics>dotnet run --framework net6.0 --configuration Release
Running (concurrency = 8, prometheusEndpoint = http://localhost:9184/metrics/), press <Esc> to stop...
2022-08-05T00:18:05.8285320Z Loops: 664,533,915, Loops/Second: 5,193,733, CPU Cycles/Loop: 3,124, RunwayTime (Seconds): 121
2022-08-05T00:18:06.0325689Z Loops: 665,604,237, Loops/Second: 5,170,911, CPU Cycles/Loop: 3,104, RunwayTime (Seconds): 121
2022-08-05T00:18:06.2391271Z Loops: 666,664,950, Loops/Second: 5,129,816, CPU Cycles/Loop: 3,126, RunwayTime (Seconds): 121
2022-08-05T00:18:06.4450077Z Loops: 667,725,432, Loops/Second: 5,185,127, CPU Cycles/Loop: 3,106, RunwayTime (Seconds): 121
2022-08-05T00:18:06.6519226Z Loops: 668,790,473, Loops/Second: 5,139,500, CPU Cycles/Loop: 3,074, RunwayTime (Seconds): 122
2022-08-05T00:18:06.8585657Z Loops: 669,851,220, Loops/Second: 5,144,074, CPU Cycles/Loop: 3,169, RunwayTime (Seconds): 122
```


### Stress Test Results (low contention) with Prometheus Exporter scraping interval = 10s
Multiple threads updating random Histogram MetricPoints in parallel
```
C:\opentelemetry-dotnet\test\OpenTelemetry.Tests.Stress.Metrics>dotnet run --framework net6.0 --configuration Release
Running (concurrency = 8, prometheusEndpoint = http://localhost:9184/metrics/), press <Esc> to stop...
2022-08-04T23:02:23.9567130Z Loops: 2,429,503,031, Loops/Second: 20,119,653, CPU Cycles/Loop: 1,128, RunwayTime (Seconds): 120
2022-08-04T23:02:24.2277354Z Loops: 2,434,415,612, Loops/Second: 19,988,132, CPU Cycles/Loop: 1,130, RunwayTime (Seconds): 121
2022-08-04T23:02:24.4725452Z Loops: 2,439,784,407, Loops/Second: 19,949,797, CPU Cycles/Loop: 1,128, RunwayTime (Seconds): 121
2022-08-04T23:02:24.7065189Z Loops: 2,444,642,611, Loops/Second: 20,134,782, CPU Cycles/Loop: 1,129, RunwayTime (Seconds): 121
2022-08-04T23:02:24.9475497Z Loops: 2,449,492,448, Loops/Second: 19,901,301, CPU Cycles/Loop: 1,130, RunwayTime (Seconds): 121
2022-08-04T23:02:25.1765231Z Loops: 2,453,822,909, Loops/Second: 19,435,860, CPU Cycles/Loop: 1,119, RunwayTime (Seconds): 122
```

### Benchmark Results

// * Summary *

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22000
Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
.NET SDK=6.0.302
  [Host]     : .NET 6.0.7 (6.0.722.32202), X64 RyuJIT
  DefaultJob : .NET 6.0.7 (6.0.722.32202), X64 RyuJIT


|                      Method | BoundCount |      Mean |    Error |    StdDev |
|---------------------------- |----------- |----------:|---------:|----------:|
|            HistogramHotPath |         10 |  46.44 ns | 0.842 ns |  0.746 ns |
|  HistogramWith1LabelHotPath |         10 |  97.67 ns | 1.968 ns |  3.447 ns |
| HistogramWith3LabelsHotPath |         10 | 202.86 ns | 4.035 ns |  4.956 ns |
| HistogramWith5LabelsHotPath |         10 | 292.78 ns | 5.758 ns |  7.282 ns |
| HistogramWith7LabelsHotPath |         10 | 355.86 ns | 7.033 ns | 14.366 ns |
|            HistogramHotPath |         20 |  49.53 ns | 1.006 ns |  0.941 ns |
|  HistogramWith1LabelHotPath |         20 | 106.52 ns | 2.099 ns |  2.943 ns |
| HistogramWith3LabelsHotPath |         20 | 207.65 ns | 4.064 ns |  5.139 ns |
| HistogramWith5LabelsHotPath |         20 | 299.79 ns | 5.967 ns |  9.465 ns |
| HistogramWith7LabelsHotPath |         20 | 358.21 ns | 7.190 ns | 14.023 ns |
|            HistogramHotPath |         50 |  59.17 ns | 1.210 ns |  2.055 ns |
|  HistogramWith1LabelHotPath |         50 | 115.68 ns | 2.265 ns |  3.023 ns |
| HistogramWith3LabelsHotPath |         50 | 221.92 ns | 4.318 ns |  4.973 ns |
| HistogramWith5LabelsHotPath |         50 | 310.69 ns | 6.006 ns | 11.571 ns |
| HistogramWith7LabelsHotPath |         50 | 378.06 ns | 7.383 ns |  8.789 ns |
|            HistogramHotPath |        100 |  75.17 ns | 1.533 ns |  3.701 ns |
|  HistogramWith1LabelHotPath |        100 | 127.82 ns | 2.528 ns |  3.105 ns |
| HistogramWith3LabelsHotPath |        100 | 235.38 ns | 4.545 ns | 10.258 ns |
| HistogramWith5LabelsHotPath |        100 | 328.82 ns | 6.550 ns | 13.817 ns |
| HistogramWith7LabelsHotPath |        100 | 393.21 ns | 7.738 ns | 10.592 ns |