### PR TITLE
Modify GH Actions to remove include-prerelease

### DIFF
--- a/.github/workflows/apicompatibility.yml
+++ b/.github/workflows/apicompatibility.yml
@@ -19,7 +19,6 @@ jobs:
     - uses: actions/setup-dotnet@v3.0.2
       with:
         dotnet-version: '7.0.x'
-        include-prerelease: true
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -26,7 +26,6 @@ jobs:
     - uses: actions/setup-dotnet@v3.0.2
       with:
         dotnet-version: '7.0.x'
-        include-prerelease: true
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -24,7 +24,6 @@ jobs:
       uses: actions/setup-dotnet@v3.0.2
       with:
         dotnet-version: '7.0.x'
-        include-prerelease: true
 
     - name: Install format tool
       run: dotnet tool install -g dotnet-format

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -30,8 +30,6 @@ jobs:
     - uses: actions/setup-dotnet@v3.0.2
       with:
         dotnet-version: '7.0.x'
-        include-prerelease: true
-
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -26,7 +26,6 @@ jobs:
     - uses: actions/setup-dotnet@v3.0.2
       with:
         dotnet-version: '7.0.x'
-        include-prerelease: true
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -26,7 +26,6 @@ jobs:
     - uses: actions/setup-dotnet@v3.0.2
       with:
         dotnet-version: '7.0.x'
-        include-prerelease: true
 
     - name: Install dependencies
       run: dotnet restore


### PR DESCRIPTION
We have this warning now:
Warning: Unexpected input(s) 'include-prerelease', valid inputs are ['dotnet-version', 'dotnet-quality', 'global-json-file', 'source-url', 'owner', 'config-file']

due to
https://github.com/actions/setup-dotnet/pull/315

This PR removes the "include-prerelease", as it no longer required.