### PR TITLE
[Traces + Logs] Clean up repo exporters to use new DI patterns

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterLoggingExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterLoggingExtensions.cs
@@ -15,6 +15,8 @@
 // </copyright>
 
 using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Internal;
 
@@ -32,9 +34,17 @@ namespace OpenTelemetry.Logs
         {
             Guard.ThrowIfNull(loggerOptions);
 
-            var options = new ConsoleExporterOptions();
-            configure?.Invoke(options);
-            return loggerOptions.AddProcessor(new SimpleLogRecordExportProcessor(new ConsoleLogRecordExporter(options)));
+            if (configure != null)
+            {
+                loggerOptions.ConfigureServices(services => services.Configure(configure));
+            }
+
+            return loggerOptions.ConfigureProvider((sp, provider) =>
+            {
+                var options = sp.GetRequiredService<IOptions<ConsoleExporterOptions>>().Value;
+
+                provider.AddProcessor(new SimpleLogRecordExportProcessor(new ConsoleLogRecordExporter(options)));
+            });
         }
     }
 }

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterHelperExtensions.cs
@@ -29,19 +29,10 @@ namespace OpenTelemetry.Trace
         /// <param name="builder"><see cref="TracerProviderBuilder"/> builder to use.</param>
         /// <param name="exportedItems">Collection which will be populated with the exported Activity.</param>
         /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The objects should not be disposed.")]
         public static TracerProviderBuilder AddInMemoryExporter(this TracerProviderBuilder builder, ICollection<Activity> exportedItems)
         {
             Guard.ThrowIfNull(builder);
             Guard.ThrowIfNull(exportedItems);
-
-            if (builder is IDeferredTracerProviderBuilder deferredTracerProviderBuilder)
-            {
-                return deferredTracerProviderBuilder.Configure((sp, builder) =>
-                {
-                    builder.AddProcessor(new SimpleActivityExportProcessor(new InMemoryExporter<Activity>(exportedItems)));
-                });
-            }
 
             return builder.AddProcessor(new SimpleActivityExportProcessor(new InMemoryExporter<Activity>(exportedItems)));
         }

--- a/src/OpenTelemetry.Exporter.Jaeger/OpenTelemetry.Exporter.Jaeger.csproj
+++ b/src/OpenTelemetry.Exporter.Jaeger/OpenTelemetry.Exporter.Jaeger.csproj
@@ -24,7 +24,6 @@
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\PooledList.cs" Link="Includes\PooledList.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\PeerServiceResolver.cs" Link="Includes\PeerServiceResolver.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\ResourceSemanticConventions.cs" Link="Includes\ResourceSemanticConventions.cs" />
-    <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\ServiceProviderExtensions.cs" Link="Includes\ServiceProviderExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\TagTransformer.cs" Link="Includes\TagTransformer.cs" />
   </ItemGroup>
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* `OtlpExporterOptions` can now be bound to `IConfiguation` and
+  `HttpClientFactory` may be used to manage the `HttpClient` instance used when
+  `HttpProtobuf` is configured
+  ([#3640](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3640))
+
 ## 1.4.0-alpha.2
 
 Released 2022-Aug-18

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs/OtlpLogExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs/OtlpLogExporterHelperExtensions.cs
@@ -15,6 +15,8 @@
 // </copyright>
 
 using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Internal;
 
@@ -28,6 +30,12 @@ namespace OpenTelemetry.Logs
         /// <summary>
         /// Adds OTLP Exporter as a configuration to the OpenTelemetry ILoggingBuilder.
         /// </summary>
+        /// <remarks>
+        /// Note: <see cref="AddOtlpExporter(OpenTelemetryLoggerOptions,
+        /// Action{OtlpExporterOptions})"/> automatically sets <see
+        /// cref="OpenTelemetryLoggerOptions.ParseStateValues"/> to <see
+        /// langword="true"/>.
+        /// </remarks>
         /// <param name="loggerOptions"><see cref="OpenTelemetryLoggerOptions"/> options to use.</param>
         /// <param name="configure">Exporter configuration options.</param>
         /// <returns>The instance of <see cref="OpenTelemetryLoggerOptions"/> to chain the calls.</returns>
@@ -35,21 +43,41 @@ namespace OpenTelemetry.Logs
         {
             Guard.ThrowIfNull(loggerOptions);
 
-            return AddOtlpExporter(loggerOptions, new OtlpExporterOptions(), configure);
+            loggerOptions.ParseStateValues = true;
+
+            if (configure != null)
+            {
+                loggerOptions.ConfigureServices(services => services.Configure(configure));
+            }
+
+            return loggerOptions.ConfigureProvider((sp, provider) =>
+            {
+                var options = sp.GetRequiredService<IOptions<OtlpExporterOptions>>().Value;
+
+                AddOtlpExporter(provider, options, sp);
+            });
         }
 
-        private static OpenTelemetryLoggerOptions AddOtlpExporter(OpenTelemetryLoggerOptions loggerOptions, OtlpExporterOptions exporterOptions, Action<OtlpExporterOptions> configure = null)
+        private static void AddOtlpExporter(
+            OpenTelemetryLoggerProvider provider,
+            OtlpExporterOptions exporterOptions,
+            IServiceProvider serviceProvider)
         {
-            configure?.Invoke(exporterOptions);
+            exporterOptions.TryEnableIHttpClientFactoryIntegration(serviceProvider, "OtlpLogExporter");
+
             var otlpExporter = new OtlpLogExporter(exporterOptions);
-            loggerOptions.ParseStateValues = true;
+
             if (exporterOptions.ExportProcessorType == ExportProcessorType.Simple)
             {
-                return loggerOptions.AddProcessor(new SimpleLogRecordExportProcessor(otlpExporter));
+                provider.AddProcessor(new SimpleLogRecordExportProcessor(otlpExporter));
             }
             else
             {
-                return loggerOptions.AddProcessor(new BatchLogRecordExportProcessor(
+                // TODO: exporterOptions.BatchExportProcessorOptions is
+                // BatchExportActivityProcessorOptions which is using tracing
+                // environment variables. There should probably be a dedicated
+                // setting for logs using BatchExportLogRecordProcessorOptions
+                provider.AddProcessor(new BatchLogRecordExportProcessor(
                     otlpExporter,
                     exporterOptions.BatchExportProcessorOptions.MaxQueueSize,
                     exporterOptions.BatchExportProcessorOptions.ScheduledDelayMilliseconds,

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
@@ -123,8 +123,9 @@ services.AddOpenTelemetryTracing((builder) => builder
 
 For users using
 [IHttpClientFactory](https://docs.microsoft.com/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests)
-you may also customize the named "OtlpTraceExporter" or "OtlpMetricExporter"
-`HttpClient` using the built-in `AddHttpClient` extension:
+you may also customize the named "OtlpTraceExporter", "OtlpMetricExporter",
+and/or "OtlpLogExporter" `HttpClient` using the built-in `AddHttpClient`
+extension:
 
 ```csharp
 services.AddHttpClient(

--- a/src/OpenTelemetry.Exporter.Zipkin/OpenTelemetry.Exporter.Zipkin.csproj
+++ b/src/OpenTelemetry.Exporter.Zipkin/OpenTelemetry.Exporter.Zipkin.csproj
@@ -19,7 +19,6 @@
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\PooledList.cs" Link="Includes\PooledList.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\PeerServiceResolver.cs" Link="Includes\PeerServiceResolver.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\ResourceSemanticConventions.cs" Link="Includes\ResourceSemanticConventions.cs" />
-    <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\ServiceProviderExtensions.cs" Link="Includes\ServiceProviderExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\TagTransformer.cs" Link="Includes\TagTransformer.cs" />
   </ItemGroup>
 

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTests.cs
@@ -82,7 +82,6 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
             OtlpTraceExporterHelperExtensions.AddOtlpExporter(
                 builder,
                 exporterOptions,
-                configure: null,
                 serviceProvider: null,
                 configureExporterInstance: otlpExporter =>
                 {


### PR DESCRIPTION
## Changes

Updates the trace & logging exporters to use the new DI API surface.

`OtlpLogExporter` got a couple features with this upgrade:

* Now obtains its options instance through `IOptions` so it can be bound to `IConfiguration`
* Now calls the `TryEnableIHttpClientFactoryIntegration` helper so it should also be able to use `HttpClientFactory` integration

## TODOs

* [X] Appropriate `CHANGELOG.md` updated for non-trivial changes

