### PR TITLE
remove `ImplicitUsings disable` from projects (part 1)

### DIFF
--- a/src/OpenTelemetry.Api/Internal/ExceptionExtensions.cs
+++ b/src/OpenTelemetry.Api/Internal/ExceptionExtensions.cs
@@ -14,9 +14,11 @@
 // limitations under the License.
 // </copyright>
 
+#pragma warning disable IDE0005 // Temporarily suppressing "Using directive is unnecessary" until other projects have been updated. See #3958.
 using System;
 using System.Globalization;
 using System.Threading;
+#pragma warning restore IDE0005
 
 namespace OpenTelemetry.Internal
 {

--- a/src/OpenTelemetry.Api/Internal/Guard.cs
+++ b/src/OpenTelemetry.Api/Internal/Guard.cs
@@ -14,11 +14,13 @@
 // limitations under the License.
 // </copyright>
 
+#pragma warning disable IDE0005 // Temporarily suppressing "Using directive is unnecessary" until other projects have been updated. See #3958.
 using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Threading;
+#pragma warning restore IDE0005
 
 #if !NET6_0_OR_GREATER
 namespace System.Runtime.CompilerServices

--- a/src/OpenTelemetry.Exporter.Console/ConsoleActivityExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleActivityExporter.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 using System.Diagnostics;
-using System.Linq;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterHelperExtensions.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Exporter;

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterLoggingExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterLoggingExtensions.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Internal;
 

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterMetricsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterMetricsExtensions.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Exporter;

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterOutputTargets.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterOutputTargets.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-
 namespace OpenTelemetry.Exporter
 {
     [Flags]

--- a/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Resources;

--- a/src/OpenTelemetry.Exporter.Console/ConsoleTagTransformer.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleTagTransformer.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Exporter;

--- a/src/OpenTelemetry.Exporter.Console/OpenTelemetry.Exporter.Console.csproj
+++ b/src/OpenTelemetry.Exporter.Console/OpenTelemetry.Exporter.Console.csproj
@@ -9,7 +9,6 @@
 
     <!-- this is temporary. will remove in future PR. -->
     <Nullable>disable</Nullable>
-    <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporter.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporter.cs
@@ -14,9 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
-
 namespace OpenTelemetry.Exporter
 {
     public class InMemoryExporter<T> : BaseExporter<T>

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterHelperExtensions.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System.Collections.Generic;
 using System.Diagnostics;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Internal;

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterLoggingExtensions.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterLoggingExtensions.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System.Collections.Generic;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Internal;
 

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterMetricsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterMetricsExtensions.cs
@@ -14,9 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
-using System.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Exporter;

--- a/src/OpenTelemetry.Exporter.InMemory/MetricSnapshot.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/MetricSnapshot.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System.Collections.Generic;
-
 namespace OpenTelemetry.Metrics
 {
     /// <summary>

--- a/src/OpenTelemetry.Exporter.InMemory/OpenTelemetry.Exporter.InMemory.csproj
+++ b/src/OpenTelemetry.Exporter.InMemory/OpenTelemetry.Exporter.InMemory.csproj
@@ -9,7 +9,6 @@
 
     <!-- this is temporary. will remove in future PR. -->
     <Nullable>disable</Nullable>
-    <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+#pragma warning disable IDE0005 // Temporarily suppressing "Using directive is unnecessary" until other projects have been updated. See #3958.
 using System;
 #if DEBUG
 using System.Collections.Generic;
@@ -22,6 +23,7 @@ using System.Linq;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Security;
+#pragma warning restore IDE0005
 
 namespace OpenTelemetry.Internal
 {

--- a/src/OpenTelemetry/Internal/TagTransformer.cs
+++ b/src/OpenTelemetry/Internal/TagTransformer.cs
@@ -14,9 +14,11 @@
 // limitations under the License.
 // </copyright>
 
+#pragma warning disable IDE0005 // Temporarily suppressing "Using directive is unnecessary" until other projects have been updated. See #3958.
 using System;
 using System.Collections.Generic;
 using System.Linq;
+#pragma warning restore IDE0005
 
 namespace OpenTelemetry.Internal;
 


### PR DESCRIPTION
Towards #3958.
Follow up to #3959.

In my previous PR, I enabled `ImplicitUsings` in `Common.props` and disabled this in projects with errors.
This PR fixes some projects and turns `ImplicitUsings` back on.

## Changes
- `#pragma warning disable IDE0005` to `OpenTelemetry` and `OpenTelemetry.Api` projects.
   These projects have shared files that are included in other projects. 
   These projects need to be fixed last, and these files need to disable the usings check.
- remove `ImplicitUsings disable` from projects
  - Exporter.Console
  - Exporter.InMemory
 

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
