### PR TITLE
[Perf optimization] Reduce memory allocation for MetricReader Collect

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,7 +34,7 @@
   <!-- non-prod packages -->
   <!-- 'net7.0' is the default `TargetFramework`. Use `VersionOverride` in the project to override the package versions from a different `TargetFramework` -->
   <ItemGroup>
-    <PackageVersion Include="BenchmarkDotNet" Version="[0.13.3,0.14)" />
+    <PackageVersion Include="BenchmarkDotNet" Version="[0.13.5,0.14)" />
     <PackageVersion Include="CommandLineParser" Version="[2.9.1,3.0)" />
     <PackageVersion Include="dotnet-xunit" Version="[2.3.1,3.0)" />
     <PackageVersion Include="Grpc.AspNetCore" Version="[2.50.0,3.0)" />

--- a/src/OpenTelemetry/Metrics/MetricReader.cs
+++ b/src/OpenTelemetry/Metrics/MetricReader.cs
@@ -277,8 +277,8 @@ namespace OpenTelemetry.Metrics
                 ? null
                 : Stopwatch.StartNew();
 
-            var collectObservableInstruments = this.parentProvider.GetObservableInstrumentCollectCallback();
-            collectObservableInstruments?.Invoke();
+            var meterProviderSdk = this.parentProvider as MeterProviderSdk;
+            meterProviderSdk?.CollectObservableInstruments();
 
             OpenTelemetrySdkEventSource.Log.MetricReaderEvent("Observable instruments collected.");
 

--- a/src/OpenTelemetry/ProviderExtensions.cs
+++ b/src/OpenTelemetry/ProviderExtensions.cs
@@ -88,14 +88,4 @@ public static class ProviderExtensions
 
         return null;
     }
-
-    internal static Action? GetObservableInstrumentCollectCallback(this BaseProvider baseProvider)
-    {
-        if (baseProvider is MeterProviderSdk meterProviderSdk)
-        {
-            return meterProviderSdk.CollectObservableInstruments;
-        }
-
-        return null;
-    }
 }

--- a/test/Benchmarks/Metrics/MetricCollectBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricCollectBenchmarks.cs
@@ -28,10 +28,10 @@ Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
   DefaultJob : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
 
 
-|  Method | UseWithRef |     Mean |    Error |   StdDev |   Gen0 | Allocated |
-|-------- |----------- |---------:|---------:|---------:|-------:|----------:|
-| Collect |      False | 16.24 us | 0.233 us | 0.621 us | 0.0153 |     160 B |
-| Collect |       True | 12.94 us | 0.092 us | 0.081 us | 0.0153 |     160 B |
+|  Method | UseWithRef |     Mean |    Error |   StdDev | Allocated |
+|-------- |----------- |---------:|---------:|---------:|----------:|
+| Collect |      False | 18.45 us | 0.161 us | 0.151 us |      96 B |
+| Collect |       True | 17.71 us | 0.347 us | 0.644 us |      96 B |
 */
 
 namespace Benchmarks.Metrics


### PR DESCRIPTION
Reduce memory allocation for Collect by 64 B

## Changes
- Avoid allocation for creating `Action` when invoking callback for Observable instruments