### PR TITLE
Make publish workflow work based on tag/branch selected

### DIFF
--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -19,18 +19,12 @@ on:
 
 jobs:
   build-pack:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [windows-latest]
-        branches: [main]
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0 # fetching all
-        ref: ${{ matrix.branches }}
 
     - uses: actions/setup-dotnet@v2
       with:
@@ -49,7 +43,7 @@ jobs:
     - name: Publish Artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ matrix.os }}-packages
+        name: windows-latest-packages
         path: '**/bin/**/*.*nupkg'
 
     - name: Publish MyGet

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Publish Artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: windows-latest-packages
+        name: ${{ inputs.ref }}-artifacts
         path: '**/bin/**/*.*nupkg'
 
     - name: Publish MyGet

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -10,6 +10,10 @@ name: Pack and publish to Myget
 on:
   workflow_dispatch:
     inputs:
+      ref:
+        description: 'The tag, branch, or SHA to publish'
+        required: true
+        type: string
       logLevel:
         description: 'Log level'
         required: true
@@ -25,6 +29,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0 # fetching all
+        ref: ${{ inputs.ref }}
 
     - uses: actions/setup-dotnet@v2
       with:

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0 # fetching all
-        ref: ${{ inputs.ref }}
+        ref: ${{ inputs.ref || 'main' }}
 
     - uses: actions/setup-dotnet@v2
       with:


### PR DESCRIPTION
Adds a `ref` parameter to the workflow that must be specified when running it. When running the workflow manually, specifying the `ref` is required. For our releases, we create both a "core" and "non-core" tag at the same SHA, and it doesn't matter which of the two tags you run the workflow with.

Looks like this:

<img width="380" alt="Screen Shot 2022-09-07 at 3 38 30 PM" src="https://user-images.githubusercontent.com/3676547/188995748-0abe53cb-dfec-4900-a7cb-4cbc93c3ebe8.png">

The nightly build will continue to use `main`.

---

There is an alternative we could explore. The pack and publish workflow could be triggered when we draft a new release. If triggered this way, then the workflow would use the SHA of the release. No need to manually run the workflow and type in the tag name.