### PR TITLE
Remove unused MicrosoftAspNetCoreHttpFeaturesNet3PkgVer

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -29,7 +29,6 @@
     <GrpcToolsPkgVer>[2.44.0,3.0)</GrpcToolsPkgVer>
     <MicrosoftAspNetCoreHttpAbstractionsPkgVer>[2.1.1,6.0)</MicrosoftAspNetCoreHttpAbstractionsPkgVer>
     <MicrosoftAspNetCoreHttpFeaturesPkgVer>[2.1.1,6.0)</MicrosoftAspNetCoreHttpFeaturesPkgVer>
-    <MicrosoftAspNetCoreHttpFeaturesNet3PkgVer>[3.1.22,4.0)</MicrosoftAspNetCoreHttpFeaturesNet3PkgVer>
     <MicrosoftCodeAnalysisAnalyzersPkgVer>[3.3.1]</MicrosoftCodeAnalysisAnalyzersPkgVer>
     <MicrosoftCodeCoveragePkgVer>[16.10.0]</MicrosoftCodeCoveragePkgVer>
     <MicrosoftExtensionsHostingAbstractionsPkgVer>[2.1.0,)</MicrosoftExtensionsHostingAbstractionsPkgVer>


### PR DESCRIPTION
Fixes N/A.

## Changes

Remove unused MicrosoftAspNetCoreHttpFeaturesNet3PkgVer

Leftover when you have dropped support for .NET Core 3.1 in `OpenTelemetry.Instrumentation.AspNetCore`
