### PR TITLE
Change StatusCode to 200 when no metrics are collected

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Bug fix for Prometheus Exporter reporting StatusCode 204
+instead of 200, when no metrics are collected
+
 ## 1.4.0-alpha.2
 
 Released 2022-Aug-18

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Bug fix for Prometheus Exporter reporting StatusCode 204
 instead of 200, when no metrics are collected
+([#3643](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3643))
 
 ## 1.4.0-alpha.2
 

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusExporterMiddleware.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusExporterMiddleware.cs
@@ -80,7 +80,7 @@ namespace OpenTelemetry.Exporter
                     else
                     {
                         // It's not expected to have no metrics to collect, but it's not necessarily a failure, either.
-                        response.StatusCode = 204;
+                        response.StatusCode = 200;
                         PrometheusExporterEventSource.Log.NoMetrics();
                     }
                 }

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 * Bug fix for Prometheus Exporter reporting StatusCode 204
-instead of 200, when no metrics are collected
+  instead of 200, when no metrics are collected
+  ([#3643](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3643))
 
 ## 1.4.0-alpha.2
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Bug fix for Prometheus Exporter reporting StatusCode 204
+instead of 200, when no metrics are collected
+
 ## 1.4.0-alpha.2
 
 Released 2022-Aug-18

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
@@ -166,7 +166,7 @@ namespace OpenTelemetry.Exporter
                     else
                     {
                         // It's not expected to have no metrics to collect, but it's not necessarily a failure, either.
-                        context.Response.StatusCode = 204;
+                        context.Response.StatusCode = 200;
                         PrometheusExporterEventSource.Log.NoMetrics();
                     }
                 }

--- a/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMiddlewareTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMiddlewareTests.cs
@@ -281,7 +281,7 @@ namespace OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests
             }
             else
             {
-                Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             }
 
             validateResponse?.Invoke(response);

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
@@ -140,7 +140,7 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
             }
             else
             {
-                Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             }
         }
     }


### PR DESCRIPTION
Fixes #3582.

## Changes

If Prometheus Exporter have no metrics to collect it reports StatusCode 200 now instead of 204.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
~* [ ] Design discussion issue #~
~* [ ] Changes in public API reviewed~
