### PR TITLE
Proposal for keeping .NET Standard

### DIFF
--- a/build/netstandard.md
+++ b/build/netstandard.md
@@ -1,4 +1,4 @@
-# The future of .NET Standard support
+# OpenTelemetry .NET and .NET Standard
 
 ## Background
 
@@ -15,7 +15,7 @@ page to view the end of support dates for each version of .NET.
 The core packages offered by OpenTelemetry .NET currently ship a .NET
 Standard build (i.e., `netstandard2.0` and/or `netstandard2.1`).
 Therefore, OpenTelemetry .NET can technically be consumed by projects targeting
-out-of-support frameworks like .NET Core 3.1, and even as far back as .NET Core 2.0.
+out-of-support frameworks like .NET Core 3.1 and even as far back as .NET Core 2.0.
 
 However, referencing the latest version of OpenTelemetry .NET by an application
 targeting .NET Core 3.1 or .NET 5 will generate the following build warnings:
@@ -28,7 +28,7 @@ These warnings can be suppressed by setting the
 OpenTelemetry .NET is not tested against out-of-support frameworks. Therefore
 there is no guarantee that it will continue to function.
 
-## Continued support of .NET Standard
+## .NET Standard builds of OpenTelemetry .NET
 
 OpenTelemetry .NET will continue to ship .NET Standard targets of its
 packages (i.e., `netstandard2.0` and/or `netstandard2.1`).
@@ -38,6 +38,11 @@ continue to be added or removed as necessary. Removal of implementation
 specific target frameworks will always be announced and may occur in minor
 version releases. For example, in the recent past we removed `net461`,
 `netcoreapp3.1`, and `net5.0` targets.
+
+We do not declare universal support for .NET Standard as that would imply we have validated
+OpenTelemetry .NET against all .NET implementations that implement .NET Standard.
+Our official support will always be stated in terms of target-specific implementations of .NET
+(see: https://github.com/open-telemetry/opentelemetry-dotnet#supported-net-versions).
 
 ## How users will be impacted
 

--- a/build/netstandard.md
+++ b/build/netstandard.md
@@ -15,7 +15,7 @@ page to view the end of support dates for each version of .NET.
 The core packages offered by OpenTelemetry .NET currently ship a .NET
 Standard build (i.e., `netstandard2.0` and/or `netstandard2.1`).
 Therefore, OpenTelemetry .NET can technically be consumed by projects targeting
-out-of-support frameworks - even as far back as .NET Core 2.0.
+out-of-support frameworks like .NET Core 3.1, and even as far back as .NET Core 2.0.
 
 However, referencing the latest version of OpenTelemetry .NET by an application
 targeting .NET Core 3.1 or .NET 5 will generate the following build warnings:

--- a/build/netstandard.md
+++ b/build/netstandard.md
@@ -41,7 +41,7 @@ version releases. For example, in the recent past we removed `net461`,
 
 We do not declare universal support for .NET Standard as that would imply we have validated
 OpenTelemetry .NET against all .NET implementations that implement .NET Standard.
-Our official support will always be stated in terms of target-specific implementations of .NET
+Our official support will always be stated in terms of implementation specific target frameworks of .NET
 (see: https://github.com/open-telemetry/opentelemetry-dotnet#supported-net-versions).
 
 ## How users will be impacted

--- a/build/netstandard.md
+++ b/build/netstandard.md
@@ -1,4 +1,4 @@
-# Dropping support for .NET Standard
+# The future of .NET Standard support
 
 ## Background
 

--- a/build/netstandard.md
+++ b/build/netstandard.md
@@ -1,0 +1,73 @@
+# Dropping support for .NET Standard
+
+## Background
+
+The OpenTelemetry .NET project depends heavily on APIs provided by .NET.
+Specifically, the APIs provided under `System.Diagnostics.DiagnosticSource`.
+
+With the release of .NET 6, [it was announced](https://github.com/dotnet/announcements/issues/190)
+that the .NET team will drop out-of-support frameworks for a number of packages
+including `System.Diagnostics.DiagnosticSource`. This practice will continue
+with the release of .NET 7. Frameworks no longer supported will include .NET
+Core 3.1 and .NET 5. Refer to the [.NET download](https://dotnet.microsoft.com/download/dotnet)
+page to view the end of support dates for each version of .NET.
+
+The core packages offered by OpenTelemetry .NET currently ship a .NET
+Standard build (i.e., `netstandard2.0` and/or `netstandard2.1`).
+Therefore, OpenTelemetry .NET can technically be consumed by projects targeting
+out-of-support frameworks - even as far back as .NET Core 2.0.
+
+However, referencing the latest version of OpenTelemetry .NET by an application
+targeting .NET Core 3.1 or .NET 5 will generate the following build warnings:
+
+> System.Diagnostics.DiagnosticSource doesn't support netcoreapp3.1. Consider updating your TargetFramework to net6.0 or later.
+> System.Diagnostics.DiagnosticSource doesn't support net5.0. Consider updating your TargetFramework to net6.0 or later.
+
+These warnings can be suppressed by setting the
+`SuppressTfmSupportBuildWarnings` MSBuild property. However,
+OpenTelemetry .NET is not tested against out-of-support frameworks. Therefore
+there is no guarantee that it will continue to function.
+
+## Continued support of .NET Standard
+
+OpenTelemetry .NET will continue to ship .NET Standard targets of its
+packages (i.e., `netstandard2.0` and/or `netstandard2.1`).
+
+Implementation specific target frameworks (e.g., `net8.0`, `net471`) may
+continue to be added or removed as necessary. Removal of implementation
+specific target frameworks will always be announced and may occur in minor
+version releases. For example, in the recent past we removed `net461`,
+`netcoreapp3.1`, and `net5.0` targets.
+
+## How users will be impacted
+
+### Removing implementation specific frameworks may cause older applications to fallback to a .NET Standard build
+
+For example, if you have an application that targets `net6.0` and you reference
+the most current version of OpenTelemetry .NET (as of today that is
+1.4.0-alpha), then you will receive a `net6.0` targeted build of OpenTelemetry.
+In a future version after .NET 8 is released, for example, we may remove the
+`net6.0` target and replace it with a `net8.0` target.
+
+You will still be able to upgrade to this later version of OpenTelemetry .NET
+from your `net6.0` targeted application, however at this point you'll receive
+a `netstandard2.x` target of OpenTelemetry .NET. Furthermore, you may begin
+to receive build warnings indicating that your target framework is no longer
+supported by `System.Diagnostics.DiagnosticSource`.
+
+This can come with some consequences like missing out on performance
+enhancements or features that were previously available in the old `net6.0`
+target of OpenTelemetry .NET. We will not intentionally break older
+applications that fallback to a .NET Standard build, but we cannot make any
+guarantees.
+
+### Referencing OpenTelemetry packages from Xamarin and Mono projects
+
+Technically, both Xamarin and Mono implement `netstandard2.0`. However,
+it is a known issue that OpenTelemetry does not currently support either
+despite currently offering a `netstandard2.0` build.
+
+If in the future OpenTelemetry .NET supports the Xamarin and/or Mono
+frameworks, we may do so either via the `nestandard2.0` target or
+implementation specific targets (e.g., `xamarin.android`, `net6.0-android`,
+etc).

--- a/build/netstandard.md
+++ b/build/netstandard.md
@@ -61,13 +61,13 @@ target of OpenTelemetry .NET. We will not intentionally break older
 applications that fallback to a .NET Standard build, but we cannot make any
 guarantees.
 
-### Referencing OpenTelemetry packages from Xamarin and Mono projects
+### Referencing OpenTelemetry packages from projects targeting other implementations of .NET
 
-Technically, both Xamarin and Mono implement `netstandard2.0`. However,
-it is a known issue that OpenTelemetry does not currently support either
-despite currently offering a `netstandard2.0` build.
+Implementations such as Xamarin and Mono implement `netstandard2.0`. However,
+it has not been confirmed that OpenTelemetry .NET support these implementations
+despite currently offering a `netstandard2.0` build
+(see: https://github.com/open-telemetry/opentelemetry-dotnet/issues/3763). 
 
-If in the future OpenTelemetry .NET supports the Xamarin and/or Mono
-frameworks, we may do so either via the `nestandard2.0` target or
-implementation specific targets (e.g., `xamarin.android`, `net6.0-android`,
-etc).
+If in the future OpenTelemetry .NET supports Xamarin and/or Mono, we may do so either 
+via the `nestandard2.0` target or implementation specific targets (e.g., `xamarin.android`,
+`net6.0-android`, etc).


### PR DESCRIPTION
This is an alternative to #3701. In my opinion, this is an equally valid stance with different pros and cons. The important thing to me is that we're clear with end users.

However, if we adopt this alternative, then I would argue that we should revert our decision to drop .NET Standard targets from both HttpClient and AspNetCore instrumentation. That is, I do not like the "one toe in, one toe out" approach to dropping or keeping .NET Standard support. Also, #3697 would be closed.

The "background" section is the same as #3701. It's everything after that which is different.