### PR TITLE
[sdk-logs] Tests and bug fixes for logging builder & provider

### DIFF
--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/Logs/OpenTelemetryDependencyInjectionLoggerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/Logs/OpenTelemetryDependencyInjectionLoggerProviderBuilderExtensions.cs
@@ -106,7 +106,7 @@ internal static class OpenTelemetryDependencyInjectionLoggerProviderBuilderExten
 
         loggerProviderBuilder.ConfigureBuilder((sp, builder) =>
         {
-            if (loggerProviderBuilder is ILoggerProviderBuilder iLoggerProviderBuilder
+            if (builder is ILoggerProviderBuilder iLoggerProviderBuilder
                 && iLoggerProviderBuilder.Provider != null)
             {
                 builder.AddInstrumentation(() => instrumentationFactory(sp, iLoggerProviderBuilder.Provider));

--- a/src/OpenTelemetry/ProviderExtensions.cs
+++ b/src/OpenTelemetry/ProviderExtensions.cs
@@ -73,6 +73,10 @@ namespace OpenTelemetry
             {
                 return meterProviderSdk.ServiceProvider;
             }
+            else if (baseProvider is LoggerProviderSdk loggerProviderSdk)
+            {
+                return loggerProviderSdk.ServiceProvider;
+            }
             else if (baseProvider is OpenTelemetryLoggerProvider openTelemetryLoggerProvider)
             {
                 return openTelemetryLoggerProvider.ServiceProvider;

--- a/test/OpenTelemetry.Tests/Logs/LoggerProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/LoggerProviderBuilderExtensionsTests.cs
@@ -1,0 +1,185 @@
+// <copyright file="LoggerProviderBuilderExtensionsTests.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Resources;
+using Xunit;
+
+namespace OpenTelemetry.Logs.Tests;
+
+public sealed class LoggerProviderBuilderExtensionsTests
+{
+    [Fact]
+    public void LoggerProviderBuilderAddInstrumentationTest()
+    {
+        List<object>? instrumentation = null;
+
+        using (var provider = Sdk.CreateLoggerProviderBuilder()
+            .AddInstrumentation<CustomInstrumentation>()
+            .AddInstrumentation((sp, provider) => new CustomInstrumentation() { Provider = provider })
+            .AddInstrumentation(new CustomInstrumentation())
+            .Build() as LoggerProviderSdk)
+        {
+            Assert.NotNull(provider);
+
+            Assert.Equal(3, provider.Instrumentations.Count);
+
+            Assert.Null(((CustomInstrumentation)provider.Instrumentations[0]).Provider);
+            Assert.False(((CustomInstrumentation)provider.Instrumentations[0]).Disposed);
+
+            Assert.NotNull(((CustomInstrumentation)provider.Instrumentations[1]).Provider);
+            Assert.False(((CustomInstrumentation)provider.Instrumentations[1]).Disposed);
+
+            Assert.Null(((CustomInstrumentation)provider.Instrumentations[2]).Provider);
+            Assert.False(((CustomInstrumentation)provider.Instrumentations[2]).Disposed);
+
+            instrumentation = new List<object>(provider.Instrumentations);
+        }
+
+        Assert.True(((CustomInstrumentation)instrumentation[0]).Disposed);
+        Assert.True(((CustomInstrumentation)instrumentation[1]).Disposed);
+        Assert.True(((CustomInstrumentation)instrumentation[2]).Disposed);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void LoggerProviderBuilderNestedResolutionUsingBuilderTest(bool callNestedConfigure)
+    {
+        bool innerTestExecuted = false;
+
+        using var provider = Sdk.CreateLoggerProviderBuilder()
+            .ConfigureServices(services =>
+            {
+                if (callNestedConfigure)
+                {
+                    services.ConfigureOpenTelemetryLoggerProvider((sp, builder) => { });
+                }
+            })
+            .ConfigureBuilder((sp, builder) =>
+            {
+                innerTestExecuted = true;
+                Assert.Throws<NotSupportedException>(() => sp.GetService<LoggerProvider>());
+            })
+            .Build();
+
+        Assert.True(innerTestExecuted);
+
+        Assert.Throws<NotSupportedException>(() => provider.GetServiceProvider()?.GetService<LoggerProvider>());
+    }
+
+    [Fact]
+    public void LoggerProviderBuilderSetResourceBuilderTests()
+    {
+        using var provider = Sdk.CreateLoggerProviderBuilder()
+            .SetResourceBuilder(ResourceBuilder
+                .CreateEmpty()
+                .AddAttributes(new[] { new KeyValuePair<string, object>("key1", "value1") }))
+            .Build() as LoggerProviderSdk;
+
+        Assert.NotNull(provider);
+
+        Assert.NotNull(provider.Resource);
+        Assert.Contains(provider.Resource.Attributes, value => value.Key == "key1" && (string)value.Value == "value1");
+    }
+
+    [Fact]
+    public void LoggerProviderBuilderConfigureResourceBuilderTests()
+    {
+        using var provider = Sdk.CreateLoggerProviderBuilder()
+            .ConfigureResource(resource => resource
+                .Clear()
+                .AddAttributes(new[] { new KeyValuePair<string, object>("key1", "value1") }))
+            .Build() as LoggerProviderSdk;
+
+        Assert.NotNull(provider);
+
+        Assert.NotNull(provider.Resource);
+        Assert.Contains(provider.Resource.Attributes, value => value.Key == "key1" && (string)value.Value == "value1");
+    }
+
+    [Fact]
+    public void LoggerProviderBuilderAddProcessorTest()
+    {
+        List<CustomProcessor> processors = new();
+
+        using (var provider = Sdk.CreateLoggerProviderBuilder()
+            .AddProcessor<CustomProcessor>()
+            .AddProcessor(sp => new CustomProcessor())
+            .AddProcessor(new CustomProcessor())
+            .Build() as LoggerProviderSdk)
+        {
+            Assert.NotNull(provider);
+            Assert.NotNull(provider.Processor);
+
+            var compositeProcessor = provider.Processor as CompositeProcessor<LogRecord>;
+
+            Assert.NotNull(compositeProcessor);
+
+            var current = compositeProcessor.Head;
+            while (current != null)
+            {
+                var processor = current.Value as CustomProcessor;
+                Assert.NotNull(processor);
+
+                processors.Add(processor);
+                Assert.False(processor.Disposed);
+
+                current = current.Next;
+            }
+        }
+
+        Assert.Equal(3, processors.Count);
+
+        foreach (var processor in processors)
+        {
+            Assert.True(processor.Disposed);
+        }
+    }
+
+    private sealed class CustomInstrumentation : IDisposable
+    {
+        public bool Disposed;
+        public LoggerProvider? Provider;
+
+        public void Dispose()
+        {
+            this.Disposed = true;
+        }
+    }
+
+    private sealed class CustomProcessor : BaseProcessor<LogRecord>
+    {
+        public bool Disposed;
+
+        protected override void Dispose(bool disposing)
+        {
+            this.Disposed = true;
+
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class CustomExporter : BaseExporter<LogRecord>
+    {
+        public override ExportResult Export(in Batch<LogRecord> batch)
+        {
+            return ExportResult.Success;
+        }
+    }
+}

--- a/test/OpenTelemetry.Tests/Logs/LoggerProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/LoggerProviderBuilderExtensionsTests.cs
@@ -61,24 +61,27 @@ public sealed class LoggerProviderBuilderExtensionsTests
     [InlineData(false)]
     public void LoggerProviderBuilderNestedResolutionUsingBuilderTest(bool callNestedConfigure)
     {
-        bool innerTestExecuted = false;
+        bool innerConfigureBuilderTestExecuted = false;
+        bool innerConfigureOpenTelemetryLoggerProviderTestExecuted = false;
 
         using var provider = Sdk.CreateLoggerProviderBuilder()
             .ConfigureServices(services =>
             {
                 if (callNestedConfigure)
                 {
-                    services.ConfigureOpenTelemetryLoggerProvider((sp, builder) => { });
+                    services.ConfigureOpenTelemetryLoggerProvider(
+                        (sp, builder) => innerConfigureOpenTelemetryLoggerProviderTestExecuted = true);
                 }
             })
             .ConfigureBuilder((sp, builder) =>
             {
-                innerTestExecuted = true;
+                innerConfigureBuilderTestExecuted = true;
                 Assert.Throws<NotSupportedException>(() => sp.GetService<LoggerProvider>());
             })
             .Build();
 
-        Assert.True(innerTestExecuted);
+        Assert.True(innerConfigureBuilderTestExecuted);
+        Assert.Equal(callNestedConfigure, innerConfigureOpenTelemetryLoggerProviderTestExecuted);
 
         Assert.Throws<NotSupportedException>(() => provider.GetServiceProvider()?.GetService<LoggerProvider>());
     }

--- a/test/OpenTelemetry.Tests/Logs/LoggerProviderSdkTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/LoggerProviderSdkTests.cs
@@ -1,4 +1,4 @@
-// <copyright file="LoggerProviderBuilderExtensionsTests.cs" company="OpenTelemetry Authors">
+// <copyright file="LoggerProviderSdkTests.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/OpenTelemetry.Tests/Logs/LoggerProviderSdkTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/LoggerProviderSdkTests.cs
@@ -1,0 +1,142 @@
+// <copyright file="LoggerProviderBuilderExtensionsTests.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#nullable enable
+
+using OpenTelemetry.Exporter;
+using Xunit;
+
+namespace OpenTelemetry.Logs.Tests;
+
+public sealed class LoggerProviderSdkTests
+{
+    [Fact]
+    public void ForceFlushTest()
+    {
+        using var provider = Sdk.CreateLoggerProviderBuilder().Build() as LoggerProviderSdk;
+
+        Assert.NotNull(provider);
+
+        Assert.True(provider.ForceFlush());
+
+        List<LogRecord> exportedItems = new();
+
+        provider.AddProcessor(new BatchLogRecordExportProcessor(new InMemoryExporter<LogRecord>(exportedItems)));
+
+        var logger = provider.GetLogger("TestLogger");
+
+        logger.EmitLog(new() { Body = "Hello world" });
+
+        Assert.Empty(exportedItems);
+
+        Assert.True(provider.ForceFlush());
+
+        Assert.Single(exportedItems);
+    }
+
+    [Fact]
+    public void ThreadStaticPoolUsedByProviderTests()
+    {
+        using var provider1 = Sdk.CreateLoggerProviderBuilder().Build() as LoggerProviderSdk;
+
+        Assert.NotNull(provider1);
+
+        Assert.Equal(LogRecordThreadStaticPool.Instance, provider1.LogRecordPool);
+
+        using var provider2 = Sdk.CreateLoggerProviderBuilder()
+            .AddProcessor(new SimpleLogRecordExportProcessor(new NoopExporter()))
+            .Build() as LoggerProviderSdk;
+
+        Assert.NotNull(provider2);
+
+        Assert.Equal(LogRecordThreadStaticPool.Instance, provider2.LogRecordPool);
+
+        using var provider3 = Sdk.CreateLoggerProviderBuilder()
+            .AddProcessor(new SimpleLogRecordExportProcessor(new NoopExporter()))
+            .AddProcessor(new SimpleLogRecordExportProcessor(new NoopExporter()))
+            .Build() as LoggerProviderSdk;
+
+        Assert.NotNull(provider3);
+
+        Assert.Equal(LogRecordThreadStaticPool.Instance, provider3.LogRecordPool);
+    }
+
+    [Fact]
+    public void SharedPoolUsedByProviderTests()
+    {
+        using var provider1 = Sdk.CreateLoggerProviderBuilder()
+            .AddProcessor(new BatchLogRecordExportProcessor(new NoopExporter()))
+            .Build() as LoggerProviderSdk;
+
+        Assert.NotNull(provider1);
+
+        Assert.Equal(LogRecordSharedPool.Current, provider1.LogRecordPool);
+
+        using var provider2 = Sdk.CreateLoggerProviderBuilder()
+            .AddProcessor(new SimpleLogRecordExportProcessor(new NoopExporter()))
+            .AddProcessor(new BatchLogRecordExportProcessor(new NoopExporter()))
+            .Build() as LoggerProviderSdk;
+
+        Assert.NotNull(provider2);
+
+        Assert.Equal(LogRecordSharedPool.Current, provider2.LogRecordPool);
+
+        using var provider3 = Sdk.CreateLoggerProviderBuilder()
+            .AddProcessor(new SimpleLogRecordExportProcessor(new NoopExporter()))
+            .AddProcessor(new CompositeProcessor<LogRecord>(new BaseProcessor<LogRecord>[]
+            {
+                    new SimpleLogRecordExportProcessor(new NoopExporter()),
+                    new BatchLogRecordExportProcessor(new NoopExporter()),
+            }))
+            .Build() as LoggerProviderSdk;
+
+        Assert.NotNull(provider3);
+
+        Assert.Equal(LogRecordSharedPool.Current, provider3.LogRecordPool);
+    }
+
+    [Fact]
+    public void AddProcessorTest()
+    {
+        using var provider = Sdk.CreateLoggerProviderBuilder()
+            .Build() as LoggerProviderSdk;
+
+        Assert.NotNull(provider);
+        Assert.Null(provider.Processor);
+
+        provider.AddProcessor(new NoopProcessor());
+
+        Assert.NotNull(provider.Processor);
+        Assert.True(provider.Processor is NoopProcessor);
+
+        provider.AddProcessor(new NoopProcessor());
+
+        Assert.NotNull(provider.Processor);
+        Assert.True(provider.Processor is CompositeProcessor<LogRecord>);
+    }
+
+    private sealed class NoopProcessor : BaseProcessor<LogRecord>
+    {
+    }
+
+    private sealed class NoopExporter : BaseExporter<LogRecord>
+    {
+        public override ExportResult Export(in Batch<LogRecord> batch)
+        {
+            return ExportResult.Success;
+        }
+    }
+}

--- a/test/OpenTelemetry.Tests/Metrics/MeterProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MeterProviderBuilderExtensionsTests.cs
@@ -219,24 +219,27 @@ namespace OpenTelemetry.Metrics.Tests
         [InlineData(false)]
         public void MeterProviderNestedResolutionUsingBuilderTest(bool callNestedConfigure)
         {
-            bool innerTestExecuted = false;
+            bool innerConfigureBuilderTestExecuted = false;
+            bool innerConfigureOpenTelemetryLoggerProviderTestExecuted = false;
 
             using var provider = Sdk.CreateMeterProviderBuilder()
                 .ConfigureServices(services =>
                 {
                     if (callNestedConfigure)
                     {
-                        services.ConfigureOpenTelemetryMeterProvider((sp, builder) => { });
+                        services.ConfigureOpenTelemetryMeterProvider(
+                            (sp, builder) => innerConfigureOpenTelemetryLoggerProviderTestExecuted = true);
                     }
                 })
                 .ConfigureBuilder((sp, builder) =>
                 {
-                    innerTestExecuted = true;
+                    innerConfigureBuilderTestExecuted = true;
                     Assert.Throws<NotSupportedException>(() => sp.GetService<MeterProvider>());
                 })
                 .Build();
 
-            Assert.True(innerTestExecuted);
+            Assert.True(innerConfigureBuilderTestExecuted);
+            Assert.Equal(callNestedConfigure, innerConfigureOpenTelemetryLoggerProviderTestExecuted);
 
             Assert.Throws<NotSupportedException>(() => provider.GetServiceProvider()?.GetService<MeterProvider>());
         }

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderBuilderExtensionsTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderBuilderExtensionsTest.cs
@@ -309,24 +309,27 @@ namespace OpenTelemetry.Trace.Tests
         [InlineData(false)]
         public void TracerProviderNestedResolutionUsingBuilderTest(bool callNestedConfigure)
         {
-            bool innerTestExecuted = false;
+            bool innerConfigureBuilderTestExecuted = false;
+            bool innerConfigureOpenTelemetryLoggerProviderTestExecuted = false;
 
             using var provider = Sdk.CreateTracerProviderBuilder()
                 .ConfigureServices(services =>
                 {
                     if (callNestedConfigure)
                     {
-                        services.ConfigureOpenTelemetryTracerProvider((sp, builder) => { });
+                        services.ConfigureOpenTelemetryTracerProvider(
+                            (sp, builder) => innerConfigureOpenTelemetryLoggerProviderTestExecuted = true);
                     }
                 })
                 .ConfigureBuilder((sp, builder) =>
                 {
-                    innerTestExecuted = true;
+                    innerConfigureBuilderTestExecuted = true;
                     Assert.Throws<NotSupportedException>(() => sp.GetService<TracerProvider>());
                 })
                 .Build();
 
-            Assert.True(innerTestExecuted);
+            Assert.True(innerConfigureBuilderTestExecuted);
+            Assert.Equal(callNestedConfigure, innerConfigureOpenTelemetryLoggerProviderTestExecuted);
 
             Assert.Throws<NotSupportedException>(() => provider.GetServiceProvider()?.GetService<TracerProvider>());
         }


### PR DESCRIPTION
Relates to #4433

## Changes

* Added tests for new SDK logging builders & provider and fixed some bugs that manifested as a result.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
