### PR TITLE
[InMemoryExporter] Throw ObjectDisposedException if Export happened after disposal

### DIFF
--- a/src/OpenTelemetry.Exporter.InMemory/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.InMemory/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+override OpenTelemetry.Exporter.InMemoryExporter<T>.Dispose(bool disposing) -> void

--- a/src/OpenTelemetry.Exporter.InMemory/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.InMemory/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+override OpenTelemetry.Exporter.InMemoryExporter<T>.Dispose(bool disposing) -> void

--- a/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Changed error handling, `InMemoryExporter` will now throw
+  `ObjectDisposedException` if `Export` is invoked after the exporter is
+  disposed.
+
 ## 1.4.0-alpha.2
 
 Released 2022-Aug-18

--- a/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Changed error handling, `InMemoryExporter` will now throw
   `ObjectDisposedException` if `Export` is invoked after the exporter is
   disposed.
+  ([#3607](https://github.com/open-telemetry/opentelemetry-dotnet/issues/3607))
 
 ## 1.4.0-alpha.2
 

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporter.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporter.cs
@@ -43,8 +43,8 @@ namespace OpenTelemetry.Exporter
         {
             if (this.disposed)
             {
-                // Since in-memory exporter is designed for testing purpose, having an early error would help developers to catch the bug during early stage of the development.
-                throw new ObjectDisposedException(this.GetType().Name, "The in-memory exporter is still being invoked after it is disposed. This indicates a wrong use of the OpenTelemetry .NET SDK, where the object lifecycle is not properly managed.");
+                // Note: In-memory exporter is designed for testing purposes so this error is strategic to surface lifecycle management bugs during development.
+                throw new ObjectDisposedException(this.GetType().Name, "The in-memory exporter is still being invoked after it has been disposed. This could be the result of invalid lifecycle management of the OpenTelemetry .NET SDK.");
             }
 
             return this.onExport(batch);

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporter.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporter.cs
@@ -24,7 +24,7 @@ namespace OpenTelemetry.Exporter
     {
         private readonly ICollection<T> exportedItems;
         private readonly ExportFunc onExport;
-        private bool disposed = false;
+        private bool disposed;
 
         public InMemoryExporter(ICollection<T> exportedItems)
         {
@@ -43,7 +43,8 @@ namespace OpenTelemetry.Exporter
         {
             if (this.disposed)
             {
-                throw new ObjectDisposedException(this.GetType().Name);
+                // Since in-memory exporter is designed for testing purpose, having an early error would help developers to catch the bug during early stage of the development.
+                throw new ObjectDisposedException(this.GetType().Name, "The in-memory exporter is still being invoked after it is disposed. This indicates a wrong use of the OpenTelemetry .NET SDK, where the object lifecycle is not properly managed.");
             }
 
             return this.onExport(batch);

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporter.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporter.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 
 namespace OpenTelemetry.Exporter
@@ -23,6 +24,7 @@ namespace OpenTelemetry.Exporter
     {
         private readonly ICollection<T> exportedItems;
         private readonly ExportFunc onExport;
+        private bool disposed = false;
 
         public InMemoryExporter(ICollection<T> exportedItems)
         {
@@ -37,7 +39,26 @@ namespace OpenTelemetry.Exporter
 
         internal delegate ExportResult ExportFunc(in Batch<T> batch);
 
-        public override ExportResult Export(in Batch<T> batch) => this.onExport(batch);
+        public override ExportResult Export(in Batch<T> batch)
+        {
+            if (this.disposed)
+            {
+                throw new ObjectDisposedException(this.GetType().Name);
+            }
+
+            return this.onExport(batch);
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (!this.disposed)
+            {
+                this.disposed = true;
+            }
+
+            base.Dispose(disposing);
+        }
 
         private ExportResult DefaultExport(in Batch<T> batch)
         {

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusExporter.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusExporter.cs
@@ -28,7 +28,7 @@ namespace OpenTelemetry.Exporter.Prometheus
     {
         private Func<int, bool> funcCollect;
         private Func<Batch<Metric>, ExportResult> funcExport;
-        private bool disposed = false;
+        private bool disposed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PrometheusExporter"/> class.


### PR DESCRIPTION
Related to #1848 and #3578.

This should help the developers catch the bugs during the development / unit testing.