### PR TITLE
Allow tests from different classes within an assembly to run in parallel

### DIFF
--- a/build/xunit.runner.json
+++ b/build/xunit.runner.json
@@ -1,4 +1,2 @@
-﻿{
-  "maxParallelThreads": 1,
-  "parallelizeTestCollections": false
+{
 }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/AssemblyInfo.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/AssemblyInfo.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/AssemblyInfo.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/test/OpenTelemetry.Tests/AssemblyInfo.cs
+++ b/test/OpenTelemetry.Tests/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+// <copyright file="AssemblyInfo.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
## Changes
- Updated `xunit.runner.json` to allow for tests from different classes within an assembly to run in parallel
- Kept the `xunit.runner.json` file to conveniently make changes in future if required
- Added `AssemblyInfo.cs` to AspNetCore, Http, OTLP, and OpenTelemetry test projects to exclude them from having their tests from different classes run in parallel. The tests in these projects are not setup to be allowed to run in parallel.

This has reduced the run time for the build-test workflow for Windows by one minute.

Note: The changes in this PR do not enable tests from different assemblies to run in parallel. The tests for each assembly would still be run sequentially. It only allows for tests from different tests collections within the same assembly to be run in parallel. Here's the link to the xUnit docs for more information: https://xunit.net/docs/running-tests-in-parallel