### PR TITLE
[sdk-logs] Introduce AddOpenTelemetryLogging ILoggingBuilder extension (proposal 2)

### DIFF
--- a/src/OpenTelemetry/Logs/Builder/LoggerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Logs/Builder/LoggerProviderBuilderExtensions.cs
@@ -18,6 +18,7 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Resources;
 
@@ -28,6 +29,24 @@ namespace OpenTelemetry.Logs;
 /// </summary>
 internal static class LoggerProviderBuilderExtensions
 {
+    /// <summary>
+    /// Registers a configuration action for the <see
+    /// cref="OpenTelemetryLoggerOptions"/> used by <see cref="ILogger"/>
+    /// integration (<see cref="OpenTelemetryLoggerProvider"/>).
+    /// </summary>
+    /// <param name="loggerProviderBuilder"><see cref="LoggerProviderBuilder"/>.</param>
+    /// <param name="configure">Configuration action.</param>
+    /// <returns>Returns <see cref="LoggerProviderBuilder"/> for chaining.</returns>
+    public static LoggerProviderBuilder ConfigureLoggerOptions(
+        this LoggerProviderBuilder loggerProviderBuilder,
+        Action<OpenTelemetryLoggerOptions> configure)
+    {
+        Guard.ThrowIfNull(configure);
+
+        return loggerProviderBuilder.ConfigureServices(
+            services => services.Configure(configure));
+    }
+
     /// <summary>
     /// Sets the <see cref="ResourceBuilder"/> from which the Resource associated with
     /// this provider is built from. Overwrites currently set ResourceBuilder.

--- a/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggerOptions.cs
+++ b/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggerOptions.cs
@@ -89,6 +89,7 @@ public class OpenTelemetryLoggerOptions
     /// </summary>
     /// <param name="processor">Log processor to add.</param>
     /// <returns>Returns <see cref="OpenTelemetryLoggerOptions"/> for chaining.</returns>
+    // todo: [Obsolete("Use the LoggerProviderBuilder class to manage processors. The AddProcessor method on OpenTelemetryLoggerOptions will be removed in a future version.")]
     public OpenTelemetryLoggerOptions AddProcessor(BaseProcessor<LogRecord> processor)
     {
         Guard.ThrowIfNull(processor);
@@ -104,6 +105,7 @@ public class OpenTelemetryLoggerOptions
     /// </summary>
     /// <param name="resourceBuilder"><see cref="ResourceBuilder"/> from which Resource will be built.</param>
     /// <returns>Returns <see cref="OpenTelemetryLoggerOptions"/> for chaining.</returns>
+    // todo: [Obsolete("Use the LoggerProviderBuilder class to manage resources. The AddProcessor method on OpenTelemetryLoggerOptions will be removed in a future version.")]
     public OpenTelemetryLoggerOptions SetResourceBuilder(ResourceBuilder resourceBuilder)
     {
         Guard.ThrowIfNull(resourceBuilder);

--- a/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggingExtensions.cs
+++ b/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggingExtensions.cs
@@ -129,6 +129,8 @@ public static class OpenTelemetryLoggingExtensions
         // Note: This will bind logger options element (eg "Logging:OpenTelemetry") to OpenTelemetryLoggerOptions
         LoggerProviderOptions.RegisterProviderOptions<OpenTelemetryLoggerOptions, OpenTelemetryLoggerProvider>(builder.Services);
 
+        builder.Services.AddOpenTelemetrySharedProviderBuilderServices();
+
         builder.Services.TryAddEnumerable(
             ServiceDescriptor.Singleton<ILoggerProvider, OpenTelemetryLoggerProvider>(
                 sp => new OpenTelemetryLoggerProvider(


### PR DESCRIPTION
Relates to #4433
Relates to #4496

## Changes

* Introduce `ILoggingBuilder.AddOpenTelemetryLogging` extension for configuring `LoggerProviderBuilder`
* Introduce `LoggerProviderBuilder.ConfigureLoggerOptions` extension for configuring `OpenTelemetryLoggerOptions`

## Overview

This is a draft implementation of @noahfalk's comment: https://github.com/open-telemetry/opentelemetry-dotnet/pull/4496#issuecomment-1550858281

I went with `AddOpenTelemetryLogging` instead of `SendToOpenTelemetry` because [all of the ILoggingBuilder extensions](https://learn.microsoft.com/dotnet/api/microsoft.extensions.logging.iloggingbuilder) today are named "AddThing" so it just seemed weird. But I'm open to naming it _whatever_.

## Details

Today we configure logging like this:

```csharp
appBuilder.Logging.AddOpenTelemetry(options =>
{
   options.IncludeFormattedMessage = true;
   options.AddConsoleExporter();
});
```

"options" is `OpenTelemetryLoggerOptions` class.

Now the OpenTelemetry Specification has `LoggerProvider` and we have a `LoggerProviderBuilder` API. The SDK `LoggerProvider` is fed into the `ILogger` integration (`OpenTelemetryLoggerProvider`).

There are different ways we could approach this. Today we have extensions for logging that target `OpenTelemetryLoggerOptions`. We will need to target `LoggerProviderBuilder` now. We could forever have two versions of every extension, but that seems lame.

This PR is adding a new extension `AddOpenTelemetryLogging` to try and bridge the two worlds. `AddOpenTelemetry` extension and `OpenTelemetryLoggerOptions.AddProcessor` and `OpenTelemetryLoggerOptions.SetResourceBuilder` methods would be obsoleted as would our existing extensions on `OpenTelemetryLoggerOptions`.

All of these styles can be interchanged.

```csharp
// Configure OTel via ILoggingBuilder
appBuilder.Logging
   .AddOpenTelemetryLogging(builder => builder
      .ConfigureLoggerOptions(options => options.IncludeFormattedMessage = true)
      .AddConsoleExporter());
```

```csharp
// Configure OTel via OpenTelemetryBuilder
appBuilder.Services
   .AddOpenTelemetry()
   .WithLogging(builder => builder
      .ConfigureLoggerOptions(options => options.IncludeFormattedMessage = true)
      .AddConsoleExporter());
```

```csharp
// Configure OTel via OpenTelemetryBuilder
appBuilder.Services
   .AddOpenTelemetry()
   .WithLogging(builder => builder.AddConsoleExporter());

// Configure ILogger options via Options API
appBuilder.Services.Configure<OpenTelemetryLoggerOptions>(options => options.IncludeFormattedMessage = true);
```

```csharp
// Configure OTel via ILoggingBuilder
appBuilder.Logging
   .AddOpenTelemetryLogging(builder => builder
      .AddConsoleExporter());

// Configure ILogger options via Options API
appBuilder.Services.Configure<OpenTelemetryLoggerOptions>(options => options.IncludeFormattedMessage = true);
```

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
