### PR TITLE
[To Metrics branch]Add ability to configure ExemplarFilter

### DIFF
--- a/docs/metrics/exemplars/grafana-datasources.yaml
+++ b/docs/metrics/exemplars/grafana-datasources.yaml
@@ -8,7 +8,7 @@ datasources:
   orgId: 1
   url: http://prometheus:9090
   basicAuth: false
-  isDefault: false
+  isDefault: true
   version: 1
   editable: false
   jsonData:
@@ -22,7 +22,7 @@ datasources:
   orgId: 1
   url: http://tempo:3200
   basicAuth: false
-  isDefault: true
+  isDefault: false
   version: 1
   editable: false
   apiVersion: 1

--- a/examples/AspNetCore/Program.cs
+++ b/examples/AspNetCore/Program.cs
@@ -106,6 +106,7 @@ appBuilder.Services.AddOpenTelemetry()
         // Ensure the MeterProvider subscribes to any custom Meters.
         builder
             .AddMeter(Instrumentation.MeterName)
+            .SetExemplarFilter(new TraceBasedExemplarFilter())
             .AddRuntimeInstrumentation()
             .AddHttpClientInstrumentation()
             .AddAspNetCoreInstrumentation();

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -53,7 +53,8 @@ namespace OpenTelemetry.Metrics
             AggregationTemporality temporality,
             int maxMetricPoints,
             double[] histogramBounds,
-            string[] tagKeysInteresting = null)
+            string[] tagKeysInteresting = null,
+            ExemplarFilter exemplarFilter = null)
         {
             this.name = name;
             this.maxMetricPoints = maxMetricPoints;
@@ -65,8 +66,7 @@ namespace OpenTelemetry.Metrics
             this.histogramBounds = histogramBounds;
             this.StartTimeExclusive = DateTimeOffset.UtcNow;
 
-            // TODO: Allow changing the ExemplarFilter.
-            this.exemplarFilter = new TraceBasedExemplarFilter();
+            this.exemplarFilter = exemplarFilter ?? new AlwaysOffExemplarFilter();
             if (tagKeysInteresting == null)
             {
                 this.updateLongCallback = this.UpdateLong;

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderExtensions.cs
@@ -304,6 +304,26 @@ namespace OpenTelemetry.Metrics
         }
 
         /// <summary>
+        /// Sets the <see cref="ExemplarFilter"/> to be used for this provider.
+        /// This is applied to all the metrics from this provider.
+        /// </summary>
+        /// <param name="meterProviderBuilder"><see cref="MeterProviderBuilder"/>.</param>
+        /// <param name="exemplarFilter"><see cref="ExemplarFilter"/> ExemplarFilter to use.</param>
+        /// <returns>The supplied <see cref="MeterProviderBuilder"/> for chaining.</returns>
+        public static MeterProviderBuilder SetExemplarFilter(this MeterProviderBuilder meterProviderBuilder, ExemplarFilter exemplarFilter)
+        {
+            meterProviderBuilder.ConfigureBuilder((sp, builder) =>
+            {
+                if (builder is MeterProviderBuilderSdk meterProviderBuilderSdk)
+                {
+                    meterProviderBuilderSdk.SetExemplarFilter(exemplarFilter);
+                }
+            });
+
+            return meterProviderBuilder;
+        }
+
+        /// <summary>
         /// Run the given actions to initialize the <see cref="MeterProvider"/>.
         /// </summary>
         /// <param name="meterProviderBuilder"><see cref="MeterProviderBuilder"/>.</param>

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderSdk.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderSdk.cs
@@ -49,6 +49,8 @@ namespace OpenTelemetry.Metrics
 
         public ResourceBuilder? ResourceBuilder { get; private set; }
 
+        public ExemplarFilter? ExemplarFilter { get; private set; }
+
         public MeterProvider? Provider => this.meterProvider;
 
         public List<MetricReader> Readers { get; } = new();
@@ -151,6 +153,15 @@ namespace OpenTelemetry.Metrics
             Debug.Assert(resourceBuilder != null, "resourceBuilder was null");
 
             this.ResourceBuilder = resourceBuilder;
+
+            return this;
+        }
+
+        public MeterProviderBuilder SetExemplarFilter(ExemplarFilter exemplarFilter)
+        {
+            Debug.Assert(exemplarFilter != null, "exemplarFilter was null");
+
+            this.ExemplarFilter = exemplarFilter;
 
             return this;
         }

--- a/src/OpenTelemetry/Metrics/Exemplar/AlwaysOffExemplarFilter.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/AlwaysOffExemplarFilter.cs
@@ -20,7 +20,7 @@ namespace OpenTelemetry.Metrics;
 /// An ExemplarFilter which makes no measurements eligible for being an Exemplar.
 /// Using this ExemplarFilter is as good as disabling Exemplar feature.
 /// </summary>
-internal sealed class AlwaysOffExemplarFilter : ExemplarFilter
+public sealed class AlwaysOffExemplarFilter : ExemplarFilter
 {
     public override bool ShouldSample(long value, ReadOnlySpan<KeyValuePair<string, object>> tags)
     {

--- a/src/OpenTelemetry/Metrics/Exemplar/AlwaysOnExemplarFilter.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/AlwaysOnExemplarFilter.cs
@@ -19,7 +19,7 @@ namespace OpenTelemetry.Metrics;
 /// <summary>
 /// An ExemplarFilter which makes all measurements eligible for being an Exemplar.
 /// </summary>
-internal sealed class AlwaysOnExemplarFilter : ExemplarFilter
+public sealed class AlwaysOnExemplarFilter : ExemplarFilter
 {
     public override bool ShouldSample(long value, ReadOnlySpan<KeyValuePair<string, object>> tags)
     {

--- a/src/OpenTelemetry/Metrics/Exemplar/ExemplarFilter.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/ExemplarFilter.cs
@@ -18,7 +18,7 @@ namespace OpenTelemetry.Metrics;
 /// <summary>
 /// The base class for defining Exemplar Filter.
 /// </summary>
-internal abstract class ExemplarFilter
+public abstract class ExemplarFilter
 {
     /// <summary>
     /// Determines if a given measurement is eligible for being

--- a/src/OpenTelemetry/Metrics/Exemplar/TraceBasedExemplarFilter.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/TraceBasedExemplarFilter.cs
@@ -22,7 +22,7 @@ namespace OpenTelemetry.Metrics;
 /// An ExemplarFilter which makes those measurements eligible for being an Exemplar,
 /// which are recorded in the context of a sampled parent activity (span).
 /// </summary>
-internal sealed class TraceBasedExemplarFilter : ExemplarFilter
+public sealed class TraceBasedExemplarFilter : ExemplarFilter
 {
     public override bool ShouldSample(long value, ReadOnlySpan<KeyValuePair<string, object>> tags)
     {

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -80,6 +80,7 @@ namespace OpenTelemetry.Metrics
                 reader.SetParentProvider(this);
                 reader.SetMaxMetricStreams(state.MaxMetricStreams);
                 reader.SetMaxMetricPointsPerMetricStream(state.MaxMetricPointsPerMetricStream);
+                reader.SetExemplarFilter(state.ExemplarFilter);
 
                 if (this.reader == null)
                 {

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -33,7 +33,8 @@ namespace OpenTelemetry.Metrics
             int maxMetricPointsPerMetricStream,
             double[] histogramBounds = null,
             string[] tagKeysInteresting = null,
-            bool histogramRecordMinMax = true)
+            bool histogramRecordMinMax = true,
+            ExemplarFilter exemplarFilter = null)
         {
             this.InstrumentIdentity = instrumentIdentity;
 
@@ -126,7 +127,7 @@ namespace OpenTelemetry.Metrics
                 throw new NotSupportedException($"Unsupported Instrument Type: {instrumentIdentity.InstrumentType.FullName}");
             }
 
-            this.aggStore = new AggregatorStore(instrumentIdentity.InstrumentName, aggType, temporality, maxMetricPointsPerMetricStream, histogramBounds ?? DefaultHistogramBounds, tagKeysInteresting);
+            this.aggStore = new AggregatorStore(instrumentIdentity.InstrumentName, aggType, temporality, maxMetricPointsPerMetricStream, histogramBounds ?? DefaultHistogramBounds, tagKeysInteresting, exemplarFilter);
             this.Temporality = temporality;
             this.InstrumentDisposed = false;
         }

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -692,7 +692,7 @@ namespace OpenTelemetry.Metrics
                                     }
                                 }
 
-                                this.histogramBuckets.ExemplarReservoir.SnapShot(outputDelta);
+                                this.histogramBuckets.ExemplarReservoir?.SnapShot(outputDelta);
 
                                 this.MetricPointStatus = MetricPointStatus.NoCollectPending;
 
@@ -767,7 +767,7 @@ namespace OpenTelemetry.Metrics
                                     }
                                 }
 
-                                this.histogramBuckets.ExemplarReservoir.SnapShot(outputDelta);
+                                this.histogramBuckets.ExemplarReservoir?.SnapShot(outputDelta);
                                 this.MetricPointStatus = MetricPointStatus.NoCollectPending;
 
                                 // Release lock

--- a/src/OpenTelemetry/Metrics/MetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/MetricReaderExt.cs
@@ -34,6 +34,8 @@ namespace OpenTelemetry.Metrics
         private Metric[] metricsCurrentBatch;
         private int metricIndex = -1;
 
+        private ExemplarFilter exemplarFilter;
+
         internal AggregationTemporality GetAggregationTemporality(Type instrumentType)
         {
             return this.temporalityFunc(instrumentType);
@@ -69,7 +71,7 @@ namespace OpenTelemetry.Metrics
                     Metric metric = null;
                     try
                     {
-                        metric = new Metric(metricStreamIdentity, this.GetAggregationTemporality(metricStreamIdentity.InstrumentType), this.maxMetricPointsPerMetricStream);
+                        metric = new Metric(metricStreamIdentity, this.GetAggregationTemporality(metricStreamIdentity.InstrumentType), this.maxMetricPointsPerMetricStream, exemplarFilter: this.exemplarFilter);
                     }
                     catch (NotSupportedException nse)
                     {
@@ -154,7 +156,7 @@ namespace OpenTelemetry.Metrics
                     }
                     else
                     {
-                        Metric metric = new(metricStreamIdentity, this.GetAggregationTemporality(metricStreamIdentity.InstrumentType), this.maxMetricPointsPerMetricStream, metricStreamIdentity.HistogramBucketBounds, metricStreamIdentity.TagKeys, metricStreamIdentity.HistogramRecordMinMax);
+                        Metric metric = new(metricStreamIdentity, this.GetAggregationTemporality(metricStreamIdentity.InstrumentType), this.maxMetricPointsPerMetricStream, metricStreamIdentity.HistogramBucketBounds, metricStreamIdentity.TagKeys, metricStreamIdentity.HistogramRecordMinMax, this.exemplarFilter);
 
                         this.instrumentIdentityToMetric[metricStreamIdentity] = metric;
                         this.metrics[index] = metric;
@@ -221,6 +223,11 @@ namespace OpenTelemetry.Metrics
             this.maxMetricStreams = maxMetricStreams;
             this.metrics = new Metric[maxMetricStreams];
             this.metricsCurrentBatch = new Metric[maxMetricStreams];
+        }
+
+        internal void SetExemplarFilter(ExemplarFilter exemplarFilter)
+        {
+            this.exemplarFilter = exemplarFilter;
         }
 
         internal void SetMaxMetricPointsPerMetricStream(int maxMetricPointsPerMetricStream)


### PR DESCRIPTION
Added ability to configure ExemplarFilter in MeterProvider.
Note that the Filter is at a meter provider level, and unfortunately it has no way to determine which Instrument is reporting the measurement. 
I can imagine use cases for ExemplarFilter being able to do different things for different metrics, but as of today it is not supported. (will recheck spec, and open issue in spec for this)