### PR TITLE
Minor fixes to logging scope examples

### DIFF
--- a/docs/logs/customizing-the-sdk/Program.cs
+++ b/docs/logs/customizing-the-sdk/Program.cs
@@ -44,7 +44,7 @@ public class Program
         // log with scopes
         using (logger.BeginScope(new List<KeyValuePair<string, object>>
         {
-            new KeyValuePair<string, object>("store", "seattle"),
+            new KeyValuePair<string, object>("store", "Seattle"),
         }))
         {
             logger.LogInformation("Hello from {food} {price}.", "tomato", 2.99);

--- a/docs/logs/customizing-the-sdk/Program.cs
+++ b/docs/logs/customizing-the-sdk/Program.cs
@@ -18,6 +18,7 @@ using Microsoft.Extensions.Logging;
 
 using OpenTelemetry.Logs;
 using OpenTelemetry.Resources;
+using System.Collections.Generic;
 
 namespace CustomizingTheSdk;
 
@@ -37,15 +38,18 @@ public class Program
 
         var logger = loggerFactory.CreateLogger<Program>();
 
-        logger.LogInformation("Hello Information");
-        logger.LogWarning("Hello Warning");
-        logger.LogError("Hello Error");
+        logger.LogInformation("Hello from {name} {price}.", "tomato", 2.99);
+        logger.LogWarning("Hello from {name} {price}.", "tomato", 2.99);
+        logger.LogError("Hello from {name} {price}.", "tomato", 2.99);
 
         // log with scopes
-        using (logger.BeginScope("operation"))
-        using (logger.BeginScope("hardware"))
+        using (logger.BeginScope(new List<KeyValuePair<string, object>>
         {
-            logger.LogError("{name} is broken.", "refrigerator");
+            new KeyValuePair<string, object>("key1", "value1"),
+            new KeyValuePair<string, object>("key", "value2"),
+        }))
+        {
+            logger.LogInformation("Hello from {food} {price}.", "tomato", 2.99);
         }
     }
 }

--- a/docs/logs/customizing-the-sdk/Program.cs
+++ b/docs/logs/customizing-the-sdk/Program.cs
@@ -14,11 +14,10 @@
 // limitations under the License.
 // </copyright>
 
+using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
-
 using OpenTelemetry.Logs;
 using OpenTelemetry.Resources;
-using System.Collections.Generic;
 
 namespace CustomizingTheSdk;
 
@@ -45,8 +44,7 @@ public class Program
         // log with scopes
         using (logger.BeginScope(new List<KeyValuePair<string, object>>
         {
-            new KeyValuePair<string, object>("key1", "value1"),
-            new KeyValuePair<string, object>("key", "value2"),
+            new KeyValuePair<string, object>("store", "seattle"),
         }))
         {
             logger.LogInformation("Hello from {food} {price}.", "tomato", 2.99);

--- a/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
@@ -97,7 +97,7 @@ namespace OpenTelemetry.Exporter
                                 ? new KeyValuePair<string, object>("OriginalFormat (a.k.a Body)", listKvp[i].Value)
                                 : listKvp[i];
 
-                            if (ConsoleTagTransformer.Instance.TryTransformTag(listKvp[i], out var result))
+                            if (ConsoleTagTransformer.Instance.TryTransformTag(valueToTransform, out var result))
                             {
                                 this.WriteLine($"{string.Empty,-4}{result}");
                             }


### PR DESCRIPTION
1. Trying to show best practices, instead of plain strings. 
Will work with .NET ILogger owners to see if they can fix https://learn.microsoft.com/en-us/dotnet/core/extensions/logging?tabs=command-line#log-scopes as well.

2. Also a minor fix to the ConsoleExporter to show "aka Body" for {OriginalFormat}