### PR TITLE
[SDK + Jaeger] Support loading environment variables from IConfiguration in Traces & Metrics

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -35,7 +35,7 @@
     <MicrosoftExtensionsHostingAbstractionsPkgVer>[2.1.0,)</MicrosoftExtensionsHostingAbstractionsPkgVer>
     <MicrosoftExtensionsLoggingPkgVer>[3.1.0,)</MicrosoftExtensionsLoggingPkgVer>
     <MicrosoftExtensionsLoggingConfigurationPkgVer>[3.1.0,)</MicrosoftExtensionsLoggingConfigurationPkgVer>
-    <MicrosoftExtensionsOptionsPkgVer>[3.1.0,)</MicrosoftExtensionsOptionsPkgVer>
+    <MicrosoftExtensionsOptionsPkgVer>[5.0.0,)</MicrosoftExtensionsOptionsPkgVer>
     <MicrosoftNETFrameworkReferenceAssembliesPkgVer>[1.0.0,2.0)</MicrosoftNETFrameworkReferenceAssembliesPkgVer>
     <MicrosoftSourceLinkGitHubPkgVer>[1.0.0,2.0)</MicrosoftSourceLinkGitHubPkgVer>
     <OpenTracingPkgVer>[0.12.1,0.13)</OpenTracingPkgVer>

--- a/build/Common.props
+++ b/build/Common.props
@@ -31,6 +31,7 @@
     <MicrosoftAspNetCoreHttpFeaturesPkgVer>[2.1.1,6.0)</MicrosoftAspNetCoreHttpFeaturesPkgVer>
     <MicrosoftCodeAnalysisAnalyzersPkgVer>[3.3.3]</MicrosoftCodeAnalysisAnalyzersPkgVer>
     <MicrosoftCodeCoveragePkgVer>[17.3.0]</MicrosoftCodeCoveragePkgVer>
+    <MicrosoftExtensionsConfigurationEnvironmentVariablesPkgVer>[3.1.0,)</MicrosoftExtensionsConfigurationEnvironmentVariablesPkgVer>
     <MicrosoftExtensionsHostingAbstractionsPkgVer>[2.1.0,)</MicrosoftExtensionsHostingAbstractionsPkgVer>
     <MicrosoftExtensionsLoggingPkgVer>[3.1.0,)</MicrosoftExtensionsLoggingPkgVer>
     <MicrosoftExtensionsLoggingConfigurationPkgVer>[3.1.0,)</MicrosoftExtensionsLoggingConfigurationPkgVer>

--- a/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Added support for loading environment variables from `IConfiguration` when
+  using the `AddJaegerExporter` extension
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.4.0-beta.1
 
 Released 2022-Sep-29

--- a/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Added support for loading environment variables from `IConfiguration` when
   using the `AddJaegerExporter` extension
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#3720](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3720))
 
 ## 1.4.0-beta.1
 

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterHelperExtensions.cs
@@ -62,10 +62,15 @@ namespace OpenTelemetry.Trace
 
             name ??= Options.DefaultName;
 
-            if (configure != null)
+            builder.ConfigureServices(services =>
             {
-                builder.ConfigureServices(services => services.Configure(name, configure));
-            }
+                if (configure != null)
+                {
+                    services.Configure(name, configure);
+                }
+
+                services.AddSingleton<IOptionsFactory<JaegerExporterOptions>, JaegerExporterOptions.JaegerExporterOptionsFactory>();
+            });
 
             return builder.ConfigureBuilder((sp, builder) =>
             {

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterHelperExtensions.cs
@@ -18,6 +18,7 @@ using System;
 using System.Net.Http;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Internal;
@@ -69,7 +70,7 @@ namespace OpenTelemetry.Trace
                     services.Configure(name, configure);
                 }
 
-                services.AddSingleton<IOptionsFactory<JaegerExporterOptions>, JaegerExporterOptions.JaegerExporterOptionsFactory>();
+                services.TryAddSingleton<IOptionsFactory<JaegerExporterOptions>, JaegerExporterOptions.JaegerExporterOptionsFactory>();
             });
 
             return builder.ConfigureBuilder((sp, builder) =>

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterHelperExtensions.cs
@@ -18,7 +18,6 @@ using System;
 using System.Net.Http;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Internal;
@@ -70,7 +69,7 @@ namespace OpenTelemetry.Trace
                     services.Configure(name, configure);
                 }
 
-                services.TryAddSingleton<IOptionsFactory<JaegerExporterOptions>, JaegerExporterOptions.JaegerExporterOptionsFactory>();
+                services.RegisterOptionsFactory(configuration => new JaegerExporterOptions(configuration));
             });
 
             return builder.ConfigureBuilder((sp, builder) =>

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptions.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Http;
 using Microsoft.Extensions.Configuration;
@@ -158,18 +159,23 @@ namespace OpenTelemetry.Exporter
         /// </remarks>
         public Func<HttpClient> HttpClientFactory { get; set; } = DefaultHttpClientFactory;
 
-        internal sealed class JaegerExporterOptionsFactory : IOptionsFactory<JaegerExporterOptions>
+        internal sealed class JaegerExporterOptionsFactory : OptionsFactory<JaegerExporterOptions>
         {
             private readonly IConfiguration configuration;
 
-            public JaegerExporterOptionsFactory(IConfiguration configuration)
+            public JaegerExporterOptionsFactory(
+                IConfiguration configuration,
+                IEnumerable<IConfigureOptions<JaegerExporterOptions>> setups,
+                IEnumerable<IPostConfigureOptions<JaegerExporterOptions>> postConfigures,
+                IEnumerable<IValidateOptions<JaegerExporterOptions>> validations)
+                : base(setups, postConfigures, validations)
             {
                 Debug.Assert(configuration != null, "configuration was null");
 
                 this.configuration = configuration;
             }
 
-            public JaegerExporterOptions Create(string name)
+            protected override JaegerExporterOptions CreateInstance(string name)
                 => new(this.configuration);
         }
     }

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterProtocolParser.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterProtocolParser.cs
@@ -20,7 +20,7 @@ internal static class JaegerExporterProtocolParser
 {
     public static bool TryParse(string value, out JaegerExportProtocol result)
     {
-        switch (value?.Trim())
+        switch (value.Trim().ToLower())
         {
             case "udp/thrift.compact":
                 result = JaegerExportProtocol.UdpCompactThrift;

--- a/src/OpenTelemetry.Exporter.Jaeger/OpenTelemetry.Exporter.Jaeger.csproj
+++ b/src/OpenTelemetry.Exporter.Jaeger/OpenTelemetry.Exporter.Jaeger.csproj
@@ -19,7 +19,7 @@
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\ActivityHelperExtensions.cs" Link="Includes\ActivityHelperExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\StatusHelper.cs" Link="Includes\StatusHelper.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\Guard.cs" Link="Includes\Guard.cs" />
-    <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\EnvironmentVariableHelper.cs" Link="Includes\EnvironmentVariableHelper.cs" />
+    <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\ConfigurationExtensions.cs" Link="Includes\ConfigurationExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\OpenTelemetrySdkEventSource.cs" Link="Includes\OpenTelemetrySdkEventSource.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\PooledList.cs" Link="Includes\PooledList.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\PeerServiceResolver.cs" Link="Includes\PeerServiceResolver.cs" />

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Added support for loading environment variables from `IConfiguration` when
+  using `TracerProviderBuilder` or `MeterProviderBuilder`
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.4.0-beta.1
 
 Released 2022-Sep-29

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Added support for loading environment variables from `IConfiguration` when
   using `TracerProviderBuilder` or `MeterProviderBuilder`
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#3720](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3720))
 
 ## 1.4.0-beta.1
 

--- a/src/OpenTelemetry/Internal/Builder/ProviderBuilderServiceCollectionExtensions.cs
+++ b/src/OpenTelemetry/Internal/Builder/ProviderBuilderServiceCollectionExtensions.cs
@@ -35,7 +35,7 @@ internal static class ProviderBuilderServiceCollectionExtensions
         // Sdk.Create* style or when manually creating a ServiceCollection. The
         // point of this registration is to make IConfiguration available in
         // those cases.
-        services.TryAddSingleton<IConfiguration>(sp => new ConfigurationBuilder().AddEnvironmentVariables().Build());
+        services!.TryAddSingleton<IConfiguration>(sp => new ConfigurationBuilder().AddEnvironmentVariables().Build());
 
         return services!;
     }

--- a/src/OpenTelemetry/Internal/Builder/ProviderBuilderServiceCollectionExtensions.cs
+++ b/src/OpenTelemetry/Internal/Builder/ProviderBuilderServiceCollectionExtensions.cs
@@ -1,0 +1,42 @@
+// <copyright file="ProviderBuilderServiceCollectionExtensions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#nullable enable
+
+using System.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+internal static class ProviderBuilderServiceCollectionExtensions
+{
+    public static IServiceCollection AddOpenTelemetryProviderBuilderServices(this IServiceCollection services)
+    {
+        Debug.Assert(services != null, "services was null");
+
+        services.AddOptions();
+
+        // Note: When using a host builder IConfiguration is automatically
+        // registered and this registration will no-op. This only runs for
+        // Sdk.Create* style or when manually creating a ServiceCollection. The
+        // point of this registration is to make IConfiguration available in
+        // those cases.
+        services.TryAddSingleton<IConfiguration>(sp => new ConfigurationBuilder().AddEnvironmentVariables().Build());
+
+        return services;
+    }
+}

--- a/src/OpenTelemetry/Internal/Builder/ProviderBuilderServiceCollectionExtensions.cs
+++ b/src/OpenTelemetry/Internal/Builder/ProviderBuilderServiceCollectionExtensions.cs
@@ -37,6 +37,6 @@ internal static class ProviderBuilderServiceCollectionExtensions
         // those cases.
         services.TryAddSingleton<IConfiguration>(sp => new ConfigurationBuilder().AddEnvironmentVariables().Build());
 
-        return services;
+        return services!;
     }
 }

--- a/src/OpenTelemetry/Internal/ConfigurationExtensions.cs
+++ b/src/OpenTelemetry/Internal/ConfigurationExtensions.cs
@@ -1,0 +1,164 @@
+// <copyright file="ConfigurationExtensions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+#if !NETFRAMEWORK && !NETSTANDARD2_0
+using System.Diagnostics.CodeAnalysis;
+#endif
+using System.Globalization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace OpenTelemetry.Internal;
+
+internal static class ConfigurationExtensions
+{
+    public delegate bool TryParseFunc<T>(
+        string value,
+#if !NETFRAMEWORK && !NETSTANDARD2_0
+        [NotNullWhen(true)]
+#endif
+        out T? parsedValue);
+
+    public static bool TryGetStringValue(
+        this IConfiguration configuration,
+        string key,
+#if !NETFRAMEWORK && !NETSTANDARD2_0
+        [NotNullWhen(true)]
+#endif
+        out string? value)
+    {
+        value = configuration.GetValue<string?>(key, null);
+
+        return !string.IsNullOrWhiteSpace(value);
+    }
+
+    public static bool TryGetUriValue(
+        this IConfiguration configuration,
+        string key,
+#if !NETFRAMEWORK && !NETSTANDARD2_0
+        [NotNullWhen(true)]
+#endif
+        out Uri? value)
+    {
+        if (!configuration.TryGetStringValue(key, out var stringValue))
+        {
+            value = null;
+            return false;
+        }
+
+        if (!Uri.TryCreate(stringValue, UriKind.Absolute, out value))
+        {
+            throw new FormatException($"{key} environment variable has an invalid value: '{stringValue}'");
+        }
+
+        return true;
+    }
+
+    public static bool TryGetIntValue(
+        this IConfiguration configuration,
+        string key,
+        out int value)
+    {
+        if (!configuration.TryGetStringValue(key, out var stringValue))
+        {
+            value = default;
+            return false;
+        }
+
+        if (!int.TryParse(stringValue, NumberStyles.None, CultureInfo.InvariantCulture, out value))
+        {
+            throw new FormatException($"{key} environment variable has an invalid value: '{stringValue}'");
+        }
+
+        return true;
+    }
+
+    public static bool TryGetValue<T>(
+        this IConfiguration configuration,
+        string key,
+        TryParseFunc<T> tryParseFunc,
+#if !NETFRAMEWORK && !NETSTANDARD2_0
+        [NotNullWhen(true)]
+#endif
+        out T? value)
+    {
+        if (!configuration.TryGetStringValue(key, out var stringValue))
+        {
+            value = default;
+            return false;
+        }
+
+        if (!tryParseFunc(stringValue!, out value))
+        {
+            throw new FormatException($"{key} environment variable has an invalid value: '{stringValue}'");
+        }
+
+        return true;
+    }
+
+    public static IServiceCollection RegisterOptionsFactory<T>(
+        this IServiceCollection services,
+        Func<IConfiguration, T> optionsFactoryFunc)
+        where T : class
+    {
+        Debug.Assert(services != null, "services was null");
+        Debug.Assert(optionsFactoryFunc != null, "optionsFactoryFunc was null");
+
+        services!.TryAddSingleton<IOptionsFactory<T>>(sp =>
+        {
+            return new DelegatingOptionsFactory<T>(
+                optionsFactoryFunc!,
+                sp.GetRequiredService<IConfiguration>(),
+                sp.GetServices<IConfigureOptions<T>>(),
+                sp.GetServices<IPostConfigureOptions<T>>(),
+                sp.GetServices<IValidateOptions<T>>());
+        });
+
+        return services!;
+    }
+
+    private sealed class DelegatingOptionsFactory<T> : OptionsFactory<T>
+        where T : class
+    {
+        private readonly Func<IConfiguration, T> optionsFactoryFunc;
+        private readonly IConfiguration configuration;
+
+        public DelegatingOptionsFactory(
+            Func<IConfiguration, T> optionsFactoryFunc,
+            IConfiguration configuration,
+            IEnumerable<IConfigureOptions<T>> setups,
+            IEnumerable<IPostConfigureOptions<T>> postConfigures,
+            IEnumerable<IValidateOptions<T>> validations)
+            : base(setups, postConfigures, validations)
+        {
+            Debug.Assert(optionsFactoryFunc != null, "optionsFactoryFunc was null");
+            Debug.Assert(configuration != null, "configuration was null");
+
+            this.optionsFactoryFunc = optionsFactoryFunc!;
+            this.configuration = configuration!;
+        }
+
+        protected override T CreateInstance(string name)
+            => this.optionsFactoryFunc(this.configuration);
+    }
+}

--- a/src/OpenTelemetry/Internal/EnvironmentVariableHelper.cs
+++ b/src/OpenTelemetry/Internal/EnvironmentVariableHelper.cs
@@ -76,6 +76,25 @@ namespace OpenTelemetry.Internal
                 return false;
             }
 
+            return LoadNumeric(envVarKey, value, out result);
+        }
+
+        /// <summary>
+        /// Reads an environment variable and parses is as a
+        /// <a href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#numeric-value">
+        /// numeric value</a> - a non-negative decimal integer.
+        /// </summary>
+        /// <param name="envVarKey">The name of the environment variable.</param>
+        /// <param name="value">The value of the environment variable.</param>
+        /// <param name="result">The parsed value of the environment variable.</param>
+        /// <returns>
+        /// Returns <c>true</c> when a non-empty value was read; otherwise, <c>false</c>.
+        /// </returns>
+        /// <exception cref="FormatException">
+        /// Thrown when failed to parse the non-empty value.
+        /// </exception>
+        public static bool LoadNumeric(string envVarKey, string value, out int result)
+        {
             if (!int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out result))
             {
                 throw new FormatException($"{envVarKey} environment variable has an invalid value: '{value}'");

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderBase.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderBase.cs
@@ -52,7 +52,7 @@ namespace OpenTelemetry.Metrics
         {
             Guard.ThrowIfNull(services);
 
-            services.AddOptions();
+            services.AddOpenTelemetryProviderBuilderServices();
             services.TryAddSingleton<MeterProvider>(sp => new MeterProviderSdk(sp, ownsServiceProvider: false));
 
             this.services = services;
@@ -65,7 +65,7 @@ namespace OpenTelemetry.Metrics
         {
             var services = new ServiceCollection();
 
-            services.AddOptions();
+            services.AddOpenTelemetryProviderBuilderServices();
 
             this.services = services;
             this.ownsServices = true;

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderServiceCollectionHelper.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderServiceCollectionHelper.cs
@@ -42,7 +42,7 @@ internal static class MeterProviderBuilderServiceCollectionHelper
         Debug.Assert(services != null, "services was null");
         Debug.Assert(configure != null, "configure was null");
 
-        return services.AddSingleton(new ConfigureMeterProviderBuilderStateCallbackRegistration(configure!));
+        return services!.AddSingleton(new ConfigureMeterProviderBuilderStateCallbackRegistration(configure!));
     }
 
     internal static void InvokeRegisteredConfigureStateCallbacks(
@@ -52,7 +52,7 @@ internal static class MeterProviderBuilderServiceCollectionHelper
         Debug.Assert(serviceProvider != null, "serviceProvider was null");
         Debug.Assert(state != null, "state was null");
 
-        var callbackRegistrations = serviceProvider.GetServices<ConfigureMeterProviderBuilderStateCallbackRegistration>();
+        var callbackRegistrations = serviceProvider!.GetServices<ConfigureMeterProviderBuilderStateCallbackRegistration>();
 
         foreach (var callbackRegistration in callbackRegistrations)
         {

--- a/src/OpenTelemetry/OpenTelemetry.csproj
+++ b/src/OpenTelemetry/OpenTelemetry.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="$(SystemReflectionEmitLightweightPkgVer)" Condition="'$(TargetFramework)' != 'net6.0'" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingPkgVer)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="$(MicrosoftExtensionsLoggingConfigurationPkgVer)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsConfigurationEnvironmentVariablesPkgVer)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry/OpenTelemetry.csproj
+++ b/src/OpenTelemetry/OpenTelemetry.csproj
@@ -17,9 +17,10 @@
 
   <ItemGroup>
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="$(SystemReflectionEmitLightweightPkgVer)" Condition="'$(TargetFramework)' != 'net6.0'" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsConfigurationEnvironmentVariablesPkgVer)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingPkgVer)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="$(MicrosoftExtensionsLoggingConfigurationPkgVer)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsConfigurationEnvironmentVariablesPkgVer)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsPkgVer)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry/Trace/Builder/TracerProviderBuilderBase.cs
+++ b/src/OpenTelemetry/Trace/Builder/TracerProviderBuilderBase.cs
@@ -51,7 +51,7 @@ namespace OpenTelemetry.Trace
         {
             Guard.ThrowIfNull(services);
 
-            services.AddOptions();
+            services.AddOpenTelemetryProviderBuilderServices();
             services.TryAddSingleton<TracerProvider>(sp => new TracerProviderSdk(sp, ownsServiceProvider: false));
 
             this.services = services;
@@ -64,7 +64,7 @@ namespace OpenTelemetry.Trace
         {
             var services = new ServiceCollection();
 
-            services.AddOptions();
+            services.AddOpenTelemetryProviderBuilderServices();
 
             this.services = services;
             this.ownsServices = true;

--- a/src/OpenTelemetry/Trace/Builder/TracerProviderBuilderServiceCollectionHelper.cs
+++ b/src/OpenTelemetry/Trace/Builder/TracerProviderBuilderServiceCollectionHelper.cs
@@ -42,7 +42,7 @@ internal static class TracerProviderBuilderServiceCollectionHelper
         Debug.Assert(services != null, "services was null");
         Debug.Assert(configure != null, "configure was null");
 
-        return services.AddSingleton(new ConfigureTracerProviderBuilderStateCallbackRegistration(configure!));
+        return services!.AddSingleton(new ConfigureTracerProviderBuilderStateCallbackRegistration(configure!));
     }
 
     internal static void InvokeRegisteredConfigureStateCallbacks(
@@ -52,7 +52,7 @@ internal static class TracerProviderBuilderServiceCollectionHelper
         Debug.Assert(serviceProvider != null, "serviceProvider was null");
         Debug.Assert(state != null, "state was null");
 
-        var callbackRegistrations = serviceProvider.GetServices<ConfigureTracerProviderBuilderStateCallbackRegistration>();
+        var callbackRegistrations = serviceProvider!.GetServices<ConfigureTracerProviderBuilderStateCallbackRegistration>();
 
         foreach (var callbackRegistration in callbackRegistrations)
         {

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterOptionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterOptionsTests.cs
@@ -15,6 +15,8 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
 using Xunit;
 
 namespace OpenTelemetry.Exporter.Jaeger.Tests
@@ -91,6 +93,29 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests
             Assert.Equal("OTEL_EXPORTER_JAEGER_AGENT_HOST", JaegerExporterOptions.OTelAgentHostEnvVarKey);
             Assert.Equal("OTEL_EXPORTER_JAEGER_AGENT_PORT", JaegerExporterOptions.OTelAgentPortEnvVarKey);
             Assert.Equal("OTEL_EXPORTER_JAEGER_ENDPOINT", JaegerExporterOptions.OTelEndpointEnvVarKey);
+        }
+
+        [Fact]
+        public void JaegerExporterOptions_FromConfigurationTest()
+        {
+            var values = new Dictionary<string, string>()
+            {
+                [JaegerExporterOptions.OTelProtocolEnvVarKey] = "http/thrift.binary",
+                [JaegerExporterOptions.OTelAgentHostEnvVarKey] = "jaeger-host",
+                [JaegerExporterOptions.OTelAgentPortEnvVarKey] = "123",
+                [JaegerExporterOptions.OTelEndpointEnvVarKey] = "http://custom-endpoint:12345",
+            };
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(values)
+                .Build();
+
+            var options = new JaegerExporterOptions(configuration);
+
+            Assert.Equal("jaeger-host", options.AgentHost);
+            Assert.Equal(123, options.AgentPort);
+            Assert.Equal(JaegerExportProtocol.HttpBinaryThrift, options.Protocol);
+            Assert.Equal(new Uri("http://custom-endpoint:12345"), options.Endpoint);
         }
 
         private static void ClearEnvVars()


### PR DESCRIPTION
Relates to #2980
Relates to #3639

## Changes

* Update SDK so that `IConfiguration` is always available in tracing & metrics builders.
* Update Jaeger to load environment variables using `IConfiguration`.

## Details

* When using a host builder (generic host or web host builder) `IConfiguration` is there by default and users may customize it.
* When using "Sdk.Create" methods or an empty `ServiceCollection` we now create an `IConfiguration` which includes environment variables by default. Users may customize it if they wish.

## TODOs

* [X] Appropriate `CHANGELOG.md` updated for non-trivial changes
