### PR TITLE
[ASP.NET Core] Remove `http.url`

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* **Breaking change** `http.url` attribute will no longer be populated.
+([#3859](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3859))
+
 * **Breaking change** The `Enrich` callback option has been removed.
   For better usability, it has been replaced by three separate options:
   `EnrichWithHttpRequest`, `EnrichWithHttpResponse` and `EnrichWithException`.

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -211,7 +211,6 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
                 activity.SetTag(SemanticConventions.AttributeHttpMethod, request.Method);
                 activity.SetTag(SemanticConventions.AttributeHttpScheme, request.Scheme);
                 activity.SetTag(SemanticConventions.AttributeHttpTarget, path);
-                activity.SetTag(SemanticConventions.AttributeHttpUrl, GetUri(request));
                 activity.SetTag(SemanticConventions.AttributeHttpFlavor, HttpTagHelper.GetFlavorTagValueFromProtocol(request.Protocol));
 
                 var userAgent = request.Headers["User-Agent"].FirstOrDefault();
@@ -376,51 +375,6 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
                     AspNetCoreInstrumentationEventSource.Log.EnrichmentException(ex);
                 }
             }
-        }
-
-        private static string GetUri(HttpRequest request)
-        {
-            // this follows the suggestions from https://github.com/dotnet/aspnetcore/issues/28906
-            var scheme = request.Scheme ?? string.Empty;
-
-            // HTTP 1.0 request with NO host header would result in empty Host.
-            // Use placeholder to avoid incorrect URL like "http:///"
-            var host = request.Host.Value ?? UnknownHostName;
-            var pathBase = request.PathBase.Value ?? string.Empty;
-            var path = request.Path.Value ?? string.Empty;
-            var queryString = request.QueryString.Value ?? string.Empty;
-            var length = scheme.Length + Uri.SchemeDelimiter.Length + host.Length + pathBase.Length
-                         + path.Length + queryString.Length;
-
-#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
-            return string.Create(length, (scheme, host, pathBase, path, queryString), (span, parts) =>
-            {
-                CopyTo(ref span, parts.scheme);
-                CopyTo(ref span, Uri.SchemeDelimiter);
-                CopyTo(ref span, parts.host);
-                CopyTo(ref span, parts.pathBase);
-                CopyTo(ref span, parts.path);
-                CopyTo(ref span, parts.queryString);
-
-                static void CopyTo(ref Span<char> buffer, ReadOnlySpan<char> text)
-                {
-                    if (!text.IsEmpty)
-                    {
-                        text.CopyTo(buffer);
-                        buffer = buffer.Slice(text.Length);
-                    }
-                }
-            });
-#else
-            return new System.Text.StringBuilder(length)
-                .Append(scheme)
-                .Append(Uri.SchemeDelimiter)
-                .Append(host)
-                .Append(pathBase)
-                .Append(path)
-                .Append(queryString)
-                .ToString();
-#endif
         }
 
 #if !NETSTANDARD2_0

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
@@ -110,7 +110,6 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
             Assert.Equal("1.1", activity.GetTagValue(SemanticConventions.AttributeHttpFlavor));
             Assert.Equal("http", activity.GetTagValue(SemanticConventions.AttributeHttpScheme));
             Assert.Equal(urlPath, activity.GetTagValue(SemanticConventions.AttributeHttpTarget));
-            Assert.Equal($"http://localhost{urlPath}{query}", activity.GetTagValue(SemanticConventions.AttributeHttpUrl));
             Assert.Equal(statusCode, activity.GetTagValue(SemanticConventions.AttributeHttpStatusCode));
 
             if (statusCode == 503)

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.server.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.server.cs
@@ -109,7 +109,6 @@ namespace OpenTelemetry.Instrumentation.Grpc.Tests
             Assert.Equal($"localhost:{this.server.Port}", activity.GetTagValue(SemanticConventions.AttributeHttpHost));
             Assert.Equal("POST", activity.GetTagValue(SemanticConventions.AttributeHttpMethod));
             Assert.Equal("/greet.Greeter/SayHello", activity.GetTagValue(SemanticConventions.AttributeHttpTarget));
-            Assert.Equal($"http://localhost:{this.server.Port}/greet.Greeter/SayHello", activity.GetTagValue(SemanticConventions.AttributeHttpUrl));
             Assert.StartsWith("grpc-dotnet", activity.GetTagValue(SemanticConventions.AttributeHttpUserAgent) as string);
         }
 


### PR DESCRIPTION
Towards #3373 

## Changes
`http.url` is no longer required or recommended attribute for server spans.

https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-server-semantic-conventions

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
