### PR TITLE
Use runtime intrinsic to count leading zero

### DIFF
--- a/src/OpenTelemetry/Internal/MathHelper.cs
+++ b/src/OpenTelemetry/Internal/MathHelper.cs
@@ -24,7 +24,6 @@ namespace OpenTelemetry.Internal;
 
 internal static class MathHelper
 {
-#if !NETCOREAPP3_0_OR_GREATER
     // https://en.wikipedia.org/wiki/Leading_zero
     private static readonly byte[] LeadingZeroLookupTable = new byte[]
     {
@@ -83,7 +82,6 @@ internal static class MathHelper
             return LeadingZero16((short)value) + 16;
         }
     }
-#endif
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int LeadingZero64(long value)

--- a/src/OpenTelemetry/Internal/MathHelper.cs
+++ b/src/OpenTelemetry/Internal/MathHelper.cs
@@ -24,6 +24,7 @@ namespace OpenTelemetry.Internal;
 
 internal static class MathHelper
 {
+#if !NETCOREAPP3_0_OR_GREATER
     // https://en.wikipedia.org/wiki/Leading_zero
     private static readonly byte[] LeadingZeroLookupTable = new byte[]
     {
@@ -82,6 +83,7 @@ internal static class MathHelper
             return LeadingZero16((short)value) + 16;
         }
     }
+#endif
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int LeadingZero64(long value)

--- a/src/OpenTelemetry/Internal/MathHelper.cs
+++ b/src/OpenTelemetry/Internal/MathHelper.cs
@@ -15,8 +15,8 @@
 // </copyright>
 
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 
 namespace OpenTelemetry.Internal;
 

--- a/src/OpenTelemetry/Internal/MathHelper.cs
+++ b/src/OpenTelemetry/Internal/MathHelper.cs
@@ -15,7 +15,9 @@
 // </copyright>
 
 using System.Diagnostics;
+#if NETCOREAPP3_0_OR_GREATER
 using System.Numerics;
+#endif
 using System.Runtime.CompilerServices;
 
 namespace OpenTelemetry.Internal;

--- a/src/OpenTelemetry/Internal/MathHelper.cs
+++ b/src/OpenTelemetry/Internal/MathHelper.cs
@@ -16,6 +16,7 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Numerics;
 
 namespace OpenTelemetry.Internal;
 
@@ -83,6 +84,9 @@ internal static class MathHelper
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int LeadingZero64(long value)
     {
+#if NETCOREAPP3_0_OR_GREATER
+        return BitOperations.LeadingZeroCount((ulong)value);
+#else
         unchecked
         {
             var high32 = (int)(value >> 32);
@@ -94,6 +98,7 @@ internal static class MathHelper
 
             return LeadingZero32((int)value) + 32;
         }
+#endif
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/test/OpenTelemetry.Tests/Internal/MathHelperTest.cs
+++ b/test/OpenTelemetry.Tests/Internal/MathHelperTest.cs
@@ -20,7 +20,6 @@ namespace OpenTelemetry.Internal.Tests;
 
 public class MathHelperTest
 {
-#if !NETCOREAPP3_0_OR_GREATER
     [Theory]
     [InlineData(0b0000_0000, 8)]
     [InlineData(0b0000_0001, 7)]
@@ -70,7 +69,6 @@ public class MathHelperTest
     {
         Assert.Equal(numberOfLeaderZeros, MathHelper.LeadingZero32(value));
     }
-#endif
 
     [Theory]
     [InlineData(0b0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000L, 64)]

--- a/test/OpenTelemetry.Tests/Internal/MathHelperTest.cs
+++ b/test/OpenTelemetry.Tests/Internal/MathHelperTest.cs
@@ -20,6 +20,7 @@ namespace OpenTelemetry.Internal.Tests;
 
 public class MathHelperTest
 {
+#if !NETCOREAPP3_0_OR_GREATER
     [Theory]
     [InlineData(0b0000_0000, 8)]
     [InlineData(0b0000_0001, 7)]
@@ -69,6 +70,7 @@ public class MathHelperTest
     {
         Assert.Equal(numberOfLeaderZeros, MathHelper.LeadingZero32(value));
     }
+#endif
 
     [Theory]
     [InlineData(0b0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000L, 64)]


### PR DESCRIPTION
Fixes #.

## Changes

The runtime intrinsic `BitOperations.LeadingZeroCount` maps to a CPU instruction in most cases which is more efficient than software implementation.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
