### PR TITLE
[Repo] Attempting to stabilize the API Compatibility CI job

### DIFF
--- a/.github/workflows/apicompatibility.yml
+++ b/.github/workflows/apicompatibility.yml
@@ -26,4 +26,4 @@ jobs:
       run: dotnet restore
 
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build -v normal --configuration Release --no-restore

--- a/.github/workflows/apicompatibility.yml
+++ b/.github/workflows/apicompatibility.yml
@@ -26,4 +26,4 @@ jobs:
       run: dotnet restore
 
     - name: Build
-      run: dotnet build -v normal --configuration Release --no-restore
+      run: dotnet build --configuration Release --no-restore

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -16,7 +16,7 @@
     <ResolvedMatchingContract Include="$(RepoRoot)\build\LastMajorVersionBinaries\$(AssemblyName)\$(OTelPreviousStableVer)\lib\$(TargetFramework)\$(AssemblyName).dll" />
   </ItemGroup>
 
-  <Target Name="PreBuild" BeforeTargets="DispatchToInnerBuilds" Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(CheckAPICompatibility)' == 'true'">
+  <Target Name="PreBuild" BeforeTargets="DispatchToInnerBuilds;ResolvedMatchingContract" Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(CheckAPICompatibility)' == 'true'">
     <!-- Note: DispatchToInnerBuilds is called for projects with multiple
     targets defined to spawn a build process for each target framework being
     compiled. Executing BEFORE that step means this runs once for a project

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -13,11 +13,17 @@
 
   <ItemGroup Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(CheckAPICompatibility)' == 'true'">
     <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="6.0.0-beta.21308.1" PrivateAssets="All" />
-    <ResolvedMatchingContract Include="..\LastMajorVersionBinaries\$(AssemblyName)\$(OTelPreviousStableVer)\lib\$(TargetFramework)\$(AssemblyName).dll" />
+    <ResolvedMatchingContract Include="$(RepoRoot)\build\LastMajorVersionBinaries\$(AssemblyName)\$(OTelPreviousStableVer)\lib\$(TargetFramework)\$(AssemblyName).dll" />
   </ItemGroup>
 
-  <Target Name="PreBuild" BeforeTargets="PreBuildEvent" Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(CheckAPICompatibility)' == 'true'">
-    <Exec Command="powershell -ExecutionPolicy Unrestricted -File &quot;$(RepoRoot)\build\PreBuild.ps1&quot; -package $(AssemblyName) -version &quot;$(OTelPreviousStableVer)&quot;" />
+  <Target Name="PreBuild" BeforeTargets="DispatchToInnerBuilds" Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(CheckAPICompatibility)' == 'true'">
+    <!-- Note: DispatchToInnerBuilds is called for projects with multiple
+    targets defined to spawn a build process for each target framework being
+    compiled. Executing BEFORE that step means this runs once for a project
+    instead of in parallel for each target framework defined. If we ever have a
+    project with only a single target, this will NOT run and an alternative
+    solution will be needed. -->
+    <Exec Command="powershell -ExecutionPolicy Unrestricted -File &quot;$(RepoRoot)\build\PreBuild.ps1&quot; -package $(AssemblyName) -version &quot;$(OTelPreviousStableVer)&quot; -workDir &quot;$(RepoRoot)\build\LastMajorVersionBinaries&quot;" />
   </Target>
 
   <Target Name="FindContractDependencyPaths" BeforeTargets="ValidateApiCompatForSrc" AfterTargets="ResolveAssemblyReferences" Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(CheckAPICompatibility)' == 'true'">

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -16,7 +16,7 @@
     <ResolvedMatchingContract Include="$(RepoRoot)\build\LastMajorVersionBinaries\$(AssemblyName)\$(OTelPreviousStableVer)\lib\$(TargetFramework)\$(AssemblyName).dll" />
   </ItemGroup>
 
-  <Target Name="PreBuild" BeforeTargets="DispatchToInnerBuilds;ResolvedMatchingContract" Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(CheckAPICompatibility)' == 'true'">
+  <Target Name="PreBuild" BeforeTargets="DispatchToInnerBuilds;ValidateApiCompatForSrc" Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(CheckAPICompatibility)' == 'true'">
     <!-- Note: DispatchToInnerBuilds is called for projects with multiple
     targets defined to spawn a build process for each target framework being
     compiled. Executing BEFORE that step means this runs once for a project

--- a/build/PreBuild.ps1
+++ b/build/PreBuild.ps1
@@ -1,7 +1,7 @@
 param(
   [string]$package,
   [string]$version,
-  [string]$workDir = "..\LastMajorVersionBinaries"
+  [string]$workDir = ".\LastMajorVersionBinaries"
 )
 
 if (-Not (Test-Path $workDir))

--- a/build/PreBuild.ps1
+++ b/build/PreBuild.ps1
@@ -1,6 +1,9 @@
-param([string]$package, [string]$version)
+param(
+  [string]$package,
+  [string]$version,
+  [string]$workDir = "..\LastMajorVersionBinaries"
+)
 
-$workDir = "..\LastMajorVersionBinaries"
 if (-Not (Test-Path $workDir))
 {
     Write-Host "Working directory for previous package versions not found, creating..."
@@ -16,6 +19,7 @@ else
     Write-Host "Retrieving $package @$version for compatibility check"
     Invoke-WebRequest -Uri https://www.nuget.org/api/v2/package/$package/$version -Outfile "$workDir\$package.$version.zip"
 }
+
 if (Test-Path -Path "$workDir\$package\$version\lib")
 {
     Write-Debug "Previous package version already extracted"

--- a/build/PreBuild.ps1
+++ b/build/PreBuild.ps1
@@ -12,7 +12,7 @@ if (-Not (Test-Path $workDir))
 
 if (Test-Path -Path "$workDir\$package.$version.zip")
 {
-    Write-Host "Previous package $package@$version already downloaded for compatibility check"
+    Write-Debug "Previous package $package@$version already downloaded for compatibility check"
 }
 else
 {
@@ -22,7 +22,7 @@ else
 
 if (Test-Path -Path "$workDir\$package\$version\lib")
 {
-    Write-Host "Previous package $package@$version already extracted to '$workDir\$package\$version\lib'"
+    Write-Debug "Previous package $package@$version already extracted to '$workDir\$package\$version\lib'"
 }
 else
 {

--- a/build/PreBuild.ps1
+++ b/build/PreBuild.ps1
@@ -6,25 +6,26 @@ param(
 
 if (-Not (Test-Path $workDir))
 {
-    Write-Host "Working directory for previous package versions not found, creating..."
+    Write-Host "Working directory for compatibility check packages '$workDir' not found, creating..."
     New-Item -Path $workDir -ItemType "directory" | Out-Null
 }
 
 if (Test-Path -Path "$workDir\$package.$version.zip")
 {
-    Write-Debug "Previous package version already downloaded"
+    Write-Host "Previous package $package@$version already downloaded for compatibility check"
 }
 else
 {
-    Write-Host "Retrieving $package @$version for compatibility check"
+    Write-Host "Retrieving package $package@$version for compatibility check"
     Invoke-WebRequest -Uri https://www.nuget.org/api/v2/package/$package/$version -Outfile "$workDir\$package.$version.zip"
 }
 
 if (Test-Path -Path "$workDir\$package\$version\lib")
 {
-    Write-Debug "Previous package version already extracted"
+    Write-Host "Previous package $package@$version already extracted to '$workDir\$package\$version\lib'"
 }
 else
 {
+    Write-Host "Extracting package $package@$version from '$workDir\$package.$version.zip' to '$workDir\$package\$version' for compatibility check"
     Expand-Archive -LiteralPath "$workDir\$package.$version.zip" -DestinationPath "$workDir\$package\$version" -Force
 }


### PR DESCRIPTION
Switches the powershell script to run once per project instead of in parallel for each target framework in a project.

This should resolve these annoying CI failures:

```
  Working directory for previous package versions not found, creating...
  Working directory for previous package versions not found, creating...
  Retrieving OpenTelemetry @1.3.1 for compatibility check
  Retrieving OpenTelemetry @1.3.1 for compatibility check
  Invoke-WebRequest : The process cannot access the file 
  'D:\a\opentelemetry-dotnet\opentelemetry-dotnet\src\LastMajorVersionBinaries\OpenTelemetry.1.3.1.zip' because it is 
  being used by another process.
```