### PR TITLE
Update package version of Microsoft.Extensions.Options to 6.0.0 and above

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -40,7 +40,7 @@
     <MicrosoftExtensionsHostingAbstractionsPkgVer>[2.1.0,)</MicrosoftExtensionsHostingAbstractionsPkgVer>
     <MicrosoftExtensionsLoggingPkgVer>[3.1.0,)</MicrosoftExtensionsLoggingPkgVer>
     <MicrosoftExtensionsLoggingConfigurationPkgVer>[3.1.0,)</MicrosoftExtensionsLoggingConfigurationPkgVer>
-    <MicrosoftExtensionsOptionsPkgVer>[5.0.0,)</MicrosoftExtensionsOptionsPkgVer>
+    <MicrosoftExtensionsOptionsPkgVer>[6.0.0,)</MicrosoftExtensionsOptionsPkgVer>
     <MicrosoftNETFrameworkReferenceAssembliesPkgVer>[1.0.0,2.0)</MicrosoftNETFrameworkReferenceAssembliesPkgVer>
     <MicrosoftSourceLinkGitHubPkgVer>[1.0.0,2.0)</MicrosoftSourceLinkGitHubPkgVer>
     <OpenTracingPkgVer>[0.12.1,0.13)</OpenTracingPkgVer>


### PR DESCRIPTION
OpenTelemetry SDK has a dependency on `Microsoft.Extensions.Options` package. The current version specified in `Common.props` is 5.0.0 and above. The version 5.0.0 of `Microsoft.Extensions.Options` package is deprecated and no longer maintained: https://www.nuget.org/packages/Microsoft.Extensions.Options/5.0.0

## Changes
- Update package version of Microsoft.Extensions.Options to [6.0.0,)