### PR TITLE
Sql for .net framework should call Enrich 

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
@@ -153,6 +153,15 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Implementation
                     activity.SetTag(SemanticConventions.AttributeDbStatement, commandText);
                 }
             }
+            
+            try
+            {
+                this.options.Enrich?.Invoke(activity, "OnCustom", eventData.Payload);
+            }
+            catch (Exception ex)
+            {
+                 SqlClientInstrumentationEventSource.Log.EnrichmentException(ex);
+            }
         }
 
         private void OnEndExecute(EventWrittenEventArgs eventData)

--- a/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentationOptions.cs
@@ -136,14 +136,14 @@ namespace OpenTelemetry.Instrumentation.SqlClient
         /// raw <c>SqlCommand</c> object.
         /// </summary>
         /// <remarks>
-        /// <para><b>Enrich is only executed on .NET and .NET Core
+        /// <para><b>Enrich is only executed on .NET Framework and .NET
         /// runtimes.</b></para>
         /// The parameters passed to the enrich action are:
         /// <list type="number">
         /// <item>The <see cref="Activity"/> being enriched.</item>
         /// <item>The name of the event. Currently only <c>"OnCustom"</c> is
         /// used but more events may be added in the future.</item>
-        /// <item>The raw <c>SqlCommand</c> object from which additional
+        /// <item>The raw <c>SqlCommand</c> object (.NET) or Event payload (.NET Framework) from which additional
         /// information can be extracted to enrich the <see
         /// cref="Activity"/>.</item>
         /// </list>


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-dotnet/issues/4080

## Changes

Call Enrich in the approximately the same place for .net framework as in .net.
Update docs to fix naming of .nets
Update docs to mention the difference in 3rd parameter.

