### PR TITLE
[logs-branch] Apply Resource dependency injection pattern to LoggerProvider

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -5,6 +5,11 @@
 * Added `LoggerProvider` API from the OpenTelemetry specification
   ([#3707](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3707))
 
+* Added dependency injection support in the `ResourceBuilder` class and added
+  support for loading environment variables from `IConfiguration` for the
+  `AddEnvironmentVariableDetector` extension when using `LoggerProvider`
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## Unreleased
 
 * Added support for loading environment variables from `IConfiguration` when

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Added dependency injection support in the `ResourceBuilder` class and added
   support for loading environment variables from `IConfiguration` for the
   `AddEnvironmentVariableDetector` extension when using `LoggerProvider`
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#3813](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3813))
 
 ## Unreleased
 

--- a/src/OpenTelemetry/ProviderExtensions.cs
+++ b/src/OpenTelemetry/ProviderExtensions.cs
@@ -78,6 +78,10 @@ namespace OpenTelemetry
             {
                 return meterProviderSdk.ServiceProvider;
             }
+            else if (baseProvider is LoggerProviderSdk loggerProviderSdk)
+            {
+                return loggerProviderSdk.ServiceProvider;
+            }
 
             return null;
         }


### PR DESCRIPTION
Relates to #3782
Relates to #3798

## Changes

Support dependency injection `Resource` patterns in `LoggerProvider`.

## TODOs

* [X] Appropriate `CHANGELOG.md` updated for non-trivial changes

