### PR TITLE
[hosting-logs] Add WithLogging

### DIFF
--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/AssemblyInfo.cs
@@ -17,5 +17,6 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("OpenTelemetry" + AssemblyInfo.PublicKey)]
+[assembly: InternalsVisibleTo("OpenTelemetry.Extensions.Hosting" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry.Tests" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry.Api.ProviderBuilderExtensions.Tests" + AssemblyInfo.PublicKey)]

--- a/src/OpenTelemetry.Api/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Api/AssemblyInfo.cs
@@ -20,6 +20,8 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("OpenTelemetry.Api.ProviderBuilderExtensions" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry.Api.ProviderBuilderExtensions.Tests" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry.Api.Tests" + AssemblyInfo.PublicKey)]
+[assembly: InternalsVisibleTo("OpenTelemetry.Extensions.Hosting" + AssemblyInfo.PublicKey)]
+[assembly: InternalsVisibleTo("OpenTelemetry.Extensions.Hosting.Tests" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry.Shims.OpenTracing.Tests" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry.Tests" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2" + AssemblyInfo.MoqPublicKey)]

--- a/src/OpenTelemetry.Extensions.Hosting/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/AssemblyInfo.cs
@@ -19,6 +19,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("OpenTelemetry.Extensions.Hosting.Tests" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2" + AssemblyInfo.MoqPublicKey)]
 
+/* Note: OpenTelemetry.Extensions.Hosting temporarily sees OpenTelemetry.Api internals for LoggerProvider
 #if SIGNED
 internal static class AssemblyInfo
 {
@@ -32,3 +33,4 @@ internal static class AssemblyInfo
     public const string MoqPublicKey = "";
 }
 #endif
+*/

--- a/src/OpenTelemetry.Extensions.Hosting/Implementation/HostingExtensionsEventSource.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Implementation/HostingExtensionsEventSource.cs
@@ -37,5 +37,11 @@ namespace OpenTelemetry.Extensions.Hosting.Implementation
         {
             this.WriteEvent(2);
         }
+
+        [Event(3, Message = "OpenTelemetry LoggerProvider was not found in application services. Logging will remain disabled.", Level = EventLevel.Warning)]
+        public void LoggerProviderNotRegistered()
+        {
+            this.WriteEvent(3);
+        }
     }
 }

--- a/src/OpenTelemetry.Extensions.Hosting/Implementation/TelemetryHostedService.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Implementation/TelemetryHostedService.cs
@@ -17,6 +17,7 @@
 using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 
@@ -63,6 +64,12 @@ internal sealed class TelemetryHostedService : IHostedService
         if (tracerProvider == null)
         {
             HostingExtensionsEventSource.Log.TracerProviderNotRegistered();
+        }
+
+        var loggerProvider = serviceProvider!.GetService<LoggerProvider>();
+        if (loggerProvider == null)
+        {
+            HostingExtensionsEventSource.Log.LoggerProviderNotRegistered();
         }
     }
 }

--- a/src/OpenTelemetry.Extensions.Hosting/OpenTelemetry.Extensions.Hosting.csproj
+++ b/src/OpenTelemetry.Extensions.Hosting/OpenTelemetry.Extensions.Hosting.csproj
@@ -18,8 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Note: OpenTelemetry.Extensions.Hosting temporarily sees OpenTelemetry.Api internals for LoggerProvider
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\ExceptionExtensions.cs" Link="Includes\ExceptionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\Guard.cs" Link="Includes\Guard.cs" />
+    -->
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryBuilder.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryBuilder.cs
@@ -15,7 +15,9 @@
 // </copyright>
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using OpenTelemetry.Internal;
+using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -126,6 +128,47 @@ public sealed class OpenTelemetryBuilder
         Guard.ThrowIfNull(configure);
 
         var builder = new TracerProviderBuilderBase(this.Services);
+
+        configure(builder);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds logging services into the builder.
+    /// </summary>
+    /// <remarks>
+    /// Notes:
+    /// <list type="bullet">
+    /// <item>This is safe to be called multiple times and by library authors.
+    /// Only a single <see cref="LoggerProvider"/> will be created for a given
+    /// <see cref="IServiceCollection"/>.</item>
+    /// <item>This operation enables <see cref="ILogger"/> integration
+    /// automatically by calling <see
+    /// cref="OpenTelemetryLoggingExtensions.AddOpenTelemetry(ILoggingBuilder)"/>.</item>
+    /// </list>
+    /// </remarks>
+    /// <returns>The supplied <see cref="OpenTelemetryBuilder"/> for chaining
+    /// calls.</returns>
+    internal OpenTelemetryBuilder WithLogging()
+        => this.WithLogging(b => { });
+
+    /// <summary>
+    /// Adds logging services into the builder.
+    /// </summary>
+    /// <remarks><inheritdoc cref="WithLogging()" path="/remarks"/></remarks>
+    /// <param name="configure"><see cref="LoggerProviderBuilder"/>
+    /// configuration callback.</param>
+    /// <returns>The supplied <see cref="OpenTelemetryBuilder"/> for chaining
+    /// calls.</returns>
+    internal OpenTelemetryBuilder WithLogging(Action<LoggerProviderBuilder> configure)
+    {
+        Guard.ThrowIfNull(configure);
+
+        // Note: This enables ILogger integration
+        this.Services.AddLogging().AddOpenTelemetry();
+
+        var builder = new LoggerProviderServiceCollectionBuilder(this.Services);
 
         configure(builder);
 

--- a/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryBuilder.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryBuilder.cs
@@ -46,7 +46,7 @@ public sealed class OpenTelemetryBuilder
 
     /// <summary>
     /// Registers an action to configure the <see cref="ResourceBuilder"/>s used
-    /// by tracing and metrics.
+    /// by tracing, metrics, and logging.
     /// </summary>
     /// <remarks>
     /// Note: This is safe to be called multiple times and by library authors.
@@ -65,6 +65,9 @@ public sealed class OpenTelemetryBuilder
             (sp, builder) => builder.ConfigureResource(configure));
 
         this.Services.ConfigureOpenTelemetryTracerProvider(
+            (sp, builder) => builder.ConfigureResource(configure));
+
+        this.Services.ConfigureOpenTelemetryLoggerProvider(
             (sp, builder) => builder.ConfigureResource(configure));
 
         return this;

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryBuilderTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryBuilderTests.cs
@@ -1,0 +1,54 @@
+// <copyright file="OpenTelemetryBuilderTests.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using Xunit;
+
+namespace OpenTelemetry.Extensions.Hosting.Tests;
+
+public class OpenTelemetryBuilderTests
+{
+    [Fact]
+    public void ConfigureResourceTest()
+    {
+        var services = new ServiceCollection();
+
+        services
+            .AddOpenTelemetry()
+            .ConfigureResource(r => r.AddResource(new Resource(new Dictionary<string, object> { ["key1"] = "value1" })))
+            .WithLogging()
+            .WithMetrics()
+            .WithTracing();
+
+        using var sp = services.BuildServiceProvider();
+
+        var tracerProvider = sp.GetRequiredService<TracerProvider>() as TracerProviderSdk;
+        var meterProvider = sp.GetRequiredService<MeterProvider>() as MeterProviderSdk;
+        var loggerProvider = sp.GetRequiredService<LoggerProvider>() as LoggerProviderSdk;
+
+        Assert.NotNull(tracerProvider);
+        Assert.NotNull(meterProvider);
+        Assert.NotNull(loggerProvider);
+
+        Assert.Contains(tracerProvider.Resource.Attributes, kvp => kvp.Key == "key1" && (string)kvp.Value == "value1");
+        Assert.Contains(meterProvider.Resource.Attributes, kvp => kvp.Key == "key1" && (string)kvp.Value == "value1");
+        Assert.Contains(loggerProvider.Resource.Attributes, kvp => kvp.Key == "key1" && (string)kvp.Value == "value1");
+    }
+}

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryServicesExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryServicesExtensionsTests.cs
@@ -340,9 +340,9 @@ public class OpenTelemetryServicesExtensionsTests
 
         Assert.NotNull(serviceProvider);
 
-        var tracerProviders = serviceProvider.GetServices<LoggerProvider>();
+        var loggerProviders = serviceProvider.GetServices<LoggerProvider>();
 
-        Assert.Single(tracerProviders);
+        Assert.Single(loggerProviders);
     }
 
     [Fact]


### PR DESCRIPTION
Relates to #4433

## Changes

* Adds `WithLogging` extension on `OpenTelemetryBuilder`

## Details

We're getting into the more interesting bits of this effort!

The current design on this PR is these 3 things are equivalent:

* Traditional API:

   ```csharp
   appBuilder.Logging.AddOpenTelemetry();
   ```

* New API:

   ```csharp
   appBuilder.Services.AddOpenTelemetry().WithLogging();
   ```

* Both APIs:

   ```csharp
   // Both may be called. Only a single LoggerProvider (OTel) and ILoggerProvider (.NET) will exist
   appBuilder.Logging.AddOpenTelemetry();
   appBuilder.Services.AddOpenTelemetry().WithLogging();
   ```

`WithLogging` doesn't necessarily need to exist and/or doesn't need to turn on the ILogger integration. Discussed this with @noahfalk a bit and we felt this was reasonable. But open to ideas/discussions/suggestions.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
