### PR TITLE
MetricPoint refactoring to keep its size fixed

### DIFF
--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -28,7 +28,7 @@ namespace OpenTelemetry.Metrics
 
         private readonly AggregationType aggType;
 
-        private HistogramBuckets histogramBuckets;
+        private MetricPointOptionalComponents mpComponents;
 
         // Represents temporality adjusted "value" for double/long metric types or "count" when histogram
         private MetricPointValueStorage runningValue;
@@ -57,16 +57,18 @@ namespace OpenTelemetry.Metrics
             if (this.aggType == AggregationType.HistogramWithBuckets ||
                 this.aggType == AggregationType.HistogramWithMinMaxBuckets)
             {
-                this.histogramBuckets = new HistogramBuckets(histogramExplicitBounds, aggregatorStore.IsExemplarEnabled());
+                this.mpComponents = new MetricPointOptionalComponents();
+                this.mpComponents.HistogramBuckets = new HistogramBuckets(histogramExplicitBounds, aggregatorStore.IsExemplarEnabled());
             }
             else if (this.aggType == AggregationType.Histogram ||
                      this.aggType == AggregationType.HistogramWithMinMax)
             {
-                this.histogramBuckets = new HistogramBuckets(null);
+                this.mpComponents = new MetricPointOptionalComponents();
+                this.mpComponents.HistogramBuckets = new HistogramBuckets(null);
             }
             else
             {
-                this.histogramBuckets = null;
+                this.mpComponents = null;
             }
 
             // Note: Intentionally set last because this is used to detect valid MetricPoints.
@@ -214,7 +216,7 @@ namespace OpenTelemetry.Metrics
                 this.ThrowNotSupportedMetricTypeException(nameof(this.GetHistogramSum));
             }
 
-            return this.histogramBuckets.SnapshotSum;
+            return this.mpComponents.HistogramBuckets.SnapshotSum;
         }
 
         /// <summary>
@@ -235,7 +237,7 @@ namespace OpenTelemetry.Metrics
                 this.ThrowNotSupportedMetricTypeException(nameof(this.GetHistogramBuckets));
             }
 
-            return this.histogramBuckets;
+            return this.mpComponents.HistogramBuckets;
         }
 
         /// <summary>
@@ -250,10 +252,10 @@ namespace OpenTelemetry.Metrics
             if (this.aggType == AggregationType.HistogramWithMinMax ||
                             this.aggType == AggregationType.HistogramWithMinMaxBuckets)
             {
-                Debug.Assert(this.histogramBuckets != null, "histogramBuckets was null");
+                Debug.Assert(this.mpComponents.HistogramBuckets != null, "histogramBuckets was null");
 
-                min = this.histogramBuckets.SnapshotMin;
-                max = this.histogramBuckets.SnapshotMax;
+                min = this.mpComponents.HistogramBuckets.SnapshotMin;
+                max = this.mpComponents.HistogramBuckets.SnapshotMax;
                 return true;
             }
 
@@ -270,13 +272,13 @@ namespace OpenTelemetry.Metrics
         public readonly Exemplar[] GetExemplars()
         {
             // TODO: Do not expose Exemplar data structure (array now)
-            return this.histogramBuckets?.Exemplars ?? Array.Empty<Exemplar>();
+            return this.mpComponents.HistogramBuckets?.Exemplars ?? Array.Empty<Exemplar>();
         }
 
         internal readonly MetricPoint Copy()
         {
             MetricPoint copy = this;
-            copy.histogramBuckets = this.histogramBuckets?.Copy();
+            copy.mpComponents.HistogramBuckets = this.mpComponents?.HistogramBuckets?.Copy();
             return copy;
         }
 
@@ -661,36 +663,37 @@ namespace OpenTelemetry.Metrics
 
                 case AggregationType.HistogramWithBuckets:
                     {
+                        var histogramBuckets = this.mpComponents.HistogramBuckets;
                         var sw = default(SpinWait);
                         while (true)
                         {
-                            if (Interlocked.Exchange(ref this.histogramBuckets.IsCriticalSectionOccupied, 1) == 0)
+                            if (Interlocked.Exchange(ref histogramBuckets.IsCriticalSectionOccupied, 1) == 0)
                             {
                                 // Lock acquired
                                 this.snapshotValue.AsLong = this.runningValue.AsLong;
-                                this.histogramBuckets.SnapshotSum = this.histogramBuckets.RunningSum;
+                                histogramBuckets.SnapshotSum = histogramBuckets.RunningSum;
 
                                 if (outputDelta)
                                 {
                                     this.runningValue.AsLong = 0;
-                                    this.histogramBuckets.RunningSum = 0;
+                                    histogramBuckets.RunningSum = 0;
                                 }
 
-                                for (int i = 0; i < this.histogramBuckets.RunningBucketCounts.Length; i++)
+                                for (int i = 0; i < histogramBuckets.RunningBucketCounts.Length; i++)
                                 {
-                                    this.histogramBuckets.SnapshotBucketCounts[i] = this.histogramBuckets.RunningBucketCounts[i];
+                                    histogramBuckets.SnapshotBucketCounts[i] = histogramBuckets.RunningBucketCounts[i];
                                     if (outputDelta)
                                     {
-                                        this.histogramBuckets.RunningBucketCounts[i] = 0;
+                                        histogramBuckets.RunningBucketCounts[i] = 0;
                                     }
                                 }
 
-                                this.histogramBuckets.Exemplars = this.histogramBuckets.ExemplarReservoir?.Collect(this.Tags, outputDelta);
+                                histogramBuckets.Exemplars = histogramBuckets.ExemplarReservoir?.Collect(this.Tags, outputDelta);
 
                                 this.MetricPointStatus = MetricPointStatus.NoCollectPending;
 
                                 // Release lock
-                                Interlocked.Exchange(ref this.histogramBuckets.IsCriticalSectionOccupied, 0);
+                                Interlocked.Exchange(ref histogramBuckets.IsCriticalSectionOccupied, 0);
                                 break;
                             }
 
@@ -702,25 +705,26 @@ namespace OpenTelemetry.Metrics
 
                 case AggregationType.Histogram:
                     {
+                        var histogramBuckets = this.mpComponents.HistogramBuckets;
                         var sw = default(SpinWait);
                         while (true)
                         {
-                            if (Interlocked.Exchange(ref this.histogramBuckets.IsCriticalSectionOccupied, 1) == 0)
+                            if (Interlocked.Exchange(ref histogramBuckets.IsCriticalSectionOccupied, 1) == 0)
                             {
                                 // Lock acquired
                                 this.snapshotValue.AsLong = this.runningValue.AsLong;
-                                this.histogramBuckets.SnapshotSum = this.histogramBuckets.RunningSum;
+                                histogramBuckets.SnapshotSum = histogramBuckets.RunningSum;
 
                                 if (outputDelta)
                                 {
                                     this.runningValue.AsLong = 0;
-                                    this.histogramBuckets.RunningSum = 0;
+                                    histogramBuckets.RunningSum = 0;
                                 }
 
                                 this.MetricPointStatus = MetricPointStatus.NoCollectPending;
 
                                 // Release lock
-                                Interlocked.Exchange(ref this.histogramBuckets.IsCriticalSectionOccupied, 0);
+                                Interlocked.Exchange(ref histogramBuckets.IsCriticalSectionOccupied, 0);
                                 break;
                             }
 
@@ -732,39 +736,40 @@ namespace OpenTelemetry.Metrics
 
                 case AggregationType.HistogramWithMinMaxBuckets:
                     {
+                        var histogramBuckets = this.mpComponents.HistogramBuckets;
                         var sw = default(SpinWait);
                         while (true)
                         {
-                            if (Interlocked.Exchange(ref this.histogramBuckets.IsCriticalSectionOccupied, 1) == 0)
+                            if (Interlocked.Exchange(ref histogramBuckets.IsCriticalSectionOccupied, 1) == 0)
                             {
                                 // Lock acquired
                                 this.snapshotValue.AsLong = this.runningValue.AsLong;
-                                this.histogramBuckets.SnapshotSum = this.histogramBuckets.RunningSum;
-                                this.histogramBuckets.SnapshotMin = this.histogramBuckets.RunningMin;
-                                this.histogramBuckets.SnapshotMax = this.histogramBuckets.RunningMax;
+                                histogramBuckets.SnapshotSum = histogramBuckets.RunningSum;
+                                histogramBuckets.SnapshotMin = histogramBuckets.RunningMin;
+                                histogramBuckets.SnapshotMax = histogramBuckets.RunningMax;
 
                                 if (outputDelta)
                                 {
                                     this.runningValue.AsLong = 0;
-                                    this.histogramBuckets.RunningSum = 0;
-                                    this.histogramBuckets.RunningMin = double.PositiveInfinity;
-                                    this.histogramBuckets.RunningMax = double.NegativeInfinity;
+                                    histogramBuckets.RunningSum = 0;
+                                    histogramBuckets.RunningMin = double.PositiveInfinity;
+                                    histogramBuckets.RunningMax = double.NegativeInfinity;
                                 }
 
-                                for (int i = 0; i < this.histogramBuckets.RunningBucketCounts.Length; i++)
+                                for (int i = 0; i < histogramBuckets.RunningBucketCounts.Length; i++)
                                 {
-                                    this.histogramBuckets.SnapshotBucketCounts[i] = this.histogramBuckets.RunningBucketCounts[i];
+                                    histogramBuckets.SnapshotBucketCounts[i] = histogramBuckets.RunningBucketCounts[i];
                                     if (outputDelta)
                                     {
-                                        this.histogramBuckets.RunningBucketCounts[i] = 0;
+                                        histogramBuckets.RunningBucketCounts[i] = 0;
                                     }
                                 }
 
-                                this.histogramBuckets.Exemplars = this.histogramBuckets.ExemplarReservoir?.Collect(this.Tags, outputDelta);
+                                histogramBuckets.Exemplars = histogramBuckets.ExemplarReservoir?.Collect(this.Tags, outputDelta);
                                 this.MetricPointStatus = MetricPointStatus.NoCollectPending;
 
                                 // Release lock
-                                Interlocked.Exchange(ref this.histogramBuckets.IsCriticalSectionOccupied, 0);
+                                Interlocked.Exchange(ref histogramBuckets.IsCriticalSectionOccupied, 0);
                                 break;
                             }
 
@@ -776,29 +781,30 @@ namespace OpenTelemetry.Metrics
 
                 case AggregationType.HistogramWithMinMax:
                     {
+                        var histogramBuckets = this.mpComponents.HistogramBuckets;
                         var sw = default(SpinWait);
                         while (true)
                         {
-                            if (Interlocked.Exchange(ref this.histogramBuckets.IsCriticalSectionOccupied, 1) == 0)
+                            if (Interlocked.Exchange(ref histogramBuckets.IsCriticalSectionOccupied, 1) == 0)
                             {
                                 // Lock acquired
                                 this.snapshotValue.AsLong = this.runningValue.AsLong;
-                                this.histogramBuckets.SnapshotSum = this.histogramBuckets.RunningSum;
-                                this.histogramBuckets.SnapshotMin = this.histogramBuckets.RunningMin;
-                                this.histogramBuckets.SnapshotMax = this.histogramBuckets.RunningMax;
+                                histogramBuckets.SnapshotSum = histogramBuckets.RunningSum;
+                                histogramBuckets.SnapshotMin = histogramBuckets.RunningMin;
+                                histogramBuckets.SnapshotMax = histogramBuckets.RunningMax;
 
                                 if (outputDelta)
                                 {
                                     this.runningValue.AsLong = 0;
-                                    this.histogramBuckets.RunningSum = 0;
-                                    this.histogramBuckets.RunningMin = double.PositiveInfinity;
-                                    this.histogramBuckets.RunningMax = double.NegativeInfinity;
+                                    histogramBuckets.RunningSum = 0;
+                                    histogramBuckets.RunningMin = double.PositiveInfinity;
+                                    histogramBuckets.RunningMax = double.NegativeInfinity;
                                 }
 
                                 this.MetricPointStatus = MetricPointStatus.NoCollectPending;
 
                                 // Release lock
-                                Interlocked.Exchange(ref this.histogramBuckets.IsCriticalSectionOccupied, 0);
+                                Interlocked.Exchange(ref histogramBuckets.IsCriticalSectionOccupied, 0);
                                 break;
                             }
 
@@ -812,20 +818,21 @@ namespace OpenTelemetry.Metrics
 
         private void UpdateHistogram(double number)
         {
+            var histogramBuckets = this.mpComponents.HistogramBuckets;
             var sw = default(SpinWait);
             while (true)
             {
-                if (Interlocked.Exchange(ref this.histogramBuckets.IsCriticalSectionOccupied, 1) == 0)
+                if (Interlocked.Exchange(ref histogramBuckets.IsCriticalSectionOccupied, 1) == 0)
                 {
                     // Lock acquired
                     unchecked
                     {
                         this.runningValue.AsLong++;
-                        this.histogramBuckets.RunningSum += number;
+                        histogramBuckets.RunningSum += number;
                     }
 
                     // Release lock
-                    Interlocked.Exchange(ref this.histogramBuckets.IsCriticalSectionOccupied, 0);
+                    Interlocked.Exchange(ref histogramBuckets.IsCriticalSectionOccupied, 0);
                     break;
                 }
 
@@ -835,22 +842,23 @@ namespace OpenTelemetry.Metrics
 
         private void UpdateHistogramWithMinMax(double number)
         {
+            var histogramBuckets = this.mpComponents.HistogramBuckets;
             var sw = default(SpinWait);
             while (true)
             {
-                if (Interlocked.Exchange(ref this.histogramBuckets.IsCriticalSectionOccupied, 1) == 0)
+                if (Interlocked.Exchange(ref histogramBuckets.IsCriticalSectionOccupied, 1) == 0)
                 {
                     // Lock acquired
                     unchecked
                     {
                         this.runningValue.AsLong++;
-                        this.histogramBuckets.RunningSum += number;
-                        this.histogramBuckets.RunningMin = Math.Min(this.histogramBuckets.RunningMin, number);
-                        this.histogramBuckets.RunningMax = Math.Max(this.histogramBuckets.RunningMax, number);
+                        histogramBuckets.RunningSum += number;
+                        histogramBuckets.RunningMin = Math.Min(histogramBuckets.RunningMin, number);
+                        histogramBuckets.RunningMax = Math.Max(histogramBuckets.RunningMax, number);
                     }
 
                     // Release lock
-                    Interlocked.Exchange(ref this.histogramBuckets.IsCriticalSectionOccupied, 0);
+                    Interlocked.Exchange(ref histogramBuckets.IsCriticalSectionOccupied, 0);
                     break;
                 }
 
@@ -860,27 +868,28 @@ namespace OpenTelemetry.Metrics
 
         private void UpdateHistogramWithBuckets(double number, ReadOnlySpan<KeyValuePair<string, object>> tags = default, bool reportExemplar = false)
         {
-            int i = this.histogramBuckets.FindBucketIndex(number);
+            var histogramBuckets = this.mpComponents.HistogramBuckets;
+            int i = histogramBuckets.FindBucketIndex(number);
 
             var sw = default(SpinWait);
             while (true)
             {
-                if (Interlocked.Exchange(ref this.histogramBuckets.IsCriticalSectionOccupied, 1) == 0)
+                if (Interlocked.Exchange(ref histogramBuckets.IsCriticalSectionOccupied, 1) == 0)
                 {
                     // Lock acquired
                     unchecked
                     {
                         this.runningValue.AsLong++;
-                        this.histogramBuckets.RunningSum += number;
-                        this.histogramBuckets.RunningBucketCounts[i]++;
+                        histogramBuckets.RunningSum += number;
+                        histogramBuckets.RunningBucketCounts[i]++;
                         if (reportExemplar)
                         {
-                            this.histogramBuckets.ExemplarReservoir.Offer(number, tags, i);
+                            histogramBuckets.ExemplarReservoir.Offer(number, tags, i);
                         }
                     }
 
                     // Release lock
-                    Interlocked.Exchange(ref this.histogramBuckets.IsCriticalSectionOccupied, 0);
+                    Interlocked.Exchange(ref histogramBuckets.IsCriticalSectionOccupied, 0);
                     break;
                 }
 
@@ -890,30 +899,31 @@ namespace OpenTelemetry.Metrics
 
         private void UpdateHistogramWithBucketsAndMinMax(double number, ReadOnlySpan<KeyValuePair<string, object>> tags = default, bool reportExemplar = false)
         {
-            int i = this.histogramBuckets.FindBucketIndex(number);
+            var histogramBuckets = this.mpComponents.HistogramBuckets;
+            int i = histogramBuckets.FindBucketIndex(number);
 
             var sw = default(SpinWait);
             while (true)
             {
-                if (Interlocked.Exchange(ref this.histogramBuckets.IsCriticalSectionOccupied, 1) == 0)
+                if (Interlocked.Exchange(ref histogramBuckets.IsCriticalSectionOccupied, 1) == 0)
                 {
                     // Lock acquired
                     unchecked
                     {
                         this.runningValue.AsLong++;
-                        this.histogramBuckets.RunningSum += number;
-                        this.histogramBuckets.RunningBucketCounts[i]++;
+                        histogramBuckets.RunningSum += number;
+                        histogramBuckets.RunningBucketCounts[i]++;
                         if (reportExemplar)
                         {
-                            this.histogramBuckets.ExemplarReservoir.Offer(number, tags, i);
+                            histogramBuckets.ExemplarReservoir.Offer(number, tags, i);
                         }
 
-                        this.histogramBuckets.RunningMin = Math.Min(this.histogramBuckets.RunningMin, number);
-                        this.histogramBuckets.RunningMax = Math.Max(this.histogramBuckets.RunningMax, number);
+                        histogramBuckets.RunningMin = Math.Min(histogramBuckets.RunningMin, number);
+                        histogramBuckets.RunningMax = Math.Max(histogramBuckets.RunningMax, number);
                     }
 
                     // Release lock
-                    Interlocked.Exchange(ref this.histogramBuckets.IsCriticalSectionOccupied, 0);
+                    Interlocked.Exchange(ref histogramBuckets.IsCriticalSectionOccupied, 0);
                     break;
                 }
 

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -278,7 +278,7 @@ namespace OpenTelemetry.Metrics
         internal readonly MetricPoint Copy()
         {
             MetricPoint copy = this;
-            copy.mpComponents.HistogramBuckets = this.mpComponents?.HistogramBuckets?.Copy();
+            copy.mpComponents = this.mpComponents?.Copy();
             return copy;
         }
 

--- a/src/OpenTelemetry/Metrics/MetricPointOptionalComponents.cs
+++ b/src/OpenTelemetry/Metrics/MetricPointOptionalComponents.cs
@@ -26,5 +26,13 @@ namespace OpenTelemetry.Metrics
     internal sealed class MetricPointOptionalComponents
     {
         public HistogramBuckets HistogramBuckets;
+
+        internal MetricPointOptionalComponents Copy()
+        {
+            MetricPointOptionalComponents copy = new MetricPointOptionalComponents();
+            copy.HistogramBuckets = this.HistogramBuckets.Copy();
+
+            return copy;
+        }
     }
 }

--- a/src/OpenTelemetry/Metrics/MetricPointOptionalComponents.cs
+++ b/src/OpenTelemetry/Metrics/MetricPointOptionalComponents.cs
@@ -1,0 +1,30 @@
+// <copyright file="MetricPointOptionalComponents.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Metrics
+{
+    /// <summary>
+    /// Stores optional components of a metric point.
+    /// Histogram, Exemplar are current components.
+    /// ExponentialHistogram is a future component.
+    /// This is done to keep the MetricPoint (struct)
+    /// size in control.
+    /// </summary>
+    internal sealed class MetricPointOptionalComponents
+    {
+        public HistogramBuckets HistogramBuckets;
+    }
+}


### PR DESCRIPTION
Discussion on this: https://github.com/open-telemetry/opentelemetry-dotnet/pull/4060/files#r1084483713

Benchmarks show hardly ~1-2 nsec diff, so this seems good way to keep MetricPoint Size fixed even with Exponential Histograms, Exemplars coming.