### PR TITLE
Add direct reference to System.Text.Encodings.Web version 4.7.2 due to CVE-2021-26701

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -49,6 +49,7 @@
     <StyleCopAnalyzersPkgVer>[1.2.0-beta.435,2.0)</StyleCopAnalyzersPkgVer>
     <SystemCollectionsImmutablePkgVer>1.4.0</SystemCollectionsImmutablePkgVer>
     <SystemDiagnosticSourcePkgVer>7.0.0</SystemDiagnosticSourcePkgVer>
+    <SystemTextEncodingsWebPkgVer>4.7.2</SystemTextEncodingsWebPkgVer>
     <SystemTextJsonPkgVer>4.7.2</SystemTextJsonPkgVer>
     <SystemThreadingTasksExtensionsPkgVer>4.5.4</SystemThreadingTasksExtensionsPkgVer>
   </PropertyGroup>

--- a/build/Common.props
+++ b/build/Common.props
@@ -49,7 +49,7 @@
     <StyleCopAnalyzersPkgVer>[1.2.0-beta.435,2.0)</StyleCopAnalyzersPkgVer>
     <SystemCollectionsImmutablePkgVer>1.4.0</SystemCollectionsImmutablePkgVer>
     <SystemDiagnosticSourcePkgVer>7.0.0</SystemDiagnosticSourcePkgVer>
-    <SystemTextJsonPkgVer>4.7.2</SystemTextJsonPkgVer>
+    <SystemTextJsonPkgVer>5.0.2</SystemTextJsonPkgVer>
     <SystemThreadingTasksExtensionsPkgVer>4.5.4</SystemThreadingTasksExtensionsPkgVer>
   </PropertyGroup>
 

--- a/build/Common.props
+++ b/build/Common.props
@@ -49,7 +49,7 @@
     <StyleCopAnalyzersPkgVer>[1.2.0-beta.435,2.0)</StyleCopAnalyzersPkgVer>
     <SystemCollectionsImmutablePkgVer>1.4.0</SystemCollectionsImmutablePkgVer>
     <SystemDiagnosticSourcePkgVer>7.0.0</SystemDiagnosticSourcePkgVer>
-    <SystemTextJsonPkgVer>5.0.2</SystemTextJsonPkgVer>
+    <SystemTextJsonPkgVer>4.7.2</SystemTextJsonPkgVer>
     <SystemThreadingTasksExtensionsPkgVer>4.5.4</SystemThreadingTasksExtensionsPkgVer>
   </PropertyGroup>
 

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Bumped the minimum required version of `System.Text.Json` to 5.0.2 in response
+* Added direct reference to `System.Text.Encodings.Web` with minimum version of `4.7.2` in response
 to [CVE-2021-26701](https://github.com/dotnet/runtime/issues/49377).
 
 ## 1.5.0-alpha.2

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Added direct reference to `System.Text.Encodings.Web` with minimum version of `4.7.2` in response
-to [CVE-2021-26701](https://github.com/dotnet/runtime/issues/49377).
+* Added direct reference to `System.Text.Encodings.Web` with minimum version of
+`4.7.2` in response to [CVE-2021-26701](https://github.com/dotnet/runtime/issues/49377).
 
 ## 1.5.0-alpha.2
 

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Bumped the minimum required version of `System.Text.Json` to 5.0.2 in response
+to [CVE-2021-26701](https://github.com/dotnet/runtime/issues/49377).
+
 ## 1.5.0-alpha.2
 
 Released 2023-Mar-31

--- a/src/OpenTelemetry.Exporter.Console/OpenTelemetry.Exporter.Console.csproj
+++ b/src/OpenTelemetry.Exporter.Console/OpenTelemetry.Exporter.Console.csproj
@@ -16,6 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebPkgVer)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonPkgVer)" />
   </ItemGroup>
 

--- a/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Bumped the minimum required version of `System.Text.Json` to 5.0.2 in response
+* Added direct reference to `System.Text.Encodings.Web` with minimum version of `4.7.2` in response
 to [CVE-2021-26701](https://github.com/dotnet/runtime/issues/49377).
 
 ## 1.5.0-alpha.2

--- a/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Added direct reference to `System.Text.Encodings.Web` with minimum version of `4.7.2` in response
-to [CVE-2021-26701](https://github.com/dotnet/runtime/issues/49377).
+* Added direct reference to `System.Text.Encodings.Web` with minimum version of
+`4.7.2` in response to [CVE-2021-26701](https://github.com/dotnet/runtime/issues/49377).
 
 ## 1.5.0-alpha.2
 

--- a/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Jaeger/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Bumped the minimum required version of `System.Text.Json` to 5.0.2 in response
+to [CVE-2021-26701](https://github.com/dotnet/runtime/issues/49377).
+
 ## 1.5.0-alpha.2
 
 Released 2023-Mar-31

--- a/src/OpenTelemetry.Exporter.Jaeger/OpenTelemetry.Exporter.Jaeger.csproj
+++ b/src/OpenTelemetry.Exporter.Jaeger/OpenTelemetry.Exporter.Jaeger.csproj
@@ -33,6 +33,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsPkgVer)" Condition="'$(TargetFramework)' != 'netstandard2.1'" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebPkgVer)" Condition="'$(TargetFramework)' != 'net6.0'" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonPkgVer)" Condition="'$(TargetFramework)' != 'net6.0'" />
   </ItemGroup>
 

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Bumped the minimum required version of `System.Text.Json` to 5.0.2 in response
+* Added direct reference to `System.Text.Encodings.Web` with minimum version of `4.7.2` in response
 to [CVE-2021-26701](https://github.com/dotnet/runtime/issues/49377).
 
 ## 1.5.0-alpha.2

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Added direct reference to `System.Text.Encodings.Web` with minimum version of `4.7.2` in response
-to [CVE-2021-26701](https://github.com/dotnet/runtime/issues/49377).
+* Added direct reference to `System.Text.Encodings.Web` with minimum version of
+`4.7.2` in response to [CVE-2021-26701](https://github.com/dotnet/runtime/issues/49377).
 
 ## 1.5.0-alpha.2
 

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Bumped the minimum required version of `System.Text.Json` to 5.0.2 in response
+to [CVE-2021-26701](https://github.com/dotnet/runtime/issues/49377).
+
 ## 1.5.0-alpha.2
 
 Released 2023-Mar-31

--- a/src/OpenTelemetry.Exporter.Zipkin/OpenTelemetry.Exporter.Zipkin.csproj
+++ b/src/OpenTelemetry.Exporter.Zipkin/OpenTelemetry.Exporter.Zipkin.csproj
@@ -28,6 +28,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry\OpenTelemetry.csproj" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebPkgVer)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonPkgVer)" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #3735 

## Changes

Added direct reference to package `System.Text.Encodings.Web` version `4.7.2` to deal with [CVE-2021-26701](https://github.com/advisories/GHSA-ghhp-997w-qr28). This overrides dependency path to a vulnerable version: `System.Text.Json/4.7.2` -> `SystemText.Encodings.Web/4.7.1`. 

See [my comment](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3789#issuecomment-1506921921) in #3789.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [X] Changes in public API reviewed (if applicable)
