### PR TITLE
[sdk-logs] Add BatchExportLogRecordProcessorOptions to SDK

### DIFF
--- a/src/OpenTelemetry/Internal/Builder/ProviderBuilderServiceCollectionExtensions.cs
+++ b/src/OpenTelemetry/Internal/Builder/ProviderBuilderServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpenTelemetry;
 using OpenTelemetry.Internal;
+using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 
@@ -34,7 +35,7 @@ internal static class ProviderBuilderServiceCollectionExtensions
 
         // TODO:
         // services!.TryAddSingleton<LoggerProviderBuilderSdk>();
-        // services!.RegisterOptionsFactory(configuration => new BatchExportLogRecordProcessorOptions(configuration));
+        services!.RegisterOptionsFactory(configuration => new BatchExportLogRecordProcessorOptions(configuration));
 
         return services!;
     }

--- a/src/OpenTelemetry/Logs/BatchExportLogRecordProcessorOptions.cs
+++ b/src/OpenTelemetry/Logs/BatchExportLogRecordProcessorOptions.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using Microsoft.Extensions.Configuration;
 using OpenTelemetry.Internal;
 

--- a/src/OpenTelemetry/Logs/BatchExportLogRecordProcessorOptions.cs
+++ b/src/OpenTelemetry/Logs/BatchExportLogRecordProcessorOptions.cs
@@ -1,0 +1,80 @@
+// <copyright file="BatchExportLogRecordProcessorOptions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using Microsoft.Extensions.Configuration;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Logs;
+
+/// <summary>
+/// Batch log processor options. OTEL_BLRP_MAX_QUEUE_SIZE,
+/// OTEL_BLRP_MAX_EXPORT_BATCH_SIZE, OTEL_BLRP_EXPORT_TIMEOUT,
+/// OTEL_BLRP_SCHEDULE_DELAY environment variables are parsed during object
+/// construction.
+/// </summary>
+/// <remarks>
+/// Notes:
+/// <list type="bullet">
+/// <item>The constructor throws <see cref="FormatException"/> if it fails
+/// to parse any of the supported environment variables.</item>
+/// <item>The environment variable keys are currently experimental and
+/// subject to change. See: <see
+/// href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#batch-logrecord-processor">OpenTelemetry
+/// Environment Variable Specification - Batch LogRecord Processor</see>.
+/// </item>
+/// </list>
+/// </remarks>
+internal class BatchExportLogRecordProcessorOptions : BatchExportProcessorOptions<LogRecord>
+{
+    internal const string MaxQueueSizeEnvVarKey = "OTEL_BLRP_MAX_QUEUE_SIZE";
+
+    internal const string MaxExportBatchSizeEnvVarKey = "OTEL_BLRP_MAX_EXPORT_BATCH_SIZE";
+
+    internal const string ExporterTimeoutEnvVarKey = "OTEL_BLRP_EXPORT_TIMEOUT";
+
+    internal const string ScheduledDelayEnvVarKey = "OTEL_BLRP_SCHEDULE_DELAY";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BatchExportLogRecordProcessorOptions"/> class.
+    /// </summary>
+    public BatchExportLogRecordProcessorOptions()
+        : this(new ConfigurationBuilder().AddEnvironmentVariables().Build())
+    {
+    }
+
+    internal BatchExportLogRecordProcessorOptions(IConfiguration configuration)
+    {
+        if (configuration.TryGetIntValue(ExporterTimeoutEnvVarKey, out var value))
+        {
+            this.ExporterTimeoutMilliseconds = value;
+        }
+
+        if (configuration.TryGetIntValue(MaxExportBatchSizeEnvVarKey, out value))
+        {
+            this.MaxExportBatchSize = value;
+        }
+
+        if (configuration.TryGetIntValue(MaxQueueSizeEnvVarKey, out value))
+        {
+            this.MaxQueueSize = value;
+        }
+
+        if (configuration.TryGetIntValue(ScheduledDelayEnvVarKey, out value))
+        {
+            this.ScheduledDelayMilliseconds = value;
+        }
+    }
+}

--- a/src/OpenTelemetry/Logs/BatchExportLogRecordProcessorOptions.cs
+++ b/src/OpenTelemetry/Logs/BatchExportLogRecordProcessorOptions.cs
@@ -30,11 +30,11 @@ namespace OpenTelemetry.Logs;
 /// <remarks>
 /// Notes:
 /// <list type="bullet">
-/// <item>The constructor throws <see cref="FormatException"/> if it fails
-/// to parse any of the supported environment variables.</item>
-/// <item>The environment variable keys are currently experimental and
-/// subject to change. See: <see
-/// href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#batch-logrecord-processor">OpenTelemetry
+/// <item>The constructor throws <see cref="FormatException"/> if it fails to
+/// parse any of the supported environment variables.</item>
+/// <item>The environment variable keys are currently experimental and subject
+/// to change. See: <see
+/// href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#batch-logrecord-processor">OpenTelemetry
 /// Environment Variable Specification - Batch LogRecord Processor</see>.
 /// </item>
 /// </list>

--- a/test/OpenTelemetry.Tests/Logs/BatchExportLogRecordProcessorOptionsTest.cs
+++ b/test/OpenTelemetry.Tests/Logs/BatchExportLogRecordProcessorOptionsTest.cs
@@ -85,14 +85,6 @@ public sealed class BatchExportLogRecordProcessorOptionsTest : IDisposable
     }
 
     [Fact]
-    public void BatchExportLogRecordProcessorOptions_InvalidPortEnvironmentVariableOverride()
-    {
-        Environment.SetEnvironmentVariable(BatchExportLogRecordProcessorOptions.ExporterTimeoutEnvVarKey, "invalid");
-
-        Assert.Throws<FormatException>(() => new BatchExportLogRecordProcessorOptions());
-    }
-
-    [Fact]
     public void BatchExportLogRecordProcessorOptions_SetterOverridesEnvironmentVariable()
     {
         Environment.SetEnvironmentVariable(BatchExportLogRecordProcessorOptions.ExporterTimeoutEnvVarKey, "123");

--- a/test/OpenTelemetry.Tests/Logs/BatchExportLogRecordProcessorOptionsTest.cs
+++ b/test/OpenTelemetry.Tests/Logs/BatchExportLogRecordProcessorOptionsTest.cs
@@ -1,0 +1,124 @@
+// <copyright file="BatchExportLogRecordProcessorOptionsTest.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#nullable enable
+
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace OpenTelemetry.Logs.Tests;
+
+public sealed class BatchExportLogRecordProcessorOptionsTest : IDisposable
+{
+    public BatchExportLogRecordProcessorOptionsTest()
+    {
+        ClearEnvVars();
+    }
+
+    public void Dispose()
+    {
+        ClearEnvVars();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void BatchExportLogRecordProcessorOptions_Defaults()
+    {
+        var options = new BatchExportLogRecordProcessorOptions();
+
+        Assert.Equal(30000, options.ExporterTimeoutMilliseconds);
+        Assert.Equal(512, options.MaxExportBatchSize);
+        Assert.Equal(2048, options.MaxQueueSize);
+        Assert.Equal(5000, options.ScheduledDelayMilliseconds);
+    }
+
+    [Fact]
+    public void BatchExportLogRecordProcessorOptions_EnvironmentVariableOverride()
+    {
+        Environment.SetEnvironmentVariable(BatchExportLogRecordProcessorOptions.ExporterTimeoutEnvVarKey, "1");
+        Environment.SetEnvironmentVariable(BatchExportLogRecordProcessorOptions.MaxExportBatchSizeEnvVarKey, "2");
+        Environment.SetEnvironmentVariable(BatchExportLogRecordProcessorOptions.MaxQueueSizeEnvVarKey, "3");
+        Environment.SetEnvironmentVariable(BatchExportLogRecordProcessorOptions.ScheduledDelayEnvVarKey, "4");
+
+        var options = new BatchExportLogRecordProcessorOptions();
+
+        Assert.Equal(1, options.ExporterTimeoutMilliseconds);
+        Assert.Equal(2, options.MaxExportBatchSize);
+        Assert.Equal(3, options.MaxQueueSize);
+        Assert.Equal(4, options.ScheduledDelayMilliseconds);
+    }
+
+    [Fact]
+    public void ExportLogRecordProcessorOptions_UsingIConfiguration()
+    {
+        var values = new Dictionary<string, string>()
+        {
+            [BatchExportLogRecordProcessorOptions.MaxQueueSizeEnvVarKey] = "1",
+            [BatchExportLogRecordProcessorOptions.MaxExportBatchSizeEnvVarKey] = "2",
+            [BatchExportLogRecordProcessorOptions.ExporterTimeoutEnvVarKey] = "3",
+            [BatchExportLogRecordProcessorOptions.ScheduledDelayEnvVarKey] = "4",
+        };
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+
+        var options = new BatchExportLogRecordProcessorOptions(configuration);
+
+        Assert.Equal(1, options.MaxQueueSize);
+        Assert.Equal(2, options.MaxExportBatchSize);
+        Assert.Equal(3, options.ExporterTimeoutMilliseconds);
+        Assert.Equal(4, options.ScheduledDelayMilliseconds);
+    }
+
+    [Fact]
+    public void BatchExportLogRecordProcessorOptions_InvalidPortEnvironmentVariableOverride()
+    {
+        Environment.SetEnvironmentVariable(BatchExportLogRecordProcessorOptions.ExporterTimeoutEnvVarKey, "invalid");
+
+        Assert.Throws<FormatException>(() => new BatchExportLogRecordProcessorOptions());
+    }
+
+    [Fact]
+    public void BatchExportLogRecordProcessorOptions_SetterOverridesEnvironmentVariable()
+    {
+        Environment.SetEnvironmentVariable(BatchExportLogRecordProcessorOptions.ExporterTimeoutEnvVarKey, "123");
+
+        var options = new BatchExportLogRecordProcessorOptions
+        {
+            ExporterTimeoutMilliseconds = 89000,
+        };
+
+        Assert.Equal(89000, options.ExporterTimeoutMilliseconds);
+    }
+
+    [Fact]
+    public void BatchExportLogRecordProcessorOptions_EnvironmentVariableNames()
+    {
+        Assert.Equal("OTEL_BLRP_EXPORT_TIMEOUT", BatchExportLogRecordProcessorOptions.ExporterTimeoutEnvVarKey);
+        Assert.Equal("OTEL_BLRP_MAX_EXPORT_BATCH_SIZE", BatchExportLogRecordProcessorOptions.MaxExportBatchSizeEnvVarKey);
+        Assert.Equal("OTEL_BLRP_MAX_QUEUE_SIZE", BatchExportLogRecordProcessorOptions.MaxQueueSizeEnvVarKey);
+        Assert.Equal("OTEL_BLRP_SCHEDULE_DELAY", BatchExportLogRecordProcessorOptions.ScheduledDelayEnvVarKey);
+    }
+
+    private static void ClearEnvVars()
+    {
+        Environment.SetEnvironmentVariable(BatchExportLogRecordProcessorOptions.ExporterTimeoutEnvVarKey, null);
+        Environment.SetEnvironmentVariable(BatchExportLogRecordProcessorOptions.MaxExportBatchSizeEnvVarKey, null);
+        Environment.SetEnvironmentVariable(BatchExportLogRecordProcessorOptions.MaxQueueSizeEnvVarKey, null);
+        Environment.SetEnvironmentVariable(BatchExportLogRecordProcessorOptions.ScheduledDelayEnvVarKey, null);
+    }
+}


### PR DESCRIPTION
Relates to #4433

## Changes

* Adds `BatchExportLogRecordProcessorOptions` to SDK. This class will be used by log exporters (ex: https://github.com/open-telemetry/opentelemetry-dotnet/pull/4416/files#diff-7a71b7f380cd5f1d4c9d5e4062ac3ea6d3491adc011052b42dec566de7fa8d24R29)

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated

