### PR TITLE
Use assembly information version for User-Agent

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 using System.Diagnostics;
+using System.Reflection;
 #if NETFRAMEWORK
 using System.Net.Http;
 #endif
@@ -51,7 +52,7 @@ namespace OpenTelemetry.Exporter
         private const OtlpExportProtocol DefaultOtlpExportProtocol = OtlpExportProtocol.Grpc;
         private const string UserAgentProduct = "OTel-OTLP-Exporter-Dotnet";
 
-        private static readonly Version UserAgentProductVersion = GetAssemblyVersion();
+        private static readonly string UserAgentProductVersion = GetAssemblyVersion();
 
         private Uri endpoint;
 
@@ -204,12 +205,12 @@ namespace OpenTelemetry.Exporter
                     sp.GetRequiredService<IOptionsMonitor<BatchExportActivityProcessorOptions>>().Get(name)));
         }
 
-        private static Version GetAssemblyVersion()
+        private static string GetAssemblyVersion()
         {
             try
             {
-                var assemblyName = typeof(OtlpExporterOptions).Assembly.GetName();
-                return assemblyName.Version;
+                var assemblyVersion = typeof(OtlpExporterOptions).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+                return assemblyVersion.InformationalVersion;
             }
             catch (Exception)
             {


### PR DESCRIPTION
## Changes

Use `AssemblyInformationalVersionAttribute` for the `User-Agent` value.

See https://github.com/open-telemetry/opentelemetry-dotnet/pull/4120/files/6f04561448ae211287f885d8b699fc68d853de29#r1094245847.

Testing locally, this currently produces a value of `1.4.0-rc.2.21+da938d797ea88c32c7cf463dda570fb594275e28`.