### PR TITLE
[ASP.NET Core] Fix `System.Text.Encodings.Web` vulnerability

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Added direct reference to `System.Text.Encodings.Web` with minimum version of
 `4.7.2` due to [CVE-2021-26701](https://github.com/dotnet/runtime/issues/49377).
 This impacts target frameworks `netstandard2.0` and `netstandard2.1` which has a
-dependency on `Microsoft.AspNetCore.Http.Abstractions` which depends on
+reference to `Microsoft.AspNetCore.Http.Abstractions` that depends on
 `System.Text.Encodings.Web` >= 4.5.0.
 ([#4399](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4399))
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -7,7 +7,7 @@
 This impacts target frameworks `netstandard2.0` and `netstandard2.1` which has a
 dependency on `Microsoft.AspNetCore.Http.Abstractions` which depends on
 `System.Text.Encodings.Web` >= 4.5.0.
-([#]())
+([#4399](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4399))
 
 * Improve perf by avoiding boxing of common status codes values.
   ([#4360](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4360),

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+* Added direct reference to `System.Text.Encodings.Web` with minimum version of
+`4.7.2` due to [CVE-2021-26701](https://github.com/dotnet/runtime/issues/49377).
+This impacts target frameworks `netstandard2.0` and `netstandard2.1` which has a
+dependency on `Microsoft.AspNetCore.Http.Abstractions` which depends on
+`System.Text.Encodings.Web` >= 4.5.0.
+([#]())
+
 * Improve perf by avoiding boxing of common status codes values.
   ([#4360](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4360),
   [#4363](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4363))

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
@@ -21,11 +21,13 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebPkgVer)" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="$(MicrosoftAspNetCoreHttpAbstractionsPkgVer)" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="$(MicrosoftAspNetCoreHttpFeaturesPkgVer)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebPkgVer)" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="$(MicrosoftAspNetCoreHttpAbstractionsPkgVer)" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="$(MicrosoftAspNetCoreHttpFeaturesPkgVer)" />
   </ItemGroup>


### PR DESCRIPTION
Follow up to https://github.com/open-telemetry/opentelemetry-dotnet/pull/4390#discussion_r1168917268

There is no version available for `Microsoft.AspNetCore.Http.Abstractions` with `System.Text.Encodings.Web` dependency >=4.7.2. That is why adding a direct reference.

Design discussion issue #

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
