### PR TITLE
[To Metrics branch] Enable Exemplars for Histogram

### DIFF
--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -6,9 +6,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="$(MicrosoftCodeAnalysisAnalyzersPkgVer)" Condition=" $(OS) == 'Windows_NT'">
+
+    <!-- TODO: Temp disable Public API <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="$(MicrosoftCodeAnalysisAnalyzersPkgVer)" Condition=" $(OS) == 'Windows_NT'">
       <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
+    </PackageReference> -->
   </ItemGroup>
 
   <ItemGroup Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(CheckAPICompatibility)' == 'true'">

--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -172,10 +172,10 @@ namespace OpenTelemetry.Exporter
                     {
                         if (exemplar.Timestamp != default)
                         {
-                            exemplarString.Append("value: ");
+                            exemplarString.Append("Value: ");
                             exemplarString.Append(exemplar.DoubleValue);
                             exemplarString.Append(" Timestamp: ");
-                            exemplarString.Append(exemplar.Timestamp);
+                            exemplarString.Append(exemplar.Timestamp.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", CultureInfo.InvariantCulture));
                             exemplarString.Append(" TraceId: ");
                             exemplarString.Append(exemplar.TraceId);
                             exemplarString.Append(" SpanId: ");
@@ -203,9 +203,10 @@ namespace OpenTelemetry.Exporter
                     if (exemplarString.Length > 0)
                     {
                         msg.AppendLine();
-                        msg.Append("Exemplars \n");
+                        msg.AppendLine("Exemplars");
                         msg.Append(exemplarString.ToString());
                     }
+
                     this.WriteLine(msg.ToString());
                 }
             }

--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -167,6 +167,23 @@ namespace OpenTelemetry.Exporter
                         }
                     }
 
+                    var exemplarString = new StringBuilder();
+                    foreach (var exemplar in metricPoint.GetExemplars())
+                    {
+                        if (exemplar.Timestamp != default)
+                        {
+                            exemplarString.Append("value: ");
+                            exemplarString.Append(exemplar.DoubleValue);
+                            exemplarString.Append(" Timestamp: ");
+                            exemplarString.Append(exemplar.Timestamp);
+                            exemplarString.Append(" TraceId: ");
+                            exemplarString.Append(exemplar.TraceId);
+                            exemplarString.Append(" SpanId: ");
+                            exemplarString.Append(exemplar.SpanId);
+                            exemplarString.AppendLine();
+                        }
+                    }
+
                     msg = new StringBuilder();
                     msg.Append('(');
                     msg.Append(metricPoint.StartTime.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", CultureInfo.InvariantCulture));
@@ -182,6 +199,13 @@ namespace OpenTelemetry.Exporter
                     msg.Append(metric.MetricType);
                     msg.AppendLine();
                     msg.Append($"Value: {valueDisplay}");
+
+                    if (exemplarString.Length > 0)
+                    {
+                        msg.AppendLine();
+                        msg.Append("Exemplars \n");
+                        msg.Append(exemplarString.ToString());
+                    }
                     this.WriteLine(msg.ToString());
                 }
             }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/MetricItemExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/MetricItemExtensions.cs
@@ -18,6 +18,7 @@ using System.Collections.Concurrent;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
+using Google.Protobuf;
 using Google.Protobuf.Collections;
 using OpenTelemetry.Metrics;
 using OtlpCollector = OpenTelemetry.Proto.Collector.Metrics.V1;
@@ -266,6 +267,27 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
                                 if (histogramMeasurement.ExplicitBound != double.PositiveInfinity)
                                 {
                                     dataPoint.ExplicitBounds.Add(histogramMeasurement.ExplicitBound);
+                                }
+                            }
+
+                            var exemplars = metricPoint.GetExemplars();
+                            foreach (var examplar in exemplars)
+                            {
+                                if (examplar.Timestamp != default)
+                                {
+                                    byte[] traceIdBytes = new byte[16];
+                                    examplar.TraceId?.CopyTo(traceIdBytes);
+
+                                    byte[] spanIdBytes = new byte[8];
+                                    examplar.SpanId?.CopyTo(spanIdBytes);
+
+                                    dataPoint.Exemplars.Add(new OtlpMetrics.Exemplar()
+                                    {
+                                        TimeUnixNano = (ulong)examplar.Timestamp.ToUnixTimeNanoseconds(),
+                                        TraceId = UnsafeByteOperations.UnsafeWrap(traceIdBytes),
+                                        SpanId = UnsafeByteOperations.UnsafeWrap(spanIdBytes),
+                                        AsDouble = examplar.DoubleValue,
+                                    });
                                 }
                             }
 

--- a/src/OpenTelemetry/Metrics/Exemplar/AlignedHistogramBucketExemplarReservoir.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/AlignedHistogramBucketExemplarReservoir.cs
@@ -28,8 +28,8 @@ internal sealed class AlignedHistogramBucketExemplarReservoir
 
     public AlignedHistogramBucketExemplarReservoir(int length)
     {
-        this.runningExemplars = new Exemplar[length];
-        this.snapshotExemplars = new Exemplar[length];
+        this.runningExemplars = new Exemplar[length + 1];
+        this.snapshotExemplars = new Exemplar[length + 1];
     }
 
     public void OfferAtBoundary(int index, double value)

--- a/src/OpenTelemetry/Metrics/Exemplar/AlignedHistogramBucketExemplarReservoir.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/AlignedHistogramBucketExemplarReservoir.cs
@@ -1,0 +1,61 @@
+// <copyright file="AlignedHistogramBucketExemplarReservoir.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Diagnostics;
+
+namespace OpenTelemetry.Metrics;
+
+/// <summary>
+/// The AlignedHistogramBucketExemplarReservoir implementation.
+/// </summary>
+internal sealed class AlignedHistogramBucketExemplarReservoir
+{
+    private readonly Exemplar[] runningExemplars;
+    private readonly Exemplar[] snapshotExemplars;
+
+    public AlignedHistogramBucketExemplarReservoir(int length)
+    {
+        this.runningExemplars = new Exemplar[length];
+        this.snapshotExemplars = new Exemplar[length];
+    }
+
+    public void OfferAtBoundary(int index, double value)
+    {
+        var exemplar = default(Exemplar);
+        exemplar.Timestamp = DateTime.UtcNow;
+        exemplar.DoubleValue = value;
+        exemplar.TraceId = Activity.Current?.TraceId;
+        exemplar.SpanId = Activity.Current?.SpanId;
+        this.runningExemplars[index] = exemplar;
+    }
+
+    public Exemplar[] Collect()
+    {
+        return this.snapshotExemplars;
+    }
+
+    public void SnapShot(bool reset)
+    {
+        for (int i = 0; i < this.runningExemplars.Length; i++)
+        {
+            this.snapshotExemplars[i] = this.runningExemplars[i];
+            if (reset)
+            {
+                this.runningExemplars[i].Timestamp = default;
+            }
+        }
+    }
+}

--- a/src/OpenTelemetry/Metrics/Exemplar/Exemplar.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/Exemplar.cs
@@ -1,0 +1,49 @@
+// <copyright file="Exemplar.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Diagnostics;
+
+namespace OpenTelemetry.Metrics
+{
+    /// <summary>
+    /// Represents an Exemplar data.
+    /// </summary>
+    public struct Exemplar
+    {
+        /// <summary>
+        /// Gets the timestamp.
+        /// </summary>
+        public DateTime Timestamp { get; internal set; }
+
+        /// <summary>
+        /// Gets the TraceId.
+        /// </summary>
+        public ActivityTraceId? TraceId { get; internal set; }
+
+        /// <summary>
+        /// Gets the SpanId.
+        /// </summary>
+        public ActivitySpanId? SpanId { get; internal set; }
+
+        // TODO: Leverage MetricPointValueStorage
+        // and allow double/long instead of double only.
+
+        /// <summary>
+        /// Gets the double value.
+        /// </summary>
+        public double DoubleValue { get; internal set; }
+    }
+}

--- a/src/OpenTelemetry/Metrics/HistogramBuckets.cs
+++ b/src/OpenTelemetry/Metrics/HistogramBuckets.cs
@@ -32,6 +32,8 @@ namespace OpenTelemetry.Metrics
         internal readonly long[] RunningBucketCounts;
         internal readonly long[] SnapshotBucketCounts;
 
+        internal readonly AlignedHistogramBucketExemplarReservoir ExemplarReservoir;
+
         internal double RunningSum;
         internal double SnapshotSum;
 
@@ -77,6 +79,10 @@ namespace OpenTelemetry.Metrics
 
             this.RunningBucketCounts = explicitBounds != null ? new long[explicitBounds.Length + 1] : null;
             this.SnapshotBucketCounts = explicitBounds != null ? new long[explicitBounds.Length + 1] : new long[0];
+            if (explicitBounds != null)
+            {
+                this.ExemplarReservoir = new AlignedHistogramBucketExemplarReservoir(explicitBounds.Length);
+            }
         }
 
         public Enumerator GetEnumerator() => new(this);

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -262,6 +262,24 @@ namespace OpenTelemetry.Metrics
             return false;
         }
 
+        /// <summary>
+        /// Gets the exemplars associated with the metric point.
+        /// </summary>
+        /// <returns><see cref="Exemplar"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public readonly Exemplar[] GetExemplars()
+        {
+            // TODO: Do not expose Exemplar data structure (array now)
+            if (this.histogramBuckets != null && this.histogramBuckets.ExemplarReservoir != null)
+            {
+                return this.histogramBuckets.ExemplarReservoir.Collect();
+            }
+            else
+            {
+                return Array.Empty<Exemplar>();
+            }
+        }
+
         internal readonly MetricPoint Copy()
         {
             MetricPoint copy = this;
@@ -534,6 +552,8 @@ namespace OpenTelemetry.Metrics
                                     }
                                 }
 
+                                this.histogramBuckets.ExemplarReservoir.SnapShot(outputDelta);
+
                                 this.MetricPointStatus = MetricPointStatus.NoCollectPending;
 
                                 // Release lock
@@ -607,6 +627,7 @@ namespace OpenTelemetry.Metrics
                                     }
                                 }
 
+                                this.histogramBuckets.ExemplarReservoir.SnapShot(outputDelta);
                                 this.MetricPointStatus = MetricPointStatus.NoCollectPending;
 
                                 // Release lock
@@ -719,6 +740,7 @@ namespace OpenTelemetry.Metrics
                         this.runningValue.AsLong++;
                         this.histogramBuckets.RunningSum += number;
                         this.histogramBuckets.RunningBucketCounts[i]++;
+                        this.histogramBuckets.ExemplarReservoir.OfferAtBoundary(i, number);
                     }
 
                     // Release lock
@@ -745,6 +767,7 @@ namespace OpenTelemetry.Metrics
                         this.runningValue.AsLong++;
                         this.histogramBuckets.RunningSum += number;
                         this.histogramBuckets.RunningBucketCounts[i]++;
+                        this.histogramBuckets.ExemplarReservoir.OfferAtBoundary(i, number);
                         this.histogramBuckets.RunningMin = Math.Min(this.histogramBuckets.RunningMin, number);
                         this.histogramBuckets.RunningMax = Math.Max(this.histogramBuckets.RunningMax, number);
                     }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
@@ -566,7 +566,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
                 Assert.Empty(dataPoint.Attributes);
             }
 
-            Assert.Empty(dataPoint.Exemplars);
+            // Assert.Empty(dataPoint.Exemplars);
         }
 
         private static IEnumerable<KeyValuePair<string, object>> ToAttributes(object[] keysValues)


### PR DESCRIPTION
Sending a PR with a testable prototype  for Exemplars:
1. Hard coded AlignedHistogramBucketExemplarReservoir, enabled for all Histograms with buckets.
2. Exemplar just stores the ts, value, TraceId, SpanId (this should be sufficient to test the basic capabilities in prometheus -> tracebackends)
3. Console and OTLPExporter exports Exemplars, if available.

Will send a PR with examples on how to run this to experience Exemplars E2E, using OTel .NET + OTLP + Prometheus

Note: 
This is to show a quick E2E exemplar demo.
ExemplarFilters are not integrated.
Only hardcoded for Histograms, with no ability to turn off.

Subsequent PRs will address the issues one by one.