### PR TITLE
[ASP.NET Core] Add additional `http.server.duration` metric attributes

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -2,17 +2,18 @@
 
 ## Unreleased
 
-* **Breaking change** `http.host` will no longer be populated on
-  `http.server.duration` metric. `net.host.name` and `net.host.port` attributes
-will be populated instead.
-[#3928](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3928)
+* **Users migrating from version `1.0.0-rc9.9` will see the following breaking
+  changes:**
+  * `http.host` will no longer be populated on `http.server.duration` metric.
+  `net.host.name` and `net.host.port` attributes will be populated instead.
+([#3928](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3928))
 
-* **Breaking change** The `http.server.duration` metric's `http.target`
-attribute is replaced with `http.route` attribute.
+  * The `http.server.duration` metric's `http.target` attribute is replaced with
+`http.route` attribute.
 ([#3903](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3903))
 
-* **Breaking change** `http.host` will no longer be populated on activity.
-  `net.host.name` and `net.host.port` attributes will be populated instead.
+  * `http.host` will no longer be populated on activity. `net.host.name` and
+  `net.host.port` attributes will be populated instead.
   ([#3858](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3858))
 
 ## 1.0.0-rc9.9

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-* Added `net.host.name` and `net.host.port` to `http.server.duration` metric.
+* Added `net.host.name` and `net.host.port` dimensions to `http.server.duration`
+metric.
 [#3928](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3928)
 
 * **Breaking change** The `http.server.duration` metric's `http.target`

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
-* Added `net.host.name` and `net.host.port` dimensions to `http.server.duration`
-metric.
+* **Breaking change** `http.host` will no longer be populated on
+  `http.server.duration` metric. `net.host.name` and `net.host.port` attributes
+will be populated instead.
 [#3928](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3928)
 
 * **Breaking change** The `http.server.duration` metric's `http.target`

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Added `net.host.name` and `net.host.port` to `http.server.duration` metric.
 Changed `http.status_code` type from string to int.
-([])()
+[#3928](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3928)
 
 * **Breaking change** The `http.server.duration` metric's `http.target`
 attribute is replaced with `http.route` attribute.

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 ## Unreleased
 
+* Added `net.host.name` and `net.host.port` to `http.server.duration` metric.
+Changed `http.status_code` type from string to int.
+([])()
+
+* **Breaking change** The `http.server.duration` metric's `http.target`
+attribute is replaced with `http.route` attribute.
+([#3903](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3903))
+
 * **Breaking change** `http.host` will no longer be populated on activity.
   `net.host.name` and `net.host.port` attributes will be populated instead.
   ([#3858](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3858))
-
-* The `http.server.duration` metric's `http.target` attribute is replaced
-with `http.route` attribute.
-([#3903](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3903))
 
 ## 1.0.0-rc9.9
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## Unreleased
 
 * Added `net.host.name` and `net.host.port` to `http.server.duration` metric.
-Changed `http.status_code` type from string to int.
 [#3928](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3928)
 
 * **Breaking change** The `http.server.duration` metric's `http.target`

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInMetricsListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInMetricsListener.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using Microsoft.AspNetCore.Http;
@@ -42,7 +43,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
         {
             if (name == OnStopEvent)
             {
-                HttpContext context = payload as HttpContext;
+                var context = payload as HttpContext;
                 if (context == null)
                 {
                     AspNetCoreInstrumentationEventSource.Log.NullPayload(nameof(HttpInMetricsListener), nameof(this.OnEventWritten));
@@ -57,56 +58,28 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
                     return;
                 }
 
-                string host;
+                TagList tags = default;
 
-                if (context.Request.Host.Port is null or 80 or 443)
-                {
-                    host = context.Request.Host.Host;
-                }
-                else
-                {
-                    host = context.Request.Host.Host + ":" + context.Request.Host.Port;
-                }
+                tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpFlavor, HttpTagHelper.GetFlavorTagValueFromProtocol(context.Request.Protocol)));
+                tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, context.Request.Scheme));
+                tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpMethod, context.Request.Method));
+                tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpStatusCode, context.Response.StatusCode));
 
-                TagList tags;
+                if (context.Request.Host.HasValue)
+                {
+                    tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeNetHostName, context.Request.Host.Host));
+
+                    if (context.Request.Host.Port is not null && context.Request.Host.Port != 80 && context.Request.Host.Port != 443)
+                    {
+                        tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeNetHostPort, context.Request.Host.Port));
+                    }
+                }
 #if NET6_0_OR_GREATER
                 var route = (context.GetEndpoint() as RouteEndpoint)?.RoutePattern.RawText;
-
-                // TODO: This is just a minimal set of attributes. See the spec for additional attributes:
-                // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md#http-server
                 if (!string.IsNullOrEmpty(route))
                 {
-                    tags = new TagList
-                    {
-                        { SemanticConventions.AttributeHttpFlavor, HttpTagHelper.GetFlavorTagValueFromProtocol(context.Request.Protocol) },
-                        { SemanticConventions.AttributeHttpScheme, context.Request.Scheme },
-                        { SemanticConventions.AttributeHttpMethod, context.Request.Method },
-                        { SemanticConventions.AttributeHttpHost, host },
-                        { SemanticConventions.AttributeHttpRoute, route },
-                        { SemanticConventions.AttributeHttpStatusCode, context.Response.StatusCode.ToString() },
-                    };
+                    tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpRoute, route));
                 }
-                else
-                {
-                    tags = new TagList
-                    {
-                        { SemanticConventions.AttributeHttpFlavor, HttpTagHelper.GetFlavorTagValueFromProtocol(context.Request.Protocol) },
-                        { SemanticConventions.AttributeHttpScheme, context.Request.Scheme },
-                        { SemanticConventions.AttributeHttpMethod, context.Request.Method },
-                        { SemanticConventions.AttributeHttpHost, host },
-                        { SemanticConventions.AttributeHttpStatusCode, context.Response.StatusCode.ToString() },
-                    };
-                }
-#else
-                tags = new TagList
-            {
-                { SemanticConventions.AttributeHttpFlavor, context.Request.Protocol },
-                { SemanticConventions.AttributeHttpScheme, context.Request.Scheme },
-                { SemanticConventions.AttributeHttpMethod, context.Request.Method },
-                { SemanticConventions.AttributeHttpHost, host },
-                { SemanticConventions.AttributeHttpStatusCode, context.Response.StatusCode.ToString() },
-            };
-
 #endif
 
                 this.httpServerDuration.Record(Activity.Current.Duration.TotalMilliseconds, tags);

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInMetricsListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInMetricsListener.cs
@@ -63,7 +63,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
                 tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpFlavor, HttpTagHelper.GetFlavorTagValueFromProtocol(context.Request.Protocol)));
                 tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, context.Request.Scheme));
                 tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpMethod, context.Request.Method));
-                tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpStatusCode, context.Response.StatusCode));
+                tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpStatusCode, context.Response.StatusCode.ToString()));
 
                 if (context.Request.Host.HasValue)
                 {

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
@@ -117,9 +117,9 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
 
             var method = new KeyValuePair<string, object>(SemanticConventions.AttributeHttpMethod, "GET");
             var scheme = new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, "http");
-            var statusCode = new KeyValuePair<string, object>(SemanticConventions.AttributeHttpStatusCode, "200");
+            var statusCode = new KeyValuePair<string, object>(SemanticConventions.AttributeHttpStatusCode, 200);
             var flavor = new KeyValuePair<string, object>(SemanticConventions.AttributeHttpFlavor, "1.1");
-            var host = new KeyValuePair<string, object>(SemanticConventions.AttributeHttpHost, "localhost");
+            var host = new KeyValuePair<string, object>(SemanticConventions.AttributeNetHostName, "localhost");
             var route = new KeyValuePair<string, object>(SemanticConventions.AttributeHttpRoute, "api/Values");
             Assert.Contains(method, attributes);
             Assert.Contains(scheme, attributes);

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
@@ -117,7 +117,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Tests
 
             var method = new KeyValuePair<string, object>(SemanticConventions.AttributeHttpMethod, "GET");
             var scheme = new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, "http");
-            var statusCode = new KeyValuePair<string, object>(SemanticConventions.AttributeHttpStatusCode, 200);
+            var statusCode = new KeyValuePair<string, object>(SemanticConventions.AttributeHttpStatusCode, "200");
             var flavor = new KeyValuePair<string, object>(SemanticConventions.AttributeHttpFlavor, "1.1");
             var host = new KeyValuePair<string, object>(SemanticConventions.AttributeNetHostName, "localhost");
             var route = new KeyValuePair<string, object>(SemanticConventions.AttributeHttpRoute, "api/Values");


### PR DESCRIPTION
Towards #3373 

## Changes

As per spec https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md#attributes

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
