### PR TITLE
Refactor ExemplarReservoir API to merge snapshot into collect

### DIFF
--- a/src/OpenTelemetry/Metrics/Exemplar/AlignedHistogramBucketExemplarReservoir.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/AlignedHistogramBucketExemplarReservoir.cs
@@ -71,12 +71,7 @@ internal sealed class AlignedHistogramBucketExemplarReservoir
         }
     }
 
-    public Exemplar[] Collect()
-    {
-        return this.snapshotExemplars;
-    }
-
-    public void SnapShot(ReadOnlyTagCollection actualTags, bool reset)
+    public Exemplar[] Collect(ReadOnlyTagCollection actualTags, bool reset)
     {
         for (int i = 0; i < this.runningExemplars.Length; i++)
         {
@@ -85,6 +80,12 @@ internal sealed class AlignedHistogramBucketExemplarReservoir
             {
                 // TODO: Better data structure to avoid this Linq.
                 // This is doing filtered = alltags - storedtags.
+                // TODO: At this stage, this logic is done inside Reservoir.
+                // Kinda hard for end users who write own reservoirs.
+                // Evaluate if this logic can be moved elsewhere.
+                // TODO: The cost is paid irrespective of whether the
+                // Exporter supports Exemplar or not. One idea is to
+                // defer this until first exporter attempts read.
                 this.snapshotExemplars[i].FilteredTags = this.runningExemplars[i].FilteredTags.Except(actualTags.KeyAndValues.ToList()).ToList();
             }
 
@@ -93,5 +94,7 @@ internal sealed class AlignedHistogramBucketExemplarReservoir
                 this.runningExemplars[i].Timestamp = default;
             }
         }
+
+        return this.snapshotExemplars;
     }
 }

--- a/src/OpenTelemetry/Metrics/Exemplar/AlignedHistogramBucketExemplarReservoir.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/AlignedHistogramBucketExemplarReservoir.cs
@@ -24,12 +24,12 @@ namespace OpenTelemetry.Metrics;
 internal sealed class AlignedHistogramBucketExemplarReservoir
 {
     private readonly Exemplar[] runningExemplars;
-    private readonly Exemplar[] snapshotExemplars;
+    private readonly Exemplar[] tempExemplars;
 
     public AlignedHistogramBucketExemplarReservoir(int length)
     {
         this.runningExemplars = new Exemplar[length + 1];
-        this.snapshotExemplars = new Exemplar[length + 1];
+        this.tempExemplars = new Exemplar[length + 1];
     }
 
     public void OfferAtBoundary(int index, double value, ReadOnlySpan<KeyValuePair<string, object>> tags)
@@ -75,7 +75,7 @@ internal sealed class AlignedHistogramBucketExemplarReservoir
     {
         for (int i = 0; i < this.runningExemplars.Length; i++)
         {
-            this.snapshotExemplars[i] = this.runningExemplars[i];
+            this.tempExemplars[i] = this.runningExemplars[i];
             if (this.runningExemplars[i].FilteredTags != null)
             {
                 // TODO: Better data structure to avoid this Linq.
@@ -86,7 +86,7 @@ internal sealed class AlignedHistogramBucketExemplarReservoir
                 // TODO: The cost is paid irrespective of whether the
                 // Exporter supports Exemplar or not. One idea is to
                 // defer this until first exporter attempts read.
-                this.snapshotExemplars[i].FilteredTags = this.runningExemplars[i].FilteredTags.Except(actualTags.KeyAndValues.ToList()).ToList();
+                this.tempExemplars[i].FilteredTags = this.runningExemplars[i].FilteredTags.Except(actualTags.KeyAndValues.ToList()).ToList();
             }
 
             if (reset)
@@ -95,6 +95,6 @@ internal sealed class AlignedHistogramBucketExemplarReservoir
             }
         }
 
-        return this.snapshotExemplars;
+        return this.tempExemplars;
     }
 }

--- a/src/OpenTelemetry/Metrics/HistogramBuckets.cs
+++ b/src/OpenTelemetry/Metrics/HistogramBuckets.cs
@@ -45,6 +45,8 @@ namespace OpenTelemetry.Metrics
 
         internal int IsCriticalSectionOccupied = 0;
 
+        internal Exemplar[] Exemplars;
+
         private readonly BucketLookupNode bucketLookupTreeRoot;
 
         private readonly Func<double, int> findHistogramBucketIndex;

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -270,14 +270,7 @@ namespace OpenTelemetry.Metrics
         public readonly Exemplar[] GetExemplars()
         {
             // TODO: Do not expose Exemplar data structure (array now)
-            if (this.histogramBuckets != null && this.histogramBuckets.ExemplarReservoir != null)
-            {
-                return this.histogramBuckets.ExemplarReservoir.Collect();
-            }
-            else
-            {
-                return Array.Empty<Exemplar>();
-            }
+            return this.histogramBuckets?.Exemplars ?? Array.Empty<Exemplar>();
         }
 
         internal readonly MetricPoint Copy()
@@ -692,7 +685,7 @@ namespace OpenTelemetry.Metrics
                                     }
                                 }
 
-                                this.histogramBuckets.ExemplarReservoir?.SnapShot(this.Tags, outputDelta);
+                                this.histogramBuckets.Exemplars = this.histogramBuckets.ExemplarReservoir?.Collect(this.Tags, outputDelta);
 
                                 this.MetricPointStatus = MetricPointStatus.NoCollectPending;
 
@@ -767,7 +760,7 @@ namespace OpenTelemetry.Metrics
                                     }
                                 }
 
-                                this.histogramBuckets.ExemplarReservoir?.SnapShot(this.Tags, outputDelta);
+                                this.histogramBuckets.Exemplars = this.histogramBuckets.ExemplarReservoir?.Collect(this.Tags, outputDelta);
                                 this.MetricPointStatus = MetricPointStatus.NoCollectPending;
 
                                 // Release lock


### PR DESCRIPTION
Trying to get closet to spec definition of Reservoir which only has Offer and Collect. This PR merges the "snapshot" operation into Collect itself, similar to how this is done for other things like histogram buckets, min/max etc.