### PR TITLE
[Logs] Support dependency injection in ResourceBuilder and load envvars from IConfiguration

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Added dependency injection support in the `ResourceBuilder` class and added
+  support for loading environment variables from `IConfiguration` for the
+  `AddEnvironmentVariableDetector` extension (Logs)
+  ([#3889](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3889))
+
 ## 1.4.0-beta.3
 
 Released 2022-Nov-07
@@ -17,7 +22,7 @@ Released 2022-Nov-07
 
 * Added dependency injection support in the `ResourceBuilder` class and added
   support for loading environment variables from `IConfiguration` for the
-  `AddEnvironmentVariableDetector` extension
+  `AddEnvironmentVariableDetector` extension (Traces & Metrics)
   ([#3782](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3782),
   [#3798](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3798))
 

--- a/src/OpenTelemetry/Logs/OpenTelemetryLoggingExtensions.cs
+++ b/src/OpenTelemetry/Logs/OpenTelemetryLoggingExtensions.cs
@@ -57,7 +57,9 @@ namespace Microsoft.Extensions.Logging
 
             builder.AddConfiguration();
 
-            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, OpenTelemetryLoggerProvider>());
+            builder.Services.TryAddEnumerable(
+                ServiceDescriptor.Singleton<ILoggerProvider, OpenTelemetryLoggerProvider>(
+                    sp => new OpenTelemetryLoggerProvider(sp)));
 
             // Note: This will bind logger options element (eg "Logging:OpenTelemetry") to OpenTelemetryLoggerOptions
             LoggerProviderOptions.RegisterProviderOptions<OpenTelemetryLoggerOptions, OpenTelemetryLoggerProvider>(builder.Services);


### PR DESCRIPTION
Relates to #3782

## Changes

#3782 added support in Tracing & Metrics but didn't address Logging. This PR fixes that so everything is nice and consistent.

## TODOs

* [X] Appropriate `CHANGELOG.md` updated for non-trivial changes

