### PR TITLE
Enabling Exemplars for all types of metrics

### DIFF
--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -134,7 +134,15 @@ namespace OpenTelemetry.Metrics
                     continue;
                 }
 
-                metricPoint.TakeSnapshot(outputDelta: true);
+                if (this.IsExemplarEnabled())
+                {
+                    metricPoint.TakeSnapshotWithExemplar(outputDelta: true);
+                }
+                else
+                {
+                    metricPoint.TakeSnapshot(outputDelta: true);
+                }
+
                 this.currentMetricPointBatch[this.batchSize] = i;
                 this.batchSize++;
             }
@@ -155,7 +163,15 @@ namespace OpenTelemetry.Metrics
                     continue;
                 }
 
-                metricPoint.TakeSnapshot(outputDelta: false);
+                if (this.IsExemplarEnabled())
+                {
+                    metricPoint.TakeSnapshotWithExemplar(outputDelta: false);
+                }
+                else
+                {
+                    metricPoint.TakeSnapshot(outputDelta: false);
+                }
+
                 this.currentMetricPointBatch[this.batchSize] = i;
                 this.batchSize++;
             }

--- a/src/OpenTelemetry/Metrics/Exemplar/SimpleExemplarReservoir.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/SimpleExemplarReservoir.cs
@@ -1,0 +1,141 @@
+// <copyright file="SimpleExemplarReservoir.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Diagnostics;
+
+namespace OpenTelemetry.Metrics;
+
+/// <summary>
+/// The SimpleExemplarReservoir implementation.
+/// </summary>
+internal sealed class SimpleExemplarReservoir : ExemplarReservoir
+{
+    private readonly int poolSize;
+    private readonly Random random;
+    private readonly Exemplar[] runningExemplars;
+    private readonly Exemplar[] tempExemplars;
+
+    private int measurementsSeen;
+
+    public SimpleExemplarReservoir(int poolSize)
+    {
+        this.poolSize = poolSize;
+        this.runningExemplars = new Exemplar[poolSize];
+        this.tempExemplars = new Exemplar[poolSize];
+        this.measurementsSeen = 0;
+        this.random = new Random();
+    }
+
+    public override void Offer(long value, ReadOnlySpan<KeyValuePair<string, object>> tags, int index = default)
+    {
+        this.Offer(value, tags);
+    }
+
+    public override void Offer(double value, ReadOnlySpan<KeyValuePair<string, object>> tags, int index = default)
+    {
+        this.Offer(value, tags);
+    }
+
+    public override Exemplar[] Collect(ReadOnlyTagCollection actualTags, bool reset)
+    {
+        for (int i = 0; i < this.runningExemplars.Length; i++)
+        {
+            this.tempExemplars[i] = this.runningExemplars[i];
+            if (this.runningExemplars[i].FilteredTags != null)
+            {
+                // TODO: Better data structure to avoid this Linq.
+                // This is doing filtered = alltags - storedtags.
+                // TODO: At this stage, this logic is done inside Reservoir.
+                // Kinda hard for end users who write own reservoirs.
+                // Evaluate if this logic can be moved elsewhere.
+                // TODO: The cost is paid irrespective of whether the
+                // Exporter supports Exemplar or not. One idea is to
+                // defer this until first exporter attempts read.
+                this.tempExemplars[i].FilteredTags = this.runningExemplars[i].FilteredTags.Except(actualTags.KeyAndValues.ToList()).ToList();
+            }
+
+            if (reset)
+            {
+                this.runningExemplars[i].Timestamp = default;
+            }
+        }
+
+        return this.tempExemplars;
+    }
+
+    private void Offer(double value, ReadOnlySpan<KeyValuePair<string, object>> tags)
+    {
+        if (this.measurementsSeen < this.poolSize)
+        {
+                ref var exemplar = ref this.runningExemplars[this.measurementsSeen];
+                exemplar.Timestamp = DateTimeOffset.UtcNow;
+                exemplar.DoubleValue = value;
+                exemplar.TraceId = Activity.Current?.TraceId;
+                exemplar.SpanId = Activity.Current?.SpanId;
+                this.StoreTags(ref exemplar, tags);
+        }
+        else
+        {
+            var index = this.random.Next(0, this.measurementsSeen);
+            if (index < this.poolSize)
+            {
+                ref var exemplar = ref this.runningExemplars[index];
+                exemplar.Timestamp = DateTimeOffset.UtcNow;
+                exemplar.DoubleValue = value;
+                exemplar.TraceId = Activity.Current?.TraceId;
+                exemplar.SpanId = Activity.Current?.SpanId;
+                this.StoreTags(ref exemplar, tags);
+            }
+        }
+
+        this.measurementsSeen++;
+    }
+
+    private void StoreTags(ref Exemplar exemplar, ReadOnlySpan<KeyValuePair<string, object>> tags)
+    {
+        if (tags == default)
+        {
+            // default tag is used to indicate
+            // the special case where all tags provided at measurement
+            // recording time are stored.
+            // In this case, Exemplars does not have to store any tags.
+            // In other words, FilteredTags will be empty.
+            return;
+        }
+
+        if (exemplar.FilteredTags == null)
+        {
+            exemplar.FilteredTags = new List<KeyValuePair<string, object>>(tags.Length);
+        }
+        else
+        {
+            // Keep the list, but clear contents.
+            exemplar.FilteredTags.Clear();
+        }
+
+        // Though only those tags that are filtered need to be
+        // stored, finding filtered list from the full tag list
+        // is expensive. So all the tags are stored in hot path (this).
+        // During snapshot, the filtered list is calculated.
+        // TODO: Evaluate alternative approaches based on perf.
+        // TODO: This is not user friendly to Reservoir authors
+        // and must be handled as transparently as feasible.
+        foreach (var tag in tags)
+        {
+            exemplar.FilteredTags.Add(tag);
+        }
+    }
+}

--- a/src/OpenTelemetry/Metrics/Exemplar/SimpleExemplarReservoir.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/SimpleExemplarReservoir.cs
@@ -28,7 +28,7 @@ internal sealed class SimpleExemplarReservoir : ExemplarReservoir
     private readonly Exemplar[] runningExemplars;
     private readonly Exemplar[] tempExemplars;
 
-    private int measurementsSeen;
+    private long measurementsSeen;
 
     public SimpleExemplarReservoir(int poolSize)
     {
@@ -70,6 +70,7 @@ internal sealed class SimpleExemplarReservoir : ExemplarReservoir
             if (reset)
             {
                 this.runningExemplars[i].Timestamp = default;
+                this.measurementsSeen = 0;
             }
         }
 
@@ -80,16 +81,16 @@ internal sealed class SimpleExemplarReservoir : ExemplarReservoir
     {
         if (this.measurementsSeen < this.poolSize)
         {
-                ref var exemplar = ref this.runningExemplars[this.measurementsSeen];
-                exemplar.Timestamp = DateTimeOffset.UtcNow;
-                exemplar.DoubleValue = value;
-                exemplar.TraceId = Activity.Current?.TraceId;
-                exemplar.SpanId = Activity.Current?.SpanId;
-                this.StoreTags(ref exemplar, tags);
+            ref var exemplar = ref this.runningExemplars[this.measurementsSeen];
+            exemplar.Timestamp = DateTimeOffset.UtcNow;
+            exemplar.DoubleValue = value;
+            exemplar.TraceId = Activity.Current?.TraceId;
+            exemplar.SpanId = Activity.Current?.SpanId;
+            this.StoreTags(ref exemplar, tags);
         }
         else
         {
-            var index = this.random.Next(0, this.measurementsSeen);
+            var index = this.random.NextInt64(0, this.measurementsSeen);
             if (index < this.poolSize)
             {
                 ref var exemplar = ref this.runningExemplars[index];

--- a/src/OpenTelemetry/Metrics/Exemplar/SimpleExemplarReservoir.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/SimpleExemplarReservoir.cs
@@ -79,11 +79,6 @@ internal sealed class SimpleExemplarReservoir : ExemplarReservoir
 
     private void Offer(double value, ReadOnlySpan<KeyValuePair<string, object>> tags)
     {
-        if (this.measurementsSeen < 0)
-        {
-            this.measurementsSeen = 0;
-        }
-
         if (this.measurementsSeen < this.poolSize)
         {
             ref var exemplar = ref this.runningExemplars[this.measurementsSeen];

--- a/src/OpenTelemetry/Metrics/Exemplar/SimpleExemplarReservoir.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/SimpleExemplarReservoir.cs
@@ -79,6 +79,11 @@ internal sealed class SimpleExemplarReservoir : ExemplarReservoir
 
     private void Offer(double value, ReadOnlySpan<KeyValuePair<string, object>> tags)
     {
+        if (this.measurementsSeen < 0)
+        {
+            this.measurementsSeen = 0;
+        }
+
         if (this.measurementsSeen < this.poolSize)
         {
             ref var exemplar = ref this.runningExemplars[this.measurementsSeen];
@@ -90,7 +95,14 @@ internal sealed class SimpleExemplarReservoir : ExemplarReservoir
         }
         else
         {
-            var index = this.random.NextInt64(0, this.measurementsSeen);
+            // TODO: RandomNext64 is only available in .NET 6 or newer.
+            int upperBound = 0;
+            unchecked
+            {
+                upperBound = (int)this.measurementsSeen;
+            }
+
+            var index = this.random.Next(0, upperBound);
             if (index < this.poolSize)
             {
                 ref var exemplar = ref this.runningExemplars[index];

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -86,7 +86,7 @@ namespace OpenTelemetry.Metrics
 
             if (reservoir != null)
             {
-                if (mpComponents == null)
+                if (this.mpComponents == null)
                 {
                     this.mpComponents = new MetricPointOptionalComponents();
                 }
@@ -414,6 +414,7 @@ namespace OpenTelemetry.Metrics
 
                             sw.SpinOnce();
                         }
+
                         break;
                     }
 
@@ -435,6 +436,7 @@ namespace OpenTelemetry.Metrics
 
                             sw.SpinOnce();
                         }
+
                         break;
                     }
 
@@ -574,6 +576,7 @@ namespace OpenTelemetry.Metrics
                                 }
 
                                 this.mpComponents.ExemplarReservoir.Offer(number, tags);
+
                                 // Release lock
                                 Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 0);
                                 break;
@@ -581,6 +584,7 @@ namespace OpenTelemetry.Metrics
 
                             sw.SpinOnce();
                         }
+
                         break;
                     }
 
@@ -598,6 +602,7 @@ namespace OpenTelemetry.Metrics
                                 }
 
                                 this.mpComponents.ExemplarReservoir.Offer(number, tags);
+
                                 // Release lock
                                 Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 0);
                                 break;
@@ -605,6 +610,7 @@ namespace OpenTelemetry.Metrics
 
                             sw.SpinOnce();
                         }
+
                         break;
                     }
 
@@ -622,6 +628,7 @@ namespace OpenTelemetry.Metrics
                                 }
 
                                 this.mpComponents.ExemplarReservoir.Offer(number, tags);
+
                                 // Release lock
                                 Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 0);
                                 break;
@@ -629,6 +636,7 @@ namespace OpenTelemetry.Metrics
 
                             sw.SpinOnce();
                         }
+
                         break;
                     }
 
@@ -960,13 +968,14 @@ namespace OpenTelemetry.Metrics
 
                             sw.SpinOnce();
                         }
+
                         break;
                     }
 
                 case AggregationType.DoubleSumIncomingDelta:
                 case AggregationType.DoubleSumIncomingCumulative:
                     {
-						var sw = default(SpinWait);
+                        var sw = default(SpinWait);
                         while (true)
                         {
                             if (Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 1) == 0)
@@ -994,12 +1003,13 @@ namespace OpenTelemetry.Metrics
 
                             sw.SpinOnce();
                         }
+
                         break;
                     }
 
                 case AggregationType.LongGauge:
                     {
-						var sw = default(SpinWait);
+                        var sw = default(SpinWait);
                         while (true)
                         {
                             if (Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 1) == 0)
@@ -1017,12 +1027,13 @@ namespace OpenTelemetry.Metrics
 
                             sw.SpinOnce();
                         }
+
                         break;
                     }
 
                 case AggregationType.DoubleGauge:
                     {
-						var sw = default(SpinWait);
+                        var sw = default(SpinWait);
                         while (true)
                         {
                             if (Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 1) == 0)
@@ -1040,6 +1051,7 @@ namespace OpenTelemetry.Metrics
 
                             sw.SpinOnce();
                         }
+
                         break;
                     }
 

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -295,7 +295,7 @@ namespace OpenTelemetry.Metrics
         public readonly Exemplar[] GetExemplars()
         {
             // TODO: Do not expose Exemplar data structure (array now)
-            return this.mpComponents.Exemplars ?? Array.Empty<Exemplar>();
+            return this.mpComponents?.Exemplars ?? Array.Empty<Exemplar>();
         }
 
         internal readonly MetricPoint Copy()
@@ -380,10 +380,11 @@ namespace OpenTelemetry.Metrics
                                 // Lock acquired
                                 unchecked
                                 {
-                                    this.runningValue.AsLong++;
+                                    this.runningValue.AsLong += number;
                                 }
 
                                 this.mpComponents.ExemplarReservoir.Offer(number, tags);
+
                                 // Release lock
                                 Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 0);
                                 break;

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -24,6 +24,9 @@ namespace OpenTelemetry.Metrics
     /// </summary>
     public struct MetricPoint
     {
+        // TODO: Ask spec to define a default value for this.
+        private const int DefaultSimpleReservoirPoolSize = 10;
+
         private readonly AggregatorStore aggregatorStore;
 
         private readonly AggregationType aggType;
@@ -54,6 +57,7 @@ namespace OpenTelemetry.Metrics
             this.deltaLastValue = default;
             this.MetricPointStatus = MetricPointStatus.NoCollectPending;
 
+            ExemplarReservoir reservoir = null;
             if (this.aggType == AggregationType.HistogramWithBuckets ||
                 this.aggType == AggregationType.HistogramWithMinMaxBuckets)
             {
@@ -61,7 +65,7 @@ namespace OpenTelemetry.Metrics
                 this.mpComponents.HistogramBuckets = new HistogramBuckets(histogramExplicitBounds);
                 if (aggregatorStore.IsExemplarEnabled())
                 {
-                    this.mpComponents.ExemplarReservoir = new AlignedHistogramBucketExemplarReservoir(histogramExplicitBounds.Length);
+                    reservoir = new AlignedHistogramBucketExemplarReservoir(histogramExplicitBounds.Length);
                 }
             }
             else if (this.aggType == AggregationType.Histogram ||
@@ -73,6 +77,21 @@ namespace OpenTelemetry.Metrics
             else
             {
                 this.mpComponents = null;
+            }
+
+            if (aggregatorStore.IsExemplarEnabled() && reservoir == null)
+            {
+                reservoir = new SimpleExemplarReservoir(DefaultSimpleReservoirPoolSize);
+            }
+
+            if (reservoir != null)
+            {
+                if (mpComponents == null)
+                {
+                    this.mpComponents = new MetricPointOptionalComponents();
+                }
+
+                this.mpComponents.ExemplarReservoir = reservoir;
             }
 
             // Note: Intentionally set last because this is used to detect valid MetricPoints.
@@ -353,31 +372,80 @@ namespace OpenTelemetry.Metrics
             {
                 case AggregationType.LongSumIncomingDelta:
                     {
-                        Interlocked.Add(ref this.runningValue.AsLong, number);
+                        var sw = default(SpinWait);
+                        while (true)
+                        {
+                            if (Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 1) == 0)
+                            {
+                                // Lock acquired
+                                unchecked
+                                {
+                                    this.runningValue.AsLong++;
+                                }
+
+                                this.mpComponents.ExemplarReservoir.Offer(number, tags);
+                                // Release lock
+                                Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 0);
+                                break;
+                            }
+
+                            sw.SpinOnce();
+                        }
+
                         break;
                     }
 
                 case AggregationType.LongSumIncomingCumulative:
                     {
-                        Interlocked.Exchange(ref this.runningValue.AsLong, number);
+                        var sw = default(SpinWait);
+                        while (true)
+                        {
+                            if (Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 1) == 0)
+                            {
+                                // Lock acquired
+                                this.runningValue.AsLong = number;
+                                this.mpComponents.ExemplarReservoir.Offer(number, tags);
+
+                                // Release lock
+                                Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 0);
+                                break;
+                            }
+
+                            sw.SpinOnce();
+                        }
                         break;
                     }
 
                 case AggregationType.LongGauge:
                     {
-                        Interlocked.Exchange(ref this.runningValue.AsLong, number);
+                        var sw = default(SpinWait);
+                        while (true)
+                        {
+                            if (Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 1) == 0)
+                            {
+                                // Lock acquired
+                                this.runningValue.AsLong = number;
+                                this.mpComponents.ExemplarReservoir.Offer(number, tags);
+
+                                // Release lock
+                                Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 0);
+                                break;
+                            }
+
+                            sw.SpinOnce();
+                        }
                         break;
                     }
 
                 case AggregationType.Histogram:
                     {
-                        this.UpdateHistogram((double)number);
+                        this.UpdateHistogram((double)number, tags, true);
                         break;
                     }
 
                 case AggregationType.HistogramWithMinMax:
                     {
-                        this.UpdateHistogramWithMinMax((double)number);
+                        this.UpdateHistogramWithMinMax((double)number, tags, true);
                         break;
                     }
 
@@ -493,49 +561,85 @@ namespace OpenTelemetry.Metrics
             {
                 case AggregationType.DoubleSumIncomingDelta:
                     {
-                        double initValue, newValue;
                         var sw = default(SpinWait);
                         while (true)
                         {
-                            initValue = this.runningValue.AsDouble;
-
-                            unchecked
+                            if (Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 1) == 0)
                             {
-                                newValue = initValue + number;
-                            }
+                                // Lock acquired
+                                unchecked
+                                {
+                                    this.runningValue.AsDouble += number;
+                                }
 
-                            if (initValue == Interlocked.CompareExchange(ref this.runningValue.AsDouble, newValue, initValue))
-                            {
+                                this.mpComponents.ExemplarReservoir.Offer(number, tags);
+                                // Release lock
+                                Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 0);
                                 break;
                             }
 
                             sw.SpinOnce();
                         }
-
                         break;
                     }
 
                 case AggregationType.DoubleSumIncomingCumulative:
                     {
-                        Interlocked.Exchange(ref this.runningValue.AsDouble, number);
+                        var sw = default(SpinWait);
+                        while (true)
+                        {
+                            if (Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 1) == 0)
+                            {
+                                // Lock acquired
+                                unchecked
+                                {
+                                    this.runningValue.AsDouble = number;
+                                }
+
+                                this.mpComponents.ExemplarReservoir.Offer(number, tags);
+                                // Release lock
+                                Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 0);
+                                break;
+                            }
+
+                            sw.SpinOnce();
+                        }
                         break;
                     }
 
                 case AggregationType.DoubleGauge:
                     {
-                        Interlocked.Exchange(ref this.runningValue.AsDouble, number);
+                        var sw = default(SpinWait);
+                        while (true)
+                        {
+                            if (Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 1) == 0)
+                            {
+                                // Lock acquired
+                                unchecked
+                                {
+                                    this.runningValue.AsDouble = number;
+                                }
+
+                                this.mpComponents.ExemplarReservoir.Offer(number, tags);
+                                // Release lock
+                                Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 0);
+                                break;
+                            }
+
+                            sw.SpinOnce();
+                        }
                         break;
                     }
 
                 case AggregationType.Histogram:
                     {
-                        this.UpdateHistogram(number);
+                        this.UpdateHistogram(number, tags, true);
                         break;
                     }
 
                 case AggregationType.HistogramWithMinMax:
                     {
-                        this.UpdateHistogramWithMinMax(number);
+                        this.UpdateHistogramWithMinMax(number, tags, true);
                         break;
                     }
 
@@ -820,7 +924,282 @@ namespace OpenTelemetry.Metrics
             }
         }
 
-        private void UpdateHistogram(double number)
+        internal void TakeSnapshotWithExemplar(bool outputDelta)
+        {
+            switch (this.aggType)
+            {
+                case AggregationType.LongSumIncomingDelta:
+                case AggregationType.LongSumIncomingCumulative:
+                    {
+                        var sw = default(SpinWait);
+                        while (true)
+                        {
+                            if (Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 1) == 0)
+                            {
+                                // Lock acquired
+
+                                if (outputDelta)
+                                {
+                                    long initValue = this.runningValue.AsLong;
+                                    this.snapshotValue.AsLong = initValue - this.deltaLastValue.AsLong;
+                                    this.deltaLastValue.AsLong = initValue;
+                                    this.MetricPointStatus = MetricPointStatus.NoCollectPending;
+                                }
+                                else
+                                {
+                                    this.snapshotValue.AsLong = this.runningValue.AsLong;
+                                }
+
+                                this.mpComponents.Exemplars = this.mpComponents.ExemplarReservoir?.Collect(this.Tags, outputDelta);
+
+                                // Release lock
+                                Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 0);
+                                break;
+                            }
+
+                            sw.SpinOnce();
+                        }
+                        break;
+                    }
+
+                case AggregationType.DoubleSumIncomingDelta:
+                case AggregationType.DoubleSumIncomingCumulative:
+                    {
+						var sw = default(SpinWait);
+                        while (true)
+                        {
+                            if (Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 1) == 0)
+                            {
+                                // Lock acquired
+
+                                if (outputDelta)
+                                {
+                                    double initValue = this.runningValue.AsDouble;
+                                    this.snapshotValue.AsDouble = initValue - this.deltaLastValue.AsDouble;
+                                    this.deltaLastValue.AsDouble = initValue;
+                                    this.MetricPointStatus = MetricPointStatus.NoCollectPending;
+                                }
+                                else
+                                {
+                                    this.snapshotValue.AsDouble = this.runningValue.AsDouble;
+                                }
+
+                                this.mpComponents.Exemplars = this.mpComponents.ExemplarReservoir?.Collect(this.Tags, outputDelta);
+
+                                // Release lock
+                                Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 0);
+                                break;
+                            }
+
+                            sw.SpinOnce();
+                        }
+                        break;
+                    }
+
+                case AggregationType.LongGauge:
+                    {
+						var sw = default(SpinWait);
+                        while (true)
+                        {
+                            if (Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 1) == 0)
+                            {
+                                // Lock acquired
+
+                                this.snapshotValue.AsLong = this.runningValue.AsLong;
+                                this.MetricPointStatus = MetricPointStatus.NoCollectPending;
+                                this.mpComponents.Exemplars = this.mpComponents.ExemplarReservoir?.Collect(this.Tags, outputDelta);
+
+                                // Release lock
+                                Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 0);
+                                break;
+                            }
+
+                            sw.SpinOnce();
+                        }
+                        break;
+                    }
+
+                case AggregationType.DoubleGauge:
+                    {
+						var sw = default(SpinWait);
+                        while (true)
+                        {
+                            if (Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 1) == 0)
+                            {
+                                // Lock acquired
+
+                                this.snapshotValue.AsDouble = this.runningValue.AsDouble;
+                                this.MetricPointStatus = MetricPointStatus.NoCollectPending;
+                                this.mpComponents.Exemplars = this.mpComponents.ExemplarReservoir?.Collect(this.Tags, outputDelta);
+
+                                // Release lock
+                                Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 0);
+                                break;
+                            }
+
+                            sw.SpinOnce();
+                        }
+                        break;
+                    }
+
+                case AggregationType.HistogramWithBuckets:
+                    {
+                        var histogramBuckets = this.mpComponents.HistogramBuckets;
+                        var sw = default(SpinWait);
+                        while (true)
+                        {
+                            if (Interlocked.Exchange(ref histogramBuckets.IsCriticalSectionOccupied, 1) == 0)
+                            {
+                                // Lock acquired
+                                this.snapshotValue.AsLong = this.runningValue.AsLong;
+                                histogramBuckets.SnapshotSum = histogramBuckets.RunningSum;
+
+                                if (outputDelta)
+                                {
+                                    this.runningValue.AsLong = 0;
+                                    histogramBuckets.RunningSum = 0;
+                                }
+
+                                for (int i = 0; i < histogramBuckets.RunningBucketCounts.Length; i++)
+                                {
+                                    histogramBuckets.SnapshotBucketCounts[i] = histogramBuckets.RunningBucketCounts[i];
+                                    if (outputDelta)
+                                    {
+                                        histogramBuckets.RunningBucketCounts[i] = 0;
+                                    }
+                                }
+
+                                this.mpComponents.Exemplars = this.mpComponents.ExemplarReservoir?.Collect(this.Tags, outputDelta);
+
+                                this.MetricPointStatus = MetricPointStatus.NoCollectPending;
+
+                                // Release lock
+                                Interlocked.Exchange(ref histogramBuckets.IsCriticalSectionOccupied, 0);
+                                break;
+                            }
+
+                            sw.SpinOnce();
+                        }
+
+                        break;
+                    }
+
+                case AggregationType.Histogram:
+                    {
+                        var histogramBuckets = this.mpComponents.HistogramBuckets;
+                        var sw = default(SpinWait);
+                        while (true)
+                        {
+                            if (Interlocked.Exchange(ref histogramBuckets.IsCriticalSectionOccupied, 1) == 0)
+                            {
+                                // Lock acquired
+                                this.snapshotValue.AsLong = this.runningValue.AsLong;
+                                histogramBuckets.SnapshotSum = histogramBuckets.RunningSum;
+
+                                if (outputDelta)
+                                {
+                                    this.runningValue.AsLong = 0;
+                                    histogramBuckets.RunningSum = 0;
+                                }
+
+                                this.mpComponents.Exemplars = this.mpComponents.ExemplarReservoir?.Collect(this.Tags, outputDelta);
+                                this.MetricPointStatus = MetricPointStatus.NoCollectPending;
+
+                                // Release lock
+                                Interlocked.Exchange(ref histogramBuckets.IsCriticalSectionOccupied, 0);
+                                break;
+                            }
+
+                            sw.SpinOnce();
+                        }
+
+                        break;
+                    }
+
+                case AggregationType.HistogramWithMinMaxBuckets:
+                    {
+                        var histogramBuckets = this.mpComponents.HistogramBuckets;
+                        var sw = default(SpinWait);
+                        while (true)
+                        {
+                            if (Interlocked.Exchange(ref histogramBuckets.IsCriticalSectionOccupied, 1) == 0)
+                            {
+                                // Lock acquired
+                                this.snapshotValue.AsLong = this.runningValue.AsLong;
+                                histogramBuckets.SnapshotSum = histogramBuckets.RunningSum;
+                                histogramBuckets.SnapshotMin = histogramBuckets.RunningMin;
+                                histogramBuckets.SnapshotMax = histogramBuckets.RunningMax;
+
+                                if (outputDelta)
+                                {
+                                    this.runningValue.AsLong = 0;
+                                    histogramBuckets.RunningSum = 0;
+                                    histogramBuckets.RunningMin = double.PositiveInfinity;
+                                    histogramBuckets.RunningMax = double.NegativeInfinity;
+                                }
+
+                                for (int i = 0; i < histogramBuckets.RunningBucketCounts.Length; i++)
+                                {
+                                    histogramBuckets.SnapshotBucketCounts[i] = histogramBuckets.RunningBucketCounts[i];
+                                    if (outputDelta)
+                                    {
+                                        histogramBuckets.RunningBucketCounts[i] = 0;
+                                    }
+                                }
+
+                                this.mpComponents.Exemplars = this.mpComponents.ExemplarReservoir?.Collect(this.Tags, outputDelta);
+                                this.MetricPointStatus = MetricPointStatus.NoCollectPending;
+
+                                // Release lock
+                                Interlocked.Exchange(ref histogramBuckets.IsCriticalSectionOccupied, 0);
+                                break;
+                            }
+
+                            sw.SpinOnce();
+                        }
+
+                        break;
+                    }
+
+                case AggregationType.HistogramWithMinMax:
+                    {
+                        var histogramBuckets = this.mpComponents.HistogramBuckets;
+                        var sw = default(SpinWait);
+                        while (true)
+                        {
+                            if (Interlocked.Exchange(ref histogramBuckets.IsCriticalSectionOccupied, 1) == 0)
+                            {
+                                // Lock acquired
+                                this.snapshotValue.AsLong = this.runningValue.AsLong;
+                                histogramBuckets.SnapshotSum = histogramBuckets.RunningSum;
+                                histogramBuckets.SnapshotMin = histogramBuckets.RunningMin;
+                                histogramBuckets.SnapshotMax = histogramBuckets.RunningMax;
+
+                                if (outputDelta)
+                                {
+                                    this.runningValue.AsLong = 0;
+                                    histogramBuckets.RunningSum = 0;
+                                    histogramBuckets.RunningMin = double.PositiveInfinity;
+                                    histogramBuckets.RunningMax = double.NegativeInfinity;
+                                }
+
+                                this.mpComponents.Exemplars = this.mpComponents.ExemplarReservoir?.Collect(this.Tags, outputDelta);
+                                this.MetricPointStatus = MetricPointStatus.NoCollectPending;
+
+                                // Release lock
+                                Interlocked.Exchange(ref histogramBuckets.IsCriticalSectionOccupied, 0);
+                                break;
+                            }
+
+                            sw.SpinOnce();
+                        }
+
+                        break;
+                    }
+            }
+        }
+
+        private void UpdateHistogram(double number, ReadOnlySpan<KeyValuePair<string, object>> tags = default, bool reportExemplar = false)
         {
             var histogramBuckets = this.mpComponents.HistogramBuckets;
             var sw = default(SpinWait);
@@ -835,6 +1214,11 @@ namespace OpenTelemetry.Metrics
                         histogramBuckets.RunningSum += number;
                     }
 
+                    if (reportExemplar)
+                    {
+                        this.mpComponents.ExemplarReservoir.Offer(number, tags);
+                    }
+
                     // Release lock
                     Interlocked.Exchange(ref histogramBuckets.IsCriticalSectionOccupied, 0);
                     break;
@@ -844,7 +1228,7 @@ namespace OpenTelemetry.Metrics
             }
         }
 
-        private void UpdateHistogramWithMinMax(double number)
+        private void UpdateHistogramWithMinMax(double number, ReadOnlySpan<KeyValuePair<string, object>> tags = default, bool reportExemplar = false)
         {
             var histogramBuckets = this.mpComponents.HistogramBuckets;
             var sw = default(SpinWait);
@@ -859,6 +1243,11 @@ namespace OpenTelemetry.Metrics
                         histogramBuckets.RunningSum += number;
                         histogramBuckets.RunningMin = Math.Min(histogramBuckets.RunningMin, number);
                         histogramBuckets.RunningMax = Math.Max(histogramBuckets.RunningMax, number);
+                    }
+
+                    if (reportExemplar)
+                    {
+                        this.mpComponents.ExemplarReservoir.Offer(number, tags);
                     }
 
                     // Release lock

--- a/src/OpenTelemetry/Metrics/MetricPointOptionalComponents.cs
+++ b/src/OpenTelemetry/Metrics/MetricPointOptionalComponents.cs
@@ -31,6 +31,8 @@ namespace OpenTelemetry.Metrics
 
         public Exemplar[] Exemplars;
 
+        public int IsCriticalSectionOccupied = 0;
+
         internal MetricPointOptionalComponents Copy()
         {
             MetricPointOptionalComponents copy = new MetricPointOptionalComponents();


### PR DESCRIPTION
Enabling Exemplars for all types of metrics:
Histogram with buckets - same as beofre, it uses AlignedHistogramResrevoir.
All others - SimpleReservoir


BenchmarkDotNet=v0.13.3, OS=Windows 10 (10.0.19045.2604)
Intel Core i7-4790 CPU 3.60GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
.NET SDK=7.0.103
  [Host]     : .NET 7.0.3 (7.0.323.6910), X64 RyuJIT AVX2
  DefaultJob : .NET 7.0.3 (7.0.323.6910), X64 RyuJIT AVX2

With ExemplarFilter = ALwaysOff

|                    Method | AggregationTemporality |      Mean |    Error |   StdDev |
|-------------------------- |----------------------- |----------:|---------:|---------:|
|            CounterHotPath |             Cumulative |  21.51 ns | 0.101 ns | 0.095 ns |
| CounterWith1LabelsHotPath |             Cumulative |  82.38 ns | 0.397 ns | 0.352 ns |
| CounterWith3LabelsHotPath |             Cumulative | 180.80 ns | 1.151 ns | 1.020 ns |
| CounterWith5LabelsHotPath |             Cumulative | 283.25 ns | 3.091 ns | 2.740 ns |
| CounterWith6LabelsHotPath |             Cumulative | 319.57 ns | 5.484 ns | 4.579 ns |
| CounterWith7LabelsHotPath |             Cumulative | 360.49 ns | 4.076 ns | 3.813 ns |
|            CounterHotPath |                  Delta |  23.03 ns | 0.111 ns | 0.099 ns |
| CounterWith1LabelsHotPath |                  Delta |  91.15 ns | 0.792 ns | 0.661 ns |
| CounterWith3LabelsHotPath |                  Delta | 175.83 ns | 1.483 ns | 1.387 ns |
| CounterWith5LabelsHotPath |                  Delta | 288.38 ns | 4.776 ns | 4.468 ns |
| CounterWith6LabelsHotPath |                  Delta | 329.11 ns | 3.964 ns | 3.708 ns |
| CounterWith7LabelsHotPath |                  Delta | 358.58 ns | 4.220 ns | 3.948 ns |



================================
With ExemplarFilter = ALwaysON
=================================


|                    Method | AggregationTemporality |      Mean |    Error |   StdDev |
|-------------------------- |----------------------- |----------:|---------:|---------:|
|            CounterHotPath |             Cumulative |  37.46 ns | 0.768 ns | 1.405 ns |
| CounterWith1LabelsHotPath |             Cumulative | 100.07 ns | 1.501 ns | 1.404 ns |
| CounterWith3LabelsHotPath |             Cumulative | 214.96 ns | 3.533 ns | 3.305 ns |
| CounterWith5LabelsHotPath |             Cumulative | 322.44 ns | 4.413 ns | 3.912 ns |
| CounterWith6LabelsHotPath |             Cumulative | 364.33 ns | 5.460 ns | 5.107 ns |
| CounterWith7LabelsHotPath |             Cumulative | 401.13 ns | 2.985 ns | 2.646 ns |
|            CounterHotPath |                  Delta |  37.63 ns | 0.782 ns | 1.507 ns |
| CounterWith1LabelsHotPath |                  Delta | 108.99 ns | 2.140 ns | 3.136 ns |
| CounterWith3LabelsHotPath |                  Delta | 216.37 ns | 1.795 ns | 1.401 ns |
| CounterWith5LabelsHotPath |                  Delta | 324.76 ns | 6.354 ns | 7.317 ns |
| CounterWith6LabelsHotPath |                  Delta | 352.93 ns | 5.594 ns | 4.959 ns |
| CounterWith7LabelsHotPath |                  Delta | 398.27 ns | 4.025 ns | 3.765 ns |

Perf drop is expected as we have to do Exemplars now + It forced the switch from simple Interlock to Lock-equivalents.
Next PRs will add more perf numbers, and mechanisms to mitigate. (some might need spec issues. I will open them and link here.)