### PR TITLE
Metric Perf improvement  when out of MetricPoints

### DIFF
--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -191,6 +191,16 @@ namespace OpenTelemetry.Metrics
 
                     if (!this.tagsToMetricPointIndexDictionary.TryGetValue(sortedTags, out aggregatorIndex))
                     {
+                        aggregatorIndex = this.metricPointIndex;
+                        if (aggregatorIndex >= this.maxMetricPoints)
+                        {
+                            // sorry! out of data points.
+                            // TODO: Once we support cleanup of
+                            // unused points (typically with delta)
+                            // we can re-claim them here.
+                            return -1;
+                        }
+
                         // Note: We are using storage from ThreadStatic for both the input order of tags and the sorted order of tags,
                         // so we need to make a deep copy for Dictionary storage.
                         var givenKeys = new string[length];
@@ -207,16 +217,6 @@ namespace OpenTelemetry.Metrics
 
                         givenTags = new Tags(givenKeys, givenValues);
                         sortedTags = new Tags(sortedTagKeys, sortedTagValues);
-
-                        aggregatorIndex = this.metricPointIndex;
-                        if (aggregatorIndex >= this.maxMetricPoints)
-                        {
-                            // sorry! out of data points.
-                            // TODO: Once we support cleanup of
-                            // unused points (typically with delta)
-                            // we can re-claim them here.
-                            return -1;
-                        }
 
                         lock (this.tagsToMetricPointIndexDictionary)
                         {


### PR DESCRIPTION
When we are out of MetricPoints, we can exit early. Currently we do alloc + copying, *before* we confirm we have room to store the new MP. This PR does the check before doing any alloc+copy.

Simple benchmark results:

```
[Benchmark]
        public void CounterWith3LabelsHotPath()
        {
            var tag1 = new KeyValuePair<string, object>("DimName1", Guid.NewGuid().ToString());
            var tag2 = new KeyValuePair<string, object>("DimName2", Guid.NewGuid().ToString());
            var tag3 = new KeyValuePair<string, object>("DimName3", Guid.NewGuid().ToString());
            this.counter.Add(100, tag1, tag2, tag3);
        }
```

Before
```
|                    Method | AggregationTemporality |     Mean |     Error |    StdDev |   Gen0 | Allocated |
|-------------------------- |----------------------- |---------:|----------:|----------:|-------:|----------:|
| CounterWith3LabelsHotPath |             Cumulative | 1.518 us | 0.0163 us | 0.0127 us | 0.1144 |     480 B |
| CounterWith3LabelsHotPath |                  Delta | 1.516 us | 0.0134 us | 0.0112 us | 0.1144 |     480 B |
```
After
```
|                    Method | AggregationTemporality |     Mean |     Error |    StdDev |   Gen0 | Allocated |
|-------------------------- |----------------------- |---------:|----------:|----------:|-------:|----------:|
| CounterWith3LabelsHotPath |             Cumulative | 1.196 us | 0.0075 us | 0.0067 us | 0.0687 |     288 B |
| CounterWith3LabelsHotPath |                  Delta | 1.200 us | 0.0158 us | 0.0148 us | 0.0687 |     288 B |
```