### PR TITLE
[api-logs] LogRecordSeverity enum tweaks

### DIFF
--- a/src/OpenTelemetry.Api/Logs/LogRecordSeverity.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordSeverity.cs
@@ -23,21 +23,96 @@ namespace OpenTelemetry.Logs;
 /// </summary>
 internal enum LogRecordSeverity
 {
-    /// <summary>Trace severity.</summary>
-    Trace,
+    /// <summary>Unknown severity (0).</summary>
+    Unknown = 0,
 
-    /// <summary>Debug severity.</summary>
-    Debug,
+    /// <summary>Trace severity (1).</summary>
+    Trace = 1,
 
-    /// <summary>Information severity.</summary>
-    Information,
+    /// <summary>Trace1 severity (1).</summary>
+    Trace1 = Trace,
 
-    /// <summary>Warning severity.</summary>
-    Warning,
+    /// <summary>Trace1 severity (2).</summary>
+    Trace2 = Trace1 + 1,
 
-    /// <summary>Error severity.</summary>
-    Error,
+    /// <summary>Trace3 severity (3).</summary>
+    Trace3 = Trace2 + 1,
 
-    /// <summary>Fatal severity.</summary>
-    Fatal,
+    /// <summary>Trace4 severity (4).</summary>
+    Trace4 = Trace3 + 1,
+
+    /// <summary>Debug severity (5).</summary>
+    Debug = 5,
+
+    /// <summary>Debug1 severity (5).</summary>
+    Debug1 = Debug,
+
+    /// <summary>Debug2 severity (6).</summary>
+    Debug2 = Debug1 + 1,
+
+    /// <summary>Debug3 severity (7).</summary>
+    Debug3 = Debug2 + 1,
+
+    /// <summary>Debug4 severity (8).</summary>
+    Debug4 = Debug3 + 1,
+
+    /// <summary>Information severity (9).</summary>
+    Information = 9,
+
+    /// <summary>Information1 severity (10).</summary>
+    Information1 = Information,
+
+    /// <summary>Information2 severity (11).</summary>
+    Information2 = Information1 + 1,
+
+    /// <summary>Information3 severity (12).</summary>
+    Information3 = Information2 + 1,
+
+    /// <summary>Information4 severity (13).</summary>
+    Information4 = Information3 + 1,
+
+    /// <summary>Warning severity (13).</summary>
+    Warning = 13,
+
+    /// <summary>Warning1 severity (13).</summary>
+    Warning1 = Warning,
+
+    /// <summary>Warning2 severity (14).</summary>
+    Warning2 = Warning1 + 1,
+
+    /// <summary>Warning3 severity (15).</summary>
+    Warning3 = Warning2 + 1,
+
+    /// <summary>Warning4 severity (16).</summary>
+    Warning4 = Warning3 + 1,
+
+    /// <summary>Error severity (17).</summary>
+    Error = 17,
+
+    /// <summary>Error1 severity (17).</summary>
+    Error1 = Error,
+
+    /// <summary>Error2 severity (18).</summary>
+    Error2 = Error1 + 1,
+
+    /// <summary>Error3 severity (19).</summary>
+    Error3 = Error2 + 1,
+
+    /// <summary>Error4 severity (20).</summary>
+    Error4 = Error3 + 1,
+
+    /// <summary>Fatal severity (21).</summary>
+    Fatal = 21,
+
+    /// <summary>Fatal1 severity (21).</summary>
+    Fatal1 = Fatal,
+
+    /// <summary>Fatal2 severity (22).</summary>
+    Fatal2 = Fatal1 + 1,
+
+    /// <summary>Fatal3 severity (23).</summary>
+    Fatal3 = Fatal2 + 1,
+
+    /// <summary>Fatal4 severity (24).</summary>
+    Fatal4 = Fatal3 + 1,
 }

--- a/src/OpenTelemetry.Api/Logs/LogRecordSeverity.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordSeverity.cs
@@ -23,8 +23,8 @@ namespace OpenTelemetry.Logs;
 /// </summary>
 internal enum LogRecordSeverity
 {
-    /// <summary>Unknown severity (0).</summary>
-    Unknown = 0,
+    /// <summary>Unspecified severity (0).</summary>
+    Unspecified = 0,
 
     /// <summary>Trace severity (1).</summary>
     Trace = 1,
@@ -50,29 +50,29 @@ internal enum LogRecordSeverity
     /// <summary>Debug4 severity (8).</summary>
     Debug4 = Debug3 + 1,
 
-    /// <summary>Information severity (9).</summary>
-    Information = 9,
+    /// <summary>Info severity (9).</summary>
+    Info = 9,
 
-    /// <summary>Information2 severity (11).</summary>
-    Information2 = Information + 1,
+    /// <summary>Info2 severity (11).</summary>
+    Info2 = Info + 1,
 
-    /// <summary>Information3 severity (12).</summary>
-    Information3 = Information2 + 1,
+    /// <summary>Info3 severity (12).</summary>
+    Info3 = Info2 + 1,
 
-    /// <summary>Information4 severity (13).</summary>
-    Information4 = Information3 + 1,
+    /// <summary>Info4 severity (13).</summary>
+    Info4 = Info3 + 1,
 
-    /// <summary>Warning severity (13).</summary>
-    Warning = 13,
+    /// <summary>Warn severity (13).</summary>
+    Warn = 13,
 
-    /// <summary>Warning2 severity (14).</summary>
-    Warning2 = Warning + 1,
+    /// <summary>Warn2 severity (14).</summary>
+    Warn2 = Warn + 1,
 
-    /// <summary>Warning3 severity (15).</summary>
-    Warning3 = Warning2 + 1,
+    /// <summary>Warn3 severity (15).</summary>
+    Warn3 = Warn2 + 1,
 
-    /// <summary>Warning4 severity (16).</summary>
-    Warning4 = Warning3 + 1,
+    /// <summary>Warn severity (16).</summary>
+    Warn4 = Warn3 + 1,
 
     /// <summary>Error severity (17).</summary>
     Error = 17,

--- a/src/OpenTelemetry.Api/Logs/LogRecordSeverity.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordSeverity.cs
@@ -29,11 +29,8 @@ internal enum LogRecordSeverity
     /// <summary>Trace severity (1).</summary>
     Trace = 1,
 
-    /// <summary>Trace1 severity (1).</summary>
-    Trace1 = Trace,
-
     /// <summary>Trace1 severity (2).</summary>
-    Trace2 = Trace1 + 1,
+    Trace2 = Trace + 1,
 
     /// <summary>Trace3 severity (3).</summary>
     Trace3 = Trace2 + 1,
@@ -44,11 +41,8 @@ internal enum LogRecordSeverity
     /// <summary>Debug severity (5).</summary>
     Debug = 5,
 
-    /// <summary>Debug1 severity (5).</summary>
-    Debug1 = Debug,
-
     /// <summary>Debug2 severity (6).</summary>
-    Debug2 = Debug1 + 1,
+    Debug2 = Debug + 1,
 
     /// <summary>Debug3 severity (7).</summary>
     Debug3 = Debug2 + 1,
@@ -59,11 +53,8 @@ internal enum LogRecordSeverity
     /// <summary>Information severity (9).</summary>
     Information = 9,
 
-    /// <summary>Information1 severity (10).</summary>
-    Information1 = Information,
-
     /// <summary>Information2 severity (11).</summary>
-    Information2 = Information1 + 1,
+    Information2 = Information + 1,
 
     /// <summary>Information3 severity (12).</summary>
     Information3 = Information2 + 1,
@@ -74,11 +65,8 @@ internal enum LogRecordSeverity
     /// <summary>Warning severity (13).</summary>
     Warning = 13,
 
-    /// <summary>Warning1 severity (13).</summary>
-    Warning1 = Warning,
-
     /// <summary>Warning2 severity (14).</summary>
-    Warning2 = Warning1 + 1,
+    Warning2 = Warning + 1,
 
     /// <summary>Warning3 severity (15).</summary>
     Warning3 = Warning2 + 1,
@@ -89,11 +77,8 @@ internal enum LogRecordSeverity
     /// <summary>Error severity (17).</summary>
     Error = 17,
 
-    /// <summary>Error1 severity (17).</summary>
-    Error1 = Error,
-
     /// <summary>Error2 severity (18).</summary>
-    Error2 = Error1 + 1,
+    Error2 = Error + 1,
 
     /// <summary>Error3 severity (19).</summary>
     Error3 = Error2 + 1,
@@ -104,11 +89,8 @@ internal enum LogRecordSeverity
     /// <summary>Fatal severity (21).</summary>
     Fatal = 21,
 
-    /// <summary>Fatal1 severity (21).</summary>
-    Fatal1 = Fatal,
-
     /// <summary>Fatal2 severity (22).</summary>
-    Fatal2 = Fatal1 + 1,
+    Fatal2 = Fatal + 1,
 
     /// <summary>Fatal3 severity (23).</summary>
     Fatal3 = Fatal2 + 1,

--- a/src/OpenTelemetry.Api/Logs/LogRecordSeverityExtensions.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordSeverityExtensions.cs
@@ -1,0 +1,83 @@
+// <copyright file="LogRecordSeverityExtensions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#nullable enable
+
+namespace OpenTelemetry.Logs;
+
+/// <summary>
+/// Contains extension methods for the <see cref="LogRecordSeverity"/> enum.
+/// </summary>
+internal static class LogRecordSeverityExtensions
+{
+    private static readonly string[] LogRecordSeverityShortNames = new string[]
+    {
+        "UNKNOWN",
+
+        "TRACE",
+        "TRACE2",
+        "TRACE3",
+        "TRACE4",
+
+        "DEBUG",
+        "DEBUG2",
+        "DEBUG3",
+        "DEBUG4",
+
+        "INFO",
+        "INFO2",
+        "INFO3",
+        "INFO4",
+
+        "WARN",
+        "WARN2",
+        "WARN3",
+        "WARN4",
+
+        "ERROR",
+        "ERROR2",
+        "ERROR3",
+        "ERROR4",
+
+        "FATAL",
+        "FATAL2",
+        "FATAL3",
+        "FATAL4",
+    };
+
+    /// <summary>
+    /// Returns the OpenTelemetry Specification short name for the <see
+    /// cref="LogRecordSeverity"/> suitable for display.
+    /// </summary>
+    /// <remarks>
+    /// See: <see
+    /// href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#displaying-severity"/>.
+    /// </remarks>
+    /// <param name="logRecordSeverity"><see cref="LogRecordSeverity"/>.</param>
+    /// <returns>OpenTelemetry Specification short name for the supplied <see
+    /// cref="LogRecordSeverity"/>.</returns>
+    public static string ToShortName(this LogRecordSeverity logRecordSeverity)
+    {
+        int severityLevel = (int)logRecordSeverity;
+
+        if (severityLevel < 0 || severityLevel > 24)
+        {
+            severityLevel = 0;
+        }
+
+        return LogRecordSeverityShortNames[severityLevel];
+    }
+}

--- a/src/OpenTelemetry.Api/Logs/LogRecordSeverityExtensions.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordSeverityExtensions.cs
@@ -25,7 +25,7 @@ internal static class LogRecordSeverityExtensions
 {
     private static readonly string[] LogRecordSeverityShortNames = new string[]
     {
-        "UNKNOWN",
+        "UNSPECIFIED",
 
         "TRACE",
         "TRACE2",

--- a/src/OpenTelemetry.Api/Logs/LogRecordSeverityExtensions.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordSeverityExtensions.cs
@@ -23,39 +23,71 @@ namespace OpenTelemetry.Logs;
 /// </summary>
 internal static class LogRecordSeverityExtensions
 {
+    internal const string UnspecifiedShortName = "UNSPECIFIED";
+
+    internal const string TraceShortName = "TRACE";
+    internal const string Trace2ShortName = TraceShortName + "2";
+    internal const string Trace3ShortName = TraceShortName + "3";
+    internal const string Trace4ShortName = TraceShortName + "4";
+
+    internal const string DebugShortName = "DEBUG";
+    internal const string Debug2ShortName = DebugShortName + "2";
+    internal const string Debug3ShortName = DebugShortName + "3";
+    internal const string Debug4ShortName = DebugShortName + "4";
+
+    internal const string InfoShortName = "INFO";
+    internal const string Info2ShortName = InfoShortName + "2";
+    internal const string Info3ShortName = InfoShortName + "3";
+    internal const string Info4ShortName = InfoShortName + "4";
+
+    internal const string WarnShortName = "WARN";
+    internal const string Warn2ShortName = WarnShortName + "2";
+    internal const string Warn3ShortName = WarnShortName + "3";
+    internal const string Warn4ShortName = WarnShortName + "4";
+
+    internal const string ErrorShortName = "ERROR";
+    internal const string Error2ShortName = ErrorShortName + "2";
+    internal const string Error3ShortName = ErrorShortName + "3";
+    internal const string Error4ShortName = ErrorShortName + "4";
+
+    internal const string FatalShortName = "FATAL";
+    internal const string Fatal2ShortName = FatalShortName + "2";
+    internal const string Fatal3ShortName = FatalShortName + "3";
+    internal const string Fatal4ShortName = FatalShortName + "4";
+
     private static readonly string[] LogRecordSeverityShortNames = new string[]
     {
-        "UNSPECIFIED",
+        UnspecifiedShortName,
 
-        "TRACE",
-        "TRACE2",
-        "TRACE3",
-        "TRACE4",
+        TraceShortName,
+        Trace2ShortName,
+        Trace3ShortName,
+        Trace4ShortName,
 
-        "DEBUG",
-        "DEBUG2",
-        "DEBUG3",
-        "DEBUG4",
+        DebugShortName,
+        Debug2ShortName,
+        Debug3ShortName,
+        Debug4ShortName,
 
-        "INFO",
-        "INFO2",
-        "INFO3",
-        "INFO4",
+        InfoShortName,
+        Info2ShortName,
+        Info3ShortName,
+        Info4ShortName,
 
-        "WARN",
-        "WARN2",
-        "WARN3",
-        "WARN4",
+        WarnShortName,
+        Warn2ShortName,
+        Warn3ShortName,
+        Warn4ShortName,
 
-        "ERROR",
-        "ERROR2",
-        "ERROR3",
-        "ERROR4",
+        ErrorShortName,
+        Error2ShortName,
+        Error3ShortName,
+        Error4ShortName,
 
-        "FATAL",
-        "FATAL2",
-        "FATAL3",
-        "FATAL4",
+        FatalShortName,
+        Fatal2ShortName,
+        Fatal3ShortName,
+        Fatal4ShortName,
     };
 
     /// <summary>

--- a/test/OpenTelemetry.Api.Tests/Logs/LogRecordSeverityExtensionsTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Logs/LogRecordSeverityExtensionsTests.cs
@@ -1,0 +1,59 @@
+// <copyright file="LogRecordSeverityExtensionsTests.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#nullable enable
+
+using Xunit;
+
+namespace OpenTelemetry.Logs.Tests;
+
+public sealed class LogRecordSeverityExtensionsTests
+{
+    [Theory]
+    [InlineData(0, LogRecordSeverityExtensions.UnspecifiedShortName)]
+    [InlineData(int.MinValue, LogRecordSeverityExtensions.UnspecifiedShortName)]
+    [InlineData(int.MaxValue, LogRecordSeverityExtensions.UnspecifiedShortName)]
+    [InlineData(1, LogRecordSeverityExtensions.TraceShortName)]
+    [InlineData(2, LogRecordSeverityExtensions.Trace2ShortName)]
+    [InlineData(3, LogRecordSeverityExtensions.Trace3ShortName)]
+    [InlineData(4, LogRecordSeverityExtensions.Trace4ShortName)]
+    [InlineData(5, LogRecordSeverityExtensions.DebugShortName)]
+    [InlineData(6, LogRecordSeverityExtensions.Debug2ShortName)]
+    [InlineData(7, LogRecordSeverityExtensions.Debug3ShortName)]
+    [InlineData(8, LogRecordSeverityExtensions.Debug4ShortName)]
+    [InlineData(9, LogRecordSeverityExtensions.InfoShortName)]
+    [InlineData(10, LogRecordSeverityExtensions.Info2ShortName)]
+    [InlineData(11, LogRecordSeverityExtensions.Info3ShortName)]
+    [InlineData(12, LogRecordSeverityExtensions.Info4ShortName)]
+    [InlineData(13, LogRecordSeverityExtensions.WarnShortName)]
+    [InlineData(14, LogRecordSeverityExtensions.Warn2ShortName)]
+    [InlineData(15, LogRecordSeverityExtensions.Warn3ShortName)]
+    [InlineData(16, LogRecordSeverityExtensions.Warn4ShortName)]
+    [InlineData(17, LogRecordSeverityExtensions.ErrorShortName)]
+    [InlineData(18, LogRecordSeverityExtensions.Error2ShortName)]
+    [InlineData(19, LogRecordSeverityExtensions.Error3ShortName)]
+    [InlineData(20, LogRecordSeverityExtensions.Error4ShortName)]
+    [InlineData(21, LogRecordSeverityExtensions.FatalShortName)]
+    [InlineData(22, LogRecordSeverityExtensions.Fatal2ShortName)]
+    [InlineData(23, LogRecordSeverityExtensions.Fatal3ShortName)]
+    [InlineData(24, LogRecordSeverityExtensions.Fatal4ShortName)]
+    public void ToShortNameTest(int logRecordSeverityValue, string expectedName)
+    {
+        var logRecordSeverity = (LogRecordSeverity)logRecordSeverityValue;
+
+        Assert.Equal(expectedName, logRecordSeverity.ToShortName());
+    }
+}


### PR DESCRIPTION
Relates to #4433

## Changes

* Incorporates some early feedback from @alanwest into the `enum LogRecordSeverity` definition.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated

