### PR TITLE
Disable PublishAot for OSX

### DIFF
--- a/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
+++ b/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
-    <PublishAot>true</PublishAot>
+    <PublishAot Condition="!$([MSBuild]::IsOSPlatform('OSX'))">true</PublishAot>
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
   </PropertyGroup>
 


### PR DESCRIPTION
I cannot currently `dotnet build` the solution on my M1.

```
OpenTelemetry.AotCompatibility.TestApp.csproj : error NU1102: Unable to find package runtime.osx-arm64.Microsoft.DotNet.ILCompiler with version (= 7.0.1) [/Users/awest/github/open-telemetry/opentelemetry-dotnet/OpenTelemetry.sln]
OpenTelemetry.AotCompatibility.TestApp.csproj : error NU1102:   - Found 3 version(s) in NuGet [ Nearest version: 8.0.0-preview.1.23110.8 ] [/Users/awest/github/open-telemetry/opentelemetry-dotnet/OpenTelemetry.sln]
OpenTelemetry.AotCompatibility.TestApp.csproj : error NU1102:   - Found 0 version(s) in .Net Core Tools [/Users/awest/github/open-telemetry/opentelemetry-dotnet/OpenTelemetry.sln]
```

We can undo the change in this PR when/if we upgrade the target framework of the test app to `net8.0`. For now, I don't think we need to be concerned about the AOT compatibility for OSX.