### PR TITLE
Revert non-core changelogs for 1.0.0-rc9.15

### DIFF
--- a/src/OpenTelemetry.Exporter.ZPages/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.ZPages/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-## 1.0.0-rc9.15
-
-Released 2023-Mar-31
-
 ## 1.0.0-rc9.14
 
 Released 2023-Feb-24

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-## 1.0.0-rc9.15
-
-Released 2023-Mar-31
-
 ## 1.0.0-rc9.14
 
 Released 2023-Feb-24

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-## 1.0.0-rc9.15
-
-Released 2023-Mar-31
-
 ## 1.0.0-rc9.14
 
 Released 2023-Feb-24

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-## 1.0.0-rc9.15
-
-Released 2023-Mar-31
-
 * Fixed an issue of missing `http.client.duration` metric data in case of
 network failures (when response is not available).
 ([#4098](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4098))

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-## 1.0.0-rc9.15
-
-Released 2023-Mar-31
-
 ## 1.0.0-rc9.14
 
 Released 2023-Feb-24

--- a/src/OpenTelemetry.Shims.OpenTracing/CHANGELOG.md
+++ b/src/OpenTelemetry.Shims.OpenTracing/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-## 1.0.0-rc9.15
-
-Released 2023-Mar-31
-
 ## 1.0.0-rc9.14
 
 Released 2023-Feb-24


### PR DESCRIPTION
We decided to hold off on releasing non-core packages for now.