### PR TITLE
[Repo] ApiCompat updates

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -38,7 +38,7 @@
     <MicrosoftNETFrameworkReferenceAssembliesPkgVer>[1.0.0,2.0)</MicrosoftNETFrameworkReferenceAssembliesPkgVer>
     <MicrosoftSourceLinkGitHubPkgVer>[1.0.0,2.0)</MicrosoftSourceLinkGitHubPkgVer>
     <OpenTracingPkgVer>[0.12.1,0.13)</OpenTracingPkgVer>
-    <OTelPreviousStableVer>1.3.0</OTelPreviousStableVer>
+    <OTelPreviousStableVer>1.3.1</OTelPreviousStableVer>
     <SerilogPkgVer>[2.8.0,3.0)</SerilogPkgVer>
     <StyleCopAnalyzersPkgVer>[1.2.0-beta.435,2.0)</StyleCopAnalyzersPkgVer>
     <SystemCollectionsImmutablePkgVer>1.4.0</SystemCollectionsImmutablePkgVer>

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/ApiCompatBaseline.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/ApiCompatBaseline.txt
@@ -1,4 +1,0 @@
-Compat issues with assembly OpenTelemetry.Exporter.OpenTelemetryProtocol:
-CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.CompilerGeneratedAttribute' exists on 'OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.get()' in the contract but not the implementation.
-CannotRemoveAttribute : Attribute 'System.Runtime.CompilerServices.CompilerGeneratedAttribute' exists on 'OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.set(System.Uri)' in the contract but not the implementation.
-Total Issues: 2


### PR DESCRIPTION
## Changes

* Bumps the version used by the ApiCompat check
* Removes the OtlpExporter `ApiCompatBaseline.txt` which should no longer be needed