### PR TITLE
[Otlp] Bump Google.Protobuf to 3.22.0 and remove reflection emit code

### DIFF
--- a/build/Common.nonprod.props
+++ b/build/Common.nonprod.props
@@ -33,7 +33,7 @@
     <BenchmarkDotNetPkgVer>[0.13.3,0.14)</BenchmarkDotNetPkgVer>
     <CommandLineParserPkgVer>[2.9.1,3.0)</CommandLineParserPkgVer>
     <DotNetXUnitCliVer>[2.3.1,3.0)</DotNetXUnitCliVer>
-    <GoogleProtobufPkgVer>[3.19.4,4.0)</GoogleProtobufPkgVer>
+    <GoogleProtobufPkgVer>[3.22.0,4.0)</GoogleProtobufPkgVer>
     <GrpcAspNetCorePkgVer>[2.50.0,3.0)</GrpcAspNetCorePkgVer>
     <GrpcAspNetCoreServerPkgVer>[2.48.0, 3.0)</GrpcAspNetCoreServerPkgVer>
     <GrpcToolsPkgVer>[2.48.0,3.0)</GrpcToolsPkgVer>

--- a/build/Common.props
+++ b/build/Common.props
@@ -27,7 +27,7 @@
       Refer to https://docs.microsoft.com/nuget/concepts/package-versioning for semver syntax.
     -->
     <MinVerPkgVer>[4.2.0,5.0)</MinVerPkgVer>
-    <GoogleProtobufPkgVer>[3.19.4,4.0)</GoogleProtobufPkgVer>
+    <GoogleProtobufPkgVer>[3.22.0,4.0)</GoogleProtobufPkgVer>
     <GrpcPkgVer>[2.44.0,3.0)</GrpcPkgVer>
     <GrpcNetClientPkgVer>[2.43.0,3.0)</GrpcNetClientPkgVer>
     <GrpcToolsPkgVer>[2.44.0,3.0)</GrpcToolsPkgVer>
@@ -49,7 +49,6 @@
     <StyleCopAnalyzersPkgVer>[1.2.0-beta.435,2.0)</StyleCopAnalyzersPkgVer>
     <SystemCollectionsImmutablePkgVer>1.4.0</SystemCollectionsImmutablePkgVer>
     <SystemDiagnosticSourcePkgVer>7.0.0</SystemDiagnosticSourcePkgVer>
-    <SystemReflectionEmitLightweightPkgVer>4.7.0</SystemReflectionEmitLightweightPkgVer>
     <SystemTextJsonPkgVer>4.7.2</SystemTextJsonPkgVer>
     <SystemThreadingTasksExtensionsPkgVer>4.5.4</SystemThreadingTasksExtensionsPkgVer>
   </PropertyGroup>

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/MetricItemExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/MetricItemExtensions.cs
@@ -15,8 +15,6 @@
 // </copyright>
 
 using System.Collections.Concurrent;
-using System.Reflection;
-using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 using Google.Protobuf.Collections;
 using OpenTelemetry.Metrics;
@@ -30,7 +28,6 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
     internal static class MetricItemExtensions
     {
         private static readonly ConcurrentBag<OtlpMetrics.ScopeMetrics> MetricListPool = new();
-        private static readonly Action<RepeatedField<OtlpMetrics.Metric>, int> RepeatedFieldOfMetricSetCountAction = CreateRepeatedFieldOfMetricSetCountAction();
 
         internal static void AddMetrics(
             this OtlpCollector.ExportMetricsServiceRequest request,
@@ -81,7 +78,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
 
             foreach (var scope in resourceMetrics.ScopeMetrics)
             {
-                RepeatedFieldOfMetricSetCountAction(scope.Metrics, 0);
+                scope.Metrics.Clear();
                 MetricListPool.Add(scope);
             }
         }
@@ -338,26 +335,5 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
             return otlpExemplar;
         }
         */
-
-        private static Action<RepeatedField<OtlpMetrics.Metric>, int> CreateRepeatedFieldOfMetricSetCountAction()
-        {
-            FieldInfo repeatedFieldOfMetricCountField = typeof(RepeatedField<OtlpMetrics.Metric>).GetField("count", BindingFlags.NonPublic | BindingFlags.Instance);
-
-            DynamicMethod dynamicMethod = new DynamicMethod(
-                "CreateSetCountAction",
-                null,
-                new[] { typeof(RepeatedField<OtlpMetrics.Metric>), typeof(int) },
-                typeof(MetricItemExtensions).Module,
-                skipVisibility: true);
-
-            var generator = dynamicMethod.GetILGenerator();
-
-            generator.Emit(OpCodes.Ldarg_0);
-            generator.Emit(OpCodes.Ldarg_1);
-            generator.Emit(OpCodes.Stfld, repeatedFieldOfMetricCountField);
-            generator.Emit(OpCodes.Ret);
-
-            return (Action<RepeatedField<OtlpMetrics.Metric>, int>)dynamicMethod.CreateDelegate(typeof(Action<RepeatedField<OtlpMetrics.Metric>, int>));
-        }
     }
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="Grpc" Version="$(GrpcPkgVer)" Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net462'" />
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufPkgVer)" />
     <PackageReference Include="Grpc.Tools" Version="$(GrpcToolsPkgVer)" PrivateAssets="all" />
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="$(SystemReflectionEmitLightweightPkgVer)" Condition="'$(TargetFramework)' != 'net6.0'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
[This could go in 1.4 but I think leave it out just so we can soak the 3.22.0 bump for a bit to make sure there are no unexpected issues.]

## Changes

A while back we were able to get a [change put into Protobuf](https://github.com/protocolbuffers/protobuf/issues/7828) to make the default clear behavior capacity-preserving. That is now available in 3.22.0 and allows us to remove the reflection emit perf hacks.

## TODOs

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes

