### PR TITLE
[InMemoryExporter] Include original stack trace in ObjectDisposedException 

### DIFF
--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporter.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporter.cs
@@ -25,6 +25,7 @@ namespace OpenTelemetry.Exporter
         private readonly ICollection<T> exportedItems;
         private readonly ExportFunc onExport;
         private bool disposed;
+        private string disposedStackTrace;
 
         public InMemoryExporter(ICollection<T> exportedItems)
         {
@@ -44,7 +45,9 @@ namespace OpenTelemetry.Exporter
             if (this.disposed)
             {
                 // Note: In-memory exporter is designed for testing purposes so this error is strategic to surface lifecycle management bugs during development.
-                throw new ObjectDisposedException(this.GetType().Name, "The in-memory exporter is still being invoked after it has been disposed. This could be the result of invalid lifecycle management of the OpenTelemetry .NET SDK.");
+                throw new ObjectDisposedException(
+                    this.GetType().Name,
+                    $"The in-memory exporter is still being invoked after it has been disposed. This could be the result of invalid lifecycle management of the OpenTelemetry .NET SDK. Dispose was called on the following stack trace:{Environment.NewLine}{this.disposedStackTrace}");
             }
 
             return this.onExport(batch);
@@ -55,6 +58,7 @@ namespace OpenTelemetry.Exporter
         {
             if (!this.disposed)
             {
+                this.disposedStackTrace = Environment.StackTrace;
                 this.disposed = true;
             }
 

--- a/test/OpenTelemetry.Tests/Logs/BatchLogRecordExportProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/BatchLogRecordExportProcessorTests.cs
@@ -90,6 +90,7 @@ namespace OpenTelemetry.Logs.Tests
             logRecord.State = state;
 
             exporter.OnEnd(logRecord);
+            exporter.ForceFlush();
 
             state.Dispose();
 

--- a/test/OpenTelemetry.Tests/Logs/BatchLogRecordExportProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/BatchLogRecordExportProcessorTests.cs
@@ -33,7 +33,8 @@ namespace OpenTelemetry.Logs.Tests
             List<LogRecord> exportedItems = new();
 
             using var exporter = new BatchLogRecordExportProcessor(
-                new InMemoryExporter<LogRecord>(exportedItems));
+                new InMemoryExporter<LogRecord>(exportedItems),
+                scheduledDelayMilliseconds: int.MaxValue);
 
             using var scope = scopeProvider.Push(exportedItems);
 
@@ -45,7 +46,6 @@ namespace OpenTelemetry.Logs.Tests
             logRecord.StateValues = state;
 
             exporter.OnEnd(logRecord);
-            exporter.Shutdown();
 
             state.Dispose();
 
@@ -71,6 +71,8 @@ namespace OpenTelemetry.Logs.Tests
                 null);
 
             Assert.True(foundScope);
+
+            exporter.Shutdown();
         }
 
         [Fact]

--- a/test/OpenTelemetry.Tests/Logs/BatchLogRecordExportProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/BatchLogRecordExportProcessorTests.cs
@@ -45,6 +45,7 @@ namespace OpenTelemetry.Logs.Tests
             logRecord.StateValues = state;
 
             exporter.OnEnd(logRecord);
+            exporter.Shutdown();
 
             state.Dispose();
 

--- a/test/OpenTelemetry.Tests/Logs/BatchLogRecordExportProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/BatchLogRecordExportProcessorTests.cs
@@ -90,7 +90,7 @@ namespace OpenTelemetry.Logs.Tests
             logRecord.State = state;
 
             exporter.OnEnd(logRecord);
-            exporter.ForceFlush();
+            exporter.Shutdown();
 
             state.Dispose();
 

--- a/test/OpenTelemetry.Tests/Logs/BatchLogRecordExportProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/BatchLogRecordExportProcessorTests.cs
@@ -32,7 +32,7 @@ namespace OpenTelemetry.Logs.Tests
 
             List<LogRecord> exportedItems = new();
 
-            using var exporter = new BatchLogRecordExportProcessor(
+            using var processor = new BatchLogRecordExportProcessor(
                 new InMemoryExporter<LogRecord>(exportedItems),
                 scheduledDelayMilliseconds: int.MaxValue);
 
@@ -45,7 +45,7 @@ namespace OpenTelemetry.Logs.Tests
             logRecord.ScopeProvider = scopeProvider;
             logRecord.StateValues = state;
 
-            exporter.OnEnd(logRecord);
+            processor.OnEnd(logRecord);
 
             state.Dispose();
 
@@ -72,7 +72,9 @@ namespace OpenTelemetry.Logs.Tests
 
             Assert.True(foundScope);
 
-            exporter.Shutdown();
+            processor.Shutdown();
+
+            Assert.Single(exportedItems);
         }
 
         [Fact]
@@ -84,7 +86,7 @@ namespace OpenTelemetry.Logs.Tests
             // StateValues/ParseStateValues behavior.
             List<LogRecord> exportedItems = new();
 
-            using var exporter = new BatchLogRecordExportProcessor(
+            using var processor = new BatchLogRecordExportProcessor(
                 new InMemoryExporter<LogRecord>(exportedItems));
 
             var logRecord = new LogRecord();
@@ -92,8 +94,8 @@ namespace OpenTelemetry.Logs.Tests
             var state = new LogRecordTest.DisposingState("Hello world");
             logRecord.State = state;
 
-            exporter.OnEnd(logRecord);
-            exporter.Shutdown();
+            processor.OnEnd(logRecord);
+            processor.Shutdown();
 
             state.Dispose();
 


### PR DESCRIPTION
Relates to #3607

Added the stack trace for the original `Dispose` call to the message when we throw `ObjectDisposedException` inside the In-memory Exporter (to help track down issues). Fixed a couple flaky tests that helped me track down 😄

/cc @reyang