### PR TITLE
[Logs] Remove ConfigureResource on OpenTelemetryLoggingOptions

### DIFF
--- a/docs/logs/customizing-the-sdk/Program.cs
+++ b/docs/logs/customizing-the-sdk/Program.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Resources;
@@ -30,7 +29,9 @@ public class Program
             builder.AddOpenTelemetry(options =>
             {
                 options.IncludeScopes = true;
-                options.ConfigureResource(r => r.AddService(serviceName: "MyService", serviceVersion: "1.0.0"));
+                options.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(
+                    serviceName: "MyService",
+                    serviceVersion: "1.0.0"));
                 options.AddConsoleExporter();
             });
         });

--- a/docs/logs/customizing-the-sdk/README.md
+++ b/docs/logs/customizing-the-sdk/README.md
@@ -52,28 +52,28 @@ var loggerFactory = LoggerFactory.Create(builder =>
 
 For more information on Processors, please review [Extending the SDK](../extending-the-sdk/README.md#processor)
 
-### ConfigureResource
+### SetResourceBuilder
 
 [Resource](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md)
 is the immutable representation of the entity producing the telemetry.
 If no `Resource` is explicitly configured, the default is to use a resource
 indicating this [Telemetry
 SDK](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/resource/semantic_conventions#telemetry-sdk).
-The `ConfigureResource` method on `OpenTelemetryLoggerOptions` can be used to
-configure the `ResourceBuilder`. It is not possible to change the resources
+The `SetResourceBuilder` method on `OpenTelemetryLoggerOptions` can be used to
+set a single `ResourceBuilder`. If `SetResourceBuilder` is called multiple
+times, only the last is kept. It is not possible to change the resource builder
 *after* creating the `LoggerFactory`.
 
-The snippet below shows configuring the `ResourceBuilder` of the provider.
+The snippet below shows configuring a custom `ResourceBuilder` to the provider.
 
 ```csharp
 var loggerFactory = LoggerFactory.Create(builder =>
 {
     builder.AddOpenTelemetry(options =>
     {
-        options.ConfigureResource(r => r.AddService(
+        options.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(
             serviceName: "MyService",
-            serviceVersion: "1.0.0"
-            ));
+            serviceVersion: "1.0.0"));
     });
 });
 ```

--- a/examples/AspNetCore/Program.cs
+++ b/examples/AspNetCore/Program.cs
@@ -130,7 +130,9 @@ appBuilder.Logging.AddOpenTelemetry(options =>
 {
     // Note: See appsettings.json Logging:OpenTelemetry section for configuration.
 
-    options.ConfigureResource(configureResource);
+    var resourceBuilder = ResourceBuilder.CreateDefault();
+    configureResource(resourceBuilder);
+    options.SetResourceBuilder(resourceBuilder);
 
     switch (logExporter)
     {

--- a/src/OpenTelemetry/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -7,7 +7,6 @@ OpenTelemetry.Logs.LogRecord.Timestamp.set -> void
 OpenTelemetry.Logs.LogRecord.TraceFlags.set -> void
 OpenTelemetry.Logs.LogRecord.TraceId.set -> void
 OpenTelemetry.Logs.LogRecord.TraceState.set -> void
-OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ConfigureResource(System.Action<OpenTelemetry.Resources.ResourceBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
 OpenTelemetry.Metrics.HistogramConfiguration
 OpenTelemetry.Metrics.HistogramConfiguration.HistogramConfiguration() -> void
 OpenTelemetry.Metrics.HistogramConfiguration.RecordMinMax.get -> bool

--- a/src/OpenTelemetry/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -7,7 +7,6 @@ OpenTelemetry.Logs.LogRecord.Timestamp.set -> void
 OpenTelemetry.Logs.LogRecord.TraceFlags.set -> void
 OpenTelemetry.Logs.LogRecord.TraceId.set -> void
 OpenTelemetry.Logs.LogRecord.TraceState.set -> void
-OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ConfigureResource(System.Action<OpenTelemetry.Resources.ResourceBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
 OpenTelemetry.Metrics.HistogramConfiguration
 OpenTelemetry.Metrics.HistogramConfiguration.HistogramConfiguration() -> void
 OpenTelemetry.Metrics.HistogramConfiguration.RecordMinMax.get -> bool

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -7,7 +7,6 @@ OpenTelemetry.Logs.LogRecord.Timestamp.set -> void
 OpenTelemetry.Logs.LogRecord.TraceFlags.set -> void
 OpenTelemetry.Logs.LogRecord.TraceId.set -> void
 OpenTelemetry.Logs.LogRecord.TraceState.set -> void
-OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ConfigureResource(System.Action<OpenTelemetry.Resources.ResourceBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
 OpenTelemetry.Metrics.HistogramConfiguration
 OpenTelemetry.Metrics.HistogramConfiguration.HistogramConfiguration() -> void
 OpenTelemetry.Metrics.HistogramConfiguration.RecordMinMax.get -> bool

--- a/src/OpenTelemetry/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
@@ -7,7 +7,6 @@ OpenTelemetry.Logs.LogRecord.Timestamp.set -> void
 OpenTelemetry.Logs.LogRecord.TraceFlags.set -> void
 OpenTelemetry.Logs.LogRecord.TraceId.set -> void
 OpenTelemetry.Logs.LogRecord.TraceState.set -> void
-OpenTelemetry.Logs.OpenTelemetryLoggerOptions.ConfigureResource(System.Action<OpenTelemetry.Resources.ResourceBuilder!>! configure) -> OpenTelemetry.Logs.OpenTelemetryLoggerOptions!
 OpenTelemetry.Metrics.HistogramConfiguration
 OpenTelemetry.Metrics.HistogramConfiguration.HistogramConfiguration() -> void
 OpenTelemetry.Metrics.HistogramConfiguration.RecordMinMax.get -> bool

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -12,6 +12,9 @@
   the `IServiceCollection.AddOpenTelemetry` API
   ([#3923](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3923))
 
+* Removed `ConfigureResource` on `OpenTelemetryLoggingOptions`
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.4.0-beta.3
 
 Released 2022-Nov-07

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -13,7 +13,7 @@
   ([#3923](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3923))
 
 * Removed `ConfigureResource` on `OpenTelemetryLoggingOptions`
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#3999](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3999))
 
 ## 1.4.0-beta.3
 

--- a/src/OpenTelemetry/Logs/Options/OpenTelemetryLoggerOptions.cs
+++ b/src/OpenTelemetry/Logs/Options/OpenTelemetryLoggerOptions.cs
@@ -82,18 +82,5 @@ namespace OpenTelemetry.Logs
             this.ResourceBuilder = resourceBuilder;
             return this;
         }
-
-        /// <summary>
-        /// Modify the <see cref="ResourceBuilder"/> from which the Resource associated with
-        /// this provider is built from in-place.
-        /// </summary>
-        /// <param name="configure">An action which modifies the provided <see cref="ResourceBuilder"/> in-place.</param>
-        /// <returns>Returns <see cref="OpenTelemetryLoggerOptions"/> for chaining.</returns>
-        public OpenTelemetryLoggerOptions ConfigureResource(Action<ResourceBuilder> configure)
-        {
-            Guard.ThrowIfNull(configure, nameof(configure));
-            configure(this.ResourceBuilder);
-            return this;
-        }
     }
 }


### PR DESCRIPTION
Relates to #3307

## Changes

We decided during API review of 1.4 to remove the `ConfigureResource` API on logs. This is a good API but we know big changes are coming to logs. In the `main-logs` branch this method has already been obsoleted and moved onto `LoggerProviderBuilder`. The goal is to bring this back soon. In the meantime, the existing `SetResourceBuilder` works just as well.

## TODOs

* [X] Appropriate `CHANGELOG.md` updated for non-trivial changes
