### PR TITLE
[sdk.metrics] Support custom metric name validation rules

### DIFF
--- a/src/OpenTelemetry/Internal/Builder/ProviderBuilderServiceCollectionExtensions.cs
+++ b/src/OpenTelemetry/Internal/Builder/ProviderBuilderServiceCollectionExtensions.cs
@@ -34,6 +34,7 @@ internal static class ProviderBuilderServiceCollectionExtensions
 
         services!.TryAddSingleton<MeterProviderBuilderSdk>();
         services!.RegisterOptionsFactory(configuration => new MetricReaderOptions(configuration));
+        services!.TryAddSingleton<MetricNameValidator>();
 
         return services!;
     }
@@ -65,6 +66,8 @@ internal static class ProviderBuilderServiceCollectionExtensions
         // those cases.
         services!.TryAddSingleton<IConfiguration>(
             sp => new ConfigurationBuilder().AddEnvironmentVariables().Build());
+
+        services!.RegisterOptionsFactory(configuration => new SdkExperimentalOptions(configuration));
 
         return services!;
     }

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderSdk.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderSdk.cs
@@ -34,7 +34,6 @@ namespace OpenTelemetry.Metrics
         private const string DefaultInstrumentationVersion = "1.0.0.0";
 
         private readonly IServiceProvider serviceProvider;
-
         private MeterProviderSdk? meterProvider;
 
         public MeterProviderBuilderSdk(IServiceProvider serviceProvider)

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderSdk.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderSdk.cs
@@ -18,7 +18,6 @@
 
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
-using System.Text.RegularExpressions;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Resources;
@@ -34,10 +33,8 @@ namespace OpenTelemetry.Metrics
         public const int MaxMetricPointsPerMetricDefault = 2000;
         private const string DefaultInstrumentationVersion = "1.0.0.0";
 
-        private static readonly Regex InstrumentNameRegex = new(
-            @"^[a-z][a-z0-9-._]{0,62}$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
         private readonly IServiceProvider serviceProvider;
+
         private MeterProviderSdk? meterProvider;
 
         public MeterProviderBuilderSdk(IServiceProvider serviceProvider)
@@ -60,39 +57,6 @@ namespace OpenTelemetry.Metrics
         public int MaxMetricStreams { get; private set; } = MaxMetricsDefault;
 
         public int MaxMetricPointsPerMetricStream { get; private set; } = MaxMetricPointsPerMetricDefault;
-
-        /// <summary>
-        /// Returns whether the given instrument name is valid according to the specification.
-        /// </summary>
-        /// <remarks>See specification: <see href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument"/>.</remarks>
-        /// <param name="instrumentName">The instrument name.</param>
-        /// <returns>Boolean indicating if the instrument is valid.</returns>
-        public static bool IsValidInstrumentName(string instrumentName)
-        {
-            if (string.IsNullOrWhiteSpace(instrumentName))
-            {
-                return false;
-            }
-
-            return InstrumentNameRegex.IsMatch(instrumentName);
-        }
-
-        /// <summary>
-        /// Returns whether the given custom view name is valid according to the specification.
-        /// </summary>
-        /// <remarks>See specification: <see href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument"/>.</remarks>
-        /// <param name="customViewName">The view name.</param>
-        /// <returns>Boolean indicating if the instrument is valid.</returns>
-        public static bool IsValidViewName(string customViewName)
-        {
-            // Only validate the view name in case it's not null. In case it's null, the view name will be the instrument name as per the spec.
-            if (customViewName == null)
-            {
-                return true;
-            }
-
-            return InstrumentNameRegex.IsMatch(customViewName);
-        }
 
         public void RegisterProvider(MeterProviderSdk meterProvider)
         {

--- a/src/OpenTelemetry/Metrics/CompositeMetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/CompositeMetricReaderExt.cs
@@ -68,12 +68,12 @@ namespace OpenTelemetry.Metrics
             }
         }
 
-        internal List<List<Metric>> AddMetricsSuperListWithViews(Instrument instrument, List<MetricStreamConfiguration> metricStreamConfigs)
+        internal List<List<Metric>> AddMetricsSuperListWithViews(MetricNameValidator metricNameValidator, Instrument instrument, List<MetricStreamConfiguration> metricStreamConfigs)
         {
             var metricsSuperList = new List<List<Metric>>(this.count);
             for (var cur = this.Head; cur != null; cur = cur.Next)
             {
-                var metrics = cur.Value.AddMetricsListWithViews(instrument, metricStreamConfigs);
+                var metrics = cur.Value.AddMetricsListWithViews(metricNameValidator, instrument, metricStreamConfigs);
                 metricsSuperList.Add(metrics);
             }
 

--- a/src/OpenTelemetry/Metrics/MetricNameValidator.cs
+++ b/src/OpenTelemetry/Metrics/MetricNameValidator.cs
@@ -1,0 +1,65 @@
+// <copyright file="MetricNameValidator.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#nullable enable
+
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Options;
+
+namespace OpenTelemetry.Metrics;
+
+internal sealed class MetricNameValidator
+{
+    private readonly Regex metricNameValidationRegex;
+
+    public MetricNameValidator(IOptions<SdkExperimentalOptions> options)
+    {
+        this.metricNameValidationRegex = new(options.Value.MetricNameValidationRegex, RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    }
+
+    /// <summary>
+    /// Returns whether the given instrument name is valid according to the specification.
+    /// </summary>
+    /// <remarks>See specification: <see href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument"/>.</remarks>
+    /// <param name="instrumentName">The instrument name.</param>
+    /// <returns>Boolean indicating if the instrument is valid.</returns>
+    public bool IsValidInstrumentName(string instrumentName)
+    {
+        if (string.IsNullOrWhiteSpace(instrumentName))
+        {
+            return false;
+        }
+
+        return this.metricNameValidationRegex.IsMatch(instrumentName);
+    }
+
+    /// <summary>
+    /// Returns whether the given custom view name is valid according to the specification.
+    /// </summary>
+    /// <remarks>See specification: <see href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument"/>.</remarks>
+    /// <param name="customViewName">The view name.</param>
+    /// <returns>Boolean indicating if the instrument is valid.</returns>
+    public bool IsValidViewName(string? customViewName)
+    {
+        // Only validate the view name in case it's not null. In case it's null, the view name will be the instrument name as per the spec.
+        if (customViewName == null)
+        {
+            return true;
+        }
+
+        return this.metricNameValidationRegex.IsMatch(customViewName);
+    }
+}

--- a/src/OpenTelemetry/Metrics/MetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/MetricReaderExt.cs
@@ -99,7 +99,7 @@ namespace OpenTelemetry.Metrics
             metric.UpdateDouble(value, tags);
         }
 
-        internal List<Metric> AddMetricsListWithViews(Instrument instrument, List<MetricStreamConfiguration> metricStreamConfigs)
+        internal List<Metric> AddMetricsListWithViews(MetricNameValidator metricNameValidator, Instrument instrument, List<MetricStreamConfiguration> metricStreamConfigs)
         {
             var maxCountMetricsToBeCreated = metricStreamConfigs.Count;
 
@@ -115,7 +115,7 @@ namespace OpenTelemetry.Metrics
                     var metricStreamConfig = metricStreamConfigs[i];
                     var metricStreamIdentity = new MetricStreamIdentity(instrument, metricStreamConfig);
 
-                    if (!MeterProviderBuilderSdk.IsValidInstrumentName(metricStreamIdentity.InstrumentName))
+                    if (!metricNameValidator.IsValidInstrumentName(metricStreamIdentity.InstrumentName))
                     {
                         OpenTelemetrySdkEventSource.Log.MetricInstrumentIgnored(
                             metricStreamIdentity.InstrumentName,

--- a/src/OpenTelemetry/Metrics/MetricStreamConfiguration.cs
+++ b/src/OpenTelemetry/Metrics/MetricStreamConfiguration.cs
@@ -21,8 +21,6 @@ namespace OpenTelemetry.Metrics
     /// </summary>
     public class MetricStreamConfiguration
     {
-        private string name;
-
         /// <summary>
         /// Gets the drop configuration.
         /// </summary>
@@ -38,19 +36,7 @@ namespace OpenTelemetry.Metrics
         /// <remarks>
         /// Note: If not provided the instrument name will be used.
         /// </remarks>
-        public string Name
-        {
-            get => this.name;
-            set
-            {
-                if (value != null && !MeterProviderBuilderSdk.IsValidViewName(value))
-                {
-                    throw new ArgumentException($"Custom view name {value} is invalid.", nameof(value));
-                }
-
-                this.name = value;
-            }
-        }
+        public string Name { get; set; }
 
         /// <summary>
         /// Gets or sets the optional description of the metric stream.

--- a/src/OpenTelemetry/SdkExperimentalOptions.cs
+++ b/src/OpenTelemetry/SdkExperimentalOptions.cs
@@ -1,0 +1,73 @@
+// <copyright file="SdkExperimentalOptions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using Microsoft.Extensions.Configuration;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry;
+
+/// <summary>
+/// Contains experimental options and feature switches for the OpenTelemetry
+/// SDK.
+/// </summary>
+/// <remarks>
+/// Note: Use at your own risk. These options and features switches...
+/// <list type="bullet">
+/// <item>May change or be removed in future versions.</item>
+/// <item>May tweak behaviors which could introduce incompatibility with SDK
+/// components and/or backends.</item>
+/// </list>
+/// </remarks>
+internal sealed class SdkExperimentalOptions
+{
+    public const string MetricNameValidationConfigurationKey = "OTEL_DOTNET_EXPERIMENTAL_METRICNAMEVALIDATIONREGEX";
+    private const string DefaultMetricNameValidationRegex = @"^[a-z][a-z0-9-._]{0,62}$";
+
+    private string metricNameValidationRegex;
+
+    public SdkExperimentalOptions()
+        : this(new ConfigurationBuilder().AddEnvironmentVariables().Build())
+    {
+    }
+
+    public SdkExperimentalOptions(IConfiguration configuration)
+    {
+        Guard.ThrowIfNull(configuration);
+
+        this.metricNameValidationRegex = configuration.GetValue(MetricNameValidationConfigurationKey, DefaultMetricNameValidationRegex);
+    }
+
+    /// <summary>
+    /// Gets or sets the regular expression used to validate instrument and view
+    /// names in metrics. Default value: ^[a-z][a-z0-9-._]{0,62}$.
+    /// </summary>
+    /// <remarks>
+    /// Note: The default value is what the OpenTelemetry Specification defines
+    /// and is guaranteed to work for Prometheus and OTLP exporters. This value
+    /// may be changed but may introduce problems in exporters and/or backends.
+    /// Use at your own risk.
+    /// </remarks>
+    public string MetricNameValidationRegex
+    {
+        get => this.metricNameValidationRegex;
+        set
+        {
+            Guard.ThrowIfNullOrWhitespace(value);
+
+            this.metricNameValidationRegex = value.Trim();
+        }
+    }
+}

--- a/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
@@ -59,7 +59,7 @@ namespace OpenTelemetry.Metrics.Tests
                 .AddInMemoryExporter(exportedItems)
                 .Build());
 
-            Assert.Contains($"Custom view name {viewNewName} is invalid.", ex.Message);
+            Assert.Contains($"View name '{viewNewName}' is invalid.", ex.Message);
 
             ex = Assert.Throws<ArgumentException>(() => Sdk.CreateMeterProviderBuilder()
                 .AddMeter(meter1.Name)
@@ -67,7 +67,7 @@ namespace OpenTelemetry.Metrics.Tests
                 .AddInMemoryExporter(exportedItems)
                 .Build());
 
-            Assert.Contains($"Custom view name {viewNewName} is invalid.", ex.Message);
+            Assert.Contains($"View name '{viewNewName}' is invalid.", ex.Message);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #4136

## Changes

* Makes the metric name validation regex configurable using EnvVars/IConfiguration.

## Design Details

This PR adds an internal class called `SdkExperimentalOptions` which holds things we want to make configurable experimentally.  I worked with @alanwest on this and it borrows from Java SDK which I'm told does similar things.

## How would this be used?

`SdkExperimentalOptions` is internal but there are still ways to influence it.

### Using EnvVars

```csharp
Environment.SetEnvironmentVariable("OTEL_DOTNET_EXPERIMENTAL_METRICNAMEVALIDATIONREGEX", ".*");
```

### Using IConfiguration

```csharp
var appBuilder = WebApplication.CreateBuilder(args);

appBuilder.Configuration["OTEL_DOTNET_EXPERIMENTAL_METRICNAMEVALIDATIONREGEX"] = ".*";
```

### Using Reflection

```csharp
appBuilder.Services.SetOpenTelemetryMetricNameValidationRegex(".*");

namespace Microsoft.Extensions.DependencyInjection
{
    internal static class MyOpenTelemetryConfigurationExtensions
    {
        public static IServiceCollection SetOpenTelemetryMetricNameValidationRegex(this IServiceCollection services, string metricNameValidationRegex)
        {
            var config = new ConfigurationBuilder()
                .AddInMemoryCollection(new Dictionary<string, string> { ["MetricNameValidationRegex"] = metricNameValidationRegex })
                .Build();

            var configureMethodInfo = typeof(OptionsConfigurationServiceCollectionExtensions).GetMethod(
                "Configure",
                BindingFlags.Public | BindingFlags.Static,
                new Type[] { typeof(IServiceCollection), typeof(IConfiguration) })
                ?? throw new InvalidOperationException("OptionsConfigurationServiceCollectionExtensions.Configure method could not be found reflectively.");

            var sdkExperimentalOptionsType = typeof(OpenTelemetry.Sdk).Assembly.GetType("OpenTelemetry.SdkExperimentalOptions")
                ?? throw new InvalidOperationException("OpenTelemetry.SdkExperimentalOptions type could not be found reflectively.");

            var typedConfigureMethodInfo = configureMethodInfo.MakeGenericMethod(sdkExperimentalOptionsType);

            typedConfigureMethodInfo.Invoke(null, new object[] { services, config });

            return services;
        }
    }
}
```

## TODOs

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests