### PR TITLE
[sdk-logs] Support builder behavior on OpenTelemetryLoggerOptions (proposal 3)

### DIFF
--- a/src/OpenTelemetry/Internal/Builder/ProviderBuilderServiceCollectionExtensions.cs
+++ b/src/OpenTelemetry/Internal/Builder/ProviderBuilderServiceCollectionExtensions.cs
@@ -35,6 +35,7 @@ internal static class ProviderBuilderServiceCollectionExtensions
 
         services!.TryAddSingleton<LoggerProviderBuilderSdk>();
         services!.RegisterOptionsFactory(configuration => new BatchExportLogRecordProcessorOptions(configuration));
+        services!.RegisterOptionsFactory((sp, configuration, name) => new OpenTelemetryLoggerOptions(sp.GetRequiredService<LoggerProviderBuilderSdk>()));
 
         return services!;
     }

--- a/src/OpenTelemetry/Logs/Builder/LoggerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Logs/Builder/LoggerProviderBuilderExtensions.cs
@@ -18,6 +18,7 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Resources;
 
@@ -28,6 +29,24 @@ namespace OpenTelemetry.Logs;
 /// </summary>
 internal static class LoggerProviderBuilderExtensions
 {
+    /// <summary>
+    /// Registers a configuration action for the <see
+    /// cref="OpenTelemetryLoggerOptions"/> used by <see cref="ILogger"/>
+    /// integration (<see cref="OpenTelemetryLoggerProvider"/>).
+    /// </summary>
+    /// <param name="loggerProviderBuilder"><see cref="LoggerProviderBuilder"/>.</param>
+    /// <param name="configure">Configuration action.</param>
+    /// <returns>Returns <see cref="LoggerProviderBuilder"/> for chaining.</returns>
+    public static LoggerProviderBuilder ConfigureLoggerOptions(
+        this LoggerProviderBuilder loggerProviderBuilder,
+        Action<OpenTelemetryLoggerOptions> configure)
+    {
+        Guard.ThrowIfNull(configure);
+
+        return loggerProviderBuilder.ConfigureServices(
+            services => services.Configure(configure));
+    }
+
     /// <summary>
     /// Sets the <see cref="ResourceBuilder"/> from which the Resource associated with
     /// this provider is built from. Overwrites currently set ResourceBuilder.

--- a/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggerOptions.cs
+++ b/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggerOptions.cs
@@ -17,6 +17,7 @@
 #nullable enable
 
 using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Resources;
 
@@ -27,8 +28,30 @@ namespace OpenTelemetry.Logs;
 /// </summary>
 public class OpenTelemetryLoggerOptions
 {
-    internal readonly List<BaseProcessor<LogRecord>> Processors = new();
-    internal ResourceBuilder? ResourceBuilder;
+    private readonly LoggerProviderBuilder? loggerProviderBuilder;
+    private readonly LoggerProviderServiceCollectionBuilder? serviceCollectionBuilder;
+    private readonly LoggerProviderBuilderSdk? loggerProviderBuilderSdk;
+
+    private bool includeFormattedMessage;
+    private bool includeScopes;
+    private bool parseStateValues;
+    private bool includeAttributes = true;
+    private bool includeTraceState;
+
+    public OpenTelemetryLoggerOptions()
+    {
+        this.loggerProviderBuilder = Sdk.CreateLoggerProviderBuilder();
+    }
+
+    internal OpenTelemetryLoggerOptions(LoggerProviderServiceCollectionBuilder loggerProviderServiceCollection)
+    {
+        this.serviceCollectionBuilder = loggerProviderServiceCollection;
+    }
+
+    internal OpenTelemetryLoggerOptions(LoggerProviderBuilderSdk loggerProviderBuilderSdk)
+    {
+        this.loggerProviderBuilderSdk = loggerProviderBuilderSdk;
+    }
 
     /// <summary>
     /// Gets or sets a value indicating whether or not formatted log message
@@ -41,14 +64,22 @@ public class OpenTelemetryLoggerOptions
     /// message template is not found, a formatted log message is always
     /// included.
     /// </remarks>
-    public bool IncludeFormattedMessage { get; set; }
+    public bool IncludeFormattedMessage
+    {
+        get => this.GetFeature(o => o.includeFormattedMessage);
+        set => this.SetFeature(o => o.includeFormattedMessage = value);
+    }
 
     /// <summary>
     /// Gets or sets a value indicating whether or not log scopes should be
     /// included on generated <see cref="LogRecord"/>s. Default value:
     /// <see langword="false"/>.
     /// </summary>
-    public bool IncludeScopes { get; set; }
+    public bool IncludeScopes
+    {
+        get => this.GetFeature(o => o.includeScopes);
+        set => this.SetFeature(o => o.includeScopes = value);
+    }
 
     /// <summary>
     /// Gets or sets a value indicating whether or not log state should be
@@ -67,14 +98,22 @@ public class OpenTelemetryLoggerOptions
     /// langword="null"/>.</item>
     /// </list>
     /// </remarks>
-    public bool ParseStateValues { get; set; }
+    public bool ParseStateValues
+    {
+        get => this.GetFeature(o => o.parseStateValues);
+        set => this.SetFeature(o => o.parseStateValues = value);
+    }
 
     /// <summary>
     /// Gets or sets a value indicating whether or not attributes specified
     /// via log state should be included on generated <see
     /// cref="LogRecord"/>s. Default value: <see langword="true"/>.
     /// </summary>
-    internal bool IncludeAttributes { get; set; } = true;
+    internal bool IncludeAttributes
+    {
+        get => this.GetFeature(o => o.includeAttributes);
+        set => this.SetFeature(o => o.includeAttributes = value);
+    }
 
     /// <summary>
     /// Gets or sets a value indicating whether or not the <see
@@ -82,18 +121,23 @@ public class OpenTelemetryLoggerOptions
     /// cref="Activity"/> should be included on generated <see
     /// cref="LogRecord"/>s. Default value: <see langword="false"/>.
     /// </summary>
-    internal bool IncludeTraceState { get; set; }
+    internal bool IncludeTraceState
+    {
+        get => this.GetFeature(o => o.includeTraceState);
+        set => this.SetFeature(o => o.includeTraceState = value);
+    }
 
     /// <summary>
     /// Adds processor to the options.
     /// </summary>
     /// <param name="processor">Log processor to add.</param>
     /// <returns>Returns <see cref="OpenTelemetryLoggerOptions"/> for chaining.</returns>
+    // todo: [Obsolete("Call ConfigureOpenTelemetry instead AddProcessor will be removed in a future version.")]
     public OpenTelemetryLoggerOptions AddProcessor(BaseProcessor<LogRecord> processor)
     {
         Guard.ThrowIfNull(processor);
 
-        this.Processors.Add(processor);
+        this.ConfigureOpenTelemetry(builder => builder.AddProcessor(processor));
 
         return this;
     }
@@ -104,12 +148,49 @@ public class OpenTelemetryLoggerOptions
     /// </summary>
     /// <param name="resourceBuilder"><see cref="ResourceBuilder"/> from which Resource will be built.</param>
     /// <returns>Returns <see cref="OpenTelemetryLoggerOptions"/> for chaining.</returns>
+    // todo: [Obsolete("Call ConfigureOpenTelemetry instead SetResourceBuilder will be removed in a future version.")]
     public OpenTelemetryLoggerOptions SetResourceBuilder(ResourceBuilder resourceBuilder)
     {
         Guard.ThrowIfNull(resourceBuilder);
 
-        this.ResourceBuilder = resourceBuilder;
+        this.ConfigureOpenTelemetry(builder => builder.SetResourceBuilder(resourceBuilder));
+
         return this;
+    }
+
+    internal void ConfigureOpenTelemetry(Action<LoggerProviderBuilder> configure)
+    {
+        Guard.ThrowIfNull(configure);
+
+        if (this.serviceCollectionBuilder != null)
+        {
+            // Used during AddOpenTelemetry lifetime. IServiceCollection is open, IServiceProvider is unavailable.
+            configure(this.serviceCollectionBuilder);
+        }
+        else if (this.loggerProviderBuilderSdk != null)
+        {
+            // Used during OpenTelemetryLoggerProvider ctor lifetime. IServiceCollection is closed, IServiceProvider is available.
+            configure(this.loggerProviderBuilderSdk);
+        }
+        else if (this.loggerProviderBuilder != null)
+        {
+            // Only used for new OpenTelemetryLoggerOptions(). Shouldn't really be done but it is possible in the shipped APIs.
+            configure(this.loggerProviderBuilder);
+        }
+        else
+        {
+            throw new NotSupportedException("ConfigureOpenTelemetry is not supported on manually created OpenTelemetryLoggerOptions instances.");
+        }
+    }
+
+    internal LoggerProvider Build()
+    {
+        if (this.loggerProviderBuilder != null)
+        {
+            return this.loggerProviderBuilder.Build();
+        }
+
+        throw new NotSupportedException("Build is only supported on manually created OpenTelemetryLoggerOptions instances.");
     }
 
     internal OpenTelemetryLoggerOptions Copy()
@@ -122,5 +203,28 @@ public class OpenTelemetryLoggerOptions
             IncludeAttributes = this.IncludeAttributes,
             IncludeTraceState = this.IncludeTraceState,
         };
+    }
+
+    private void SetFeature(Action<OpenTelemetryLoggerOptions> action)
+    {
+        if (this.serviceCollectionBuilder != null)
+        {
+            this.serviceCollectionBuilder.ConfigureServices(services =>
+                services.Configure<OpenTelemetryLoggerOptions>(o => action(o)));
+        }
+        else
+        {
+            action(this);
+        }
+    }
+
+    private bool GetFeature(Func<OpenTelemetryLoggerOptions, bool> func)
+    {
+        if (this.serviceCollectionBuilder != null)
+        {
+            throw new NotSupportedException("OpenTelemetryLoggerOptions cannot be read during AddOpenTelemetry invocation.");
+        }
+
+        return func(this);
     }
 }

--- a/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggerProvider.cs
+++ b/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggerProvider.cs
@@ -54,22 +54,7 @@ public class OpenTelemetryLoggerProvider : BaseProvider, ILoggerProvider, ISuppo
 
         var optionsInstance = options.CurrentValue;
 
-        this.Provider = Sdk
-            .CreateLoggerProviderBuilder()
-            .ConfigureBuilder((sp, builder) =>
-            {
-                if (optionsInstance.ResourceBuilder != null)
-                {
-                    builder.SetResourceBuilder(optionsInstance.ResourceBuilder);
-                }
-
-                foreach (var processor in optionsInstance.Processors)
-                {
-                    builder.AddProcessor(processor);
-                }
-            })
-            .Build();
-
+        this.Provider = optionsInstance.Build();
         this.Options = optionsInstance.Copy();
         this.ownsProvider = true;
     }

--- a/src/OpenTelemetry/Logs/LoggerProviderSdk.cs
+++ b/src/OpenTelemetry/Logs/LoggerProviderSdk.cs
@@ -19,6 +19,7 @@
 using System.Diagnostics;
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Resources;
 
@@ -61,6 +62,11 @@ internal sealed class LoggerProviderSdk : LoggerProvider
         {
             configureProviderBuilder.ConfigureBuilder(serviceProvider!, state);
         }
+
+        // Note: Accessing options here allows the final instance to apply
+        // ConfigureOpenTelemetry actions against the LoggerProviderBuilderSdk
+        // instance
+        _ = serviceProvider!.GetRequiredService<IOptionsMonitor<OpenTelemetryLoggerOptions>>().CurrentValue;
 
         var resourceBuilder = state.ResourceBuilder ?? ResourceBuilder.CreateDefault();
         resourceBuilder.ServiceProvider = serviceProvider;

--- a/test/OpenTelemetry.Tests/Logs/OpenTelemetryLoggingExtensionsTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/OpenTelemetryLoggingExtensionsTests.cs
@@ -18,6 +18,7 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using OpenTelemetry.Resources;
 using Xunit;
 
 namespace OpenTelemetry.Logs.Tests;
@@ -58,7 +59,8 @@ public sealed class OpenTelemetryLoggingExtensionsTests
     {
         int configureCallbackInvocations = 0;
         int optionsCallbackInvocations = 0;
-        OpenTelemetryLoggerOptions? optionsInstance = null;
+        OpenTelemetryLoggerOptions? addOpenTelemetryOptionsInstance = null;
+        OpenTelemetryLoggerOptions? configureOptionsInstance = null;
 
         var serviceCollection = new ServiceCollection();
 
@@ -81,20 +83,41 @@ public sealed class OpenTelemetryLoggingExtensionsTests
 
         Assert.NotNull(loggerFactory);
 
-        Assert.NotNull(optionsInstance);
+        if (numberOfBuilderRegistrations > 0)
+        {
+            Assert.NotNull(addOpenTelemetryOptionsInstance);
+        }
+        else
+        {
+            Assert.Null(addOpenTelemetryOptionsInstance);
+        }
+
+        if (numberOfOptionsRegistrations > 0)
+        {
+            Assert.NotNull(configureOptionsInstance);
+        }
+        else
+        {
+            Assert.Null(configureOptionsInstance);
+        }
+
+        if (numberOfBuilderRegistrations > 0 || numberOfOptionsRegistrations > 0)
+        {
+            Assert.False(ReferenceEquals(addOpenTelemetryOptionsInstance, configureOptionsInstance));
+        }
 
         Assert.Equal(numberOfBuilderRegistrations, configureCallbackInvocations);
         Assert.Equal(numberOfOptionsRegistrations, optionsCallbackInvocations);
 
         void ConfigureCallback(OpenTelemetryLoggerOptions options)
         {
-            if (optionsInstance == null)
+            if (addOpenTelemetryOptionsInstance == null)
             {
-                optionsInstance = options;
+                addOpenTelemetryOptionsInstance = options;
             }
             else
             {
-                Assert.Equal(optionsInstance, options);
+                Assert.False(ReferenceEquals(configureOptionsInstance, options));
             }
 
             configureCallbackInvocations++;
@@ -102,16 +125,104 @@ public sealed class OpenTelemetryLoggingExtensionsTests
 
         void OptionsCallback(OpenTelemetryLoggerOptions options)
         {
-            if (optionsInstance == null)
+            if (configureOptionsInstance == null)
             {
-                optionsInstance = options;
+                configureOptionsInstance = options;
             }
             else
             {
-                Assert.Equal(optionsInstance, options);
+                Assert.True(ReferenceEquals(configureOptionsInstance, options));
+                Assert.Equal(configureOptionsInstance, options);
             }
 
             optionsCallbackInvocations++;
         }
+    }
+
+    [Fact]
+    public void ServiceCollectionAddOpenTelemetryConfigureOpenTelemetryTest()
+    {
+        var serviceCollection = new ServiceCollection();
+
+        serviceCollection.AddLogging(logging => logging
+            .AddOpenTelemetry(options =>
+            {
+                options.IncludeFormattedMessage = true;
+
+                options.AddProcessor(new CustomProcessor());
+                options.SetResourceBuilder(
+                    ResourceBuilder.CreateEmpty().AddAttributes(
+                        new Dictionary<string, object> { ["key1"] = "value1" }));
+
+                options.ConfigureOpenTelemetry(builder => builder
+                    .ConfigureServices(services => services.AddSingleton<CustomType>())
+                    .ConfigureResource(r => r.AddAttributes(new Dictionary<string, object> { ["key2"] = "value2" }))
+                    .AddProcessor(new CustomProcessor())
+                    .AddProcessor<CustomProcessor>());
+            }));
+
+        serviceCollection.Configure<OpenTelemetryLoggerOptions>(options =>
+        {
+            options.ConfigureOpenTelemetry(builder =>
+            {
+                Assert.Throws<NotSupportedException>(() => builder.AddProcessor<CustomProcessor>());
+                builder.AddProcessor(new CustomProcessor());
+
+                var deferredBuilder = builder as IDeferredLoggerProviderBuilder;
+                Assert.NotNull(deferredBuilder);
+
+                deferredBuilder.Configure((sp, builder) =>
+                    builder.ConfigureResource(r => r.AddAttributes(new Dictionary<string, object> { ["key3"] = "value3" })));
+            });
+        });
+
+        using var sp = serviceCollection.BuildServiceProvider();
+
+        var customType = sp.GetService<CustomType>();
+
+        Assert.NotNull(customType);
+
+        var loggerFactory = sp.GetService<ILoggerFactory>();
+
+        Assert.NotNull(loggerFactory);
+
+        var loggerProvider = sp.GetRequiredService<LoggerProvider>() as LoggerProviderSdk;
+
+        Assert.NotNull(loggerProvider);
+
+        var compositeProcessor = loggerProvider.Processor as CompositeProcessor<LogRecord>;
+
+        Assert.NotNull(compositeProcessor);
+
+        var processorCount = 0;
+        var current = compositeProcessor.Head;
+        while (current != null)
+        {
+            processorCount++;
+            current = current.Next;
+        }
+
+        Assert.Equal(4, processorCount);
+
+        Assert.Contains(loggerProvider.Resource.Attributes, kvp => kvp.Key == "key1" && (string)kvp.Value == "value1");
+        Assert.Contains(loggerProvider.Resource.Attributes, kvp => kvp.Key == "key2" && (string)kvp.Value == "value2");
+        Assert.Contains(loggerProvider.Resource.Attributes, kvp => kvp.Key == "key3" && (string)kvp.Value == "value3");
+
+        var iloggerProviders = sp.GetServices<ILoggerProvider>();
+
+        Assert.NotNull(iloggerProviders);
+        Assert.Single(iloggerProviders);
+
+        var iloggerProvider = iloggerProviders.First() as OpenTelemetryLoggerProvider;
+
+        Assert.NotNull(iloggerProvider);
+    }
+
+    private sealed class CustomType
+    {
+    }
+
+    private sealed class CustomProcessor : BaseProcessor<LogRecord>
+    {
     }
 }


### PR DESCRIPTION
Relates to #4433
Relates to #4501

/cc @noahfalk

## Changes

* Introduce `OpenTelemetryLoggerOptions.ConfigureOpenTelemetry` method for configuring `LoggerProviderBuilder`
* Introduce `LoggerProviderBuilder.ConfigureLoggerOptions` extension for configuring `OpenTelemetryLoggerOptions`

## Overview

Some have already asked and I'm sure others will ask in the future: Why can't `OpenTelemetryLoggerOptions` just be a `LoggerProviderBuilder`?

Builders and options are fundamentally different things. Builders (typically) operate on the `IServiceCollection`. Options are (typically) requested through the `IServiceProvider`.

What this PR does is hack it to work. When `AddOpenTelemetry` is called we create an `OpenTelemetryLoggerOptions` instance bound to the `IServiceCollection` and invoke the configuration delegate immediately. Later on we retrieve a different `OpenTelemetryLoggerOptions` instance once the `IServiceProvider` is available.

## Details

Today we configure logging like this:

```csharp
appBuilder.Logging.AddOpenTelemetry(options =>
{
   options.IncludeFormattedMessage = true;
   options.AddConsoleExporter();
});
```

"options" is `OpenTelemetryLoggerOptions` class.

Now the OpenTelemetry Specification has `LoggerProvider` and we have a `LoggerProviderBuilder` API. The SDK `LoggerProvider` is fed into the `ILogger` integration (`OpenTelemetryLoggerProvider`).

There are different ways we could approach this. Today we have extensions for logging that target `OpenTelemetryLoggerOptions`. We will need to target `LoggerProviderBuilder` now. We could forever have two versions of every extension, but that seems lame.

This PR is adding a new method `ConfigureOpenTelemetry` on `OpenTelemetryLoggerOptions` to try and bridge the two worlds. `OpenTelemetryLoggerOptions.AddProcessor` and `OpenTelemetryLoggerOptions.SetResourceBuilder` methods would be obsoleted as would our existing extensions on `OpenTelemetryLoggerOptions`.

All of these styles can be interchanged.

```csharp
// Configure OTel via ILoggingBuilder
appBuilder.Logging
   .AddOpenTelemetryLogging(options=> {
      options.IncludeFormattedMessage = true;
      options.ConfigureOpenTelemetry(builder => builder.AddConsoleExporter());
   });
```

```csharp
// Configure OTel via OpenTelemetryBuilder
appBuilder.Services
   .AddOpenTelemetry()
   .WithLogging(builder => builder
      .ConfigureLoggerOptions(options => options.IncludeFormattedMessage = true)
      .AddConsoleExporter());
```

```csharp
// Configure OTel via OpenTelemetryBuilder
appBuilder.Services
   .AddOpenTelemetry()
   .WithLogging(builder => builder.AddConsoleExporter());

// Configure ILogger options via Options API
appBuilder.Services.Configure<OpenTelemetryLoggerOptions>(options => options.IncludeFormattedMessage = true);
```

```csharp
// Configure OTel via ILoggingBuilder
appBuilder.Logging
   .AddOpenTelemetryLogging(builder => builder.AddConsoleExporter());

// Configure ILogger options via Options API
appBuilder.Services.Configure<OpenTelemetryLoggerOptions>(options => options.IncludeFormattedMessage = true);
```

```csharp
// Configure OTel via ILoggingBuilder
appBuilder.Logging.AddOpenTelemetryLogging();

// Configure ILogger options via Options API
appBuilder.Services.Configure<OpenTelemetryLoggerOptions>(options => {
   options.IncludeFormattedMessage = true;
   options.ConfigureOpenTelemetry(builder => builder.AddConsoleExporter()); // This isn't really desired but is now allowed
});
```

```csharp
// Configure OTel via OpenTelemetryBuilder
appBuilder.Services
   .AddOpenTelemetry()
   .WithLogging();

// Configure ILogger options via Options API
appBuilder.Services.Configure<OpenTelemetryLoggerOptions>(options => {
   options.IncludeFormattedMessage = true;
   options.ConfigureOpenTelemetry(builder => builder.AddConsoleExporter()); // This isn't really desired but is now allowed
});
```

## Breaking changes

I couldn't make this work breaking changes 😭 

This works today...

```csharp
appBuilder.Services.Configure<OpenTelemetryLoggerOptions>(options => options.IncludeFormattedMessage = true);
appBuilder.Logging.AddOpenTelemetryLogging(options => {
   if (options.IncludeFormattedMessage)
   {
       // Do something if IncludeFormattedMessage is turned on
   }
});
```

What will happen now is...

```csharp
appBuilder.Services.Configure<OpenTelemetryLoggerOptions>(options => options.IncludeFormattedMessage = true);
appBuilder.Logging.AddOpenTelemetryLogging(options => {
   if (options.IncludeFormattedMessage) // <- NotSupportedException is thrown here
   {
       // Code is unreachable
   }
});
```

This is because before the delegate passed to `AddOpenTelemetry` is executed on the final `OpenTelemetryLoggerOptions` instance being built by Options API. This PR needs to make a different `OpenTelemetryLoggerOptions` instance and invoke the callback immediately. What that means is the getters on that `OpenTelemetryLoggerOptions` really have no idea what the state will be of the actual instance when created through Options API. They could just return lies, I decided to have them throw.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
