### PR TITLE
Fix folder name for package publish workflow

### DIFF
--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Publish Artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ github.ref || 'main' }}-packages
+        name: ${{ github.ref_name }}-packages
         path: '**/bin/**/*.*nupkg'
 
     - name: Publish MyGet


### PR DESCRIPTION
The current workflow to publish packages is failing because it uses the full name of the tag/branch for the folder name. The full name contains a forward slash which is not allowed.

- https://github.com/open-telemetry/opentelemetry-dotnet/actions/runs/3155519159/jobs/5134267776
- https://github.com/open-telemetry/opentelemetry-dotnet/actions/runs/3155539642

## Changes
- Use `github.ref_name` to get just the name of the tag/branch
