### PR TITLE
Support Prometheus UNIT metadata

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -5,11 +5,12 @@
 * Bug fix for Prometheus Exporter reporting StatusCode 204
 instead of 200, when no metrics are collected
 ([#3643](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3643))
-
 * Added overloads which accept a name to the `MeterProviderBuilder`
   `AddPrometheusExporter` extension to allow for more fine-grained options
   management
   ([#3648](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3648))
+* Added support for OpenMetrics UNIT metadata
+  ([#3651](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3651))
 
 ## 1.4.0-alpha.2
 
@@ -21,7 +22,6 @@ Released 2022-Aug-18
   ([#3430](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3430)
   [#3503](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3503)
   [#3507](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3507))
-
 * Added `IEndpointRouteBuilder` extension methods to help with Prometheus
   middleware configuration on ASP.NET Core
   ([#3295](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3295))
@@ -41,10 +41,8 @@ Released 2022-Apr-15
 * Added `IApplicationBuilder` extension methods to help with Prometheus
   middleware configuration on ASP.NET Core
   ([#3029](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3029))
-
 * Changed Prometheus exporter to return 204 No Content and log a warning event
   if there are no metrics to collect.
-
 * Removes .NET Framework 4.6.1. The minimum .NET Framework
   version supported is .NET 4.6.2. ([#3190](https://github.com/open-telemetry/opentelemetry-dotnet/issues/3190))
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -5,11 +5,12 @@
 * Bug fix for Prometheus Exporter reporting StatusCode 204
   instead of 200, when no metrics are collected
   ([#3643](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3643))
-
 * Added overloads which accept a name to the `MeterProviderBuilder`
   `AddPrometheusHttpListener` extension to allow for more fine-grained options
   management
   ([#3648](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3648))
+* Added support for OpenMetrics UNIT metadata
+  ([#3651](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3651))
 
 ## 1.4.0-alpha.2
 
@@ -41,10 +42,8 @@ Released 2022-Apr-15
 * Added `IApplicationBuilder` extension methods to help with Prometheus
   middleware configuration on ASP.NET Core
   ([#3029](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3029))
-
 * Changed Prometheus exporter to return 204 No Content and log a warning event
   if there are no metrics to collect.
-
 * Removes .NET Framework 4.6.1. The minimum .NET Framework
   version supported is .NET 4.6.2. ([#3190](https://github.com/open-telemetry/opentelemetry-dotnet/issues/3190))
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializerExt.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializerExt.cs
@@ -36,13 +36,10 @@ namespace OpenTelemetry.Exporter.Prometheus
 
         public static int WriteMetric(byte[] buffer, int cursor, Metric metric)
         {
-            if (!string.IsNullOrWhiteSpace(metric.Description))
-            {
-                cursor = WriteHelpText(buffer, cursor, metric.Name, metric.Unit, metric.Description);
-            }
-
             int metricType = (int)metric.MetricType >> 4;
-            cursor = WriteTypeInfo(buffer, cursor, metric.Name, metric.Unit, MetricTypes[metricType]);
+            cursor = WriteTypeMetadata(buffer, cursor, metric.Name, metric.Unit, MetricTypes[metricType]);
+            cursor = WriteUnitMetadata(buffer, cursor, metric.Name, metric.Unit);
+            cursor = WriteHelpMetadata(buffer, cursor, metric.Name, metric.Unit, metric.Description);
 
             if (!metric.MetricType.IsHistogram())
             {


### PR DESCRIPTION
## Changes

* Added support for UNIT metadata.
* Renamed some of the internal methods to better align with OpenMetrics terms (e.g. "metadata").
* Adjusted the ordering of the metadata to follow the OpenMetrics best practices.

Reference: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#overall-structure

![image](https://user-images.githubusercontent.com/17327289/189961496-730e7982-03b2-4bb3-98fb-1931c6266788.png)

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
