### PR TITLE
Support customized OTLP endpoint for log example

### DIFF
--- a/examples/Console/Program.cs
+++ b/examples/Console/Program.cs
@@ -162,6 +162,9 @@ namespace Examples.Console
         [Option("useExporter", Default = "otlp", HelpText = "Options include otlp or console.", Required = false)]
         public string UseExporter { get; set; }
 
+        [Option('e', "endpoint", HelpText = "Target to which the OTLP exporter is going to send logs (default value depends on protocol).", Default = null)]
+        public string Endpoint { get; set; }
+
         [Option('p', "protocol", HelpText = "Transport protocol used by OTLP exporter. Supported values: grpc and http/protobuf. Only applicable if Exporter is OTLP", Default = "grpc")]
         public string Protocol { get; set; }
     }

--- a/examples/Console/TestLogs.cs
+++ b/examples/Console/TestLogs.cs
@@ -47,7 +47,7 @@ namespace Examples.Console
                          * Open another terminal window at the examples/Console/ directory and
                          * launch the OTLP example by running:
                          *
-                         *     dotnet run logs --useExporter otlp
+                         *     dotnet run logs --useExporter otlp -e http://localhost:4317
                          *
                          * The OpenTelemetry Collector will output all received logs to the stdout of its terminal.
                          *
@@ -58,28 +58,29 @@ namespace Examples.Console
                         // See: https://docs.microsoft.com/aspnet/core/grpc/troubleshoot#call-insecure-grpc-services-with-net-core-client
                         AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
 
+                        var protocol = OpenTelemetry.Exporter.OtlpExportProtocol.Grpc;
+
                         if (options.Protocol.Trim().ToLower().Equals("grpc"))
                         {
-                            opt.AddOtlpExporter(otlpOptions =>
-                            {
-                                otlpOptions.Protocol = OpenTelemetry.Exporter.OtlpExportProtocol.Grpc;
-                            });
+                            protocol = OpenTelemetry.Exporter.OtlpExportProtocol.Grpc;
                         }
                         else if (options.Protocol.Trim().ToLower().Equals("http/protobuf"))
                         {
-                            opt.AddOtlpExporter(otlpOptions =>
-                            {
-                                otlpOptions.Protocol = OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf;
-                            });
+                            protocol = OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf;
                         }
                         else
                         {
                             System.Console.WriteLine($"Export protocol {options.Protocol} is not supported. Default protocol 'grpc' will be used.");
-                            opt.AddOtlpExporter(otlpOptions =>
-                            {
-                                otlpOptions.Protocol = OpenTelemetry.Exporter.OtlpExportProtocol.Grpc;
-                            });
                         }
+
+                        opt.AddOtlpExporter(otlpOptions =>
+                        {
+                            otlpOptions.Protocol = protocol;
+                            if (!string.IsNullOrWhiteSpace(options.Endpoint))
+                            {
+                                otlpOptions.Endpoint = new Uri(options.Endpoint);
+                            }
+                        });
                     }
                     else
                     {


### PR DESCRIPTION
## Changes

The current OTLP example doesn't accept endpoint from command line. This PR add the support following the convention from OTLP trace/metrics exporter.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
