### PR TITLE
remove pinned version of docfx

### DIFF
--- a/.github/workflows/docfx.yml
+++ b/.github/workflows/docfx.yml
@@ -15,9 +15,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: install docfx
-      # specifying 2.58.5 version as latest release (2.58.8) has an issue
-      # https://github.com/dotnet/docfx/issues/7689
-      run: choco install docfx -y --version=2.58.5
+      run: choco install docfx -y
 
     - name: run .\build\docfx.cmd
       shell: cmd


### PR DESCRIPTION
This was pinned to v2.58.5 in Nov 2021 due to corrupted installations. (#2559)
Current version is 2.59.4

## Changes
- remove pinned version, allowing CI to use latest version 

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
