### PR TITLE
OTLP exporter: Set observed timestamp

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs/CHANGELOG.md
@@ -16,6 +16,14 @@
   and `Attributes` are equivalent).
   ([#4334](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4334))
 
+* Fixed issue where the
+  [observed time](https://github.com/open-telemetry/opentelemetry-proto/blob/395c8422fe90080314c7d9b4114d701a0c049e1f/opentelemetry/proto/logs/v1/logs.proto#L138)
+  field of the OTLP log record was not set. It is now correctly set to equal
+  the
+  [time](https://github.com/open-telemetry/opentelemetry-proto/blob/395c8422fe90080314c7d9b4114d701a0c049e1f/opentelemetry/proto/logs/v1/logs.proto#L121)
+  field.
+  ([#4444](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4444))
+
 ## 1.5.0-alpha.2
 
 Released 2023-Mar-31

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
@@ -66,9 +66,11 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
 
             try
             {
+                var timestamp = (ulong)logRecord.Timestamp.ToUnixTimeNanoseconds();
                 otlpLogRecord = new OtlpLogs.LogRecord
                 {
-                    TimeUnixNano = (ulong)logRecord.Timestamp.ToUnixTimeNanoseconds(),
+                    TimeUnixNano = timestamp,
+                    ObservedTimeUnixNano = timestamp,
                     SeverityNumber = GetSeverityNumber(logRecord.LogLevel),
                     SeverityText = LogLevels[(int)logRecord.LogLevel],
                 };

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
@@ -278,6 +278,27 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
         }
 
         [Fact]
+        public void CheckToOtlpLogRecordTimestamps()
+        {
+            var logRecords = new List<LogRecord>();
+            using var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddOpenTelemetry(options =>
+                {
+                    options.AddInMemoryExporter(logRecords);
+                });
+            });
+
+            var logger = loggerFactory.CreateLogger("OtlpLogExporterTests");
+            logger.LogInformation("Log message");
+            var logRecord = logRecords[0];
+            var otlpLogRecord = logRecord.ToOtlpLog(DefaultSdkLimitOptions);
+
+            Assert.True(otlpLogRecord.TimeUnixNano > 0);
+            Assert.True(otlpLogRecord.ObservedTimeUnixNano > 0);
+        }
+
+        [Fact]
         public void CheckToOtlpLogRecordTraceIdSpanIdFlagWithNoActivity()
         {
             var logRecords = new List<LogRecord>();


### PR DESCRIPTION
Observed timestamp should equal the timestamp. See: https://github.com/open-telemetry/opentelemetry-proto/blob/395c8422fe90080314c7d9b4114d701a0c049e1f/opentelemetry/proto/logs/v1/logs.proto#L123-L129

```proto
  // time_unix_nano is the time when the event occurred.
  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
  // Value of 0 indicates unknown or missing timestamp.
  fixed64 time_unix_nano = 1;

  // Time when the event was observed by the collection system.
  // For events that originate in OpenTelemetry (e.g. using OpenTelemetry Logging SDK)
  // this timestamp is typically set at the generation time and is equal to Timestamp.
  // For events originating externally and collected by OpenTelemetry (e.g. using
  // Collector) this is the time when OpenTelemetry's code observed the event measured
  // by the clock of the OpenTelemetry code. This field MUST be set once the event is
  // observed by OpenTelemetry.
  //
  // For converting OpenTelemetry log data to formats that support only one timestamp or
  // when receiving OpenTelemetry log data by recipients that support only one timestamp
  // internally the following logic is recommended:
  //   - Use time_unix_nano if it is present, otherwise use observed_time_unix_nano.
  //
  // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
  // Value of 0 indicates unknown or missing timestamp.
  fixed64 observed_time_unix_nano = 11;
```