### PR TITLE
Remove semVer prefix

### DIFF
--- a/src/OpenTelemetry.Api/README.md
+++ b/src/OpenTelemetry.Api/README.md
@@ -186,7 +186,7 @@ here as well.
     ```csharp
     static ActivitySource activitySource = new ActivitySource(
         "companyname.product.instrumentationlibrary",
-        "semver1.0.0");
+        "1.0.0");
     ```
 
     The above requires import of the `System.Diagnostics` namespace.
@@ -483,7 +483,7 @@ Windows-based .NET implementation).
     ```csharp
     static Meter meter = new Meter(
         "companyname.product.instrumentationlibrary",
-        "semver1.0.0");
+        "1.0.0");
     ```
 
     The above requires import of the `System.Diagnostics.Metrics` namespace.

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderBase.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderBase.cs
@@ -38,6 +38,7 @@ namespace OpenTelemetry.Metrics
     public abstract class MeterProviderBuilderBase : MeterProviderBuilder, IDeferredMeterProviderBuilder
     {
         internal readonly MeterProviderBuilderState? State;
+        private const string DefaultInstrumentationVersion = "1.0.0.0";
 
         private readonly bool ownsServices;
         private IServiceCollection? services;
@@ -281,7 +282,7 @@ namespace OpenTelemetry.Metrics
             this.ConfigureState((sp, state)
                 => state.AddInstrumentation(
                     typeof(T).Name,
-                    typeof(T).Assembly.GetName().Version.ToString(),
+                    typeof(T).Assembly.GetName().Version?.ToString() ?? DefaultInstrumentationVersion,
                     instrumentationFactory(sp)));
 
             return this;

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderBase.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderBase.cs
@@ -281,7 +281,7 @@ namespace OpenTelemetry.Metrics
             this.ConfigureState((sp, state)
                 => state.AddInstrumentation(
                     typeof(T).Name,
-                    "semver:" + typeof(T).Assembly.GetName().Version,
+                    typeof(T).Assembly.GetName().Version.ToString(),
                     instrumentationFactory(sp)));
 
             return this;

--- a/src/OpenTelemetry/Trace/Builder/TracerProviderBuilderBase.cs
+++ b/src/OpenTelemetry/Trace/Builder/TracerProviderBuilderBase.cs
@@ -260,7 +260,7 @@ namespace OpenTelemetry.Trace
             this.ConfigureState((sp, state)
                 => state.AddInstrumentation(
                     typeof(T).Name,
-                    "semver:" + typeof(T).Assembly.GetName().Version,
+                    typeof(T).Assembly.GetName().Version.ToString(),
                     instrumentationFactory(sp)));
 
             return this;

--- a/src/OpenTelemetry/Trace/Builder/TracerProviderBuilderBase.cs
+++ b/src/OpenTelemetry/Trace/Builder/TracerProviderBuilderBase.cs
@@ -36,6 +36,7 @@ namespace OpenTelemetry.Trace
     public abstract class TracerProviderBuilderBase : TracerProviderBuilder, IDeferredTracerProviderBuilder
     {
         internal readonly TracerProviderBuilderState? State;
+        private const string DefaultInstrumentationVersion = "1.0.0.0";
 
         private readonly bool ownsServices;
         private IServiceCollection? services;
@@ -260,7 +261,7 @@ namespace OpenTelemetry.Trace
             this.ConfigureState((sp, state)
                 => state.AddInstrumentation(
                     typeof(T).Name,
-                    typeof(T).Assembly.GetName().Version.ToString(),
+                    typeof(T).Assembly.GetName().Version?.ToString() ?? DefaultInstrumentationVersion,
                     instrumentationFactory(sp)));
 
             return this;

--- a/test/OpenTelemetry.Tests/Resources/ResourceBuilderTests.cs
+++ b/test/OpenTelemetry.Tests/Resources/ResourceBuilderTests.cs
@@ -55,12 +55,12 @@ namespace OpenTelemetry.Resources.Tests
         [Fact]
         public void ServiceResource_ServiceNameAndInstanceAndNamespaceAndVersion()
         {
-            var resource = ResourceBuilder.CreateEmpty().AddService("my-service", "my-namespace", "semVer:1.2.3", serviceInstanceId: "123").Build();
+            var resource = ResourceBuilder.CreateEmpty().AddService("my-service", "my-namespace", "1.2.3", serviceInstanceId: "123").Build();
             Assert.Equal(4, resource.Attributes.Count());
             Assert.Contains(new KeyValuePair<string, object>(ResourceSemanticConventions.AttributeServiceName, "my-service"), resource.Attributes);
             Assert.Contains(new KeyValuePair<string, object>(ResourceSemanticConventions.AttributeServiceInstance, "123"), resource.Attributes);
             Assert.Contains(new KeyValuePair<string, object>(ResourceSemanticConventions.AttributeServiceNamespace, "my-namespace"), resource.Attributes);
-            Assert.Contains(new KeyValuePair<string, object>(ResourceSemanticConventions.AttributeServiceVersion, "semVer:1.2.3"), resource.Attributes);
+            Assert.Contains(new KeyValuePair<string, object>(ResourceSemanticConventions.AttributeServiceVersion, "1.2.3"), resource.Attributes);
         }
 
         [Fact]


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-specification/pull/873

## Changes
- Remove references to semVer prefix
- Use `1.0.0.0` as the default instrumentation version