### PR TITLE
Fix min/max snapshot for explicit bounds histogram

### DIFF
--- a/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Fixed issue where the `MetricSnapshot` of a histogram did not capture the min
+  and max values.
+  ([#4306](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4306))
+
 ## 1.5.0-alpha.1
 
 Released 2023-Mar-07

--- a/src/OpenTelemetry/Metrics/HistogramBuckets.cs
+++ b/src/OpenTelemetry/Metrics/HistogramBuckets.cs
@@ -87,6 +87,8 @@ namespace OpenTelemetry.Metrics
 
             Array.Copy(this.SnapshotBucketCounts, copy.SnapshotBucketCounts, this.SnapshotBucketCounts.Length);
             copy.SnapshotSum = this.SnapshotSum;
+            copy.SnapshotMin = this.SnapshotMin;
+            copy.SnapshotMax = this.SnapshotMax;
 
             return copy;
         }

--- a/test/OpenTelemetry.Tests/Metrics/MetricSnapshotTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricSnapshotTests.cs
@@ -117,6 +117,9 @@ namespace OpenTelemetry.Metrics.Tests
             ref readonly var metricPoint1 = ref metricPoints1Enumerator.Current;
             Assert.Equal(1, metricPoint1.GetHistogramCount());
             Assert.Equal(10, metricPoint1.GetHistogramSum());
+            metricPoint1.TryGetHistogramMinMaxValues(out var min, out var max);
+            Assert.Equal(10, min);
+            Assert.Equal(10, max);
 
             // Verify Snapshot 1
             Assert.Single(exportedSnapshots);
@@ -124,6 +127,9 @@ namespace OpenTelemetry.Metrics.Tests
             Assert.Single(snapshot1.MetricPoints);
             Assert.Equal(1, snapshot1.MetricPoints[0].GetHistogramCount());
             Assert.Equal(10, snapshot1.MetricPoints[0].GetHistogramSum());
+            snapshot1.MetricPoints[0].TryGetHistogramMinMaxValues(out min, out max);
+            Assert.Equal(10, min);
+            Assert.Equal(10, max);
 
             // Verify Metric == Snapshot
             Assert.Equal(metric1.Name, snapshot1.Name);
@@ -141,6 +147,9 @@ namespace OpenTelemetry.Metrics.Tests
             // This value is expected to be updated.
             Assert.Equal(2, metricPoint1.GetHistogramCount());
             Assert.Equal(15, metricPoint1.GetHistogramSum());
+            metricPoint1.TryGetHistogramMinMaxValues(out min, out max);
+            Assert.Equal(5, min);
+            Assert.Equal(10, max);
 
             // Verify Metric 2
             Assert.Equal(2, exportedMetrics.Count);
@@ -150,11 +159,17 @@ namespace OpenTelemetry.Metrics.Tests
             ref readonly var metricPoint2 = ref metricPoints2Enumerator.Current;
             Assert.Equal(2, metricPoint2.GetHistogramCount());
             Assert.Equal(15, metricPoint2.GetHistogramSum());
+            metricPoint2.TryGetHistogramMinMaxValues(out min, out max);
+            Assert.Equal(5, min);
+            Assert.Equal(10, max);
 
             // Verify Snapshot 1 after second export
             // This value is expected to be unchanged.
             Assert.Equal(1, snapshot1.MetricPoints[0].GetHistogramCount());
             Assert.Equal(10, snapshot1.MetricPoints[0].GetHistogramSum());
+            snapshot1.MetricPoints[0].TryGetHistogramMinMaxValues(out min, out max);
+            Assert.Equal(10, min);
+            Assert.Equal(10, max);
 
             // Verify Snapshot 2
             Assert.Equal(2, exportedSnapshots.Count);
@@ -162,6 +177,9 @@ namespace OpenTelemetry.Metrics.Tests
             Assert.Single(snapshot2.MetricPoints);
             Assert.Equal(2, snapshot2.MetricPoints[0].GetHistogramCount());
             Assert.Equal(15, snapshot2.MetricPoints[0].GetHistogramSum());
+            snapshot2.MetricPoints[0].TryGetHistogramMinMaxValues(out min, out max);
+            Assert.Equal(5, min);
+            Assert.Equal(10, max);
         }
     }
 }


### PR DESCRIPTION
The min and max values were not captured in the MetricSnapshot for the InMemory exporter.