### PR TITLE
[Repo] Revert OpenTelemetry.Instrumentation.AspNet OpenTelemetry.proj change

### DIFF
--- a/OpenTelemetry.proj
+++ b/OpenTelemetry.proj
@@ -4,9 +4,6 @@
 
     <PackProjects Include="src\**\*.csproj" />
 
-    <!-- Windows specific projects -->
-    <PackProjects Remove="src\OpenTelemetry.Instrumentation.AspNet\OpenTelemetry.Instrumentation.AspNet.csproj" Condition="'$(OS)' != 'Windows_NT'" />
-
     <!-- Not pack SemanticConventions project for now -->
     <SolutionProjects Remove="src\OpenTelemetry.SemanticConventions\OpenTelemetry.SemanticConventions.csproj" />
     <PackProjects Remove="src\OpenTelemetry.SemanticConventions\OpenTelemetry.SemanticConventions.csproj" Condition="'$(OS)' != 'Windows_NT'" />


### PR DESCRIPTION
It looks like #2069 added a rule for `OpenTelemetry.Instrumentation.AspNet` (which was moved to contrib a while back) to `OpenTelemetry.proj`. Reverting that bit.