### PR TITLE
[OtlpExporter] Registration extension configuration delegate fix

### DIFF
--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterHelperExtensions.cs
@@ -71,7 +71,7 @@ namespace OpenTelemetry.Trace
                 }
 
                 services.RegisterOptionsFactory(
-                    (sp, configuration) => new JaegerExporterOptions(
+                    (sp, configuration, name) => new JaegerExporterOptions(
                         configuration,
                         sp.GetRequiredService<IOptionsMonitor<BatchExportActivityProcessorOptions>>().Get(name)));
             });

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs/OtlpLogExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs/OtlpLogExporterHelperExtensions.cs
@@ -14,8 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+using System.Diagnostics;
 using OpenTelemetry.Exporter;
-using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Logs
 {
@@ -59,7 +59,9 @@ namespace OpenTelemetry.Logs
 
             // TODO: We are using span/activity batch environment variable keys
             // here when we should be using the ones for logs.
-            var defaultBatchOptions = exporterOptions.BatchExportProcessorOptions = new BatchExportActivityProcessorOptions();
+            var defaultBatchOptions = exporterOptions.BatchExportProcessorOptions;
+
+            Debug.Assert(defaultBatchOptions != null, "defaultBatchOptions was null");
 
             configure?.Invoke(exporterOptions);
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs/OtlpLogExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs/OtlpLogExporterHelperExtensions.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System.Runtime.Serialization;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Trace;
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs/OtlpLogExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs/OtlpLogExporterHelperExtensions.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System.Runtime.Serialization;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Trace;
 
@@ -31,7 +32,7 @@ namespace OpenTelemetry.Logs
         /// <param name="loggerOptions"><see cref="OpenTelemetryLoggerOptions"/> options to use.</param>
         /// <returns>The instance of <see cref="OpenTelemetryLoggerOptions"/> to chain the calls.</returns>
         public static OpenTelemetryLoggerOptions AddOtlpExporter(this OpenTelemetryLoggerOptions loggerOptions)
-            => AddOtlpExporter(loggerOptions, configure: null);
+            => AddOtlpExporterInternal(loggerOptions, configure: null);
 
         /// <summary>
         /// Adds OTLP Exporter as a configuration to the OpenTelemetry ILoggingBuilder.
@@ -47,14 +48,19 @@ namespace OpenTelemetry.Logs
         public static OpenTelemetryLoggerOptions AddOtlpExporter(
             this OpenTelemetryLoggerOptions loggerOptions,
             Action<OtlpExporterOptions> configure)
-            => AddOtlpExporter(loggerOptions, new(), configure);
+            => AddOtlpExporterInternal(loggerOptions, configure);
 
-        private static OpenTelemetryLoggerOptions AddOtlpExporter(
+        private static OpenTelemetryLoggerOptions AddOtlpExporterInternal(
             OpenTelemetryLoggerOptions loggerOptions,
-            OtlpExporterOptions exporterOptions,
             Action<OtlpExporterOptions> configure)
         {
             loggerOptions.ParseStateValues = true;
+
+            var exporterOptions = new OtlpExporterOptions();
+
+            // TODO: We are using span/activity batch environment variable keys
+            // here when we should be using the ones for logs.
+            var defaultBatchOptions = exporterOptions.BatchExportProcessorOptions = new BatchExportActivityProcessorOptions();
 
             configure?.Invoke(exporterOptions);
 
@@ -66,7 +72,7 @@ namespace OpenTelemetry.Logs
             }
             else
             {
-                var batchOptions = exporterOptions.BatchExportProcessorOptions ?? new BatchExportActivityProcessorOptions();
+                var batchOptions = exporterOptions.BatchExportProcessorOptions ?? defaultBatchOptions;
 
                 loggerOptions.AddProcessor(new BatchLogRecordExportProcessor(
                     otlpExporter,

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -19,6 +19,8 @@ using System.Diagnostics;
 using System.Net.Http;
 #endif
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
@@ -189,5 +191,13 @@ namespace OpenTelemetry.Exporter
         /// Gets a value indicating whether <see cref="Endpoint" /> was modified via its setter.
         /// </summary>
         internal bool ProgrammaticallyModifiedEndpoint { get; private set; }
+
+        internal static void RegisterOtlpExporterOptionsFactory(IServiceCollection services)
+        {
+            services.RegisterOptionsFactory(
+                (sp, configuration, name) => new OtlpExporterOptions(
+                    configuration,
+                    sp.GetRequiredService<IOptionsMonitor<BatchExportActivityProcessorOptions>>().Get(name)));
+        }
     }
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -53,13 +53,16 @@ namespace OpenTelemetry.Exporter
         /// Initializes a new instance of the <see cref="OtlpExporterOptions"/> class.
         /// </summary>
         public OtlpExporterOptions()
-            : this(new ConfigurationBuilder().AddEnvironmentVariables().Build())
+            : this(new ConfigurationBuilder().AddEnvironmentVariables().Build(), new())
         {
         }
 
-        internal OtlpExporterOptions(IConfiguration configuration)
+        internal OtlpExporterOptions(
+            IConfiguration configuration,
+            BatchExportActivityProcessorOptions defaultBatchOptions)
         {
             Debug.Assert(configuration != null, "configuration was null");
+            Debug.Assert(defaultBatchOptions != null, "defaultBatchOptions was null");
 
             if (configuration.TryGetUriValue(EndpointEnvVarName, out var endpoint))
             {
@@ -91,6 +94,8 @@ namespace OpenTelemetry.Exporter
                     Timeout = TimeSpan.FromMilliseconds(this.TimeoutMilliseconds),
                 };
             };
+
+            this.BatchExportProcessorOptions = defaultBatchOptions;
         }
 
         /// <summary>

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -53,13 +53,11 @@ namespace OpenTelemetry.Exporter
         /// Initializes a new instance of the <see cref="OtlpExporterOptions"/> class.
         /// </summary>
         public OtlpExporterOptions()
-            : this(new ConfigurationBuilder().AddEnvironmentVariables().Build(), new())
+            : this(new ConfigurationBuilder().AddEnvironmentVariables().Build())
         {
         }
 
-        internal OtlpExporterOptions(
-            IConfiguration configuration,
-            BatchExportActivityProcessorOptions defaultBatchOptions = null)
+        internal OtlpExporterOptions(IConfiguration configuration)
         {
             Debug.Assert(configuration != null, "configuration was null");
 
@@ -93,8 +91,6 @@ namespace OpenTelemetry.Exporter
                     Timeout = TimeSpan.FromMilliseconds(this.TimeoutMilliseconds),
                 };
             };
-
-            this.BatchExportProcessorOptions = defaultBatchOptions;
         }
 
         /// <summary>

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
@@ -18,7 +18,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Internal;
-using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Metrics
 {
@@ -69,7 +68,7 @@ namespace OpenTelemetry.Metrics
                     services.Configure(finalOptionsName, configureExporter);
                 }
 
-                OtlpTraceExporterHelperExtensions.RegisterOtlpExporterOptionsFactory(services);
+                OtlpExporterOptions.RegisterOtlpExporterOptionsFactory(services);
             });
 
             return builder.ConfigureBuilder((sp, builder) =>
@@ -127,7 +126,7 @@ namespace OpenTelemetry.Metrics
 
             builder.ConfigureServices(services =>
             {
-                OtlpTraceExporterHelperExtensions.RegisterOtlpExporterOptionsFactory(services);
+                OtlpExporterOptions.RegisterOtlpExporterOptionsFactory(services);
             });
 
             return builder.ConfigureBuilder((sp, builder) =>

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
@@ -81,7 +81,8 @@ namespace OpenTelemetry.Metrics
                     // If we are NOT using named options, we execute the
                     // configuration delegate inline. The reason for this is
                     // OtlpExporterOptions is shared by all signals. Without a
-                    // name, delegates for all signals will mix together.
+                    // name, delegates for all signals will mix together. See:
+                    // https://github.com/open-telemetry/opentelemetry-dotnet/issues/4043
                     configureExporter(exporterOptions);
                 }
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
@@ -18,6 +18,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Internal;
+using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Metrics
 {
@@ -57,25 +58,37 @@ namespace OpenTelemetry.Metrics
         {
             Guard.ThrowIfNull(builder);
 
-            name ??= Options.DefaultName;
+            var finalOptionsName = name ?? Options.DefaultName;
 
             builder.ConfigureServices(services =>
             {
-                if (configureExporter != null)
+                if (name != null && configureExporter != null)
                 {
-                    services.Configure(name, configureExporter);
+                    // If we are using named options we register the
+                    // configuration delegate into options pipeline.
+                    services.Configure(finalOptionsName, configureExporter);
                 }
 
-                services.RegisterOptionsFactory(configuration
-                    => new OtlpExporterOptions(configuration, defaultBatchOptions: null));
+                OtlpTraceExporterHelperExtensions.RegisterOtlpExporterOptionsFactory(services);
             });
 
             return builder.ConfigureBuilder((sp, builder) =>
             {
+                var exporterOptions = sp.GetRequiredService<IOptionsMonitor<OtlpExporterOptions>>().Get(finalOptionsName);
+
+                if (name == null && configureExporter != null)
+                {
+                    // If we are NOT using named options, we execute the
+                    // configuration delegate inline. The reason for this is
+                    // OtlpExporterOptions is shared by all signals. Without a
+                    // name, delegates for all signals will mix together.
+                    configureExporter(exporterOptions);
+                }
+
                 AddOtlpExporter(
                     builder,
-                    sp.GetRequiredService<IOptionsMonitor<OtlpExporterOptions>>().Get(name),
-                    sp.GetRequiredService<IOptionsMonitor<MetricReaderOptions>>().Get(name),
+                    exporterOptions,
+                    sp.GetRequiredService<IOptionsMonitor<MetricReaderOptions>>().Get(finalOptionsName),
                     sp);
             });
         }
@@ -113,8 +126,7 @@ namespace OpenTelemetry.Metrics
 
             builder.ConfigureServices(services =>
             {
-                services.RegisterOptionsFactory(configuration
-                    => new OtlpExporterOptions(configuration, defaultBatchOptions: null));
+                OtlpTraceExporterHelperExtensions.RegisterOtlpExporterOptionsFactory(services);
             });
 
             return builder.ConfigureBuilder((sp, builder) =>

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
@@ -59,32 +59,52 @@ namespace OpenTelemetry.Trace
         {
             Guard.ThrowIfNull(builder);
 
-            name ??= Options.DefaultName;
+            var finalOptionsName = name ?? Options.DefaultName;
 
             builder.ConfigureServices(services =>
             {
-                if (configure != null)
+                if (name != null && configure != null)
                 {
-                    services.Configure(name, configure);
+                    // If we are using named options we register the
+                    // configuration delegate into options pipeline.
+                    services.Configure(finalOptionsName, configure);
                 }
 
+                RegisterOtlpExporterOptionsFactory(services);
                 services.RegisterOptionsFactory(configuration => new SdkLimitOptions(configuration));
-                services.RegisterOptionsFactory(
-                    (sp, configuration) => new OtlpExporterOptions(
-                        configuration,
-                        sp.GetRequiredService<IOptionsMonitor<BatchExportActivityProcessorOptions>>().Get(name)));
             });
 
             return builder.ConfigureBuilder((sp, builder) =>
             {
-                var exporterOptions = sp.GetRequiredService<IOptionsMonitor<OtlpExporterOptions>>().Get(name);
+                var exporterOptions = sp.GetRequiredService<IOptionsMonitor<OtlpExporterOptions>>().Get(finalOptionsName);
 
-                // Note: Not using name here for SdkLimitOptions. There should
-                // only be one provider for a given service collection so
-                // SdkLimitOptions is treated as a single default instance.
+                if (name == null && configure != null)
+                {
+                    // If we are NOT using named options, we execute the
+                    // configuration delegate inline. The reason for this is
+                    // OtlpExporterOptions is shared by all signals. Without a
+                    // name, delegates for all signals will mix together.
+                    configure(exporterOptions);
+                }
+
+                // Note: Not using finalOptionsName here for SdkLimitOptions.
+                // There should only be one provider for a given service
+                // collection so SdkLimitOptions is treated as a single default
+                // instance.
                 var sdkOptionsManager = sp.GetRequiredService<IOptionsMonitor<SdkLimitOptions>>().CurrentValue;
 
                 AddOtlpExporter(builder, exporterOptions, sdkOptionsManager, sp);
+            });
+        }
+
+        internal static void RegisterOtlpExporterOptionsFactory(IServiceCollection services)
+        {
+            services.RegisterOptionsFactory((sp, configuration, name) =>
+            {
+                return new OtlpExporterOptions(configuration)
+                {
+                    BatchExportProcessorOptions = sp.GetRequiredService<IOptionsMonitor<BatchExportActivityProcessorOptions>>().Get(name),
+                };
             });
         }
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
@@ -100,13 +100,10 @@ namespace OpenTelemetry.Trace
 
         internal static void RegisterOtlpExporterOptionsFactory(IServiceCollection services)
         {
-            services.RegisterOptionsFactory((sp, configuration, name) =>
-            {
-                return new OtlpExporterOptions(configuration)
-                {
-                    BatchExportProcessorOptions = sp.GetRequiredService<IOptionsMonitor<BatchExportActivityProcessorOptions>>().Get(name),
-                };
-            });
+            services.RegisterOptionsFactory(
+                (sp, configuration, name) => new OtlpExporterOptions(
+                    configuration,
+                    sp.GetRequiredService<IOptionsMonitor<BatchExportActivityProcessorOptions>>().Get(name)));
         }
 
         internal static TracerProviderBuilder AddOtlpExporter(

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
@@ -83,7 +83,8 @@ namespace OpenTelemetry.Trace
                     // If we are NOT using named options, we execute the
                     // configuration delegate inline. The reason for this is
                     // OtlpExporterOptions is shared by all signals. Without a
-                    // name, delegates for all signals will mix together.
+                    // name, delegates for all signals will mix together. See:
+                    // https://github.com/open-telemetry/opentelemetry-dotnet/issues/4043
                     configure(exporterOptions);
                 }
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
@@ -70,7 +70,7 @@ namespace OpenTelemetry.Trace
                     services.Configure(finalOptionsName, configure);
                 }
 
-                RegisterOtlpExporterOptionsFactory(services);
+                OtlpExporterOptions.RegisterOtlpExporterOptionsFactory(services);
                 services.RegisterOptionsFactory(configuration => new SdkLimitOptions(configuration));
             });
 
@@ -96,14 +96,6 @@ namespace OpenTelemetry.Trace
 
                 AddOtlpExporter(builder, exporterOptions, sdkOptionsManager, sp);
             });
-        }
-
-        internal static void RegisterOtlpExporterOptionsFactory(IServiceCollection services)
-        {
-            services.RegisterOptionsFactory(
-                (sp, configuration, name) => new OtlpExporterOptions(
-                    configuration,
-                    sp.GetRequiredService<IOptionsMonitor<BatchExportActivityProcessorOptions>>().Get(name)));
         }
 
         internal static TracerProviderBuilder AddOtlpExporter(

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporterHelperExtensions.cs
@@ -71,7 +71,7 @@ namespace OpenTelemetry.Trace
                 }
 
                 services.RegisterOptionsFactory(
-                    (sp, configuration) => new ZipkinExporterOptions(
+                    (sp, configuration, name) => new ZipkinExporterOptions(
                         configuration,
                         sp.GetRequiredService<IOptionsMonitor<BatchExportActivityProcessorOptions>>().Get(name)));
             });

--- a/src/OpenTelemetry/Internal/ConfigurationExtensions.cs
+++ b/src/OpenTelemetry/Internal/ConfigurationExtensions.cs
@@ -125,7 +125,7 @@ internal static class ConfigurationExtensions
         services!.TryAddSingleton<IOptionsFactory<T>>(sp =>
         {
             return new DelegatingOptionsFactory<T>(
-                optionsFactoryFunc!,
+                (c, n) => optionsFactoryFunc!(c),
                 sp.GetRequiredService<IConfiguration>(),
                 sp.GetServices<IConfigureOptions<T>>(),
                 sp.GetServices<IPostConfigureOptions<T>>(),
@@ -137,7 +137,7 @@ internal static class ConfigurationExtensions
 
     public static IServiceCollection RegisterOptionsFactory<T>(
         this IServiceCollection services,
-        Func<IServiceProvider, IConfiguration, T> optionsFactoryFunc)
+        Func<IServiceProvider, IConfiguration, string, T> optionsFactoryFunc)
         where T : class
     {
         Debug.Assert(services != null, "services was null");
@@ -146,7 +146,7 @@ internal static class ConfigurationExtensions
         services!.TryAddSingleton<IOptionsFactory<T>>(sp =>
         {
             return new DelegatingOptionsFactory<T>(
-                c => optionsFactoryFunc!(sp, c),
+                (c, n) => optionsFactoryFunc!(sp, c, n),
                 sp.GetRequiredService<IConfiguration>(),
                 sp.GetServices<IConfigureOptions<T>>(),
                 sp.GetServices<IPostConfigureOptions<T>>(),
@@ -159,11 +159,11 @@ internal static class ConfigurationExtensions
     private sealed class DelegatingOptionsFactory<T> : OptionsFactory<T>
         where T : class
     {
-        private readonly Func<IConfiguration, T> optionsFactoryFunc;
+        private readonly Func<IConfiguration, string, T> optionsFactoryFunc;
         private readonly IConfiguration configuration;
 
         public DelegatingOptionsFactory(
-            Func<IConfiguration, T> optionsFactoryFunc,
+            Func<IConfiguration, string, T> optionsFactoryFunc,
             IConfiguration configuration,
             IEnumerable<IConfigureOptions<T>> setups,
             IEnumerable<IPostConfigureOptions<T>> postConfigures,
@@ -178,6 +178,6 @@ internal static class ConfigurationExtensions
         }
 
         protected override T CreateInstance(string name)
-            => this.optionsFactoryFunc(this.configuration);
+            => this.optionsFactoryFunc(this.configuration, name);
     }
 }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsTests.cs
@@ -87,7 +87,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
                 .AddInMemoryCollection(values)
                 .Build();
 
-            var options = new OtlpExporterOptions(configuration);
+            var options = new OtlpExporterOptions(configuration, new());
 
             Assert.Equal(new Uri("http://test:8888"), options.Endpoint);
             Assert.Equal("A=2,B=3", options.Headers);


### PR DESCRIPTION
Fixes #4043

[Check out #4043 for a really good writeup of the issue.]

## Changes

* Restores the 1.3 behavior (where configuration delegates were executed inline and not through Options API) for `AddOtlpExporter` extensions when named options are NOT used.
