### PR TITLE
Fix environment variable when contains URI with splitter sign = inside

### DIFF
--- a/src/OpenTelemetry/Resources/OtelEnvResourceDetector.cs
+++ b/src/OpenTelemetry/Resources/OtelEnvResourceDetector.cs
@@ -15,6 +15,8 @@
 // </copyright>
 
 using System.Collections.Generic;
+using System.Linq;
+
 using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Resources
@@ -45,7 +47,15 @@ namespace OpenTelemetry.Resources
             string[] rawAttributes = resourceAttributes.Split(AttributeListSplitter);
             foreach (string rawKeyValuePair in rawAttributes)
             {
+#if NET6_0 || NETSTANDARD2_1_OR_GREATER
+                string[] keyValuePair = rawKeyValuePair.Split(AttributeKeyValueSplitter,2);
+#else
                 string[] keyValuePair = rawKeyValuePair.Split(AttributeKeyValueSplitter);
+                if(keyValuePair.Length > 2)
+                {
+                    keyValuePair = new string[] { keyValuePair[0], string.Join(AttributeKeyValueSplitter.ToString(), keyValuePair.Skip(1)) };
+                }
+#endif
                 if (keyValuePair.Length != 2)
                 {
                     continue;

--- a/test/OpenTelemetry.Tests/Resources/OtelEnvResourceDetectorTest.cs
+++ b/test/OpenTelemetry.Tests/Resources/OtelEnvResourceDetectorTest.cs
@@ -75,5 +75,18 @@ namespace OpenTelemetry.Resources.Tests
             Assert.Single(resource.Attributes);
             Assert.Contains(new KeyValuePair<string, object>("Key2", "Val2"), resource.Attributes);
         }
+        [Fact]
+        public void OtelEnvResource_WithEnvVar_3()
+        {
+            // Arrange
+            var envVarValue = "Key1=Val1,Key2=https://localhost/val1=test1&val2=test2";
+            Environment.SetEnvironmentVariable(OtelEnvResourceDetector.EnvVarKey, envVarValue);
+            var resource = new OtelEnvResourceDetector().Detect();
+
+            // Assert
+            Assert.NotEqual(Resource.Empty, resource);
+            Assert.Contains(new KeyValuePair<string, object>("Key1", "Val1"), resource.Attributes);
+            Assert.Contains(new KeyValuePair<string, object>("Key2", "https://localhost/val1=test1&val2=test2"), resource.Attributes);
+        }
     }
 }


### PR DESCRIPTION
Fixes #.
When OTEL_RESOURCE_ATTRIBUTES contains KeyValuePair key=http://localhost/key=value&key2=value2 it does not detect very well because it splits with "=" and  get more then length of 2

## Changes

```
#if NET6_0 || NETSTANDARD2_1_OR_GREATER
                string[] keyValuePair = rawKeyValuePair.Split(AttributeKeyValueSplitter,2);
#else
                string[] keyValuePair = rawKeyValuePair.Split(AttributeKeyValueSplitter);
                if(keyValuePair.Length > 2)
                {
                    keyValuePair = new string[] { keyValuePair[0], string.Join(AttributeKeyValueSplitter.ToString(), keyValuePair.Skip(1)) };
                }
#endif
```
Please provide a brief description of the changes here.

trying to spit only on the first occurrence of AttributeKeyValueSplitter and because that is supported in net6 and NETSTANDARD2_1_OR_GREATER I need to add additional work around wor previus Dotnet release

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
