### PR TITLE
Minor refactor on histogram metric update

### DIFF
--- a/test/Benchmarks/README.md
+++ b/test/Benchmarks/README.md
@@ -3,11 +3,11 @@
 Navigate to `./test/Benchmarks` directory and run the following command:
 
 ```sh
-dotnet run -c Release -f net6.0 -- -m
+dotnet run -c Release -f net7.0 -- -m
 ```
 
 [How to use console arguments](https://benchmarkdotnet.org/articles/guides/console-args.html)
 
 - `-m` enables MemoryDiagnoser and prints memory statistics
 - `-f` allows you to filter the benchmarks by their full name using glob patterns
-  - `dotnet run -c Release -f net6.0 -- -f *TraceBenchmarks*`
+  - `dotnet run -c Release -f net7.0 -- -f *TraceBenchmarks*`

--- a/test/OpenTelemetry.Tests.Stress.Metrics/README.md
+++ b/test/OpenTelemetry.Tests.Stress.Metrics/README.md
@@ -14,5 +14,5 @@ for `Counter` and uncomment everything related to `Histogram` in the
 Open a console, run the following command from the current folder:
 
 ```sh
-dotnet run --framework net6.0 --configuration Release
+dotnet run --framework net7.0 --configuration Release
 ```


### PR DESCRIPTION
No functionality change, just extracted all histogram update logic to own methods.
The UpdateLong already check the aggregation type, but for Histogram, it invokes UpdateDouble, which repeats the check for aggregation type. This PR avoids that and hence slightly improves perf.