### PR TITLE
[HttpClient] Add `net.peer.name` and `net.peer.port` on metric dimensions

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## Unreleased
 
-* **Breaking change** `http.host` will no longer be populated. `net.peer.name`
-  and `net.peer.port` attributes will be populated instead.
+* Added `net.peer.name` and `net.peer.port` as dimensions on
+  `http.client.duration` metric.
+  ()
+
+* **Breaking change** `http.host` will no longer be populated on activity.
+  `net.peer.name` and `net.peer.port` attributes will be populated instead.
   ([#3832](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3832))
 
 ## 1.0.0-rc9.9

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Added `net.peer.name` and `net.peer.port` as dimensions on
   `http.client.duration` metric.
-  ()
+  ([#3907](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3907))
 
 * **Breaking change** `http.host` will no longer be populated on activity.
   `net.peer.name` and `net.peer.port` attributes will be populated instead.

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
@@ -50,9 +50,6 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
                     var request = response.RequestMessage;
 
                     TagList tags;
-
-                    // TODO: This is just a minimal set of attributes. See the spec for additional attributes:
-                    // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md#http-client
                     if (!request.RequestUri.IsDefaultPort)
                     {
                         tags = new TagList

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
@@ -49,15 +49,33 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
                 {
                     var request = response.RequestMessage;
 
+                    TagList tags;
+
                     // TODO: This is just a minimal set of attributes. See the spec for additional attributes:
                     // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md#http-client
-                    var tags = new KeyValuePair<string, object>[]
+                    if (!request.RequestUri.IsDefaultPort)
                     {
-                        new KeyValuePair<string, object>(SemanticConventions.AttributeHttpMethod, HttpTagHelper.GetNameForHttpMethod(request.Method)),
-                        new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, request.RequestUri.Scheme),
-                        new KeyValuePair<string, object>(SemanticConventions.AttributeHttpStatusCode, (int)response.StatusCode),
-                        new KeyValuePair<string, object>(SemanticConventions.AttributeHttpFlavor, HttpTagHelper.GetFlavorTagValueFromProtocolVersion(request.Version)),
-                    };
+                        tags = new TagList
+                        {
+                            new KeyValuePair<string, object>(SemanticConventions.AttributeHttpMethod, HttpTagHelper.GetNameForHttpMethod(request.Method)),
+                            new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, request.RequestUri.Scheme),
+                            new KeyValuePair<string, object>(SemanticConventions.AttributeHttpStatusCode, (int)response.StatusCode),
+                            new KeyValuePair<string, object>(SemanticConventions.AttributeHttpFlavor, HttpTagHelper.GetFlavorTagValueFromProtocolVersion(request.Version)),
+                            new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerName, request.RequestUri.Host),
+                            new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerPort, request.RequestUri.Port),
+                        };
+                    }
+                    else
+                    {
+                        tags = new TagList
+                        {
+                            new KeyValuePair<string, object>(SemanticConventions.AttributeHttpMethod, HttpTagHelper.GetNameForHttpMethod(request.Method)),
+                            new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, request.RequestUri.Scheme),
+                            new KeyValuePair<string, object>(SemanticConventions.AttributeHttpStatusCode, (int)response.StatusCode),
+                            new KeyValuePair<string, object>(SemanticConventions.AttributeHttpFlavor, HttpTagHelper.GetFlavorTagValueFromProtocolVersion(request.Version)),
+                            new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerName, request.RequestUri.Host),
+                        };
+                    }
 
                     this.httpClientDuration.Record(activity.Duration.TotalMilliseconds, tags);
                 }

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.cs
@@ -200,11 +200,15 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
                 var scheme = new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, "http");
                 var statusCode = new KeyValuePair<string, object>(SemanticConventions.AttributeHttpStatusCode, tc.ResponseCode == 0 ? 200 : tc.ResponseCode);
                 var flavor = new KeyValuePair<string, object>(SemanticConventions.AttributeHttpFlavor, "2.0");
+                var hostName = new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerName, host);
+                var portNumber = new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerPort, port);
                 Assert.Contains(method, attributes);
                 Assert.Contains(scheme, attributes);
                 Assert.Contains(statusCode, attributes);
                 Assert.Contains(flavor, attributes);
-                Assert.Equal(4, attributes.Length);
+                Assert.Contains(hostName, attributes);
+                Assert.Contains(portNumber, attributes);
+                Assert.Equal(6, attributes.Length);
 #endif
             }
             else


### PR DESCRIPTION
Towards #3373 

## Changes

Added dimensions as per [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md#attributes)

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
