### PR TITLE
fix: change Environment Var parsing to not throw FormatException (part1)

### DIFF
--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Changed EnvironmentVariable parsing to not throw a `FormatException` and
+  instead log a warning.
+  ([#4095](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4095))
+
 ## 1.4.0-rc.2
 
 Released 2023-Jan-09

--- a/src/OpenTelemetry/Internal/ConfigurationExtensions.cs
+++ b/src/OpenTelemetry/Internal/ConfigurationExtensions.cs
@@ -67,7 +67,6 @@ internal static class ConfigurationExtensions
         if (!Uri.TryCreate(stringValue, UriKind.Absolute, out value))
         {
             OpenTelemetrySdkEventSource.Log.InvalidEnvironmentVariable(key, stringValue);
-            value = default;
             return false;
         }
 
@@ -88,7 +87,6 @@ internal static class ConfigurationExtensions
         if (!int.TryParse(stringValue, NumberStyles.None, CultureInfo.InvariantCulture, out value))
         {
             OpenTelemetrySdkEventSource.Log.InvalidEnvironmentVariable(key, stringValue);
-            value = default;
             return false;
         }
 
@@ -113,7 +111,6 @@ internal static class ConfigurationExtensions
         if (!tryParseFunc(stringValue!, out value))
         {
             OpenTelemetrySdkEventSource.Log.InvalidEnvironmentVariable(key, stringValue);
-            value = default;
             return false;
         }
 

--- a/src/OpenTelemetry/Internal/ConfigurationExtensions.cs
+++ b/src/OpenTelemetry/Internal/ConfigurationExtensions.cs
@@ -66,7 +66,9 @@ internal static class ConfigurationExtensions
 
         if (!Uri.TryCreate(stringValue, UriKind.Absolute, out value))
         {
-            throw new FormatException($"{key} environment variable has an invalid value: '{stringValue}'");
+            OpenTelemetrySdkEventSource.Log.InvalidEnvironmentVariable(key, stringValue);
+            value = default;
+            return false;
         }
 
         return true;
@@ -85,7 +87,9 @@ internal static class ConfigurationExtensions
 
         if (!int.TryParse(stringValue, NumberStyles.None, CultureInfo.InvariantCulture, out value))
         {
-            throw new FormatException($"{key} environment variable has an invalid value: '{stringValue}'");
+            OpenTelemetrySdkEventSource.Log.InvalidEnvironmentVariable(key, stringValue);
+            value = default;
+            return false;
         }
 
         return true;
@@ -108,7 +112,9 @@ internal static class ConfigurationExtensions
 
         if (!tryParseFunc(stringValue!, out value))
         {
-            throw new FormatException($"{key} environment variable has an invalid value: '{stringValue}'");
+            OpenTelemetrySdkEventSource.Log.InvalidEnvironmentVariable(key, stringValue);
+            value = default;
+            return false;
         }
 
         return true;

--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -409,6 +409,12 @@ namespace OpenTelemetry.Internal
             this.WriteEvent(46, message);
         }
 
+        [Event(47, Message = "{0} environment variable has an invalid value: '{1}'", Level = EventLevel.Warning)]
+        public void InvalidEnvironmentVariable(string key, string value)
+        {
+            this.WriteEvent(47, key, value);
+        }
+
 #if DEBUG
         public class OpenTelemetryEventListener : EventListener
         {

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterOptionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterOptionsTests.cs
@@ -64,7 +64,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests
             Assert.Equal(new Uri("http://custom-endpoint:12345"), options.Endpoint);
         }
 
-        [Theory]
+        [Theory(Skip = "https://github.com/open-telemetry/opentelemetry-dotnet/issues/3690")]
         [InlineData(JaegerExporterOptions.OTelAgentPortEnvVarKey)]
         [InlineData(JaegerExporterOptions.OTelProtocolEnvVarKey)]
         public void JaegerExporterOptions_InvalidEnvironmentVariableOverride(string envVar)

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsTests.cs
@@ -95,7 +95,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
             Assert.Equal(OtlpExportProtocol.HttpProtobuf, options.Protocol);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/open-telemetry/opentelemetry-dotnet/issues/3690")]
         public void OtlpExporterOptions_InvalidEndpointVariableOverride()
         {
             Environment.SetEnvironmentVariable(OtlpExporterOptions.EndpointEnvVarName, "invalid");
@@ -103,7 +103,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
             Assert.Throws<FormatException>(() => new OtlpExporterOptions());
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/open-telemetry/opentelemetry-dotnet/issues/3690")]
         public void OtlpExporterOptions_InvalidTimeoutVariableOverride()
         {
             Environment.SetEnvironmentVariable(OtlpExporterOptions.TimeoutEnvVarName, "invalid");
@@ -111,7 +111,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
             Assert.Throws<FormatException>(() => new OtlpExporterOptions());
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/open-telemetry/opentelemetry-dotnet/issues/3690")]
         public void OtlpExporterOptions_InvalidProtocolVariableOverride()
         {
             Environment.SetEnvironmentVariable(OtlpExporterOptions.ProtocolEnvVarName, "invalid");

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
@@ -189,7 +189,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Tests
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/open-telemetry/opentelemetry-dotnet/issues/3690")]
         public void ErrorGettingUriFromEnvVarSetsDefaultEndpointValue()
         {
             try

--- a/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorOptionsTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorOptionsTest.cs
@@ -82,7 +82,7 @@ namespace OpenTelemetry.Trace.Tests
             Assert.Equal(4, options.ScheduledDelayMilliseconds);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/open-telemetry/opentelemetry-dotnet/issues/3690")]
         public void BatchExportProcessorOptions_InvalidPortEnvironmentVariableOverride()
         {
             Environment.SetEnvironmentVariable(BatchExportActivityProcessorOptions.ExporterTimeoutEnvVarKey, "invalid");


### PR DESCRIPTION
Towards #3690

> According the [OTel spec](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.13.0/specification/sdk-environment-variables.md?plain=1#L24):
> 
> > For variables accepting an enum value, if the user provides a value the SDK does not recognize, the SDK MUST generate a warning and gracefully ignore the setting.


In this PR, I changed the TryParse to NOT throw `FormatException` and instead log to EventSource.
Unit tests and documentation will be fixed in a follow up PR to keep the PR a reasonable size.


## Changes
- `ConfigurationExtensions`
  remove throw FormatException and instead log a Warning in EventSource.
- temporarily disable unit tests.

  

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed
