### PR TITLE
More performance improvement when views are used

### DIFF
--- a/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
+++ b/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
@@ -77,52 +77,79 @@ namespace OpenTelemetry.Metrics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void SplitToKeysAndValues(ReadOnlySpan<KeyValuePair<string, object>> tags, int tagLength, HashSet<string> tagKeysInteresting, out string[] tagKeys, out object[] tagValues, out int actualLength)
         {
-            // Iterate over tags to find the exact length.
-            int i = 0;
-            for (var n = 0; n < tagLength; n++)
-            {
-                if (tagKeysInteresting.Contains(tags[n].Key))
-                {
-                    i++;
-                }
-            }
-
-            actualLength = i;
-
-            if (actualLength == 0)
+            // We do not know ahead the actual length, so start with max possible length.
+            var maxLength = Math.Min(tagKeysInteresting.Count, tagLength);
+            if (maxLength == 0)
             {
                 tagKeys = null;
                 tagValues = null;
             }
-            else if (actualLength <= MaxTagCacheSize)
+            else if (maxLength <= MaxTagCacheSize)
             {
-                tagKeys = this.primaryTagStorage[actualLength - 1].TagKeys;
-                tagValues = this.primaryTagStorage[actualLength - 1].TagValues;
+                tagKeys = this.primaryTagStorage[maxLength - 1].TagKeys;
+                tagValues = this.primaryTagStorage[maxLength - 1].TagValues;
             }
             else
             {
-                tagKeys = new string[actualLength];
-                tagValues = new object[actualLength];
+                tagKeys = new string[maxLength];
+                tagValues = new object[maxLength];
             }
 
-            // Iterate again (!) to assign the actual value.
-            // TODO: The dual iteration over tags might be
-            // avoidable if we change the tagKey and tagObject
-            // to be a different type (eg: List).
-            // It might lead to some wasted memory.
-            // Also, it requires changes to the Dictionary
-            // used for lookup.
-            // The TODO here is to make that change
-            // separately, after benchmarking.
-            i = 0;
+            actualLength = 0;
             for (var n = 0; n < tagLength; n++)
             {
+                // Copy only interesting tags, and keep count.
                 var tag = tags[n];
                 if (tagKeysInteresting.Contains(tag.Key))
                 {
-                    tagKeys[i] = tag.Key;
-                    tagValues[i] = tag.Value;
-                    i++;
+                    tagKeys[actualLength] = tag.Key;
+                    tagValues[actualLength] = tag.Value;
+                    actualLength++;
+                }
+            }
+
+            // If the actual length was equal to max, great!
+            // else, we need to pick the array of the actual length,
+            // and copy tags into it.
+            // This optimizes the common scenario:
+            // User is interested only in TagA and TagB
+            // and incoming measurement has TagA and TagB and many more.
+            // In this case, the actual length would be same as max length,
+            // and the following copy is avoided.
+            if (actualLength < maxLength)
+            {
+                if (actualLength == 0)
+                {
+                    tagKeys = null;
+                    tagValues = null;
+                    return;
+                }
+                else if (actualLength <= MaxTagCacheSize)
+                {
+                    var tmpKeys = this.primaryTagStorage[actualLength - 1].TagKeys;
+                    var tmpValues = this.primaryTagStorage[actualLength - 1].TagValues;
+                    for (var n = 0; n < actualLength; n++)
+                    {
+                        tmpKeys[n] = tagKeys[n];
+                        tmpValues[n] = tagValues[n];
+                    }
+
+                    tagKeys = tmpKeys;
+                    tagValues = tmpValues;
+                }
+                else
+                {
+                    var tmpKeys = new string[actualLength];
+                    var tmpValues = new object[actualLength];
+
+                    for (var n = 0; n < actualLength; n++)
+                    {
+                        tmpKeys[n] = tagKeys[n];
+                        tmpValues[n] = tagValues[n];
+                    }
+
+                    tagKeys = tmpKeys;
+                    tagValues = tmpValues;
                 }
             }
         }

--- a/test/Benchmarks/Metrics/MetricsViewBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricsViewBenchmarks.cs
@@ -34,10 +34,10 @@ Intel Core i7-4790 CPU 3.60GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
 
 |         Method |           ViewConfig |     Mean |   Error |  StdDev | Allocated |
 |--------------- |--------------------- |---------:|--------:|--------:|----------:|
-| CounterHotPath |               NoView | 284.7 ns | 2.25 ns | 2.00 ns |         - |
-| CounterHotPath |    ViewNoInstrSelect | 294.0 ns | 3.69 ns | 3.27 ns |         - |
-| CounterHotPath |     ViewSelectsInstr | 366.7 ns | 4.83 ns | 4.52 ns |         - |
-| CounterHotPath | ViewS(...)names [26] | 293.1 ns | 1.51 ns | 1.18 ns |         - |
+| CounterHotPath |               NoView | 290.1 ns | 2.49 ns | 2.08 ns |         - |
+| CounterHotPath |    ViewNoInstrSelect | 294.1 ns | 1.64 ns | 1.45 ns |         - |
+| CounterHotPath |     ViewSelectsInstr | 306.5 ns | 3.56 ns | 3.15 ns |         - |
+| CounterHotPath | ViewS(...)names [26] | 301.1 ns | 2.13 ns | 1.89 ns |         - |
 */
 
 namespace Benchmarks.Metrics


### PR DESCRIPTION
When a View is used to select specified tags only, the current implementation required iterating + dict lookup over the full tags **twice**. This PR fixes that dual iteration/lookup, by assuming the max tag length. If it turns out that the actual length is smaller, an additional copy is required, but in the common scenario of user using this feature to "drop unwanted dimensions", the additional copy is also avoided.

Before this PR, using view to select subset of dimensions resulted in ~80 ns overhead ( 270 vs 191).
With this PR, the overhead is reduced to ~15. (The overhead is inevitable, as we need to check every incoming tag against the set of configured tags) In percentage terms, the 40% overhead is reduced to 4% :)

Note: There was an alternative suggestion to fix this by changing the data type from [] to List. That require a lot more re-architecting and can still result in wasted memory, so not pursued now. I'll continue checking its feasibility, while working on more View features/Exemplars.