### PR TITLE
Remove Env from CI `DOTNET_MULTILEVEL_LOOKUP = 1`

### DIFF
--- a/.github/workflows/apicompatibility.yml
+++ b/.github/workflows/apicompatibility.yml
@@ -11,8 +11,7 @@ jobs:
     runs-on: windows-latest
     env:
       CheckAPICompatibility: true
-      # https://github.com/actions/setup-dotnet/issues/122
-      DOTNET_MULTILEVEL_LOOKUP: 1
+
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -19,7 +19,6 @@ jobs:
       matrix:
         os: [windows-latest]
 
-
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -18,10 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest]
-    env:
-      OS: ${{ matrix.os }}
-      # https://github.com/actions/setup-dotnet/issues/122
-      DOTNET_MULTILEVEL_LOOKUP: 1
+
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -13,9 +13,6 @@ on:
 jobs:
   build-test:
     runs-on: windows-latest
-    env:
-      # https://github.com/actions/setup-dotnet/issues/122
-      DOTNET_MULTILEVEL_LOOKUP: 1
 
     strategy:
       matrix:


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-dotnet/issues/3014

Remove `DOTNET_MULTILEVEL_LOOKUP = 1`
I believe it was only needed for .NET Core 3.1 and below