### PR TITLE
Move exemplarreservoir to outside of Histogram

### DIFF
--- a/src/OpenTelemetry/Metrics/HistogramBuckets.cs
+++ b/src/OpenTelemetry/Metrics/HistogramBuckets.cs
@@ -32,8 +32,6 @@ namespace OpenTelemetry.Metrics
         internal readonly long[] RunningBucketCounts;
         internal readonly long[] SnapshotBucketCounts;
 
-        internal readonly ExemplarReservoir ExemplarReservoir;
-
         internal double RunningSum;
         internal double SnapshotSum;
 
@@ -45,13 +43,11 @@ namespace OpenTelemetry.Metrics
 
         internal int IsCriticalSectionOccupied = 0;
 
-        internal Exemplar[] Exemplars;
-
         private readonly BucketLookupNode bucketLookupTreeRoot;
 
         private readonly Func<double, int> findHistogramBucketIndex;
 
-        internal HistogramBuckets(double[] explicitBounds, bool enableExemplar = false)
+        internal HistogramBuckets(double[] explicitBounds)
         {
             this.ExplicitBounds = explicitBounds;
             this.findHistogramBucketIndex = this.FindBucketIndexLinear;
@@ -81,10 +77,6 @@ namespace OpenTelemetry.Metrics
 
             this.RunningBucketCounts = explicitBounds != null ? new long[explicitBounds.Length + 1] : null;
             this.SnapshotBucketCounts = explicitBounds != null ? new long[explicitBounds.Length + 1] : new long[0];
-            if (explicitBounds != null && enableExemplar)
-            {
-                this.ExemplarReservoir = new AlignedHistogramBucketExemplarReservoir(explicitBounds.Length);
-            }
         }
 
         public Enumerator GetEnumerator() => new(this);

--- a/src/OpenTelemetry/Metrics/MetricPointOptionalComponents.cs
+++ b/src/OpenTelemetry/Metrics/MetricPointOptionalComponents.cs
@@ -27,6 +27,10 @@ namespace OpenTelemetry.Metrics
     {
         public HistogramBuckets HistogramBuckets;
 
+        public ExemplarReservoir ExemplarReservoir;
+
+        public Exemplar[] Exemplars;
+
         internal MetricPointOptionalComponents Copy()
         {
             MetricPointOptionalComponents copy = new MetricPointOptionalComponents();

--- a/test/OpenTelemetry.Tests.Stress.Metrics/Program.cs
+++ b/test/OpenTelemetry.Tests.Stress.Metrics/Program.cs
@@ -25,7 +25,7 @@ public partial class Program
     private const int ArraySize = 10;
 
     // Note: Uncomment the below line if you want to run Histogram stress test
-    // private const int MaxHistogramMeasurement = 1000;
+    private const int MaxHistogramMeasurement = 1000;
 
     private static readonly Meter TestMeter = new(Utils.GetCurrentMethodName());
     private static readonly Counter<long> TestCounter = TestMeter.CreateCounter<long>("TestCounter");
@@ -33,7 +33,7 @@ public partial class Program
     private static readonly ThreadLocal<Random> ThreadLocalRandom = new(() => new Random());
 
     // Note: Uncomment the below line if you want to run Histogram stress test
-    // private static readonly Histogram<long> TestHistogram = TestMeter.CreateHistogram<long>("TestHistogram");
+    private static readonly Histogram<long> TestHistogram = TestMeter.CreateHistogram<long>("TestHistogram");
 
     public static void Main()
     {
@@ -44,6 +44,7 @@ public partial class Program
 
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
             .AddMeter(TestMeter.Name)
+            .SetExemplarFilter(new AlwaysOnExemplarFilter())
             .AddPrometheusHttpListener(
                 options => options.UriPrefixes = new string[] { $"http://localhost:9185/" })
             .Build();
@@ -51,26 +52,27 @@ public partial class Program
         Stress(prometheusPort: 9464);
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected static void Run()
-    {
-        var random = ThreadLocalRandom.Value;
-        TestCounter.Add(
-            100,
-            new("DimName1", DimensionValues[random.Next(0, ArraySize)]),
-            new("DimName2", DimensionValues[random.Next(0, ArraySize)]),
-            new("DimName3", DimensionValues[random.Next(0, ArraySize)]));
-    }
-
-    // Note: Uncomment the below lines if you want to run Histogram stress test
+    // Note: Uncomment the below lines if you want to run Counter stress test
     // [MethodImpl(MethodImplOptions.AggressiveInlining)]
     // protected static void Run()
     // {
     //    var random = ThreadLocalRandom.Value;
-    //    TestHistogram.Record(
-    //        random.Next(MaxHistogramMeasurement),
+    //    TestCounter.Add(
+    //        100,
     //        new("DimName1", DimensionValues[random.Next(0, ArraySize)]),
     //        new("DimName2", DimensionValues[random.Next(0, ArraySize)]),
     //        new("DimName3", DimensionValues[random.Next(0, ArraySize)]));
     // }
+
+    // Note: Uncomment the below lines if you want to run Histogram stress test
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected static void Run()
+    {
+        var random = ThreadLocalRandom.Value;
+        TestHistogram.Record(
+            random.Next(MaxHistogramMeasurement),
+            new("DimName1", DimensionValues[random.Next(0, ArraySize)]),
+            new("DimName2", DimensionValues[random.Next(0, ArraySize)]),
+            new("DimName3", DimensionValues[random.Next(0, ArraySize)]));
+    }
 }


### PR DESCRIPTION
The next PR enables Exemplar for all metrics. This is setting stage by moving ExemplarReservoir logic directly into MetricPoint.