### PR TITLE
Add Support for HttpSemanticConvention breaking changes.

### DIFF
--- a/src/OpenTelemetry.Api/Internal/HttpSemanticConventionHelper.cs
+++ b/src/OpenTelemetry.Api/Internal/HttpSemanticConventionHelper.cs
@@ -1,0 +1,67 @@
+// <copyright file="HttpSemanticConventionHelper.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenTelemetry.Internal
+{
+    using System;
+
+    /// <summary>
+    /// Helper class for Http Semantic Conventions.
+    /// </summary>
+    /// <remarks>
+    /// Due to a breaking change in the semantic convention, affected instrumentation libraries
+    /// must inspect an environment variable to determine which attributes to emit.
+    /// This is expected to be removed when the instrumentation libraries reach Stable.
+    /// <see href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md"/>.
+    /// </remarks>
+    internal static class HttpSemanticConventionHelper
+    {
+        [Flags]
+        internal enum HttpSemanticConvention
+        {
+            /// <summary>
+            /// Instructs an instrumentation library to emit the old experimental HTTP attributes.
+            /// </summary>
+            Old = 0x1,
+
+            /// <summary>
+            /// Instructs an instrumentation library to emit the new, stable Http attributes.
+            /// </summary>
+            New = 0x2,
+
+            /// <summary>
+            /// Instructs an instrumentation library to emit both the old and new attributes.
+            /// </summary>
+            Dupe = Old | New,
+        }
+
+        public static HttpSemanticConvention GetSemConvOptIn()
+        {
+            var envVarValue = Environment.GetEnvironmentVariable("OTEL_SEMCONV_STABILITY_OPT_IN ");
+            return EvaluateValue(envVarValue);
+        }
+
+        internal static HttpSemanticConvention EvaluateValue(string value)
+        {
+            return value?.ToLower() switch
+            {
+                "http" => HttpSemanticConvention.New,
+                "http/dup" => HttpSemanticConvention.Dupe,
+                _ => HttpSemanticConvention.Old,
+            };
+        }
+    }
+}

--- a/src/OpenTelemetry.Api/Internal/HttpSemanticConventionHelper.cs
+++ b/src/OpenTelemetry.Api/Internal/HttpSemanticConventionHelper.cs
@@ -14,54 +14,53 @@
 // limitations under the License.
 // </copyright>
 
-namespace OpenTelemetry.Internal
+namespace OpenTelemetry.Internal;
+
+/// <summary>
+/// Helper class for Http Semantic Conventions.
+/// </summary>
+/// <remarks>
+/// Due to a breaking change in the semantic convention, affected instrumentation libraries
+/// must inspect an environment variable to determine which attributes to emit.
+/// This is expected to be removed when the instrumentation libraries reach Stable.
+/// <see href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md"/>.
+/// </remarks>
+internal static class HttpSemanticConventionHelper
 {
-    /// <summary>
-    /// Helper class for Http Semantic Conventions.
-    /// </summary>
-    /// <remarks>
-    /// Due to a breaking change in the semantic convention, affected instrumentation libraries
-    /// must inspect an environment variable to determine which attributes to emit.
-    /// This is expected to be removed when the instrumentation libraries reach Stable.
-    /// <see href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md"/>.
-    /// </remarks>
-    internal static class HttpSemanticConventionHelper
+    [Flags]
+    internal enum HttpSemanticConvention
     {
-        [Flags]
-        internal enum HttpSemanticConvention
+        /// <summary>
+        /// Instructs an instrumentation library to emit the old experimental HTTP attributes.
+        /// </summary>
+        Old = 0x1,
+
+        /// <summary>
+        /// Instructs an instrumentation library to emit the new, stable Http attributes.
+        /// </summary>
+        New = 0x2,
+
+        /// <summary>
+        /// Instructs an instrumentation library to emit both the old and new attributes.
+        /// </summary>
+        Dupe = Old | New,
+    }
+
+    public static HttpSemanticConvention GetSemanticConventionOptIn()
+    {
+        try
         {
-            /// <summary>
-            /// Instructs an instrumentation library to emit the old experimental HTTP attributes.
-            /// </summary>
-            Old = 0x1,
-
-            /// <summary>
-            /// Instructs an instrumentation library to emit the new, stable Http attributes.
-            /// </summary>
-            New = 0x2,
-
-            /// <summary>
-            /// Instructs an instrumentation library to emit both the old and new attributes.
-            /// </summary>
-            Dupe = Old | New,
+            var envVarValue = Environment.GetEnvironmentVariable("OTEL_SEMCONV_STABILITY_OPT_IN");
+            return envVarValue?.ToLowerInvariant() switch
+            {
+                "http" => HttpSemanticConvention.New,
+                "http/dup" => HttpSemanticConvention.Dupe,
+                _ => HttpSemanticConvention.Old,
+            };
         }
-
-        public static HttpSemanticConvention GetSemanticConventionOptIn()
+        catch
         {
-            try
-            {
-                var envVarValue = Environment.GetEnvironmentVariable("OTEL_SEMCONV_STABILITY_OPT_IN");
-                return envVarValue?.ToLowerInvariant() switch
-                {
-                    "http" => HttpSemanticConvention.New,
-                    "http/dup" => HttpSemanticConvention.Dupe,
-                    _ => HttpSemanticConvention.Old,
-                };
-            }
-            catch
-            {
-                return HttpSemanticConvention.Old;
-            }
+            return HttpSemanticConvention.Old;
         }
     }
 }

--- a/src/OpenTelemetry.Api/Internal/HttpSemanticConventionHelper.cs
+++ b/src/OpenTelemetry.Api/Internal/HttpSemanticConventionHelper.cs
@@ -53,22 +53,17 @@ namespace OpenTelemetry.Internal
             try
             {
                 var envVarValue = Environment.GetEnvironmentVariable("OTEL_SEMCONV_STABILITY_OPT_IN");
-                return EvaluateValue(envVarValue);
+                return envVarValue?.ToLowerInvariant() switch
+                {
+                    "http" => HttpSemanticConvention.New,
+                    "http/dup" => HttpSemanticConvention.Dupe,
+                    _ => HttpSemanticConvention.Old,
+                };
             }
             catch
             {
                 return HttpSemanticConvention.Old;
             }
-        }
-
-        internal static HttpSemanticConvention EvaluateValue(string value)
-        {
-            return value?.ToLowerInvariant() switch
-            {
-                "http" => HttpSemanticConvention.New,
-                "http/dup" => HttpSemanticConvention.Dupe,
-                _ => HttpSemanticConvention.Old,
-            };
         }
     }
 }

--- a/src/OpenTelemetry.Api/Internal/HttpSemanticConventionHelper.cs
+++ b/src/OpenTelemetry.Api/Internal/HttpSemanticConventionHelper.cs
@@ -16,8 +16,6 @@
 
 namespace OpenTelemetry.Internal
 {
-    using System;
-
     /// <summary>
     /// Helper class for Http Semantic Conventions.
     /// </summary>

--- a/src/OpenTelemetry.Api/Internal/HttpSemanticConventionHelper.cs
+++ b/src/OpenTelemetry.Api/Internal/HttpSemanticConventionHelper.cs
@@ -48,7 +48,7 @@ namespace OpenTelemetry.Internal
             Dupe = Old | New,
         }
 
-        public static HttpSemanticConvention GetSemConvOptIn()
+        public static HttpSemanticConvention GetSemanticConventionOptIn()
         {
             var envVarValue = Environment.GetEnvironmentVariable("OTEL_SEMCONV_STABILITY_OPT_IN");
             return EvaluateValue(envVarValue);

--- a/src/OpenTelemetry.Api/Internal/HttpSemanticConventionHelper.cs
+++ b/src/OpenTelemetry.Api/Internal/HttpSemanticConventionHelper.cs
@@ -63,7 +63,7 @@ namespace OpenTelemetry.Internal
 
         internal static HttpSemanticConvention EvaluateValue(string value)
         {
-            return value?.ToLower() switch
+            return value?.ToLowerInvariant() switch
             {
                 "http" => HttpSemanticConvention.New,
                 "http/dup" => HttpSemanticConvention.Dupe,

--- a/src/OpenTelemetry.Api/Internal/HttpSemanticConventionHelper.cs
+++ b/src/OpenTelemetry.Api/Internal/HttpSemanticConventionHelper.cs
@@ -50,7 +50,7 @@ namespace OpenTelemetry.Internal
 
         public static HttpSemanticConvention GetSemConvOptIn()
         {
-            var envVarValue = Environment.GetEnvironmentVariable("OTEL_SEMCONV_STABILITY_OPT_IN ");
+            var envVarValue = Environment.GetEnvironmentVariable("OTEL_SEMCONV_STABILITY_OPT_IN");
             return EvaluateValue(envVarValue);
         }
 

--- a/src/OpenTelemetry.Api/Internal/HttpSemanticConventionHelper.cs
+++ b/src/OpenTelemetry.Api/Internal/HttpSemanticConventionHelper.cs
@@ -50,8 +50,15 @@ namespace OpenTelemetry.Internal
 
         public static HttpSemanticConvention GetSemanticConventionOptIn()
         {
-            var envVarValue = Environment.GetEnvironmentVariable("OTEL_SEMCONV_STABILITY_OPT_IN");
-            return EvaluateValue(envVarValue);
+            try
+            {
+                var envVarValue = Environment.GetEnvironmentVariable("OTEL_SEMCONV_STABILITY_OPT_IN");
+                return EvaluateValue(envVarValue);
+            }
+            catch
+            {
+                return HttpSemanticConvention.Old;
+            }
         }
 
         internal static HttpSemanticConvention EvaluateValue(string value)

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -29,6 +29,7 @@ using OpenTelemetry.Instrumentation.GrpcNetClient;
 #endif
 using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
+using static OpenTelemetry.Internal.HttpSemanticConventionHelper;
 
 namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
 {
@@ -62,7 +63,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
 #endif
         private readonly PropertyFetcher<Exception> stopExceptionFetcher = new("Exception");
         private readonly AspNetCoreInstrumentationOptions options;
-        private readonly HttpSemanticConventionHelper.HttpSemanticConvention httpSemanticConvention;
+        private readonly HttpSemanticConvention httpSemanticConvention;
 
         public HttpInListener(AspNetCoreInstrumentationOptions options)
             : base(DiagnosticSourceName)
@@ -71,7 +72,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
 
             this.options = options;
 
-            this.httpSemanticConvention = HttpSemanticConventionHelper.GetSemConvOptIn();
+            this.httpSemanticConvention = GetSemanticConventionOptIn();
         }
 
         public override void OnEventWritten(string name, object payload)

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -62,6 +62,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
 #endif
         private readonly PropertyFetcher<Exception> stopExceptionFetcher = new("Exception");
         private readonly AspNetCoreInstrumentationOptions options;
+        private readonly HttpSemanticConventionHelper.HttpSemanticConvention httpSemanticConvention;
 
         public HttpInListener(AspNetCoreInstrumentationOptions options)
             : base(DiagnosticSourceName)
@@ -69,6 +70,8 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
             Guard.ThrowIfNull(options);
 
             this.options = options;
+
+            this.httpSemanticConvention = HttpSemanticConventionHelper.GetSemConvOptIn();
         }
 
         public override void OnEventWritten(string name, object payload)

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
@@ -14,6 +14,7 @@
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.GrpcNetClient\GrpcTagHelper.cs" Link="Includes\GrpcTagHelper.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.GrpcNetClient\StatusCanonicalCode.cs" Link="Includes\StatusCanonicalCode.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\HttpSemanticConventionHelper.cs" Link="Includes\HttpSemanticConventionHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Api.Tests/Internal/HttpSemanticConventionHelperTest.cs
+++ b/test/OpenTelemetry.Api.Tests/Internal/HttpSemanticConventionHelperTest.cs
@@ -38,17 +38,31 @@ namespace OpenTelemetry.Api.Tests.Internal
         }
 
         [Fact]
-        public void VerifyEvaluate()
+        public void VerifyGetSemanticConventionOptIn()
         {
-            Assert.Equal(HttpSemanticConvention.Old, EvaluateValue(null));
-            Assert.Equal(HttpSemanticConvention.Old, EvaluateValue(string.Empty));
-            Assert.Equal(HttpSemanticConvention.Old, EvaluateValue("junk"));
-            Assert.Equal(HttpSemanticConvention.Old, EvaluateValue("none"));
-            Assert.Equal(HttpSemanticConvention.Old, EvaluateValue("NONE"));
-            Assert.Equal(HttpSemanticConvention.New, EvaluateValue("http"));
-            Assert.Equal(HttpSemanticConvention.New, EvaluateValue("HTTP"));
-            Assert.Equal(HttpSemanticConvention.Dupe, EvaluateValue("http/dup"));
-            Assert.Equal(HttpSemanticConvention.Dupe, EvaluateValue("HTTP/DUP"));
+            this.RunTestWithEnvironmentVariable(null, HttpSemanticConvention.Old);
+            this.RunTestWithEnvironmentVariable(string.Empty, HttpSemanticConvention.Old);
+            this.RunTestWithEnvironmentVariable("junk", HttpSemanticConvention.Old);
+            this.RunTestWithEnvironmentVariable("none", HttpSemanticConvention.Old);
+            this.RunTestWithEnvironmentVariable("NONE", HttpSemanticConvention.Old);
+            this.RunTestWithEnvironmentVariable("http", HttpSemanticConvention.New);
+            this.RunTestWithEnvironmentVariable("HTTP", HttpSemanticConvention.New);
+            this.RunTestWithEnvironmentVariable("http/dup", HttpSemanticConvention.Dupe);
+            this.RunTestWithEnvironmentVariable("HTTP/DUP", HttpSemanticConvention.Dupe);
+        }
+
+        private void RunTestWithEnvironmentVariable(string value, HttpSemanticConvention expected)
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("OTEL_SEMCONV_STABILITY_OPT_IN", value);
+
+                Assert.Equal(expected, GetSemanticConventionOptIn());
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("OTEL_SEMCONV_STABILITY_OPT_IN", null);
+            }
         }
     }
 }

--- a/test/OpenTelemetry.Api.Tests/Internal/HttpSemanticConventionHelperTest.cs
+++ b/test/OpenTelemetry.Api.Tests/Internal/HttpSemanticConventionHelperTest.cs
@@ -1,0 +1,52 @@
+// <copyright file="HttpSemanticConventionHelperTest.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using Xunit;
+using static OpenTelemetry.Internal.HttpSemanticConventionHelper;
+
+namespace OpenTelemetry.Api.Tests.Internal
+{
+    public class HttpSemanticConventionHelperTest
+    {
+        [Fact]
+        public void VerifyFlags()
+        {
+            var testValue = HttpSemanticConvention.Dupe;
+            Assert.True(testValue.HasFlag(HttpSemanticConvention.Old));
+            Assert.True(testValue.HasFlag(HttpSemanticConvention.New));
+
+            testValue = HttpSemanticConvention.Old;
+            Assert.True(testValue.HasFlag(HttpSemanticConvention.Old));
+            Assert.False(testValue.HasFlag(HttpSemanticConvention.New));
+
+            testValue = HttpSemanticConvention.New;
+            Assert.False(testValue.HasFlag(HttpSemanticConvention.Old));
+            Assert.True(testValue.HasFlag(HttpSemanticConvention.New));
+        }
+
+        [Fact]
+        public void VerifyEvaluate()
+        {
+            Assert.Equal(HttpSemanticConvention.Old, EvaluateValue(null));
+            Assert.Equal(HttpSemanticConvention.Old, EvaluateValue(string.Empty));
+            Assert.Equal(HttpSemanticConvention.Old, EvaluateValue("junk"));
+            Assert.Equal(HttpSemanticConvention.Old, EvaluateValue("none"));
+            Assert.Equal(HttpSemanticConvention.New, EvaluateValue("http"));
+            Assert.Equal(HttpSemanticConvention.New, EvaluateValue("HTTP"));
+            Assert.Equal(HttpSemanticConvention.Dupe, EvaluateValue("http/dup"));
+        }
+    }
+}

--- a/test/OpenTelemetry.Api.Tests/Internal/HttpSemanticConventionHelperTest.cs
+++ b/test/OpenTelemetry.Api.Tests/Internal/HttpSemanticConventionHelperTest.cs
@@ -17,52 +17,51 @@
 using Xunit;
 using static OpenTelemetry.Internal.HttpSemanticConventionHelper;
 
-namespace OpenTelemetry.Api.Tests.Internal
+namespace OpenTelemetry.Api.Tests.Internal;
+
+public class HttpSemanticConventionHelperTest
 {
-    public class HttpSemanticConventionHelperTest
+    [Fact]
+    public void VerifyFlags()
     {
-        [Fact]
-        public void VerifyFlags()
+        var testValue = HttpSemanticConvention.Dupe;
+        Assert.True(testValue.HasFlag(HttpSemanticConvention.Old));
+        Assert.True(testValue.HasFlag(HttpSemanticConvention.New));
+
+        testValue = HttpSemanticConvention.Old;
+        Assert.True(testValue.HasFlag(HttpSemanticConvention.Old));
+        Assert.False(testValue.HasFlag(HttpSemanticConvention.New));
+
+        testValue = HttpSemanticConvention.New;
+        Assert.False(testValue.HasFlag(HttpSemanticConvention.Old));
+        Assert.True(testValue.HasFlag(HttpSemanticConvention.New));
+    }
+
+    [Fact]
+    public void VerifyGetSemanticConventionOptIn()
+    {
+        this.RunTestWithEnvironmentVariable(null, HttpSemanticConvention.Old);
+        this.RunTestWithEnvironmentVariable(string.Empty, HttpSemanticConvention.Old);
+        this.RunTestWithEnvironmentVariable("junk", HttpSemanticConvention.Old);
+        this.RunTestWithEnvironmentVariable("none", HttpSemanticConvention.Old);
+        this.RunTestWithEnvironmentVariable("NONE", HttpSemanticConvention.Old);
+        this.RunTestWithEnvironmentVariable("http", HttpSemanticConvention.New);
+        this.RunTestWithEnvironmentVariable("HTTP", HttpSemanticConvention.New);
+        this.RunTestWithEnvironmentVariable("http/dup", HttpSemanticConvention.Dupe);
+        this.RunTestWithEnvironmentVariable("HTTP/DUP", HttpSemanticConvention.Dupe);
+    }
+
+    private void RunTestWithEnvironmentVariable(string value, HttpSemanticConvention expected)
+    {
+        try
         {
-            var testValue = HttpSemanticConvention.Dupe;
-            Assert.True(testValue.HasFlag(HttpSemanticConvention.Old));
-            Assert.True(testValue.HasFlag(HttpSemanticConvention.New));
+            Environment.SetEnvironmentVariable("OTEL_SEMCONV_STABILITY_OPT_IN", value);
 
-            testValue = HttpSemanticConvention.Old;
-            Assert.True(testValue.HasFlag(HttpSemanticConvention.Old));
-            Assert.False(testValue.HasFlag(HttpSemanticConvention.New));
-
-            testValue = HttpSemanticConvention.New;
-            Assert.False(testValue.HasFlag(HttpSemanticConvention.Old));
-            Assert.True(testValue.HasFlag(HttpSemanticConvention.New));
+            Assert.Equal(expected, GetSemanticConventionOptIn());
         }
-
-        [Fact]
-        public void VerifyGetSemanticConventionOptIn()
+        finally
         {
-            this.RunTestWithEnvironmentVariable(null, HttpSemanticConvention.Old);
-            this.RunTestWithEnvironmentVariable(string.Empty, HttpSemanticConvention.Old);
-            this.RunTestWithEnvironmentVariable("junk", HttpSemanticConvention.Old);
-            this.RunTestWithEnvironmentVariable("none", HttpSemanticConvention.Old);
-            this.RunTestWithEnvironmentVariable("NONE", HttpSemanticConvention.Old);
-            this.RunTestWithEnvironmentVariable("http", HttpSemanticConvention.New);
-            this.RunTestWithEnvironmentVariable("HTTP", HttpSemanticConvention.New);
-            this.RunTestWithEnvironmentVariable("http/dup", HttpSemanticConvention.Dupe);
-            this.RunTestWithEnvironmentVariable("HTTP/DUP", HttpSemanticConvention.Dupe);
-        }
-
-        private void RunTestWithEnvironmentVariable(string value, HttpSemanticConvention expected)
-        {
-            try
-            {
-                Environment.SetEnvironmentVariable("OTEL_SEMCONV_STABILITY_OPT_IN", value);
-
-                Assert.Equal(expected, GetSemanticConventionOptIn());
-            }
-            finally
-            {
-                Environment.SetEnvironmentVariable("OTEL_SEMCONV_STABILITY_OPT_IN", null);
-            }
+            Environment.SetEnvironmentVariable("OTEL_SEMCONV_STABILITY_OPT_IN", null);
         }
     }
 }

--- a/test/OpenTelemetry.Api.Tests/Internal/HttpSemanticConventionHelperTest.cs
+++ b/test/OpenTelemetry.Api.Tests/Internal/HttpSemanticConventionHelperTest.cs
@@ -44,9 +44,11 @@ namespace OpenTelemetry.Api.Tests.Internal
             Assert.Equal(HttpSemanticConvention.Old, EvaluateValue(string.Empty));
             Assert.Equal(HttpSemanticConvention.Old, EvaluateValue("junk"));
             Assert.Equal(HttpSemanticConvention.Old, EvaluateValue("none"));
+            Assert.Equal(HttpSemanticConvention.Old, EvaluateValue("NONE"));
             Assert.Equal(HttpSemanticConvention.New, EvaluateValue("http"));
             Assert.Equal(HttpSemanticConvention.New, EvaluateValue("HTTP"));
             Assert.Equal(HttpSemanticConvention.Dupe, EvaluateValue("http/dup"));
+            Assert.Equal(HttpSemanticConvention.Dupe, EvaluateValue("HTTP/DUP"));
         }
     }
 }


### PR DESCRIPTION
Design discussion issue #4484 

Http Semantic Convention is introducing breaking changes.
This PR introduces a new helper class to read and parse the new environment variable.

During startup, an instrumentation library should check for an environment variable.
Based on the parsed value, that library will either emit the old attributes, new attributes, or both.




## Changes
- Add Helper class to parse environment variable
- Add enum to represent Semantic Convention decision.
- Add unit tests to validate Parser and Enum Flags.
- Update `HttpInListener` ctor in `Instrumentation.AspNetCore`

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
