### PR TITLE
[di-tracing] Fix the TracerProviderBuilder.AddInstrumentation factory pattern extension

### DIFF
--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
-* Fixed the `TracerProviderBuilder.AddInstrumentation` factory extension.
+* Fixed a bug which prevented the
+  `TracerProviderBuilder.AddInstrumentation(IServiceProvider, TracerProvider)`
+  factory extension from being called during construction of the SDK
+  `TracerProvider`.
   ([#4468](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4468))
 
 ## 1.5.0-alpha.2

--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fixed the `TracerProviderBuilder.AddInstrumentation` factory extension.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.5.0-alpha.2
 
 Released 2023-Mar-31

--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Fixed the `TracerProviderBuilder.AddInstrumentation` factory extension.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#4468](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4468))
 
 ## 1.5.0-alpha.2
 

--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/Trace/OpenTelemetryDependencyInjectionTracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/Trace/OpenTelemetryDependencyInjectionTracerProviderBuilderExtensions.cs
@@ -106,7 +106,7 @@ public static class OpenTelemetryDependencyInjectionTracerProviderBuilderExtensi
 
         tracerProviderBuilder.ConfigureBuilder((sp, builder) =>
         {
-            if (tracerProviderBuilder is ITracerProviderBuilder iTracerProviderBuilder
+            if (builder is ITracerProviderBuilder iTracerProviderBuilder
                 && iTracerProviderBuilder.Provider != null)
             {
                 builder.AddInstrumentation(() => instrumentationFactory(sp, iTracerProviderBuilder.Provider));

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderBuilderExtensionsTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderBuilderExtensionsTest.cs
@@ -173,6 +173,39 @@ namespace OpenTelemetry.Trace.Tests
         }
 
         [Fact]
+        public void AddInstrumentationTest()
+        {
+            List<object> instrumentation = null;
+
+            using (var provider = Sdk.CreateTracerProviderBuilder()
+                .AddInstrumentation<MyInstrumentation>()
+                .AddInstrumentation((sp, provider) => new MyInstrumentation() { Provider = provider })
+                .AddInstrumentation(new MyInstrumentation())
+                .Build() as TracerProviderSdk)
+            {
+                Assert.NotNull(provider);
+
+                Assert.Equal(3, provider.Instrumentations.Count);
+
+                Assert.Null(((MyInstrumentation)provider.Instrumentations[0]).Provider);
+                Assert.False(((MyInstrumentation)provider.Instrumentations[0]).Disposed);
+
+                Assert.NotNull(((MyInstrumentation)provider.Instrumentations[1]).Provider);
+                Assert.False(((MyInstrumentation)provider.Instrumentations[1]).Disposed);
+
+                Assert.Null(((MyInstrumentation)provider.Instrumentations[2]).Provider);
+                Assert.False(((MyInstrumentation)provider.Instrumentations[2]).Disposed);
+
+                instrumentation = new List<object>(provider.Instrumentations);
+            }
+
+            Assert.NotNull(instrumentation);
+            Assert.True(((MyInstrumentation)instrumentation[0]).Disposed);
+            Assert.True(((MyInstrumentation)instrumentation[1]).Disposed);
+            Assert.True(((MyInstrumentation)instrumentation[2]).Disposed);
+        }
+
+        [Fact]
         public void SetAndConfigureResourceTest()
         {
             var builder = Sdk.CreateTracerProviderBuilder();
@@ -431,6 +464,7 @@ namespace OpenTelemetry.Trace.Tests
 
         private sealed class MyInstrumentation : IDisposable
         {
+            internal TracerProvider Provider;
             internal bool Disposed;
 
             public void Dispose()


### PR DESCRIPTION
Relates to #4471

## Changes

* Fix a bug which prevents the `TracerProviderBuilder.AddInstrumentation(IServiceProvider, TracerProvider)` factory extension from being called during construction of the SDK `TracerProvider`.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
