### PR TITLE
[Logs-branch] Serilog activity enricher

### DIFF
--- a/src/OpenTelemetry.Extensions.Serilog/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions.Serilog/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -1,8 +1,12 @@
 #nullable enable
+OpenTelemetry.Logs.OpenTelemetrySerilogEnricherOptions
+OpenTelemetry.Logs.OpenTelemetrySerilogEnricherOptions.IncludeTraceState.get -> bool
+OpenTelemetry.Logs.OpenTelemetrySerilogEnricherOptions.IncludeTraceState.set -> void
+OpenTelemetry.Logs.OpenTelemetrySerilogEnricherOptions.OpenTelemetrySerilogEnricherOptions() -> void
 OpenTelemetry.Logs.OpenTelemetrySerilogSinkOptions
 OpenTelemetry.Logs.OpenTelemetrySerilogSinkOptions.IncludeRenderedMessage.get -> bool
 OpenTelemetry.Logs.OpenTelemetrySerilogSinkOptions.IncludeRenderedMessage.set -> void
 OpenTelemetry.Logs.OpenTelemetrySerilogSinkOptions.OpenTelemetrySerilogSinkOptions() -> void
 Serilog.OpenTelemetrySerilogExtensions
 static Serilog.OpenTelemetrySerilogExtensions.OpenTelemetry(this Serilog.Configuration.LoggerSinkConfiguration! loggerConfiguration, OpenTelemetry.Logs.LoggerProvider! loggerProvider, OpenTelemetry.Logs.OpenTelemetrySerilogSinkOptions? options = null, bool disposeProvider = false) -> Serilog.LoggerConfiguration!
-static Serilog.OpenTelemetrySerilogExtensions.WithOpenTelemetry(this Serilog.Configuration.LoggerEnrichmentConfiguration! loggerEnrichmentConfiguration) -> Serilog.LoggerConfiguration!
+static Serilog.OpenTelemetrySerilogExtensions.WithOpenTelemetry(this Serilog.Configuration.LoggerEnrichmentConfiguration! loggerEnrichmentConfiguration, OpenTelemetry.Logs.OpenTelemetrySerilogEnricherOptions? options = null) -> Serilog.LoggerConfiguration!

--- a/src/OpenTelemetry.Extensions.Serilog/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions.Serilog/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -5,3 +5,4 @@ OpenTelemetry.Logs.OpenTelemetrySerilogSinkOptions.IncludeRenderedMessage.set ->
 OpenTelemetry.Logs.OpenTelemetrySerilogSinkOptions.OpenTelemetrySerilogSinkOptions() -> void
 Serilog.OpenTelemetrySerilogExtensions
 static Serilog.OpenTelemetrySerilogExtensions.OpenTelemetry(this Serilog.Configuration.LoggerSinkConfiguration! loggerConfiguration, OpenTelemetry.Logs.LoggerProvider! loggerProvider, OpenTelemetry.Logs.OpenTelemetrySerilogSinkOptions? options = null, bool disposeProvider = false) -> Serilog.LoggerConfiguration!
+static Serilog.OpenTelemetrySerilogExtensions.WithOpenTelemetry(this Serilog.Configuration.LoggerEnrichmentConfiguration! loggerEnrichmentConfiguration) -> Serilog.LoggerConfiguration!

--- a/src/OpenTelemetry.Extensions.Serilog/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions.Serilog/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -1,8 +1,12 @@
 #nullable enable
+OpenTelemetry.Logs.OpenTelemetrySerilogEnricherOptions
+OpenTelemetry.Logs.OpenTelemetrySerilogEnricherOptions.IncludeTraceState.get -> bool
+OpenTelemetry.Logs.OpenTelemetrySerilogEnricherOptions.IncludeTraceState.set -> void
+OpenTelemetry.Logs.OpenTelemetrySerilogEnricherOptions.OpenTelemetrySerilogEnricherOptions() -> void
 OpenTelemetry.Logs.OpenTelemetrySerilogSinkOptions
 OpenTelemetry.Logs.OpenTelemetrySerilogSinkOptions.IncludeRenderedMessage.get -> bool
 OpenTelemetry.Logs.OpenTelemetrySerilogSinkOptions.IncludeRenderedMessage.set -> void
 OpenTelemetry.Logs.OpenTelemetrySerilogSinkOptions.OpenTelemetrySerilogSinkOptions() -> void
 Serilog.OpenTelemetrySerilogExtensions
 static Serilog.OpenTelemetrySerilogExtensions.OpenTelemetry(this Serilog.Configuration.LoggerSinkConfiguration! loggerConfiguration, OpenTelemetry.Logs.LoggerProvider! loggerProvider, OpenTelemetry.Logs.OpenTelemetrySerilogSinkOptions? options = null, bool disposeProvider = false) -> Serilog.LoggerConfiguration!
-static Serilog.OpenTelemetrySerilogExtensions.WithOpenTelemetry(this Serilog.Configuration.LoggerEnrichmentConfiguration! loggerEnrichmentConfiguration) -> Serilog.LoggerConfiguration!
+static Serilog.OpenTelemetrySerilogExtensions.WithOpenTelemetry(this Serilog.Configuration.LoggerEnrichmentConfiguration! loggerEnrichmentConfiguration, OpenTelemetry.Logs.OpenTelemetrySerilogEnricherOptions? options = null) -> Serilog.LoggerConfiguration!

--- a/src/OpenTelemetry.Extensions.Serilog/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions.Serilog/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -5,3 +5,4 @@ OpenTelemetry.Logs.OpenTelemetrySerilogSinkOptions.IncludeRenderedMessage.set ->
 OpenTelemetry.Logs.OpenTelemetrySerilogSinkOptions.OpenTelemetrySerilogSinkOptions() -> void
 Serilog.OpenTelemetrySerilogExtensions
 static Serilog.OpenTelemetrySerilogExtensions.OpenTelemetry(this Serilog.Configuration.LoggerSinkConfiguration! loggerConfiguration, OpenTelemetry.Logs.LoggerProvider! loggerProvider, OpenTelemetry.Logs.OpenTelemetrySerilogSinkOptions? options = null, bool disposeProvider = false) -> Serilog.LoggerConfiguration!
+static Serilog.OpenTelemetrySerilogExtensions.WithOpenTelemetry(this Serilog.Configuration.LoggerEnrichmentConfiguration! loggerEnrichmentConfiguration) -> Serilog.LoggerConfiguration!

--- a/src/OpenTelemetry.Extensions.Serilog/OpenTelemetrySerilogEnricher.cs
+++ b/src/OpenTelemetry.Extensions.Serilog/OpenTelemetrySerilogEnricher.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Diagnostics;
 using Serilog.Core;
 using Serilog.Events;

--- a/src/OpenTelemetry.Extensions.Serilog/OpenTelemetrySerilogEnricher.cs
+++ b/src/OpenTelemetry.Extensions.Serilog/OpenTelemetrySerilogEnricher.cs
@@ -1,0 +1,46 @@
+// <copyright file="OpenTelemetrySerilogEnricher.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace OpenTelemetry.Logs
+{
+    internal sealed class OpenTelemetrySerilogEnricher : ILogEventEnricher
+    {
+        public void Enrich(
+            LogEvent logEvent,
+            ILogEventPropertyFactory propertyFactory)
+        {
+            Debug.Assert(logEvent != null, "LogEvent was null.");
+            Debug.Assert(propertyFactory != null, "PropertyFactory was null.");
+
+            Activity? activity = Activity.Current;
+            if (activity == null)
+            {
+                return;
+            }
+
+            logEvent!.AddPropertyIfAbsent(propertyFactory!.CreateProperty(nameof(Activity.SpanId), activity.SpanId.ToHexString()));
+            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(nameof(Activity.TraceId), activity.TraceId.ToHexString()));
+            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(nameof(Activity.ParentSpanId), activity.ParentSpanId.ToHexString()));
+            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("TraceFlags", activity.ActivityTraceFlags));
+        }
+    }
+}
+

--- a/src/OpenTelemetry.Extensions.Serilog/OpenTelemetrySerilogEnricher.cs
+++ b/src/OpenTelemetry.Extensions.Serilog/OpenTelemetrySerilogEnricher.cs
@@ -37,7 +37,12 @@ namespace OpenTelemetry.Logs
 
             logEvent!.AddPropertyIfAbsent(propertyFactory!.CreateProperty(nameof(Activity.SpanId), activity.SpanId.ToHexString()));
             logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(nameof(Activity.TraceId), activity.TraceId.ToHexString()));
-            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(nameof(Activity.ParentSpanId), activity.ParentSpanId.ToHexString()));
+
+            if (activity.ParentSpanId != default)
+            {
+                logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(nameof(Activity.ParentSpanId), activity.ParentSpanId.ToHexString()));
+            }
+
             logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("TraceFlags", activity.ActivityTraceFlags));
         }
     }

--- a/src/OpenTelemetry.Extensions.Serilog/OpenTelemetrySerilogEnricherOptions.cs
+++ b/src/OpenTelemetry.Extensions.Serilog/OpenTelemetrySerilogEnricherOptions.cs
@@ -1,0 +1,35 @@
+// <copyright file="OpenTelemetrySerilogEnricherOptions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Diagnostics;
+using Serilog.Events;
+
+namespace OpenTelemetry.Logs;
+
+/// <summary>
+/// Contains options that control the behavior of the OpenTelemetry Serilog enricher.
+/// </summary>
+public class OpenTelemetrySerilogEnricherOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether or not the <see
+    /// cref="Activity.TraceStateString"/> for the current <see
+    /// cref="Activity"/> should be included on <see cref="LogEvent"/>s as the
+    /// "TraceState" property. Default value: <see langword="false"/>.
+    /// </summary>
+    public bool IncludeTraceState { get; set; }
+}
+

--- a/src/OpenTelemetry.Extensions.Serilog/OpenTelemetrySerilogExtensions.cs
+++ b/src/OpenTelemetry.Extensions.Serilog/OpenTelemetrySerilogExtensions.cs
@@ -18,53 +18,55 @@ using OpenTelemetry.Internal;
 using OpenTelemetry.Logs;
 using Serilog.Configuration;
 
-namespace Serilog
+namespace Serilog;
+
+/// <summary>
+/// Contains Serilog extension methods.
+/// </summary>
+public static class OpenTelemetrySerilogExtensions
 {
     /// <summary>
-    /// Contains Serilog extension methods.
+    /// Adds a sink to Serilog <see cref="LoggerConfiguration"/> which will
+    /// write to OpenTelemetry.
     /// </summary>
-    public static class OpenTelemetrySerilogExtensions
+    /// <param name="loggerConfiguration"><see
+    /// cref="LoggerSinkConfiguration"/>.</param>
+    /// <param name="loggerProvider"><see
+    /// cref="OpenTelemetryLoggerProvider"/>.</param>
+    /// <param name="options"><see cref="OpenTelemetrySerilogSinkOptions"/>.</param>
+    /// <param name="disposeProvider">Controls whether or not the supplied
+    /// <paramref name="loggerProvider"/> will be disposed when
+    /// the logger is disposed. Default value: <see
+    /// langword="false"/>.</param>
+    /// <returns>Supplied <see cref="LoggerConfiguration"/> for chaining calls.</returns>
+    public static LoggerConfiguration OpenTelemetry(
+        this LoggerSinkConfiguration loggerConfiguration,
+        LoggerProvider loggerProvider,
+        OpenTelemetrySerilogSinkOptions? options = null,
+        bool disposeProvider = false)
     {
-        /// <summary>
-        /// Adds a sink to Serilog <see cref="LoggerConfiguration"/> which will
-        /// write to OpenTelemetry.
-        /// </summary>
-        /// <param name="loggerConfiguration"><see
-        /// cref="LoggerSinkConfiguration"/>.</param>
-        /// <param name="loggerProvider"><see
-        /// cref="OpenTelemetryLoggerProvider"/>.</param>
-        /// <param name="options"><see cref="OpenTelemetrySerilogSinkOptions"/>.</param>
-        /// <param name="disposeProvider">Controls whether or not the supplied
-        /// <paramref name="loggerProvider"/> will be disposed when
-        /// the logger is disposed. Default value: <see
-        /// langword="false"/>.</param>
-        /// <returns>Supplied <see cref="LoggerConfiguration"/> for chaining calls.</returns>
-        public static LoggerConfiguration OpenTelemetry(
-            this LoggerSinkConfiguration loggerConfiguration,
-            LoggerProvider loggerProvider,
-            OpenTelemetrySerilogSinkOptions? options = null,
-            bool disposeProvider = false)
-        {
-            Guard.ThrowIfNull(loggerConfiguration);
-            Guard.ThrowIfNull(loggerProvider);
+        Guard.ThrowIfNull(loggerConfiguration);
+        Guard.ThrowIfNull(loggerProvider);
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
-            return loggerConfiguration.Sink(new OpenTelemetrySerilogSink(loggerProvider, options, disposeProvider));
+        return loggerConfiguration.Sink(new OpenTelemetrySerilogSink(loggerProvider, options, disposeProvider));
 #pragma warning restore CA2000 // Dispose objects before losing scope
-        }
+    }
 
-        /// <summary>
-        /// Enrich logger output with information regarding the <see
-        /// cref="System.Diagnostics.Activity"/> at the time of logging, if any.
-        /// </summary>
-        /// <param name="loggerEnrichmentConfiguration"><see
-        /// cref="LoggerEnrichmentConfiguration"/>.</param>
-        /// <returns>Associated <see cref="LoggerConfiguration"/> for chaining calls.</returns>
-        public static LoggerConfiguration WithOpenTelemetry(
-            this LoggerEnrichmentConfiguration loggerEnrichmentConfiguration)
-        {
-            Guard.ThrowIfNull(loggerEnrichmentConfiguration);
-            return loggerEnrichmentConfiguration.With<OpenTelemetrySerilogEnricher>();
-        }
+    /// <summary>
+    /// Enrich logger output with information regarding the <see
+    /// cref="System.Diagnostics.Activity"/> at the time of logging, if any.
+    /// </summary>
+    /// <param name="loggerEnrichmentConfiguration"><see
+    /// cref="LoggerEnrichmentConfiguration"/>.</param>
+    /// <param name="options"><see cref="OpenTelemetrySerilogEnricherOptions"/>.</param>
+    /// <returns>Associated <see cref="LoggerConfiguration"/> for chaining calls.</returns>
+    public static LoggerConfiguration WithOpenTelemetry(
+        this LoggerEnrichmentConfiguration loggerEnrichmentConfiguration,
+        OpenTelemetrySerilogEnricherOptions? options = null)
+    {
+        Guard.ThrowIfNull(loggerEnrichmentConfiguration);
+
+        return loggerEnrichmentConfiguration.With(new OpenTelemetrySerilogEnricher(options ?? new()));
     }
 }

--- a/src/OpenTelemetry.Extensions.Serilog/OpenTelemetrySerilogExtensions.cs
+++ b/src/OpenTelemetry.Extensions.Serilog/OpenTelemetrySerilogExtensions.cs
@@ -52,5 +52,19 @@ namespace Serilog
             return loggerConfiguration.Sink(new OpenTelemetrySerilogSink(loggerProvider, options, disposeProvider));
 #pragma warning restore CA2000 // Dispose objects before losing scope
         }
+
+        /// <summary>
+        /// Enrich logger output with information regarding the <see
+        /// cref="System.Diagnostics.Activity"/> at the time of logging, if any.
+        /// </summary>
+        /// <param name="loggerEnrichmentConfiguration"><see
+        /// cref="LoggerEnrichmentConfiguration"/>.</param>
+        /// <returns>Associated <see cref="LoggerConfiguration"/> for chaining calls.</returns>
+        public static LoggerConfiguration WithOpenTelemetry(
+            this LoggerEnrichmentConfiguration loggerEnrichmentConfiguration)
+        {
+            Guard.ThrowIfNull(loggerEnrichmentConfiguration);
+            return loggerEnrichmentConfiguration.With<OpenTelemetrySerilogEnricher>();
+        }
     }
 }

--- a/src/OpenTelemetry.Extensions.Serilog/README.md
+++ b/src/OpenTelemetry.Extensions.Serilog/README.md
@@ -31,6 +31,44 @@ Log.Logger = new LoggerConfiguration()
 Log.CloseAndFlush();
 ```
 
+## Activity Enricher
+The next example assumes that at least one `ActivityListener` have been registered prior to calling `StartActivity`,
+otherwise, `StartActivity` will return `null`.
+```csharp
+Log.Logger = new LoggerConfiguration()
+    .WriteTo.OpenTelemetry(openTelemetryLoggerProvider, disposeProvider: true)
+    .Enrich.WithOpenTelemetry() // <-- Register enricher
+    .CreateLogger();
+
+/// ...
+ActivitySource activitySource = new(ServiceName);
+activitySource.StartActivity(
+    activityKind,
+    startTime: DateTimeOffset.NowUtc,
+    name: name
+);
+
+Log.Logger.Information("Starting application");
+/// ...
+```
+
+The example above will output this JSON:
+```json
+{
+    "Timestamp": "2022-09-26T02:45:07.1008180-04:00",
+    "Level": "Information",
+    "MessageTemplate": "Application starting",
+    "RenderedMessage": "Application starting",
+    "Properties": {
+        "SpanId": "9250f033e82cc807",
+        "TraceId": "a1c08f86409507de8bf6e38416c8f3de",
+        "TraceFlags": "None"
+    }
+}
+```
+
+In cases where you have a nested activity, the property `ParentSpanId` will be included.
+
 ## References
 
 * [OpenTelemetry Project](https://opentelemetry.io/)

--- a/test/OpenTelemetry.Extensions.Serilog.Tests/OpenTelemetrySerilogEnricherTests.cs
+++ b/test/OpenTelemetry.Extensions.Serilog.Tests/OpenTelemetrySerilogEnricherTests.cs
@@ -1,0 +1,109 @@
+// <copyright file="OpenTelemetrySerilogEnricherTests.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using Xunit;
+
+namespace OpenTelemetry.Extensions.Serilog.Tests
+{
+    public class OpenTelemetrySerilogEnricherTests
+    {
+        [Fact]
+        public void SerilogBasicLogWithoutActivityTest()
+        {
+            List<LogEvent> emittedLogs = new();
+
+            Log.Logger = new LoggerConfiguration()
+                .Enrich.WithOpenTelemetry()
+                .WriteTo.Sink(new InMemorySink(emittedLogs))
+                .CreateLogger();
+
+            Log.Logger.Information("Hello {greeting}", "World");
+
+            Log.CloseAndFlush();
+
+            Assert.Single(emittedLogs);
+
+            LogEvent logEvent = emittedLogs[0];
+
+            Assert.Single(logEvent.Properties);
+        }
+
+        [Fact]
+        public void SerilogBasicLogWithActivityTest()
+        {
+            using var activity = new Activity("Test");
+            activity.Start();
+
+            List<LogEvent> emittedLogs = new();
+
+            Log.Logger = new LoggerConfiguration()
+                .Enrich.WithOpenTelemetry()
+                .WriteTo.Sink(new InMemorySink(emittedLogs))
+                .CreateLogger();
+
+            Log.Logger.Information("Hello {greeting}", "World");
+
+            Log.CloseAndFlush();
+
+            Assert.Single(emittedLogs);
+
+            LogEvent logEvent = emittedLogs[0];
+
+            AssertPropertyExistsAndHaveValue(logEvent, nameof(Activity.SpanId), $"\"{activity.SpanId.ToHexString()}\"");
+            AssertPropertyExistsAndHaveValue(logEvent, nameof(Activity.TraceId), $"\"{activity.TraceId.ToHexString()}\"");
+            AssertPropertyExistsAndHaveValue(logEvent, nameof(Activity.ParentSpanId), $"\"{activity.ParentSpanId.ToHexString()}\"");
+            AssertPropertyExistsAndHaveValue(logEvent, "TraceFlags", activity.ActivityTraceFlags.ToString());
+
+            // We don't need to quote the `ActivityTraceFlags` as Serilog doesn't quote value types
+        }
+
+        private static void AssertPropertyExistsAndHaveValue(
+            LogEvent logEvent,
+            string propertyName,
+            string expectedValue)
+        {
+            Assert.True(logEvent.Properties.ContainsKey(propertyName));
+
+            using var writer = new StringWriter();
+
+            logEvent.Properties[propertyName].Render(writer);
+
+            Assert.Equal(expectedValue, writer.ToString());
+        }
+
+        private sealed class InMemorySink : ILogEventSink
+        {
+            private readonly List<LogEvent> emittedLogs;
+
+            public InMemorySink(List<LogEvent> emittedLogs)
+            {
+                this.emittedLogs = emittedLogs;
+            }
+
+            public void Emit(LogEvent logEvent)
+            {
+                this.emittedLogs.Add(logEvent);
+            }
+        }
+    }
+}

--- a/test/OpenTelemetry.Extensions.Serilog.Tests/OpenTelemetrySerilogEnricherTests.cs
+++ b/test/OpenTelemetry.Extensions.Serilog.Tests/OpenTelemetrySerilogEnricherTests.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;


### PR DESCRIPTION
Relates to #3546 
Fixes #3453 

## Changes

Implement a Serilog enricher which adds the `SpanId`, `TraceId`, `ParentSpanId` and `ActivityTraceFlags` properties to log events when the `Activity.Current` is not null, otherwise, these properties are not added

## TODOs

* ~[ ] Appropriate `CHANGELOG.md` updated for non-trivial changes~ Skipping because we haven't released this yet.
* [ ] Changes in public API reviewed
