### PR TITLE
Fix ConsoleExporter Histogram output with correct lowerbound

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -127,6 +127,7 @@ namespace OpenTelemetry.Exporter
                                 if (histogramMeasurement.ExplicitBound != double.PositiveInfinity)
                                 {
                                     bucketsBuilder.Append(histogramMeasurement.ExplicitBound);
+                                    previousExplicitBound = histogramMeasurement.ExplicitBound;
                                 }
                                 else
                                 {


### PR DESCRIPTION
Output from Current (broken)
Value: Sum: 507522 Count: 1000 Min: 1 Max: 998 
(-Infinity,0]:0
(0,5]:8
(0,10]:5
(0,25]:16
(0,50]:23
(0,75]:18
(0,100]:25
(0,250]:140
(0,500]:254
(0,750]:250
(0,1000]:261
(0,2500]:0
(0,5000]:0
(0,7500]:0
(0,10000]:0
(0,+Infinity]:0

vs this PR output:

Value: Sum: 500293 Count: 1000 Min: 1 Max: 999
(-Infinity,0]:0
(0,5]:7
(5,10]:5
(10,25]:20
(25,50]:23
(50,75]:23
(75,100]:20
(100,250]:166
(250,500]:241
(500,750]:227
(750,1000]:268
(1000,2500]:0
(2500,5000]:0
(5000,7500]:0
(7500,10000]:0
(10000,+Infinity]:0