### PR TITLE
[Logs-branch] More spec-compliant handling of InstrumentationScope

### DIFF
--- a/src/OpenTelemetry.Api/InstrumentationScope.cs
+++ b/src/OpenTelemetry.Api/InstrumentationScope.cs
@@ -25,6 +25,8 @@ namespace OpenTelemetry;
 /// </summary>
 public sealed class InstrumentationScope
 {
+    internal IReadOnlyDictionary<string, object>? AttributeBacking;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="InstrumentationScope"/> class.
     /// </summary>
@@ -63,5 +65,9 @@ public sealed class InstrumentationScope
     /// Gets the attributes which should be associated with log records created
     /// by the instrumentation library.
     /// </summary>
-    public IReadOnlyDictionary<string, object>? Attributes { get; init; }
+    public IReadOnlyDictionary<string, object>? Attributes
+    {
+        get => this.AttributeBacking;
+        init => this.AttributeBacking = value;
+    }
 }

--- a/src/OpenTelemetry.Api/Internal/SemanticConventions.cs
+++ b/src/OpenTelemetry.Api/Internal/SemanticConventions.cs
@@ -107,5 +107,8 @@ namespace OpenTelemetry.Trace
         public const string AttributeExceptionType = "exception.type";
         public const string AttributeExceptionMessage = "exception.message";
         public const string AttributeExceptionStacktrace = "exception.stacktrace";
+
+        public const string AttributeLogEventDomain = "event.domain";
+        public const string AttributeLogEventName = "event.name";
     }
 }

--- a/src/OpenTelemetry.Api/Logs/LoggerOptions.cs
+++ b/src/OpenTelemetry.Api/Logs/LoggerOptions.cs
@@ -18,6 +18,7 @@
 
 using System.Collections.Generic;
 using OpenTelemetry.Internal;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Logs;
 
@@ -68,7 +69,7 @@ public sealed class LoggerOptions
         get
         {
             var attributes = this.InstrumentationScope.AttributeBacking;
-            if (attributes != null && attributes.TryGetValue("event.domain", out var eventDomain))
+            if (attributes != null && attributes.TryGetValue(SemanticConventions.AttributeLogEventDomain, out var eventDomain))
             {
                 return eventDomain as string;
             }
@@ -92,11 +93,11 @@ public sealed class LoggerOptions
 
             if (value != null)
             {
-                newAttributes["event.domain"] = value;
+                newAttributes[SemanticConventions.AttributeLogEventDomain] = value;
             }
             else
             {
-                newAttributes.Remove("event.domain");
+                newAttributes.Remove(SemanticConventions.AttributeLogEventDomain);
             }
 
             this.InstrumentationScope.AttributeBacking = newAttributes;

--- a/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
@@ -161,6 +161,29 @@ namespace OpenTelemetry.Exporter
                     }
                 }
 
+                var instrumentationScope = logRecord.InstrumentationScope;
+                if (instrumentationScope != null)
+                {
+                    this.WriteLine($"{"\nInstrumentationScope associated with LogRecord:",-RightPaddingLength}");
+                    this.WriteLine($"{"Name:",-RightPaddingLength}{logRecord.InstrumentationScope.Name}");
+                    if (instrumentationScope.Version != null)
+                    {
+                        this.WriteLine($"{"Version:",-RightPaddingLength}{logRecord.InstrumentationScope.Version}");
+                    }
+
+                    if (instrumentationScope.Attributes != null)
+                    {
+                        this.WriteLine("Attributes (Key:Value):");
+                        foreach (var attribute in instrumentationScope.Attributes)
+                        {
+                            if (ConsoleTagTransformer.Instance.TryTransformTag(attribute, out var result))
+                            {
+                                this.WriteLine($"{string.Empty,-4}{result}");
+                            }
+                        }
+                    }
+                }
+
                 this.WriteLine(string.Empty);
             }
 

--- a/src/OpenTelemetry/Logs/LogRecord.cs
+++ b/src/OpenTelemetry/Logs/LogRecord.cs
@@ -329,6 +329,7 @@ namespace OpenTelemetry.Logs
 
             var copy = new LogRecord()
             {
+                InstrumentationScope = this.InstrumentationScope,
                 Data = this.Data,
                 ILoggerData = this.ILoggerData.Copy(),
                 Attributes = this.Attributes == null ? null : new List<KeyValuePair<string, object?>>(this.Attributes),

--- a/src/OpenTelemetry/Logs/LoggerSdk.cs
+++ b/src/OpenTelemetry/Logs/LoggerSdk.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using OpenTelemetry.Internal;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Logs;
 
@@ -69,7 +70,7 @@ internal sealed class LoggerSdk : Logger
 
             Debug.Assert(exportedAttributes != null, "exportedAttributes was null");
 
-            exportedAttributes!.Add(new KeyValuePair<string, object?>("event.name", name));
+            exportedAttributes!.Add(new KeyValuePair<string, object?>(SemanticConventions.AttributeLogEventName, name));
 
             logRecord.Attributes = exportedAttributes;
 

--- a/src/OpenTelemetry/Logs/LoggerSdk.cs
+++ b/src/OpenTelemetry/Logs/LoggerSdk.cs
@@ -46,7 +46,7 @@ internal sealed class LoggerSdk : Logger
     {
         Guard.ThrowIfNullOrWhitespace(name);
 
-        string eventDomain = this.EnsureEventDomain();
+        this.EnsureEventDomain();
 
         var provider = this.loggerProvider;
         var processor = provider.Processor;
@@ -66,7 +66,6 @@ internal sealed class LoggerSdk : Logger
             Debug.Assert(exportedAttributes != null, "exportedAttributes was null");
 
             exportedAttributes!.Add(new KeyValuePair<string, object?>("event.name", name));
-            exportedAttributes!.Add(new KeyValuePair<string, object?>("event.domain", eventDomain));
 
             logRecord.Attributes = exportedAttributes;
 
@@ -104,7 +103,7 @@ internal sealed class LoggerSdk : Logger
         }
     }
 
-    private string EnsureEventDomain()
+    private void EnsureEventDomain()
     {
         string? eventDomain = this.eventDomain;
 
@@ -119,7 +118,5 @@ internal sealed class LoggerSdk : Logger
 
             this.eventDomain = eventDomain;
         }
-
-        return eventDomain!;
     }
 }

--- a/src/OpenTelemetry/Logs/LoggerSdk.cs
+++ b/src/OpenTelemetry/Logs/LoggerSdk.cs
@@ -44,6 +44,10 @@ internal sealed class LoggerSdk : Logger
     /// <inheritdoc />
     public override void EmitEvent(string name, in LogRecordData data, in LogRecordAttributeList attributes = default)
     {
+        // Note: This method will throw if event.name or event.domain is missing
+        // or null. This was done intentionally see discussion:
+        // https://github.com/open-telemetry/opentelemetry-specification/pull/2768#discussion_r972447436
+
         Guard.ThrowIfNullOrWhitespace(name);
 
         this.EnsureEventDomain();

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
@@ -23,6 +23,7 @@ using Microsoft.Extensions.Logging;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Logs;
+using OpenTelemetry.Proto.Collector.Logs.V1;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
 using Xunit;
@@ -484,6 +485,54 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
 
             Assert.Contains(SemanticConventions.AttributeExceptionStacktrace, otlpLogRecordAttributes);
             Assert.Contains(logRecord.Exception.ToInvariantString(), otlpLogRecordAttributes);
+        }
+
+        [Fact]
+        public void CheckAddBatchInstrumentationScopeProcessed()
+        {
+            List<LogRecord> exportedLogRecords = new();
+
+            using (var provider = Sdk.CreateLoggerProviderBuilder()
+                .AddInMemoryExporter(exportedLogRecords)
+                .Build())
+            {
+                var loggerA = provider.GetLogger(new InstrumentationScope("testLogger1")
+                {
+                    Attributes = new Dictionary<string, object> { ["mycustom.key1"] = "value1" },
+                });
+                var loggerB = provider.GetLogger(
+                    new LoggerOptions(
+                        new InstrumentationScope("testLogger2")
+                        {
+                            Attributes = new Dictionary<string, object> { ["mycustom.key2"] = "value2" },
+                        })
+                    {
+                        EventDomain = "testLogger2EventDomain",
+                    });
+
+                loggerA.EmitLog(default, default);
+                loggerB.EmitEvent("event1", default, default);
+            }
+
+            Assert.Equal(2, exportedLogRecords.Count);
+
+            var batch = new Batch<LogRecord>(exportedLogRecords.ToArray(), 2);
+
+            ExportLogsServiceRequest request = new();
+
+            request.AddBatch(new(), in batch);
+
+            Assert.Equal(2, request.ResourceLogs[0].ScopeLogs.Count);
+
+            Assert.Equal("testLogger1", request.ResourceLogs[0].ScopeLogs[0].Scope.Name);
+            Assert.Equal("mycustom.key1", request.ResourceLogs[0].ScopeLogs[0].Scope.Attributes[0].Key);
+            Assert.Equal("value1", request.ResourceLogs[0].ScopeLogs[0].Scope.Attributes[0].Value.StringValue);
+
+            Assert.Equal("testLogger2", request.ResourceLogs[0].ScopeLogs[1].Scope.Name);
+            Assert.Equal("mycustom.key2", request.ResourceLogs[0].ScopeLogs[1].Scope.Attributes[0].Key);
+            Assert.Equal("value2", request.ResourceLogs[0].ScopeLogs[1].Scope.Attributes[0].Value.StringValue);
+            Assert.Equal("event.domain", request.ResourceLogs[0].ScopeLogs[1].Scope.Attributes[1].Key);
+            Assert.Equal("testLogger2EventDomain", request.ResourceLogs[0].ScopeLogs[1].Scope.Attributes[1].Value.StringValue);
         }
     }
 }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
@@ -531,7 +531,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
             Assert.Equal("testLogger2", request.ResourceLogs[0].ScopeLogs[1].Scope.Name);
             Assert.Equal("mycustom.key2", request.ResourceLogs[0].ScopeLogs[1].Scope.Attributes[0].Key);
             Assert.Equal("value2", request.ResourceLogs[0].ScopeLogs[1].Scope.Attributes[0].Value.StringValue);
-            Assert.Equal("event.domain", request.ResourceLogs[0].ScopeLogs[1].Scope.Attributes[1].Key);
+            Assert.Equal(SemanticConventions.AttributeLogEventDomain, request.ResourceLogs[0].ScopeLogs[1].Scope.Attributes[1].Key);
             Assert.Equal("testLogger2EventDomain", request.ResourceLogs[0].ScopeLogs[1].Scope.Attributes[1].Value.StringValue);
         }
     }


### PR DESCRIPTION
## Changes

Previously we were setting `event.domain` on each `LogRecord`. The spec actually says it should be added to the `InstrumentationScope` associated with the `Logger` emitting the `LogRecord`.
