### PR TITLE
Expose exponential histogram data

### DIFF
--- a/src/OpenTelemetry/.publicApi/net462/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry/.publicApi/net462/PublicAPI.Shipped.txt
@@ -10,7 +10,7 @@
 ~OpenTelemetry.Metrics.Metric.MeterVersion.get -> string
 ~OpenTelemetry.Metrics.Metric.Name.get -> string
 ~OpenTelemetry.Metrics.Metric.Unit.get -> string
-~OpenTelemetry.Metrics.MetricPoint.GetHistogramBuckets() -> OpenTelemetry.Metrics.HistogramBuckets
+OpenTelemetry.Metrics.MetricPoint.GetHistogramBuckets() -> OpenTelemetry.Metrics.HistogramBuckets!
 ~OpenTelemetry.Metrics.MetricStreamConfiguration.Description.get -> string
 ~OpenTelemetry.Metrics.MetricStreamConfiguration.Description.set -> void
 ~OpenTelemetry.Metrics.MetricStreamConfiguration.Name.get -> string

--- a/src/OpenTelemetry/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -15,11 +15,13 @@ OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.Current.get -> long
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.Enumerator() -> void
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.MoveNext() -> bool
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.ExponentialHistogramBuckets() -> void
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.GetEnumerator() -> OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Offset.get -> int
 OpenTelemetry.Metrics.ExponentialHistogramData
-OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
-OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
+OpenTelemetry.Metrics.ExponentialHistogramData.ExponentialHistogramData() -> void
+OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets
+OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets
 OpenTelemetry.Metrics.ExponentialHistogramData.Scale.get -> int
 OpenTelemetry.Metrics.ExponentialHistogramData.ZeroCount.get -> long
 OpenTelemetry.Metrics.TraceBasedExemplarFilter
@@ -29,7 +31,7 @@ static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetExemplarFilter(th
 ~abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~OpenTelemetry.Metrics.Exemplar.FilteredTags.get -> System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string, object>>
 ~OpenTelemetry.Metrics.MetricPoint.GetExemplars() -> OpenTelemetry.Metrics.Exemplar[]
-~OpenTelemetry.Metrics.MetricPoint.GetExponentialHistogramData() -> OpenTelemetry.Metrics.ExponentialHistogramData
+OpenTelemetry.Metrics.MetricPoint.GetExponentialHistogramData() -> OpenTelemetry.Metrics.ExponentialHistogramData
 ~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool

--- a/src/OpenTelemetry/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -10,6 +10,18 @@ OpenTelemetry.Metrics.Exemplar.Timestamp.get -> System.DateTimeOffset
 OpenTelemetry.Metrics.Exemplar.TraceId.get -> System.Diagnostics.ActivityTraceId?
 OpenTelemetry.Metrics.ExemplarFilter
 OpenTelemetry.Metrics.ExemplarFilter.ExemplarFilter() -> void
+OpenTelemetry.Metrics.ExponentialHistogramBuckets
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.Current.get -> long
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.Enumerator() -> void
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.MoveNext() -> bool
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.GetEnumerator() -> OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.Offset.get -> int
+OpenTelemetry.Metrics.ExponentialHistogramData
+OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
+OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
+OpenTelemetry.Metrics.ExponentialHistogramData.Scale.get -> int
+OpenTelemetry.Metrics.ExponentialHistogramData.ZeroCount.get -> long
 OpenTelemetry.Metrics.TraceBasedExemplarFilter
 OpenTelemetry.Metrics.TraceBasedExemplarFilter.TraceBasedExemplarFilter() -> void
 static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetExemplarFilter(this OpenTelemetry.Metrics.MeterProviderBuilder! meterProviderBuilder, OpenTelemetry.Metrics.ExemplarFilter! exemplarFilter) -> OpenTelemetry.Metrics.MeterProviderBuilder!
@@ -17,6 +29,7 @@ static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetExemplarFilter(th
 ~abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~OpenTelemetry.Metrics.Exemplar.FilteredTags.get -> System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string, object>>
 ~OpenTelemetry.Metrics.MetricPoint.GetExemplars() -> OpenTelemetry.Metrics.Exemplar[]
+~OpenTelemetry.Metrics.MetricPoint.GetExponentialHistogramData() -> OpenTelemetry.Metrics.ExponentialHistogramData
 ~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool

--- a/src/OpenTelemetry/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -15,11 +15,9 @@ OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.Current.get -> long
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.Enumerator() -> void
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.MoveNext() -> bool
-OpenTelemetry.Metrics.ExponentialHistogramBuckets.ExponentialHistogramBuckets() -> void
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.GetEnumerator() -> OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Offset.get -> int
 OpenTelemetry.Metrics.ExponentialHistogramData
-OpenTelemetry.Metrics.ExponentialHistogramData.ExponentialHistogramData() -> void
 OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
 OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
 OpenTelemetry.Metrics.ExponentialHistogramData.Scale.get -> int

--- a/src/OpenTelemetry/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -20,8 +20,8 @@ OpenTelemetry.Metrics.ExponentialHistogramBuckets.GetEnumerator() -> OpenTelemet
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Offset.get -> int
 OpenTelemetry.Metrics.ExponentialHistogramData
 OpenTelemetry.Metrics.ExponentialHistogramData.ExponentialHistogramData() -> void
-OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets
-OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets
+OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
+OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
 OpenTelemetry.Metrics.ExponentialHistogramData.Scale.get -> int
 OpenTelemetry.Metrics.ExponentialHistogramData.ZeroCount.get -> long
 OpenTelemetry.Metrics.TraceBasedExemplarFilter
@@ -30,8 +30,8 @@ static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetExemplarFilter(th
 ~abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~OpenTelemetry.Metrics.Exemplar.FilteredTags.get -> System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string, object>>
-~OpenTelemetry.Metrics.MetricPoint.GetExemplars() -> OpenTelemetry.Metrics.Exemplar[]
-OpenTelemetry.Metrics.MetricPoint.GetExponentialHistogramData() -> OpenTelemetry.Metrics.ExponentialHistogramData
+OpenTelemetry.Metrics.MetricPoint.GetExemplars() -> OpenTelemetry.Metrics.Exemplar[]!
+OpenTelemetry.Metrics.MetricPoint.GetExponentialHistogramData() -> OpenTelemetry.Metrics.ExponentialHistogramData!
 ~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool

--- a/src/OpenTelemetry/.publicApi/net6.0/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry/.publicApi/net6.0/PublicAPI.Shipped.txt
@@ -10,7 +10,7 @@
 ~OpenTelemetry.Metrics.Metric.MeterVersion.get -> string
 ~OpenTelemetry.Metrics.Metric.Name.get -> string
 ~OpenTelemetry.Metrics.Metric.Unit.get -> string
-~OpenTelemetry.Metrics.MetricPoint.GetHistogramBuckets() -> OpenTelemetry.Metrics.HistogramBuckets
+OpenTelemetry.Metrics.MetricPoint.GetHistogramBuckets() -> OpenTelemetry.Metrics.HistogramBuckets!
 ~OpenTelemetry.Metrics.MetricStreamConfiguration.Description.get -> string
 ~OpenTelemetry.Metrics.MetricStreamConfiguration.Description.set -> void
 ~OpenTelemetry.Metrics.MetricStreamConfiguration.Name.get -> string

--- a/src/OpenTelemetry/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -15,11 +15,13 @@ OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.Current.get -> long
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.Enumerator() -> void
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.MoveNext() -> bool
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.ExponentialHistogramBuckets() -> void
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.GetEnumerator() -> OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Offset.get -> int
 OpenTelemetry.Metrics.ExponentialHistogramData
-OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
-OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
+OpenTelemetry.Metrics.ExponentialHistogramData.ExponentialHistogramData() -> void
+OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets
+OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets
 OpenTelemetry.Metrics.ExponentialHistogramData.Scale.get -> int
 OpenTelemetry.Metrics.ExponentialHistogramData.ZeroCount.get -> long
 OpenTelemetry.Metrics.TraceBasedExemplarFilter
@@ -29,7 +31,7 @@ static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetExemplarFilter(th
 ~abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~OpenTelemetry.Metrics.Exemplar.FilteredTags.get -> System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string, object>>
 ~OpenTelemetry.Metrics.MetricPoint.GetExemplars() -> OpenTelemetry.Metrics.Exemplar[]
-~OpenTelemetry.Metrics.MetricPoint.GetExponentialHistogramData() -> OpenTelemetry.Metrics.ExponentialHistogramData
+OpenTelemetry.Metrics.MetricPoint.GetExponentialHistogramData() -> OpenTelemetry.Metrics.ExponentialHistogramData
 ~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool

--- a/src/OpenTelemetry/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -10,6 +10,18 @@ OpenTelemetry.Metrics.Exemplar.Timestamp.get -> System.DateTimeOffset
 OpenTelemetry.Metrics.Exemplar.TraceId.get -> System.Diagnostics.ActivityTraceId?
 OpenTelemetry.Metrics.ExemplarFilter
 OpenTelemetry.Metrics.ExemplarFilter.ExemplarFilter() -> void
+OpenTelemetry.Metrics.ExponentialHistogramBuckets
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.Current.get -> long
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.Enumerator() -> void
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.MoveNext() -> bool
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.GetEnumerator() -> OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.Offset.get -> int
+OpenTelemetry.Metrics.ExponentialHistogramData
+OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
+OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
+OpenTelemetry.Metrics.ExponentialHistogramData.Scale.get -> int
+OpenTelemetry.Metrics.ExponentialHistogramData.ZeroCount.get -> long
 OpenTelemetry.Metrics.TraceBasedExemplarFilter
 OpenTelemetry.Metrics.TraceBasedExemplarFilter.TraceBasedExemplarFilter() -> void
 static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetExemplarFilter(this OpenTelemetry.Metrics.MeterProviderBuilder! meterProviderBuilder, OpenTelemetry.Metrics.ExemplarFilter! exemplarFilter) -> OpenTelemetry.Metrics.MeterProviderBuilder!
@@ -17,6 +29,7 @@ static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetExemplarFilter(th
 ~abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~OpenTelemetry.Metrics.Exemplar.FilteredTags.get -> System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string, object>>
 ~OpenTelemetry.Metrics.MetricPoint.GetExemplars() -> OpenTelemetry.Metrics.Exemplar[]
+~OpenTelemetry.Metrics.MetricPoint.GetExponentialHistogramData() -> OpenTelemetry.Metrics.ExponentialHistogramData
 ~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool

--- a/src/OpenTelemetry/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -15,11 +15,9 @@ OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.Current.get -> long
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.Enumerator() -> void
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.MoveNext() -> bool
-OpenTelemetry.Metrics.ExponentialHistogramBuckets.ExponentialHistogramBuckets() -> void
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.GetEnumerator() -> OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Offset.get -> int
 OpenTelemetry.Metrics.ExponentialHistogramData
-OpenTelemetry.Metrics.ExponentialHistogramData.ExponentialHistogramData() -> void
 OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
 OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
 OpenTelemetry.Metrics.ExponentialHistogramData.Scale.get -> int

--- a/src/OpenTelemetry/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -20,8 +20,8 @@ OpenTelemetry.Metrics.ExponentialHistogramBuckets.GetEnumerator() -> OpenTelemet
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Offset.get -> int
 OpenTelemetry.Metrics.ExponentialHistogramData
 OpenTelemetry.Metrics.ExponentialHistogramData.ExponentialHistogramData() -> void
-OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets
-OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets
+OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
+OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
 OpenTelemetry.Metrics.ExponentialHistogramData.Scale.get -> int
 OpenTelemetry.Metrics.ExponentialHistogramData.ZeroCount.get -> long
 OpenTelemetry.Metrics.TraceBasedExemplarFilter
@@ -30,8 +30,8 @@ static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetExemplarFilter(th
 ~abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~OpenTelemetry.Metrics.Exemplar.FilteredTags.get -> System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string, object>>
-~OpenTelemetry.Metrics.MetricPoint.GetExemplars() -> OpenTelemetry.Metrics.Exemplar[]
-OpenTelemetry.Metrics.MetricPoint.GetExponentialHistogramData() -> OpenTelemetry.Metrics.ExponentialHistogramData
+OpenTelemetry.Metrics.MetricPoint.GetExemplars() -> OpenTelemetry.Metrics.Exemplar[]!
+OpenTelemetry.Metrics.MetricPoint.GetExponentialHistogramData() -> OpenTelemetry.Metrics.ExponentialHistogramData!
 ~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Shipped.txt
@@ -10,7 +10,7 @@
 ~OpenTelemetry.Metrics.Metric.MeterVersion.get -> string
 ~OpenTelemetry.Metrics.Metric.Name.get -> string
 ~OpenTelemetry.Metrics.Metric.Unit.get -> string
-~OpenTelemetry.Metrics.MetricPoint.GetHistogramBuckets() -> OpenTelemetry.Metrics.HistogramBuckets
+OpenTelemetry.Metrics.MetricPoint.GetHistogramBuckets() -> OpenTelemetry.Metrics.HistogramBuckets!
 ~OpenTelemetry.Metrics.MetricStreamConfiguration.Description.get -> string
 ~OpenTelemetry.Metrics.MetricStreamConfiguration.Description.set -> void
 ~OpenTelemetry.Metrics.MetricStreamConfiguration.Name.get -> string

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -15,11 +15,13 @@ OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.Current.get -> long
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.Enumerator() -> void
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.MoveNext() -> bool
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.ExponentialHistogramBuckets() -> void
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.GetEnumerator() -> OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Offset.get -> int
 OpenTelemetry.Metrics.ExponentialHistogramData
-OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
-OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
+OpenTelemetry.Metrics.ExponentialHistogramData.ExponentialHistogramData() -> void
+OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets
+OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets
 OpenTelemetry.Metrics.ExponentialHistogramData.Scale.get -> int
 OpenTelemetry.Metrics.ExponentialHistogramData.ZeroCount.get -> long
 OpenTelemetry.Metrics.TraceBasedExemplarFilter
@@ -29,7 +31,7 @@ static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetExemplarFilter(th
 ~abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~OpenTelemetry.Metrics.Exemplar.FilteredTags.get -> System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string, object>>
 ~OpenTelemetry.Metrics.MetricPoint.GetExemplars() -> OpenTelemetry.Metrics.Exemplar[]
-~OpenTelemetry.Metrics.MetricPoint.GetExponentialHistogramData() -> OpenTelemetry.Metrics.ExponentialHistogramData
+OpenTelemetry.Metrics.MetricPoint.GetExponentialHistogramData() -> OpenTelemetry.Metrics.ExponentialHistogramData
 ~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -10,6 +10,18 @@ OpenTelemetry.Metrics.Exemplar.Timestamp.get -> System.DateTimeOffset
 OpenTelemetry.Metrics.Exemplar.TraceId.get -> System.Diagnostics.ActivityTraceId?
 OpenTelemetry.Metrics.ExemplarFilter
 OpenTelemetry.Metrics.ExemplarFilter.ExemplarFilter() -> void
+OpenTelemetry.Metrics.ExponentialHistogramBuckets
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.Current.get -> long
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.Enumerator() -> void
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.MoveNext() -> bool
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.GetEnumerator() -> OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.Offset.get -> int
+OpenTelemetry.Metrics.ExponentialHistogramData
+OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
+OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
+OpenTelemetry.Metrics.ExponentialHistogramData.Scale.get -> int
+OpenTelemetry.Metrics.ExponentialHistogramData.ZeroCount.get -> long
 OpenTelemetry.Metrics.TraceBasedExemplarFilter
 OpenTelemetry.Metrics.TraceBasedExemplarFilter.TraceBasedExemplarFilter() -> void
 static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetExemplarFilter(this OpenTelemetry.Metrics.MeterProviderBuilder! meterProviderBuilder, OpenTelemetry.Metrics.ExemplarFilter! exemplarFilter) -> OpenTelemetry.Metrics.MeterProviderBuilder!
@@ -17,6 +29,7 @@ static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetExemplarFilter(th
 ~abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~OpenTelemetry.Metrics.Exemplar.FilteredTags.get -> System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string, object>>
 ~OpenTelemetry.Metrics.MetricPoint.GetExemplars() -> OpenTelemetry.Metrics.Exemplar[]
+~OpenTelemetry.Metrics.MetricPoint.GetExponentialHistogramData() -> OpenTelemetry.Metrics.ExponentialHistogramData
 ~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -15,11 +15,9 @@ OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.Current.get -> long
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.Enumerator() -> void
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.MoveNext() -> bool
-OpenTelemetry.Metrics.ExponentialHistogramBuckets.ExponentialHistogramBuckets() -> void
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.GetEnumerator() -> OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Offset.get -> int
 OpenTelemetry.Metrics.ExponentialHistogramData
-OpenTelemetry.Metrics.ExponentialHistogramData.ExponentialHistogramData() -> void
 OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
 OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
 OpenTelemetry.Metrics.ExponentialHistogramData.Scale.get -> int

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -20,8 +20,8 @@ OpenTelemetry.Metrics.ExponentialHistogramBuckets.GetEnumerator() -> OpenTelemet
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Offset.get -> int
 OpenTelemetry.Metrics.ExponentialHistogramData
 OpenTelemetry.Metrics.ExponentialHistogramData.ExponentialHistogramData() -> void
-OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets
-OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets
+OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
+OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
 OpenTelemetry.Metrics.ExponentialHistogramData.Scale.get -> int
 OpenTelemetry.Metrics.ExponentialHistogramData.ZeroCount.get -> long
 OpenTelemetry.Metrics.TraceBasedExemplarFilter
@@ -30,8 +30,8 @@ static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetExemplarFilter(th
 ~abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~OpenTelemetry.Metrics.Exemplar.FilteredTags.get -> System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string, object>>
-~OpenTelemetry.Metrics.MetricPoint.GetExemplars() -> OpenTelemetry.Metrics.Exemplar[]
-OpenTelemetry.Metrics.MetricPoint.GetExponentialHistogramData() -> OpenTelemetry.Metrics.ExponentialHistogramData
+OpenTelemetry.Metrics.MetricPoint.GetExemplars() -> OpenTelemetry.Metrics.Exemplar[]!
+OpenTelemetry.Metrics.MetricPoint.GetExponentialHistogramData() -> OpenTelemetry.Metrics.ExponentialHistogramData!
 ~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool

--- a/src/OpenTelemetry/.publicApi/netstandard2.1/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.1/PublicAPI.Shipped.txt
@@ -10,7 +10,7 @@
 ~OpenTelemetry.Metrics.Metric.MeterVersion.get -> string
 ~OpenTelemetry.Metrics.Metric.Name.get -> string
 ~OpenTelemetry.Metrics.Metric.Unit.get -> string
-~OpenTelemetry.Metrics.MetricPoint.GetHistogramBuckets() -> OpenTelemetry.Metrics.HistogramBuckets
+OpenTelemetry.Metrics.MetricPoint.GetHistogramBuckets() -> OpenTelemetry.Metrics.HistogramBuckets!
 ~OpenTelemetry.Metrics.MetricStreamConfiguration.Description.get -> string
 ~OpenTelemetry.Metrics.MetricStreamConfiguration.Description.set -> void
 ~OpenTelemetry.Metrics.MetricStreamConfiguration.Name.get -> string

--- a/src/OpenTelemetry/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
@@ -15,11 +15,13 @@ OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.Current.get -> long
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.Enumerator() -> void
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.MoveNext() -> bool
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.ExponentialHistogramBuckets() -> void
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.GetEnumerator() -> OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Offset.get -> int
 OpenTelemetry.Metrics.ExponentialHistogramData
-OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
-OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
+OpenTelemetry.Metrics.ExponentialHistogramData.ExponentialHistogramData() -> void
+OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets
+OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets
 OpenTelemetry.Metrics.ExponentialHistogramData.Scale.get -> int
 OpenTelemetry.Metrics.ExponentialHistogramData.ZeroCount.get -> long
 OpenTelemetry.Metrics.TraceBasedExemplarFilter
@@ -29,7 +31,7 @@ static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetExemplarFilter(th
 ~abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~OpenTelemetry.Metrics.Exemplar.FilteredTags.get -> System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string, object>>
 ~OpenTelemetry.Metrics.MetricPoint.GetExemplars() -> OpenTelemetry.Metrics.Exemplar[]
-~OpenTelemetry.Metrics.MetricPoint.GetExponentialHistogramData() -> OpenTelemetry.Metrics.ExponentialHistogramData
+OpenTelemetry.Metrics.MetricPoint.GetExponentialHistogramData() -> OpenTelemetry.Metrics.ExponentialHistogramData
 ~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool

--- a/src/OpenTelemetry/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
@@ -10,6 +10,18 @@ OpenTelemetry.Metrics.Exemplar.Timestamp.get -> System.DateTimeOffset
 OpenTelemetry.Metrics.Exemplar.TraceId.get -> System.Diagnostics.ActivityTraceId?
 OpenTelemetry.Metrics.ExemplarFilter
 OpenTelemetry.Metrics.ExemplarFilter.ExemplarFilter() -> void
+OpenTelemetry.Metrics.ExponentialHistogramBuckets
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.Current.get -> long
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.Enumerator() -> void
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.MoveNext() -> bool
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.GetEnumerator() -> OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator
+OpenTelemetry.Metrics.ExponentialHistogramBuckets.Offset.get -> int
+OpenTelemetry.Metrics.ExponentialHistogramData
+OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
+OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
+OpenTelemetry.Metrics.ExponentialHistogramData.Scale.get -> int
+OpenTelemetry.Metrics.ExponentialHistogramData.ZeroCount.get -> long
 OpenTelemetry.Metrics.TraceBasedExemplarFilter
 OpenTelemetry.Metrics.TraceBasedExemplarFilter.TraceBasedExemplarFilter() -> void
 static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetExemplarFilter(this OpenTelemetry.Metrics.MeterProviderBuilder! meterProviderBuilder, OpenTelemetry.Metrics.ExemplarFilter! exemplarFilter) -> OpenTelemetry.Metrics.MeterProviderBuilder!
@@ -17,6 +29,7 @@ static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetExemplarFilter(th
 ~abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~OpenTelemetry.Metrics.Exemplar.FilteredTags.get -> System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string, object>>
 ~OpenTelemetry.Metrics.MetricPoint.GetExemplars() -> OpenTelemetry.Metrics.Exemplar[]
+~OpenTelemetry.Metrics.MetricPoint.GetExponentialHistogramData() -> OpenTelemetry.Metrics.ExponentialHistogramData
 ~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool

--- a/src/OpenTelemetry/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
@@ -15,11 +15,9 @@ OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.Current.get -> long
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.Enumerator() -> void
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator.MoveNext() -> bool
-OpenTelemetry.Metrics.ExponentialHistogramBuckets.ExponentialHistogramBuckets() -> void
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.GetEnumerator() -> OpenTelemetry.Metrics.ExponentialHistogramBuckets.Enumerator
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Offset.get -> int
 OpenTelemetry.Metrics.ExponentialHistogramData
-OpenTelemetry.Metrics.ExponentialHistogramData.ExponentialHistogramData() -> void
 OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
 OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
 OpenTelemetry.Metrics.ExponentialHistogramData.Scale.get -> int

--- a/src/OpenTelemetry/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
@@ -20,8 +20,8 @@ OpenTelemetry.Metrics.ExponentialHistogramBuckets.GetEnumerator() -> OpenTelemet
 OpenTelemetry.Metrics.ExponentialHistogramBuckets.Offset.get -> int
 OpenTelemetry.Metrics.ExponentialHistogramData
 OpenTelemetry.Metrics.ExponentialHistogramData.ExponentialHistogramData() -> void
-OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets
-OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets
+OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
+OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
 OpenTelemetry.Metrics.ExponentialHistogramData.Scale.get -> int
 OpenTelemetry.Metrics.ExponentialHistogramData.ZeroCount.get -> long
 OpenTelemetry.Metrics.TraceBasedExemplarFilter
@@ -30,8 +30,8 @@ static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetExemplarFilter(th
 ~abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~OpenTelemetry.Metrics.Exemplar.FilteredTags.get -> System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string, object>>
-~OpenTelemetry.Metrics.MetricPoint.GetExemplars() -> OpenTelemetry.Metrics.Exemplar[]
-OpenTelemetry.Metrics.MetricPoint.GetExponentialHistogramData() -> OpenTelemetry.Metrics.ExponentialHistogramData
+OpenTelemetry.Metrics.MetricPoint.GetExemplars() -> OpenTelemetry.Metrics.Exemplar[]!
+OpenTelemetry.Metrics.MetricPoint.GetExponentialHistogramData() -> OpenTelemetry.Metrics.ExponentialHistogramData!
 ~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
 ~override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool

--- a/src/OpenTelemetry/Metrics/Base2ExponentialBucketHistogram.cs
+++ b/src/OpenTelemetry/Metrics/Base2ExponentialBucketHistogram.cs
@@ -38,10 +38,7 @@ internal sealed class Base2ExponentialBucketHistogram
 
     internal int IsCriticalSectionOccupied = 0;
 
-    internal int SnapshotScale;
-    internal long SnapshotZeroCount;
-    internal CircularBufferBuckets SnapshotPositiveBuckets;
-    internal CircularBufferBuckets SnapshotNegativeBuckets;
+    internal ExponentialHistogramData SnapshotExponentialHistogramData = new ExponentialHistogramData();
 
     private int scale;
     private double scalingFactor; // 2 ^ scale / log(2)
@@ -228,14 +225,14 @@ internal sealed class Base2ExponentialBucketHistogram
 
     internal void Snapshot()
     {
-        this.SnapshotScale = this.Scale;
-        this.SnapshotZeroCount = this.ZeroCount;
-        this.SnapshotPositiveBuckets = this.PositiveBuckets.Copy();
-        this.SnapshotNegativeBuckets = this.NegativeBuckets.Copy();
+        this.SnapshotExponentialHistogramData.Scale = this.Scale;
+        this.SnapshotExponentialHistogramData.ZeroCount = this.ZeroCount;
+        this.SnapshotExponentialHistogramData.PositiveBuckets.SnapshotBuckets(this.PositiveBuckets);
+        this.SnapshotExponentialHistogramData.NegativeBuckets.SnapshotBuckets(this.NegativeBuckets);
     }
 
     internal ExponentialHistogramData GetExponentialHistogramData()
     {
-        return new(this.SnapshotScale, this.SnapshotZeroCount, this.SnapshotPositiveBuckets, this.SnapshotNegativeBuckets);
+        return this.SnapshotExponentialHistogramData;
     }
 }

--- a/src/OpenTelemetry/Metrics/Base2ExponentialBucketHistogram.cs
+++ b/src/OpenTelemetry/Metrics/Base2ExponentialBucketHistogram.cs
@@ -135,9 +135,6 @@ internal sealed class Base2ExponentialBucketHistogram
 
     internal CircularBufferBuckets NegativeBuckets { get; }
 
-    internal ExponentialHistogramData SnapshotExponentialHistogramBuckets =>
-        new ExponentialHistogramData(this.SnapshotScale, this.SnapshotZeroCount, this.SnapshotPositiveBuckets, this.SnapshotNegativeBuckets);
-
     /// <summary>
     /// Maps a finite positive IEEE 754 double-precision floating-point
     /// number to <c>Bucket[index] = ( base ^ index, base ^ (index + 1) ]</c>,
@@ -235,5 +232,10 @@ internal sealed class Base2ExponentialBucketHistogram
         this.SnapshotZeroCount = this.ZeroCount;
         this.SnapshotPositiveBuckets = this.PositiveBuckets.Copy();
         this.SnapshotNegativeBuckets = this.NegativeBuckets.Copy();
+    }
+
+    internal ExponentialHistogramData GetExponentialHistogramData()
+    {
+        return new(this.SnapshotScale, this.SnapshotZeroCount, this.SnapshotPositiveBuckets, this.SnapshotNegativeBuckets);
     }
 }

--- a/src/OpenTelemetry/Metrics/Base2ExponentialBucketHistogram.cs
+++ b/src/OpenTelemetry/Metrics/Base2ExponentialBucketHistogram.cs
@@ -135,8 +135,8 @@ internal sealed class Base2ExponentialBucketHistogram
 
     internal CircularBufferBuckets NegativeBuckets { get; }
 
-    internal ExponentialBucketSnapshot ExponentialBucketSnapshot =>
-        new ExponentialBucketSnapshot(this.SnapshotScale, this.SnapshotZeroCount, this.SnapshotPositiveBuckets, this.SnapshotNegativeBuckets);
+    internal ExponentialHistogramData SnapshotExponentialHistogramBuckets =>
+        new ExponentialHistogramData(this.SnapshotScale, this.SnapshotZeroCount, this.SnapshotPositiveBuckets, this.SnapshotNegativeBuckets);
 
     /// <summary>
     /// Maps a finite positive IEEE 754 double-precision floating-point

--- a/src/OpenTelemetry/Metrics/CircularBufferBuckets.cs
+++ b/src/OpenTelemetry/Metrics/CircularBufferBuckets.cs
@@ -278,24 +278,14 @@ internal sealed class CircularBufferBuckets
         }
     }
 
-    internal CircularBufferBuckets Copy()
+    internal void Copy(long[] dst)
     {
-        // TODO: Consider avoiding allocating a new one every time.
-        // Maybe we can have two instances that we swap between snapshots.
-        var copy = new CircularBufferBuckets(this.Capacity);
-        copy.begin = this.begin;
-        copy.end = this.end;
+        Debug.Assert(dst.Length == this.Capacity, "The length of the destination array must equal the capacity.");
 
         if (this.trait != null)
         {
-            copy.trait = new long[this.trait.Length];
-            for (var i = 0; i < copy.trait.Length; ++i)
-            {
-                copy.trait[i] = this.trait[i];
-            }
+            Array.Copy(this.trait, dst, this.Capacity);
         }
-
-        return copy;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/OpenTelemetry/Metrics/ExponentialHistogramBuckets.cs
+++ b/src/OpenTelemetry/Metrics/ExponentialHistogramBuckets.cs
@@ -1,4 +1,4 @@
-// <copyright file="ExponentialBuckets.cs" company="OpenTelemetry Authors">
+// <copyright file="ExponentialHistogramBuckets.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,16 +14,20 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 namespace OpenTelemetry.Metrics;
 
-internal class ExponentialBuckets
+public class ExponentialHistogramBuckets
 {
     private readonly CircularBufferBuckets buckets;
 
-    internal ExponentialBuckets(CircularBufferBuckets buckets)
+    internal ExponentialHistogramBuckets(CircularBufferBuckets buckets)
     {
         this.buckets = buckets;
     }
+
+    public int Offset => this.buckets.Offset;
 
     public Enumerator GetEnumerator() => new(this.buckets);
 

--- a/src/OpenTelemetry/Metrics/ExponentialHistogramBuckets.cs
+++ b/src/OpenTelemetry/Metrics/ExponentialHistogramBuckets.cs
@@ -18,7 +18,7 @@
 
 namespace OpenTelemetry.Metrics;
 
-public class ExponentialHistogramBuckets
+public sealed class ExponentialHistogramBuckets
 {
     private int size;
     private long[] buckets = Array.Empty<long>();

--- a/src/OpenTelemetry/Metrics/ExponentialHistogramBuckets.cs
+++ b/src/OpenTelemetry/Metrics/ExponentialHistogramBuckets.cs
@@ -18,7 +18,7 @@
 
 namespace OpenTelemetry.Metrics;
 
-public class ExponentialHistogramBuckets
+public readonly struct ExponentialHistogramBuckets
 {
     private readonly CircularBufferBuckets buckets;
 

--- a/src/OpenTelemetry/Metrics/ExponentialHistogramBuckets.cs
+++ b/src/OpenTelemetry/Metrics/ExponentialHistogramBuckets.cs
@@ -27,7 +27,7 @@ public readonly struct ExponentialHistogramBuckets
         this.buckets = buckets;
     }
 
-    public int Offset => this.buckets.Offset;
+    public readonly int Offset => this.buckets.Offset;
 
     public Enumerator GetEnumerator() => new(this.buckets);
 

--- a/src/OpenTelemetry/Metrics/ExponentialHistogramData.cs
+++ b/src/OpenTelemetry/Metrics/ExponentialHistogramData.cs
@@ -18,19 +18,17 @@
 
 namespace OpenTelemetry.Metrics;
 
-public readonly struct ExponentialHistogramData
+public class ExponentialHistogramData
 {
-    internal ExponentialHistogramData(int scale, long zeroCount, CircularBufferBuckets positiveBuckets, CircularBufferBuckets negativeBuckets)
+    internal ExponentialHistogramData()
     {
-        this.Scale = scale;
-        this.ZeroCount = zeroCount;
-        this.PositiveBuckets = new(positiveBuckets);
-        this.NegativeBuckets = new(negativeBuckets);
+        this.PositiveBuckets = new();
+        this.NegativeBuckets = new();
     }
 
-    public int Scale { get; }
+    public int Scale { get; internal set; }
 
-    public long ZeroCount { get; }
+    public long ZeroCount { get; internal set; }
 
     public ExponentialHistogramBuckets PositiveBuckets { get; }
 

--- a/src/OpenTelemetry/Metrics/ExponentialHistogramData.cs
+++ b/src/OpenTelemetry/Metrics/ExponentialHistogramData.cs
@@ -18,7 +18,7 @@
 
 namespace OpenTelemetry.Metrics;
 
-public class ExponentialHistogramData
+public readonly struct ExponentialHistogramData
 {
     internal ExponentialHistogramData(int scale, long zeroCount, CircularBufferBuckets positiveBuckets, CircularBufferBuckets negativeBuckets)
     {

--- a/src/OpenTelemetry/Metrics/ExponentialHistogramData.cs
+++ b/src/OpenTelemetry/Metrics/ExponentialHistogramData.cs
@@ -18,7 +18,7 @@
 
 namespace OpenTelemetry.Metrics;
 
-public class ExponentialHistogramData
+public sealed class ExponentialHistogramData
 {
     internal ExponentialHistogramData()
     {

--- a/src/OpenTelemetry/Metrics/ExponentialHistogramData.cs
+++ b/src/OpenTelemetry/Metrics/ExponentialHistogramData.cs
@@ -1,4 +1,4 @@
-// <copyright file="ExponentialBucketSnapshot.cs" company="OpenTelemetry Authors">
+// <copyright file="ExponentialHistogramData.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,16 +14,16 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 namespace OpenTelemetry.Metrics;
 
-internal class ExponentialBucketSnapshot
+public class ExponentialHistogramData
 {
-    internal ExponentialBucketSnapshot(int scale, long snapshotZeroCount, CircularBufferBuckets positiveBuckets, CircularBufferBuckets negativeBuckets)
+    internal ExponentialHistogramData(int scale, long zeroCount, CircularBufferBuckets positiveBuckets, CircularBufferBuckets negativeBuckets)
     {
         this.Scale = scale;
-        this.ZeroCount = snapshotZeroCount;
-        this.PositiveOffset = positiveBuckets.Offset;
-        this.NegativeOffset = negativeBuckets.Offset;
+        this.ZeroCount = zeroCount;
         this.PositiveBuckets = new(positiveBuckets);
         this.NegativeBuckets = new(negativeBuckets);
     }
@@ -32,11 +32,7 @@ internal class ExponentialBucketSnapshot
 
     public long ZeroCount { get; }
 
-    public int PositiveOffset { get; }
+    public ExponentialHistogramBuckets PositiveBuckets { get; }
 
-    public int NegativeOffset { get; }
-
-    public ExponentialBuckets PositiveBuckets { get; }
-
-    public ExponentialBuckets NegativeBuckets { get; }
+    public ExponentialHistogramBuckets NegativeBuckets { get; }
 }

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -277,23 +277,22 @@ namespace OpenTelemetry.Metrics
         }
 
         /// <summary>
-        /// Gets the buckets of the histogram associated with the metric point.
+        /// Gets the exponential histogram data associated with the metric point.
         /// </summary>
         /// <remarks>
         /// Applies to <see cref="MetricType.Histogram"/> metric type.
         /// </remarks>
-        /// <returns><see cref="Base2ExponentialBucketHistogram"/>.</returns>
+        /// <returns><see cref="ExponentialHistogramData"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#pragma warning disable SA1202 // Elements should be ordered by access. GetExponentialBucketSnapshot will be public soon.
-        internal readonly ExponentialBucketSnapshot GetExponentialBucketSnapshot()
+        public readonly ExponentialHistogramData GetExponentialHistogramData()
         {
             if (this.aggType != AggregationType.Base2ExponentialHistogram &&
                 this.aggType != AggregationType.Base2ExponentialHistogramWithMinMax)
             {
-                this.ThrowNotSupportedMetricTypeException(nameof(this.GetExponentialBucketSnapshot));
+                this.ThrowNotSupportedMetricTypeException(nameof(this.GetExponentialHistogramData));
             }
 
-            return this.mpComponents.Base2ExponentialBucketHistogram.ExponentialBucketSnapshot;
+            return this.mpComponents.Base2ExponentialBucketHistogram.SnapshotExponentialHistogramBuckets;
         }
 
         /// <summary>
@@ -304,7 +303,6 @@ namespace OpenTelemetry.Metrics
         /// <returns>True if minimum and maximum value exist, false otherwise.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryGetHistogramMinMaxValues(out double min, out double max)
-#pragma warning restore SA1202 // Elements should be ordered by access
         {
             if (this.aggType == AggregationType.HistogramWithMinMax ||
                             this.aggType == AggregationType.HistogramWithMinMaxBuckets)

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
@@ -284,7 +286,7 @@ namespace OpenTelemetry.Metrics
         /// </remarks>
         /// <returns><see cref="ExponentialHistogramData"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public readonly ExponentialHistogramData GetExponentialHistogramData()
+        public ExponentialHistogramData GetExponentialHistogramData()
         {
             if (this.aggType != AggregationType.Base2ExponentialHistogram &&
                 this.aggType != AggregationType.Base2ExponentialHistogramWithMinMax)

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -292,7 +292,7 @@ namespace OpenTelemetry.Metrics
                 this.ThrowNotSupportedMetricTypeException(nameof(this.GetExponentialHistogramData));
             }
 
-            return this.mpComponents.Base2ExponentialBucketHistogram.SnapshotExponentialHistogramBuckets;
+            return this.mpComponents.Base2ExponentialBucketHistogram.GetExponentialHistogramData();
         }
 
         /// <summary>

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -33,7 +33,7 @@ namespace OpenTelemetry.Metrics
 
         private readonly AggregationType aggType;
 
-        private MetricPointOptionalComponents mpComponents;
+        private MetricPointOptionalComponents? mpComponents;
 
         // Represents temporality adjusted "value" for double/long metric types or "count" when histogram
         private MetricPointValueStorage runningValue;
@@ -60,15 +60,15 @@ namespace OpenTelemetry.Metrics
             this.deltaLastValue = default;
             this.MetricPointStatus = MetricPointStatus.NoCollectPending;
 
-            ExemplarReservoir reservoir = null;
+            ExemplarReservoir? reservoir = null;
             if (this.aggType == AggregationType.HistogramWithBuckets ||
                 this.aggType == AggregationType.HistogramWithMinMaxBuckets)
             {
                 this.mpComponents = new MetricPointOptionalComponents();
                 this.mpComponents.HistogramBuckets = new HistogramBuckets(histogramExplicitBounds);
-                if (aggregatorStore.IsExemplarEnabled())
+                if (aggregatorStore!.IsExemplarEnabled())
                 {
-                    reservoir = new AlignedHistogramBucketExemplarReservoir(histogramExplicitBounds.Length);
+                    reservoir = new AlignedHistogramBucketExemplarReservoir(histogramExplicitBounds!.Length);
                 }
             }
             else if (this.aggType == AggregationType.Histogram ||
@@ -88,7 +88,7 @@ namespace OpenTelemetry.Metrics
                 this.mpComponents = null;
             }
 
-            if (aggregatorStore.IsExemplarEnabled() && reservoir == null)
+            if (aggregatorStore!.IsExemplarEnabled() && reservoir == null)
             {
                 reservoir = new SimpleExemplarReservoir(DefaultSimpleReservoirPoolSize);
             }
@@ -252,7 +252,7 @@ namespace OpenTelemetry.Metrics
                 this.ThrowNotSupportedMetricTypeException(nameof(this.GetHistogramSum));
             }
 
-            return this.mpComponents.HistogramBuckets != null
+            return this.mpComponents!.HistogramBuckets != null
                 ? this.mpComponents.HistogramBuckets.SnapshotSum
                 : this.mpComponents.Base2ExponentialBucketHistogram.SnapshotSum;
         }
@@ -275,7 +275,7 @@ namespace OpenTelemetry.Metrics
                 this.ThrowNotSupportedMetricTypeException(nameof(this.GetHistogramBuckets));
             }
 
-            return this.mpComponents.HistogramBuckets;
+            return this.mpComponents!.HistogramBuckets;
         }
 
         /// <summary>
@@ -294,7 +294,7 @@ namespace OpenTelemetry.Metrics
                 this.ThrowNotSupportedMetricTypeException(nameof(this.GetExponentialHistogramData));
             }
 
-            return this.mpComponents.Base2ExponentialBucketHistogram.GetExponentialHistogramData();
+            return this.mpComponents!.Base2ExponentialBucketHistogram.GetExponentialHistogramData();
         }
 
         /// <summary>
@@ -309,19 +309,19 @@ namespace OpenTelemetry.Metrics
             if (this.aggType == AggregationType.HistogramWithMinMax ||
                             this.aggType == AggregationType.HistogramWithMinMaxBuckets)
             {
-                Debug.Assert(this.mpComponents.HistogramBuckets != null, "histogramBuckets was null");
+                Debug.Assert(this.mpComponents!.HistogramBuckets != null, "histogramBuckets was null");
 
-                min = this.mpComponents.HistogramBuckets.SnapshotMin;
-                max = this.mpComponents.HistogramBuckets.SnapshotMax;
+                min = this.mpComponents!.HistogramBuckets!.SnapshotMin;
+                max = this.mpComponents!.HistogramBuckets!.SnapshotMax;
                 return true;
             }
 
             if (this.aggType == AggregationType.Base2ExponentialHistogramWithMinMax)
             {
-                Debug.Assert(this.mpComponents.Base2ExponentialBucketHistogram != null, "base2ExponentialBucketHistogram was null");
+                Debug.Assert(this.mpComponents!.Base2ExponentialBucketHistogram != null, "base2ExponentialBucketHistogram was null");
 
-                min = this.mpComponents.Base2ExponentialBucketHistogram.SnapshotMin;
-                max = this.mpComponents.Base2ExponentialBucketHistogram.SnapshotMax;
+                min = this.mpComponents!.Base2ExponentialBucketHistogram!.SnapshotMin;
+                max = this.mpComponents!.Base2ExponentialBucketHistogram!.SnapshotMax;
                 return true;
             }
 
@@ -430,7 +430,7 @@ namespace OpenTelemetry.Metrics
                         var sw = default(SpinWait);
                         while (true)
                         {
-                            if (Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 1) == 0)
+                            if (Interlocked.Exchange(ref this.mpComponents!.IsCriticalSectionOccupied, 1) == 0)
                             {
                                 // Lock acquired
                                 unchecked
@@ -459,7 +459,7 @@ namespace OpenTelemetry.Metrics
                         var sw = default(SpinWait);
                         while (true)
                         {
-                            if (Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 1) == 0)
+                            if (Interlocked.Exchange(ref this.mpComponents!.IsCriticalSectionOccupied, 1) == 0)
                             {
                                 // Lock acquired
                                 this.runningValue.AsLong = number;
@@ -481,7 +481,7 @@ namespace OpenTelemetry.Metrics
                         var sw = default(SpinWait);
                         while (true)
                         {
-                            if (Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 1) == 0)
+                            if (Interlocked.Exchange(ref this.mpComponents!.IsCriticalSectionOccupied, 1) == 0)
                             {
                                 // Lock acquired
                                 this.runningValue.AsLong = number;
@@ -649,7 +649,7 @@ namespace OpenTelemetry.Metrics
                         var sw = default(SpinWait);
                         while (true)
                         {
-                            if (Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 1) == 0)
+                            if (Interlocked.Exchange(ref this.mpComponents!.IsCriticalSectionOccupied, 1) == 0)
                             {
                                 // Lock acquired
                                 unchecked
@@ -678,7 +678,7 @@ namespace OpenTelemetry.Metrics
                         var sw = default(SpinWait);
                         while (true)
                         {
-                            if (Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 1) == 0)
+                            if (Interlocked.Exchange(ref this.mpComponents!.IsCriticalSectionOccupied, 1) == 0)
                             {
                                 // Lock acquired
                                 unchecked
@@ -704,7 +704,7 @@ namespace OpenTelemetry.Metrics
                         var sw = default(SpinWait);
                         while (true)
                         {
-                            if (Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 1) == 0)
+                            if (Interlocked.Exchange(ref this.mpComponents!.IsCriticalSectionOccupied, 1) == 0)
                             {
                                 // Lock acquired
                                 unchecked
@@ -877,7 +877,7 @@ namespace OpenTelemetry.Metrics
 
                 case AggregationType.HistogramWithBuckets:
                     {
-                        var histogramBuckets = this.mpComponents.HistogramBuckets;
+                        var histogramBuckets = this.mpComponents!.HistogramBuckets;
                         var sw = default(SpinWait);
                         while (true)
                         {
@@ -919,7 +919,7 @@ namespace OpenTelemetry.Metrics
 
                 case AggregationType.Histogram:
                     {
-                        var histogramBuckets = this.mpComponents.HistogramBuckets;
+                        var histogramBuckets = this.mpComponents!.HistogramBuckets;
                         var sw = default(SpinWait);
                         while (true)
                         {
@@ -950,7 +950,7 @@ namespace OpenTelemetry.Metrics
 
                 case AggregationType.HistogramWithMinMaxBuckets:
                     {
-                        var histogramBuckets = this.mpComponents.HistogramBuckets;
+                        var histogramBuckets = this.mpComponents!.HistogramBuckets;
                         var sw = default(SpinWait);
                         while (true)
                         {
@@ -995,7 +995,7 @@ namespace OpenTelemetry.Metrics
 
                 case AggregationType.HistogramWithMinMax:
                     {
-                        var histogramBuckets = this.mpComponents.HistogramBuckets;
+                        var histogramBuckets = this.mpComponents!.HistogramBuckets;
                         var sw = default(SpinWait);
                         while (true)
                         {
@@ -1030,7 +1030,7 @@ namespace OpenTelemetry.Metrics
 
                 case AggregationType.Base2ExponentialHistogram:
                     {
-                        var histogram = this.mpComponents.Base2ExponentialBucketHistogram;
+                        var histogram = this.mpComponents!.Base2ExponentialBucketHistogram;
                         var sw = default(SpinWait);
                         while (true)
                         {
@@ -1063,7 +1063,7 @@ namespace OpenTelemetry.Metrics
 
                 case AggregationType.Base2ExponentialHistogramWithMinMax:
                     {
-                        var histogram = this.mpComponents.Base2ExponentialBucketHistogram;
+                        var histogram = this.mpComponents!.Base2ExponentialBucketHistogram;
                         var sw = default(SpinWait);
                         while (true)
                         {
@@ -1110,7 +1110,7 @@ namespace OpenTelemetry.Metrics
                         var sw = default(SpinWait);
                         while (true)
                         {
-                            if (Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 1) == 0)
+                            if (Interlocked.Exchange(ref this.mpComponents!.IsCriticalSectionOccupied, 1) == 0)
                             {
                                 // Lock acquired
 
@@ -1145,7 +1145,7 @@ namespace OpenTelemetry.Metrics
                         var sw = default(SpinWait);
                         while (true)
                         {
-                            if (Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 1) == 0)
+                            if (Interlocked.Exchange(ref this.mpComponents!.IsCriticalSectionOccupied, 1) == 0)
                             {
                                 // Lock acquired
 
@@ -1179,7 +1179,7 @@ namespace OpenTelemetry.Metrics
                         var sw = default(SpinWait);
                         while (true)
                         {
-                            if (Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 1) == 0)
+                            if (Interlocked.Exchange(ref this.mpComponents!.IsCriticalSectionOccupied, 1) == 0)
                             {
                                 // Lock acquired
 
@@ -1203,7 +1203,7 @@ namespace OpenTelemetry.Metrics
                         var sw = default(SpinWait);
                         while (true)
                         {
-                            if (Interlocked.Exchange(ref this.mpComponents.IsCriticalSectionOccupied, 1) == 0)
+                            if (Interlocked.Exchange(ref this.mpComponents!.IsCriticalSectionOccupied, 1) == 0)
                             {
                                 // Lock acquired
 
@@ -1224,7 +1224,7 @@ namespace OpenTelemetry.Metrics
 
                 case AggregationType.HistogramWithBuckets:
                     {
-                        var histogramBuckets = this.mpComponents.HistogramBuckets;
+                        var histogramBuckets = this.mpComponents!.HistogramBuckets;
                         var sw = default(SpinWait);
                         while (true)
                         {
@@ -1266,7 +1266,7 @@ namespace OpenTelemetry.Metrics
 
                 case AggregationType.Histogram:
                     {
-                        var histogramBuckets = this.mpComponents.HistogramBuckets;
+                        var histogramBuckets = this.mpComponents!.HistogramBuckets;
                         var sw = default(SpinWait);
                         while (true)
                         {
@@ -1298,7 +1298,7 @@ namespace OpenTelemetry.Metrics
 
                 case AggregationType.HistogramWithMinMaxBuckets:
                     {
-                        var histogramBuckets = this.mpComponents.HistogramBuckets;
+                        var histogramBuckets = this.mpComponents!.HistogramBuckets;
                         var sw = default(SpinWait);
                         while (true)
                         {
@@ -1343,7 +1343,7 @@ namespace OpenTelemetry.Metrics
 
                 case AggregationType.HistogramWithMinMax:
                     {
-                        var histogramBuckets = this.mpComponents.HistogramBuckets;
+                        var histogramBuckets = this.mpComponents!.HistogramBuckets;
                         var sw = default(SpinWait);
                         while (true)
                         {
@@ -1381,7 +1381,7 @@ namespace OpenTelemetry.Metrics
 
         private void UpdateHistogram(double number, ReadOnlySpan<KeyValuePair<string, object>> tags = default, bool reportExemplar = false)
         {
-            var histogramBuckets = this.mpComponents.HistogramBuckets;
+            var histogramBuckets = this.mpComponents!.HistogramBuckets;
             var sw = default(SpinWait);
             while (true)
             {
@@ -1410,7 +1410,7 @@ namespace OpenTelemetry.Metrics
 
         private void UpdateHistogramWithMinMax(double number, ReadOnlySpan<KeyValuePair<string, object>> tags = default, bool reportExemplar = false)
         {
-            var histogramBuckets = this.mpComponents.HistogramBuckets;
+            var histogramBuckets = this.mpComponents!.HistogramBuckets;
             var sw = default(SpinWait);
             while (true)
             {
@@ -1441,7 +1441,7 @@ namespace OpenTelemetry.Metrics
 
         private void UpdateHistogramWithBuckets(double number, ReadOnlySpan<KeyValuePair<string, object>> tags = default, bool reportExemplar = false)
         {
-            var histogramBuckets = this.mpComponents.HistogramBuckets;
+            var histogramBuckets = this.mpComponents!.HistogramBuckets;
             int i = histogramBuckets.FindBucketIndex(number);
 
             var sw = default(SpinWait);
@@ -1472,7 +1472,7 @@ namespace OpenTelemetry.Metrics
 
         private void UpdateHistogramWithBucketsAndMinMax(double number, ReadOnlySpan<KeyValuePair<string, object>> tags = default, bool reportExemplar = false)
         {
-            var histogramBuckets = this.mpComponents.HistogramBuckets;
+            var histogramBuckets = this.mpComponents!.HistogramBuckets;
             int i = histogramBuckets.FindBucketIndex(number);
 
             var sw = default(SpinWait);
@@ -1508,7 +1508,7 @@ namespace OpenTelemetry.Metrics
         private void UpdateBase2ExponentialHistogram(double number, ReadOnlySpan<KeyValuePair<string, object>> tags = default, bool reportExemplar = false)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            var histogram = this.mpComponents.Base2ExponentialBucketHistogram;
+            var histogram = this.mpComponents!.Base2ExponentialBucketHistogram;
 
             var sw = default(SpinWait);
             while (true)
@@ -1536,7 +1536,7 @@ namespace OpenTelemetry.Metrics
         private void UpdateBase2ExponentialHistogramWithMinMax(double number, ReadOnlySpan<KeyValuePair<string, object>> tags = default, bool reportExemplar = false)
 #pragma warning restore IDE0060 // Remove unused parameter
         {
-            var histogram = this.mpComponents.Base2ExponentialBucketHistogram;
+            var histogram = this.mpComponents!.Base2ExponentialBucketHistogram;
 
             var sw = default(SpinWait);
             while (true)

--- a/test/OpenTelemetry.Tests/Metrics/AggregatorTest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/AggregatorTest.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-using System.Diagnostics.Metrics;
 using Xunit;
 
 namespace OpenTelemetry.Metrics.Tests
@@ -222,7 +221,7 @@ namespace OpenTelemetry.Metrics.Tests
             var sum = metricPoint.GetHistogramSum();
             var hasMinMax = metricPoint.TryGetHistogramMinMaxValues(out var min, out var max);
 
-            AssertExponentialBucketsAreCorrect(expectedHistogram, metricPoint.GetExponentialBucketSnapshot());
+            AssertExponentialBucketsAreCorrect(expectedHistogram, metricPoint.GetExponentialHistogramData());
             Assert.Equal(40, sum);
             Assert.Equal(7, count);
 
@@ -245,7 +244,7 @@ namespace OpenTelemetry.Metrics.Tests
 
             if (aggregationTemporality == AggregationTemporality.Cumulative)
             {
-                AssertExponentialBucketsAreCorrect(expectedHistogram, metricPoint.GetExponentialBucketSnapshot());
+                AssertExponentialBucketsAreCorrect(expectedHistogram, metricPoint.GetExponentialHistogramData());
                 Assert.Equal(40, sum);
                 Assert.Equal(7, count);
 
@@ -263,7 +262,7 @@ namespace OpenTelemetry.Metrics.Tests
             else
             {
                 expectedHistogram.Reset();
-                AssertExponentialBucketsAreCorrect(expectedHistogram, metricPoint.GetExponentialBucketSnapshot());
+                AssertExponentialBucketsAreCorrect(expectedHistogram, metricPoint.GetExponentialHistogramData());
                 Assert.Equal(0, sum);
                 Assert.Equal(0, count);
 
@@ -280,21 +279,21 @@ namespace OpenTelemetry.Metrics.Tests
             }
         }
 
-        private static void AssertExponentialBucketsAreCorrect(Base2ExponentialBucketHistogram expectedHistogram, ExponentialBucketSnapshot buckets)
+        private static void AssertExponentialBucketsAreCorrect(Base2ExponentialBucketHistogram expectedHistogram, ExponentialHistogramData data)
         {
-            Assert.Equal(expectedHistogram.Scale, buckets.Scale);
-            Assert.Equal(expectedHistogram.ZeroCount, buckets.ZeroCount);
-            Assert.Equal(expectedHistogram.PositiveBuckets.Offset, buckets.PositiveOffset);
-            Assert.Equal(expectedHistogram.NegativeBuckets.Offset, buckets.NegativeOffset);
+            Assert.Equal(expectedHistogram.Scale, data.Scale);
+            Assert.Equal(expectedHistogram.ZeroCount, data.ZeroCount);
+            Assert.Equal(expectedHistogram.PositiveBuckets.Offset, data.PositiveBuckets.Offset);
+            Assert.Equal(expectedHistogram.NegativeBuckets.Offset, data.NegativeBuckets.Offset);
 
             var index = expectedHistogram.PositiveBuckets.Offset;
-            foreach (var bucketCount in buckets.PositiveBuckets)
+            foreach (var bucketCount in data.PositiveBuckets)
             {
                 Assert.Equal(expectedHistogram.PositiveBuckets[index++], bucketCount);
             }
 
             index = expectedHistogram.NegativeBuckets.Offset;
-            foreach (var bucketCount in buckets.NegativeBuckets)
+            foreach (var bucketCount in data.NegativeBuckets)
             {
                 Assert.Equal(expectedHistogram.PositiveBuckets[index++], bucketCount);
             }


### PR DESCRIPTION
This PR exposes new public API. The primary consumer of this API are metric exporter authors. Note that while this PR exposes new public API, it does not yet expose anything that enables end users to use exponential histograms yet.

The types and methods in this PR were introduced in prior PRs, this PR just makes them public and renames a few things.

## New Public API

```csharp
namespace OpenTelemetry.Metrics;

public struct MetricPoint
{
    public ExponentialHistogramData GetExponentialHistogramData()
}

public readonly struct ExponentialHistogramData
{
    public int Scale { get; }
    public long ZeroCount { get; }
    public ExponentialHistogramBuckets PositiveBuckets { get; }
    public ExponentialHistogramBuckets NegativeBuckets { get; }
}

public readonly struct ExponentialHistogramBuckets
{
    public int Offset { get; }
    public Enumerator GetEnumerator()
    public struct Enumerator
    {
        public long Current { get; }
        public bool MoveNext()
    }
}
```

## Example API Usage

Consider what the OTLP exporter (not part of this PR) would look like using the API in this PR:

```csharp
var dataPoint = new OtlpMetrics.ExponentialHistogramDataPoint();
var buckets = metricPoint.GetExponentialHistogramData();
dataPoint.Scale = buckets.Scale;

dataPoint.Positive = new OtlpMetrics.ExponentialHistogramDataPoint.Types.Buckets();
dataPoint.Positive.Offset = buckets.PositiveBuckets.Offset;
foreach (var bucketCount in buckets.PositiveBuckets)
{
    dataPoint.Positive.BucketCounts.Add((ulong)bucketCount);
}

dataPoint.Negative = new OtlpMetrics.ExponentialHistogramDataPoint.Types.Buckets();
dataPoint.Negative.Offset = buckets.NegativeBuckets.Offset;
foreach (var bucketCount in buckets.NegativeBuckets)
{
    dataPoint.Negative.BucketCounts.Add((ulong)bucketCount);
}
```
