### PR TITLE
{To metrics} Add ExemplarReservoir base class

### DIFF
--- a/src/OpenTelemetry/Metrics/Exemplar/AlignedHistogramBucketExemplarReservoir.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/AlignedHistogramBucketExemplarReservoir.cs
@@ -44,6 +44,33 @@ internal sealed class AlignedHistogramBucketExemplarReservoir : ExemplarReservoi
         this.OfferAtBoundary(value, tags, index);
     }
 
+    public override Exemplar[] Collect(ReadOnlyTagCollection actualTags, bool reset)
+    {
+        for (int i = 0; i < this.runningExemplars.Length; i++)
+        {
+            this.tempExemplars[i] = this.runningExemplars[i];
+            if (this.runningExemplars[i].FilteredTags != null)
+            {
+                // TODO: Better data structure to avoid this Linq.
+                // This is doing filtered = alltags - storedtags.
+                // TODO: At this stage, this logic is done inside Reservoir.
+                // Kinda hard for end users who write own reservoirs.
+                // Evaluate if this logic can be moved elsewhere.
+                // TODO: The cost is paid irrespective of whether the
+                // Exporter supports Exemplar or not. One idea is to
+                // defer this until first exporter attempts read.
+                this.tempExemplars[i].FilteredTags = this.runningExemplars[i].FilteredTags.Except(actualTags.KeyAndValues.ToList()).ToList();
+            }
+
+            if (reset)
+            {
+                this.runningExemplars[i].Timestamp = default;
+            }
+        }
+
+        return this.tempExemplars;
+    }
+
     private void OfferAtBoundary(double value, ReadOnlySpan<KeyValuePair<string, object>> tags, int index)
     {
         ref var exemplar = ref this.runningExemplars[index];
@@ -81,32 +108,5 @@ internal sealed class AlignedHistogramBucketExemplarReservoir : ExemplarReservoi
         {
             exemplar.FilteredTags.Add(tag);
         }
-    }
-
-    public override Exemplar[] Collect(ReadOnlyTagCollection actualTags, bool reset)
-    {
-        for (int i = 0; i < this.runningExemplars.Length; i++)
-        {
-            this.tempExemplars[i] = this.runningExemplars[i];
-            if (this.runningExemplars[i].FilteredTags != null)
-            {
-                // TODO: Better data structure to avoid this Linq.
-                // This is doing filtered = alltags - storedtags.
-                // TODO: At this stage, this logic is done inside Reservoir.
-                // Kinda hard for end users who write own reservoirs.
-                // Evaluate if this logic can be moved elsewhere.
-                // TODO: The cost is paid irrespective of whether the
-                // Exporter supports Exemplar or not. One idea is to
-                // defer this until first exporter attempts read.
-                this.tempExemplars[i].FilteredTags = this.runningExemplars[i].FilteredTags.Except(actualTags.KeyAndValues.ToList()).ToList();
-            }
-
-            if (reset)
-            {
-                this.runningExemplars[i].Timestamp = default;
-            }
-        }
-
-        return this.tempExemplars;
     }
 }

--- a/src/OpenTelemetry/Metrics/Exemplar/ExemplarReservoir.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/ExemplarReservoir.cs
@@ -1,0 +1,42 @@
+// <copyright file="ExemplarReservoir.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+namespace OpenTelemetry.Metrics;
+
+/// <summary>
+/// The base class for defining Exemplar Reservoir.
+/// </summary>
+public abstract class ExemplarReservoir
+{
+    /// <summary>
+    /// Offers measurement to the reservoir.
+    /// </summary>
+    /// <param name="value">The value of the measurement.</param>
+    /// <param name="tags">The complete set of tags provided with the measurement.</param>
+    /// <param name="index">The histogram bucket index where this measurement is going to be stored.
+    /// This is optional and is only relevant for Histogram with buckets.</param>
+    public abstract void Offer(long value, ReadOnlySpan<KeyValuePair<string, object>> tags, int index = default);
+
+    /// <summary>
+    /// Offers measurement to the reservoir.
+    /// </summary>
+    /// <param name="value">The value of the measurement.</param>
+    /// <param name="tags">The complete set of tags provided with the measurement.</param>
+    /// <param name="index">The histogram bucket index where this measurement is going to be stored.
+    /// This is optional and is only relevant for Histogram with buckets.</param>
+    public abstract void Offer(double value, ReadOnlySpan<KeyValuePair<string, object>> tags, int index = default);
+
+    public abstract Exemplar[] Collect(ReadOnlyTagCollection actualTags, bool reset);
+}

--- a/src/OpenTelemetry/Metrics/HistogramBuckets.cs
+++ b/src/OpenTelemetry/Metrics/HistogramBuckets.cs
@@ -32,7 +32,7 @@ namespace OpenTelemetry.Metrics
         internal readonly long[] RunningBucketCounts;
         internal readonly long[] SnapshotBucketCounts;
 
-        internal readonly AlignedHistogramBucketExemplarReservoir ExemplarReservoir;
+        internal readonly ExemplarReservoir ExemplarReservoir;
 
         internal double RunningSum;
         internal double SnapshotSum;

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -875,7 +875,7 @@ namespace OpenTelemetry.Metrics
                         this.histogramBuckets.RunningBucketCounts[i]++;
                         if (reportExemplar)
                         {
-                            this.histogramBuckets.ExemplarReservoir.OfferAtBoundary(i, number, tags);
+                            this.histogramBuckets.ExemplarReservoir.Offer(number, tags, i);
                         }
                     }
 
@@ -905,7 +905,7 @@ namespace OpenTelemetry.Metrics
                         this.histogramBuckets.RunningBucketCounts[i]++;
                         if (reportExemplar)
                         {
-                            this.histogramBuckets.ExemplarReservoir.OfferAtBoundary(i, number, tags);
+                            this.histogramBuckets.ExemplarReservoir.Offer(number, tags, i);
                         }
 
                         this.histogramBuckets.RunningMin = Math.Min(this.histogramBuckets.RunningMin, number);


### PR DESCRIPTION
Trying to see how to get closer to spec, and also to add one more ExemplarReservoir for non-histogram-with-bucket metric types.
The code user needs to write for own ExemplarReservoir is quite ugly still, but I'll make them cleaner next.