### PR TITLE
remove `ImplicitUsings disable` from projects (part 5)

### DIFF
--- a/src/OpenTelemetry.Exporter.ZPages/Implementation/ZPagesActivityAggregate.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/Implementation/ZPagesActivityAggregate.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Diagnostics;
 
 namespace OpenTelemetry.Exporter.ZPages.Implementation

--- a/src/OpenTelemetry.Exporter.ZPages/Implementation/ZPagesActivityTracker.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/Implementation/ZPagesActivityTracker.cs
@@ -14,9 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Timers;
 
 namespace OpenTelemetry.Exporter.ZPages.Implementation

--- a/src/OpenTelemetry.Exporter.ZPages/Implementation/ZPagesExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/Implementation/ZPagesExporterEventSource.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Diagnostics.Tracing;
 using OpenTelemetry.Internal;
 

--- a/src/OpenTelemetry.Exporter.ZPages/OpenTelemetry.Exporter.ZPages.csproj
+++ b/src/OpenTelemetry.Exporter.ZPages/OpenTelemetry.Exporter.ZPages.csproj
@@ -8,7 +8,6 @@
 
     <!-- this is temporary. will remove in future PR. -->
     <Nullable>disable</Nullable>
-    <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Exporter.ZPages/ZPagesExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/ZPagesExporterHelperExtensions.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-
 using OpenTelemetry.Exporter.ZPages;
 using OpenTelemetry.Internal;
 

--- a/src/OpenTelemetry.Exporter.ZPages/ZPagesExporterStatsHttpServer.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/ZPagesExporterStatsHttpServer.cs
@@ -14,12 +14,8 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Collections.Concurrent;
-using System.IO;
 using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
 using OpenTelemetry.Exporter.ZPages.Implementation;
 using OpenTelemetry.Internal;
 

--- a/src/OpenTelemetry.Exporter.ZPages/ZPagesProcessor.cs
+++ b/src/OpenTelemetry.Exporter.ZPages/ZPagesProcessor.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Diagnostics;
 using OpenTelemetry.Exporter.ZPages.Implementation;
 using OpenTelemetry.Trace;

--- a/src/OpenTelemetry.Extensions.Hosting/Implementation/HostingExtensionsEventSource.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Implementation/HostingExtensionsEventSource.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Diagnostics.Tracing;
 using OpenTelemetry.Internal;
 

--- a/src/OpenTelemetry.Extensions.Hosting/Implementation/TelemetryHostedService.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Implementation/TelemetryHostedService.cs
@@ -14,10 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using OpenTelemetry.Metrics;

--- a/src/OpenTelemetry.Extensions.Hosting/Metrics/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Metrics/MeterProviderBuilderExtensions.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace OpenTelemetry.Metrics

--- a/src/OpenTelemetry.Extensions.Hosting/OpenTelemetry.Extensions.Hosting.csproj
+++ b/src/OpenTelemetry.Extensions.Hosting/OpenTelemetry.Extensions.Hosting.csproj
@@ -7,7 +7,6 @@
 
     <!-- this is temporary. will remove in future PR. -->
     <Nullable>disable</Nullable>
-    <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryServicesExtensions.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryServicesExtensions.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using OpenTelemetry.Extensions.Hosting.Implementation;

--- a/src/OpenTelemetry.Extensions.Hosting/Trace/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Trace/TracerProviderBuilderExtensions.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace OpenTelemetry.Trace

--- a/src/OpenTelemetry.Extensions.Propagators/B3Propagator.cs
+++ b/src/OpenTelemetry.Extensions.Propagators/B3Propagator.cs
@@ -14,10 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Text;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Internal;

--- a/src/OpenTelemetry.Extensions.Propagators/JaegerPropagator.cs
+++ b/src/OpenTelemetry.Extensions.Propagators/JaegerPropagator.cs
@@ -14,10 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Internal;
 

--- a/src/OpenTelemetry.Extensions.Propagators/OpenTelemetry.Extensions.Propagators.csproj
+++ b/src/OpenTelemetry.Extensions.Propagators/OpenTelemetry.Extensions.Propagators.csproj
@@ -9,7 +9,6 @@
 
     <!-- this is temporary. will remove in future PR. -->
     <Nullable>disable</Nullable>
-    <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Extensions.Propagators/OpenTelemetryPropagatorsEventSource.cs
+++ b/src/OpenTelemetry.Extensions.Propagators/OpenTelemetryPropagatorsEventSource.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Diagnostics.Tracing;
 
 namespace OpenTelemetry.Internal


### PR DESCRIPTION
Towards #3958.
Follow up to #3959.

In my previous PR, I enabled `ImplicitUsings` in `Common.props` and disabled this in projects with errors.
This PR fixes some projects and turns `ImplicitUsings` back on.

## Changes
- `#pragma warning disable IDE0005` to `OpenTelemetry` and `OpenTelemetry.Api` projects.
   These projects have shared files that are included in other projects. 
   These projects need to be fixed last, and these files need to disable the usings check.
- remove `ImplicitUsings disable` from projects
  - Exporter.ZPages
  - Extensions.Hosting
  - Extensions.Propogators

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
