### PR TITLE
[Instrumentation.AspNetCore] Document metrics

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
@@ -87,7 +87,7 @@ public void ConfigureServices(IServiceCollection services)
 
 #### List of metrics produced
 
-The instrumentation was implemented based on [metrics semantic
+The instrumentation is implemented based on [metrics semantic
 conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md#metric-httpclientduration).
 Currently, the instrumentation supports the following metric.
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
@@ -37,12 +37,17 @@ dotnet add package --prerelease OpenTelemetry.Instrumentation.AspNetCore
 ### Step 2: Enable ASP.NET Core Instrumentation at application startup
 
 ASP.NET Core instrumentation must be enabled at application startup. This is
-typically done in the `ConfigureServices` of your `Startup` class.
+typically done in the `ConfigureServices` of your `Startup` class. Both examples
+below enables OpenTelemetry by `AddOpenTelemetry()` on `IServiceCollection`.
+ This extension method requires adding the package
+[`OpenTelemetry.Extensions.Hosting`](../OpenTelemetry.Extensions.Hosting/README.md)
+to the application. This ensures instrumentations are disposed when the host
+is shutdown.
 
 #### Traces
 
 The following example demonstrates adding ASP.NET Core instrumentation with the
-extension method `AddOpenTelemetry().WithTracing()` on `IServiceCollection`
+extension method `WithTracing()` on `OpenTelemetryBuilder`.
 then extension method `AddAspNetCoreInstrumentation()` on `TracerProviderBuilder`
 to the application. This example also sets up the OTLP (OpenTelemetry Protocol)
 Exporter, which requires adding the package
@@ -65,7 +70,7 @@ public void ConfigureServices(IServiceCollection services)
 #### Metrics
 
 The following example demonstrates adding ASP.NET Core instrumentation with the
-extension method `AddOpenTelemetry().WithMetrics()` on `IServiceCollection`
+extension method `WithMetrics()` on `OpenTelemetryBuilder`
 then extension method `AddAspNetCoreInstrumentation()` on `MeterProviderBuilder`
 to the application. This example also sets up the OTLP (OpenTelemetry Protocol)
 Exporter, which requires adding the package

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
@@ -43,7 +43,7 @@ typically done in the `ConfigureServices` of your `Startup` class.
 
 The following example demonstrates adding ASP.NET Core instrumentation with the
 extension method `AddOpenTelemetry().WithTracing()` on `IServiceCollection`
-then extension method `AddHttpClientInstrumentation()` on `TracerProviderBuilder`
+then extension method `AddAspNetCoreInstrumentation()` on `TracerProviderBuilder`
 to the application. This example also sets up the OTLP (OpenTelemetry Protocol)
 Exporter, which requires adding the package
 [`OpenTelemetry.Exporter.OpenTelemetryProtocol`](../OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md)
@@ -66,7 +66,7 @@ public void ConfigureServices(IServiceCollection services)
 
 The following example demonstrates adding ASP.NET Core instrumentation with the
 extension method `AddOpenTelemetry().WithMetrics()` on `IServiceCollection`
-then extension method `AddHttpClientInstrumentation()` on `MeterProviderBuilder`
+then extension method `AddAspNetCoreInstrumentation()` on `MeterProviderBuilder`
 to the application. This example also sets up the OTLP (OpenTelemetry Protocol)
 Exporter, which requires adding the package
 [`OpenTelemetry.Exporter.OpenTelemetryProtocol`](../OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md)
@@ -88,12 +88,12 @@ public void ConfigureServices(IServiceCollection services)
 #### List of metrics produced
 
 The instrumentation is implemented based on [metrics semantic
-conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md#metric-httpclientduration).
+conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md#metric-httpserverduration).
 Currently, the instrumentation supports the following metric.
 
 | Name  | Instrument Type | Unit | Description |
 |-------|-----------------|------|-------------|
-| `http.client.duration` | Histogram | `ms` | Measures the duration of outbound HTTP requests. |
+| `http.server.duration` | Histogram | `ms` | Measures the duration of inbound HTTP requests. |
 
 ## Advanced configuration
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
@@ -37,17 +37,17 @@ dotnet add package --prerelease OpenTelemetry.Instrumentation.AspNetCore
 ### Step 2: Enable ASP.NET Core Instrumentation at application startup
 
 ASP.NET Core instrumentation must be enabled at application startup. This is
-typically done in the `ConfigureServices` of your `Startup` class. The example
-below enables this instrumentation by using an extension method on
-`IServiceCollection`. This extension method requires adding the package
-[`OpenTelemetry.Extensions.Hosting`](../OpenTelemetry.Extensions.Hosting/README.md)
-to the application. This ensures the instrumentation is disposed when the host
-is shutdown.
+typically done in the `ConfigureServices` of your `Startup` class.
 
-Additionally, this examples sets up the OpenTelemetry Jaeger exporter, which
-requires adding the package
-[`OpenTelemetry.Exporter.Jaeger`](../OpenTelemetry.Exporter.Jaeger/README.md) to
-the application.
+#### Traces
+
+The following example demonstrates adding ASP.NET Core instrumentation with the
+extension method `AddOpenTelemetry().WithTracing()` on `IServiceCollection`
+then extension method `AddHttpClientInstrumentation()` on `TracerProviderBuilder`
+to the application. This example also sets up the OTLP (OpenTelemetry Protocol)
+Exporter, which requires adding the package
+[`OpenTelemetry.Exporter.OpenTelemetryProtocol`](../OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md)
+to the application.
 
 ```csharp
 using Microsoft.Extensions.DependencyInjection;
@@ -58,15 +58,42 @@ public void ConfigureServices(IServiceCollection services)
     services.AddOpenTelemetry()
         .WithTracing(builder => builder
             .AddAspNetCoreInstrumentation()
-            .AddJaegerExporter());
+            .AddOtlpExporter());
 }
 ```
 
-## Metrics
+#### Metrics
 
-This package produces following metrics:
+The following example demonstrates adding ASP.NET Core instrumentation with the
+extension method `AddOpenTelemetry().WithMetrics()` on `IServiceCollection`
+then extension method `AddHttpClientInstrumentation()` on `MeterProviderBuilder`
+to the application. This example also sets up the OTLP (OpenTelemetry Protocol)
+Exporter, which requires adding the package
+[`OpenTelemetry.Exporter.OpenTelemetryProtocol`](../OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md)
+to the application.
 
-* [`http.server.duration`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md#metric-httpserverduration)
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Metrics;
+
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddOpenTelemetry()
+        .WithMetrics(builder => builder
+            .AddAspNetCoreInstrumentation()
+            .AddOtlpExporter());
+}
+```
+
+#### List of metrics produced
+
+The instrumentation was implemented based on [metrics semantic
+conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md#metric-httpclientduration).
+Currently, the instrumentation supports the following metric.
+
+| Name  | Instrument Type | Unit | Description |
+|-------|-----------------|------|-------------|
+| `http.client.duration` | Histogram | `ms` | Measures the duration of outbound HTTP requests. |
 
 ## Advanced configuration
 
@@ -93,7 +120,7 @@ services.Configure<AspNetCoreInstrumentationOptions>(options =>
 services.AddOpenTelemetry()
     .WithTracing(builder => builder
         .AddAspNetCoreInstrumentation()
-        .AddJaegerExporter());
+        .AddOtlpExporter());
 ```
 
 ### Filter
@@ -116,7 +143,7 @@ services.AddOpenTelemetry()
             // only collect telemetry about HTTP GET requests
             return httpContext.Request.Method.Equals("GET");
         })
-        .AddJaegerExporter());
+        .AddOtlpExporter());
 ```
 
 It is important to note that this `Filter` option is specific to this

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
@@ -38,7 +38,7 @@ dotnet add package --prerelease OpenTelemetry.Instrumentation.AspNetCore
 
 ASP.NET Core instrumentation must be enabled at application startup. This is
 typically done in the `ConfigureServices` of your `Startup` class. Both examples
-below enables OpenTelemetry by `AddOpenTelemetry()` on `IServiceCollection`.
+below enables OpenTelemetry by calling `AddOpenTelemetry()` on `IServiceCollection`.
  This extension method requires adding the package
 [`OpenTelemetry.Extensions.Hosting`](../OpenTelemetry.Extensions.Hosting/README.md)
 to the application. This ensures instrumentations are disposed when the host

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
@@ -62,6 +62,12 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
+## Metrics
+
+This package produces following metrics:
+
+* [`http.server.duration`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md#metric-httpserverduration)
+
 ## Advanced configuration
 
 This instrumentation can be configured to change the default behavior by using

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
@@ -49,9 +49,8 @@ is shutdown.
 The following example demonstrates adding ASP.NET Core instrumentation with the
 extension method `WithTracing()` on `OpenTelemetryBuilder`.
 then extension method `AddAspNetCoreInstrumentation()` on `TracerProviderBuilder`
-to the application. This example also sets up the OTLP (OpenTelemetry Protocol)
-Exporter, which requires adding the package
-[`OpenTelemetry.Exporter.OpenTelemetryProtocol`](../OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md)
+to the application. This example also sets up the Console Exporter,
+which requires adding the package [`OpenTelemetry.Exporter.Console`](../OpenTelemetry.Exporter.Console/README.md)
 to the application.
 
 ```csharp
@@ -63,7 +62,7 @@ public void ConfigureServices(IServiceCollection services)
     services.AddOpenTelemetry()
         .WithTracing(builder => builder
             .AddAspNetCoreInstrumentation()
-            .AddOtlpExporter());
+            .AddConsoleExporter());
 }
 ```
 
@@ -72,9 +71,8 @@ public void ConfigureServices(IServiceCollection services)
 The following example demonstrates adding ASP.NET Core instrumentation with the
 extension method `WithMetrics()` on `OpenTelemetryBuilder`
 then extension method `AddAspNetCoreInstrumentation()` on `MeterProviderBuilder`
-to the application. This example also sets up the OTLP (OpenTelemetry Protocol)
-Exporter, which requires adding the package
-[`OpenTelemetry.Exporter.OpenTelemetryProtocol`](../OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md)
+to the application. This example also sets up the Console Exporter,
+which requires adding the package [`OpenTelemetry.Exporter.Console`](../OpenTelemetry.Exporter.Console/README.md)
 to the application.
 
 ```csharp
@@ -86,7 +84,7 @@ public void ConfigureServices(IServiceCollection services)
     services.AddOpenTelemetry()
         .WithMetrics(builder => builder
             .AddAspNetCoreInstrumentation()
-            .AddOtlpExporter());
+            .AddConsoleExporter());
 }
 ```
 
@@ -125,7 +123,7 @@ services.Configure<AspNetCoreInstrumentationOptions>(options =>
 services.AddOpenTelemetry()
     .WithTracing(builder => builder
         .AddAspNetCoreInstrumentation()
-        .AddOtlpExporter());
+        .AddConsoleExporter());
 ```
 
 ### Filter
@@ -148,7 +146,7 @@ services.AddOpenTelemetry()
             // only collect telemetry about HTTP GET requests
             return httpContext.Request.Method.Equals("GET");
         })
-        .AddOtlpExporter());
+        .AddConsoleExporter());
 ```
 
 It is important to note that this `Filter` option is specific to this

--- a/src/OpenTelemetry.Instrumentation.Http/README.md
+++ b/src/OpenTelemetry.Instrumentation.Http/README.md
@@ -102,7 +102,7 @@ to see how to enable this instrumentation in an ASP.NET application.
 
 #### List of metrics produced
 
-The instrumentation was implemented based on [metrics semantic
+The instrumentation is implemented based on [metrics semantic
 conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md#metric-httpclientduration).
 Currently, the instrumentation supports the following metric.
 


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/2292

## Changes

Changes based on https://github.com/open-telemetry/opentelemetry-dotnet/pull/4216/files

Document how to add AspNetCore metrics.
Document list of AspNetCore metrics.
Change Jeager exporter to Console exporter (as Jeager will be deprecated shortly). ~~Console exporter from Http example is not good idea for the ASP.NET Core application.~~

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
