### PR TITLE
Add BaseOtlpExporterOptions

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net462/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net462/PublicAPI.Shipped.txt
@@ -1,19 +1,9 @@
 OpenTelemetry.Exporter.OtlpExporterOptions
 OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
 OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.get -> System.Uri
-OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
 OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.Headers.get -> string
-OpenTelemetry.Exporter.OtlpExporterOptions.Headers.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.HttpClientFactory.get -> System.Func<System.Net.Http.HttpClient>
-OpenTelemetry.Exporter.OtlpExporterOptions.HttpClientFactory.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.OtlpExporterOptions() -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.Protocol.get -> OpenTelemetry.Exporter.OtlpExportProtocol
-OpenTelemetry.Exporter.OtlpExporterOptions.Protocol.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.TimeoutMilliseconds.get -> int
-OpenTelemetry.Exporter.OtlpExporterOptions.TimeoutMilliseconds.set -> void
 OpenTelemetry.Exporter.OtlpExportProtocol
 OpenTelemetry.Exporter.OtlpExportProtocol.Grpc = 0 -> OpenTelemetry.Exporter.OtlpExportProtocol
 OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf = 1 -> OpenTelemetry.Exporter.OtlpExportProtocol

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,12 @@
+OpenTelemetry.Exporter.BaseOtlpExporterOptions
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.BaseOtlpExporterOptions(Microsoft.Extensions.Configuration.IConfiguration configuration) -> void
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.Endpoint.get -> System.Uri
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.Endpoint.set -> void
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.Headers.get -> string
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.Headers.set -> void
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.HttpClientFactory.get -> System.Func<System.Net.Http.HttpClient>
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.HttpClientFactory.set -> void
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.Protocol.get -> OpenTelemetry.Exporter.OtlpExportProtocol
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.Protocol.set -> void
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.TimeoutMilliseconds.get -> int
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.TimeoutMilliseconds.set -> void

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net6.0/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net6.0/PublicAPI.Shipped.txt
@@ -1,19 +1,9 @@
 OpenTelemetry.Exporter.OtlpExporterOptions
 OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
 OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.get -> System.Uri
-OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
 OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.Headers.get -> string
-OpenTelemetry.Exporter.OtlpExporterOptions.Headers.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.HttpClientFactory.get -> System.Func<System.Net.Http.HttpClient>
-OpenTelemetry.Exporter.OtlpExporterOptions.HttpClientFactory.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.OtlpExporterOptions() -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.Protocol.get -> OpenTelemetry.Exporter.OtlpExportProtocol
-OpenTelemetry.Exporter.OtlpExporterOptions.Protocol.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.TimeoutMilliseconds.get -> int
-OpenTelemetry.Exporter.OtlpExporterOptions.TimeoutMilliseconds.set -> void
 OpenTelemetry.Exporter.OtlpExportProtocol
 OpenTelemetry.Exporter.OtlpExportProtocol.Grpc = 0 -> OpenTelemetry.Exporter.OtlpExportProtocol
 OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf = 1 -> OpenTelemetry.Exporter.OtlpExportProtocol

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,12 @@
+OpenTelemetry.Exporter.BaseOtlpExporterOptions
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.BaseOtlpExporterOptions(Microsoft.Extensions.Configuration.IConfiguration configuration) -> void
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.Endpoint.get -> System.Uri
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.Endpoint.set -> void
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.Headers.get -> string
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.Headers.set -> void
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.HttpClientFactory.get -> System.Func<System.Net.Http.HttpClient>
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.HttpClientFactory.set -> void
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.Protocol.get -> OpenTelemetry.Exporter.OtlpExportProtocol
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.Protocol.set -> void
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.TimeoutMilliseconds.get -> int
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.TimeoutMilliseconds.set -> void

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.0/PublicAPI.Shipped.txt
@@ -1,19 +1,9 @@
 OpenTelemetry.Exporter.OtlpExporterOptions
 OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
 OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.get -> System.Uri
-OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
 OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.Headers.get -> string
-OpenTelemetry.Exporter.OtlpExporterOptions.Headers.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.HttpClientFactory.get -> System.Func<System.Net.Http.HttpClient>
-OpenTelemetry.Exporter.OtlpExporterOptions.HttpClientFactory.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.OtlpExporterOptions() -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.Protocol.get -> OpenTelemetry.Exporter.OtlpExportProtocol
-OpenTelemetry.Exporter.OtlpExporterOptions.Protocol.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.TimeoutMilliseconds.get -> int
-OpenTelemetry.Exporter.OtlpExporterOptions.TimeoutMilliseconds.set -> void
 OpenTelemetry.Exporter.OtlpExportProtocol
 OpenTelemetry.Exporter.OtlpExportProtocol.Grpc = 0 -> OpenTelemetry.Exporter.OtlpExportProtocol
 OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf = 1 -> OpenTelemetry.Exporter.OtlpExportProtocol

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,12 @@
+OpenTelemetry.Exporter.BaseOtlpExporterOptions
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.BaseOtlpExporterOptions(Microsoft.Extensions.Configuration.IConfiguration configuration) -> void
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.Endpoint.get -> System.Uri
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.Endpoint.set -> void
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.Headers.get -> string
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.Headers.set -> void
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.HttpClientFactory.get -> System.Func<System.Net.Http.HttpClient>
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.HttpClientFactory.set -> void
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.Protocol.get -> OpenTelemetry.Exporter.OtlpExportProtocol
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.Protocol.set -> void
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.TimeoutMilliseconds.get -> int
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.TimeoutMilliseconds.set -> void

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.1/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.1/PublicAPI.Shipped.txt
@@ -1,19 +1,9 @@
 OpenTelemetry.Exporter.OtlpExporterOptions
 OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.get -> OpenTelemetry.BatchExportProcessorOptions<System.Diagnostics.Activity>
 OpenTelemetry.Exporter.OtlpExporterOptions.BatchExportProcessorOptions.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.get -> System.Uri
-OpenTelemetry.Exporter.OtlpExporterOptions.Endpoint.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
 OpenTelemetry.Exporter.OtlpExporterOptions.ExportProcessorType.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.Headers.get -> string
-OpenTelemetry.Exporter.OtlpExporterOptions.Headers.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.HttpClientFactory.get -> System.Func<System.Net.Http.HttpClient>
-OpenTelemetry.Exporter.OtlpExporterOptions.HttpClientFactory.set -> void
 OpenTelemetry.Exporter.OtlpExporterOptions.OtlpExporterOptions() -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.Protocol.get -> OpenTelemetry.Exporter.OtlpExportProtocol
-OpenTelemetry.Exporter.OtlpExporterOptions.Protocol.set -> void
-OpenTelemetry.Exporter.OtlpExporterOptions.TimeoutMilliseconds.get -> int
-OpenTelemetry.Exporter.OtlpExporterOptions.TimeoutMilliseconds.set -> void
 OpenTelemetry.Exporter.OtlpExportProtocol
 OpenTelemetry.Exporter.OtlpExportProtocol.Grpc = 0 -> OpenTelemetry.Exporter.OtlpExportProtocol
 OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf = 1 -> OpenTelemetry.Exporter.OtlpExportProtocol

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,0 +1,12 @@
+OpenTelemetry.Exporter.BaseOtlpExporterOptions
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.BaseOtlpExporterOptions(Microsoft.Extensions.Configuration.IConfiguration configuration) -> void
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.Endpoint.get -> System.Uri
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.Endpoint.set -> void
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.Headers.get -> string
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.Headers.set -> void
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.HttpClientFactory.get -> System.Func<System.Net.Http.HttpClient>
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.HttpClientFactory.set -> void
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.Protocol.get -> OpenTelemetry.Exporter.OtlpExportProtocol
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.Protocol.set -> void
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.TimeoutMilliseconds.get -> int
+OpenTelemetry.Exporter.BaseOtlpExporterOptions.TimeoutMilliseconds.set -> void

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/BaseOtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/BaseOtlpExporterOptions.cs
@@ -1,0 +1,188 @@
+// <copyright file="BaseOtlpExporterOptions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NETFRAMEWORK
+using System.Net.Http;
+#endif
+using System.Diagnostics;
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+using OpenTelemetry.Internal;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace OpenTelemetry.Exporter
+{
+    /// <summary>
+    /// Base otlp exporter options.
+    /// </summary>
+    public abstract class BaseOtlpExporterOptions
+    {
+        internal const string EndpointEnvVarName = "OTEL_EXPORTER_OTLP_ENDPOINT";
+        internal const string HeadersEnvVarName = "OTEL_EXPORTER_OTLP_HEADERS";
+        internal const string TimeoutEnvVarName = "OTEL_EXPORTER_OTLP_TIMEOUT";
+        internal const string ProtocolEnvVarName = "OTEL_EXPORTER_OTLP_PROTOCOL";
+
+        internal static readonly KeyValuePair<string, string>[] StandardHeaders = new KeyValuePair<string, string>[]
+        {
+            new KeyValuePair<string, string>("User-Agent", GetUserAgentString()),
+        };
+
+        internal Func<HttpClient> DefaultHttpClientFactory;
+
+        private const string DefaultGrpcEndpoint = "http://localhost:4317";
+        private const string DefaultHttpEndpoint = "http://localhost:4318";
+        private const OtlpExportProtocol DefaultOtlpExportProtocol = OtlpExportProtocol.Grpc;
+        private const string UserAgentProduct = "OTel-OTLP-Exporter-Dotnet";
+
+        private Uri endpoint;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BaseOtlpExporterOptions"/> class.
+        /// </summary>
+        /// <param name="configuration">IConfiguration object.</param>
+        protected BaseOtlpExporterOptions(IConfiguration configuration)
+        {
+            Debug.Assert(configuration != null, "configuration was null");
+            if (configuration.TryGetUriValue(EndpointEnvVarName, out var endpoint))
+            {
+                this.endpoint = endpoint;
+            }
+
+            if (configuration.TryGetStringValue(HeadersEnvVarName, out var headers))
+            {
+                this.Headers = headers;
+            }
+
+            if (configuration.TryGetIntValue(TimeoutEnvVarName, out var timeout))
+            {
+                this.TimeoutMilliseconds = timeout;
+            }
+
+            if (configuration.TryGetValue<OtlpExportProtocol>(
+                ProtocolEnvVarName,
+                OtlpExportProtocolParser.TryParse,
+                out var protocol))
+            {
+                this.Protocol = protocol;
+            }
+
+            this.HttpClientFactory = this.DefaultHttpClientFactory = () =>
+            {
+                return new HttpClient
+                {
+                    Timeout = TimeSpan.FromMilliseconds(this.TimeoutMilliseconds),
+                };
+            };
+        }
+
+        /// <summary>
+        /// Gets or sets the target to which the exporter is going to send telemetry.
+        /// Must be a valid Uri with scheme (http or https) and host, and
+        /// may contain a port and path. The default value is
+        /// * http://localhost:4317 for <see cref="OtlpExportProtocol.Grpc"/>
+        /// * http://localhost:4318 for <see cref="OtlpExportProtocol.HttpProtobuf"/>.
+        /// </summary>
+        public Uri Endpoint
+        {
+            get
+            {
+                if (this.endpoint == null)
+                {
+                    this.endpoint = this.Protocol == OtlpExportProtocol.Grpc
+                        ? new Uri(DefaultGrpcEndpoint)
+                        : new Uri(DefaultHttpEndpoint);
+                }
+
+                return this.endpoint;
+            }
+
+            set
+            {
+                this.endpoint = value;
+                this.ProgrammaticallyModifiedEndpoint = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets optional headers for the connection. Refer to the <a href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#specifying-headers-via-environment-variables">
+        /// specification</a> for information on the expected format for Headers.
+        /// </summary>
+        public string Headers { get; set; }
+
+        /// <summary>
+        /// Gets or sets the max waiting time (in milliseconds) for the backend to process each batch. The default value is 10000.
+        /// </summary>
+        public int TimeoutMilliseconds { get; set; } = 10000;
+
+        /// <summary>
+        /// Gets or sets the the OTLP transport protocol. Supported values: Grpc and HttpProtobuf.
+        /// </summary>
+        public OtlpExportProtocol Protocol { get; set; } = DefaultOtlpExportProtocol;
+
+        /// <summary>
+        /// Gets or sets the factory function called to create the <see
+        /// cref="HttpClient"/> instance that will be used at runtime to
+        /// transmit telemetry over HTTP. The returned instance will be reused
+        /// for all export invocations.
+        /// </summary>
+        /// <remarks>
+        /// Notes:
+        /// <list type="bullet">
+        /// <item>This is only invoked for the <see
+        /// cref="OtlpExportProtocol.HttpProtobuf"/> protocol.</item>
+        /// <item>The default behavior when using the <see
+        /// cref="OtlpTraceExporterHelperExtensions.AddOtlpExporter(TracerProviderBuilder,
+        /// Action{OtlpExporterOptions})"/> extension is if an <a
+        /// href="https://docs.microsoft.com/dotnet/api/system.net.http.ihttpclientfactory">IHttpClientFactory</a>
+        /// instance can be resolved through the application <see
+        /// cref="IServiceProvider"/> then an <see cref="HttpClient"/> will be
+        /// created through the factory with the name "OtlpTraceExporter"
+        /// otherwise an <see cref="HttpClient"/> will be instantiated
+        /// directly.</item>
+        /// <item>The default behavior when using the <see
+        /// cref="OtlpMetricExporterExtensions.AddOtlpExporter(MeterProviderBuilder,
+        /// Action{OtlpExporterOptions})"/> extension is if an <a
+        /// href="https://docs.microsoft.com/dotnet/api/system.net.http.ihttpclientfactory">IHttpClientFactory</a>
+        /// instance can be resolved through the application <see
+        /// cref="IServiceProvider"/> then an <see cref="HttpClient"/> will be
+        /// created through the factory with the name "OtlpMetricExporter"
+        /// otherwise an <see cref="HttpClient"/> will be instantiated
+        /// directly.</item>
+        /// </list>
+        /// </remarks>
+        public Func<HttpClient> HttpClientFactory { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether <see cref="Endpoint" /> was modified via its setter.
+        /// </summary>
+        internal bool ProgrammaticallyModifiedEndpoint { get; private set; }
+
+        private static string GetUserAgentString()
+        {
+            try
+            {
+                var assemblyVersion = typeof(OtlpExporterOptions).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+                var informationalVersion = assemblyVersion.InformationalVersion;
+                return string.IsNullOrEmpty(informationalVersion) ? UserAgentProduct : $"{UserAgentProduct}/{informationalVersion}";
+            }
+            catch (Exception)
+            {
+                return UserAgentProduct;
+            }
+        }
+    }
+}

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -15,15 +15,10 @@
 // </copyright>
 
 using System.Diagnostics;
-using System.Reflection;
-#if NETFRAMEWORK
-using System.Net.Http;
-#endif
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Internal;
-using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Exporter
@@ -33,27 +28,8 @@ namespace OpenTelemetry.Exporter
     /// OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_HEADERS, OTEL_EXPORTER_OTLP_TIMEOUT, OTEL_EXPORTER_OTLP_PROTOCOL
     /// environment variables are parsed during object construction.
     /// </summary>
-    public class OtlpExporterOptions
+    public class OtlpExporterOptions : BaseOtlpExporterOptions
     {
-        internal const string EndpointEnvVarName = "OTEL_EXPORTER_OTLP_ENDPOINT";
-        internal const string HeadersEnvVarName = "OTEL_EXPORTER_OTLP_HEADERS";
-        internal const string TimeoutEnvVarName = "OTEL_EXPORTER_OTLP_TIMEOUT";
-        internal const string ProtocolEnvVarName = "OTEL_EXPORTER_OTLP_PROTOCOL";
-
-        internal static readonly KeyValuePair<string, string>[] StandardHeaders = new KeyValuePair<string, string>[]
-        {
-            new KeyValuePair<string, string>("User-Agent", GetUserAgentString()),
-        };
-
-        internal readonly Func<HttpClient> DefaultHttpClientFactory;
-
-        private const string DefaultGrpcEndpoint = "http://localhost:4317";
-        private const string DefaultHttpEndpoint = "http://localhost:4318";
-        private const OtlpExportProtocol DefaultOtlpExportProtocol = OtlpExportProtocol.Grpc;
-        private const string UserAgentProduct = "OTel-OTLP-Exporter-Dotnet";
-
-        private Uri endpoint;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="OtlpExporterOptions"/> class.
         /// </summary>
@@ -65,87 +41,12 @@ namespace OpenTelemetry.Exporter
         internal OtlpExporterOptions(
             IConfiguration configuration,
             BatchExportActivityProcessorOptions defaultBatchOptions)
+            : base(configuration)
         {
-            Debug.Assert(configuration != null, "configuration was null");
             Debug.Assert(defaultBatchOptions != null, "defaultBatchOptions was null");
-
-            if (configuration.TryGetUriValue(EndpointEnvVarName, out var endpoint))
-            {
-                this.endpoint = endpoint;
-            }
-
-            if (configuration.TryGetStringValue(HeadersEnvVarName, out var headers))
-            {
-                this.Headers = headers;
-            }
-
-            if (configuration.TryGetIntValue(TimeoutEnvVarName, out var timeout))
-            {
-                this.TimeoutMilliseconds = timeout;
-            }
-
-            if (configuration.TryGetValue<OtlpExportProtocol>(
-                ProtocolEnvVarName,
-                OtlpExportProtocolParser.TryParse,
-                out var protocol))
-            {
-                this.Protocol = protocol;
-            }
-
-            this.HttpClientFactory = this.DefaultHttpClientFactory = () =>
-            {
-                return new HttpClient
-                {
-                    Timeout = TimeSpan.FromMilliseconds(this.TimeoutMilliseconds),
-                };
-            };
 
             this.BatchExportProcessorOptions = defaultBatchOptions;
         }
-
-        /// <summary>
-        /// Gets or sets the target to which the exporter is going to send telemetry.
-        /// Must be a valid Uri with scheme (http or https) and host, and
-        /// may contain a port and path. The default value is
-        /// * http://localhost:4317 for <see cref="OtlpExportProtocol.Grpc"/>
-        /// * http://localhost:4318 for <see cref="OtlpExportProtocol.HttpProtobuf"/>.
-        /// </summary>
-        public Uri Endpoint
-        {
-            get
-            {
-                if (this.endpoint == null)
-                {
-                    this.endpoint = this.Protocol == OtlpExportProtocol.Grpc
-                        ? new Uri(DefaultGrpcEndpoint)
-                        : new Uri(DefaultHttpEndpoint);
-                }
-
-                return this.endpoint;
-            }
-
-            set
-            {
-                this.endpoint = value;
-                this.ProgrammaticallyModifiedEndpoint = true;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets optional headers for the connection. Refer to the <a href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#specifying-headers-via-environment-variables">
-        /// specification</a> for information on the expected format for Headers.
-        /// </summary>
-        public string Headers { get; set; }
-
-        /// <summary>
-        /// Gets or sets the max waiting time (in milliseconds) for the backend to process each batch. The default value is 10000.
-        /// </summary>
-        public int TimeoutMilliseconds { get; set; } = 10000;
-
-        /// <summary>
-        /// Gets or sets the the OTLP transport protocol. Supported values: Grpc and HttpProtobuf.
-        /// </summary>
-        public OtlpExportProtocol Protocol { get; set; } = DefaultOtlpExportProtocol;
 
         /// <summary>
         /// Gets or sets the export processor type to be used with the OpenTelemetry Protocol Exporter. The default value is <see cref="ExportProcessorType.Batch"/>.
@@ -157,64 +58,12 @@ namespace OpenTelemetry.Exporter
         /// </summary>
         public BatchExportProcessorOptions<Activity> BatchExportProcessorOptions { get; set; }
 
-        /// <summary>
-        /// Gets or sets the factory function called to create the <see
-        /// cref="HttpClient"/> instance that will be used at runtime to
-        /// transmit telemetry over HTTP. The returned instance will be reused
-        /// for all export invocations.
-        /// </summary>
-        /// <remarks>
-        /// Notes:
-        /// <list type="bullet">
-        /// <item>This is only invoked for the <see
-        /// cref="OtlpExportProtocol.HttpProtobuf"/> protocol.</item>
-        /// <item>The default behavior when using the <see
-        /// cref="OtlpTraceExporterHelperExtensions.AddOtlpExporter(TracerProviderBuilder,
-        /// Action{OtlpExporterOptions})"/> extension is if an <a
-        /// href="https://docs.microsoft.com/dotnet/api/system.net.http.ihttpclientfactory">IHttpClientFactory</a>
-        /// instance can be resolved through the application <see
-        /// cref="IServiceProvider"/> then an <see cref="HttpClient"/> will be
-        /// created through the factory with the name "OtlpTraceExporter"
-        /// otherwise an <see cref="HttpClient"/> will be instantiated
-        /// directly.</item>
-        /// <item>The default behavior when using the <see
-        /// cref="OtlpMetricExporterExtensions.AddOtlpExporter(MeterProviderBuilder,
-        /// Action{OtlpExporterOptions})"/> extension is if an <a
-        /// href="https://docs.microsoft.com/dotnet/api/system.net.http.ihttpclientfactory">IHttpClientFactory</a>
-        /// instance can be resolved through the application <see
-        /// cref="IServiceProvider"/> then an <see cref="HttpClient"/> will be
-        /// created through the factory with the name "OtlpMetricExporter"
-        /// otherwise an <see cref="HttpClient"/> will be instantiated
-        /// directly.</item>
-        /// </list>
-        /// </remarks>
-        public Func<HttpClient> HttpClientFactory { get; set; }
-
-        /// <summary>
-        /// Gets a value indicating whether <see cref="Endpoint" /> was modified via its setter.
-        /// </summary>
-        internal bool ProgrammaticallyModifiedEndpoint { get; private set; }
-
         internal static void RegisterOtlpExporterOptionsFactory(IServiceCollection services)
         {
             services.RegisterOptionsFactory(
                 (sp, configuration, name) => new OtlpExporterOptions(
                     configuration,
                     sp.GetRequiredService<IOptionsMonitor<BatchExportActivityProcessorOptions>>().Get(name)));
-        }
-
-        private static string GetUserAgentString()
-        {
-            try
-            {
-                var assemblyVersion = typeof(OtlpExporterOptions).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
-                var informationalVersion = assemblyVersion.InformationalVersion;
-                return string.IsNullOrEmpty(informationalVersion) ? UserAgentProduct : $"{UserAgentProduct}/{informationalVersion}";
-            }
-            catch (Exception)
-            {
-                return UserAgentProduct;
-            }
         }
     }
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
@@ -89,7 +89,7 @@ namespace OpenTelemetry.Exporter
                     });
             }
 
-            foreach (var header in OtlpExporterOptions.StandardHeaders)
+            foreach (var header in BaseOtlpExporterOptions.StandardHeaders)
             {
                 addHeader(headers, header.Key, header.Value);
             }


### PR DESCRIPTION
Towards #4388 
Design discussion issue #

## Changes

This PR introduces a new class `BaseOtlpExporterOptions`. Options that are common across all 3 signals are moved here. 

`OtlpExporterOptions` will now only contain two options `ExportProcessorType` and `BatchExportProcessorOptions`.

Will add `OtlpLogExporterOptions` in follow up PR.

Open question:
1) Should we include `ExportProcessorType` and `BatchExportProcessorOptions` for OtlpLogExporterOptions? 
                                                                      OR
   Should we update the extension methods for adding log exporter to include these? https://github.com/open-telemetry/opentelemetry-dotnet/issues/2552

e.g.
```csharp
AddOtlpExporterInternal(OpenTelemetryLoggerOptions loggerOptions, 
Action<OtlpLogExporterOptions, BatchLogExportProcessorOptions> configureExporterAndBatchProcessor)`
```

similar to what we have on [metrics](https://github.com/open-telemetry/opentelemetry-dotnet/blob/9a7bd9f55ad3f643484fe7d62d92c2553c623da1/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs#L112)

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
