### PR TITLE
[ASP.NET Core] Fix broken instrumentation

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentation.cs
@@ -26,6 +26,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore
     {
         private static readonly HashSet<string> DiagnosticSourceEvents = new()
         {
+            "Microsoft.AspNetCore.Hosting.HttpRequestIn",
             "Microsoft.AspNetCore.Hosting.HttpRequestIn.Start",
             "Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop",
             "Microsoft.AspNetCore.Mvc.BeforeAction",


### PR DESCRIPTION
Fixes #https://github.com/open-telemetry/opentelemetry-dotnet/pull/3519#issuecomment-1262783396

This surfaced a gap in our tests. From my brief investigation, the issue is coming from [here](https://github.com/dotnet/aspnetcore/blob/01177230911caab93dff106e4f0d973a06f51bf3/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs#L61). This will enable activity creation and once the activity is created we were subscribing to `.Start` and `.Stop` events.

We probably need to test with and without `builder.Logging.ClearProviders()`. Will look in to this separately and update our tests accordingly.


## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
