### PR TITLE
Add unit tests for Exemplars

### DIFF
--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -374,7 +374,7 @@ namespace OpenTelemetry.Metrics
                 if (this.IsExemplarEnabled())
                 {
                     var shouldSample = this.exemplarFilter.ShouldSample(value, tags);
-                    this.metricPoints[index].UpdateWithExemplar(value, tags: default, shouldSample);
+                    this.metricPoints[index].UpdateWithExemplar(value, tags: tags, shouldSample);
                 }
                 else
                 {
@@ -438,7 +438,7 @@ namespace OpenTelemetry.Metrics
                 if (this.IsExemplarEnabled())
                 {
                     var shouldSample = this.exemplarFilter.ShouldSample(value, tags);
-                    this.metricPoints[index].UpdateWithExemplar(value, tags: default, shouldSample);
+                    this.metricPoints[index].UpdateWithExemplar(value, tags: tags, shouldSample);
                 }
                 else
                 {

--- a/src/OpenTelemetry/Metrics/MetricPointOptionalComponents.cs
+++ b/src/OpenTelemetry/Metrics/MetricPointOptionalComponents.cs
@@ -39,6 +39,7 @@ namespace OpenTelemetry.Metrics
         {
             MetricPointOptionalComponents copy = new MetricPointOptionalComponents();
             copy.HistogramBuckets = this.HistogramBuckets.Copy();
+            Array.Copy(this.Exemplars, copy.Exemplars, this.Exemplars.Length);
 
             return copy;
         }

--- a/src/OpenTelemetry/Metrics/MetricPointOptionalComponents.cs
+++ b/src/OpenTelemetry/Metrics/MetricPointOptionalComponents.cs
@@ -39,8 +39,12 @@ namespace OpenTelemetry.Metrics
         {
             MetricPointOptionalComponents copy = new MetricPointOptionalComponents();
             copy.HistogramBuckets = this.HistogramBuckets.Copy();
-            Array.Copy(this.Exemplars, copy.Exemplars, this.Exemplars.Length);
+            if (this.Exemplars != null)
+            {
+                Array.Copy(this.Exemplars, copy.Exemplars, this.Exemplars.Length);
+            }
 
+            // TODO: Copy Base2ExponentialBucketHistogram
             return copy;
         }
     }

--- a/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
@@ -151,7 +151,7 @@ namespace OpenTelemetry.Metrics.Tests
             using var meterProvider = Sdk.CreateMeterProviderBuilder()
                 .AddMeter(meter.Name)
                 .SetExemplarFilter(new AlwaysOnExemplarFilter())
-                .AddView(histogram.Name, new MetricStreamConfiguration() { TagKeys = new string[] { "key1" }})
+                .AddView(histogram.Name, new MetricStreamConfiguration() { TagKeys = new string[] { "key1" } })
                 .AddInMemoryExporter(exportedItems, metricReaderOptions =>
                 {
                     metricReaderOptions.TemporalityPreference = MetricReaderTemporalityPreference.Delta;
@@ -161,7 +161,7 @@ namespace OpenTelemetry.Metrics.Tests
             var measurementValues = GenerateRandomValues(10);
             foreach (var value in measurementValues)
             {
-                histogram.Record(value, new ("key1", "value1"), new ("key2", "value1"));
+                histogram.Record(value, new("key1", "value1"), new("key2", "value1"));
             }
 
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);

--- a/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
@@ -161,7 +161,7 @@ namespace OpenTelemetry.Metrics.Tests
             var measurementValues = GenerateRandomValues(10);
             foreach (var value in measurementValues)
             {
-                histogram.Record(value, new("key1", "value1"), new("key2", "value1"));
+                histogram.Record(value, new("key1", "value1"), new("key2", "value1"), new("key3", "value1"));
             }
 
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
@@ -172,11 +172,11 @@ namespace OpenTelemetry.Metrics.Tests
             var exemplars = GetExemplars(metricPoint.Value);
             Assert.NotNull(exemplars);
             var filteredTags = exemplars[0].FilteredTags;
-            Assert.Equal(1, filteredTags.Count);
+            Assert.Equal(2, filteredTags.Count);
             Assert.NotNull(filteredTags);
         }
 
-        private double[] GenerateRandomValues(int count)
+        private static double[] GenerateRandomValues(int count)
         {
             var random = new Random();
             var values = new double[count];
@@ -188,7 +188,7 @@ namespace OpenTelemetry.Metrics.Tests
             return values;
         }
 
-        private void ValidateExemplars(Exemplar[] exemplars, DateTimeOffset startTime, DateTimeOffset endTime, double[] measurementValues, bool traceContextExists)
+        private static void ValidateExemplars(Exemplar[] exemplars, DateTimeOffset startTime, DateTimeOffset endTime, double[] measurementValues, bool traceContextExists)
         {
             Assert.NotNull(exemplars);
             foreach (var exemplar in exemplars)

--- a/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
@@ -1,0 +1,212 @@
+// <copyright file="MetricExemplarTests.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using OpenTelemetry.Tests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace OpenTelemetry.Metrics.Tests
+{
+    public class MetricExemplarTests : MetricTestsBase
+    {
+        private const int MaxTimeToAllowForFlush = 10000;
+        private readonly ITestOutputHelper output;
+
+        public MetricExemplarTests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        [Fact]
+        public void TestExemplarsCounter()
+        {
+            DateTime testStartTime = DateTime.UtcNow;
+            var exportedItems = new List<Metric>();
+
+            using var meter = new Meter($"{Utils.GetCurrentMethodName()}");
+            var counter = meter.CreateCounter<double>("testCounter");
+            using var meterProvider = Sdk.CreateMeterProviderBuilder()
+                .AddMeter(meter.Name)
+                .SetExemplarFilter(new AlwaysOnExemplarFilter())
+                .AddInMemoryExporter(exportedItems, metricReaderOptions =>
+                {
+                    metricReaderOptions.TemporalityPreference = MetricReaderTemporalityPreference.Delta;
+                })
+                .Build();
+
+            var measurementValues = GenerateRandomValues(10);
+            foreach (var value in measurementValues)
+            {
+                counter.Add(value);
+            }
+
+            meterProvider.ForceFlush(MaxTimeToAllowForFlush);
+            var metricPoint = GetFirstMetricPoint(exportedItems);
+            Assert.NotNull(metricPoint);
+            Assert.True(metricPoint.Value.StartTime >= testStartTime);
+            Assert.True(metricPoint.Value.EndTime != default);
+            var exemplars = GetExemplars(metricPoint.Value);
+            ValidateExemplars(exemplars, metricPoint.Value.StartTime, metricPoint.Value.EndTime, measurementValues, false);
+
+            exportedItems.Clear();
+
+#if NETFRAMEWORK
+            Thread.Sleep(10); // Compensates for low resolution timing in netfx.
+#endif
+
+            measurementValues = GenerateRandomValues(10);
+            foreach (var value in measurementValues)
+            {
+                var act = new Activity("test").Start();
+                counter.Add(value);
+                act.Stop();
+            }
+
+            meterProvider.ForceFlush(MaxTimeToAllowForFlush);
+            metricPoint = GetFirstMetricPoint(exportedItems);
+            Assert.NotNull(metricPoint);
+            Assert.True(metricPoint.Value.StartTime >= testStartTime);
+            Assert.True(metricPoint.Value.EndTime != default);
+            exemplars = GetExemplars(metricPoint.Value);
+            ValidateExemplars(exemplars, metricPoint.Value.StartTime, metricPoint.Value.EndTime, measurementValues, true);
+        }
+
+        [Fact]
+        public void TestExemplarsHistogram()
+        {
+            DateTime testStartTime = DateTime.UtcNow;
+            var exportedItems = new List<Metric>();
+
+            using var meter = new Meter($"{Utils.GetCurrentMethodName()}");
+            var histogram = meter.CreateHistogram<double>("testHistogram");
+            using var meterProvider = Sdk.CreateMeterProviderBuilder()
+                .AddMeter(meter.Name)
+                .SetExemplarFilter(new AlwaysOnExemplarFilter())
+                .AddInMemoryExporter(exportedItems, metricReaderOptions =>
+                {
+                    metricReaderOptions.TemporalityPreference = MetricReaderTemporalityPreference.Delta;
+                })
+                .Build();
+
+            var measurementValues = GenerateRandomValues(10);
+            foreach (var value in measurementValues)
+            {
+                histogram.Record(value);
+            }
+
+            meterProvider.ForceFlush(MaxTimeToAllowForFlush);
+            var metricPoint = GetFirstMetricPoint(exportedItems);
+            Assert.NotNull(metricPoint);
+            Assert.True(metricPoint.Value.StartTime >= testStartTime);
+            Assert.True(metricPoint.Value.EndTime != default);
+            var exemplars = GetExemplars(metricPoint.Value);
+            ValidateExemplars(exemplars, metricPoint.Value.StartTime, metricPoint.Value.EndTime, measurementValues, false);
+
+            exportedItems.Clear();
+
+#if NETFRAMEWORK
+            Thread.Sleep(10); // Compensates for low resolution timing in netfx.
+#endif
+
+            measurementValues = GenerateRandomValues(10);
+            foreach (var value in measurementValues)
+            {
+                var act = new Activity("test").Start();
+                histogram.Record(value);
+                act.Stop();
+            }
+
+            meterProvider.ForceFlush(MaxTimeToAllowForFlush);
+            metricPoint = GetFirstMetricPoint(exportedItems);
+            Assert.NotNull(metricPoint);
+            Assert.True(metricPoint.Value.StartTime >= testStartTime);
+            Assert.True(metricPoint.Value.EndTime != default);
+            exemplars = GetExemplars(metricPoint.Value);
+            ValidateExemplars(exemplars, metricPoint.Value.StartTime, metricPoint.Value.EndTime, measurementValues, true);
+        }
+
+        [Fact]
+        public void TestExemplarsFilterTags()
+        {
+            DateTime testStartTime = DateTime.UtcNow;
+            var exportedItems = new List<Metric>();
+
+            using var meter = new Meter($"{Utils.GetCurrentMethodName()}");
+            var histogram = meter.CreateHistogram<double>("testHistogram");
+            using var meterProvider = Sdk.CreateMeterProviderBuilder()
+                .AddMeter(meter.Name)
+                .SetExemplarFilter(new AlwaysOnExemplarFilter())
+                .AddView(histogram.Name, new MetricStreamConfiguration() { TagKeys = new string[] { "key1" }})
+                .AddInMemoryExporter(exportedItems, metricReaderOptions =>
+                {
+                    metricReaderOptions.TemporalityPreference = MetricReaderTemporalityPreference.Delta;
+                })
+                .Build();
+
+            var measurementValues = GenerateRandomValues(10);
+            foreach (var value in measurementValues)
+            {
+                histogram.Record(value, new ("key1", "value1"), new ("key2", "value1"));
+            }
+
+            meterProvider.ForceFlush(MaxTimeToAllowForFlush);
+            var metricPoint = GetFirstMetricPoint(exportedItems);
+            Assert.NotNull(metricPoint);
+            Assert.True(metricPoint.Value.StartTime >= testStartTime);
+            Assert.True(metricPoint.Value.EndTime != default);
+            var exemplars = GetExemplars(metricPoint.Value);
+            Assert.NotNull(exemplars);
+            var filteredTags = exemplars[0].FilteredTags;
+            Assert.Equal(1, filteredTags.Count);
+            Assert.NotNull(filteredTags);
+        }
+
+        private double[] GenerateRandomValues(int count)
+        {
+            var random = new Random();
+            var values = new double[count];
+            for (int i = 0; i < count; i++)
+            {
+                values[i] = random.NextDouble();
+            }
+
+            return values;
+        }
+
+        private void ValidateExemplars(Exemplar[] exemplars, DateTimeOffset startTime, DateTimeOffset endTime, double[] measurementValues, bool traceContextExists)
+        {
+            Assert.NotNull(exemplars);
+            foreach (var exemplar in exemplars)
+            {
+                Assert.True(exemplar.Timestamp > startTime && exemplar.Timestamp < endTime);
+                Assert.Contains(exemplar.DoubleValue, measurementValues);
+                Assert.Null(exemplar.FilteredTags);
+                if (traceContextExists)
+                {
+                    Assert.NotEqual(default, exemplar.TraceId);
+                    Assert.NotEqual(default, exemplar.SpanId);
+                }
+                else
+                {
+                    Assert.Equal(default, exemplar.TraceId);
+                    Assert.Equal(default, exemplar.SpanId);
+                }
+            }
+        }
+    }
+}

--- a/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
@@ -195,7 +195,7 @@ namespace OpenTelemetry.Metrics.Tests
             Assert.NotNull(exemplars);
             foreach (var exemplar in exemplars)
             {
-                Assert.True(exemplar.Timestamp > startTime && exemplar.Timestamp < endTime);
+                Assert.True(exemplar.Timestamp >= startTime && exemplar.Timestamp <= endTime, $"{startTime} < {exemplar.Timestamp} < {endTime}");
                 Assert.Contains(exemplar.DoubleValue, measurementValues);
                 Assert.Null(exemplar.FilteredTags);
                 if (traceContextExists)

--- a/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
@@ -126,9 +126,8 @@ namespace OpenTelemetry.Metrics.Tests
             measurementValues = GenerateRandomValues(10);
             foreach (var value in measurementValues)
             {
-                var act = new Activity("test").Start();
+                using var act = new Activity("test").Start();
                 histogram.Record(value);
-                act.Stop();
             }
 
             meterProvider.ForceFlush(MaxTimeToAllowForFlush);
@@ -171,9 +170,12 @@ namespace OpenTelemetry.Metrics.Tests
             Assert.True(metricPoint.Value.EndTime != default);
             var exemplars = GetExemplars(metricPoint.Value);
             Assert.NotNull(exemplars);
-            var filteredTags = exemplars[0].FilteredTags;
-            Assert.Equal(2, filteredTags.Count);
-            Assert.NotNull(filteredTags);
+            foreach (var exemplar in exemplars)
+            {
+                Assert.NotNull(exemplar.FilteredTags);
+                Assert.Contains(new("key2", "value1"), exemplar.FilteredTags);
+                Assert.Contains(new("key3", "value1"), exemplar.FilteredTags);
+            }
         }
 
         private static double[] GenerateRandomValues(int count)

--- a/test/OpenTelemetry.Tests/Metrics/MetricTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricTestsBase.cs
@@ -122,4 +122,9 @@ public class MetricTestsBase
             index++;
         }
     }
+
+    public static Exemplar[] GetExemplars(MetricPoint mp)
+    {
+        return mp.GetExemplars().Where(exemplar => exemplar.Timestamp != default).ToArray();
+    }
 }


### PR DESCRIPTION
Adding a basic test as we have a working exemplar now to catch regressions while doing further refactoring. 
Quite basic one, to unblock a alpha.1 release, to be followed by more thorough ones.