### PR TITLE
[sdk-logs] Update LogRecord for Logger API additions

### DIFF
--- a/src/OpenTelemetry/Logs/LoggerSdk.cs
+++ b/src/OpenTelemetry/Logs/LoggerSdk.cs
@@ -51,7 +51,7 @@ internal sealed class LoggerSdk : Logger
             logRecord.Data = data;
             logRecord.ILoggerData = default;
 
-            // TODO: logRecord.Logger = this;
+            logRecord.Logger = this;
 
             logRecord.Attributes = attributes.Export(ref logRecord.AttributeStorage);
 


### PR DESCRIPTION
Relates to #4433

## Changes

* Updates `LogRecord` for additions of `Logger`, `SeverityText`, and `Severity`.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
