### PR TITLE
[Repo] Remove duplicate content from SDK README

### DIFF
--- a/docs/trace/customizing-the-sdk/README.md
+++ b/docs/trace/customizing-the-sdk/README.md
@@ -39,8 +39,8 @@ tracerProvider.Dispose()
 
 **Note:** The `Sdk.CreateTracerProviderBuilder()` API is available for all
 runtimes. Additionally, for `ASP.NET Core` and [.NET Generic
-Host](https://learn.microsoft.com/dotnet/core/extensions/generic-host) users
-helper extensions are also provided in the
+Host](https://learn.microsoft.com/dotnet/core/extensions/generic-host) users,
+helper extensions are provided in the
 [OpenTelemetry.Extensions.Hosting](../../../src/OpenTelemetry.Extensions.Hosting/README.md)
 package to simplify configuration and management of the `TracerProvider`.
 

--- a/docs/trace/customizing-the-sdk/README.md
+++ b/docs/trace/customizing-the-sdk/README.md
@@ -134,7 +134,7 @@ exact method name.
 
 Follow [this](../extending-the-sdk/README.md#instrumentation-library) document
 to learn about the instrumentation libraries shipped from this repo and writing
-custom instrumentation.
+custom instrumentation libraries.
 
 ### Processors & Exporters
 

--- a/docs/trace/customizing-the-sdk/README.md
+++ b/docs/trace/customizing-the-sdk/README.md
@@ -1,4 +1,4 @@
-# Customizing OpenTelemetry .NET SDK
+# Customizing OpenTelemetry .NET SDK for Tracing
 
 ## TracerProvider
 
@@ -35,8 +35,14 @@ var tracerProvider = Sdk.CreateTracerProviderBuilder().Build();
 
 // Dispose at application shutdown
 tracerProvider.Dispose()
-
 ```
+
+**Note:** The `Sdk.CreateTracerProviderBuilder()` API is available for all
+runtimes but for `ASP.NET Core` and [.NET Generic
+Host](https://learn.microsoft.com/dotnet/core/extensions/generic-host) users
+helper extensions are also provided in the
+[OpenTelemetry.Extensions.Hosting](../../../src/OpenTelemetry.Extensions.Hosting/README.md)
+package to simplify configuration and management of the `TracerProvider`.
 
 In a typical application, a single `TracerProvider` is created at application
 startup and disposed at application shutdown. It is important to ensure that the
@@ -53,7 +59,7 @@ leveraging the built-in Dependency Injection container as shown
 
 `TracerProvider` holds the tracing configuration, which includes the following:
 
-1. The list of `ActivitySource`s (aka Tracers) from which traces are collected.
+1. The list of `ActivitySource`s (aka `Tracer`s) from which traces are collected.
 2. The list of instrumentations enabled via
    [InstrumentationLibrary](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/glossary.md#instrumentation-library).
 3. The list of
@@ -127,9 +133,10 @@ refer to corresponding documentation of the instrumentation library to know the
 exact method name.
 
 Follow [this](../extending-the-sdk/README.md#instrumentation-library) document
-to learn about the instrumentation libraries shipped from this repo.
+to learn about the instrumentation libraries shipped from this repo and writing
+custom instrumentation.
 
-### Processor
+### Processors & Exporters
 
 [Processors](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#span-processor)
 allows hooks for start and end of `Activity`. If no processors are configured,
@@ -195,8 +202,10 @@ exporting purposes, the SDK provides the following built-in processors:
   : This is an exporting processor which passes telemetry to the configured
   exporter without any batching.
 
-Follow [this](../extending-the-sdk/README.md#processor) document
-to learn about how to write own processors.
+Follow [this](../extending-the-sdk/README.md#processor) document to learn about
+writing custom processors. Follow
+[this](../extending-the-sdk/README.md#exporter) document to learn about writing
+custom exporters.
 
 *The processors shipped from this SDK are generics, and supports tracing and
 logging, by supporting `Activity` and `LogRecord` respectively.*
@@ -227,7 +236,7 @@ resource, and `AddService()` which adds
 resource. It also allows adding `ResourceDetector`s.
 
 Follow [this](../extending-the-sdk/README.md#resource-detector) document
-to learn about how to write own resource detectors.
+to learn about writing custom resource detectors.
 
 The snippet below shows configuring the `Resource` associated with the provider.
 
@@ -250,7 +259,7 @@ environmental variables:
 | `OTEL_RESOURCE_ATTRIBUTES` | Key-value pairs to be used as resource attributes. See the [Resource SDK specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.5.0/specification/resource/sdk.md#specifying-resource-information-via-an-environment-variable) for more details. |
 | `OTEL_SERVICE_NAME`        | Sets the value of the `service.name` resource attribute. If `service.name` is also provided in `OTEL_RESOURCE_ATTRIBUTES`, then `OTEL_SERVICE_NAME` takes precedence. |
 
-### Sampler
+### Samplers
 
 [Samplers](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#sampler)
 are used to control the noise and overhead introduced by OpenTelemetry by
@@ -274,13 +283,26 @@ var tracerProvider = Sdk.CreateTracerProviderBuilder()
 ```
 
 Follow [this](../extending-the-sdk/README.md#sampler) document
-to learn about how to write own samplers.
+to learn about writing custom samplers.
 
 ## Context Propagation
 
-// TODO: OpenTelemetry Sdk contents about Context. // TODO: Links to built-in
-instrumentations doing Propagation.
+The OpenTelemetry API exposes a method to obtain the default propagator which is
+no-op, by default. This SDK replaces the no-op with a [composite
+propagator](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/api-propagators.md#composite-propagator)
+containing the Baggage Propagator and TraceContext propagator. This default
+propagator can be overridden with the below snippet.
 
-## Configuration using Dependency Injection
+```csharp
+using OpenTelemetry;
 
-// TODO: Placeholder
+Sdk.SetDefaultTextMapPropagator(new MyCustomPropagator());
+```
+
+## Dependency Injection Support
+
+// TODO: Add details here
+
+## Configuration files and Environment Variables
+
+// TODO: Add details here

--- a/docs/trace/customizing-the-sdk/README.md
+++ b/docs/trace/customizing-the-sdk/README.md
@@ -38,7 +38,7 @@ tracerProvider.Dispose()
 ```
 
 **Note:** The `Sdk.CreateTracerProviderBuilder()` API is available for all
-runtimes but for `ASP.NET Core` and [.NET Generic
+runtimes. Additionally, for `ASP.NET Core` and [.NET Generic
 Host](https://learn.microsoft.com/dotnet/core/extensions/generic-host) users
 helper extensions are also provided in the
 [OpenTelemetry.Extensions.Hosting](../../../src/OpenTelemetry.Extensions.Hosting/README.md)

--- a/docs/trace/getting-started/README.md
+++ b/docs/trace/getting-started/README.md
@@ -114,7 +114,7 @@ TracerProvider --> | System.Diagnostics.Activity | Processor --> | Batch | Conso
 As shown in the above program, a valid `TracerProvider` must be configured and
 built to collect traces with OpenTelemetry .NET SDK. `TracerProvider` holds all
 the configuration for tracing like samplers, processors, etc. and is highly
-[customizable](../../../src/OpenTelemetry/README.md#tracing-configuration).
+[customizable](../customizing-the-sdk/README.md#tracerprovider-configuration).
 
 ## OpenTelemetry .NET and relation with .NET Activity API
 

--- a/src/OpenTelemetry/README.md
+++ b/src/OpenTelemetry/README.md
@@ -6,15 +6,8 @@
 * [Installation](#installation)
 * [Introduction](#introduction)
 * [Getting started with Logging](#getting-started-with-logging)
+* [Getting started with Metrics](#getting-started-with-metrics)
 * [Getting started with Tracing](#getting-started-with-tracing)
-* [Tracing configuration](#tracing-configuration)
-  * [Activity Source](#activity-source)
-  * [Instrumentation](#instrumentation)
-  * [Processor](#processor)
-  * [Resource](#resource)
-  * [Sampler](#sampler)
-* [Advanced topics](#advanced-topics)
-  * [Propagators](#propagators)
 * [Troubleshooting](#troubleshooting)
   * [Configuration Parameters](#configuration-parameters)
   * [Remarks](#remarks)
@@ -57,264 +50,27 @@ which provides the ability to enrich logs emitted with `ILogger` with
 `ILogger` based API will become the OpenTelemetry .NET implementation of
 OpenTelemetry logging.
 
+## Getting started with Metrics
+
+If you are new to
+[metrics](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md),
+it is recommended to follow [get started in 5
+minutes](../../docs/metrics/getting-started/README.md) to get up and running.
+
+For a more detailed explanation of SDK metric features see [Customizing
+OpenTelemetry .NET SDK for
+Metrics](../../docs/metrics/customizing-the-sdk/README.md).
+
 ## Getting started with Tracing
 
 If you are new to
 [traces](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md),
 it is recommended to follow [get started in 5
-minutes](../../docs/trace/getting-started/README.md) to get up and running. The
-rest of this document explains various components of this OpenTelemetry SDK
-implementation.
+minutes](../../docs/trace/getting-started/README.md) to get up and running.
 
-To start using OpenTelemetry for tracing, one must configure and build a valid
-[`TracerProvider`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#tracer-provider).
-
-Building a `TracerProvider` is done using `TracerProviderBuilder` which must be
-obtained by calling `Sdk.CreateTracerProviderBuilder()`. `TracerProviderBuilder`
-exposes various methods which configures the provider it is going to build. This
-includes methods like `SetSampler`, `AddProcessor` etc, and are explained in
-subsequent sections of this document. Once configuration is done, calling
-`Build()` on the `TracerProviderBuilder` builds the `TracerProvider` instance.
-Once built, changes to its configuration is not allowed, with the exception of
-adding more processors. In most cases, a single `TracerProvider` is created at
-the application startup, and is disposed when application shuts down.
-
-// TODO: Add Asp.Net Core notes showing where this code should go.
-
-The snippet below shows how to build a basic `TracerProvider`. This will create
-a provider with default configuration, and is not particularly useful. The
-subsequent sections shows how to configure the provider.
-
-```csharp
-using OpenTelemetry;
-using OpenTelemetry.Trace;
-
-using var tracerProvider = Sdk.CreateTracerProviderBuilder().Build();
-```
-
-## Tracing configuration
-
-`TracerProvider` holds the SDK configuration. It includes the following:
-
-1. The list of `ActivitySource`s (aka Tracer) from which traces are collected.
-2. The list of instrumentations enabled via
-   [InstrumentationLibrary](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/glossary.md#instrumentation-library).
-3. The list of
-   [Processors](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#span-processor)
-
-4. The
-   [Resource](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md)
-   associated with the traces.
-5. The
-   [Sampler](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#sampler)
-   to be used.
-
-### Activity Source
-
-`ActivitySource` denotes a
-[`Tracer`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#tracer),
-which is used to start activities. The SDK follows an explicit opt-in model for
-listening to activity sources. i.e, by default, it listens to no sources. Every
-activity source which produce telemetry must be explicitly added to the tracer
-provider to start collecting traces from them.
-
-`AddSource` method on `TracerProviderBuilder` can be used to add a
-`ActivitySource` to the provider. Multiple `AddSource` can be called to add more
-than one source. It also supports wildcard subscription model as well.
-
-Similar to `Sampler` and `Resource`, it is not possible to add sources *after*
-the provider is built, by calling the `Build()` method on the
-`TracerProviderBuilder`.
-
-The snippet below shows how to add activity sources to the provider.
-
-```csharp
-using OpenTelemetry;
-using OpenTelemetry.Trace;
-
-using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-    // The following subscribes to activities from Activity Source
-    // named "MyCompany.MyProduct.MyLibrary" only.
-    .AddSource("MyCompany.MyProduct.MyLibrary")
-    // The following subscribes to activities from all Activity Sources
-    // whose name starts with "ABCCompany.XYZProduct.".
-    .AddSource("ABCCompany.XYZProduct.*")
-    .Build();
-```
-
-### Instrumentation
-
-While the OpenTelemetry API can be used to instrument any library manually,
-[Instrumentation
-Libraries](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#instrumentation-libraries)
-are available for a lot of commonly used libraries. Such instrumentations can be
-added the tracer provider, by using the `AddInstrumentation` on the
-`TracerProviderBuilder`. It is not required to attach the instrumentation to the
-provider, unless the life cycle of the instrumentation must be managed by the
-provider. If the instrumentation must be activated/shutdown/disposed along with
-the provider, then the instrumentation must be added to the provider.
-
-Follow
-[this](../../docs/trace/extending-the-sdk/README.md#instrumentation-library)
-document to learn about the instrumentation libraries shipped from this repo,
-and also to learn about writing own instrumentations.
-
-### Processor
-
-[Processors](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#span-processor)
-allows hooks for start and end of telemetry. If no processors are configured,
-then traces are simply dropped by the SDK. `AddProcessor` method on
-`TracerProviderBuilder` should be used to add a processor. There can be any
-number of processors added to the provider, and they are invoked in the same
-order as they are added. Unlike `Sampler` or `Resource`, processors can be added
-to the provider even *after* it is built.
-
-The snippet below shows how to add processors to the provider before and after
-it is built.
-
-```csharp
-using OpenTelemetry;
-using OpenTelemetry.Trace;
-
-using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-    .AddProcessor(new MyProcessor1())
-    .AddProcessor(new MyProcessor2()))
-    .Build();
-
-// Processors can be added to provider even after it is built.
-// Only those traces which are emitted after this line, will be sent to it.
-tracerProvider.AddProcessor(new MyProcessor3());
-```
-
-A `TracerProvider` assumes ownership of any processors added to it. This means
-that, provider will call `Shutdown` method on the processor, when it is
-shutdown, and disposes the processor when it is disposed. If multiple providers
-are being setup in an application, then separate instances of processors must be
-configured on them. Otherwise, shutting down one provider can cause the
-processor in other provider to be shut down as well, leading to undesired
-results.
-
-Processors can be used for enriching the telemetry and exporting the telemetry
-to an exporter. For enriching purposes, one must write a custom processor, and
-override the `OnStart` method with logic to enrich the telemetry. For exporting
-purposes, the SDK provides the following built-in processors:
-
-* [BatchExportProcessor&lt;T&gt;](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#batching-processor)
-  : This is an exporting processor which batches the telemetry before sending to
-  the configured exporter.
-
-  The following environment variables can be used to override the default
-  values of the `BatchExportActivityProcessorOptions`.
-
-  | Environment variable             | `BatchExportActivityProcessorOptions` property |
-  | -------------------------------- | ---------------------------------------------- |
-  | `OTEL_BSP_SCHEDULE_DELAY`        | `ScheduledDelayMilliseconds`                   |
-  | `OTEL_BSP_EXPORT_TIMEOUT`        | `ExporterTimeoutMilliseconds`                  |
-  | `OTEL_BSP_MAX_QUEUE_SIZE`        | `MaxQueueSize`                                 |
-  | `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` | `MaxExportBatchSizeEnvVarKey`                  |
-
-  `FormatException` is thrown in case of an invalid value for any of the
-  supported environment variables.
-
-* [CompositeProcessor&lt;T&gt;](../../src/OpenTelemetry/CompositeProcessor.cs)
-  : This is a processor which can be composed from multiple processors. This is
-  typically used to construct multiple processing pipelines, each ending with
-  its own exporter.
-
-* [SimpleExportProcessor&lt;T&gt;](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#simple-processor)
-  : This is an exporting processor which passes telemetry to the configured
-  exporter without any batching.
-
-Follow [this](../../docs/trace/extending-the-sdk/README.md#processor) document
-to learn about how to write own processors.
-
-*The processors shipped from this SDK are generics, and supports tracing and
-logging, by supporting `Activity` and `LogRecord` respectively.*
-
-### Resource
-
-[Resource](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md)
-is the immutable representation of the entity producing the telemetry. If no
-`Resource` is explicitly configured, the default is to use a resource indicating
-this [Telemetry
-SDK](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/resource/semantic_conventions#telemetry-sdk).
-The `ConfigureResource` method on `TracerProviderBuilder` can be used to set a
-configure the resource on the provider. When the provider is built, it automatically
-builds the final `Resource` from the configured `ResourceBuilder`. As with
-samplers, there can only be a single `Resource` associated with a provider.
-It is not possible to change the resource builder *after* the provider is
-built, by calling the `Build()` method on the `TracerProviderBuilder`.
-`ResourceBuilder` offers various methods to construct resource comprising
-of multiple attributes from various sources.
-
-The snippet below shows configuring a custom `ResourceBuilder` to the provider.
-
-```csharp
-using OpenTelemetry;
-using OpenTelemetry.Resources;
-using OpenTelemetry.Trace;
-
-using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-    .ConfigureResource(r => r.AddService("MyServiceName"))
-    .Build();
-```
-
-It is also possible to configure the `Resource` by using following
-environmental variables:
-
-| Environment variable       | Description                                        |
-| -------------------------- | -------------------------------------------------- |
-| `OTEL_RESOURCE_ATTRIBUTES` | Key-value pairs to be used as resource attributes. See the [Resource SDK specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.5.0/specification/resource/sdk.md#specifying-resource-information-via-an-environment-variable) for more details. |
-| `OTEL_SERVICE_NAME`        | Sets the value of the `service.name` resource attribute. If `service.name` is also provided in `OTEL_RESOURCE_ATTRIBUTES`, then `OTEL_SERVICE_NAME` takes precedence. |
-
-### Sampler
-
-[Samplers](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#sampler)
-are used to control the noise and overhead introduced by OpenTelemetry by
-reducing the number of samples of traces collected and sent to the processors.
-If no sampler is explicitly configured, the default is to use
-`ParentBased(root=AlwaysOn)`. `SetSampler` method on `TracerProviderBuilder` can
-be used to set sampler. Only one sampler can be associated with a provider. If
-multiple `SetSampler` is called, the last one wins. Also, it is not possible to
-change the sampler *after* the provider is built, by calling the `Build()`
-method on the `TracerProviderBuilder`.
-
-The snippet below shows configuring a custom sampler to the provider.
-
-```csharp
-using OpenTelemetry;
-using OpenTelemetry.Trace;
-
-using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-    .SetSampler(new TraceIdRatioBasedSampler(0.25))
-    .Build();
-```
-
-## Advanced topics
-
-* Trace
-  * [Building your own
-    Exporter](../../docs/trace/extending-the-sdk/README.md#exporter)
-  * [Building your own Instrumentation
-    Library](../../docs/trace/extending-the-sdk/README.md#instrumentation-library)
-  * [Building your own
-    Processor](../../docs/trace/extending-the-sdk/README.md#processor)
-  * [Building your own
-    Sampler](../../docs/trace/extending-the-sdk/README.md#sampler)
-
-### Propagators
-
-The OpenTelemetry API exposes a method to obtain the default propagator which is
-no-op, by default. This SDK replaces the no-op with a [composite
-propagator](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/api-propagators.md#composite-propagator)
-containing the Baggage Propagator and TraceContext propagator. This default
-propagator can be overridden with the below snippet.
-
-```csharp
-using OpenTelemetry;
-
-Sdk.SetDefaultTextMapPropagator(new MyCustomPropagator());
-```
+For a more detailed explanation of SDK tracing features see [Customizing
+OpenTelemetry .NET SDK for
+Tracing](../../docs/trace/customizing-the-sdk/README.md).
 
 ## Troubleshooting
 

--- a/src/OpenTelemetry/README.md
+++ b/src/OpenTelemetry/README.md
@@ -34,10 +34,8 @@ and enable the SDK, when they install a particular exporter.
 
 ## Getting started with Logging
 
-If you are new to logging, it is recommended to follow [get started in 5
-minutes](../../docs/logs/getting-started/README.md) to get up and running with
-logging integration with
-[`ILogger`](https://docs.microsoft.com/dotnet/api/microsoft.extensions.logging.ilogger).
+If you are new to logging, it is recommended to first follow the [getting started in 5
+minutes](../../docs/logs/getting-started/README.md) guide to get up and running.
 
 While [OpenTelemetry
 logging](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/overview.md)
@@ -54,8 +52,9 @@ OpenTelemetry logging.
 
 If you are new to
 [metrics](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md),
-it is recommended to follow [get started in 5
-minutes](../../docs/metrics/getting-started/README.md) to get up and running.
+it is first recommended to follow the [getting started in 5
+minutes](../../docs/metrics/getting-started/README.md) guide to get up and
+running.
 
 For a more detailed explanation of SDK metric features see [Customizing
 OpenTelemetry .NET SDK for
@@ -65,8 +64,9 @@ Metrics](../../docs/metrics/customizing-the-sdk/README.md).
 
 If you are new to
 [traces](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md),
-it is recommended to follow [get started in 5
-minutes](../../docs/trace/getting-started/README.md) to get up and running.
+it is recommended to first follow the [getting started in 5
+minutes](../../docs/trace/getting-started/README.md) guide to get up and
+running.
 
 For a more detailed explanation of SDK tracing features see [Customizing
 OpenTelemetry .NET SDK for

--- a/src/OpenTelemetry/README.md
+++ b/src/OpenTelemetry/README.md
@@ -34,8 +34,9 @@ and enable the SDK, when they install a particular exporter.
 
 ## Getting started with Logging
 
-If you are new to logging, it is recommended to first follow the [getting started in 5
-minutes](../../docs/logs/getting-started/README.md) guide to get up and running.
+If you are new to logging, it is recommended to first follow the [getting
+started in 5 minutes](../../docs/logs/getting-started/README.md) guide to get up
+and running.
 
 While [OpenTelemetry
 logging](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/overview.md)


### PR DESCRIPTION
## Changes

Removes the duplicate content from the OpenTelemetry README and links instead to the `customizing-the-sdk` README(s).
