### PR TITLE
Add Otlp trace exporter options class

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/BaseOtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/BaseOtlpExporterOptions.cs
@@ -1,0 +1,133 @@
+// <copyright file="BaseOtlpExporterOptions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NETFRAMEWORK
+using System.Net.Http;
+#endif
+using System.Reflection;
+
+namespace OpenTelemetry.Exporter
+{
+    /// <summary>
+    /// Base otlp exporter options.
+    /// </summary>
+    internal abstract class BaseOtlpExporterOptions
+    {
+        internal const string EndpointEnvVarName = "OTEL_EXPORTER_OTLP_ENDPOINT";
+        internal const string HeadersEnvVarName = "OTEL_EXPORTER_OTLP_HEADERS";
+        internal const string TimeoutEnvVarName = "OTEL_EXPORTER_OTLP_TIMEOUT";
+        internal const string ProtocolEnvVarName = "OTEL_EXPORTER_OTLP_PROTOCOL";
+
+        internal static readonly KeyValuePair<string, string>[] StandardHeaders = new KeyValuePair<string, string>[]
+        {
+            new KeyValuePair<string, string>("User-Agent", GetUserAgentString()),
+        };
+
+        internal Func<HttpClient> DefaultHttpClientFactory;
+
+        protected Uri endpoint;
+
+        private const string DefaultGrpcEndpoint = "http://localhost:4317";
+        private const string DefaultHttpEndpoint = "http://localhost:4318";
+        private const OtlpExportProtocol DefaultOtlpExportProtocol = OtlpExportProtocol.Grpc;
+        private const string UserAgentProduct = "OTel-OTLP-Exporter-Dotnet";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BaseOtlpExporterOptions"/> class.
+        /// </summary>
+        protected BaseOtlpExporterOptions()
+        {
+            this.HttpClientFactory = this.DefaultHttpClientFactory = () =>
+            {
+                return new HttpClient
+                {
+                    Timeout = TimeSpan.FromMilliseconds(this.TimeoutMilliseconds),
+                };
+            };
+        }
+
+        /// <summary>
+        /// Gets or sets the target to which the exporter is going to send telemetry.
+        /// Must be a valid Uri with scheme (http or https) and host, and
+        /// may contain a port and path. The default value is
+        /// * http://localhost:4317 for <see cref="OtlpExportProtocol.Grpc"/>
+        /// * http://localhost:4318 for <see cref="OtlpExportProtocol.HttpProtobuf"/>.
+        /// </summary>
+        public Uri Endpoint
+        {
+            get
+            {
+                if (this.endpoint == null)
+                {
+                    this.endpoint = this.Protocol == OtlpExportProtocol.Grpc
+                        ? new Uri(DefaultGrpcEndpoint)
+                        : new Uri(DefaultHttpEndpoint);
+                }
+
+                return this.endpoint;
+            }
+
+            set
+            {
+                this.endpoint = value;
+                this.ProgrammaticallyModifiedEndpoint = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets optional headers for the connection. Refer to the <a href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#specifying-headers-via-environment-variables">
+        /// specification</a> for information on the expected format for Headers.
+        /// </summary>
+        public string Headers { get; set; }
+
+        /// <summary>
+        /// Gets or sets the max waiting time (in milliseconds) for the backend to process each batch. The default value is 10000.
+        /// </summary>
+        public int TimeoutMilliseconds { get; set; } = 10000;
+
+        /// <summary>
+        /// Gets or sets the the OTLP transport protocol. Supported values: Grpc and HttpProtobuf.
+        /// </summary>
+        public OtlpExportProtocol Protocol { get; set; } = DefaultOtlpExportProtocol;
+
+        /// <summary>
+        /// Gets or sets the factory function called to create the <see
+        /// cref="HttpClient"/> instance that will be used at runtime to
+        /// transmit telemetry over HTTP. The returned instance will be reused
+        /// for all export invocations.
+        /// </summary>
+        public Func<HttpClient> HttpClientFactory { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether <see cref="Endpoint" /> was modified via its setter.
+        /// </summary>
+        internal bool ProgrammaticallyModifiedEndpoint { get; private set; }
+
+        private static string GetUserAgentString()
+        {
+            try
+            {
+                var assemblyVersion = typeof(OtlpExporterOptions).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+                var informationalVersion = assemblyVersion.InformationalVersion;
+                return string.IsNullOrEmpty(informationalVersion) ? UserAgentProduct : $"{UserAgentProduct}/{informationalVersion}";
+            }
+            catch (Exception)
+            {
+                return UserAgentProduct;
+            }
+        }
+    }
+}

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterOptions.cs
@@ -1,0 +1,85 @@
+// <copyright file="OtlpTraceExporterOptions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Exporter.OpenTelemetryProtocol
+{
+    internal class OtlpTraceExporterOptions : BaseOtlpExporterOptions
+    {
+        internal const string TraceEndpointEnvVarName = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT";
+        internal const string TraceHeadersEnvVarName = "OTEL_EXPORTER_OTLP_TRACES_HEADERS";
+        internal const string TraceTimeoutEnvVarName = "OTEL_EXPORTER_OTLP_TRACES_TIMEOUT";
+        internal const string TraceProtocolEnvVarName = "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OtlpTraceExporterOptions"/> class.
+        /// </summary>
+        public OtlpTraceExporterOptions()
+            : this(new ConfigurationBuilder().AddEnvironmentVariables().Build())
+        {
+        }
+
+        public OtlpTraceExporterOptions(IConfiguration configuration)
+        {
+            Debug.Assert(configuration != null, "configuration was null");
+
+            if (configuration.TryGetUriValue(TraceEndpointEnvVarName, out var traceEndpoint))
+            {
+                this.endpoint = traceEndpoint;
+            }
+            else if (configuration.TryGetUriValue(EndpointEnvVarName, out var endpoint))
+            {
+                this.endpoint = endpoint;
+            }
+
+            if (configuration.TryGetStringValue(TraceHeadersEnvVarName, out var traceHeaders))
+            {
+                this.Headers = traceHeaders;
+            }
+            else if (configuration.TryGetStringValue(HeadersEnvVarName, out var headers))
+            {
+                this.Headers = headers;
+            }
+
+            if (configuration.TryGetIntValue(TraceTimeoutEnvVarName, out var traceTimeout))
+            {
+                this.TimeoutMilliseconds = traceTimeout;
+            }
+            else if (configuration.TryGetIntValue(TimeoutEnvVarName, out var timeout))
+            {
+                this.TimeoutMilliseconds = timeout;
+            }
+
+            if (configuration.TryGetValue<OtlpExportProtocol>(
+                TraceProtocolEnvVarName,
+                OtlpExportProtocolParser.TryParse,
+                out var traceProtocol))
+            {
+                this.Protocol = traceProtocol;
+            }
+            else if (configuration.TryGetValue<OtlpExportProtocol>(
+                ProtocolEnvVarName,
+                OtlpExportProtocolParser.TryParse,
+                out var protocol))
+            {
+                this.Protocol = protocol;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Towards #4479 

Design discussion issue #

## Changes
This PR adds `OtlpTraceExporterOptions` for configuring trace specific exporter options. The class is kept internal for now to allow the work to be done in parts.

All the signal specific exporter option classes will derive from `BaseOtlpExporterOptions` class.

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
