### PR TITLE
[Otlp] Make sure Otlp trace and metric exporters have dedicated options instances

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* `AddOtlpExporter` extension methods will now always create a new options
+  instance when named options are NOT used.
+  ([#4200](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4200))
+
 ## 1.4.0-rc.4
 
 Released 2023-Feb-10

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
@@ -73,16 +73,25 @@ namespace OpenTelemetry.Metrics
 
             return builder.AddReader(sp =>
             {
-                var exporterOptions = sp.GetRequiredService<IOptionsMonitor<OtlpExporterOptions>>().Get(finalOptionsName);
+                OtlpExporterOptions exporterOptions;
 
-                if (name == null && configureExporter != null)
+                if (name == null)
                 {
-                    // If we are NOT using named options, we execute the
-                    // configuration delegate inline. The reason for this is
+                    // If we are NOT using named options we create a new
+                    // instance always. The reason for this is
                     // OtlpExporterOptions is shared by all signals. Without a
                     // name, delegates for all signals will mix together. See:
                     // https://github.com/open-telemetry/opentelemetry-dotnet/issues/4043
-                    configureExporter(exporterOptions);
+                    exporterOptions = sp.GetRequiredService<IOptionsFactory<OtlpExporterOptions>>().Create(finalOptionsName);
+
+                    // Configuration delegate is executed inline on the fresh instance.
+                    configureExporter?.Invoke(exporterOptions);
+                }
+                else
+                {
+                    // When using named options we can properly utilize Options
+                    // API to create or reuse an instance.
+                    exporterOptions = sp.GetRequiredService<IOptionsMonitor<OtlpExporterOptions>>().Get(finalOptionsName);
                 }
 
                 return BuildOtlpExporterMetricReader(

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
@@ -641,6 +641,8 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
         [Fact]
         public void NonnamedOptionsMutateSharedInstanceTest()
         {
+            var testOptionsInstance = new OtlpExporterOptions();
+
             OtlpExporterOptions tracerOptions = null;
             OtlpExporterOptions meterOptions = null;
 
@@ -649,11 +651,15 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
             services.AddOpenTelemetry()
                 .WithTracing(builder => builder.AddOtlpExporter(o =>
                 {
+                    Assert.Equal(testOptionsInstance.Endpoint, o.Endpoint);
+
                     tracerOptions = o;
                     o.Endpoint = new("http://localhost/traces");
                 }))
                 .WithMetrics(builder => builder.AddOtlpExporter(o =>
                 {
+                    Assert.Equal(testOptionsInstance.Endpoint, o.Endpoint);
+
                     meterOptions = o;
                     o.Endpoint = new("http://localhost/metrics");
                 }));
@@ -676,12 +682,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
             Assert.NotNull(meterOptions);
             Assert.Equal("http://localhost/metrics", meterOptions.Endpoint.OriginalString);
 
-            // Note: tracerOptions & meterOptions are actually the same instance
-            // in memory and that instance was actually mutated after
-            // OtlpTraceExporter was created but this is OK because it doesn't
-            // use the options after ctor.
-            Assert.True(ReferenceEquals(tracerOptions, meterOptions));
-            Assert.Equal("http://localhost/metrics", tracerOptions.Endpoint.OriginalString);
+            Assert.False(ReferenceEquals(tracerOptions, meterOptions));
         }
 
         [Fact]


### PR DESCRIPTION
Relates to #4043
Relates to #4058

## Changes

* This is a little deeper fix than what I did on #4058. Previously we still modified a single instance. For things like endpoint which are being set each time it isn't a problem. But considering a property like `PersistentBlobProvider` being added on #4121 if it is set for traces, metrics would inherit it unless it was cleared or set to something else. We could run into hard to detect and subtle bugs. To make it work nicely without needing some mechanism to "reset" options back to default, I decided to just make sure we new up a new instance when building the processor/exporter. The best fix would be to have dedicated classes (eg OtlpTraceExporterOptions & OtlpMetricExporterOptions) but hard to do without breaking things. @alanwest had the idea to introduce those and clean this up when we split up the projects.

Example which works fine without this change:

```
.WithTraces({
  endpoint = traceEndpoint
})
.WithMetrics({
  endpoint = metricEndpoint
})
```

Example which will be bugged without this change:
```
.WithTraces({
  endpoint = traceEndpoint
})
.WithMetrics({
  headers = metricHeaders
})
```

That second example depending on whether TracerProvider or MeterProvider is started first, either trace will have metricHeaders or metrics will have traceEndpoint.