### PR TITLE
[sdk] SuppressInstrumentationScope perf tweaks

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Implementation of `SuppressInstrumentationScope` changed to improve
+  performance.
+  ([#4304](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4304))
+
 ## 1.5.0-alpha.1
 
 Released 2023-Mar-07

--- a/src/OpenTelemetry/SuppressInstrumentationScope.cs
+++ b/src/OpenTelemetry/SuppressInstrumentationScope.cs
@@ -24,21 +24,24 @@ namespace OpenTelemetry
     public sealed class SuppressInstrumentationScope : IDisposable
     {
         // An integer value which controls whether instrumentation should be suppressed (disabled).
-        // * 0: instrumentation is not suppressed
-        // * [int.MinValue, -1]: instrumentation is always suppressed
-        // * [1, int.MaxValue]: instrumentation is suppressed in a reference-counting mode
-        private static readonly RuntimeContextSlot<int> Slot = RuntimeContext.RegisterSlot<int>("otel.suppress_instrumentation");
+        // * null: instrumentation is not suppressed
+        // * Value = [int.MinValue, -1]: instrumentation is always suppressed
+        // * Value = [1, int.MaxValue]: instrumentation is suppressed in a reference-counting mode
+        private static readonly RuntimeContextSlot<SuppressInstrumentationScope?> Slot = RuntimeContext.RegisterSlot<SuppressInstrumentationScope?>("otel.suppress_instrumentation");
 
-        private readonly int previousValue;
+        private readonly SuppressInstrumentationScope? previousScope;
         private bool disposed;
 
         internal SuppressInstrumentationScope(bool value = true)
         {
-            this.previousValue = Slot.Get();
-            Slot.Set(value ? -1 : 0);
+            this.previousScope = Slot.Get();
+            this.Depth = value ? -1 : 0;
+            Slot.Set(this);
         }
 
-        internal static bool IsSuppressed => Slot.Get() != 0;
+        internal static bool IsSuppressed => (Slot.Get()?.Depth ?? 0) != 0;
+
+        internal int Depth { get; private set; }
 
         /// <summary>
         /// Begins a new scope in which instrumentation is suppressed (disabled).
@@ -70,21 +73,34 @@ namespace OpenTelemetry
         /// <summary>
         /// Enters suppression mode.
         /// If suppression mode is enabled (slot is a negative integer), do nothing.
-        /// If suppression mode is not enabled (slot is zero), enter reference-counting suppression mode.
+        /// If suppression mode is not enabled (slot is null), enter reference-counting suppression mode.
         /// If suppression mode is enabled (slot is a positive integer), increment the ref count.
         /// </summary>
         /// <returns>The updated suppression slot value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Enter()
         {
-            var value = Slot.Get();
+            var currentScope = Slot.Get();
 
-            if (value >= 0)
+            if (currentScope == null)
             {
-                Slot.Set(++value);
+                Slot.Set(
+                    new SuppressInstrumentationScope(true)
+                    {
+                        Depth = 1,
+                    });
+
+                return 0;
             }
 
-            return value;
+            var currentDepth = currentScope.Depth;
+
+            if (currentDepth >= 0)
+            {
+                currentScope.Depth = currentDepth + 1;
+            }
+
+            return currentDepth;
         }
 
         /// <inheritdoc/>
@@ -92,7 +108,7 @@ namespace OpenTelemetry
         {
             if (!this.disposed)
             {
-                Slot.Set(this.previousValue);
+                Slot.Set(this.previousScope);
                 this.disposed = true;
             }
         }
@@ -100,27 +116,45 @@ namespace OpenTelemetry
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int IncrementIfTriggered()
         {
-            var value = Slot.Get();
+            var currentScope = Slot.Get();
 
-            if (value > 0)
+            if (currentScope == null)
             {
-                Slot.Set(++value);
+                return 0;
             }
 
-            return value;
+            var currentDepth = currentScope.Depth;
+
+            if (currentScope.Depth > 0)
+            {
+                currentScope.Depth = currentDepth + 1;
+            }
+
+            return currentDepth;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int DecrementIfTriggered()
         {
-            var value = Slot.Get();
+            var currentScope = Slot.Get();
 
-            if (value > 0)
+            if (currentScope == null)
             {
-                Slot.Set(--value);
+                return 0;
             }
 
-            return value;
+            var currentDepth = currentScope.Depth;
+
+            if (currentDepth == 1)
+            {
+                Slot.Set(currentScope.previousScope);
+            }
+            else if (currentScope.Depth > 0)
+            {
+                currentScope.Depth = currentDepth - 1;
+            }
+
+            return currentDepth;
         }
     }
 }

--- a/src/OpenTelemetry/SuppressInstrumentationScope.cs
+++ b/src/OpenTelemetry/SuppressInstrumentationScope.cs
@@ -72,9 +72,9 @@ namespace OpenTelemetry
 
         /// <summary>
         /// Enters suppression mode.
-        /// If suppression mode is enabled (slot is a negative integer), do nothing.
+        /// If suppression mode is enabled (slot.Depth is a negative integer), do nothing.
         /// If suppression mode is not enabled (slot is null), enter reference-counting suppression mode.
-        /// If suppression mode is enabled (slot is a positive integer), increment the ref count.
+        /// If suppression mode is enabled (slot.Depth is a positive integer), increment the ref count.
         /// </summary>
         /// <returns>The updated suppression slot value.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -90,14 +90,14 @@ namespace OpenTelemetry
                         Depth = 1,
                     });
 
-                return 0;
+                return 1;
             }
 
             var currentDepth = currentScope.Depth;
 
             if (currentDepth >= 0)
             {
-                currentScope.Depth = currentDepth + 1;
+                currentScope.Depth = ++currentDepth;
             }
 
             return currentDepth;
@@ -127,7 +127,7 @@ namespace OpenTelemetry
 
             if (currentScope.Depth > 0)
             {
-                currentScope.Depth = currentDepth + 1;
+                currentScope.Depth = ++currentDepth;
             }
 
             return currentDepth;
@@ -145,13 +145,16 @@ namespace OpenTelemetry
 
             var currentDepth = currentScope.Depth;
 
-            if (currentDepth == 1)
+            if (currentScope.Depth > 0)
             {
-                Slot.Set(currentScope.previousScope);
-            }
-            else if (currentScope.Depth > 0)
-            {
-                currentScope.Depth = currentDepth - 1;
+                if (--currentDepth == 0)
+                {
+                    Slot.Set(currentScope.previousScope);
+                }
+                else
+                {
+                    currentScope.Depth = currentDepth;
+                }
             }
 
             return currentDepth;

--- a/src/OpenTelemetry/SuppressInstrumentationScope.cs
+++ b/src/OpenTelemetry/SuppressInstrumentationScope.cs
@@ -25,8 +25,8 @@ namespace OpenTelemetry
     {
         // An integer value which controls whether instrumentation should be suppressed (disabled).
         // * null: instrumentation is not suppressed
-        // * Value = [int.MinValue, -1]: instrumentation is always suppressed
-        // * Value = [1, int.MaxValue]: instrumentation is suppressed in a reference-counting mode
+        // * Depth = [int.MinValue, -1]: instrumentation is always suppressed
+        // * Depth = [1, int.MaxValue]: instrumentation is suppressed in a reference-counting mode
         private static readonly RuntimeContextSlot<SuppressInstrumentationScope?> Slot = RuntimeContext.RegisterSlot<SuppressInstrumentationScope?>("otel.suppress_instrumentation");
 
         private readonly SuppressInstrumentationScope? previousScope;

--- a/test/Benchmarks/SuppressInstrumentationScopeBenchmarks.cs
+++ b/test/Benchmarks/SuppressInstrumentationScopeBenchmarks.cs
@@ -1,0 +1,44 @@
+// <copyright file="SuppressInstrumentationScopeBenchmarks.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using BenchmarkDotNet.Attributes;
+
+namespace OpenTelemetry.Benchmarks;
+
+public class SuppressInstrumentationScopeBenchmarks
+{
+    [Benchmark]
+    public void Begin()
+    {
+        using var scope1 = SuppressInstrumentationScope.Begin();
+
+        using var scope2 = SuppressInstrumentationScope.Begin();
+
+        using var scope3 = SuppressInstrumentationScope.Begin();
+    }
+
+    [Benchmark]
+    public void Enter()
+    {
+        SuppressInstrumentationScope.Enter();
+
+        SuppressInstrumentationScope.IncrementIfTriggered();
+
+        SuppressInstrumentationScope.DecrementIfTriggered();
+
+        SuppressInstrumentationScope.DecrementIfTriggered();
+    }
+}

--- a/test/OpenTelemetry.Tests/SuppressInstrumentationTest.cs
+++ b/test/OpenTelemetry.Tests/SuppressInstrumentationTest.cs
@@ -72,7 +72,7 @@ namespace OpenTelemetry.Tests
             await Task.Factory.StartNew(() =>
             {
                 Assert.False(Sdk.SuppressInstrumentation);
-                SuppressInstrumentationScope.Enter();
+                Assert.Equal(1, SuppressInstrumentationScope.Enter());
                 Assert.True(Sdk.SuppressInstrumentation);
             }).ConfigureAwait(false);
 
@@ -84,13 +84,13 @@ namespace OpenTelemetry.Tests
         {
             // Instrumentation is not suppressed, DecrementIfTriggered is a no op
             Assert.False(Sdk.SuppressInstrumentation);
-            SuppressInstrumentationScope.DecrementIfTriggered();
+            Assert.Equal(0, SuppressInstrumentationScope.DecrementIfTriggered());
             Assert.False(Sdk.SuppressInstrumentation);
 
             // Instrumentation is suppressed in reference counting mode, DecrementIfTriggered should work
-            SuppressInstrumentationScope.Enter();
+            Assert.Equal(1, SuppressInstrumentationScope.Enter());
             Assert.True(Sdk.SuppressInstrumentation);
-            SuppressInstrumentationScope.DecrementIfTriggered();
+            Assert.Equal(0, SuppressInstrumentationScope.DecrementIfTriggered());
             Assert.False(Sdk.SuppressInstrumentation); // Instrumentation is not suppressed anymore
         }
 
@@ -99,16 +99,16 @@ namespace OpenTelemetry.Tests
         {
             // Instrumentation is not suppressed, IncrementIfTriggered is a no op
             Assert.False(Sdk.SuppressInstrumentation);
-            SuppressInstrumentationScope.IncrementIfTriggered();
+            Assert.Equal(0, SuppressInstrumentationScope.IncrementIfTriggered());
             Assert.False(Sdk.SuppressInstrumentation);
 
             // Instrumentation is suppressed in reference counting mode, IncrementIfTriggered should work
-            SuppressInstrumentationScope.Enter();
-            SuppressInstrumentationScope.IncrementIfTriggered();
+            Assert.Equal(1, SuppressInstrumentationScope.Enter());
+            Assert.Equal(2, SuppressInstrumentationScope.IncrementIfTriggered());
             Assert.True(Sdk.SuppressInstrumentation);
-            SuppressInstrumentationScope.DecrementIfTriggered();
+            Assert.Equal(1, SuppressInstrumentationScope.DecrementIfTriggered());
             Assert.True(Sdk.SuppressInstrumentation); // Instrumentation is still suppressed as IncrementIfTriggered incremented the slot count after Enter, need to decrement the slot count again to enable instrumentation
-            SuppressInstrumentationScope.DecrementIfTriggered();
+            Assert.Equal(0, SuppressInstrumentationScope.DecrementIfTriggered());
             Assert.False(Sdk.SuppressInstrumentation); // Instrumentation is not suppressed anymore
         }
     }


### PR DESCRIPTION
## Changes

Tweaked the implementation of `SuppressInstrumentationScope` to achieve better perf.

Before...

* We stored an `int` in the context slot. That `int` had to be boxed when scopes were created and we boxed a 0 when scopes were disposed.
* Any time we incremented or decremented in reference counting mode we pushed a new `int` to the context slot which had to be boxed AND creates a new `ExecutionContext`.

After...

* We store the `SuppressInstrumentationScope` instance itself in the context slot. That avoids the boxing and gives us storage for the reference count which we can increment/decrement freely without creating any new `ExecutionContext`s.

## Benchmarks

Before:

| Method |      Mean |    Error |   StdDev |   Gen0 | Allocated |
|------- |----------:|---------:|---------:|-------:|----------:|
|  Begin | 143.91 ns | 2.027 ns | 1.896 ns | 0.0515 |     648 B |
|  Enter |  99.49 ns | 1.226 ns | 1.147 ns | 0.0305 |     384 B |

After:

| Method |      Mean |    Error |   StdDev |   Gen0 | Allocated |
|------- |----------:|---------:|---------:|-------:|----------:|
|  Begin | 125.37 ns | 1.738 ns | 1.626 ns | 0.0362 |     456 B |
|  Enter |  59.17 ns | 0.710 ns | 0.664 ns | 0.0082 |     104 B |

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [X] Unit tests added/updated
