### PR TITLE
fix W3CTraceContextTests integration test

### DIFF
--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/Dockerfile
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/Dockerfile
@@ -4,7 +4,6 @@
 
 ARG SDK_VERSION=7.0
 FROM ubuntu AS w3c
-ENV SPEC_LEVEL=2
 #Install git
 WORKDIR /w3c
 RUN apt-get update && apt-get install -y git

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/Dockerfile
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/Dockerfile
@@ -4,6 +4,7 @@
 
 ARG SDK_VERSION=7.0
 FROM ubuntu AS w3c
+ENV SPEC_LEVEL=2
 #Install git
 WORKDIR /w3c
 RUN apt-get update && apt-get install -y git

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/W3CTraceContextTests.cs
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/W3CTraceContextTests.cs
@@ -96,7 +96,7 @@ namespace OpenTelemetry.Instrumentation.W3cTraceContext.Tests
             // 2) harness sends an invalid traceparent with illegal characters in trace_flags ... FAIL
             string lastLine = ParseLastLine(result);
             this.output.WriteLine("result:" + result);
-            Assert.StartsWith("FAILED (failures=2, skipped=1)", lastLine);
+            Assert.StartsWith("FAILED (failures=3)", lastLine);
         }
 
         private static string RunCommand(string command, string args)

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/W3CTraceContextTests.cs
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/W3CTraceContextTests.cs
@@ -96,7 +96,7 @@ namespace OpenTelemetry.Instrumentation.W3cTraceContext.Tests
             // 2) harness sends an invalid traceparent with illegal characters in trace_flags ... FAIL
             string lastLine = ParseLastLine(result);
             this.output.WriteLine("result:" + result);
-            Assert.StartsWith("FAILED (failures=2)", lastLine);
+            Assert.StartsWith("FAILED (failures=2, skipped=1)", lastLine);
         }
 
         private static string RunCommand(string command, string args)

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/docker-compose.yml
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/docker-compose.yml
@@ -11,3 +11,4 @@ services:
     command: --TestCaseFilter:CategoryName=W3CTraceContextTests
     environment:
       - OTEL_W3CTRACECONTEXT=enabled
+      - SPEC_LEVEL=2


### PR DESCRIPTION
This test started failing yesterday and is blocking PRs.

- run history: https://github.com/open-telemetry/opentelemetry-dotnet/actions/workflows/integration.yml
- test log: https://github.com/open-telemetry/opentelemetry-dotnet/actions/runs/3527043563/jobs/5915663782#step:3:1337

This test pulls `test.py` from another repo.

https://github.com/open-telemetry/opentelemetry-dotnet/blob/943c856c1c6295a536bc8a1c89896febc0be6107/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/Dockerfile#L10

https://github.com/open-telemetry/opentelemetry-dotnet/blob/943c856c1c6295a536bc8a1c89896febc0be6107/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/W3CTraceContextTests.cs#L90

`test.py` was updated yesterday in this PR: https://github.com/w3c/trace-context/pull/500


## Changes
- set environment variable to run new test.
- update assert string.

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed

