### PR TITLE
Add strategy back to the CI workflow for markdown files

### DIFF
--- a/.github/workflows/ci-md.yml
+++ b/.github/workflows/ci-md.yml
@@ -15,6 +15,13 @@ on:
 
 jobs:
   build-test:
+    strategy:
+      matrix:
+        os: [ windows-latest, ubuntu-latest ]
+        version: [ net462, net6.0, net7.0 ]
+        exclude:
+        - os: ubuntu-latest
+          version: net462
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Required CI checks for PRs with only markdown files are not being run. For example: #3892 

![image](https://user-images.githubusercontent.com/66651184/201440362-19fbcc8d-92e3-4f33-b2f7-da55e149b2cc.png)


## Changes
- Add strategy back to the CI workflow for markdown files
