### PR TITLE
Minor perf improvement for metric

### DIFF
--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -201,22 +201,25 @@ namespace OpenTelemetry.Metrics
                             return -1;
                         }
 
-                        // Note: We are using storage from ThreadStatic for both the input order of tags and the sorted order of tags,
+                        // Note: We are using storage from ThreadStatic (for upto MaxTagCacheSize tags) for both the input order of tags and the sorted order of tags,
                         // so we need to make a deep copy for Dictionary storage.
-                        var givenKeys = new string[length];
-                        tagKeys.CopyTo(givenKeys, 0);
+                        if (length <= ThreadStaticStorage.MaxTagCacheSize)
+                        {
+                            var givenKeys = new string[length];
+                            tagKeys.CopyTo(givenKeys, 0);
 
-                        var givenValues = new object[length];
-                        tagValues.CopyTo(givenValues, 0);
+                            var givenValues = new object[length];
+                            tagValues.CopyTo(givenValues, 0);
 
-                        var sortedTagKeys = new string[length];
-                        tempSortedTagKeys.CopyTo(sortedTagKeys, 0);
+                            var sortedTagKeys = new string[length];
+                            tempSortedTagKeys.CopyTo(sortedTagKeys, 0);
 
-                        var sortedTagValues = new object[length];
-                        tempSortedTagValues.CopyTo(sortedTagValues, 0);
+                            var sortedTagValues = new object[length];
+                            tempSortedTagValues.CopyTo(sortedTagValues, 0);
 
-                        givenTags = new Tags(givenKeys, givenValues);
-                        sortedTags = new Tags(sortedTagKeys, sortedTagValues);
+                            givenTags = new Tags(givenKeys, givenValues);
+                            sortedTags = new Tags(sortedTagKeys, sortedTagValues);
+                        }
 
                         lock (this.tagsToMetricPointIndexDictionary)
                         {

--- a/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
+++ b/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
@@ -23,7 +23,7 @@ namespace OpenTelemetry.Metrics
 {
     internal sealed class ThreadStaticStorage
     {
-        private const int MaxTagCacheSize = 8;
+        internal const int MaxTagCacheSize = 8;
 
         [ThreadStatic]
         private static ThreadStaticStorage storage;


### PR DESCRIPTION
While adding tags to the Dictionary, we currently do a copy of the tags, as the tags are using TLS. However, the TLS is used only for upto 8 tags, and for >8 tags, we allocate arrays on heap and use it. (https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs#L59-L68)

The copy is only needed if we are using TLS. This PR optimized for this scenario by avoiding the copy when not using TLS.

Note: The test coverage for the "copy" seems missing. Need to add that, irrespective of this PR. 