### PR TITLE
Incorporate ExemplarFilter

### DIFF
--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -41,6 +41,7 @@ namespace OpenTelemetry.Metrics
         private readonly UpdateLongDelegate updateLongCallback;
         private readonly UpdateDoubleDelegate updateDoubleCallback;
         private readonly int maxMetricPoints;
+        private readonly ExemplarFilter exemplarFilter;
         private int metricPointIndex = 0;
         private int batchSize = 0;
         private int metricCapHitMessageLogged;
@@ -63,6 +64,9 @@ namespace OpenTelemetry.Metrics
             this.outputDelta = temporality == AggregationTemporality.Delta;
             this.histogramBounds = histogramBounds;
             this.StartTimeExclusive = DateTimeOffset.UtcNow;
+
+            // TODO: Allow changing the ExemplarFilter.
+            this.exemplarFilter = new TraceBasedExemplarFilter();
             if (tagKeysInteresting == null)
             {
                 this.updateLongCallback = this.UpdateLong;
@@ -85,6 +89,13 @@ namespace OpenTelemetry.Metrics
         internal DateTimeOffset StartTimeExclusive { get; private set; }
 
         internal DateTimeOffset EndTimeInclusive { get; private set; }
+
+        internal bool IsExemplarEnabled()
+        {
+            // Using this filter to indicate On/Off
+            // instead of another separate flag.
+            return (this.exemplarFilter is not AlwaysOffExemplarFilter);
+        }
 
         internal void Update(long value, ReadOnlySpan<KeyValuePair<string, object>> tags)
         {
@@ -309,7 +320,15 @@ namespace OpenTelemetry.Metrics
                     return;
                 }
 
-                this.metricPoints[index].Update(value);
+                 // TODO: can special case built-in filters to be bit faster.
+                if (this.exemplarFilter.ShouldSample(value, tags))
+                {
+                    this.metricPoints[index].UpdateWithExemplar(value);
+                }
+                else
+                {
+                    this.metricPoints[index].Update(value);
+                }
             }
             catch (Exception)
             {
@@ -332,7 +351,15 @@ namespace OpenTelemetry.Metrics
                     return;
                 }
 
-                this.metricPoints[index].Update(value);
+                 // TODO: can special case built-in filters to be bit faster.
+                if (this.exemplarFilter.ShouldSample(value, tags))
+                {
+                    this.metricPoints[index].UpdateWithExemplar(value);
+                }
+                else
+                {
+                    this.metricPoints[index].Update(value);
+                }
             }
             catch (Exception)
             {
@@ -355,7 +382,15 @@ namespace OpenTelemetry.Metrics
                     return;
                 }
 
-                this.metricPoints[index].Update(value);
+                // TODO: can special case built-in filters to be bit faster.
+                if (this.exemplarFilter.ShouldSample(value, tags))
+                {
+                    this.metricPoints[index].UpdateWithExemplar(value);
+                }
+                else
+                {
+                    this.metricPoints[index].Update(value);
+                }
             }
             catch (Exception)
             {
@@ -378,7 +413,15 @@ namespace OpenTelemetry.Metrics
                     return;
                 }
 
-                this.metricPoints[index].Update(value);
+                // TODO: can special case built-in filters to be bit faster.
+                if (this.exemplarFilter.ShouldSample(value, tags))
+                {
+                    this.metricPoints[index].UpdateWithExemplar(value);
+                }
+                else
+                {
+                    this.metricPoints[index].Update(value);
+                }
             }
             catch (Exception)
             {

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -94,7 +94,7 @@ namespace OpenTelemetry.Metrics
         {
             // Using this filter to indicate On/Off
             // instead of another separate flag.
-            return (this.exemplarFilter is not AlwaysOffExemplarFilter);
+            return this.exemplarFilter is not AlwaysOffExemplarFilter;
         }
 
         internal void Update(long value, ReadOnlySpan<KeyValuePair<string, object>> tags)

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -320,7 +320,7 @@ namespace OpenTelemetry.Metrics
                     return;
                 }
 
-                 // TODO: can special case built-in filters to be bit faster.
+                // TODO: can special case built-in filters to be bit faster.
                 if (this.exemplarFilter.ShouldSample(value, tags))
                 {
                     this.metricPoints[index].UpdateWithExemplar(value);
@@ -351,7 +351,7 @@ namespace OpenTelemetry.Metrics
                     return;
                 }
 
-                 // TODO: can special case built-in filters to be bit faster.
+                // TODO: can special case built-in filters to be bit faster.
                 if (this.exemplarFilter.ShouldSample(value, tags))
                 {
                     this.metricPoints[index].UpdateWithExemplar(value);

--- a/src/OpenTelemetry/Metrics/HistogramBuckets.cs
+++ b/src/OpenTelemetry/Metrics/HistogramBuckets.cs
@@ -49,7 +49,7 @@ namespace OpenTelemetry.Metrics
 
         private readonly Func<double, int> findHistogramBucketIndex;
 
-        internal HistogramBuckets(double[] explicitBounds)
+        internal HistogramBuckets(double[] explicitBounds, bool enableExemplar = false)
         {
             this.ExplicitBounds = explicitBounds;
             this.findHistogramBucketIndex = this.FindBucketIndexLinear;
@@ -79,7 +79,7 @@ namespace OpenTelemetry.Metrics
 
             this.RunningBucketCounts = explicitBounds != null ? new long[explicitBounds.Length + 1] : null;
             this.SnapshotBucketCounts = explicitBounds != null ? new long[explicitBounds.Length + 1] : new long[0];
-            if (explicitBounds != null)
+            if (explicitBounds != null && enableExemplar)
             {
                 this.ExemplarReservoir = new AlignedHistogramBucketExemplarReservoir(explicitBounds.Length);
             }

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -409,7 +409,6 @@ namespace OpenTelemetry.Metrics
             this.MetricPointStatus = MetricPointStatus.CollectPending;
         }
 
-
         internal void Update(double number)
         {
             switch (this.aggType)
@@ -915,6 +914,7 @@ namespace OpenTelemetry.Metrics
                         {
                             this.histogramBuckets.ExemplarReservoir.OfferAtBoundary(i, number);
                         }
+
                         this.histogramBuckets.RunningMin = Math.Min(this.histogramBuckets.RunningMin, number);
                         this.histogramBuckets.RunningMax = Math.Max(this.histogramBuckets.RunningMax, number);
                     }


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-dotnet/issues/2527
This PR adds ExemplarFilter to the hot path. i.e In hoth path, the configured ExemplarFilter (currently hardcoded to TraceBasedFilter) is given the raw metric, and based on the decision by Filter, Exemplar is offered to Reservoir.

(Reminder that Exemplar is currently hardcoded to histogram with buckets only, to continue polishing e2e demo, which I am sending as next PR)