### PR TITLE
updated DroppedCount in BatchExportProcessor to use Volatile.Read()

### DIFF
--- a/src/OpenTelemetry/BatchExportProcessor.cs
+++ b/src/OpenTelemetry/BatchExportProcessor.cs
@@ -83,7 +83,7 @@ namespace OpenTelemetry
         /// <summary>
         /// Gets the number of telemetry objects dropped by the processor.
         /// </summary>
-        internal long DroppedCount => this.droppedCount;
+        internal long DroppedCount => Volatile.Read(ref this.droppedCount);
 
         /// <summary>
         /// Gets the number of telemetry objects received by the processor.

--- a/src/OpenTelemetry/BatchExportProcessor.cs
+++ b/src/OpenTelemetry/BatchExportProcessor.cs
@@ -219,7 +219,7 @@ namespace OpenTelemetry
                 return false;
             }
 
-            OpenTelemetrySdkEventSource.Log.DroppedExportProcessorItems(this.GetType().Name, this.exporter.GetType().Name, this.droppedCount);
+            OpenTelemetrySdkEventSource.Log.DroppedExportProcessorItems(this.GetType().Name, this.exporter.GetType().Name, this.DroppedCount);
 
             if (timeoutMilliseconds == Timeout.Infinite)
             {


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-dotnet/issues/4226
Related to https://github.com/open-telemetry/opentelemetry-dotnet/pull/4294
Design discussion issue #

## Changes
Updated DroppedCount in BatchExportProcessor to use Volatile.Read() for the same reasoning in https://github.com/open-telemetry/opentelemetry-dotnet/pull/4294.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
