### PR TITLE
[sdk-logs] Introduce ConfigureOpenTelemetry ILoggingBuilder extension (proposal 1)

### DIFF
--- a/src/OpenTelemetry/Logs/Builder/LoggerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Logs/Builder/LoggerProviderBuilderExtensions.cs
@@ -18,6 +18,7 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Resources;
 
@@ -28,6 +29,24 @@ namespace OpenTelemetry.Logs;
 /// </summary>
 internal static class LoggerProviderBuilderExtensions
 {
+    /// <summary>
+    /// Registers a configuration action for the <see
+    /// cref="OpenTelemetryLoggerOptions"/> used by <see cref="ILogger"/>
+    /// integration (<see cref="OpenTelemetryLoggerProvider"/>).
+    /// </summary>
+    /// <param name="loggerProviderBuilder"><see cref="LoggerProviderBuilder"/>.</param>
+    /// <param name="configure">Configuration action.</param>
+    /// <returns>Returns <see cref="LoggerProviderBuilder"/> for chaining.</returns>
+    public static LoggerProviderBuilder ConfigureLoggerOptions(
+        this LoggerProviderBuilder loggerProviderBuilder,
+        Action<OpenTelemetryLoggerOptions> configure)
+    {
+        Guard.ThrowIfNull(configure);
+
+        return loggerProviderBuilder.ConfigureServices(
+            services => services.Configure(configure));
+    }
+
     /// <summary>
     /// Sets the <see cref="ResourceBuilder"/> from which the Resource associated with
     /// this provider is built from. Overwrites currently set ResourceBuilder.

--- a/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggerOptions.cs
+++ b/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggerOptions.cs
@@ -89,6 +89,7 @@ public class OpenTelemetryLoggerOptions
     /// </summary>
     /// <param name="processor">Log processor to add.</param>
     /// <returns>Returns <see cref="OpenTelemetryLoggerOptions"/> for chaining.</returns>
+    // todo: [Obsolete("Call ConfigureOpenTelemetry to configure the LoggerProvider and manage processors. The AddProcessor method on OpenTelemetryLoggerOptions will be removed in a future version.")]
     public OpenTelemetryLoggerOptions AddProcessor(BaseProcessor<LogRecord> processor)
     {
         Guard.ThrowIfNull(processor);
@@ -104,6 +105,7 @@ public class OpenTelemetryLoggerOptions
     /// </summary>
     /// <param name="resourceBuilder"><see cref="ResourceBuilder"/> from which Resource will be built.</param>
     /// <returns>Returns <see cref="OpenTelemetryLoggerOptions"/> for chaining.</returns>
+    // todo: [Obsolete("Call ConfigureOpenTelemetry to configure the LoggerProvider and manage resources. The SetResourceBuilder method on OpenTelemetryLoggerOptions will be removed in a future version.")]
     public OpenTelemetryLoggerOptions SetResourceBuilder(ResourceBuilder resourceBuilder)
     {
         Guard.ThrowIfNull(resourceBuilder);

--- a/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggingExtensions.cs
+++ b/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggingExtensions.cs
@@ -51,6 +51,7 @@ public static class OpenTelemetryLoggingExtensions
         // Note: This will bind logger options element (eg "Logging:OpenTelemetry") to OpenTelemetryLoggerOptions
         LoggerProviderOptions.RegisterProviderOptions<OpenTelemetryLoggerOptions, OpenTelemetryLoggerProvider>(builder.Services);
 
+        // Note: This code is to support legacy AddProcessor & SetResourceBuilder APIs on OpenTelemetryLoggerOptions.
         new LoggerProviderServiceCollectionBuilder(builder.Services).ConfigureBuilder(
             (sp, logging) =>
             {
@@ -70,6 +71,8 @@ public static class OpenTelemetryLoggingExtensions
 
                 options.Processors.Clear();
             });
+
+        builder.Services.AddOpenTelemetrySharedProviderBuilderServices();
 
         builder.Services.TryAddEnumerable(
             ServiceDescriptor.Singleton<ILoggerProvider, OpenTelemetryLoggerProvider>(

--- a/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggingExtensions.cs
+++ b/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggingExtensions.cs
@@ -99,4 +99,28 @@ public static class OpenTelemetryLoggingExtensions
 
         return AddOpenTelemetry(builder);
     }
+
+    /// <summary>
+    /// Configures the <see cref="LoggerProviderBuilder" /> which will be used
+    /// by the OpenTelemetry logger named 'OpenTelemetry' added to the <see
+    /// cref="ILoggerFactory"/>.
+    /// </summary>
+    /// Note: This is safe to be called multiple times and by library authors.
+    /// Only a single <see cref="OpenTelemetryLoggerProvider"/> and <see
+    /// cref="LoggerProvider"/> will be created for a given <see
+    /// cref="IServiceCollection"/>.
+    /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
+    /// <param name="configure">Configuration action.</param>
+    /// <returns>The supplied <see cref="ILoggingBuilder"/> for call chaining.</returns>
+    internal static ILoggingBuilder ConfigureOpenTelemetry(
+        this ILoggingBuilder builder,
+        Action<LoggerProviderBuilder> configure)
+    {
+        Guard.ThrowIfNull(builder);
+        Guard.ThrowIfNull(configure);
+
+        configure(new LoggerProviderServiceCollectionBuilder(builder.Services));
+
+        return builder;
+    }
 }


### PR DESCRIPTION
Relates to #4433

/cc @noahfalk

## Changes

* Introduce `ILoggingBuilder.ConfigureOpenTelemetry` extension for configuring `LoggerProviderBuilder`
* Introduce `LoggerProviderBuilder.ConfigureLoggerOptions` extension for configuring `OpenTelemetryLoggerOptions`

## Details

Today we configure logging like this:

```csharp
appBuilder.Logging.AddOpenTelemetry(options =>
{
   options.IncludeFormattedMessage = true;
   options.AddConsoleExporter();
});
```

"options" is `OpenTelemetryLoggerOptions` class.

Now the OpenTelemetry Specification has `LoggerProvider` and we have a `LoggerProviderBuilder` API. The SDK `LoggerProvider` is fed into the `ILogger` integration (`OpenTelemetryLoggerProvider`).

There are different ways we could approach this. Today we have extensions for logging that target `OpenTelemetryLoggerOptions`. We will need to target `LoggerProviderBuilder` now. We could forever have two versions of every extension, but that seems lame.

This PR is adding a new extension `ConfigureOpenTelemetry` to try and bridge the two worlds. `AddProcessor` and `SetResourceBuilder` on `OpenTelemetryLoggerOptions` would be obsoleted as would our existing extensions on `OpenTelemetryLoggerOptions`.

### API Usage

All of these styles can be interchanged.

```csharp
// Configure OTel via ILoggingBuilder
appBuilder.Logging
   .AddOpenTelemetry(options => options.IncludeFormattedMessage = true)
   .ConfigureOpenTelemetry(builder => builder.AddConsoleExporter());
```

```csharp
// Configure OTel via OpenTelemetryBuilder
appBuilder.Services
   .AddOpenTelemetry()
   .WithLogging(builder => builder.AddConsoleExporter());

// Configure ILogger options via ILoggingBuilder
appBuilder.Logging
   .AddOpenTelemetry(options => options.IncludeFormattedMessage = true)
```

```csharp
// Configure OTel via OpenTelemetryBuilder
appBuilder.Services
   .AddOpenTelemetry()
   .WithLogging(builder => builder.AddConsoleExporter());

// Configure ILogger options via Options API
appBuilder.Services.Configure<OpenTelemetryLoggerOptions>(options => options.IncludeFormattedMessage = true);
```

```csharp
// Configure OTel via ILoggingBuilder
appBuilder.Logging
   .AddOpenTelemetry()
   .ConfigureOpenTelemetry(builder => builder.AddConsoleExporter());

// Configure ILogger options via Options API
appBuilder.Services.Configure<OpenTelemetryLoggerOptions>(options => options.IncludeFormattedMessage = true);
```

```csharp
// Configure OTel via OpenTelemetryBuilder
appBuilder.Services
   .AddOpenTelemetry()
   .WithLogging(builder => builder
      .ConfigureLoggerOptions(options => options.IncludeFormattedMessage = true)
      .AddConsoleExporter());
```

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
