### PR TITLE
Add missing end of code block backticks

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
@@ -149,7 +149,7 @@ services.AddOpenTelemetryTracing((builder) =>
         };
     })
 });
-
+```
 
 [Processor](../../docs/trace/extending-the-sdk/README.md#processor),
 is the general extensibility point to add additional properties to any activity.


### PR DESCRIPTION
Quick fix to add closing backticks for code block in the README for the ASP .NET Core instrumentation.