### PR TITLE
Fix ApiCompat

### DIFF
--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -11,23 +11,29 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>
+  
+  <PropertyGroup>
+    <RunApiCompat>true</RunApiCompat>
+  </PropertyGroup>  
 
-  <ItemGroup Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(CheckAPICompatibility)' == 'true'">
+  <ItemGroup Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(CheckAPICompatibility)' == 'true' AND '$(RunApiCompat)' == 'true'">
     <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="6.0.0-beta.21308.1" PrivateAssets="All" />
     <ResolvedMatchingContract Include="$(RepoRoot)\build\LastMajorVersionBinaries\$(AssemblyName)\$(OTelPreviousStableVer)\lib\$(TargetFramework)\$(AssemblyName).dll" />
   </ItemGroup>
 
-  <Target Name="PreBuild" BeforeTargets="DispatchToInnerBuilds;ValidateApiCompatForSrc" Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(CheckAPICompatibility)' == 'true'">
+  <Target Name="PreBuild" BeforeTargets="DispatchToInnerBuilds;ValidateApiCompatForSrc" Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(CheckAPICompatibility)' == 'true' AND '$(RunApiCompat)' == 'true'">
     <!-- Note: DispatchToInnerBuilds is called for projects with multiple
     targets defined to spawn a build process for each target framework being
     compiled. Executing BEFORE that step means this runs once for a project
     instead of in parallel for each target framework defined. If we ever have a
     project with only a single target, this will NOT run and an alternative
     solution will be needed. -->
+    <Message Text="ApiCompat: Running the powershell script to download the package for $(MSBuildProjectName)." Importance="High"/>
     <Exec Command="powershell -ExecutionPolicy Unrestricted -File &quot;$(RepoRoot)\build\PreBuild.ps1&quot; -package $(AssemblyName) -version &quot;$(OTelPreviousStableVer)&quot; -workDir &quot;$(RepoRoot)\build\LastMajorVersionBinaries&quot;" />
   </Target>
 
-  <Target Name="FindContractDependencyPaths" BeforeTargets="ValidateApiCompatForSrc" AfterTargets="ResolveAssemblyReferences" Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(CheckAPICompatibility)' == 'true'">
+  <Target Name="FindContractDependencyPaths" BeforeTargets="ValidateApiCompatForSrc" AfterTargets="ResolveAssemblyReferences" Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(CheckAPICompatibility)' == 'true' AND '$(RunApiCompat)' == 'true'">
+    <Message Text="ApiCompat: Finding the contract dependency path for $(MSBuildProjectName)." Importance="High"/>
     <ItemGroup>
       <_ReferencePathDirectories Include="@(ReferencePath -> '%(RootDir)%(Directory)')" />
     </ItemGroup>

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -11,10 +11,10 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-  
+
   <PropertyGroup>
     <RunApiCompat>true</RunApiCompat>
-  </PropertyGroup>  
+  </PropertyGroup>
 
   <ItemGroup Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(CheckAPICompatibility)' == 'true' AND '$(RunApiCompat)' == 'true'">
     <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="6.0.0-beta.21308.1" PrivateAssets="All" />

--- a/build/PreBuild.ps1
+++ b/build/PreBuild.ps1
@@ -12,7 +12,7 @@ if (-Not (Test-Path $workDir))
 
 if (Test-Path -Path "$workDir\$package.$version.zip")
 {
-    Write-Debug "Previous package $package@$version already downloaded for compatibility check"
+    Write-Host "Previous package $package@$version already downloaded for compatibility check"
 }
 else
 {
@@ -30,7 +30,7 @@ else
 
 if (Test-Path -Path "$workDir\$package\$version\lib")
 {
-    Write-Debug "Previous package $package@$version already extracted to '$workDir\$package\$version\lib'"
+    Write-Host "Previous package $package@$version already extracted to '$workDir\$package\$version\lib'"
 }
 else
 {

--- a/build/PreBuild.ps1
+++ b/build/PreBuild.ps1
@@ -17,7 +17,15 @@ if (Test-Path -Path "$workDir\$package.$version.zip")
 else
 {
     Write-Host "Retrieving package $package@$version for compatibility check"
-    Invoke-WebRequest -Uri https://www.nuget.org/api/v2/package/$package/$version -Outfile "$workDir\$package.$version.zip"
+    try
+    {
+        $Response = Invoke-WebRequest -Uri https://www.nuget.org/api/v2/package/$package/$version -Outfile "$workDir\$package.$version.zip"
+    }
+    catch
+    {
+        $StatusCode = $_.Exception.Response.StatusCode.value__
+        throw "Error downloading the package $package@$version. Status code of the received response: $StatusCode"
+    }
 }
 
 if (Test-Path -Path "$workDir\$package\$version\lib")
@@ -27,5 +35,12 @@ if (Test-Path -Path "$workDir\$package\$version\lib")
 else
 {
     Write-Host "Extracting package $package@$version from '$workDir\$package.$version.zip' to '$workDir\$package\$version' for compatibility check"
-    Expand-Archive -LiteralPath "$workDir\$package.$version.zip" -DestinationPath "$workDir\$package\$version" -Force
+    try
+    {
+        Expand-Archive -LiteralPath "$workDir\$package.$version.zip" -DestinationPath "$workDir\$package\$version" -Force
+    }
+    catch
+    {
+        throw "Error extracting $package@$version.zip"
+    }
 }


### PR DESCRIPTION
There are a few issues with the ApiCompat setup:
- It does not fail even when it encounters an error while downloading or extracting the package from the .zip file. Look at the `BlobNotFound` errors in this successful [run](https://github.com/open-telemetry/opentelemetry-dotnet/actions/runs/4672523551/jobs/8274798534) of ApiCompat
- `RunApiCompat` property is set to `false` in a few projects to skip the ApiCompat check, but it does not do anything. `RunApiCompat` property is not used at all

## Changes
- Update the powershell script to throw when an error occurs while downloading or extracting the package from the .zip file. This would cause the CI check to fail when such an error occurs.
- Use the `RunApiCompat` property as another conditional check so that projects can opt out of it if required
- Update the build logging
