### PR TITLE
[Sql Instrumentation] Unify exposed public API

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Http/HttpClientInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/HttpClientInstrumentationOptions.cs
@@ -33,12 +33,12 @@ namespace OpenTelemetry.Instrumentation.Http
         /// collect telemetry about requests on a per request basis.
         /// </summary>
         /// <remarks>
-        /// Notes:
-        /// <list type="bullet">
-        /// <item><b>FilterHttpRequestMessage is only executed on .NET and .NET
+        /// <para><b>FilterHttpRequestMessage is only executed on .NET and .NET
         /// Core runtimes. <see cref="HttpClient"/> and <see
         /// cref="HttpWebRequest"/> on .NET and .NET Core are both implemented
-        /// using <see cref="HttpRequestMessage"/>.</b></item>
+        /// using <see cref="HttpRequestMessage"/>.</b></para>
+        /// Notes:
+        /// <list type="bullet">
         /// <item>The return value for the filter function is interpreted as:
         /// <list type="bullet">
         /// <item>If filter returns <see langword="true" />, the request is
@@ -51,38 +51,32 @@ namespace OpenTelemetry.Instrumentation.Http
         public Func<HttpRequestMessage, bool> FilterHttpRequestMessage { get; set; }
 
         /// <summary>
-        /// Gets or sets an action to enrich an Activity with <see cref="HttpRequestMessage"/>.
+        /// Gets or sets an action to enrich an <see cref="Activity"/> with <see cref="HttpRequestMessage"/>.
         /// </summary>
         /// <remarks>
         /// <para><b>EnrichWithHttpRequestMessage is only executed on .NET and .NET
         /// Core runtimes. <see cref="HttpClient"/> and <see
         /// cref="HttpWebRequest"/> on .NET and .NET Core are both implemented
         /// using <see cref="HttpRequestMessage"/>.</b></para>
-        /// <para><see cref="Activity"/>: the activity being enriched.</para>
-        /// <para><see cref="HttpRequestMessage"/> object from which additional information can be extracted to enrich the activity.</para>
         /// </remarks>
         public Action<Activity, HttpRequestMessage> EnrichWithHttpRequestMessage { get; set; }
 
         /// <summary>
-        /// Gets or sets an action to enrich an Activity with <see cref="HttpResponseMessage"/>.
+        /// Gets or sets an action to enrich an <see cref="Activity"/> with <see cref="HttpResponseMessage"/>.
         /// </summary>
         /// <remarks>
         /// <para><b>EnrichWithHttpResponseMessage is only executed on .NET and .NET
         /// Core runtimes. <see cref="HttpClient"/> and <see
         /// cref="HttpWebRequest"/> on .NET and .NET Core are both implemented
         /// using <see cref="HttpRequestMessage"/>.</b></para>
-        /// <para><see cref="Activity"/>: the activity being enriched.</para>
-        /// <para><see cref="HttpResponseMessage"/> object from which additional information can be extracted to enrich the activity.</para>
         /// </remarks>
         public Action<Activity, HttpResponseMessage> EnrichWithHttpResponseMessage { get; set; }
 
         /// <summary>
-        /// Gets or sets an action to enrich an Activity with <see cref="Exception"/>.
+        /// Gets or sets an action to enrich an <see cref="Activity"/> with <see cref="Exception"/>.
         /// </summary>
         /// <remarks>
         /// <para><b>EnrichWithException is called for all runtimes.</b></para>
-        /// <para><see cref="Activity"/>: the activity being enriched.</para>
-        /// <para><see cref="Exception"/> object from which additional information can be extracted to enrich the activity.</para>
         /// </remarks>
         public Action<Activity, Exception> EnrichWithException { get; set; }
 
@@ -91,12 +85,12 @@ namespace OpenTelemetry.Instrumentation.Http
         /// collect telemetry about requests on a per request basis.
         /// </summary>
         /// <remarks>
-        /// Notes:
-        /// <list type="bullet">
-        /// <item><b>FilterHttpWebRequest is only executed on .NET Framework
+        /// <para><b>FilterHttpWebRequest is only executed on .NET Framework
         /// runtimes. <see cref="HttpClient"/> and <see cref="HttpWebRequest"/>
         /// on .NET Framework are both implemented using <see
-        /// cref="HttpWebRequest"/>.</b></item>
+        /// cref="HttpWebRequest"/>.</b></para>
+        /// Notes:
+        /// <list type="bullet">
         /// <item>The return value for the filter function is interpreted as:
         /// <list type="bullet">
         /// <item>If filter returns <see langword="true" />, the request is
@@ -109,36 +103,37 @@ namespace OpenTelemetry.Instrumentation.Http
         public Func<HttpWebRequest, bool> FilterHttpWebRequest { get; set; }
 
         /// <summary>
-        /// Gets or sets an action to enrich an Activity with <see cref="HttpWebRequest"/>.
+        /// Gets or sets an action to enrich an <see cref="Activity"/> with <see cref="HttpWebRequest"/>.
         /// </summary>
         /// <remarks>
         /// <para><b>EnrichWithHttpWebRequest is only executed on .NET Framework
         /// runtimes. <see cref="HttpClient"/> and <see cref="HttpWebRequest"/>
         /// on .NET Framework are both implemented using <see
         /// cref="HttpWebRequest"/>.</b></para>
-        /// <para><see cref="Activity"/>: the activity being enriched.</para>
-        /// <para><see cref="HttpWebRequest"/> object from which additional information can be extracted to enrich the activity.</para>
         /// </remarks>
         public Action<Activity, HttpWebRequest> EnrichWithHttpWebRequest { get; set; }
 
         /// <summary>
-        /// Gets or sets an action to enrich an Activity with <see cref="HttpWebResponse"/>.
+        /// Gets or sets an action to enrich an <see cref="Activity"/> with <see cref="HttpWebResponse"/>.
         /// </summary>
         /// <remarks>
         /// <para><b>EnrichWithHttpWebResponse is only executed on .NET Framework
         /// runtimes. <see cref="HttpClient"/> and <see cref="HttpWebRequest"/>
         /// on .NET Framework are both implemented using <see
         /// cref="HttpWebRequest"/>.</b></para>
-        /// <para><see cref="Activity"/>: the activity being enriched.</para>
-        /// <para><see cref="HttpWebResponse"/> object from which additional information can be extracted to enrich the activity.</para>
         /// </remarks>
         public Action<Activity, HttpWebResponse> EnrichWithHttpWebResponse { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether exception will be recorded as an <see cref="ActivityEvent"/> or not.
+        /// Gets or sets a value indicating whether exception will be recorded
+        /// as an <see cref="ActivityEvent"/> or not. Default value: <see
+        /// langword="false"/>.
         /// </summary>
         /// <remarks>
-        /// See: <see href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/exceptions.md" />.
+        /// <para><b>RecordException is supported on all runtimes.</b></para>
+        /// <para>For specification details see: <see
+        /// href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/exceptions.md"
+        /// />.</para>
         /// </remarks>
         public bool RecordException { get; set; }
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -3,8 +3,14 @@ OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.EnableCo
 OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.EnableConnectionLevelAttributes.set -> void
 OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.Enrich.get -> System.Action<System.Diagnostics.Activity, string, object>
 OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.Enrich.set -> void
-OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.SetDbStatement.get -> bool
-OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.SetDbStatement.set -> void
+OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.Filter.get -> System.Func<object, bool>
+OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.Filter.set -> void
+OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.RecordException.get -> bool
+OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.RecordException.set -> void
+OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.SetDbStatementForStoredProcedure.get -> bool
+OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.SetDbStatementForStoredProcedure.set -> void
+OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.SetDbStatementForText.get -> bool
+OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.SetDbStatementForText.set -> void
 OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.SqlClientInstrumentationOptions() -> void
 OpenTelemetry.Trace.TracerProviderBuilderExtensions
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddSqlClientInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions> configureSqlClientInstrumentationOptions = null) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -6,7 +6,7 @@
   `netstandard2.0` targets. `SetDbStatement` has been removed. Use
   `SetDbStatementForText` to capture command text and stored procedure names on
   .NET Framework.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#3900](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3900))
 
 ## 1.0.0-rc9.9
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -5,7 +5,9 @@
 * **Breaking change**: The same API is now exposed for `net462` and
   `netstandard2.0` targets. `SetDbStatement` has been removed. Use
   `SetDbStatementForText` to capture command text and stored procedure names on
-  .NET Framework.
+  .NET Framework. Note: `Enrich`, `Filter`, `RecordException`, and
+  `SetDbStatementForStoredProcedure` options are NOT supported on .NET
+  Framework.
   ([#3900](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3900))
 
 ## 1.0.0-rc9.9

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+* **Breaking change**: The same API is now exposed for `net462` and
+  `netstandard2.0` targets. `SetDbStatement` has been removed. Use
+  `SetDbStatementForText` to capture command text and stored procedure names on
+  .NET Framework.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.0.0-rc9.9
 
 Released 2022-Nov-07

--- a/src/OpenTelemetry.Instrumentation.SqlClient/README.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/README.md
@@ -71,18 +71,20 @@ For an ASP.NET application, adding instrumentation is typically done in the
 This instrumentation can be configured to change the default behavior by using
 `SqlClientInstrumentationOptions`.
 
-### Capturing 'db.statement'
+### Capturing database statements
 
-The `SqlClientInstrumentationOptions` class exposes several properties that can
-be used to configure how the
+The `SqlClientInstrumentationOptions` class exposes two properties that can be
+used to configure how the
 [`db.statement`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#call-level-attributes)
-attribute is captured upon execution of a query.
+attribute is captured upon execution of a query but the behavior depends on the
+runtime used.
 
-#### .NET & .NET Core
+#### .NET and .NET Core
 
-On .NET Core, two properties are available: `SetDbStatementForStoredProcedure`
-and `SetDbStatementForText`. These properties control capturing of
-`CommandType.StoredProcedure` and `CommandType.Text` respectively.
+On .NET and .NET Core, two properties are available:
+`SetDbStatementForStoredProcedure` and `SetDbStatementForText`. These properties
+control capturing of `CommandType.StoredProcedure` and `CommandType.Text`
+respectively.
 
 `SetDbStatementForStoredProcedure` is _true_ by default and will set
 [`db.statement`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#call-level-attributes)
@@ -140,7 +142,9 @@ using var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .Build();
 ```
 
-### EnableConnectionLevelAttributes - All runtimes
+### EnableConnectionLevelAttributes
+
+**Note:** EnableConnectionLevelAttributes is supported on all runtimes.
 
 By default, `EnabledConnectionLevelAttributes` is disabled and this
 instrumentation sets the `peer.service` attribute to the
@@ -161,7 +165,9 @@ using var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .Build();
 ```
 
-### Enrich - .NET & .NET Core only
+### Enrich
+
+**Note:** Enrich is supported on .NET and .NET Core runtimes only.
 
 This option can be used to enrich the activity with additional information from
 the raw `SqlCommand` object. The `Enrich` action is called only when
@@ -195,7 +201,9 @@ general extensibility point to add additional properties to any activity. The
 `Enrich` option is specific to this instrumentation, and is provided to get
 access to `SqlCommand` object.
 
-### RecordException - .NET & .NET Core only
+### RecordException
+
+**Note:** RecordException is supported on .NET and .NET Core runtimes only.
 
 This option can be set to instruct the instrumentation to record SqlExceptions
 as Activity
@@ -211,7 +219,9 @@ using var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .Build();
 ```
 
-### Filter - .NET & .NET Core only
+### Filter
+
+**Note:** Filter is supported on .NET and .NET Core runtimes only.
 
 This option can be used to filter out activities based on the properties of the
 `SqlCommand` object being instrumented using a `Func<object, bool>`. The

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
@@ -13,13 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
 #if NETFRAMEWORK
 using System;
 using System.Data;
 using System.Data.SqlClient;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
-using System.Linq;
 using System.Threading.Tasks;
 using Moq;
 using OpenTelemetry.Instrumentation.SqlClient.Implementation;
@@ -55,7 +55,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests
                 .AddProcessor(activityProcessor.Object)
                 .AddSqlClientInstrumentation(options =>
                 {
-                    options.SetDbStatement = captureText;
+                    options.SetDbStatementForText = captureText;
                 })
                 .Build();
 
@@ -112,7 +112,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests
                 .AddProcessor(activityProcessor.Object)
                 .AddSqlClientInstrumentation(options =>
                 {
-                    options.SetDbStatement = captureText;
+                    options.SetDbStatementForText = captureText;
                     options.EnableConnectionLevelAttributes = enableConnectionLevelAttributes;
                 })
                 .Build();


### PR DESCRIPTION
Relates to #3793

## Changes

* Exposes the same API for all targets to fix package resolution issues when consuming Sql instrumentation into netstandard2.0 projects.

## Public API Changes

```diff
namespace OpenTelemetry.Instrumentation.SqlClient
{
    public class SqlClientInstrumentationOptions
    {
-#if NETFRAMEWORK
-       public bool SetDbStatement { get; set; }
-#else
        public bool SetDbStatementForStoredProcedure { get; set; } = true;
        public bool SetDbStatementForText { get; set; }
        public Func<object, bool> Filter { get; set; }
        public bool RecordException { get; set; }
-#endif
        public Action<Activity, string, object> Enrich { get; set; }
        public bool EnableConnectionLevelAttributes { get; set; }
    }
}
```

## TODOs

* [X] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Changes in public API reviewed
