### PR TITLE
Added in changes for retrieving a helpful service name when none have been provided

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* Updated how the service.name is generated. It only uses unknown_service when it can't be retrieved via reflection.
+    It now is generated when possible by the Assembly Name, if the service is hosted in IIS and using .NET Framework
+    it will use the SiteName/VirtualDirectory
+  ([#2781](https://github.com/open-telemetry/opentelemetry-dotnet/issues/2781))
+
 ## 1.4.0-rc.4
 
 Released 2023-Feb-10

--- a/src/OpenTelemetry/OpenTelemetry.csproj
+++ b/src/OpenTelemetry/OpenTelemetry.csproj
@@ -17,7 +17,11 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'net6.0'">
     <RunApiCompat>false</RunApiCompat>
   </PropertyGroup>
-
+  
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
+    <Reference Include="System.Web" />
+  </ItemGroup>
+  
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="$(MicrosoftExtensionsLoggingConfigurationPkgVer)" />
   </ItemGroup>

--- a/src/OpenTelemetry/Resources/ResourceBuilder.cs
+++ b/src/OpenTelemetry/Resources/ResourceBuilder.cs
@@ -33,7 +33,7 @@ namespace OpenTelemetry.Resources
 
         static ResourceBuilder()
         {
-            string serviceName = GetServiceName();
+            string? serviceName = GetServiceName();
 
             DefaultResource = new Resource(new Dictionary<string, object>
             {
@@ -69,7 +69,7 @@ namespace OpenTelemetry.Resources
             return defaultServiceName;
         }
 
-        private static string GetGeneratedServiceName()
+        private static string? GetGeneratedServiceName()
         {
 #if NETFRAMEWORK
             // System.Web.dll is only available on .NET Framework
@@ -80,7 +80,7 @@ namespace OpenTelemetry.Resources
                 return (System.Web.Hosting.HostingEnvironment.SiteName + System.Web.Hosting.HostingEnvironment.ApplicationVirtualPath).TrimEnd('/');
             }
 #endif
-            return Assembly.GetEntryAssembly()?.GetName().Name ?? GetCurrentProcessName();
+            return Assembly.GetEntryAssembly()?.GetName().Name;
         }
 
         /// <summary>

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterTests.cs
@@ -184,7 +184,7 @@ namespace OpenTelemetry.Exporter.Jaeger.Tests
 
             jaegerTraceExporter.SetResourceAndInitializeBatch(Resource.Empty);
 
-            Assert.StartsWith("unknown_service:", process.ServiceName);
+            Assert.NotEmpty(process.ServiceName);
 
             jaegerTraceExporter.SetResourceAndInitializeBatch(ResourceBuilder.CreateEmpty().AddService("MyService").Build());
 

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/ExportClient/OtlpHttpTraceExportClientTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/ExportClient/OtlpHttpTraceExportClientTests.cs
@@ -209,7 +209,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
                 }
                 else
                 {
-                    Assert.Contains(resourceSpan.Resource.Attributes, (kvp) => kvp.Key == ResourceSemanticConventions.AttributeServiceName && kvp.Value.ToString().Contains("unknown_service:"));
+                    Assert.Contains(resourceSpan.Resource.Attributes, (kvp) => kvp.Key == ResourceSemanticConventions.AttributeServiceName && !string.IsNullOrEmpty(kvp.Value.StringValue));
                 }
             }
         }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
@@ -214,7 +214,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
             }
             else
             {
-                Assert.Contains(otlpResource.Attributes, (kvp) => kvp.Key == ResourceSemanticConventions.AttributeServiceName && kvp.Value.ToString().Contains("unknown_service:"));
+                Assert.Contains(otlpResource.Attributes, (kvp) => kvp.Key == ResourceSemanticConventions.AttributeServiceName && !string.IsNullOrEmpty(kvp.Value.StringValue));
             }
 
             Assert.Single(resourceMetric.ScopeMetrics);

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpResourceTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpResourceTests.cs
@@ -44,7 +44,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
             }
             else
             {
-                Assert.Contains(otlpResource.Attributes, (kvp) => kvp.Key == ResourceSemanticConventions.AttributeServiceName && kvp.Value.ToString().Contains("unknown_service:"));
+                Assert.Contains(otlpResource.Attributes, (kvp) => kvp.Key == ResourceSemanticConventions.AttributeServiceName && !string.IsNullOrEmpty(kvp.Value.StringValue));
             }
         }
     }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
@@ -203,7 +203,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
                 }
                 else
                 {
-                    Assert.Contains(otlpResource.Attributes, (kvp) => kvp.Key == ResourceSemanticConventions.AttributeServiceName && kvp.Value.ToString().Contains("unknown_service:"));
+                    Assert.Contains(otlpResource.Attributes, (kvp) => kvp.Key == ResourceSemanticConventions.AttributeServiceName && !string.IsNullOrEmpty(kvp.Value.StringValue));
                 }
 
                 var scopeSpans = request.ResourceSpans.First().ScopeSpans;

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
@@ -298,7 +298,7 @@ namespace OpenTelemetry.Exporter.Zipkin.Tests
 
             zipkinExporter.SetLocalEndpointFromResource(Resource.Empty);
 
-            Assert.StartsWith("unknown_service:", zipkinExporter.LocalEndpoint.ServiceName);
+            Assert.NotEmpty(zipkinExporter.LocalEndpoint.ServiceName);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes 
#2781 
https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/2189#issuecomment-1432041198
I have also opened https://github.com/open-telemetry/opentelemetry-specification/issues/3210 if this is required for the change.
## Changes

This includes checking for IIS Hosting and returning site name + virtual directory. This is consistent with how DataDog and Splunk handle this in their custom instrumentation.

Fixed tests to remove looking for unknown_service:

For significant contributions please make sure you have completed the following items:

* [x] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
* [x] Changes in public API reviewed
