### PR TITLE
Standardize GetHashCode implementation

### DIFF
--- a/src/OpenTelemetry.Api/Baggage.cs
+++ b/src/OpenTelemetry.Api/Baggage.cs
@@ -345,17 +345,17 @@ namespace OpenTelemetry
         {
             var baggage = this.baggage ?? EmptyBaggage;
 
-            unchecked
+            int hash = 17;
+            foreach (var item in baggage)
             {
-                int res = 17;
-                foreach (var item in baggage)
+                unchecked
                 {
-                    res = (res * 23) + baggage.Comparer.GetHashCode(item.Key);
-                    res = (res * 23) + item.Value.GetHashCode();
+                    hash = (hash * 23) + baggage.Comparer.GetHashCode(item.Key);
+                    hash = (hash * 23) + item.Value.GetHashCode();
                 }
-
-                return res;
             }
+
+            return hash;
         }
 
         private static BaggageHolder EnsureBaggageHolder()

--- a/src/OpenTelemetry.Api/Baggage.cs
+++ b/src/OpenTelemetry.Api/Baggage.cs
@@ -345,7 +345,7 @@ namespace OpenTelemetry
         {
             var baggage = this.baggage ?? EmptyBaggage;
 
-            int hash = 17;
+            var hash = 17;
             foreach (var item in baggage)
             {
                 unchecked

--- a/src/OpenTelemetry.Api/Context/Propagation/PropagationContext.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/PropagationContext.cs
@@ -71,10 +71,14 @@ namespace OpenTelemetry.Context.Propagation
         /// <inheritdoc/>
         public override int GetHashCode()
         {
-            var hashCode = 323591981;
-            hashCode = (hashCode * -1521134295) + this.ActivityContext.GetHashCode();
-            hashCode = (hashCode * -1521134295) + this.Baggage.GetHashCode();
-            return hashCode;
+            var hash = 323591981;
+            unchecked
+            {
+                hash = (hash * -1521134295) + this.ActivityContext.GetHashCode();
+                hash = (hash * -1521134295) + this.Baggage.GetHashCode();
+            }
+
+            return hash;
         }
     }
 }

--- a/src/OpenTelemetry.Api/Trace/Status.cs
+++ b/src/OpenTelemetry.Api/Trace/Status.cs
@@ -103,10 +103,14 @@ namespace OpenTelemetry.Trace
         /// <inheritdoc/>
         public override int GetHashCode()
         {
-            var result = 1;
-            result = (31 * result) + this.StatusCode.GetHashCode();
-            result = (31 * result) + (this.Description?.GetHashCode() ?? 0);
-            return result;
+            var hash = 17;
+            unchecked
+            {
+                hash = (31 * hash) + this.StatusCode.GetHashCode();
+                hash = (31 * hash) + (this.Description?.GetHashCode() ?? 0);
+            }
+
+            return hash;
         }
 
         /// <inheritdoc/>

--- a/src/OpenTelemetry/Metrics/MetricStreamIdentity.cs
+++ b/src/OpenTelemetry/Metrics/MetricStreamIdentity.cs
@@ -37,9 +37,30 @@ namespace OpenTelemetry.Metrics
             this.HistogramBucketBounds = (metricStreamConfiguration as ExplicitBucketHistogramConfiguration)?.CopiedBoundaries;
             this.HistogramRecordMinMax = (metricStreamConfiguration as HistogramConfiguration)?.RecordMinMax ?? true;
 
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
+            HashCode hashCode = default;
+            hashCode.Add(this.InstrumentType.GetHashCode());
+            hashCode.Add(this.MeterName.GetHashCode());
+            hashCode.Add(this.MeterVersion.GetHashCode());
+            hashCode.Add(this.InstrumentName.GetHashCode());
+            hashCode.Add(this.HistogramRecordMinMax.GetHashCode());
+            hashCode.Add(this.Unit.GetHashCode());
+            hashCode.Add(this.Description.GetHashCode());
+            hashCode.Add(this.ViewId?.GetHashCode() ?? 0);
+            hashCode.Add(this.TagKeys != null ? StringArrayComparer.GetHashCode(this.TagKeys) : 0);
+            if (this.HistogramBucketBounds != null)
+            {
+                for (var i = 0; i < this.HistogramBucketBounds.Length; ++i)
+                {
+                    hashCode.Add(this.HistogramBucketBounds[i].GetHashCode());
+                }
+            }
+
+            var hash = hashCode.ToHashCode();
+#else
+            var hash = 17;
             unchecked
             {
-                var hash = 17;
                 hash = (hash * 31) + this.InstrumentType.GetHashCode();
                 hash = (hash * 31) + this.MeterName.GetHashCode();
                 hash = (hash * 31) + this.MeterVersion.GetHashCode();
@@ -57,9 +78,10 @@ namespace OpenTelemetry.Metrics
                         hash = (hash * 31) + this.HistogramBucketBounds[i].GetHashCode();
                     }
                 }
-
-                this.hashCode = hash;
             }
+
+#endif
+            this.hashCode = hash;
         }
 
         public string MeterName { get; }

--- a/src/OpenTelemetry/Metrics/MetricStreamIdentity.cs
+++ b/src/OpenTelemetry/Metrics/MetricStreamIdentity.cs
@@ -66,9 +66,9 @@ namespace OpenTelemetry.Metrics
                 hash = (hash * 31) + this.MeterVersion.GetHashCode();
                 hash = (hash * 31) + this.InstrumentName.GetHashCode();
                 hash = (hash * 31) + this.HistogramRecordMinMax.GetHashCode();
-                hash = (hash * 31) + this.Unit?.GetHashCode() ?? 0;
-                hash = (hash * 31) + this.Description?.GetHashCode() ?? 0;
-                hash = (hash * 31) + this.ViewId ?? 0;
+                hash = (hash * 31) + (this.Unit?.GetHashCode() ?? 0);
+                hash = (hash * 31) + (this.Description?.GetHashCode() ?? 0);
+                hash = (hash * 31) + (this.ViewId ?? 0);
                 hash = (hash * 31) + (this.TagKeys != null ? StringArrayComparer.GetHashCode(this.TagKeys) : 0);
                 if (this.HistogramBucketBounds != null)
                 {

--- a/src/OpenTelemetry/Metrics/MetricStreamIdentity.cs
+++ b/src/OpenTelemetry/Metrics/MetricStreamIdentity.cs
@@ -46,8 +46,8 @@ namespace OpenTelemetry.Metrics
             hashCode.Add(this.HistogramRecordMinMax.GetHashCode());
             hashCode.Add(this.Unit.GetHashCode());
             hashCode.Add(this.Description.GetHashCode());
-            hashCode.Add(this.ViewId?.GetHashCode() ?? 0);
-            hashCode.Add(this.TagKeys != null ? StringArrayComparer.GetHashCode(this.TagKeys) : 0);
+            hashCode.Add(this.ViewId?.GetHashCode());
+            hashCode.Add(this.TagKeys, StringArrayComparer);
             if (this.HistogramBucketBounds != null)
             {
                 for (var i = 0; i < this.HistogramBucketBounds.Length; ++i)
@@ -66,10 +66,10 @@ namespace OpenTelemetry.Metrics
                 hash = (hash * 31) + this.MeterVersion.GetHashCode();
                 hash = (hash * 31) + this.InstrumentName.GetHashCode();
                 hash = (hash * 31) + this.HistogramRecordMinMax.GetHashCode();
-                hash = this.Unit == null ? hash : (hash * 31) + this.Unit.GetHashCode();
-                hash = this.Description == null ? hash : (hash * 31) + this.Description.GetHashCode();
-                hash = !this.ViewId.HasValue ? hash : (hash * 31) + this.ViewId.Value;
-                hash = this.TagKeys == null ? hash : (hash * 31) + StringArrayComparer.GetHashCode(this.TagKeys);
+                hash = (hash * 31) + this.Unit?.GetHashCode() ?? 0;
+                hash = (hash * 31) + this.Description?.GetHashCode() ?? 0;
+                hash = (hash * 31) + this.ViewId ?? 0;
+                hash = (hash * 31) + (this.TagKeys != null ? StringArrayComparer.GetHashCode(this.TagKeys) : 0);
                 if (this.HistogramBucketBounds != null)
                 {
                     var len = this.HistogramBucketBounds.Length;

--- a/src/OpenTelemetry/Metrics/StringArrayEqualityComparer.cs
+++ b/src/OpenTelemetry/Metrics/StringArrayEqualityComparer.cs
@@ -65,7 +65,7 @@ namespace OpenTelemetry.Metrics
             {
                 unchecked
                 {
-                    hash = (hash * 31) + strings[i]?.GetHashCode() ?? 0;
+                    hash = (hash * 31) + (strings[i]?.GetHashCode() ?? 0);
                 }
             }
 #endif

--- a/src/OpenTelemetry/Metrics/StringArrayEqualityComparer.cs
+++ b/src/OpenTelemetry/Metrics/StringArrayEqualityComparer.cs
@@ -61,9 +61,9 @@ namespace OpenTelemetry.Metrics
 #else
             var hash = 17;
 
-            unchecked
+            for (int i = 0; i < strings.Length; i++)
             {
-                for (int i = 0; i < strings.Length; i++)
+                unchecked
                 {
                     hash = (hash * 31) + strings[i]?.GetHashCode() ?? 0;
                 }

--- a/src/OpenTelemetry/Metrics/StringArrayEqualityComparer.cs
+++ b/src/OpenTelemetry/Metrics/StringArrayEqualityComparer.cs
@@ -50,15 +50,25 @@ namespace OpenTelemetry.Metrics
 
         public int GetHashCode(string[] strings)
         {
-            int hash = 17;
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
+            HashCode hashCode = default;
+            for (int i = 0; i < strings.Length; i++)
+            {
+                hashCode.Add(strings[i]?.GetHashCode() ?? 0);
+            }
+
+            var hash = hashCode.ToHashCode();
+#else
+            var hash = 17;
 
             unchecked
             {
                 for (int i = 0; i < strings.Length; i++)
                 {
-                    hash = (hash * 31) + strings[i].GetHashCode();
+                    hash = (hash * 31) + strings[i]?.GetHashCode() ?? 0;
                 }
             }
+#endif
 
             return hash;
         }

--- a/src/OpenTelemetry/Metrics/Tags.cs
+++ b/src/OpenTelemetry/Metrics/Tags.cs
@@ -24,17 +24,28 @@ namespace OpenTelemetry.Metrics
         {
             this.KeyValuePairs = keyValuePairs;
 
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
+            HashCode hashCode = default;
+            for (int i = 0; i < this.KeyValuePairs.Length; i++)
+            {
+                ref var item = ref this.KeyValuePairs[i];
+                hashCode.Add(item.Key?.GetHashCode() ?? 0);
+                hashCode.Add(item.Value?.GetHashCode() ?? 0);
+            }
+
+            var hash = hashCode.ToHashCode();
+#else
             var hash = 17;
             for (int i = 0; i < this.KeyValuePairs.Length; i++)
             {
                 ref var item = ref this.KeyValuePairs[i];
-
                 unchecked
                 {
-                    hash = (hash * 31) + item.Key.GetHashCode();
+                    hash = (hash * 31) + item.Key?.GetHashCode() ?? 0;
                     hash = (hash * 31) + item.Value?.GetHashCode() ?? 0;
                 }
             }
+#endif
 
             this.hashCode = hash;
         }
@@ -71,7 +82,7 @@ namespace OpenTelemetry.Metrics
                 }
 
                 // Equality check for Values
-                if (!left.Value?.Equals(other.KeyValuePairs[i].Value) ?? right.Value != null)
+                if (!left.Value?.Equals(right.Value) ?? right.Value != null)
                 {
                     return false;
                 }

--- a/src/OpenTelemetry/Metrics/Tags.cs
+++ b/src/OpenTelemetry/Metrics/Tags.cs
@@ -41,8 +41,8 @@ namespace OpenTelemetry.Metrics
                 ref var item = ref this.KeyValuePairs[i];
                 unchecked
                 {
-                    hash = (hash * 31) + item.Key?.GetHashCode() ?? 0;
-                    hash = (hash * 31) + item.Value?.GetHashCode() ?? 0;
+                    hash = (hash * 31) + (item.Key?.GetHashCode() ?? 0);
+                    hash = (hash * 31) + (item.Value?.GetHashCode() ?? 0);
                 }
             }
 #endif

--- a/src/OpenTelemetry/Trace/SamplingResult.cs
+++ b/src/OpenTelemetry/Trace/SamplingResult.cs
@@ -130,7 +130,7 @@ namespace OpenTelemetry.Trace
             {
                 hash = (31 * hash) + this.Decision.GetHashCode();
                 hash = (31 * hash) + this.Attributes.GetHashCode();
-                hash = (31 * hash) + this.TraceStateString?.GetHashCode() ?? 0;
+                hash = (31 * hash) + (this.TraceStateString?.GetHashCode() ?? 0);
             }
 #endif
             return hash;

--- a/src/OpenTelemetry/Trace/SamplingResult.cs
+++ b/src/OpenTelemetry/Trace/SamplingResult.cs
@@ -117,11 +117,23 @@ namespace OpenTelemetry.Trace
         /// <inheritdoc/>
         public override int GetHashCode()
         {
-            var result = 1;
-            result = (31 * result) + this.Decision.GetHashCode();
-            result = (31 * result) + this.Attributes.GetHashCode();
-            result = this.TraceStateString == null ? result : (result * 31) + this.TraceStateString.GetHashCode();
-            return result;
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
+            HashCode hashCode = default;
+            hashCode.Add(this.Decision.GetHashCode());
+            hashCode.Add(this.Attributes.GetHashCode());
+            hashCode.Add(this.TraceStateString?.GetHashCode() ?? 0);
+
+            var hash = hashCode.ToHashCode();
+#else
+            var hash = 17;
+            unchecked
+            {
+                hash = (31 * hash) + this.Decision.GetHashCode();
+                hash = (31 * hash) + this.Attributes.GetHashCode();
+                hash = this.TraceStateString == null ? hash : (hash * 31) + this.TraceStateString.GetHashCode();
+            }
+#endif
+            return hash;
         }
 
         /// <inheritdoc/>

--- a/src/OpenTelemetry/Trace/SamplingResult.cs
+++ b/src/OpenTelemetry/Trace/SamplingResult.cs
@@ -130,7 +130,7 @@ namespace OpenTelemetry.Trace
             {
                 hash = (31 * hash) + this.Decision.GetHashCode();
                 hash = (31 * hash) + this.Attributes.GetHashCode();
-                hash = this.TraceStateString == null ? hash : (hash * 31) + this.TraceStateString.GetHashCode();
+                hash = (31 * hash) + this.TraceStateString?.GetHashCode() ?? 0;
             }
 #endif
             return hash;

--- a/test/Benchmarks/Metrics/MetricsBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricsBenchmarks.cs
@@ -30,21 +30,20 @@ Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
   [Host]     : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
   DefaultJob : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
 
-
 |                    Method | AggregationTemporality |      Mean |    Error |   StdDev | Allocated |
 |-------------------------- |----------------------- |----------:|---------:|---------:|----------:|
-|            CounterHotPath |             Cumulative |  13.82 ns | 0.020 ns | 0.018 ns |         - |
-| CounterWith1LabelsHotPath |             Cumulative |  61.06 ns | 0.276 ns | 0.231 ns |         - |
-| CounterWith3LabelsHotPath |             Cumulative | 135.11 ns | 0.609 ns | 0.540 ns |         - |
-| CounterWith5LabelsHotPath |             Cumulative | 207.05 ns | 0.232 ns | 0.181 ns |         - |
-| CounterWith6LabelsHotPath |             Cumulative | 235.28 ns | 0.513 ns | 0.480 ns |         - |
-| CounterWith7LabelsHotPath |             Cumulative | 261.48 ns | 0.665 ns | 0.589 ns |         - |
-|            CounterHotPath |                  Delta |  13.88 ns | 0.110 ns | 0.103 ns |         - |
-| CounterWith1LabelsHotPath |                  Delta |  58.28 ns | 0.375 ns | 0.351 ns |         - |
-| CounterWith3LabelsHotPath |                  Delta | 128.66 ns | 0.246 ns | 0.230 ns |         - |
-| CounterWith5LabelsHotPath |                  Delta | 210.62 ns | 1.246 ns | 1.166 ns |         - |
-| CounterWith6LabelsHotPath |                  Delta | 233.51 ns | 0.656 ns | 0.614 ns |         - |
-| CounterWith7LabelsHotPath |                  Delta | 263.35 ns | 0.865 ns | 0.766 ns |         - |
+|            CounterHotPath |             Cumulative |  13.83 ns | 0.030 ns | 0.026 ns |         - |
+| CounterWith1LabelsHotPath |             Cumulative |  60.59 ns | 0.075 ns | 0.067 ns |         - |
+| CounterWith3LabelsHotPath |             Cumulative | 141.04 ns | 0.422 ns | 0.395 ns |         - |
+| CounterWith5LabelsHotPath |             Cumulative | 221.42 ns | 0.923 ns | 0.818 ns |         - |
+| CounterWith6LabelsHotPath |             Cumulative | 252.18 ns | 1.040 ns | 0.973 ns |         - |
+| CounterWith7LabelsHotPath |             Cumulative | 278.59 ns | 0.457 ns | 0.428 ns |         - |
+|            CounterHotPath |                  Delta |  13.76 ns | 0.024 ns | 0.023 ns |         - |
+| CounterWith1LabelsHotPath |                  Delta |  62.50 ns | 0.094 ns | 0.083 ns |         - |
+| CounterWith3LabelsHotPath |                  Delta | 140.97 ns | 0.590 ns | 0.523 ns |         - |
+| CounterWith5LabelsHotPath |                  Delta | 222.37 ns | 0.467 ns | 0.390 ns |         - |
+| CounterWith6LabelsHotPath |                  Delta | 254.25 ns | 1.387 ns | 1.298 ns |         - |
+| CounterWith7LabelsHotPath |                  Delta | 279.22 ns | 0.843 ns | 0.747 ns |         - |
 */
 
 namespace Benchmarks.Metrics


### PR DESCRIPTION
## Changes
- Use `HashCode.Add` and `HashCode.ToHashCode` methods to generate the HashCode on `netstandard2.1` and `net6.0` and greater
- Add zero for values that could be null
- Add missing unchecked blocks
