### PR TITLE
[HttpClient] update `http.status_code` metric dimension to string

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
@@ -55,7 +55,7 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
                     {
                         new KeyValuePair<string, object>(SemanticConventions.AttributeHttpMethod, HttpTagHelper.GetNameForHttpMethod(request.Method)),
                         new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, request.RequestUri.Scheme),
-                        new KeyValuePair<string, object>(SemanticConventions.AttributeHttpStatusCode, (int)response.StatusCode),
+                        new KeyValuePair<string, object>(SemanticConventions.AttributeHttpStatusCode, HttpTagHelper.GetStatusCodeStringFromHttpStatusCode(response.StatusCode)),
                         new KeyValuePair<string, object>(SemanticConventions.AttributeHttpFlavor, HttpTagHelper.GetFlavorTagValueFromProtocolVersion(request.Version)),
                     };
 

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpTagHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpTagHelper.cs
@@ -15,6 +15,7 @@
 // </copyright>
 using System;
 using System.Collections.Concurrent;
+using System.Net;
 using System.Net.Http;
 
 namespace OpenTelemetry.Instrumentation.Http.Implementation
@@ -29,11 +30,13 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
         private static readonly ConcurrentDictionary<HttpMethod, string> HttpMethodNameCache = new();
         private static readonly ConcurrentDictionary<string, ConcurrentDictionary<int, string>> HostAndPortToStringCache = new();
         private static readonly ConcurrentDictionary<Version, string> ProtocolVersionToStringCache = new();
+        private static readonly ConcurrentDictionary<HttpStatusCode, string> HttpStatusCodeCache = new();
 
         private static readonly Func<string, string> ConvertMethodToOperationNameRef = ConvertMethodToOperationName;
         private static readonly Func<HttpMethod, string> ConvertHttpMethodToOperationNameRef = ConvertHttpMethodToOperationName;
         private static readonly Func<HttpMethod, string> ConvertHttpMethodToNameRef = ConvertHttpMethodToName;
         private static readonly Func<Version, string> ConvertProtocolVersionToStringRef = ConvertProtocolVersionToString;
+        private static readonly Func<HttpStatusCode, string> ConvertHtpStatusCodeToStringRef = ConvertHttpStatusCodeToString;
 
         /// <summary>
         /// Gets the OpenTelemetry standard name for an activity based on its Http method.
@@ -62,6 +65,13 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
         /// <param name="protocolVersion"><see cref="Version"/>.</param>
         /// <returns>Span flavor value.</returns>
         public static string GetFlavorTagValueFromProtocolVersion(Version protocolVersion) => ProtocolVersionToStringCache.GetOrAdd(protocolVersion, ConvertProtocolVersionToStringRef);
+
+        /// <summary>
+        /// Gets the http.status_code tag value />.
+        /// </summary>
+        /// <param name="statusCode"><see cref="HttpStatusCode"/>.</param>
+        /// <returns>Status Code value.</returns>
+        public static string GetStatusCodeStringFromHttpStatusCode(HttpStatusCode statusCode) => HttpStatusCodeCache.GetOrAdd(statusCode, ConvertHtpStatusCodeToStringRef);
 
         /// <summary>
         /// Gets the OpenTelemetry standard host tag value for a span based on its request <see cref="Uri"/>.
@@ -116,5 +126,7 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
         private static string ConvertHttpMethodToName(HttpMethod method) => method.ToString();
 
         private static string ConvertProtocolVersionToString(Version protocolVersion) => protocolVersion.ToString();
+
+        private static string ConvertHttpStatusCodeToString(HttpStatusCode statusCode) => ((int)statusCode).ToString();
     }
 }

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.cs
@@ -165,7 +165,7 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
 
                 var method = new KeyValuePair<string, object>(SemanticConventions.AttributeHttpMethod, tc.Method);
                 var scheme = new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, "http");
-                var statusCode = new KeyValuePair<string, object>(SemanticConventions.AttributeHttpStatusCode, tc.ResponseCode == 0 ? 200 : tc.ResponseCode);
+                var statusCode = new KeyValuePair<string, object>(SemanticConventions.AttributeHttpStatusCode, tc.ResponseCode == 0 ? "200" : tc.ResponseCode.ToString());
                 var flavor = new KeyValuePair<string, object>(SemanticConventions.AttributeHttpFlavor, "2.0");
                 Assert.Contains(method, attributes);
                 Assert.Contains(scheme, attributes);


### PR DESCRIPTION
Fixes #.

## Changes

As per [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md#:~:text=http.status_code,200%20(String))

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
