### PR TITLE
[ASP.NET Core] Add `http.server.active_requests` metric with different DiagnosticSourceSubscribers for different metrics

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreMetrics.cs
@@ -41,7 +41,8 @@ namespace OpenTelemetry.Instrumentation.AspNetCore
         private readonly Func<string, object, object, bool> isEnabled = (eventName, _, _)
             => DiagnosticSourceEvents.Contains(eventName);
 
-        private readonly DiagnosticSourceSubscriber diagnosticSourceSubscriber;
+        private readonly DiagnosticSourceSubscriber httpServerDurationDiagnosticSourceSubscriber;
+        private readonly DiagnosticSourceSubscriber httpActiveRequestsDiagnosticSourceSubscriber;
         private readonly Meter meter;
 
         /// <summary>
@@ -50,14 +51,18 @@ namespace OpenTelemetry.Instrumentation.AspNetCore
         public AspNetCoreMetrics()
         {
             this.meter = new Meter(InstrumentationName, InstrumentationVersion);
-            this.diagnosticSourceSubscriber = new DiagnosticSourceSubscriber(new HttpInMetricsListener("Microsoft.AspNetCore", this.meter), this.isEnabled);
-            this.diagnosticSourceSubscriber.Subscribe();
+            this.httpServerDurationDiagnosticSourceSubscriber = new DiagnosticSourceSubscriber(new HttpInDurationMetricsListener("Microsoft.AspNetCore", this.meter), this.isEnabled);
+            this.httpActiveRequestsDiagnosticSourceSubscriber = new DiagnosticSourceSubscriber(new HttpInActiveRequestsMetricsListener("Microsoft.AspNetCore", this.meter), this.isEnabled);
+
+            this.httpServerDurationDiagnosticSourceSubscriber.Subscribe();
+            this.httpActiveRequestsDiagnosticSourceSubscriber.Subscribe();
         }
 
         /// <inheritdoc/>
         public void Dispose()
         {
-            this.diagnosticSourceSubscriber?.Dispose();
+            this.httpServerDurationDiagnosticSourceSubscriber?.Dispose();
+            this.httpActiveRequestsDiagnosticSourceSubscriber?.Dispose();
             this.meter?.Dispose();
         }
     }

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInActiveRequestsMetricsListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInActiveRequestsMetricsListener.cs
@@ -69,8 +69,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
 
                 this.httpServerActiveRequests.Add(1, tags);
             }
-
-            if (name == OnStopEvent)
+            else if (name == OnStopEvent)
             {
                 var context = payload as HttpContext;
                 if (context == null)

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInActiveRequestsMetricsListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInActiveRequestsMetricsListener.cs
@@ -1,0 +1,105 @@
+// <copyright file="HttpInActiveRequestsMetricsListener.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Microsoft.AspNetCore.Http;
+using OpenTelemetry.Trace;
+
+namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
+{
+    internal sealed class HttpInActiveRequestsMetricsListener : ListenerHandler
+    {
+        private const string OnStartEvent = "Microsoft.AspNetCore.Hosting.HttpRequestIn.Start";
+        private const string OnStopEvent = "Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop";
+
+        private readonly Meter meter;
+        private readonly UpDownCounter<long> httpServerActiveRequests;
+
+        public HttpInActiveRequestsMetricsListener(string name, Meter meter)
+            : base(name)
+        {
+            this.meter = meter;
+            this.httpServerActiveRequests = meter.CreateUpDownCounter<long>("http.server.active_requests", "measures the number of concurrent HTTP requests that are currently in-flight");
+        }
+
+        public override void OnEventWritten(string name, object payload)
+        {
+            if (name == OnStartEvent)
+            {
+                var context = payload as HttpContext;
+                if (context == null)
+                {
+                    AspNetCoreInstrumentationEventSource.Log.NullPayload(nameof(HttpInActiveRequestsMetricsListener), nameof(this.OnEventWritten));
+                    return;
+                }
+
+                // TODO: Prometheus pulls metrics by invoking the /metrics endpoint. Decide if it makes sense to suppress this.
+                // Below is just a temporary way of achieving this suppression for metrics (we should consider suppressing traces too).
+                // If we want to suppress activity from Prometheus then we should use SuppressInstrumentationScope.
+                if (context.Request.Path.HasValue && context.Request.Path.Value.Contains("metrics"))
+                {
+                    return;
+                }
+
+                TagList tags = default;
+
+                tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpFlavor, HttpTagHelper.GetFlavorTagValueFromProtocol(context.Request.Protocol)));
+                tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, context.Request.Scheme));
+                tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpMethod, context.Request.Method));
+
+                if (context.Request.Host.HasValue)
+                {
+                    tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeNetHostName, context.Request.Host.Host));
+                }
+
+                this.httpServerActiveRequests.Add(1, tags);
+            }
+
+            if (name == OnStopEvent)
+            {
+                var context = payload as HttpContext;
+                if (context == null)
+                {
+                    AspNetCoreInstrumentationEventSource.Log.NullPayload(nameof(HttpInDurationMetricsListener), nameof(this.OnEventWritten));
+                    return;
+                }
+
+                // TODO: Prometheus pulls metrics by invoking the /metrics endpoint. Decide if it makes sense to suppress this.
+                // Below is just a temporary way of achieving this suppression for metrics (we should consider suppressing traces too).
+                // If we want to suppress activity from Prometheus then we should use SuppressInstrumentationScope.
+                if (context.Request.Path.HasValue && context.Request.Path.Value.Contains("metrics"))
+                {
+                    return;
+                }
+
+                TagList tags = default;
+
+                tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpFlavor, HttpTagHelper.GetFlavorTagValueFromProtocol(context.Request.Protocol)));
+                tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, context.Request.Scheme));
+                tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpMethod, context.Request.Method));
+
+                if (context.Request.Host.HasValue)
+                {
+                    tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeNetHostName, context.Request.Host.Host));
+                }
+
+                this.httpServerActiveRequests.Add(-1, tags);
+            }
+        }
+    }
+}

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInDurationMetricsListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInDurationMetricsListener.cs
@@ -1,4 +1,4 @@
-// <copyright file="HttpInMetricsListener.cs" company="OpenTelemetry Authors">
+// <copyright file="HttpInDurationMetricsListener.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,14 +25,14 @@ using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
 {
-    internal sealed class HttpInMetricsListener : ListenerHandler
+    internal sealed class HttpInDurationMetricsListener : ListenerHandler
     {
         private const string OnStopEvent = "Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop";
 
         private readonly Meter meter;
         private readonly Histogram<double> httpServerDuration;
 
-        public HttpInMetricsListener(string name, Meter meter)
+        public HttpInDurationMetricsListener(string name, Meter meter)
             : base(name)
         {
             this.meter = meter;
@@ -46,7 +46,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
                 var context = payload as HttpContext;
                 if (context == null)
                 {
-                    AspNetCoreInstrumentationEventSource.Log.NullPayload(nameof(HttpInMetricsListener), nameof(this.OnEventWritten));
+                    AspNetCoreInstrumentationEventSource.Log.NullPayload(nameof(HttpInDurationMetricsListener), nameof(this.OnEventWritten));
                     return;
                 }
 


### PR DESCRIPTION
Fixes #.

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
