### PR TITLE
Remove unnecessary using statements

### DIFF
--- a/docs/logs/extending-the-sdk/LoggerExtensions.cs
+++ b/docs/logs/extending-the-sdk/LoggerExtensions.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using OpenTelemetry;
 using OpenTelemetry.Logs;
 

--- a/docs/logs/extending-the-sdk/MyExporter.cs
+++ b/docs/logs/extending-the-sdk/MyExporter.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Text;
 using OpenTelemetry;
 using OpenTelemetry.Logs;

--- a/docs/logs/extending-the-sdk/MyProcessor.cs
+++ b/docs/logs/extending-the-sdk/MyProcessor.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using OpenTelemetry;
 using OpenTelemetry.Logs;
 

--- a/docs/logs/extending-the-sdk/Program.cs
+++ b/docs/logs/extending-the-sdk/Program.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 

--- a/docs/logs/redaction/MyClassWithRedactionEnumerator.cs
+++ b/docs/logs/redaction/MyClassWithRedactionEnumerator.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 using System.Collections;
-using System.Collections.Generic;
 
 namespace Redaction
 {

--- a/docs/logs/redaction/MyRedactionProcessor.cs
+++ b/docs/logs/redaction/MyRedactionProcessor.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System.Collections.Generic;
 using OpenTelemetry;
 using OpenTelemetry.Logs;
 

--- a/docs/metrics/customizing-the-sdk/Program.cs
+++ b/docs/metrics/customizing-the-sdk/Program.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Diagnostics.Metrics;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;

--- a/docs/metrics/extending-the-sdk/MyExporter.cs
+++ b/docs/metrics/extending-the-sdk/MyExporter.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Text;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;

--- a/docs/metrics/extending-the-sdk/MyExporterExtensions.cs
+++ b/docs/metrics/extending-the-sdk/MyExporterExtensions.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Threading;
 using OpenTelemetry.Metrics;
 
 internal static class MyExporterExtensions

--- a/docs/metrics/extending-the-sdk/Program.cs
+++ b/docs/metrics/extending-the-sdk/Program.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using OpenTelemetry;

--- a/docs/metrics/getting-started-prometheus-grafana/Program.cs
+++ b/docs/metrics/getting-started-prometheus-grafana/Program.cs
@@ -14,9 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Diagnostics.Metrics;
-using System.Threading;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 

--- a/docs/metrics/learning-more-instruments/Program.cs
+++ b/docs/metrics/learning-more-instruments/Program.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using OpenTelemetry;

--- a/docs/trace/extending-the-sdk/MyExporter.cs
+++ b/docs/trace/extending-the-sdk/MyExporter.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Diagnostics;
 using System.Text;
 using OpenTelemetry;

--- a/docs/trace/extending-the-sdk/MyExporterExtensions.cs
+++ b/docs/trace/extending-the-sdk/MyExporterExtensions.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using OpenTelemetry;
 using OpenTelemetry.Trace;
 

--- a/docs/trace/extending-the-sdk/MyFilteringProcessor.cs
+++ b/docs/trace/extending-the-sdk/MyFilteringProcessor.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Diagnostics;
 using OpenTelemetry;
 

--- a/docs/trace/extending-the-sdk/MyProcessor.cs
+++ b/docs/trace/extending-the-sdk/MyProcessor.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Diagnostics;
 using OpenTelemetry;
 

--- a/docs/trace/extending-the-sdk/MyResourceDetector.cs
+++ b/docs/trace/extending-the-sdk/MyResourceDetector.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System.Collections.Generic;
 using OpenTelemetry.Resources;
 
 internal class MyResourceDetector : IResourceDetector

--- a/docs/trace/extending-the-sdk/MySampler.cs
+++ b/docs/trace/extending-the-sdk/MySampler.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using OpenTelemetry.Trace;
 
 internal class MySampler : Sampler

--- a/docs/trace/reporting-exceptions/Program.cs
+++ b/docs/trace/reporting-exceptions/Program.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Diagnostics;
 using OpenTelemetry;
 using OpenTelemetry.Trace;

--- a/examples/Console/InstrumentationWithActivitySource.cs
+++ b/examples/Console/InstrumentationWithActivitySource.cs
@@ -14,16 +14,10 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
-using System.IO;
 using System.Net;
-using System.Net.Http;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Examples.Console
 {

--- a/examples/Console/TestHttpClient.cs
+++ b/examples/Console/TestHttpClient.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 using System.Diagnostics;
-using System.Net.Http;
 using OpenTelemetry;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;

--- a/examples/Console/TestInMemoryExporter.cs
+++ b/examples/Console/TestInMemoryExporter.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System.Collections.Generic;
 using System.Diagnostics;
 using OpenTelemetry;
 using OpenTelemetry.Resources;

--- a/examples/Console/TestLogs.cs
+++ b/examples/Console/TestLogs.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
 

--- a/examples/Console/TestMetrics.cs
+++ b/examples/Console/TestMetrics.cs
@@ -14,11 +14,8 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
-using System.Threading.Tasks;
 using OpenTelemetry;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Metrics;

--- a/examples/Console/TestOtlpExporter.cs
+++ b/examples/Console/TestOtlpExporter.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using OpenTelemetry;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Resources;

--- a/examples/Console/TestPrometheusExporter.cs
+++ b/examples/Console/TestPrometheusExporter.cs
@@ -14,12 +14,8 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
-using System.Threading;
-using System.Threading.Tasks;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;

--- a/examples/Console/TestZPagesExporter.cs
+++ b/examples/Console/TestZPagesExporter.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 using System.Diagnostics;
-using System.Threading;
 using OpenTelemetry;
 using OpenTelemetry.Exporter.ZPages;
 using OpenTelemetry.Trace;

--- a/examples/Console/TestZipkinExporter.cs
+++ b/examples/Console/TestZipkinExporter.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using OpenTelemetry;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;

--- a/examples/GrpcService/Program.cs
+++ b/examples/GrpcService/Program.cs
@@ -14,9 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Hosting;
-
 namespace Examples.GrpcService
 {
     public class Program

--- a/examples/GrpcService/Services/GreeterService.cs
+++ b/examples/GrpcService/Services/GreeterService.cs
@@ -14,9 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-using System.Threading.Tasks;
 using Grpc.Core;
-using Microsoft.Extensions.Logging;
 
 namespace Examples.GrpcService
 {

--- a/examples/GrpcService/Startup.cs
+++ b/examples/GrpcService/Startup.cs
@@ -14,13 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using OpenTelemetry;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;

--- a/examples/MicroserviceExample/Utils/Messaging/MessageReceiver.cs
+++ b/examples/MicroserviceExample/Utils/Messaging/MessageReceiver.cs
@@ -14,12 +14,8 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Text;
-using System.Threading;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 using OpenTelemetry.Context.Propagation;

--- a/examples/MicroserviceExample/Utils/Messaging/MessageSender.cs
+++ b/examples/MicroserviceExample/Utils/Messaging/MessageSender.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 using Microsoft.Extensions.Logging;

--- a/examples/MicroserviceExample/Utils/Messaging/RabbitMqHelper.cs
+++ b/examples/MicroserviceExample/Utils/Messaging/RabbitMqHelper.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Diagnostics;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;

--- a/examples/MicroserviceExample/WebApi/Controllers/SendMessageController.cs
+++ b/examples/MicroserviceExample/WebApi/Controllers/SendMessageController.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using Utils.Messaging;
 
 namespace WebApi.Controllers

--- a/examples/MicroserviceExample/WebApi/Program.cs
+++ b/examples/MicroserviceExample/WebApi/Program.cs
@@ -14,9 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Hosting;
-
 namespace WebApi
 {
     public class Program

--- a/examples/MicroserviceExample/WebApi/Startup.cs
+++ b/examples/MicroserviceExample/WebApi/Startup.cs
@@ -14,12 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using OpenTelemetry;
 using OpenTelemetry.Trace;
 using Utils.Messaging;

--- a/examples/MicroserviceExample/WorkerService/Program.cs
+++ b/examples/MicroserviceExample/WorkerService/Program.cs
@@ -14,9 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using OpenTelemetry;
 using OpenTelemetry.Trace;
 using Utils.Messaging;

--- a/examples/MicroserviceExample/WorkerService/Worker.cs
+++ b/examples/MicroserviceExample/WorkerService/Worker.cs
@@ -14,9 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Hosting;
 using Utils.Messaging;
 
 namespace WorkerService

--- a/test/Benchmarks/Exporter/OtlpGrpcExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/OtlpGrpcExporterBenchmarks.cs
@@ -15,10 +15,7 @@
 // </copyright>
 
 extern alias OpenTelemetryProtocol;
-
-using System;
 using System.Diagnostics;
-using System.Threading;
 using BenchmarkDotNet.Attributes;
 using Benchmarks.Helper;
 using Grpc.Core;

--- a/test/Benchmarks/Exporter/OtlpGrpcExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/OtlpGrpcExporterBenchmarks.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 extern alias OpenTelemetryProtocol;
+
 using System.Diagnostics;
 using BenchmarkDotNet.Attributes;
 using Benchmarks.Helper;

--- a/test/Benchmarks/Exporter/OtlpHttpExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/OtlpHttpExporterBenchmarks.cs
@@ -16,9 +16,7 @@
 
 extern alias OpenTelemetryProtocol;
 
-using System;
 using System.Diagnostics;
-using System.IO;
 using BenchmarkDotNet.Attributes;
 using Benchmarks.Helper;
 using OpenTelemetry;

--- a/test/Benchmarks/Exporter/PrometheusSerializerBenchmarks.cs
+++ b/test/Benchmarks/Exporter/PrometheusSerializerBenchmarks.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using BenchmarkDotNet.Attributes;
 using OpenTelemetry;

--- a/test/Benchmarks/Exporter/ZipkinExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/ZipkinExporterBenchmarks.cs
@@ -15,10 +15,7 @@
 // </copyright>
 
 extern alias Zipkin;
-
-using System;
 using System.Diagnostics;
-using System.IO;
 using BenchmarkDotNet.Attributes;
 using Benchmarks.Helper;
 using OpenTelemetry;

--- a/test/Benchmarks/Exporter/ZipkinExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/ZipkinExporterBenchmarks.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 extern alias Zipkin;
+
 using System.Diagnostics;
 using BenchmarkDotNet.Attributes;
 using Benchmarks.Helper;

--- a/test/Benchmarks/Helper/ActivityHelper.cs
+++ b/test/Benchmarks/Helper/ActivityHelper.cs
@@ -14,10 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 
 namespace Benchmarks.Helper
 {

--- a/test/Benchmarks/Instrumentation/DiagnosticSourceSubscriberBenchmark.cs
+++ b/test/Benchmarks/Instrumentation/DiagnosticSourceSubscriberBenchmark.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using BenchmarkDotNet.Attributes;
 using OpenTelemetry.Instrumentation;

--- a/test/Benchmarks/Instrumentation/InstrumentedHttpClientBenchmark.cs
+++ b/test/Benchmarks/Instrumentation/InstrumentedHttpClientBenchmark.cs
@@ -14,10 +14,8 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Diagnostics;
 using System.Net.Http;
-using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using OpenTelemetry;
 using OpenTelemetry.Resources;

--- a/test/Benchmarks/Instrumentation/UninstrumentedHttpClientBenchmark.cs
+++ b/test/Benchmarks/Instrumentation/UninstrumentedHttpClientBenchmark.cs
@@ -14,9 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Net.Http;
-using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using OpenTelemetry.Tests;
 

--- a/test/Benchmarks/Logs/LogScopeBenchmarks.cs
+++ b/test/Benchmarks/Logs/LogScopeBenchmarks.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using BenchmarkDotNet.Attributes;
 using Microsoft.Extensions.Logging;

--- a/test/Benchmarks/Metrics/HistogramBenchmarks.cs
+++ b/test/Benchmarks/Metrics/HistogramBenchmarks.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using BenchmarkDotNet.Attributes;

--- a/test/Benchmarks/Metrics/MetricCollectBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricCollectBenchmarks.cs
@@ -14,11 +14,7 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.Metrics;
-using System.Threading;
-using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;

--- a/test/Benchmarks/Metrics/MetricsBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricsBenchmarks.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using BenchmarkDotNet.Attributes;

--- a/test/Benchmarks/Metrics/MetricsViewBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricsViewBenchmarks.cs
@@ -14,11 +14,8 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
-using System.Threading;
 using BenchmarkDotNet.Attributes;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;

--- a/test/Benchmarks/TestExporter.cs
+++ b/test/Benchmarks/TestExporter.cs
@@ -14,8 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
-
 namespace OpenTelemetry.Tests
 {
     internal class TestExporter<T> : BaseExporter<T>

--- a/test/Benchmarks/Trace/SamplerBenchmarks.cs
+++ b/test/Benchmarks/Trace/SamplerBenchmarks.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Diagnostics;
 using BenchmarkDotNet.Attributes;
 using OpenTelemetry;

--- a/test/OpenTelemetry.Tests.Stress.Logs/DummyProcessor.cs
+++ b/test/OpenTelemetry.Tests.Stress.Logs/DummyProcessor.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using OpenTelemetry;
 using OpenTelemetry.Logs;
 
 namespace OpenTelemetry.Tests.Stress;

--- a/test/OpenTelemetry.Tests.Stress.Logs/Program.cs
+++ b/test/OpenTelemetry.Tests.Stress.Logs/Program.cs
@@ -16,7 +16,6 @@
 
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
-using OpenTelemetry.Logs;
 
 namespace OpenTelemetry.Tests.Stress;
 

--- a/test/OpenTelemetry.Tests.Stress.Metrics/Program.cs
+++ b/test/OpenTelemetry.Tests.Stress.Metrics/Program.cs
@@ -14,10 +14,8 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Diagnostics.Metrics;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using OpenTelemetry.Metrics;
 
 namespace OpenTelemetry.Tests.Stress;

--- a/test/OpenTelemetry.Tests.Stress/Skeleton.cs
+++ b/test/OpenTelemetry.Tests.Stress/Skeleton.cs
@@ -14,13 +14,9 @@
 // limitations under the License.
 // </copyright>
 
-using System;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Threading;
-using System.Threading.Tasks;
 using OpenTelemetry.Metrics;
 
 namespace OpenTelemetry.Tests.Stress;

--- a/test/TestApp.AspNetCore/Controllers/ChildActivityController.cs
+++ b/test/TestApp.AspNetCore/Controllers/ChildActivityController.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using OpenTelemetry;

--- a/test/TestApp.AspNetCore/Controllers/ValuesController.cs
+++ b/test/TestApp.AspNetCore/Controllers/ValuesController.cs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
-using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
 
 namespace TestApp.AspNetCore.Controllers


### PR DESCRIPTION
## Changes
- Remove unnecessary using statements from docs, examples, Benchmarks and Stress Tests
