### PR TITLE
[sdk-logs] LogRecord LogLevel/Severity conversion test

### DIFF
--- a/src/OpenTelemetry.Api/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Api/AssemblyInfo.cs
@@ -21,6 +21,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("OpenTelemetry.Api.ProviderBuilderExtensions.Tests" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry.Api.Tests" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry.Shims.OpenTracing.Tests" + AssemblyInfo.PublicKey)]
+[assembly: InternalsVisibleTo("OpenTelemetry.Tests" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2" + AssemblyInfo.MoqPublicKey)]
 
 #if SIGNED

--- a/src/OpenTelemetry/Logs/LogRecord.cs
+++ b/src/OpenTelemetry/Logs/LogRecord.cs
@@ -162,13 +162,16 @@ namespace OpenTelemetry.Logs
         {
             get
             {
-                if (!this.Data.Severity.HasValue)
+                if (this.Data.Severity.HasValue)
                 {
-                    return LogLevel.Trace;
+                    uint severity = (uint)this.Data.Severity.Value;
+                    if (severity >= 1 && severity <= 24)
+                    {
+                        return (LogLevel)((severity - 1) / 4);
+                    }
                 }
 
-                uint severity = (uint)this.Data.Severity.Value;
-                return (LogLevel)((severity - 1) / 4);
+                return LogLevel.Trace;
             }
 
             set

--- a/test/OpenTelemetry.Tests/Logs/LogRecordTest.cs
+++ b/test/OpenTelemetry.Tests/Logs/LogRecordTest.cs
@@ -916,6 +916,53 @@ namespace OpenTelemetry.Logs.Tests
             Assert.Equal("Hello earth", logRecord.Body);
         }
 
+        [Theory]
+        [InlineData((int)LogRecordSeverity.Unspecified, LogLevel.Trace)]
+        [InlineData(int.MaxValue, LogLevel.Trace)]
+        [InlineData((int)LogRecordSeverity.Trace, LogLevel.Trace, (int)LogRecordSeverity.Trace)]
+        [InlineData((int)LogRecordSeverity.Trace2, LogLevel.Trace, (int)LogRecordSeverity.Trace)]
+        [InlineData((int)LogRecordSeverity.Trace3, LogLevel.Trace, (int)LogRecordSeverity.Trace)]
+        [InlineData((int)LogRecordSeverity.Trace4, LogLevel.Trace, (int)LogRecordSeverity.Trace)]
+        [InlineData((int)LogRecordSeverity.Debug, LogLevel.Debug, (int)LogRecordSeverity.Debug)]
+        [InlineData((int)LogRecordSeverity.Debug2, LogLevel.Debug, (int)LogRecordSeverity.Debug)]
+        [InlineData((int)LogRecordSeverity.Debug3, LogLevel.Debug, (int)LogRecordSeverity.Debug)]
+        [InlineData((int)LogRecordSeverity.Debug4, LogLevel.Debug, (int)LogRecordSeverity.Debug)]
+        [InlineData((int)LogRecordSeverity.Info, LogLevel.Information, (int)LogRecordSeverity.Info)]
+        [InlineData((int)LogRecordSeverity.Info2, LogLevel.Information, (int)LogRecordSeverity.Info)]
+        [InlineData((int)LogRecordSeverity.Info3, LogLevel.Information, (int)LogRecordSeverity.Info)]
+        [InlineData((int)LogRecordSeverity.Info4, LogLevel.Information, (int)LogRecordSeverity.Info)]
+        [InlineData((int)LogRecordSeverity.Warn, LogLevel.Warning, (int)LogRecordSeverity.Warn)]
+        [InlineData((int)LogRecordSeverity.Warn2, LogLevel.Warning, (int)LogRecordSeverity.Warn)]
+        [InlineData((int)LogRecordSeverity.Warn3, LogLevel.Warning, (int)LogRecordSeverity.Warn)]
+        [InlineData((int)LogRecordSeverity.Warn4, LogLevel.Warning, (int)LogRecordSeverity.Warn)]
+        [InlineData((int)LogRecordSeverity.Error, LogLevel.Error, (int)LogRecordSeverity.Error)]
+        [InlineData((int)LogRecordSeverity.Error2, LogLevel.Error, (int)LogRecordSeverity.Error)]
+        [InlineData((int)LogRecordSeverity.Error3, LogLevel.Error, (int)LogRecordSeverity.Error)]
+        [InlineData((int)LogRecordSeverity.Error4, LogLevel.Error, (int)LogRecordSeverity.Error)]
+        [InlineData((int)LogRecordSeverity.Fatal, LogLevel.Critical, (int)LogRecordSeverity.Fatal)]
+        [InlineData((int)LogRecordSeverity.Fatal2, LogLevel.Critical, (int)LogRecordSeverity.Fatal)]
+        [InlineData((int)LogRecordSeverity.Fatal3, LogLevel.Critical, (int)LogRecordSeverity.Fatal)]
+        [InlineData((int)LogRecordSeverity.Fatal4, LogLevel.Critical, (int)LogRecordSeverity.Fatal)]
+        public void SeverityLogLevelTest(int logSeverity, LogLevel logLevel, int? transformedLogSeverity = null)
+        {
+            var severity = (LogRecordSeverity)logSeverity;
+
+            var logRecord = new LogRecord
+            {
+                Severity = severity,
+            };
+
+            Assert.Equal(logLevel, logRecord.LogLevel);
+
+            if (transformedLogSeverity.HasValue)
+            {
+                logRecord.LogLevel = logLevel;
+
+                Assert.Equal((LogRecordSeverity)transformedLogSeverity.Value, logRecord.Severity);
+                Assert.Equal(logLevel.ToString(), logRecord.SeverityText);
+            }
+        }
+
         private static ILoggerFactory InitializeLoggerFactory(out List<LogRecord> exportedItems, Action<OpenTelemetryLoggerOptions> configure = null)
         {
             var items = exportedItems = new List<LogRecord>();


### PR DESCRIPTION
Relates to #4433
Relates to #4456

## Changes

* Adds a test and fixes a bug for the logic introduced on #4456

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
