### PR TITLE
[logs-branch] Port circular reference fix for LoggerProvider + IConfiguration for ExportLogRecordProcessorOptions

### DIFF
--- a/src/OpenTelemetry/Internal/Builder/ProviderBuilderServiceCollectionExtensions.cs
+++ b/src/OpenTelemetry/Internal/Builder/ProviderBuilderServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ using System.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpenTelemetry.Internal;
+using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 
@@ -30,6 +31,9 @@ internal static class ProviderBuilderServiceCollectionExtensions
     public static IServiceCollection AddOpenTelemetryLoggerProviderBuilderServices(this IServiceCollection services)
     {
         services.AddOpenTelemetryProviderBuilderServices();
+
+        services.TryAddSingleton<LoggerProviderBuilderState>();
+        services.RegisterOptionsFactory(configuration => new ExportLogRecordProcessorOptions(configuration));
 
         return services;
     }

--- a/src/OpenTelemetry/Logs/Builder/LoggerProviderBuilderSdk.cs
+++ b/src/OpenTelemetry/Logs/Builder/LoggerProviderBuilderSdk.cs
@@ -67,6 +67,8 @@ internal sealed class LoggerProviderBuilderSdk : LoggerProviderBuilder, IDeferre
         var services = new ServiceCollection();
 
         services.AddOpenTelemetryLoggerProviderBuilderServices();
+        services.AddSingleton<LoggerProvider>(
+            sp => throw new NotSupportedException("External LoggerProvider created through Sdk.CreateLoggerProviderBuilder cannot be accessed using service provider."));
 
         this.services = services;
         this.ownsServices = true;

--- a/src/OpenTelemetry/Logs/ExportLogRecordProcessorOptions.cs
+++ b/src/OpenTelemetry/Logs/ExportLogRecordProcessorOptions.cs
@@ -21,6 +21,9 @@ using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Logs;
 
+/// <summary>
+/// Options for configuring either a <see cref="SimpleLogRecordExportProcessor"/> or <see cref="BatchLogRecordExportProcessor"/>.
+/// </summary>
 public class ExportLogRecordProcessorOptions
 {
     private BatchExportLogRecordProcessorOptions? batchExportProcessorOptions;

--- a/src/OpenTelemetry/Logs/LoggerProviderSdk.cs
+++ b/src/OpenTelemetry/Logs/LoggerProviderSdk.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Resources;
 
@@ -49,6 +50,9 @@ internal sealed class LoggerProviderSdk : LoggerProvider
     {
         Debug.Assert(serviceProvider != null, "serviceProvider was null");
 
+        var state = serviceProvider!.GetRequiredService<LoggerProviderBuilderState>();
+        state.RegisterProvider(nameof(LoggerProvider), this);
+
         OpenTelemetrySdkEventSource.Log.LoggerProviderSdkEvent("Building LoggerProviderSdk.");
 
         this.ServiceProvider = serviceProvider!;
@@ -59,9 +63,6 @@ internal sealed class LoggerProviderSdk : LoggerProvider
 
             Debug.Assert(this.ownedServiceProvider != null, "ownedServiceProvider was null");
         }
-
-        var state = new LoggerProviderBuilderState(serviceProvider!);
-        state.RegisterProvider(nameof(LoggerProvider), this);
 
         CallbackHelper.InvokeRegisteredConfigureStateCallbacks(
             serviceProvider!,

--- a/test/OpenTelemetry.Tests/Logs/BatchExportLogRecordProcessorOptionsTest.cs
+++ b/test/OpenTelemetry.Tests/Logs/BatchExportLogRecordProcessorOptionsTest.cs
@@ -1,0 +1,132 @@
+// <copyright file="BatchExportLogRecordProcessorOptionsTest.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace OpenTelemetry.Logs.Tests
+{
+    public class BatchExportLogRecordProcessorOptionsTest : IDisposable
+    {
+        public BatchExportLogRecordProcessorOptionsTest()
+        {
+            ClearEnvVars();
+        }
+
+        public void Dispose()
+        {
+            ClearEnvVars();
+            GC.SuppressFinalize(this);
+        }
+
+        [Fact]
+        public void BatchExportProcessorOptions_Defaults()
+        {
+            var options = new BatchExportLogRecordProcessorOptions();
+
+            Assert.Equal(30000, options.ExporterTimeoutMilliseconds);
+            Assert.Equal(512, options.MaxExportBatchSize);
+            Assert.Equal(2048, options.MaxQueueSize);
+            Assert.Equal(5000, options.ScheduledDelayMilliseconds);
+        }
+
+        [Fact]
+        public void BatchExportProcessorOptions_EnvironmentVariableOverride()
+        {
+            Environment.SetEnvironmentVariable(BatchExportLogRecordProcessorOptions.ExporterTimeoutEnvVarKey, "1");
+            Environment.SetEnvironmentVariable(BatchExportLogRecordProcessorOptions.MaxExportBatchSizeEnvVarKey, "2");
+            Environment.SetEnvironmentVariable(BatchExportLogRecordProcessorOptions.MaxQueueSizeEnvVarKey, "3");
+            Environment.SetEnvironmentVariable(BatchExportLogRecordProcessorOptions.ScheduledDelayEnvVarKey, "4");
+
+            var options = new BatchExportLogRecordProcessorOptions();
+
+            Assert.Equal(1, options.ExporterTimeoutMilliseconds);
+            Assert.Equal(2, options.MaxExportBatchSize);
+            Assert.Equal(3, options.MaxQueueSize);
+            Assert.Equal(4, options.ScheduledDelayMilliseconds);
+        }
+
+        [Fact]
+        public void ExportLogRecordProcessorOptions_UsingIConfiguration()
+        {
+            var values = new Dictionary<string, string>()
+            {
+                [BatchExportLogRecordProcessorOptions.MaxQueueSizeEnvVarKey] = "1",
+                [BatchExportLogRecordProcessorOptions.MaxExportBatchSizeEnvVarKey] = "2",
+                [BatchExportLogRecordProcessorOptions.ExporterTimeoutEnvVarKey] = "3",
+                [BatchExportLogRecordProcessorOptions.ScheduledDelayEnvVarKey] = "4",
+            };
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(values)
+                .Build();
+
+            var parentOptions = new ExportLogRecordProcessorOptions(configuration);
+
+            Assert.Equal(1, parentOptions.BatchExportProcessorOptions.MaxQueueSize);
+            Assert.Equal(2, parentOptions.BatchExportProcessorOptions.MaxExportBatchSize);
+            Assert.Equal(3, parentOptions.BatchExportProcessorOptions.ExporterTimeoutMilliseconds);
+            Assert.Equal(4, parentOptions.BatchExportProcessorOptions.ScheduledDelayMilliseconds);
+
+            var options = new BatchExportLogRecordProcessorOptions(configuration);
+
+            Assert.Equal(1, options.MaxQueueSize);
+            Assert.Equal(2, options.MaxExportBatchSize);
+            Assert.Equal(3, options.ExporterTimeoutMilliseconds);
+            Assert.Equal(4, options.ScheduledDelayMilliseconds);
+        }
+
+        [Fact]
+        public void BatchExportProcessorOptions_InvalidPortEnvironmentVariableOverride()
+        {
+            Environment.SetEnvironmentVariable(BatchExportLogRecordProcessorOptions.ExporterTimeoutEnvVarKey, "invalid");
+
+            Assert.Throws<FormatException>(() => new BatchExportLogRecordProcessorOptions());
+        }
+
+        [Fact]
+        public void BatchExportProcessorOptions_SetterOverridesEnvironmentVariable()
+        {
+            Environment.SetEnvironmentVariable(BatchExportLogRecordProcessorOptions.ExporterTimeoutEnvVarKey, "123");
+
+            var options = new BatchExportLogRecordProcessorOptions
+            {
+                ExporterTimeoutMilliseconds = 89000,
+            };
+
+            Assert.Equal(89000, options.ExporterTimeoutMilliseconds);
+        }
+
+        [Fact]
+        public void BatchExportProcessorOptions_EnvironmentVariableNames()
+        {
+            Assert.Equal("OTEL_BLRP_EXPORT_TIMEOUT", BatchExportLogRecordProcessorOptions.ExporterTimeoutEnvVarKey);
+            Assert.Equal("OTEL_BLRP_MAX_EXPORT_BATCH_SIZE", BatchExportLogRecordProcessorOptions.MaxExportBatchSizeEnvVarKey);
+            Assert.Equal("OTEL_BLRP_MAX_QUEUE_SIZE", BatchExportLogRecordProcessorOptions.MaxQueueSizeEnvVarKey);
+            Assert.Equal("OTEL_BLRP_SCHEDULE_DELAY", BatchExportLogRecordProcessorOptions.ScheduledDelayEnvVarKey);
+        }
+
+        private static void ClearEnvVars()
+        {
+            Environment.SetEnvironmentVariable(BatchExportLogRecordProcessorOptions.ExporterTimeoutEnvVarKey, null);
+            Environment.SetEnvironmentVariable(BatchExportLogRecordProcessorOptions.MaxExportBatchSizeEnvVarKey, null);
+            Environment.SetEnvironmentVariable(BatchExportLogRecordProcessorOptions.MaxQueueSizeEnvVarKey, null);
+            Environment.SetEnvironmentVariable(BatchExportLogRecordProcessorOptions.ScheduledDelayEnvVarKey, null);
+        }
+    }
+}


### PR DESCRIPTION
Relates to #3776
Relates to #3803

## Changes

* Ports the fix for the circular reference issue to `LoggerProvider`
* Adds `IConfiguration` support for "BLRP" envvars
