### PR TITLE
Minor perf tweaks in Metrics

### DIFF
--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -252,15 +252,7 @@ namespace OpenTelemetry.Metrics
                 }
                 else
                 {
-                    // Note: We are using storage from ThreadStatic, so need to make a deep copy for Dictionary storage.
-                    var givenKeys = new string[length];
-                    var givenValues = new object[length];
-
-                    tagKeys.CopyTo(givenKeys, 0);
-                    tagValues.CopyTo(givenValues, 0);
-
-                    givenTags = new Tags(givenKeys, givenValues);
-
+                    // This else block is for tag length = 1
                     aggregatorIndex = this.metricPointIndex;
                     if (aggregatorIndex >= this.maxMetricPoints)
                     {
@@ -270,6 +262,15 @@ namespace OpenTelemetry.Metrics
                         // we can re-claim them here.
                         return -1;
                     }
+
+                    // Note: We are using storage from ThreadStatic, so need to make a deep copy for Dictionary storage.
+                    var givenKeys = new string[length];
+                    var givenValues = new object[length];
+
+                    tagKeys.CopyTo(givenKeys, 0);
+                    tagValues.CopyTo(givenValues, 0);
+
+                    givenTags = new Tags(givenKeys, givenValues);
 
                     lock (this.tagsToMetricPointIndexDictionary)
                     {


### PR DESCRIPTION
Same fix as https://github.com/open-telemetry/opentelemetry-dotnet/pull/3826 applied to single tag case. (To check if we have MetricPoints available, before alloc+copy)

Minor adjustments to the benchmarks (not related to this PRs perf fix)