### PR TITLE
[logs-branch] Support loading OtlpLogExporter envvars from IConfiguration

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs/CHANGELOG.md
@@ -7,6 +7,10 @@
   management
   ([#3707](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3707))
 
+* `OtlpExporterOptions` can now be bound to `IConfiguation` when using the
+  `OtlpLogExporterHelperExtensions.AddOtlpExporter` extension
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## Unreleased
 
 ## 1.4.0-beta.2

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 * `OtlpExporterOptions` can now be bound to `IConfiguation` when using the
   `OtlpLogExporterHelperExtensions.AddOtlpExporter` extension
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#3812](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3812))
 
 ## Unreleased
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
@@ -80,9 +80,9 @@ namespace OpenTelemetry.Trace
                 // Note: Not using name here for SdkLimitOptions. There should
                 // only be one provider for a given service collection so
                 // SdkLimitOptions is treated as a single default instance.
-                var sdkOptionsManager = sp.GetRequiredService<IOptionsMonitor<SdkLimitOptions>>().CurrentValue;
+                var sdkLimitOptions = sp.GetRequiredService<IOptionsMonitor<SdkLimitOptions>>().CurrentValue;
 
-                AddOtlpExporter(builder, exporterOptions, sdkOptionsManager, sp);
+                AddOtlpExporter(builder, exporterOptions, sdkLimitOptions, sp);
             });
         }
 

--- a/src/OpenTelemetry/Internal/Builder/ProviderBuilderServiceCollectionExtensions.cs
+++ b/src/OpenTelemetry/Internal/Builder/ProviderBuilderServiceCollectionExtensions.cs
@@ -27,6 +27,13 @@ namespace Microsoft.Extensions.DependencyInjection;
 
 internal static class ProviderBuilderServiceCollectionExtensions
 {
+    public static IServiceCollection AddOpenTelemetryLoggerProviderBuilderServices(this IServiceCollection services)
+    {
+        services.AddOpenTelemetryProviderBuilderServices();
+
+        return services;
+    }
+
     public static IServiceCollection AddOpenTelemetryMeterProviderBuilderServices(this IServiceCollection services)
     {
         services.AddOpenTelemetryProviderBuilderServices();

--- a/src/OpenTelemetry/Logs/Builder/LoggerProviderBuilderSdk.cs
+++ b/src/OpenTelemetry/Logs/Builder/LoggerProviderBuilderSdk.cs
@@ -53,7 +53,7 @@ internal sealed class LoggerProviderBuilderSdk : LoggerProviderBuilder, IDeferre
     {
         Debug.Assert(services != null, "services was null");
 
-        services.AddOptions();
+        services!.AddOpenTelemetryLoggerProviderBuilderServices();
         services!.TryAddSingleton<LoggerProvider>(sp => new LoggerProviderSdk(sp, ownsServiceProvider: false));
 
         this.services = services;
@@ -66,7 +66,7 @@ internal sealed class LoggerProviderBuilderSdk : LoggerProviderBuilder, IDeferre
     {
         var services = new ServiceCollection();
 
-        services.AddOptions();
+        services.AddOpenTelemetryLoggerProviderBuilderServices();
 
         this.services = services;
         this.ownsServices = true;


### PR DESCRIPTION
Relates to #3760

## Changes

Applies the `IConfiguration` pattern to OtlpLogExporter paths.

## TODOs

* [X] Appropriate `CHANGELOG.md` updated for non-trivial changes
