### PR TITLE
[SDK] Fix circular reference issue in MeterProvider buildup

### DIFF
--- a/src/OpenTelemetry/Internal/Builder/ProviderBuilderServiceCollectionExtensions.cs
+++ b/src/OpenTelemetry/Internal/Builder/ProviderBuilderServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ internal static class ProviderBuilderServiceCollectionExtensions
     {
         services.AddOpenTelemetryProviderBuilderServices();
 
+        services.TryAddSingleton<MeterProviderBuilderState>();
         services.RegisterOptionsFactory(configuration => new MetricReaderOptions(configuration));
 
         return services;
@@ -40,8 +41,8 @@ internal static class ProviderBuilderServiceCollectionExtensions
     {
         services.AddOpenTelemetryProviderBuilderServices();
 
-        services.RegisterOptionsFactory(configuration => new ExportActivityProcessorOptions(configuration));
         services.TryAddSingleton<TracerProviderBuilderState>();
+        services.RegisterOptionsFactory(configuration => new ExportActivityProcessorOptions(configuration));
 
         return services;
     }

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderBase.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderBase.cs
@@ -46,14 +46,14 @@ namespace OpenTelemetry.Metrics
             this.State = state;
         }
 
-        // This ctor is for AddOpenTelemetryTracing scenario where the builder
-        // is bound to an external service collection.
+        // This ctor is for ConfigureOpenTelemetryMetrics +
+        // AddOpenTelemetryMetrics scenarios where the builder is bound to an
+        // external service collection.
         internal MeterProviderBuilderBase(IServiceCollection services)
         {
             Guard.ThrowIfNull(services);
 
             services.AddOpenTelemetryMeterProviderBuilderServices();
-
             services.TryAddSingleton<MeterProvider>(sp => new MeterProviderSdk(sp, ownsServiceProvider: false));
 
             this.services = services;
@@ -67,6 +67,8 @@ namespace OpenTelemetry.Metrics
             var services = new ServiceCollection();
 
             services.AddOpenTelemetryMeterProviderBuilderServices();
+            services.AddSingleton<MeterProvider>(
+                sp => throw new NotSupportedException("External MeterProvider created through Sdk.CreateMeterProviderBuilder cannot be accessed using service provider."));
 
             this.services = services;
             this.ownsServices = true;

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderState.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderState.cs
@@ -41,6 +41,7 @@ namespace OpenTelemetry.Metrics
         internal int MaxMetricStreams = MaxMetricsDefault;
         internal int MaxMetricPointsPerMetricStream = MaxMetricPointsPerMetricDefault;
 
+        private bool hasEnteredBuildPhase;
         private MeterProviderBuilderSdk? builder;
 
         public MeterProviderBuilderState(IServiceProvider serviceProvider)
@@ -51,6 +52,16 @@ namespace OpenTelemetry.Metrics
         }
 
         public MeterProviderBuilderSdk Builder => this.builder ??= new MeterProviderBuilderSdk(this);
+
+        public void CheckForCircularBuild()
+        {
+            if (this.hasEnteredBuildPhase)
+            {
+                throw new NotSupportedException("MeterProvider cannot be accessed while build is executing.");
+            }
+
+            this.hasEnteredBuildPhase = true;
+        }
 
         public void AddInstrumentation(
             string instrumentationName,

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -22,6 +22,7 @@ using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Text;
+using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Resources;
 
@@ -47,6 +48,9 @@ namespace OpenTelemetry.Metrics
         {
             Debug.Assert(serviceProvider != null, "serviceProvider was null");
 
+            var state = serviceProvider!.GetRequiredService<MeterProviderBuilderState>();
+            state.CheckForCircularBuild();
+
             this.ServiceProvider = serviceProvider!;
 
             if (ownsServiceProvider)
@@ -56,8 +60,6 @@ namespace OpenTelemetry.Metrics
             }
 
             OpenTelemetrySdkEventSource.Log.MeterProviderSdkEvent("Building MeterProvider.");
-
-            var state = new MeterProviderBuilderState(serviceProvider!);
 
             MeterProviderBuilderServiceCollectionHelper.InvokeRegisteredConfigureStateCallbacks(
                 serviceProvider!,


### PR DESCRIPTION
## Changes

Same fix as #3803 only for `MeterProvider`.