### PR TITLE
Recommend VS2022 preview

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,9 @@ of Windows.
 * Visual Studio 2022+ or Visual Studio Code
 * .NET Framework 4.6.2+
 
+**NOTE** : Visual Studio 2022 preview is **recommended** due to projects
+targeting `.net7.0` which is in preview currently.
+
 ### Public API
 
 It is critical to keep public API surface small and clean. This repository is


### PR DESCRIPTION
Getting lots of warnings like below while building with VS2022

`CSC : warning CS8032: An instance of analyzer Microsoft.CodeAnalysis.CSharp.UseExpressionBody.UseExpressionBodyDiagnosticAnalyzer cannot be created from C:\Program Files\dotnet\sdk\7.0.100-preview.6.22275.1\Sdks\Microsoft.NET.Sdk\codestyle\cs\Microsoft.CodeAnalysis.CSharp.CodeStyle.dll : Could not load file or assembly 'Microsoft.CodeAnalysis, Version=4.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' or one of its dependencies. The system cannot find the file specified..`

Build works well with VS2022 preview and is also recommended for [.NET7.0](https://devblogs.microsoft.com/dotnet/announcing-dotnet-7-preview-6/#:~:text=.NET%207%20Preview%206%20has%20been%20tested%20with%20Visual%20Studio%2017.3%20Preview%203.%20We%20recommend%20you%20use%20the%20preview%20channel%20builds%20if%20you%20want%20to%20try%20.NET%207%20with%20Visual%20Studio%20family%20products.)

Updating the contributing.md. 

Note: this needs to be reverted after stable `.net7.0` release.