### PR TITLE
Update value of the resource attribute `telemetry.sdk.version`

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,13 +2,16 @@
 
 ## Unreleased
 
-* The default resource provided by `ResourceBuilder.CreateDefault()` now
-  adds the `telemetry.sdk.*` attributes defined in the
+* The default resource provided by `ResourceBuilder.CreateDefault()` now adds
+  the `telemetry.sdk.*` attributes defined in the
   [specification](https://github.com/open-telemetry/opentelemetry-specification/tree/12fcec1ff255b1535db75708e52a3a21f86f0fae/specification/resource/semantic_conventions#semantic-attributes-with-sdk-provided-default-value).
   ([#4369](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4369))
 * Fixed an issue with `HashCode` computations throwing exceptions on .NET
   Standard 2.1 targets.
   ([#4362](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4362))
+* Update value of the resource attribute Telemetry SDK version to show the tag
+  name which resembles the package version of the SDK.
+  ([#4375](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4375))
 
 ## 1.5.0-alpha.2
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Fixed an issue with `HashCode` computations throwing exceptions on .NET
   Standard 2.1 targets.
   ([#4362](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4362))
-* Update value of the resource attribute Telemetry SDK version to show the tag
+* Update value of the resource attribute `telemetry.sdk.version` to show the tag
   name which resembles the package version of the SDK.
   ([#4375](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4375))
 

--- a/src/OpenTelemetry/Resources/ResourceBuilderExtensions.cs
+++ b/src/OpenTelemetry/Resources/ResourceBuilderExtensions.cs
@@ -32,7 +32,7 @@ namespace OpenTelemetry.Resources
         {
             [ResourceSemanticConventions.AttributeTelemetrySdkName] = "opentelemetry",
             [ResourceSemanticConventions.AttributeTelemetrySdkLanguage] = "dotnet",
-            [ResourceSemanticConventions.AttributeTelemetrySdkVersion] = GetFileVersion(),
+            [ResourceSemanticConventions.AttributeTelemetrySdkVersion] = GetAssemblyInformationalVersion(),
         });
 
         /// <summary>
@@ -126,11 +126,24 @@ namespace OpenTelemetry.Resources
                 .AddDetectorInternal(sp => new OtelServiceNameEnvVarDetector(sp?.GetService<IConfiguration>() ?? configuration.Value));
         }
 
-        private static string GetFileVersion()
+        private static string GetAssemblyInformationalVersion()
         {
             try
             {
-                return typeof(Resource).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version ?? string.Empty;
+                var informationalVersion = typeof(Resource).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+
+                if (informationalVersion == null)
+                {
+                    return string.Empty;
+                }
+
+                // informationalVersion could be in the following format:
+                // {majorVersion}.{minorVersion}.{patchVersion}.{pre-release label}.{pre-release version}.{gitHeight}.{Git SHA of current commit}
+                // The following parts are optional: pre-release label, pre-release version, git height, Git SHA of current commit
+                // for example: 1.5.0-alpha.1.40+807f703e1b4d9874a92bd86d9f2d4ebe5b5d52e4
+
+                var indexOfPlusSign = informationalVersion.IndexOf('+');
+                return indexOfPlusSign > 0 ? informationalVersion.Substring(0, indexOfPlusSign) : informationalVersion;
             }
             catch (Exception)
             {


### PR DESCRIPTION
## Changes
- Update value of the resource attribute `telemetry.sdk.version` to show the tag name (which resembles the package version) instead of showing version number with revision

### Current behavior:
- If you use, `1.4.0` version of the SDK, the value logged for telemetry.sdk.version is `1.4.0.802`
- If you use, `1.4.0-rc.4` version of the SDK, the value logged for telemetry.sdk.version is `1.4.0.788`


### With this PR:
- If you use, `1.4.0` version of the SDK, the value logged for telemetry.sdk.version is `1.4.0`
- If you use, `1.4.0-rc.4` version of the SDK, the value logged for telemetry.sdk.version is `1.4.0-rc.4`

Note: You would see this behavior going forward once we start to make newer releases.

* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
