### PR TITLE
Fix Prometheus test

### DIFF
--- a/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusCollectionManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.Tests/PrometheusCollectionManagerTests.cs
@@ -29,11 +29,7 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
 {
     public sealed class PrometheusCollectionManagerTests
     {
-#if NETFRAMEWORK
-        [Fact(Skip = "Might be flaky. Might be a bug. See: https://github.com/open-telemetry/opentelemetry-dotnet/pull/3618#issuecomment-1232200946")]
-#else
         [Fact]
-#endif
         public async Task EnterExitCollectTest()
         {
             using var meter = new Meter(Utils.GetCurrentMethodName());


### PR DESCRIPTION
Follow up from https://github.com/open-telemetry/opentelemetry-dotnet/pull/3618#issuecomment-1232200946

Failing test on `net462`

```
[xUnit.net 00:00:46.17]     OpenTelemetry.Exporter.Prometheus.Tests.PrometheusCollectionManagerTests.EnterExitCollectTest [FAIL]
[xUnit.net 00:00:46.17]       Assert.Equal() Failure
[xUnit.net 00:00:46.17]       Expected: 1
[xUnit.net 00:00:46.17]       Actual:   2
[xUnit.net 00:00:46.18]       Stack Trace:
[xUnit.net 00:00:46.18]         test\OpenTelemetry.Exporter.Prometheus.Tests\PrometheusCollectionManagerTests.cs(107,0): at OpenTelemetry.Exporter.Prometheus.Tests.PrometheusCollectionManagerTests.<EnterExitCollectTest>d__0.MoveNext()
[xUnit.net 00:00:46.18]         --- End of stack trace from previous location where exception was thrown ---
[xUnit.net 00:00:46.18]            at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
[xUnit.net 00:00:46.18]            at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
[xUnit.net 00:00:46.18]         --- End of stack trace from previous location where exception was thrown ---
[xUnit.net 00:00:46.18]            at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
[xUnit.net 00:00:46.18]            at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
[xUnit.net 00:00:46.18]         --- End of stack trace from previous location where exception was thrown ---
[xUnit.net 00:00:46.18]            at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
```