### PR TITLE
Limit character set according to spec

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fix instrument naming enforcement implementation to match the spec.
+  ([#3821](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3821))
+
 * Added support for loading environment variables from `IConfiguration` when
   using the `MetricReaderOptions` & `BatchExportActivityProcessorOptions`
   classes.

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderSdk.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderSdk.cs
@@ -24,7 +24,7 @@ namespace OpenTelemetry.Metrics
     internal sealed class MeterProviderBuilderSdk : MeterProviderBuilderBase
     {
         private static readonly Regex InstrumentNameRegex = new(
-            @"^[a-zA-Z][-.\w]{0,62}$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            @"^[a-z][a-z0-9-._]{0,62}$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         public MeterProviderBuilderSdk()
         {

--- a/test/OpenTelemetry.Tests/Metrics/MetricTestData.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricTestData.cs
@@ -28,6 +28,7 @@ namespace OpenTelemetry.Metrics.Tests
                     new object[] { "1first-char-not-alphabetic" },
                     new object[] { "invalid+separator" },
                     new object[] { new string('m', 64) },
+                    new object[] { "aµ" },
            };
 
         public static IEnumerable<object[]> ValidInstrumentNames
@@ -39,6 +40,7 @@ namespace OpenTelemetry.Metrics.Tests
                     new object[] { "my.metric" },
                     new object[] { "my_metric2" },
                     new object[] { new string('m', 63) },
+                    new object[] { "CaSe-InSeNsItIvE" },
            };
 
         public static IEnumerable<object[]> InvalidHistogramBoundaries

--- a/test/OpenTelemetry.Tests/Metrics/MetricTestData.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricTestData.cs
@@ -28,7 +28,7 @@ namespace OpenTelemetry.Metrics.Tests
                     new object[] { "1first-char-not-alphabetic" },
                     new object[] { "invalid+separator" },
                     new object[] { new string('m', 64) },
-                    new object[] { "aµ" },
+                    new object[] { "a\xb5" }, // `\xb5` is the Micro character
            };
 
         public static IEnumerable<object[]> ValidInstrumentNames


### PR DESCRIPTION
## Changes

`\w` matches to more than just the intended `a-zA-Z0-9_` https://learn.microsoft.com/en-us/dotnet/standard/base-types/character-classes-in-regular-expressions#word-character-w

Before the change the addition to `InvalidInstrumentNames` would fail the test. the value is `aµ`. The Micro is considered `Letter, Lowercase` by the `\w` match. But this is just to show that any character belonging to the categories shown could have made an instrument name become out of spec.

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
