### PR TITLE
Update AspNetCore benchmarks

### DIFF
--- a/build/Common.nonprod.props
+++ b/build/Common.nonprod.props
@@ -30,7 +30,7 @@
       Please sort alphabetically.
       Refer to https://docs.microsoft.com/nuget/concepts/package-versioning for semver syntax.
     -->
-    <BenchmarkDotNetPkgVer>[0.13.3,0.14)</BenchmarkDotNetPkgVer>
+    <BenchmarkDotNetPkgVer>[0.13.5,0.14)</BenchmarkDotNetPkgVer>
     <CommandLineParserPkgVer>[2.9.1,3.0)</CommandLineParserPkgVer>
     <DotNetXUnitCliVer>[2.3.1,3.0)</DotNetXUnitCliVer>
     <GoogleProtobufPkgVer>[3.22.0,4.0)</GoogleProtobufPkgVer>

--- a/test/Benchmarks/Instrumentation/AspNetCoreInstrumentationBenchmarks.cs
+++ b/test/Benchmarks/Instrumentation/AspNetCoreInstrumentationBenchmarks.cs
@@ -17,30 +17,30 @@
 #if !NETFRAMEWORK
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 
 /*
-// * Summary *
+BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.23424.1000)
+Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
+.NET SDK=7.0.203
+  [Host]     : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
+  DefaultJob : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
 
-BenchmarkDotNet=v0.13.3, OS=Windows 10 (10.0.19045.2604)
-Intel Core i7-4790 CPU 3.60GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
-.NET SDK=7.0.103
-  [Host] : .NET 7.0.3 (7.0.323.6910), X64 RyuJIT AVX2
 
-Job=InProcess  Toolchain=InProcessEmitToolchain
-
-|                                      Method |     Mean |   Error |  StdDev |   Gen0 | Allocated |
-|-------------------------------------------- |---------:|--------:|--------:|-------:|----------:|
-|                 UninstrumentedAspNetCoreApp | 149.4 us | 2.94 us | 2.75 us | 0.4883 |   2.54 KB |
-| InstrumentedAspNetCoreAppWithDefaultOptions | 171.9 us | 2.65 us | 2.48 us | 0.7324 |   3.79 KB |
+|                     Method | EnableInstrumentation |     Mean |   Error |  StdDev |   Gen0 | Allocated |
+|--------------------------- |---------------------- |---------:|--------:|--------:|-------:|----------:|
+| GetRequestForAspNetCoreApp |                  None | 226.8 us | 4.00 us | 3.74 us |      - |   2.45 KB |
+| GetRequestForAspNetCoreApp |                Traces | 235.2 us | 4.44 us | 4.15 us | 0.4883 |   3.59 KB |
+| GetRequestForAspNetCoreApp |               Metrics | 229.1 us | 4.44 us | 4.36 us |      - |   2.92 KB |
+| GetRequestForAspNetCoreApp |       Traces, Metrics | 230.6 us | 4.54 us | 5.23 us | 0.4883 |   3.66 KB |
 */
 
 namespace Benchmarks.Instrumentation
 {
-    [InProcess]
     public class AspNetCoreInstrumentationBenchmarks
     {
         private HttpClient httpClient;
@@ -48,55 +48,102 @@ namespace Benchmarks.Instrumentation
         private TracerProvider tracerProvider;
         private MeterProvider meterProvider;
 
-        [GlobalSetup(Target = nameof(UninstrumentedAspNetCoreApp))]
-        public void UninstrumentedAspNetCoreAppGlobalSetup()
+        [Flags]
+        public enum EnableInstrumentationOption
         {
-            this.StartWebApplication();
-            this.httpClient = new HttpClient();
+            /// <summary>
+            /// Instrumentation is not enabled for any signal.
+            /// </summary>
+            None = 0,
+
+            /// <summary>
+            /// Instrumentation is enbled only for Traces.
+            /// </summary>
+            Traces = 1,
+
+            /// <summary>
+            /// Instrumentation is enbled only for Metrics.
+            /// </summary>
+            Metrics = 2,
         }
 
-        [GlobalSetup(Target = nameof(InstrumentedAspNetCoreAppWithDefaultOptions))]
-        public void InstrumentedAspNetCoreAppWithDefaultOptionsGlobalSetup()
+        [Params(0, 1, 2, 3)]
+        public EnableInstrumentationOption EnableInstrumentation { get; set; }
+
+        [GlobalSetup(Target = nameof(GetRequestForAspNetCoreApp))]
+        public void GetRequestForAspNetCoreAppGlobalSetup()
         {
-            this.StartWebApplication();
-            this.httpClient = new HttpClient();
+            if (this.EnableInstrumentation == EnableInstrumentationOption.None)
+            {
+                this.StartWebApplication();
+                this.httpClient = new HttpClient();
+            }
+            else if (this.EnableInstrumentation == EnableInstrumentationOption.Traces)
+            {
+                this.StartWebApplication();
+                this.httpClient = new HttpClient();
 
-            this.tracerProvider = Sdk.CreateTracerProviderBuilder()
-                .AddAspNetCoreInstrumentation()
-                .Build();
+                this.tracerProvider = Sdk.CreateTracerProviderBuilder()
+                    .AddAspNetCoreInstrumentation()
+                    .Build();
+            }
+            else if (this.EnableInstrumentation == EnableInstrumentationOption.Metrics)
+            {
+                this.StartWebApplication();
+                this.httpClient = new HttpClient();
 
-            var exportedItems = new List<Metric>();
-            this.meterProvider = Sdk.CreateMeterProviderBuilder()
-                .AddAspNetCoreInstrumentation()
-                .AddInMemoryExporter(exportedItems)
-                .Build();
+                this.meterProvider = Sdk.CreateMeterProviderBuilder()
+                    .AddAspNetCoreInstrumentation()
+                    .Build();
+            }
+            else if (this.EnableInstrumentation.HasFlag(EnableInstrumentationOption.Traces) &&
+                this.EnableInstrumentation.HasFlag(EnableInstrumentationOption.Metrics))
+            {
+                this.StartWebApplication();
+                this.httpClient = new HttpClient();
+
+                this.tracerProvider = Sdk.CreateTracerProviderBuilder()
+                    .AddAspNetCoreInstrumentation()
+                    .Build();
+
+                this.meterProvider = Sdk.CreateMeterProviderBuilder()
+                    .AddAspNetCoreInstrumentation()
+                    .Build();
+            }
         }
 
-        [GlobalCleanup(Target = nameof(UninstrumentedAspNetCoreApp))]
-        public async Task GlobalCleanupUninstrumentedAspNetCoreAppAsync()
+        [GlobalCleanup(Target = nameof(GetRequestForAspNetCoreApp))]
+        public void GetRequestForAspNetCoreAppGlobalCleanup()
         {
-            this.httpClient.Dispose();
-            await this.app.DisposeAsync().ConfigureAwait(false);
-        }
-
-        [GlobalCleanup(Target = nameof(InstrumentedAspNetCoreAppWithDefaultOptions))]
-        public async Task GlobalCleanupInstrumentedAspNetCoreAppWithDefaultOptionsAsync()
-        {
-            this.httpClient.Dispose();
-            await this.app.DisposeAsync().ConfigureAwait(false);
-            this.tracerProvider.Dispose();
-            this.meterProvider.Dispose();
+            if (this.EnableInstrumentation == EnableInstrumentationOption.None)
+            {
+                this.httpClient.Dispose();
+                this.app.DisposeAsync().GetAwaiter().GetResult();
+            }
+            else if (this.EnableInstrumentation == EnableInstrumentationOption.Traces)
+            {
+                this.httpClient.Dispose();
+                this.app.DisposeAsync().GetAwaiter().GetResult();
+                this.tracerProvider.Dispose();
+            }
+            else if (this.EnableInstrumentation == EnableInstrumentationOption.Metrics)
+            {
+                this.httpClient.Dispose();
+                this.app.DisposeAsync().GetAwaiter().GetResult();
+                this.meterProvider.Dispose();
+            }
+            else if (this.EnableInstrumentation.HasFlag(EnableInstrumentationOption.Traces) &&
+                this.EnableInstrumentation.HasFlag(EnableInstrumentationOption.Metrics))
+            {
+                this.httpClient.Dispose();
+                this.app.DisposeAsync().GetAwaiter().GetResult();
+                this.tracerProvider.Dispose();
+                this.meterProvider.Dispose();
+            }
         }
 
         [Benchmark]
-        public async Task UninstrumentedAspNetCoreApp()
-        {
-            var httpResponse = await this.httpClient.GetAsync("http://localhost:5000").ConfigureAwait(false);
-            httpResponse.EnsureSuccessStatusCode();
-        }
-
-        [Benchmark]
-        public async Task InstrumentedAspNetCoreAppWithDefaultOptions()
+        public async Task GetRequestForAspNetCoreApp()
         {
             var httpResponse = await this.httpClient.GetAsync("http://localhost:5000").ConfigureAwait(false);
             httpResponse.EnsureSuccessStatusCode();
@@ -107,7 +154,7 @@ namespace Benchmarks.Instrumentation
             var builder = WebApplication.CreateBuilder();
             builder.Logging.ClearProviders();
             var app = builder.Build();
-            app.MapGet("/", () => $"Hello World!");
+            app.MapGet("/", async context => await context.Response.WriteAsync($"Hello World!"));
             app.RunAsync();
 
             this.app = app;


### PR DESCRIPTION
## Changes
- Add instrumentation options `Params` to have a benchmark method run for each of the possible combinations:
  - No instrumentation enabled
  - Instrumentation enabled only for Traces
  - Instrumentation enabled only for Metrics
  - Instrumentation enabled for both Traces and Metrics

- Update the web application builder setup to use `async/await`
- Update BenchmarkDotNet version to 0.13.5


Benchmark results:

|                     Method | EnableInstrumentation |     Mean |   Error |  StdDev |   Gen0 | Allocated |
|--------------------------- |---------------------- |---------:|--------:|--------:|-------:|----------:|
| GetRequestForAspNetCoreApp |                  None | 226.8 us | 4.00 us | 3.74 us |      - |   2.45 KB |
| GetRequestForAspNetCoreApp |                Traces | 235.2 us | 4.44 us | 4.15 us | 0.4883 |   3.59 KB |
| GetRequestForAspNetCoreApp |               Metrics | 229.1 us | 4.44 us | 4.36 us |      - |   2.92 KB |
| GetRequestForAspNetCoreApp |       Traces, Metrics | 230.6 us | 4.54 us | 5.23 us | 0.4883 |   3.66 KB |
