### PR TITLE
Update versions of common packages used in tests and examples

### DIFF
--- a/OpenTelemetry.sln
+++ b/OpenTelemetry.sln
@@ -104,6 +104,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\markdownlint.yml = .github\workflows\markdownlint.yml
 		.github\workflows\publish-packages-1.0.yml = .github\workflows\publish-packages-1.0.yml
 		.github\workflows\sanitycheck.yml = .github\workflows\sanitycheck.yml
+		.github\workflows\stale.yml = .github\workflows\stale.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{C1542297-8763-4DF4-957C-489ED771C21D}"

--- a/build/Common.nonprod.props
+++ b/build/Common.nonprod.props
@@ -30,7 +30,7 @@
       Please sort alphabetically.
       Refer to https://docs.microsoft.com/nuget/concepts/package-versioning for semver syntax.
     -->
-    <BenchmarkDotNetPkgVer>[0.13.2,0.14)</BenchmarkDotNetPkgVer>
+    <BenchmarkDotNetPkgVer>[0.13.3,0.14)</BenchmarkDotNetPkgVer>
     <CommandLineParserPkgVer>[2.3.0,3.0)</CommandLineParserPkgVer>
     <DotNetXUnitCliVer>[2.3.1,3.0)</DotNetXUnitCliVer>
     <GoogleProtobufPkgVer>[3.19.4,4.0)</GoogleProtobufPkgVer>

--- a/build/Common.nonprod.props
+++ b/build/Common.nonprod.props
@@ -31,18 +31,18 @@
       Refer to https://docs.microsoft.com/nuget/concepts/package-versioning for semver syntax.
     -->
     <BenchmarkDotNetPkgVer>[0.13.3,0.14)</BenchmarkDotNetPkgVer>
-    <CommandLineParserPkgVer>[2.3.0,3.0)</CommandLineParserPkgVer>
+    <CommandLineParserPkgVer>[2.9.1,3.0)</CommandLineParserPkgVer>
     <DotNetXUnitCliVer>[2.3.1,3.0)</DotNetXUnitCliVer>
     <GoogleProtobufPkgVer>[3.19.4,4.0)</GoogleProtobufPkgVer>
-    <GrpcAspNetCorePkgVer>[2.48.0,3.0)</GrpcAspNetCorePkgVer>
+    <GrpcAspNetCorePkgVer>[2.50.0,3.0)</GrpcAspNetCorePkgVer>
     <GrpcAspNetCoreServerPkgVer>[2.48.0, 3.0)</GrpcAspNetCoreServerPkgVer>
     <GrpcToolsPkgVer>[2.48.0,3.0)</GrpcToolsPkgVer>
     <MicrosoftExtensionsHostingPkgVer>[3.1.6,5.0)</MicrosoftExtensionsHostingPkgVer>
     <MicrosoftExtensionsLoggingPkgVer>[6.0.0,)</MicrosoftExtensionsLoggingPkgVer>
     <MicrosoftExtensionsLoggingAbstractionsPkgVer>[6.0.0,)</MicrosoftExtensionsLoggingAbstractionsPkgVer>
-    <MicrosoftNETTestSdkPkgVer>[17.3.0]</MicrosoftNETTestSdkPkgVer>
+    <MicrosoftNETTestSdkPkgVer>[17.4.1]</MicrosoftNETTestSdkPkgVer>
     <MoqPkgVer>[4.18.3,5.0)</MoqPkgVer>
-    <RabbitMQClientPkgVer>[6.1.0,7.0)</RabbitMQClientPkgVer>
+    <RabbitMQClientPkgVer>[6.4.0,7.0)</RabbitMQClientPkgVer>
     <RuntimeInstrumentationPkgVer>[1.0.0,2.0)</RuntimeInstrumentationPkgVer>
     <SwashbuckleAspNetCorePkgVer>[6.4.0]</SwashbuckleAspNetCorePkgVer>
     <SystemTextJsonPkgVer>6.0.5</SystemTextJsonPkgVer>

--- a/build/Common.props
+++ b/build/Common.props
@@ -34,7 +34,7 @@
     <MicrosoftAspNetCoreHttpAbstractionsPkgVer>[2.1.1,6.0)</MicrosoftAspNetCoreHttpAbstractionsPkgVer>
     <MicrosoftAspNetCoreHttpFeaturesPkgVer>[2.1.1,6.0)</MicrosoftAspNetCoreHttpFeaturesPkgVer>
     <MicrosoftCodeAnalysisAnalyzersPkgVer>[3.3.3]</MicrosoftCodeAnalysisAnalyzersPkgVer>
-    <MicrosoftCodeCoveragePkgVer>[17.3.0]</MicrosoftCodeCoveragePkgVer>
+    <MicrosoftCodeCoveragePkgVer>[17.4.1]</MicrosoftCodeCoveragePkgVer>
     <MicrosoftExtensionsConfigurationEnvironmentVariablesPkgVer>[3.1.0,)</MicrosoftExtensionsConfigurationEnvironmentVariablesPkgVer>
     <MicrosoftExtensionsDependencyInjectionAbstractionsPkgVer>[3.1.0,)</MicrosoftExtensionsDependencyInjectionAbstractionsPkgVer>
     <MicrosoftExtensionsHostingAbstractionsPkgVer>[2.1.0,)</MicrosoftExtensionsHostingAbstractionsPkgVer>

--- a/build/Common.props
+++ b/build/Common.props
@@ -41,8 +41,8 @@
     <MicrosoftExtensionsLoggingPkgVer>[3.1.0,)</MicrosoftExtensionsLoggingPkgVer>
     <MicrosoftExtensionsLoggingConfigurationPkgVer>[3.1.0,)</MicrosoftExtensionsLoggingConfigurationPkgVer>
     <MicrosoftExtensionsOptionsPkgVer>[5.0.0,)</MicrosoftExtensionsOptionsPkgVer>
-    <MicrosoftNETFrameworkReferenceAssembliesPkgVer>[1.0.0,2.0)</MicrosoftNETFrameworkReferenceAssembliesPkgVer>
-    <MicrosoftSourceLinkGitHubPkgVer>[1.0.0,2.0)</MicrosoftSourceLinkGitHubPkgVer>
+    <MicrosoftNETFrameworkReferenceAssembliesPkgVer>[1.0.3,2.0)</MicrosoftNETFrameworkReferenceAssembliesPkgVer>
+    <MicrosoftSourceLinkGitHubPkgVer>[1.1.1,2.0)</MicrosoftSourceLinkGitHubPkgVer>
     <OpenTracingPkgVer>[0.12.1,0.13)</OpenTracingPkgVer>
     <OTelPreviousStableVer>1.3.2</OTelPreviousStableVer>
     <SerilogPkgVer>[2.8.0,3.0)</SerilogPkgVer>

--- a/build/process-codecoverage.ps1
+++ b/build/process-codecoverage.ps1
@@ -1,4 +1,4 @@
-﻿[xml]$commonProps = Get-Content -Path $PSScriptRoot\Common.props
+[xml]$commonProps = Get-Content -Path $PSScriptRoot\Common.props
 $microsoftCodeCoveragePkgVer = [string]$commonProps.Project.PropertyGroup.MicrosoftCodeCoveragePkgVer # This is collected in the format: "[16.10.0]"
 $microsoftCodeCoveragePkgVer = $microsoftCodeCoveragePkgVer.Trim();
 $microsoftCodeCoveragePkgVer = $microsoftCodeCoveragePkgVer.SubString(1, $microsoftCodeCoveragePkgVer.Length - 2) # Removing square brackets
@@ -6,7 +6,7 @@ $files = Get-ChildItem "TestResults" -Filter "*.coverage" -Recurse
 Write-Host $env:USERPROFILE
 foreach ($file in $files)
 {
-    $command = $env:USERPROFILE+ '\.nuget\packages\microsoft.codecoverage\' + $microsoftCodeCoveragePkgVer + '\build\netstandard1.0\CodeCoverage\CodeCoverage.exe analyze /output:' + $file.DirectoryName + '\' + $file.Name + '.xml '+ $file.FullName
+    $command = $env:USERPROFILE+ '\.nuget\packages\microsoft.codecoverage\' + $microsoftCodeCoveragePkgVer + '\build\netstandard2.0\CodeCoverage\CodeCoverage.exe analyze /output:' + $file.DirectoryName + '\' + $file.Name + '.xml '+ $file.FullName
     Write-Host $command
     Invoke-Expression $command
 }

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/OpenTelemetry.Instrumentation.AspNetCore.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/OpenTelemetry.Instrumentation.AspNetCore.Tests.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">


### PR DESCRIPTION
## Changes
- Update `Microsoft.SourceLink.GitHub` package version to `1.1.1`
- Update `Microsoft.NETFramework.ReferenceAssemblies` package version to `1.0.3`
- Update process Code Coverage script to use the latest version of the `Microsoft.CodeCoverage` packa
- Update versions of packages used by example and test projects
- Add `stale.yml` workflow to the solution