### PR TITLE
Fix duplicate instrument registration with Views

### DIFF
--- a/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricAPITest.cs
@@ -405,7 +405,7 @@ namespace OpenTelemetry.Metrics.Tests
             // Ensure that the two instruments have different MetricStreamIdentity but the same MetricStreamName
             var meterProviderBuilder = Sdk.CreateMeterProviderBuilder()
                 .AddMeter(meter.Name)
-                .AddView("duplicateInstrumentName", new MetricStreamConfiguration { Name = "instrumentName", Description = "duplicateInstrument" }) 
+                .AddView("duplicateInstrumentName", new MetricStreamConfiguration { Name = "instrumentName", Description = "duplicateInstrument" })
                 .AddInMemoryExporter(exportedItems);
 
             using var meterProvider = meterProviderBuilder.Build();


### PR DESCRIPTION
## Changes
- Add the missing `continue` statement when a duplicate `MetricStreamName` is found when using Views. There were multiple registrations being made for the same `MetricStreamName`
- Switch the order of checks to perform the lesser computationally expensive operation to find an existing`MetricStreamName` before finding an existing `MetricStreamIdentity`
