### PR TITLE
Rename AggregationType to better reflect intent

### DIFF
--- a/src/OpenTelemetry/Metrics/AggregationType.cs
+++ b/src/OpenTelemetry/Metrics/AggregationType.cs
@@ -56,21 +56,21 @@ namespace OpenTelemetry.Metrics
         /// <summary>
         /// Histogram with sum, count, buckets.
         /// </summary>
-        Histogram = 6,
+        HistogramWithBuckets = 6,
 
         /// <summary>
         /// Histogram with sum, count, min, max, buckets.
         /// </summary>
-        HistogramMinMax = 7,
+        HistogramWithMinMaxBuckets = 7,
 
         /// <summary>
         /// Histogram with sum, count.
         /// </summary>
-        HistogramSumCount = 8,
+        Histogram = 8,
 
         /// <summary>
         /// Histogram with sum, count, min, max.
         /// </summary>
-        HistogramSumCountMinMax = 9,
+        HistogramWithMinMax = 9,
     }
 }

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -120,8 +120,8 @@ namespace OpenTelemetry.Metrics
                 this.MetricType = MetricType.Histogram;
 
                 aggType = histogramBounds != null && histogramBounds.Length == 0
-                    ? (histogramRecordMinMax ? AggregationType.HistogramSumCountMinMax : AggregationType.HistogramSumCount)
-                    : (histogramRecordMinMax ? AggregationType.HistogramMinMax : AggregationType.Histogram);
+                    ? (histogramRecordMinMax ? AggregationType.HistogramWithMinMax : AggregationType.Histogram)
+                    : (histogramRecordMinMax ? AggregationType.HistogramWithMinMaxBuckets : AggregationType.HistogramWithBuckets);
             }
             else
             {

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -58,13 +58,13 @@ namespace OpenTelemetry.Metrics
             this.deltaLastValue = default;
             this.MetricPointStatus = MetricPointStatus.NoCollectPending;
 
-            if (this.aggType == AggregationType.Histogram ||
-                this.aggType == AggregationType.HistogramMinMax)
+            if (this.aggType == AggregationType.HistogramWithBuckets ||
+                this.aggType == AggregationType.HistogramWithMinMaxBuckets)
             {
                 this.histogramBuckets = new HistogramBuckets(histogramExplicitBounds);
             }
-            else if (this.aggType == AggregationType.HistogramSumCount ||
-                     this.aggType == AggregationType.HistogramSumCountMinMax)
+            else if (this.aggType == AggregationType.Histogram ||
+                     this.aggType == AggregationType.HistogramWithMinMax)
             {
                 this.histogramBuckets = new HistogramBuckets(null);
             }
@@ -189,10 +189,10 @@ namespace OpenTelemetry.Metrics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public readonly long GetHistogramCount()
         {
-            if (this.aggType != AggregationType.Histogram &&
-                this.aggType != AggregationType.HistogramSumCount &&
-                this.aggType != AggregationType.HistogramMinMax &&
-                this.aggType != AggregationType.HistogramSumCountMinMax)
+            if (this.aggType != AggregationType.HistogramWithBuckets &&
+                this.aggType != AggregationType.Histogram &&
+                this.aggType != AggregationType.HistogramWithMinMaxBuckets &&
+                this.aggType != AggregationType.HistogramWithMinMax)
             {
                 this.ThrowNotSupportedMetricTypeException(nameof(this.GetHistogramCount));
             }
@@ -210,10 +210,10 @@ namespace OpenTelemetry.Metrics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public readonly double GetHistogramSum()
         {
-            if (this.aggType != AggregationType.Histogram &&
-                this.aggType != AggregationType.HistogramSumCount &&
-                this.aggType != AggregationType.HistogramMinMax &&
-                this.aggType != AggregationType.HistogramSumCountMinMax)
+            if (this.aggType != AggregationType.HistogramWithBuckets &&
+                this.aggType != AggregationType.Histogram &&
+                this.aggType != AggregationType.HistogramWithMinMaxBuckets &&
+                this.aggType != AggregationType.HistogramWithMinMax)
             {
                 this.ThrowNotSupportedMetricTypeException(nameof(this.GetHistogramSum));
             }
@@ -231,10 +231,10 @@ namespace OpenTelemetry.Metrics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public readonly HistogramBuckets GetHistogramBuckets()
         {
-            if (this.aggType != AggregationType.Histogram &&
-                this.aggType != AggregationType.HistogramSumCount &&
-                this.aggType != AggregationType.HistogramMinMax &&
-                this.aggType != AggregationType.HistogramSumCountMinMax)
+            if (this.aggType != AggregationType.HistogramWithBuckets &&
+                this.aggType != AggregationType.Histogram &&
+                this.aggType != AggregationType.HistogramWithMinMaxBuckets &&
+                this.aggType != AggregationType.HistogramWithMinMax)
             {
                 this.ThrowNotSupportedMetricTypeException(nameof(this.GetHistogramBuckets));
             }
@@ -279,8 +279,8 @@ namespace OpenTelemetry.Metrics
         /// <returns>A minimum and maximum value exist.</returns>
         public bool HasMinMax()
         {
-            return this.aggType == AggregationType.HistogramMinMax ||
-                   this.aggType == AggregationType.HistogramSumCountMinMax;
+            return this.aggType == AggregationType.HistogramWithMinMaxBuckets ||
+                   this.aggType == AggregationType.HistogramWithMinMax;
         }
 
         internal readonly MetricPoint Copy()
@@ -312,10 +312,10 @@ namespace OpenTelemetry.Metrics
                         break;
                     }
 
+                case AggregationType.HistogramWithBuckets:
+                case AggregationType.HistogramWithMinMaxBuckets:
                 case AggregationType.Histogram:
-                case AggregationType.HistogramMinMax:
-                case AggregationType.HistogramSumCount:
-                case AggregationType.HistogramSumCountMinMax:
+                case AggregationType.HistogramWithMinMax:
                     {
                         this.Update((double)number);
 
@@ -378,7 +378,7 @@ namespace OpenTelemetry.Metrics
                         break;
                     }
 
-                case AggregationType.Histogram:
+                case AggregationType.HistogramWithBuckets:
                     {
                         int i = this.histogramBuckets.FindBucketIndex(number);
 
@@ -406,7 +406,7 @@ namespace OpenTelemetry.Metrics
                         break;
                     }
 
-                case AggregationType.HistogramSumCount:
+                case AggregationType.Histogram:
                     {
                         var sw = default(SpinWait);
                         while (true)
@@ -431,7 +431,7 @@ namespace OpenTelemetry.Metrics
                         break;
                     }
 
-                case AggregationType.HistogramMinMax:
+                case AggregationType.HistogramWithMinMaxBuckets:
                     {
                         int i = this.histogramBuckets.FindBucketIndex(number);
 
@@ -461,7 +461,7 @@ namespace OpenTelemetry.Metrics
                         break;
                     }
 
-                case AggregationType.HistogramSumCountMinMax:
+                case AggregationType.HistogramWithMinMax:
                     {
                         var sw = default(SpinWait);
                         while (true)
@@ -602,7 +602,7 @@ namespace OpenTelemetry.Metrics
                         break;
                     }
 
-                case AggregationType.Histogram:
+                case AggregationType.HistogramWithBuckets:
                     {
                         var sw = default(SpinWait);
                         while (true)
@@ -641,7 +641,7 @@ namespace OpenTelemetry.Metrics
                         break;
                     }
 
-                case AggregationType.HistogramSumCount:
+                case AggregationType.Histogram:
                     {
                         var sw = default(SpinWait);
                         while (true)
@@ -671,7 +671,7 @@ namespace OpenTelemetry.Metrics
                         break;
                     }
 
-                case AggregationType.HistogramMinMax:
+                case AggregationType.HistogramWithMinMaxBuckets:
                     {
                         var sw = default(SpinWait);
                         while (true)
@@ -714,7 +714,7 @@ namespace OpenTelemetry.Metrics
                         break;
                     }
 
-                case AggregationType.HistogramSumCountMinMax:
+                case AggregationType.HistogramWithMinMax:
                     {
                         var sw = default(SpinWait);
                         while (true)

--- a/test/OpenTelemetry.Tests/Metrics/AggregatorTest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/AggregatorTest.cs
@@ -21,12 +21,12 @@ namespace OpenTelemetry.Metrics.Tests
 {
     public class AggregatorTest
     {
-        private readonly AggregatorStore aggregatorStore = new("test", AggregationType.Histogram, AggregationTemporality.Cumulative, 1024, Metric.DefaultHistogramBounds);
+        private readonly AggregatorStore aggregatorStore = new("test", AggregationType.HistogramWithBuckets, AggregationTemporality.Cumulative, 1024, Metric.DefaultHistogramBounds);
 
         [Fact]
         public void HistogramDistributeToAllBucketsDefault()
         {
-            var histogramPoint = new MetricPoint(this.aggregatorStore, AggregationType.Histogram, null, null, Metric.DefaultHistogramBounds);
+            var histogramPoint = new MetricPoint(this.aggregatorStore, AggregationType.HistogramWithBuckets, null, null, Metric.DefaultHistogramBounds);
             histogramPoint.Update(-1);
             histogramPoint.Update(0);
             histogramPoint.Update(2);
@@ -77,7 +77,7 @@ namespace OpenTelemetry.Metrics.Tests
         public void HistogramDistributeToAllBucketsCustom()
         {
             var boundaries = new double[] { 10, 20 };
-            var histogramPoint = new MetricPoint(this.aggregatorStore, AggregationType.Histogram, null, null, boundaries);
+            var histogramPoint = new MetricPoint(this.aggregatorStore, AggregationType.HistogramWithBuckets, null, null, boundaries);
 
             // 5 recordings <=10
             histogramPoint.Update(-10);
@@ -125,7 +125,7 @@ namespace OpenTelemetry.Metrics.Tests
                 boundaries[i] = i;
             }
 
-            var histogramPoint = new MetricPoint(this.aggregatorStore, AggregationType.Histogram, null, null, boundaries);
+            var histogramPoint = new MetricPoint(this.aggregatorStore, AggregationType.HistogramWithBuckets, null, null, boundaries);
 
             // Act
             histogramPoint.Update(-1);
@@ -158,7 +158,7 @@ namespace OpenTelemetry.Metrics.Tests
         public void HistogramWithOnlySumCount()
         {
             var boundaries = Array.Empty<double>();
-            var histogramPoint = new MetricPoint(this.aggregatorStore, AggregationType.HistogramSumCount, null, null, boundaries);
+            var histogramPoint = new MetricPoint(this.aggregatorStore, AggregationType.Histogram, null, null, boundaries);
 
             histogramPoint.Update(-10);
             histogramPoint.Update(0);


### PR DESCRIPTION
Sum,Count is the only thing which is always present for a Histogram. Everything else is optional. The internal enum is updated to better reflect this.

Histogram - sum and count
HistogramWithBuckets - sum and count + buckets
HistogramWithMinMax - sum and count + Min/Max
HistogramWithMinMaxBuckets - sum and count + Min/Max + buckets