### PR TITLE
Bump NETCOREAPP3_0_OR_GREATER to NET6_0_OR_GREATER

### DIFF
--- a/src/OpenTelemetry.Api/Internal/Guard.cs
+++ b/src/OpenTelemetry.Api/Internal/Guard.cs
@@ -42,7 +42,7 @@ namespace System.Runtime.CompilerServices
 }
 #endif
 
-#if !NETCOREAPP3_0_OR_GREATER && !NETSTANDARD2_1_OR_GREATER
+#if !NET6_0_OR_GREATER && !NETSTANDARD2_1_OR_GREATER
 namespace System.Diagnostics.CodeAnalysis
 {
     /// <summary>Specifies that an output is not <see langword="null"/> even if

--- a/src/OpenTelemetry/Internal/MathHelper.cs
+++ b/src/OpenTelemetry/Internal/MathHelper.cs
@@ -15,7 +15,7 @@
 // </copyright>
 
 using System.Diagnostics;
-#if NETCOREAPP3_0_OR_GREATER
+#if NET6_0_OR_GREATER
 using System.Numerics;
 #endif
 using System.Runtime.CompilerServices;
@@ -86,7 +86,7 @@ internal static class MathHelper
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int LeadingZero64(long value)
     {
-#if NETCOREAPP3_0_OR_GREATER
+#if NET6_0_OR_GREATER
         return BitOperations.LeadingZeroCount((ulong)value);
 #else
         unchecked


### PR DESCRIPTION
We no longer have anything that targets `netcoreapp3.x` or `net5`