### PR TITLE
Add `AnalysisLevel` to Common.props

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -6,6 +6,7 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)debug.snk</AssemblyOriginatorKeyFile>
     <DefineConstants>$(DefineConstants);SIGNED</DefineConstants>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <AnalysisLevel>latest-All</AnalysisLevel>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/examples/MicroserviceExample/Utils/Messaging/MessageReceiver.cs
+++ b/examples/MicroserviceExample/Utils/Messaging/MessageReceiver.cs
@@ -98,7 +98,7 @@ namespace Utils.Messaging
             }
             catch (Exception ex)
             {
-                this.logger.LogError(ex, "Failed to extract trace context: {ex}");
+                this.logger.LogError(ex, "Failed to extract trace context.");
             }
 
             return Enumerable.Empty<string>();

--- a/test/OpenTelemetry.Exporter.Console.Tests/OpenTelemetry.Exporter.Console.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.Console.Tests/OpenTelemetry.Exporter.Console.Tests.csproj
@@ -6,7 +6,6 @@
     <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <Nullable>enable</Nullable>
-    <AnalysisLevel>latest-all</AnalysisLevel>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 


### PR DESCRIPTION
towards #3958

## Changes
- Add `AnalysisLevel` to `Common.props`
- Remove `AnalysisLevel` from projects that already had this setting.
- fix issue
  - MicrosorviceExample: CA2017	Number of parameters supplied in the logging message template do not match the number of named placeholders


Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
