### PR TITLE
[Instrumentation.SqlClient] Document not supported version

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/README.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/README.md
@@ -11,6 +11,11 @@ and
 [System.Data.SqlClient](https://www.nuget.org/packages/System.Data.SqlClient)
 and collects traces about database operations.
 
+> **Warning**
+> Instrumentation is not working with `Microsoft.Data.SqlClient` v3.* due to
+the [issue](https://github.com/dotnet/SqlClient/pull/1258). It was fixed in 4.0
+and later.
+>
 > **Note**
 > This component is based on the OpenTelemetry semantic conventions for
 [traces](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions).


### PR DESCRIPTION
Fixes #4243.

## Changes

Document that `Microsoft.Data.SqlClient` v3.* is not supported.

For significant contributions please make sure you have completed the following items:

* ~~[ ] Appropriate `CHANGELOG.md` updated for non-trivial changes~~
* ~~[ ] Design discussion issue #~~
* ~~[ ] Changes in public API reviewed~~
