### PR TITLE
Editorial: remove --prerelease for packages that already shipped stable version

### DIFF
--- a/docs/metrics/getting-started-aspnetcore/README.md
+++ b/docs/metrics/getting-started-aspnetcore/README.md
@@ -18,8 +18,8 @@ and
 packages:
 
 ```sh
-dotnet add package OpenTelemetry.Exporter.Console --prerelease
-dotnet add package OpenTelemetry.Extensions.Hosting --prerelease
+dotnet add package OpenTelemetry.Exporter.Console
+dotnet add package OpenTelemetry.Extensions.Hosting
 dotnet add package OpenTelemetry.Instrumentation.AspNetCore --prerelease
 ```
 

--- a/docs/metrics/getting-started-prometheus-grafana/README.md
+++ b/docs/metrics/getting-started-prometheus-grafana/README.md
@@ -27,7 +27,7 @@ Add a reference to [Prometheus
 Exporter Http Listener](../../../src/OpenTelemetry.Exporter.Prometheus.HttpListener/README.md):
 
 ```sh
-dotnet add package --prerelease OpenTelemetry.Exporter.Prometheus.HttpListener
+dotnet add package OpenTelemetry.Exporter.Prometheus.HttpListener --prerelease
 ```
 
 Now, we are going to make some small tweaks to the example in the

--- a/docs/trace/getting-started-aspnetcore/README.md
+++ b/docs/trace/getting-started-aspnetcore/README.md
@@ -18,8 +18,8 @@ and
 packages:
 
 ```sh
-dotnet add package OpenTelemetry.Exporter.Console --prerelease
-dotnet add package OpenTelemetry.Extensions.Hosting --prerelease
+dotnet add package OpenTelemetry.Exporter.Console
+dotnet add package OpenTelemetry.Extensions.Hosting
 dotnet add package OpenTelemetry.Instrumentation.AspNetCore --prerelease
 ```
 


### PR DESCRIPTION
@CodeBlanch not sure if this was intentional https://github.com/open-telemetry/opentelemetry-dotnet/pull/4381/files#r1164681639.