### PR TITLE
[sdk] Only use BCL HashCode for .NET 6+

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Fixed an issue with `HashCode` computations throwing exceptions on .NET
+  Standard 2.1 targets.
+  ([#4362](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4362))
+
 ## 1.5.0-alpha.2
 
 Released 2023-Mar-31

--- a/src/OpenTelemetry/Metrics/MetricStreamIdentity.cs
+++ b/src/OpenTelemetry/Metrics/MetricStreamIdentity.cs
@@ -39,7 +39,7 @@ namespace OpenTelemetry.Metrics
             this.ExponentialHistogramMaxScale = (metricStreamConfiguration as Base2ExponentialBucketHistogramConfiguration)?.MaxScale ?? 0;
             this.HistogramRecordMinMax = (metricStreamConfiguration as HistogramConfiguration)?.RecordMinMax ?? true;
 
-#if NETSTANDARD2_1 || NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
             HashCode hashCode = default;
             hashCode.Add(this.InstrumentType);
             hashCode.Add(this.MeterName);

--- a/src/OpenTelemetry/Metrics/StringArrayEqualityComparer.cs
+++ b/src/OpenTelemetry/Metrics/StringArrayEqualityComparer.cs
@@ -50,7 +50,7 @@ namespace OpenTelemetry.Metrics
 
         public int GetHashCode(string[] strings)
         {
-#if NETSTANDARD2_1 || NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
             HashCode hashCode = default;
             for (int i = 0; i < strings.Length; i++)
             {

--- a/src/OpenTelemetry/Metrics/Tags.cs
+++ b/src/OpenTelemetry/Metrics/Tags.cs
@@ -24,7 +24,7 @@ namespace OpenTelemetry.Metrics
         {
             this.KeyValuePairs = keyValuePairs;
 
-#if NETSTANDARD2_1 || NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
             HashCode hashCode = default;
             for (int i = 0; i < this.KeyValuePairs.Length; i++)
             {

--- a/src/OpenTelemetry/Trace/SamplingResult.cs
+++ b/src/OpenTelemetry/Trace/SamplingResult.cs
@@ -117,7 +117,7 @@ namespace OpenTelemetry.Trace
         /// <inheritdoc/>
         public override int GetHashCode()
         {
-#if NETSTANDARD2_1 || NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
             HashCode hashCode = default;
             hashCode.Add(this.Decision);
             hashCode.Add(this.Attributes);


### PR DESCRIPTION
Relates to #4204

## Changes

* Updates preprocessor directives around `System.HashCode` so it is only used on .NET6+ runtimes.

## Details

We were talking about metrics not working on .NET Core 3.1 (#4204) today on the SIG. The issue seems to be differences around `null` handling in `HashCode`, which is very strange. I did some digging on it.

* .NET Core 3.1: https://github.com/dotnet/corefx/blob/34a90650962f0a911b471584b5eeb9ba7de5581e/src/Common/src/CoreLib/System/HashCode.cs#L304-L307
* .NET current: https://github.com/dotnet/runtime/blob/c36e26d1f6d11c657e8083ecbcbe831b29afa27a/src/libraries/System.Private.CoreLib/src/System/HashCode.cs#L307-L310

It seems like [this PR accidentally introduced a breaking logical change](https://github.com/dotnet/runtime/pull/32090/files#diff-d4ef89b3c1ce1b20fc9498b190afc0387fbc7a709335cf2859583957ce4cb126L306) in `HashCode`.

What this means is .NET Standard 2.1 and .NET6+ versions of `HashCode` have logical differences. To be safe and avoid any issues I thought it best just to use our fallback logic for .NET Standard 2.1.

PS: There is an out-of-band NuGet version of [HashCode](https://www.nuget.org/packages/Microsoft.Bcl.HashCode/). I tried all versions of it, none of them have the `null` logic updated to match dotnet/runtime current state.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes

