### PR TITLE
[AspNetCore] Avoid boxing of status code tags

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Improve perf by avoiding boxing of common status codes values.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.0.0-rc9.14
 
 Released 2023-Feb-24

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Improve perf by avoiding boxing of common status codes values.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#4360](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4360))
 
 ## 1.0.0-rc9.14
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -240,7 +240,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
 
                 var response = context.Response;
 
-                activity.SetTag(SemanticConventions.AttributeHttpStatusCode, response.StatusCode);
+                activity.SetTag(SemanticConventions.AttributeHttpStatusCode, TelemetryHelper.GetBoxedStatusCode(response.StatusCode));
 
 #if !NETSTANDARD2_0
                 if (this.options.EnableGrpcAspNetCoreSupport && TryGetGrpcMethod(activity, out var grpcMethod))

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInMetricsListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInMetricsListener.cs
@@ -80,7 +80,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
                 tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpFlavor, HttpTagHelper.GetFlavorTagValueFromProtocol(context.Request.Protocol)));
                 tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, context.Request.Scheme));
                 tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpMethod, context.Request.Method));
-                tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpStatusCode, context.Response.StatusCode));
+                tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpStatusCode, TelemetryHelper.GetBoxedStatusCode(context.Response.StatusCode)));
 
                 if (context.Request.Host.HasValue)
                 {

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/TelemetryHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/TelemetryHelper.cs
@@ -18,6 +18,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation;
 
 internal static class TelemetryHelper
 {
+#pragma warning disable SA1509 // Opening braces should not be preceded by blank line
     // Status Codes listed at http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
     private static readonly Dictionary<int, object> BoxedStatusCodes = new()
     {
@@ -89,6 +90,7 @@ internal static class TelemetryHelper
         { 510, 510 },
         { 511, 511 },
     };
+#pragma warning restore SA1509 // Opening braces should not be preceded by blank line
 
     public static object GetBoxedStatusCode(int statusCode)
     {

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/TelemetryHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/TelemetryHelper.cs
@@ -1,0 +1,102 @@
+// <copyright file="TelemetryHelper.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation;
+
+internal static class TelemetryHelper
+{
+    // Status Codes listed at http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+    private static readonly Dictionary<int, object> BoxedStatusCodes = new()
+    {
+        { 100, 100 },
+        { 101, 101 },
+        { 102, 102 },
+
+        { 200, 200 },
+        { 201, 201 },
+        { 202, 202 },
+        { 203, 203 },
+        { 204, 204 },
+        { 205, 205 },
+        { 206, 206 },
+        { 207, 207 },
+        { 208, 208 },
+        { 226, 226 },
+
+        { 300, 300 },
+        { 301, 301 },
+        { 302, 302 },
+        { 303, 303 },
+        { 304, 304 },
+        { 305, 305 },
+        { 306, 306 },
+        { 307, 307 },
+        { 308, 308 },
+
+        { 400, 400 },
+        { 401, 401 },
+        { 402, 402 },
+        { 403, 403 },
+        { 404, 404 },
+        { 405, 405 },
+        { 406, 406 },
+        { 407, 407 },
+        { 408, 408 },
+        { 409, 409 },
+        { 410, 410 },
+        { 411, 411 },
+        { 412, 412 },
+        { 413, 413 },
+        { 414, 414 },
+        { 415, 415 },
+        { 416, 416 },
+        { 417, 417 },
+        { 418, 418 },
+        { 419, 419 },
+        { 421, 421 },
+        { 422, 422 },
+        { 423, 423 },
+        { 424, 424 },
+        { 426, 426 },
+        { 428, 428 },
+        { 429, 429 },
+        { 431, 431 },
+        { 451, 451 },
+        { 499, 499 },
+
+        { 500, 500 },
+        { 501, 501 },
+        { 502, 502 },
+        { 503, 503 },
+        { 504, 504 },
+        { 505, 505 },
+        { 506, 506 },
+        { 507, 507 },
+        { 508, 508 },
+        { 510, 510 },
+        { 511, 511 },
+    };
+
+    public static object GetBoxedStatusCode(int statusCode)
+    {
+        if (BoxedStatusCodes.TryGetValue(statusCode, out var result))
+        {
+            return result;
+        }
+
+        return statusCode;
+    }
+}


### PR DESCRIPTION
## Changes

* Use a dictionary of pre-boxed status code values to avoid boxing perf hit on every request. Borrowed from [AspNetCore's upcoming metric support](https://github.com/dotnet/aspnetcore/blob/5ea934a3196f6d0532853bde83a3c03c2e62083e/src/Hosting/Hosting/src/Internal/HostingMetrics.cs#L159).

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
