### PR TITLE
[Jaeger] Update preprocessor directives in Jaeger thrift code

### DIFF
--- a/src/OpenTelemetry.Exporter.Jaeger/ApacheThrift/Protocol/TBinaryProtocol.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/ApacheThrift/Protocol/TBinaryProtocol.cs
@@ -192,7 +192,7 @@ namespace Thrift.Protocol
             WriteI64(BitConverter.DoubleToInt64Bits(d));
         }
 
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
         public override void WriteBinary(ReadOnlySpan<byte> bytes)
         {
             WriteI32(bytes.Length);

--- a/src/OpenTelemetry.Exporter.Jaeger/ApacheThrift/Protocol/TCompactProtocol.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/ApacheThrift/Protocol/TCompactProtocol.cs
@@ -356,7 +356,7 @@ namespace Thrift.Protocol
             Transport.Write(PreAllocatedBuffer, 0, 8);
         }
 
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
         public override void WriteBinary(ReadOnlySpan<byte> bytes)
         {
             Int32ToVarInt((uint)bytes.Length, ref PreAllocatedVarInt);

--- a/src/OpenTelemetry.Exporter.Jaeger/ApacheThrift/Protocol/TProtocol.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/ApacheThrift/Protocol/TProtocol.cs
@@ -143,7 +143,7 @@ namespace Thrift.Protocol
 
         public virtual void WriteString(string s)
         {
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
             if (s.Length <= 128)
             {
                 Span<byte> buffer = stackalloc byte[256];
@@ -165,7 +165,7 @@ namespace Thrift.Protocol
             }
         }
 
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
         public abstract void WriteBinary(ReadOnlySpan<byte> bytes);
 #endif
 

--- a/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Enabled performance optimizations for .NET 6.0+ runtimes.
+  ([#4349](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4349))
+
 ## 1.5.0-alpha.1
 
 Released 2023-Mar-07


### PR DESCRIPTION
## Changes

* Updates preprocessor directives in Jaeger thrift code to be aware of the net6.0 target.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
