### PR TITLE
Update prometheus ports to the default `9464`

### DIFF
--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
@@ -31,10 +31,10 @@ namespace OpenTelemetry.Exporter.Prometheus.Tests
         private readonly string meterName = Utils.GetCurrentMethodName();
 
         [Theory]
-        [InlineData("http://+:9184")]
-        [InlineData("http://*:9184")]
-        [InlineData("http://+:9184/")]
-        [InlineData("http://*:9184/")]
+        [InlineData("http://+:9464")]
+        [InlineData("http://*:9464")]
+        [InlineData("http://+:9464/")]
+        [InlineData("http://*:9464/")]
         [InlineData("https://example.com")]
         [InlineData("http://127.0.0.1")]
         [InlineData("http://example.com", "https://example.com", "http://127.0.0.1")]

--- a/test/OpenTelemetry.Tests.Stress.Logs/Program.cs
+++ b/test/OpenTelemetry.Tests.Stress.Logs/Program.cs
@@ -37,7 +37,7 @@ public partial class Program
 
         logger = loggerFactory.CreateLogger<Program>();
 
-        Stress(prometheusPort: 9184);
+        Stress(prometheusPort: 9464);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/test/OpenTelemetry.Tests.Stress.Metrics/Program.cs
+++ b/test/OpenTelemetry.Tests.Stress.Metrics/Program.cs
@@ -50,7 +50,7 @@ public partial class Program
                 options => options.UriPrefixes = new string[] { $"http://localhost:9185/" })
             .Build();
 
-        Stress(prometheusPort: 9184);
+        Stress(prometheusPort: 9464);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/test/OpenTelemetry.Tests.Stress.Traces/Program.cs
+++ b/test/OpenTelemetry.Tests.Stress.Traces/Program.cs
@@ -31,7 +31,7 @@ public partial class Program
             .AddSource(ActivitySource.Name)
             .Build();
 
-        Stress(prometheusPort: 9184);
+        Stress(prometheusPort: 9464);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/test/OpenTelemetry.Tests.Stress/Meat.cs
+++ b/test/OpenTelemetry.Tests.Stress/Meat.cs
@@ -22,7 +22,7 @@ public partial class Program
 {
     public static void Main()
     {
-        Stress(concurrency: 1, prometheusPort: 9184);
+        Stress(concurrency: 1, prometheusPort: 9464);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/test/OpenTelemetry.Tests.Stress/README.md
+++ b/test/OpenTelemetry.Tests.Stress/README.md
@@ -43,7 +43,7 @@ Running (concurrency = 1), press <Esc> to stop...
 The stress test metrics are exposed via
 [Prometheus HttpListener](../../src/OpenTelemetry.Exporter.Prometheus.HttpListener/README.md),
 which can be accessed via
-[http://localhost:9184/metrics/](http://localhost:9184/metrics/).
+[http://localhost:9464/metrics/](http://localhost:9464/metrics/).
 
 Following shows a section of the metrics exposed in prometheus format:
 
@@ -82,7 +82,7 @@ public partial class Program
 {
     public static void Main()
     {
-        Stress(concurrency: 10, prometheusPort: 9184);
+        Stress(concurrency: 10, prometheusPort: 9464);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Some docs referenced the current port `9464` and the project used the old one `9184`.
Simply updating the default value for such projects.
Note: test file is not functionally any different but I figured I'd change everything together to minimize possible confusion.