### PR TITLE
[1.3.1 Patch] Update CHANGELOG for 1.3.1

### DIFF
--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 ## Unreleased
 
+## 1.3.1
+
+Released 2022-Sep-06
+
 * Added support for the .NET7 version of the
   `System.Diagnostics.DiagnosticSource` package
-  ([#3605](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3605))
+  ([#3605](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3605)).
+  For more details, refer to the issue
+  ([#3629](https://github.com/open-telemetry/opentelemetry-dotnet/issues/3629)).
 
 ## 1.3.0
 

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.1
+
+Released 2022-Sep-06
+
 ## 1.3.0
 
 Released 2022-Jun-03

--- a/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.1
+
+Released 2022-Sep-06
+
 ## 1.3.0
 
 Released 2022-Jun-03

--- a/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 Released 2022-Sep-06
 
+* Fixed an issue that can crash applications when using 1.3.0 of the exporter
+  with System.Diagnostics.DiagnosticSource 7.0+.
+  ([#3629](https://github.com/open-telemetry/opentelemetry-dotnet/issues/3629))
+
 ## 1.3.0
 
 Released 2022-Jun-03

--- a/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.1
+
+Released 2022-Sep-06
+
 ## 1.3.0
 
 Released 2022-Jun-03

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 Released 2022-Sep-06
 
+* Fixed an issue that can crash applications when using 1.3.0 of the exporter
+  with System.Diagnostics.DiagnosticSource 7.0+.
+  ([#3629](https://github.com/open-telemetry/opentelemetry-dotnet/issues/3629))
+
 ## 1.3.0
 
 Released 2022-Jun-03

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.1
+
+Released 2022-Sep-06
+
 ## 1.3.0
 
 Released 2022-Jun-03

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 Released 2022-Sep-06
 
+* Fixed an issue that can crash applications when using 1.3.0 of the exporter
+  with System.Diagnostics.DiagnosticSource 7.0+.
+  ([#3629](https://github.com/open-telemetry/opentelemetry-dotnet/issues/3629))
+
 ## 1.3.0
 
 Released 2022-Jun-03

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.1
+
+Released 2022-Sep-06
+
 ## 1.3.0
 
 Released 2022-Jun-03

--- a/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.1
+
+Released 2022-Sep-06
+
 ## 1.3.0
 
 Released 2022-Jun-03

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.3.1
+
+Released 2022-Sep-06
+
 ## 1.3.0
 
 Released 2022-Jun-03


### PR DESCRIPTION
## Changes
- Update CHANGELOG for 1.3.1

Excluded `OpenTelemetry.Exporter.Prometheus` and `OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs` packages