### PR TITLE
Bump System.Text.Json version due to CVE-2021-26701

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -45,7 +45,7 @@
     <SystemCollectionsImmutablePkgVer>1.4.0</SystemCollectionsImmutablePkgVer>
     <SystemDiagnosticSourcePkgVer>7.0.0-rc.2.22472.3</SystemDiagnosticSourcePkgVer>
     <SystemReflectionEmitLightweightPkgVer>4.7.0</SystemReflectionEmitLightweightPkgVer>
-    <SystemTextJsonPkgVer>4.7.0</SystemTextJsonPkgVer>
+    <SystemTextJsonPkgVer>4.7.2</SystemTextJsonPkgVer>
     <SystemThreadingTasksExtensionsPkgVer>4.5.3</SystemThreadingTasksExtensionsPkgVer>
   </PropertyGroup>
 

--- a/build/Common.props
+++ b/build/Common.props
@@ -46,7 +46,7 @@
     <SystemDiagnosticSourcePkgVer>7.0.0-rc.2.22472.3</SystemDiagnosticSourcePkgVer>
     <SystemReflectionEmitLightweightPkgVer>4.7.0</SystemReflectionEmitLightweightPkgVer>
     <SystemTextJsonPkgVer>4.7.2</SystemTextJsonPkgVer>
-    <SystemThreadingTasksExtensionsPkgVer>4.5.3</SystemThreadingTasksExtensionsPkgVer>
+    <SystemThreadingTasksExtensionsPkgVer>4.5.4</SystemThreadingTasksExtensionsPkgVer>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Bumped the minimum required version of `System.Text.Json` to 4.7.2 in response
+to [CVE-2021-26701](https://github.com/dotnet/runtime/issues/49377).
+([#3789](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3789))
+
 LogRecordExporter to print full exception details instead of just Message, when
 using `ILogger` to log exception.
 ([#3784](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3784))

--- a/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Bumped the minimum required version of `System.Text.Json` to 4.7.2 in response
+to [CVE-2021-26701](https://github.com/dotnet/runtime/issues/49377).
+([#3789](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3789))
+
 ## 1.4.0-beta.2
 
 Released 2022-Oct-17

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Bumped the minimum required version of `System.Text.Json` to 4.7.2 in response
+to [CVE-2021-26701](https://github.com/dotnet/runtime/issues/49377).
+([#3789](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3789))
+
 ## 1.4.0-beta.2
 
 Released 2022-Oct-17


### PR DESCRIPTION
Fixes #3735.

Read more: https://github.com/dotnet/runtime/issues/49377