### PR TITLE
Add dedicated method to enable Exemplar feature

### DIFF
--- a/docs/metrics/customizing-the-sdk/README.md
+++ b/docs/metrics/customizing-the-sdk/README.md
@@ -411,6 +411,24 @@ context, if any. It also provides "Filtered Tags", which are attributes (Tags)
 that are [dropped by a view](#select-specific-tags). Exemplars are an opt-in
 feature, and allow customization via ExemplarFilter and ExemplarReservoir.
 
+#### Enabling Exemplars
+
+Exemplars feature is not enabled by default. The following
+snippet shows how to enable the feature.
+
+```csharp
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+
+using var meterProvider = Sdk.CreateMeterProviderBuilder()
+    // rest of config not shown
+    .EnableExemplar()
+    .Build();
+```
+
+Enabling Exemplar as shown here will enable it default settings for
+[ExemplarFilter](#exemplarfilter) and [ExemplarReservoir](#exemplarreservoir).
+
 #### ExemplarFilter
 
 `ExemplarFilter` determines which measurements are eligible to become an
@@ -423,10 +441,10 @@ OpenTelemetry SDK comes with the following Filters:
 
 * `AlwaysOnExemplarFilter` - makes all measurements eligible for being an Exemplar.
 * `AlwaysOffExemplarFilter` - makes no measurements eligible for being an
-  Exemplar. Use this to turn-off Exemplar feature.
-* `TraceBasedExemplarFilter` - makes those measurements eligible for being an
-Exemplar, which are recorded in the context of a sampled parent `Activity`
-(span).
+  Exemplar. Using this is as good as turning-off Exemplar feature.
+* `TraceBasedExemplarFilter` - (Default) makes those measurements eligible for
+being an Exemplar, which are recorded in the context of a sampled parent
+`Activity` (span).
 
 `SetExemplarFilter` method on `MeterProviderBuilder` can be used to set the
 desired `ExemplarFilter`.
@@ -442,10 +460,6 @@ using var meterProvider = Sdk.CreateMeterProviderBuilder()
     .SetExemplarFilter(new TraceBasedExemplarFilter())
     .Build();
 ```
-
-> **Note**
-> As of today, there is no separate toggle for enable/disable Exemplar
-feature. It can be turned off by using `AlwaysOffExemplarFilter`.
 
 If the built-in `ExemplarFilter`s are not meeting the needs, one may author
 custom `ExemplarFilter` as shown
@@ -463,7 +477,10 @@ and is responsible for storing Exemplars.
 `AlignedHistogramBucketExemplarReservoir` is the default reservoir used for
 Histograms with buckets, and it stores one exemplar per histogram bucket. The
 exemplar stored is the last measurement recorded - i.e. any new measurement
-overwrites the previous one.
+overwrites the previous one. `SimpleExemplarReservoir` is the default reservoir
+used for all other metric types. This exemplar uses the equivalent of [naive
+reservoir sampling](https://en.wikipedia.org/wiki/Reservoir_sampling) algorithm
+to determine which measurements gets stored as exemplars.
 
 Currently there is no ability to change the Reservoir used.
 

--- a/examples/AspNetCore/Program.cs
+++ b/examples/AspNetCore/Program.cs
@@ -106,7 +106,7 @@ appBuilder.Services.AddOpenTelemetry()
         // Ensure the MeterProvider subscribes to any custom Meters.
         builder
             .AddMeter(Instrumentation.MeterName)
-            .SetExemplarFilter(new TraceBasedExemplarFilter())
+            .EnableExemplar()
             .AddRuntimeInstrumentation()
             .AddHttpClientInstrumentation()
             .AddAspNetCoreInstrumentation();

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderExtensions.cs
@@ -326,6 +326,24 @@ namespace OpenTelemetry.Metrics
         }
 
         /// <summary>
+        /// Enables Exemplars.
+        /// </summary>
+        /// <param name="meterProviderBuilder"><see cref="MeterProviderBuilder"/>.</param>
+        /// <returns>The supplied <see cref="MeterProviderBuilder"/> for chaining.</returns>
+        public static MeterProviderBuilder EnableExemplar(this MeterProviderBuilder meterProviderBuilder)
+        {
+            meterProviderBuilder.ConfigureBuilder((sp, builder) =>
+            {
+                if (builder is MeterProviderBuilderSdk meterProviderBuilderSdk)
+                {
+                    meterProviderBuilderSdk.EnableExemplar();
+                }
+            });
+
+            return meterProviderBuilder;
+        }
+
+        /// <summary>
         /// Run the given actions to initialize the <see cref="MeterProvider"/>.
         /// </summary>
         /// <param name="meterProviderBuilder"><see cref="MeterProviderBuilder"/>.</param>

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderSdk.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderSdk.cs
@@ -56,6 +56,8 @@ namespace OpenTelemetry.Metrics
 
         public ExemplarFilter? ExemplarFilter { get; private set; }
 
+        public bool EnableExemplarSampling { get; private set; }
+
         public MeterProvider? Provider => this.meterProvider;
 
         public List<MetricReader> Readers { get; } = new();
@@ -168,6 +170,12 @@ namespace OpenTelemetry.Metrics
 
             this.ExemplarFilter = exemplarFilter;
 
+            return this;
+        }
+
+        public MeterProviderBuilder EnableExemplar()
+        {
+            this.EnableExemplarSampling = true;
             return this;
         }
 

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -81,6 +81,10 @@ namespace OpenTelemetry.Metrics
                 reader.SetMaxMetricStreams(state.MaxMetricStreams);
                 reader.SetMaxMetricPointsPerMetricStream(state.MaxMetricPointsPerMetricStream);
                 reader.SetExemplarFilter(state.ExemplarFilter);
+                if (state.EnableExemplarSampling)
+                {
+                    reader.EnableExemplar();
+                }
 
                 if (this.reader == null)
                 {

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -36,7 +36,8 @@ namespace OpenTelemetry.Metrics
             double[] histogramBounds = null,
             string[] tagKeysInteresting = null,
             bool histogramRecordMinMax = true,
-            ExemplarFilter exemplarFilter = null)
+            ExemplarFilter exemplarFilter = null,
+            bool enableExemplarSampling = false)
         {
             this.InstrumentIdentity = instrumentIdentity;
 
@@ -129,7 +130,7 @@ namespace OpenTelemetry.Metrics
                 throw new NotSupportedException($"Unsupported Instrument Type: {instrumentIdentity.InstrumentType.FullName}");
             }
 
-            this.aggStore = new AggregatorStore(instrumentIdentity.InstrumentName, aggType, temporality, maxMetricPointsPerMetricStream, histogramBounds ?? DefaultHistogramBounds, DefaultExponentialHistogramMaxBuckets, tagKeysInteresting, exemplarFilter);
+            this.aggStore = new AggregatorStore(instrumentIdentity.InstrumentName, aggType, temporality, maxMetricPointsPerMetricStream, histogramBounds ?? DefaultHistogramBounds, DefaultExponentialHistogramMaxBuckets, tagKeysInteresting, exemplarFilter, enableExemplarSampling);
             this.Temporality = temporality;
             this.InstrumentDisposed = false;
         }

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -400,7 +400,7 @@ namespace OpenTelemetry.Metrics
             this.MetricPointStatus = MetricPointStatus.CollectPending;
         }
 
-        internal void UpdateWithExemplar(long number, ReadOnlySpan<KeyValuePair<string, object>> tags)
+        internal void UpdateWithExemplar(long number, ReadOnlySpan<KeyValuePair<string, object>> tags, bool isSampled)
         {
             switch (this.aggType)
             {
@@ -417,7 +417,10 @@ namespace OpenTelemetry.Metrics
                                     this.runningValue.AsLong += number;
                                 }
 
-                                this.mpComponents.ExemplarReservoir.Offer(number, tags);
+                                if (isSampled)
+                                {
+                                    this.mpComponents.ExemplarReservoir.Offer(number, tags);
+                                }
 
                                 // Release lock
                                 Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 0);
@@ -616,7 +619,7 @@ namespace OpenTelemetry.Metrics
             this.MetricPointStatus = MetricPointStatus.CollectPending;
         }
 
-        internal void UpdateWithExemplar(double number, ReadOnlySpan<KeyValuePair<string, object>> tags)
+        internal void UpdateWithExemplar(double number, ReadOnlySpan<KeyValuePair<string, object>> tags, bool isSampled)
         {
             switch (this.aggType)
             {
@@ -633,7 +636,10 @@ namespace OpenTelemetry.Metrics
                                     this.runningValue.AsDouble += number;
                                 }
 
-                                this.mpComponents.ExemplarReservoir.Offer(number, tags);
+                                if (isSampled)
+                                {
+                                    this.mpComponents.ExemplarReservoir.Offer(number, tags);
+                                }
 
                                 // Release lock
                                 Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 0);

--- a/src/OpenTelemetry/Metrics/MetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/MetricReaderExt.cs
@@ -36,6 +36,8 @@ namespace OpenTelemetry.Metrics
 
         private ExemplarFilter exemplarFilter;
 
+        private bool enableExemplarSampling;
+
         internal AggregationTemporality GetAggregationTemporality(Type instrumentType)
         {
             return this.temporalityFunc(instrumentType);
@@ -71,7 +73,7 @@ namespace OpenTelemetry.Metrics
                     Metric metric = null;
                     try
                     {
-                        metric = new Metric(metricStreamIdentity, this.GetAggregationTemporality(metricStreamIdentity.InstrumentType), this.maxMetricPointsPerMetricStream, exemplarFilter: this.exemplarFilter);
+                        metric = new Metric(metricStreamIdentity, this.GetAggregationTemporality(metricStreamIdentity.InstrumentType), this.maxMetricPointsPerMetricStream, exemplarFilter: this.exemplarFilter, enableExemplarSampling: this.enableExemplarSampling);
                     }
                     catch (NotSupportedException nse)
                     {
@@ -156,7 +158,7 @@ namespace OpenTelemetry.Metrics
                     }
                     else
                     {
-                        Metric metric = new(metricStreamIdentity, this.GetAggregationTemporality(metricStreamIdentity.InstrumentType), this.maxMetricPointsPerMetricStream, metricStreamIdentity.HistogramBucketBounds, metricStreamIdentity.TagKeys, metricStreamIdentity.HistogramRecordMinMax, this.exemplarFilter);
+                        Metric metric = new(metricStreamIdentity, this.GetAggregationTemporality(metricStreamIdentity.InstrumentType), this.maxMetricPointsPerMetricStream, metricStreamIdentity.HistogramBucketBounds, metricStreamIdentity.TagKeys, metricStreamIdentity.HistogramRecordMinMax, this.exemplarFilter, this.enableExemplarSampling);
 
                         this.instrumentIdentityToMetric[metricStreamIdentity] = metric;
                         this.metrics[index] = metric;
@@ -228,6 +230,11 @@ namespace OpenTelemetry.Metrics
         internal void SetExemplarFilter(ExemplarFilter exemplarFilter)
         {
             this.exemplarFilter = exemplarFilter;
+        }
+
+        internal void EnableExemplar()
+        {
+            this.enableExemplarSampling = true;
         }
 
         internal void SetMaxMetricPointsPerMetricStream(int maxMetricPointsPerMetricStream)

--- a/test/Benchmarks/Metrics/ExemplarBenchmarks.cs
+++ b/test/Benchmarks/Metrics/ExemplarBenchmarks.cs
@@ -85,6 +85,7 @@ namespace Benchmarks.Metrics
 
             this.provider = Sdk.CreateMeterProviderBuilder()
                 .AddMeter(this.meter.Name)
+                .EnableExemplar()
                 .SetExemplarFilter(exemplarFilter)
                 .AddView("HistogramWithTagReduction", new MetricStreamConfiguration() { TagKeys = new string[] { "DimName1", "DimName2", "DimName3" } })
                 .AddInMemoryExporter(exportedItems, metricReaderOptions =>

--- a/test/OpenTelemetry.Tests.Stress.Metrics/Program.cs
+++ b/test/OpenTelemetry.Tests.Stress.Metrics/Program.cs
@@ -44,6 +44,7 @@ public partial class Program
 
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
             .AddMeter(TestMeter.Name)
+            .EnableExemplar()
             .SetExemplarFilter(new AlwaysOnExemplarFilter())
             .AddPrometheusHttpListener(
                 options => options.UriPrefixes = new string[] { $"http://localhost:9185/" })


### PR DESCRIPTION
`EnableExemplar()` - Enables the feature with all defaults.
`TraceBasedExemplarFilter` - default filter.
`AlignedHistogramBucketExemplarReservoir` and `SimpleExemplarReservoir` - default reservoir for histogram with buckets and others respectively.

`EnableExemplar()` + `AlwaysOffExemplatFilter` gives same effect as the feature being disabled completely.

`AlwaysOnExemplatFilter`, etc *alone* is not sufficient to turn on the feature, as it must be done via `EnableExemplar()` call first.

Also addresses https://github.com/open-telemetry/opentelemetry-dotnet/pull/4256#discussion_r1124113958