### PR TITLE
Fix Jaeger console example dotnet run command

### DIFF
--- a/examples/Console/TestJaegerExporter.cs
+++ b/examples/Console/TestJaegerExporter.cs
@@ -45,9 +45,10 @@ namespace Examples.Console
             // the reporoot\examples\Console\.
             // (eg: C:\repos\opentelemetry-dotnet\examples\Console\)
             //
-            // dotnet run jaeger -h localhost -p 6831
+            // dotnet run --project Examples.Console.csproj -- jaeger -h localhost -p 6831
             // For non-Windows (e.g., MacOS)
             // dotnet run jaeger -- -h localhost -p 6831
+            // Navigate to http://localhost:16686 to access the Jaeger UI.
             return RunWithActivity(host, port);
         }
 


### PR DESCRIPTION
Fixes #3953 

## Changes

Fix the Jaeger console example dotnet run command. Add comment on how to access localhost Jaeger UI.
