### PR TITLE
Add MetricType.ExponentialHistogram

### DIFF
--- a/src/OpenTelemetry/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -22,6 +22,7 @@ OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTeleme
 OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
 OpenTelemetry.Metrics.ExponentialHistogramData.Scale.get -> int
 OpenTelemetry.Metrics.ExponentialHistogramData.ZeroCount.get -> long
+OpenTelemetry.Metrics.MetricType.ExponentialHistogram = 80 -> OpenTelemetry.Metrics.MetricType
 OpenTelemetry.Metrics.TraceBasedExemplarFilter
 OpenTelemetry.Metrics.TraceBasedExemplarFilter.TraceBasedExemplarFilter() -> void
 static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetExemplarFilter(this OpenTelemetry.Metrics.MeterProviderBuilder! meterProviderBuilder, OpenTelemetry.Metrics.ExemplarFilter! exemplarFilter) -> OpenTelemetry.Metrics.MeterProviderBuilder!

--- a/src/OpenTelemetry/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -22,6 +22,7 @@ OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTeleme
 OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
 OpenTelemetry.Metrics.ExponentialHistogramData.Scale.get -> int
 OpenTelemetry.Metrics.ExponentialHistogramData.ZeroCount.get -> long
+OpenTelemetry.Metrics.MetricType.ExponentialHistogram = 80 -> OpenTelemetry.Metrics.MetricType
 OpenTelemetry.Metrics.TraceBasedExemplarFilter
 OpenTelemetry.Metrics.TraceBasedExemplarFilter.TraceBasedExemplarFilter() -> void
 static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetExemplarFilter(this OpenTelemetry.Metrics.MeterProviderBuilder! meterProviderBuilder, OpenTelemetry.Metrics.ExemplarFilter! exemplarFilter) -> OpenTelemetry.Metrics.MeterProviderBuilder!

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -22,6 +22,7 @@ OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTeleme
 OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
 OpenTelemetry.Metrics.ExponentialHistogramData.Scale.get -> int
 OpenTelemetry.Metrics.ExponentialHistogramData.ZeroCount.get -> long
+OpenTelemetry.Metrics.MetricType.ExponentialHistogram = 80 -> OpenTelemetry.Metrics.MetricType
 OpenTelemetry.Metrics.TraceBasedExemplarFilter
 OpenTelemetry.Metrics.TraceBasedExemplarFilter.TraceBasedExemplarFilter() -> void
 static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetExemplarFilter(this OpenTelemetry.Metrics.MeterProviderBuilder! meterProviderBuilder, OpenTelemetry.Metrics.ExemplarFilter! exemplarFilter) -> OpenTelemetry.Metrics.MeterProviderBuilder!

--- a/src/OpenTelemetry/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
@@ -22,6 +22,7 @@ OpenTelemetry.Metrics.ExponentialHistogramData.NegativeBuckets.get -> OpenTeleme
 OpenTelemetry.Metrics.ExponentialHistogramData.PositiveBuckets.get -> OpenTelemetry.Metrics.ExponentialHistogramBuckets!
 OpenTelemetry.Metrics.ExponentialHistogramData.Scale.get -> int
 OpenTelemetry.Metrics.ExponentialHistogramData.ZeroCount.get -> long
+OpenTelemetry.Metrics.MetricType.ExponentialHistogram = 80 -> OpenTelemetry.Metrics.MetricType
 OpenTelemetry.Metrics.TraceBasedExemplarFilter
 OpenTelemetry.Metrics.TraceBasedExemplarFilter.TraceBasedExemplarFilter() -> void
 static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetExemplarFilter(this OpenTelemetry.Metrics.MeterProviderBuilder! meterProviderBuilder, OpenTelemetry.Metrics.ExemplarFilter! exemplarFilter) -> OpenTelemetry.Metrics.MeterProviderBuilder!

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -38,7 +38,7 @@ namespace OpenTelemetry.Metrics
         private readonly int[] currentMetricPointBatch;
         private readonly AggregationType aggType;
         private readonly double[] histogramBounds;
-        private readonly int exponentialHistogramMaxBuckets;
+        private readonly int exponentialHistogramMaxSize;
         private readonly UpdateLongDelegate updateLongCallback;
         private readonly UpdateDoubleDelegate updateDoubleCallback;
         private readonly int maxMetricPoints;
@@ -49,27 +49,24 @@ namespace OpenTelemetry.Metrics
         private bool zeroTagMetricPointInitialized;
 
         internal AggregatorStore(
-            string name,
+            MetricStreamIdentity metricStreamIdentity,
             AggregationType aggType,
             AggregationTemporality temporality,
             int maxMetricPoints,
-            double[] histogramBounds,
-            int exponentialHistogramMaxBuckets,
-            string[] tagKeysInteresting = null,
             ExemplarFilter exemplarFilter = null)
         {
-            this.name = name;
+            this.name = metricStreamIdentity.InstrumentName;
             this.maxMetricPoints = maxMetricPoints;
             this.metricPointCapHitMessage = $"Maximum MetricPoints limit reached for this Metric stream. Configured limit: {this.maxMetricPoints}";
             this.metricPoints = new MetricPoint[maxMetricPoints];
             this.currentMetricPointBatch = new int[maxMetricPoints];
             this.aggType = aggType;
             this.outputDelta = temporality == AggregationTemporality.Delta;
-            this.histogramBounds = histogramBounds;
-            this.exponentialHistogramMaxBuckets = exponentialHistogramMaxBuckets;
+            this.histogramBounds = metricStreamIdentity.HistogramBucketBounds;
+            this.exponentialHistogramMaxSize = metricStreamIdentity.ExponentialHistogramMaxSize;
             this.StartTimeExclusive = DateTimeOffset.UtcNow;
             this.exemplarFilter = exemplarFilter ?? new AlwaysOffExemplarFilter();
-            if (tagKeysInteresting == null)
+            if (metricStreamIdentity.TagKeys == null)
             {
                 this.updateLongCallback = this.UpdateLong;
                 this.updateDoubleCallback = this.UpdateDouble;
@@ -78,7 +75,7 @@ namespace OpenTelemetry.Metrics
             {
                 this.updateLongCallback = this.UpdateLongCustomTags;
                 this.updateDoubleCallback = this.UpdateDoubleCustomTags;
-                var hs = new HashSet<string>(tagKeysInteresting, StringComparer.Ordinal);
+                var hs = new HashSet<string>(metricStreamIdentity.TagKeys, StringComparer.Ordinal);
                 this.tagKeysInteresting = hs;
                 this.tagsKeysInterestingCount = hs.Count;
             }
@@ -191,7 +188,7 @@ namespace OpenTelemetry.Metrics
                 {
                     if (!this.zeroTagMetricPointInitialized)
                     {
-                        this.metricPoints[0] = new MetricPoint(this, this.aggType, null, this.histogramBounds, this.exponentialHistogramMaxBuckets);
+                        this.metricPoints[0] = new MetricPoint(this, this.aggType, null, this.histogramBounds, this.exponentialHistogramMaxSize);
                         this.zeroTagMetricPointInitialized = true;
                     }
                 }
@@ -258,7 +255,7 @@ namespace OpenTelemetry.Metrics
                                 }
 
                                 ref var metricPoint = ref this.metricPoints[aggregatorIndex];
-                                metricPoint = new MetricPoint(this, this.aggType, sortedTags.KeyValuePairs, this.histogramBounds, this.exponentialHistogramMaxBuckets);
+                                metricPoint = new MetricPoint(this, this.aggType, sortedTags.KeyValuePairs, this.histogramBounds, this.exponentialHistogramMaxSize);
 
                                 // Add to dictionary *after* initializing MetricPoint
                                 // as other threads can start writing to the
@@ -307,7 +304,7 @@ namespace OpenTelemetry.Metrics
                             }
 
                             ref var metricPoint = ref this.metricPoints[aggregatorIndex];
-                            metricPoint = new MetricPoint(this, this.aggType, givenTags.KeyValuePairs, this.histogramBounds, this.exponentialHistogramMaxBuckets);
+                            metricPoint = new MetricPoint(this, this.aggType, givenTags.KeyValuePairs, this.histogramBounds, this.exponentialHistogramMaxSize);
 
                             // Add to dictionary *after* initializing MetricPoint
                             // as other threads can start writing to the

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -62,7 +62,7 @@ namespace OpenTelemetry.Metrics
             this.currentMetricPointBatch = new int[maxMetricPoints];
             this.aggType = aggType;
             this.outputDelta = temporality == AggregationTemporality.Delta;
-            this.histogramBounds = metricStreamIdentity.HistogramBucketBounds;
+            this.histogramBounds = metricStreamIdentity.HistogramBucketBounds ?? Metric.DefaultHistogramBounds;
             this.exponentialHistogramMaxSize = metricStreamIdentity.ExponentialHistogramMaxSize;
             this.StartTimeExclusive = DateTimeOffset.UtcNow;
             this.exemplarFilter = exemplarFilter ?? new AlwaysOffExemplarFilter();

--- a/src/OpenTelemetry/Metrics/MetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/MetricReaderExt.cs
@@ -156,7 +156,7 @@ namespace OpenTelemetry.Metrics
                     }
                     else
                     {
-                        Metric metric = new(metricStreamIdentity, this.GetAggregationTemporality(metricStreamIdentity.InstrumentType), this.maxMetricPointsPerMetricStream, metricStreamIdentity.HistogramBucketBounds, metricStreamIdentity.TagKeys, metricStreamIdentity.HistogramRecordMinMax, this.exemplarFilter);
+                        Metric metric = new(metricStreamIdentity, this.GetAggregationTemporality(metricStreamIdentity.InstrumentType), this.maxMetricPointsPerMetricStream, this.exemplarFilter);
 
                         this.instrumentIdentityToMetric[metricStreamIdentity] = metric;
                         this.metrics[index] = metric;

--- a/src/OpenTelemetry/Metrics/MetricStreamIdentity.cs
+++ b/src/OpenTelemetry/Metrics/MetricStreamIdentity.cs
@@ -35,6 +35,7 @@ namespace OpenTelemetry.Metrics
             this.MetricStreamName = $"{this.MeterName}.{this.MeterVersion}.{this.InstrumentName}";
             this.TagKeys = metricStreamConfiguration?.CopiedTagKeys;
             this.HistogramBucketBounds = (metricStreamConfiguration as ExplicitBucketHistogramConfiguration)?.CopiedBoundaries;
+            this.ExponentialHistogramMaxSize = (metricStreamConfiguration as Base2ExponentialBucketHistogramConfiguration)?.MaxSize ?? 0;
             this.HistogramRecordMinMax = (metricStreamConfiguration as HistogramConfiguration)?.RecordMinMax ?? true;
 
 #if NETSTANDARD2_1 || NET6_0_OR_GREATER
@@ -48,6 +49,7 @@ namespace OpenTelemetry.Metrics
             hashCode.Add(this.Description);
             hashCode.Add(this.ViewId);
             hashCode.Add(this.TagKeys, StringArrayComparer);
+            hashCode.Add(this.ExponentialHistogramMaxSize);
             if (this.HistogramBucketBounds != null)
             {
                 for (var i = 0; i < this.HistogramBucketBounds.Length; ++i)
@@ -66,6 +68,7 @@ namespace OpenTelemetry.Metrics
                 hash = (hash * 31) + this.MeterVersion.GetHashCode();
                 hash = (hash * 31) + this.InstrumentName.GetHashCode();
                 hash = (hash * 31) + this.HistogramRecordMinMax.GetHashCode();
+                hash = (hash * 31) + this.ExponentialHistogramMaxSize.GetHashCode();
                 hash = (hash * 31) + (this.Unit?.GetHashCode() ?? 0);
                 hash = (hash * 31) + (this.Description?.GetHashCode() ?? 0);
                 hash = (hash * 31) + (this.ViewId ?? 0);
@@ -104,6 +107,8 @@ namespace OpenTelemetry.Metrics
 
         public double[] HistogramBucketBounds { get; }
 
+        public int ExponentialHistogramMaxSize { get; }
+
         public bool HistogramRecordMinMax { get; }
 
         public static bool operator ==(MetricStreamIdentity metricIdentity1, MetricStreamIdentity metricIdentity2) => metricIdentity1.Equals(metricIdentity2);
@@ -125,6 +130,7 @@ namespace OpenTelemetry.Metrics
                 && this.Description == other.Description
                 && this.ViewId == other.ViewId
                 && this.HistogramRecordMinMax == other.HistogramRecordMinMax
+                && this.ExponentialHistogramMaxSize == other.ExponentialHistogramMaxSize
                 && StringArrayComparer.Equals(this.TagKeys, other.TagKeys)
                 && HistogramBoundsEqual(this.HistogramBucketBounds, other.HistogramBucketBounds);
         }

--- a/src/OpenTelemetry/Metrics/MetricType.cs
+++ b/src/OpenTelemetry/Metrics/MetricType.cs
@@ -25,9 +25,9 @@ namespace OpenTelemetry.Metrics
             0x20: Gauge
             0x30: Summary (reserved)
             0x40: Histogram
-            0x50: HistogramWithMinMax (reserved)
-            0x60: ExponentialHistogram (reserved)
-            0x70: ExponentialHistogramWithMinMax (reserved)
+            0x50: ExponentialHistogram
+            0x60: (unused)
+            0x70: (unused)
             0x80: SumNonMonotonic
 
         Point kind:
@@ -67,6 +67,11 @@ namespace OpenTelemetry.Metrics
         /// Histogram.
         /// </summary>
         Histogram = 0x40,
+
+        /// <summary>
+        /// Exponential Histogram.
+        /// </summary>
+        ExponentialHistogram = 0x50,
 
         /// <summary>
         /// Non-monotonic Sum of Long type.


### PR DESCRIPTION
Adds `MetricType.ExponentialHistogram`. Even though it becomes part of the public API in this PR, this PR still does not yet expose the ability to configure the exponential histogram aggregation.

I've also begun refactoring things a bit. I'm not thrilled by how the constructors for Metric, AggregatorStore, and MetricPoint keep growing. With this PR I could have added yet another parameter to the Metric constructor for ExponentialHistogramMaxSize. Later I would then also need to add ExponentialHistogramMaxScale. Instead this information is already on the MetricStreamIdentity. The refactor in this PR is a small step, but there's definitely more we can do to further simplify this code further.