### PR TITLE
HttpClient instrumentation: Clarify drop of support for .NET 5 and prior

### DIFF
--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -14,7 +14,7 @@ Released 2022-Aug-18
   build time). This is because .NET 5 reached EOL in May 2022 and .NET
   Core 3.1 reaches EOL in December 2022. End of support
   dates for .NET are published
-  [here](https://dotnet.microsoft.com/en-us/download/dotnet).
+  [here](https://dotnet.microsoft.com/download/dotnet).
 
   There is no guarantee that System.Diagnostics.DiagnosticSource will continue
   to work on older versions of .NET. However, the build warning can be

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -12,7 +12,9 @@ Released 2022-Aug-18
   warning at build time as described [here](https://github.com/dotnet/runtime/pull/72518)
   (note: building using older versions of the .NET SDK produces an error at
   build time). This is because .NET 5 reached EOL in May 2022 and .NET
-  Core 3.1 reaches EOL in December 2022.
+  Core 3.1 reaches EOL in December 2022. End of support
+  dates for .NET are published
+  [here](https://dotnet.microsoft.com/en-us/download/dotnet).
 
   There is no guarantee that System.Diagnostics.DiagnosticSource will continue
   to work on older versions of .NET. However, the build warning can be

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -16,7 +16,9 @@
 Released 2022-Aug-18
 
 * Removed `netstandard2.0` and `netstandard2.1` targets. .NET 5 reached EOL
-  in May 2022 and .NET Core 3.1 reaches EOL in December 2022. The
+  in May 2022 and .NET Core 3.1 reaches EOL in December 2022. End of support
+  dates for .NET are published
+  [here](https://dotnet.microsoft.com/en-us/download/dotnet). The
   instrumentation for ASP.NET Core now requires .NET 6 or later.
   ([#3567](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3567))
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -18,7 +18,7 @@ Released 2022-Aug-18
 * Removed `netstandard2.0` and `netstandard2.1` targets. .NET 5 reached EOL
   in May 2022 and .NET Core 3.1 reaches EOL in December 2022. End of support
   dates for .NET are published
-  [here](https://dotnet.microsoft.com/en-us/download/dotnet). The
+  [here](https://dotnet.microsoft.com/download/dotnet). The
   instrumentation for ASP.NET Core now requires .NET 6 or later.
   ([#3567](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3567))
 

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## Unreleased
 
 * Dropped `netstandard2.0` target and added `net6.0`. .NET 5 reached EOL
-  in May 2022 and .NET Core 3.1 reaches EOL in December 2022. The
-  instrumentation for HttpClient now requires .NET 6 or later.
+  in May 2022 and .NET Core 3.1 reaches EOL in December 2022. End of support
+  dates for .NET are published
+  [here](https://dotnet.microsoft.com/en-us/download/dotnet).
+  The instrumentation for HttpClient now requires .NET 6 or later.
   This does not affect applications targeting .NET Framework.
   ([#3664](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3664))
 

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Dropped `netstandard2.0` target and added `net6.0`. .NET 5 reached EOL
   in May 2022 and .NET Core 3.1 reaches EOL in December 2022. End of support
   dates for .NET are published
-  [here](https://dotnet.microsoft.com/en-us/download/dotnet).
+  [here](https://dotnet.microsoft.com/download/dotnet).
   The instrumentation for HttpClient now requires .NET 6 or later.
   This does not affect applications targeting .NET Framework.
   ([#3664](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3664))

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
-* Dropped `netstandard2.0` target and added `net6.0`
+* Dropped `netstandard2.0` target and added `net6.0`. .NET 5 reached EOL
+  in May 2022 and .NET Core 3.1 reaches EOL in December 2022. The
+  instrumentation for HttpClient now requires .NET 6 or later.
+  This does not affect applications targeting .NET Framework.
   ([#3664](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3664))
 
 * Added overloads which accept a name to the `TracerProviderBuilder`


### PR DESCRIPTION
Related discussion https://github.com/open-telemetry/opentelemetry-dotnet/pull/3664#discussion_r971371656.