### PR TITLE
Document limit env vars supported in OTLP exporter

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
@@ -72,6 +72,24 @@ values of the `PeriodicExportingMetricReaderOptions`
 | `OTEL_METRIC_EXPORT_INTERVAL` | `ExportIntervalMilliseconds`                    |
 | `OTEL_METRIC_EXPORT_TIMEOUT`  | `ExportTimeoutMilliseconds`                     |
 
+The following environment variables can be used to override the default
+values of the attribute limits
+(following the [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.15.0/specification/sdk-environment-variables.md#attribute-limits)).
+
+* `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT`
+* `OTEL_ATTRIBUTE_COUNT_LIMIT`
+
+The following environment variables can be used to override the default
+values of the span limits
+(following the [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.15.0/specification/sdk-environment-variables.md#span-limits)).
+
+* `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT`
+* `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT`
+* `OTEL_SPAN_EVENT_COUNT_LIMIT`
+* `OTEL_SPAN_LINK_COUNT_LIMIT`
+* `OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT`
+* `OTEL_LINK_ATTRIBUTE_COUNT_LIMIT`
+
 `FormatException` is thrown in case of an invalid value for any of the
 supported environment variables.
 


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-dotnet/issues/3949

Follows https://github.com/open-telemetry/opentelemetry-dotnet/pull/3376

## Changes

Document feature introduced in 1.4.0-beta.2.