### PR TITLE
Add telemetry.sdk.* attributes to default resource

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* The default resource provided by `ResourceBuilder.CreateDefault()` now
+  adds the `telemetry.sdk.*` attributes defined in the
+  [specification](https://github.com/open-telemetry/opentelemetry-specification/tree/12fcec1ff255b1535db75708e52a3a21f86f0fae/specification/resource/semantic_conventions#semantic-attributes-with-sdk-provided-default-value).
+  ([#4369](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4369))
 * Fixed an issue with `HashCode` computations throwing exceptions on .NET
   Standard 2.1 targets.
   ([#4362](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4362))

--- a/src/OpenTelemetry/Resources/ResourceBuilder.cs
+++ b/src/OpenTelemetry/Resources/ResourceBuilder.cs
@@ -59,8 +59,8 @@ namespace OpenTelemetry.Resources
         internal IServiceProvider? ServiceProvider { get; set; }
 
         /// <summary>
-        /// Creates a <see cref="ResourceBuilder"/> instance with Default
-        /// service.name added. See <a
+        /// Creates a <see cref="ResourceBuilder"/> instance with default attributes
+        /// added. See <a
         /// href="https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/resource/semantic_conventions#semantic-attributes-with-sdk-provided-default-value">resource
         /// semantic conventions</a> for details.
         /// Additionally it adds resource attributes parsed from OTEL_RESOURCE_ATTRIBUTES, OTEL_SERVICE_NAME environment variables

--- a/src/OpenTelemetry/Resources/ResourceBuilder.cs
+++ b/src/OpenTelemetry/Resources/ResourceBuilder.cs
@@ -70,7 +70,10 @@ namespace OpenTelemetry.Resources
         /// </summary>
         /// <returns>Created <see cref="ResourceBuilder"/>.</returns>
         public static ResourceBuilder CreateDefault()
-            => new ResourceBuilder().AddResource(DefaultResource).AddEnvironmentVariableDetector();
+            => new ResourceBuilder()
+                .AddResource(DefaultResource)
+                .AddTelemetrySdk()
+                .AddEnvironmentVariableDetector();
 
         /// <summary>
         /// Creates an empty <see cref="ResourceBuilder"/> instance.

--- a/test/OpenTelemetry.Tests/Resources/ResourceTest.cs
+++ b/test/OpenTelemetry.Tests/Resources/ResourceTest.cs
@@ -602,7 +602,7 @@ namespace OpenTelemetry.Resources.Tests
             ValidateAttributes(resource.Attributes);
         }
 
-        private static void ValidateTelemetrySdkAttributes(IEnumerable<KeyValuePair<string, object>> attributes)
+        internal static void ValidateTelemetrySdkAttributes(IEnumerable<KeyValuePair<string, object>> attributes)
         {
             Assert.Contains(new KeyValuePair<string, object>("telemetry.sdk.name", "opentelemetry"), attributes);
             Assert.Contains(new KeyValuePair<string, object>("telemetry.sdk.language", "dotnet"), attributes);
@@ -610,7 +610,7 @@ namespace OpenTelemetry.Resources.Tests
             Assert.Single(versionAttribute);
         }
 
-        private static void ValidateDefaultAttributes(IEnumerable<KeyValuePair<string, object>> attributes)
+        internal static void ValidateDefaultAttributes(IEnumerable<KeyValuePair<string, object>> attributes)
         {
             var serviceName = attributes.Where(pair => pair.Key.Equals("service.name"));
             Assert.Single(serviceName);

--- a/test/OpenTelemetry.Tests/Resources/ResourceTest.cs
+++ b/test/OpenTelemetry.Tests/Resources/ResourceTest.cs
@@ -395,6 +395,7 @@ namespace OpenTelemetry.Resources.Tests
             // Assert
             var attributes = resource.Attributes;
             Assert.Equal(4, attributes.Count());
+            ValidateDefaultAttributes(attributes);
             ValidateTelemetrySdkAttributes(attributes);
         }
 
@@ -406,8 +407,9 @@ namespace OpenTelemetry.Resources.Tests
 
             // Assert
             var attributes = resource.Attributes;
-            Assert.Single(attributes);
+            Assert.Equal(4, attributes.Count());
             ValidateDefaultAttributes(attributes);
+            ValidateTelemetrySdkAttributes(attributes);
         }
 
         [Fact]
@@ -418,9 +420,10 @@ namespace OpenTelemetry.Resources.Tests
 
             // Assert
             var attributes = resource.Attributes;
-            Assert.Equal(3, attributes.Count());
+            Assert.Equal(6, attributes.Count());
             ValidateAttributes(attributes, 0, 1);
             ValidateDefaultAttributes(attributes);
+            ValidateTelemetrySdkAttributes(attributes);
         }
 
         [Fact]
@@ -432,11 +435,12 @@ namespace OpenTelemetry.Resources.Tests
 
             // Assert
             var attributes = resource.Attributes;
-            Assert.Equal(5, attributes.Count());
+            Assert.Equal(8, attributes.Count());
             ValidateAttributes(attributes, 0, 1);
             ValidateDefaultAttributes(attributes);
             Assert.Contains(new KeyValuePair<string, object>("EVKey1", "EVVal1"), attributes);
             Assert.Contains(new KeyValuePair<string, object>("EVKey2", "EVVal2"), attributes);
+            ValidateTelemetrySdkAttributes(attributes);
         }
 
         [Fact]
@@ -448,9 +452,10 @@ namespace OpenTelemetry.Resources.Tests
 
             // Assert
             var attributes = resource.Attributes;
-            Assert.Equal(3, attributes.Count());
+            Assert.Equal(6, attributes.Count());
             Assert.Contains(new KeyValuePair<string, object>("EVKey1", "EVVal1"), attributes);
             Assert.Contains(new KeyValuePair<string, object>("EVKey2", "EVVal2"), attributes);
+            ValidateTelemetrySdkAttributes(attributes);
         }
 
         [Fact]
@@ -462,9 +467,10 @@ namespace OpenTelemetry.Resources.Tests
 
             // Assert
             var attributes = resource.Attributes;
-            Assert.Equal(3, attributes.Count());
+            Assert.Equal(6, attributes.Count());
             ValidateAttributes(attributes, 0, 1);
             Assert.Contains(new KeyValuePair<string, object>("service.name", "some-service"), attributes);
+            ValidateTelemetrySdkAttributes(attributes);
         }
 
         [Fact]
@@ -477,9 +483,10 @@ namespace OpenTelemetry.Resources.Tests
 
             // Assert
             var attributes = resource.Attributes;
-            Assert.Equal(3, attributes.Count());
+            Assert.Equal(6, attributes.Count());
             ValidateAttributes(attributes, 0, 1);
             Assert.Contains(new KeyValuePair<string, object>("service.name", "from-service-name"), attributes);
+            ValidateTelemetrySdkAttributes(attributes);
         }
 
         [Fact]
@@ -492,9 +499,10 @@ namespace OpenTelemetry.Resources.Tests
 
             // Assert
             var attributes = resource.Attributes;
-            Assert.Equal(4, attributes.Count());
+            Assert.Equal(7, attributes.Count());
             ValidateAttributes(attributes, 0, 1);
             Assert.Contains(new KeyValuePair<string, object>("service.name", "from-code"), attributes);
+            ValidateTelemetrySdkAttributes(attributes);
         }
 
         [Fact]

--- a/test/OpenTelemetry.Tests/Resources/ResourceTest.cs
+++ b/test/OpenTelemetry.Tests/Resources/ResourceTest.cs
@@ -570,6 +570,21 @@ namespace OpenTelemetry.Resources.Tests
             Assert.True(validTestRun);
         }
 
+        internal static void ValidateTelemetrySdkAttributes(IEnumerable<KeyValuePair<string, object>> attributes)
+        {
+            Assert.Contains(new KeyValuePair<string, object>("telemetry.sdk.name", "opentelemetry"), attributes);
+            Assert.Contains(new KeyValuePair<string, object>("telemetry.sdk.language", "dotnet"), attributes);
+            var versionAttribute = attributes.Where(pair => pair.Key.Equals("telemetry.sdk.version"));
+            Assert.Single(versionAttribute);
+        }
+
+        internal static void ValidateDefaultAttributes(IEnumerable<KeyValuePair<string, object>> attributes)
+        {
+            var serviceName = attributes.Where(pair => pair.Key.Equals("service.name"));
+            Assert.Single(serviceName);
+            Assert.Contains("unknown_service", serviceName.FirstOrDefault().Value as string);
+        }
+
         private static void ClearEnvVars()
         {
             Environment.SetEnvironmentVariable(OtelEnvResourceDetector.EnvVarKey, null);
@@ -600,21 +615,6 @@ namespace OpenTelemetry.Resources.Tests
             Assert.NotNull(resource.Attributes);
             Assert.Equal(attributeCount, resource.Attributes.Count());
             ValidateAttributes(resource.Attributes);
-        }
-
-        internal static void ValidateTelemetrySdkAttributes(IEnumerable<KeyValuePair<string, object>> attributes)
-        {
-            Assert.Contains(new KeyValuePair<string, object>("telemetry.sdk.name", "opentelemetry"), attributes);
-            Assert.Contains(new KeyValuePair<string, object>("telemetry.sdk.language", "dotnet"), attributes);
-            var versionAttribute = attributes.Where(pair => pair.Key.Equals("telemetry.sdk.version"));
-            Assert.Single(versionAttribute);
-        }
-
-        internal static void ValidateDefaultAttributes(IEnumerable<KeyValuePair<string, object>> attributes)
-        {
-            var serviceName = attributes.Where(pair => pair.Key.Equals("service.name"));
-            Assert.Single(serviceName);
-            Assert.Contains("unknown_service", serviceName.FirstOrDefault().Value as string);
         }
 
         private static Dictionary<string, object> CreateAttributes(int attributeCount, int startIndex = 0)

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
@@ -17,6 +17,7 @@
 using System.Diagnostics;
 using OpenTelemetry.Instrumentation;
 using OpenTelemetry.Resources;
+using OpenTelemetry.Resources.Tests;
 using OpenTelemetry.Tests;
 using Xunit;
 
@@ -1077,9 +1078,11 @@ namespace OpenTelemetry.Trace.Tests
 
             Assert.NotNull(resource);
             Assert.NotEqual(Resource.Empty, resource);
-            Assert.Single(resource.Attributes);
-            Assert.Equal(ResourceSemanticConventions.AttributeServiceName, resource.Attributes.FirstOrDefault().Key);
-            Assert.Contains("unknown_service", (string)resource.Attributes.FirstOrDefault().Value);
+
+            var attributes = resource.Attributes;
+            Assert.Equal(4, attributes.Count());
+            ResourceTest.ValidateDefaultAttributes(attributes);
+            ResourceTest.ValidateTelemetrySdkAttributes(attributes);
         }
 
         [Theory]


### PR DESCRIPTION
The `telemetry.sdk.*` resource attributes are now required by default. See: https://github.com/open-telemetry/opentelemetry-specification/pull/3202