### PR TITLE
Fix CHANGELOG entry placement

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -161,6 +161,10 @@ Released 2022-Aug-02
   ([#3378](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3378))
 * Handle possible exception when initializing the default service name.
   ([#3405](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3405))
+* Add `ConfigureResource` which can replace SetResourceBuilder more succinctly
+  in most cases and has greater flexibility (applies to TracerProviderBuilder,
+  MeterProviderBuilder, OpenTelemetryLoggingOptions).
+  ([#3307](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3307))
 * `LogRecord` instances are now reused to reduce memory pressure
   ([#3385](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3385))
 * Fix exact match of activity source name when `wildcard` is used.
@@ -182,10 +186,6 @@ Released 2022-June-1
 * Swallow `ObjectDisposedException` in `BatchExportProcessor` and
   `PeriodicExportingMetricReader`.
   ([#3291](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3291))
-* Add `ConfigureResource` which can replace SetResourceBuilder more succinctly
-  in most cases and has greater flexibility (applies to TracerProviderBuilder,
-  MeterProviderBuilder, OpenTelemetryLoggingOptions).
-  ([#3307](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3307))
 
 ## 1.3.0-beta.2
 


### PR DESCRIPTION
This CHANGELOG entry was placed by mistake in an already released version (1.3.0-rc.2 released on 2022-June-1) during PR #3307's merge time (Jun 27, 2022).

## Changes

Moved CHANGELOG entry to the right place. It should've be appended in the `Unreleased` section of the [PR's CHANGELOG](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3307/files#diff-ed0c207aa4540884308c819edb91d46ac61fc3526b0c74f93ceddeafc7abd14a), which is a version later than 1.3.0 and after the entry for PR 3405.

For significant contributions please make sure you have completed the following items:

~~* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes~~
~~* [ ] Design discussion issue #~~
~~* [ ] Changes in public API reviewed~~
