### PR TITLE
[Logs] Fix buffered log scopes being reused

### DIFF
--- a/src/OpenTelemetry/Logs/LogRecord.cs
+++ b/src/OpenTelemetry/Logs/LogRecord.cs
@@ -33,6 +33,7 @@ namespace OpenTelemetry.Logs
     {
         internal LogRecordData Data;
         internal List<KeyValuePair<string, object?>>? AttributeStorage;
+        internal List<object?>? ScopeStorage;
         internal List<object?>? BufferedScopes;
         internal int PoolReferenceCount = int.MaxValue;
 
@@ -309,11 +310,13 @@ namespace OpenTelemetry.Logs
                 return;
             }
 
-            List<object?> scopes = this.BufferedScopes ??= new List<object?>(LogRecordPoolHelper.DefaultMaxNumberOfScopes);
+            var scopeStorage = this.ScopeStorage ??= new List<object?>(LogRecordPoolHelper.DefaultMaxNumberOfScopes);
 
-            this.ScopeProvider.ForEachScope(AddScopeToBufferedList, scopes);
+            this.ScopeProvider.ForEachScope(AddScopeToBufferedList, scopeStorage);
 
             this.ScopeProvider = null;
+
+            this.BufferedScopes = scopeStorage;
         }
 
         private readonly struct ScopeForEachState<TState>

--- a/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs
@@ -60,6 +60,7 @@ namespace OpenTelemetry.Logs
                 record.ScopeProvider = provider.IncludeScopes ? this.ScopeProvider : null;
                 record.State = provider.ParseStateValues ? null : state;
                 record.StateValues = provider.ParseStateValues ? ParseState(record, state) : null;
+                record.BufferedScopes = null;
 
                 ref LogRecordData data = ref record.Data;
 

--- a/src/OpenTelemetry/Logs/Pool/LogRecordPoolHelper.cs
+++ b/src/OpenTelemetry/Logs/Pool/LogRecordPoolHelper.cs
@@ -41,19 +41,19 @@ namespace OpenTelemetry.Logs
                 }
             }
 
-            var bufferedScopes = logRecord.BufferedScopes;
-            if (bufferedScopes != null)
+            var scopeStorage = logRecord.ScopeStorage;
+            if (scopeStorage != null)
             {
-                if (bufferedScopes.Count > DefaultMaxNumberOfScopes)
+                if (scopeStorage.Count > DefaultMaxNumberOfScopes)
                 {
                     // Don't allow the pool to grow unconstained.
-                    logRecord.BufferedScopes = null;
+                    logRecord.ScopeStorage = null;
                 }
                 else
                 {
                     /* List<T>.Clear sets the count/size to 0 but it maintains the
                     underlying array (capacity). */
-                    bufferedScopes.Clear();
+                    scopeStorage.Clear();
                 }
             }
         }

--- a/test/OpenTelemetry.Tests/Logs/LogRecordTest.cs
+++ b/test/OpenTelemetry.Tests/Logs/LogRecordTest.cs
@@ -771,6 +771,39 @@ namespace OpenTelemetry.Logs.Tests
             Assert.Same("Hello world", actualState.Value);
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ReusedLogRecordScopeTest(bool buffer)
+        {
+            var processor = new ScopeProcessor(buffer);
+
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddOpenTelemetry(options =>
+                {
+                    options.IncludeScopes = true;
+                    options.AddProcessor(processor);
+                });
+            });
+
+            var logger = loggerFactory.CreateLogger("TestLogger");
+
+            using (var scope1 = logger.BeginScope("scope1"))
+            {
+                logger.LogInformation("message1");
+            }
+
+            using (var scope2 = logger.BeginScope("scope2"))
+            {
+                logger.LogInformation("message2");
+            }
+
+            Assert.Equal(2, processor.Scopes.Count);
+            Assert.Equal("scope1", processor.Scopes[0]);
+            Assert.Equal("scope2", processor.Scopes[1]);
+        }
+
         private static ILoggerFactory InitializeLoggerFactory(out List<LogRecord> exportedItems, Action<OpenTelemetryLoggerOptions> configure = null)
         {
             var items = exportedItems = new List<LogRecord>();
@@ -914,6 +947,33 @@ namespace OpenTelemetry.Logs.Tests
         private class CustomState
         {
             public string Property { get; set; }
+        }
+
+        private class ScopeProcessor : BaseProcessor<LogRecord>
+        {
+            private readonly bool buffer;
+
+            public ScopeProcessor(bool buffer)
+            {
+                this.buffer = buffer;
+            }
+
+            public List<object> Scopes { get; } = new();
+
+            public override void OnEnd(LogRecord data)
+            {
+                data.ForEachScope<object>(
+                    (scope, state) =>
+                    {
+                        this.Scopes.Add(scope.Scope);
+                    },
+                    null);
+
+                if (this.buffer)
+                {
+                    data.Buffer();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #3727

## Changes

Fixes buffered scopes being reused if accessed before `LogRecord.Buffer` is invoked. Impacts custom processors trying to enumerate scopes before buffering is invoked by [BatchLogRecordExportProcessor](https://github.com/open-telemetry/opentelemetry-dotnet/blob/e826f9d2337978cdcd6d5f623216c40d17e5b649/src/OpenTelemetry/Logs/BatchLogRecordExportProcessor.cs#L60).

## TODOs

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
