### PR TITLE
Add benchmark numbers and remove invalid case

### DIFF
--- a/test/Benchmarks/Helper/ActivityCreationScenarios.cs
+++ b/test/Benchmarks/Helper/ActivityCreationScenarios.cs
@@ -52,17 +52,5 @@ namespace Benchmarks.Helper
             activity?.SetTag("tag3", true);
             activity?.Stop();
         }
-
-        public static void CreateActivityWithAttributesAndCustomProperty(ActivitySource source)
-        {
-            using var activity = source.StartActivity("name");
-            activity?.SetTag("tag1", "string");
-            activity?.SetTag("tag2", 1);
-
-            // use custom property instead of tags
-            // activity?.SetTag("customPropTag1", "somecustomValue");
-            activity?.SetCustomProperty("customPropTag1", "somecustomValue");
-            activity?.Stop();
-        }
     }
 }

--- a/test/Benchmarks/Trace/OpenTelemetrySdkBenchmarksActivity.cs
+++ b/test/Benchmarks/Trace/OpenTelemetrySdkBenchmarksActivity.cs
@@ -20,8 +20,6 @@ using Benchmarks.Helper;
 using OpenTelemetry;
 using OpenTelemetry.Trace;
 
-namespace Benchmarks.Trace
-{
 /*
 // * Summary *
 
@@ -40,6 +38,9 @@ Intel Core i7-4790 CPU 3.60GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
 |              CreateActivity_WithAttributes_NoopProcessor | 541.4 ns | 3.32 ns | 2.94 ns | 0.1488 |     624 B |
 |                    CreateActiviti_WithKind_NoopProcessor | 437.5 ns | 2.05 ns | 1.92 ns | 0.0992 |     416 B |
 */
+
+namespace Benchmarks.Trace
+{
     public class OpenTelemetrySdkBenchmarksActivity
     {
         private readonly ActivitySource benchmarkSource = new("Benchmark");

--- a/test/Benchmarks/Trace/OpenTelemetrySdkBenchmarksActivity.cs
+++ b/test/Benchmarks/Trace/OpenTelemetrySdkBenchmarksActivity.cs
@@ -22,6 +22,24 @@ using OpenTelemetry.Trace;
 
 namespace Benchmarks.Trace
 {
+/*
+// * Summary *
+
+BenchmarkDotNet=v0.13.2, OS=Windows 10 (10.0.19044.2130/21H2/November2021Update)
+Intel Core i7-4790 CPU 3.60GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
+.NET SDK=7.0.100-preview.7.22377.5
+  [Host]     : .NET 6.0.10 (6.0.1022.47605), X64 RyuJIT AVX2
+  DefaultJob : .NET 6.0.10 (6.0.1022.47605), X64 RyuJIT AVX2
+
+
+|                                                   Method |     Mean |   Error |  StdDev |   Gen0 | Allocated |
+|--------------------------------------------------------- |---------:|--------:|--------:|-------:|----------:|
+|                             CreateActivity_NoopProcessor | 457.9 ns | 1.39 ns | 1.23 ns | 0.0992 |     416 B |
+|           CreateActivity_WithParentContext_NoopProcessor | 104.8 ns | 0.43 ns | 0.36 ns |      - |         - |
+|                CreateActivity_WithParentId_NoopProcessor | 221.9 ns | 0.44 ns | 0.39 ns | 0.0343 |     144 B |
+|              CreateActivity_WithAttributes_NoopProcessor | 541.4 ns | 3.32 ns | 2.94 ns | 0.1488 |     624 B |
+|                    CreateActiviti_WithKind_NoopProcessor | 437.5 ns | 2.05 ns | 1.92 ns | 0.0992 |     416 B |
+*/
     public class OpenTelemetrySdkBenchmarksActivity
     {
         private readonly ActivitySource benchmarkSource = new("Benchmark");
@@ -55,9 +73,6 @@ namespace Benchmarks.Trace
 
         [Benchmark]
         public void CreateActivity_WithAttributes_NoopProcessor() => ActivityCreationScenarios.CreateActivityWithAttributes(this.benchmarkSource);
-
-        [Benchmark]
-        public void CreateActivity_WithAttributesAndCustomProp_NoopProcessor() => ActivityCreationScenarios.CreateActivityWithAttributesAndCustomProperty(this.benchmarkSource);
 
         [Benchmark]
         public void CreateActiviti_WithKind_NoopProcessor() => ActivityCreationScenarios.CreateActivityWithKind(this.benchmarkSource);

--- a/test/Benchmarks/Trace/TraceBenchmarks.cs
+++ b/test/Benchmarks/Trace/TraceBenchmarks.cs
@@ -21,6 +21,31 @@ using OpenTelemetry.Trace;
 
 namespace Benchmarks.Trace
 {
+/*
+// * Summary *
+
+BenchmarkDotNet=v0.13.2, OS=Windows 10 (10.0.19044.2130/21H2/November2021Update)
+Intel Core i7-4790 CPU 3.60GHz(Haswell), 1 CPU, 8 logical and 4 physical cores
+.NET SDK= 7.0.100-preview.7.22377.5
+    [Host]     : .NET 6.0.10 (6.0.1022.47605), X64 RyuJIT AVX2
+    DefaultJob : .NET 6.0.10 (6.0.1022.47605), X64 RyuJIT AVX2
+
+
+|                           Method |      Mean |    Error |   StdDev |   Gen0 | Allocated |
+|--------------------------------- |----------:|---------:|---------:|-------:|----------:|
+|                       NoListener |  20.86 ns | 0.379 ns | 0.336 ns |      - |         - |
+|           PropagationDataListner | 376.51 ns | 1.361 ns | 1.273 ns | 0.0992 |     416 B |
+|                   AllDataListner | 377.38 ns | 2.715 ns | 2.407 ns | 0.0992 |     416 B |
+|        AllDataAndRecordedListner | 375.79 ns | 3.393 ns | 3.008 ns | 0.0992 |     416 B |
+|                     OneProcessor | 432.98 ns | 1.562 ns | 1.461 ns | 0.0992 |     416 B |
+|                    TwoProcessors | 430.16 ns | 2.538 ns | 2.250 ns | 0.0992 |     416 B |
+|                  ThreeProcessors | 427.39 ns | 3.243 ns | 2.875 ns | 0.0992 |     416 B |
+|               OneInstrumentation | 411.56 ns | 2.310 ns | 2.161 ns | 0.0992 |     416 B |
+|              TwoInstrumentations | 422.27 ns | 3.304 ns | 2.929 ns | 0.0992 |     416 B |
+|    LegacyActivity_ExactMatchMode | 726.59 ns | 4.852 ns | 4.301 ns | 0.0992 |     416 B |
+| LegacyActivity_WildcardMatchMode | 825.79 ns | 7.846 ns | 6.955 ns | 0.0992 |     416 B |
+
+*/
     public class TraceBenchmarks
     {
         private readonly ActivitySource sourceWithNoListener = new("Benchmark.NoListener");

--- a/test/Benchmarks/Trace/TraceBenchmarks.cs
+++ b/test/Benchmarks/Trace/TraceBenchmarks.cs
@@ -19,8 +19,6 @@ using BenchmarkDotNet.Attributes;
 using OpenTelemetry;
 using OpenTelemetry.Trace;
 
-namespace Benchmarks.Trace
-{
 /*
 // * Summary *
 
@@ -46,6 +44,9 @@ Intel Core i7-4790 CPU 3.60GHz(Haswell), 1 CPU, 8 logical and 4 physical cores
 | LegacyActivity_WildcardMatchMode | 825.79 ns | 7.846 ns | 6.955 ns | 0.0992 |     416 B |
 
 */
+
+namespace Benchmarks.Trace
+{
     public class TraceBenchmarks
     {
         private readonly ActivitySource sourceWithNoListener = new("Benchmark.NoListener");


### PR DESCRIPTION
Removed the benchmark using CustomProperty. OTel does not use it ever.
Added numbers for quick reference.