### PR TITLE
[sdk-logs] Introduce OpenTelemetryLoggingBuilder (proposal 4)

### DIFF
--- a/src/OpenTelemetry.Api/Logs/LoggerProviderBuilder.cs
+++ b/src/OpenTelemetry.Api/Logs/LoggerProviderBuilder.cs
@@ -21,7 +21,7 @@ namespace OpenTelemetry.Logs;
 /// <summary>
 /// LoggerProviderBuilder base class.
 /// </summary>
-internal abstract class LoggerProviderBuilder
+public abstract class LoggerProviderBuilder
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="LoggerProviderBuilder"/> class.

--- a/src/OpenTelemetry/Logs/Builder/LoggerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Logs/Builder/LoggerProviderBuilderExtensions.cs
@@ -18,6 +18,7 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Resources;
 
@@ -28,6 +29,24 @@ namespace OpenTelemetry.Logs;
 /// </summary>
 internal static class LoggerProviderBuilderExtensions
 {
+    /// <summary>
+    /// Registers a configuration action for the <see
+    /// cref="OpenTelemetryLoggerOptions"/> used by <see cref="ILogger"/>
+    /// integration (<see cref="OpenTelemetryLoggerProvider"/>).
+    /// </summary>
+    /// <param name="loggerProviderBuilder"><see cref="LoggerProviderBuilder"/>.</param>
+    /// <param name="configure">Configuration action.</param>
+    /// <returns>Returns <see cref="LoggerProviderBuilder"/> for chaining.</returns>
+    public static LoggerProviderBuilder ConfigureLoggerOptions(
+        this LoggerProviderBuilder loggerProviderBuilder,
+        Action<OpenTelemetryLoggerOptions> configure)
+    {
+        Guard.ThrowIfNull(configure);
+
+        return loggerProviderBuilder.ConfigureServices(
+            services => services.Configure(configure));
+    }
+
     /// <summary>
     /// Sets the <see cref="ResourceBuilder"/> from which the Resource associated with
     /// this provider is built from. Overwrites currently set ResourceBuilder.

--- a/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggerOptions.cs
+++ b/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggerOptions.cs
@@ -89,6 +89,7 @@ public class OpenTelemetryLoggerOptions
     /// </summary>
     /// <param name="processor">Log processor to add.</param>
     /// <returns>Returns <see cref="OpenTelemetryLoggerOptions"/> for chaining.</returns>
+    // todo: [Obsolete("Use the OpenTelemetryLoggingBuilder returned by AddOpenTelemetry or call IServiceCollection.ConfigureOpenTelemetryLoggerProvider instead. AddProcessor will be removed in a future version.")]
     public OpenTelemetryLoggerOptions AddProcessor(BaseProcessor<LogRecord> processor)
     {
         Guard.ThrowIfNull(processor);
@@ -104,6 +105,7 @@ public class OpenTelemetryLoggerOptions
     /// </summary>
     /// <param name="resourceBuilder"><see cref="ResourceBuilder"/> from which Resource will be built.</param>
     /// <returns>Returns <see cref="OpenTelemetryLoggerOptions"/> for chaining.</returns>
+    // todo: [Obsolete("Use the OpenTelemetryLoggingBuilder returned by AddOpenTelemetry or call IServiceCollection.ConfigureOpenTelemetryLoggerProvider instead. SetResourceBuilder will be removed in a future version.")]
     public OpenTelemetryLoggerOptions SetResourceBuilder(ResourceBuilder resourceBuilder)
     {
         Guard.ThrowIfNull(resourceBuilder);

--- a/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggingBuilder.cs
+++ b/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggingBuilder.cs
@@ -1,0 +1,63 @@
+// <copyright file="OpenTelemetryLoggingBuilder.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#nullable enable
+
+using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace OpenTelemetry.Logs;
+
+/// <summary>
+/// An <see cref="ILoggingBuilder"/> implementation that exposes methods for configuring OpenTelemetry.
+/// </summary>
+public sealed class OpenTelemetryLoggingBuilder : LoggerProviderBuilder, ILoggerProviderBuilder, ILoggingBuilder
+{
+    private readonly LoggerProviderServiceCollectionBuilder innerBuiler;
+
+    internal OpenTelemetryLoggingBuilder(IServiceCollection services)
+    {
+        Debug.Assert(services != null, "services was null");
+
+        services.AddOpenTelemetrySharedProviderBuilderServices();
+
+        this.innerBuiler = new LoggerProviderServiceCollectionBuilder(services!);
+        this.Services = services!;
+    }
+
+    /// <inheritdoc />
+    public IServiceCollection Services { get; }
+
+    /// <inheritdoc/>
+    LoggerProvider? ILoggerProviderBuilder.Provider => null;
+
+    /// <inheritdoc/>
+    public override LoggerProviderBuilder AddInstrumentation<TInstrumentation>(Func<TInstrumentation> instrumentationFactory)
+        => this.innerBuiler.AddInstrumentation(instrumentationFactory);
+
+    /// <inheritdoc/>
+    LoggerProviderBuilder IDeferredLoggerProviderBuilder.Configure(Action<IServiceProvider, LoggerProviderBuilder> configure)
+    {
+        return ((IDeferredLoggerProviderBuilder)this.innerBuiler).Configure(configure);
+    }
+
+    /// <inheritdoc/>
+    LoggerProviderBuilder ILoggerProviderBuilder.ConfigureServices(Action<IServiceCollection> configure)
+    {
+        return this.innerBuiler.ConfigureServices(configure);
+    }
+}

--- a/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggingExtensions.cs
+++ b/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggingExtensions.cs
@@ -40,8 +40,8 @@ public static class OpenTelemetryLoggingExtensions
     /// will be created for a given <see cref="IServiceCollection"/>.
     /// </remarks>
     /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
-    /// <returns>The supplied <see cref="ILoggingBuilder"/> for call chaining.</returns>
-    public static ILoggingBuilder AddOpenTelemetry(
+    /// <returns><see cref="OpenTelemetryLoggingBuilder"/>.</returns>
+    public static OpenTelemetryLoggingBuilder AddOpenTelemetry(
         this ILoggingBuilder builder)
     {
         Guard.ThrowIfNull(builder);
@@ -51,6 +51,7 @@ public static class OpenTelemetryLoggingExtensions
         // Note: This will bind logger options element (eg "Logging:OpenTelemetry") to OpenTelemetryLoggerOptions
         LoggerProviderOptions.RegisterProviderOptions<OpenTelemetryLoggerOptions, OpenTelemetryLoggerProvider>(builder.Services);
 
+        // Note: This is to support legacy AddProcessor & SetResourceBuilder APIs on OpenTelemetryLoggerOptions
         new LoggerProviderServiceCollectionBuilder(builder.Services).ConfigureBuilder(
             (sp, logging) =>
             {
@@ -78,7 +79,7 @@ public static class OpenTelemetryLoggingExtensions
                     sp.GetRequiredService<IOptionsMonitor<OpenTelemetryLoggerOptions>>().CurrentValue,
                     disposeProvider: false)));
 
-        return builder;
+        return new OpenTelemetryLoggingBuilder(builder.Services);
     }
 
     /// <summary>
@@ -87,8 +88,8 @@ public static class OpenTelemetryLoggingExtensions
     /// <remarks><inheritdoc cref="AddOpenTelemetry(ILoggingBuilder)" path="/remarks"/></remarks>
     /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
     /// <param name="configure">Optional configuration action.</param>
-    /// <returns>The supplied <see cref="ILoggingBuilder"/> for call chaining.</returns>
-    public static ILoggingBuilder AddOpenTelemetry(
+    /// <returns><see cref="OpenTelemetryLoggingBuilder"/>.</returns>
+    public static OpenTelemetryLoggingBuilder AddOpenTelemetry(
         this ILoggingBuilder builder,
         Action<OpenTelemetryLoggerOptions>? configure)
     {


### PR DESCRIPTION
Relates to #4433
Relates to #4502

## Changes

* Introduce `OpenTelemetryLoggingBuilder` as the thing returned by the `ILoggingBuilder.AddOpenTelemetry` extension
* Introduce `LoggerProviderBuilder.ConfigureLoggerOptions` extension for configuring `OpenTelemetryLoggerOptions`

## Details

Today we configure logging like this:

```csharp
appBuilder.Logging.AddOpenTelemetry(options =>
{
   options.IncludeFormattedMessage = true;
   options.AddConsoleExporter();
});
```

"options" is `OpenTelemetryLoggerOptions` class.

Now the OpenTelemetry Specification has `LoggerProvider` and we have a `LoggerProviderBuilder` API. The SDK `LoggerProvider` is fed into the `ILogger` integration (`OpenTelemetryLoggerProvider`).

There are different ways we could approach this. Today we have extensions for logging that target `OpenTelemetryLoggerOptions`. We will need to target `LoggerProviderBuilder` now. We could forever have two versions of every extension, but that seems lame.

This PR is adding a new class `OpenTelemetryLoggingBuilder` to try and bridge the two worlds. Previously the `ILoggingBuilder.AddOpenTelemetry` extension returned the `ILoggingBuilder` passed into the call. Now it returns `OpenTelemetryLoggingBuilder` which implements `ILoggingBuilder`. This shouldn't be a source breaking change. It may be a binary breaking change, need to investigate that. `OpenTelemetryLoggerOptions.AddProcessor` and `OpenTelemetryLoggerOptions.SetResourceBuilder` methods would be obsoleted as would our existing extensions on `OpenTelemetryLoggerOptions`.

All of these styles can be interchanged.

```csharp
// Configure OTel via ILoggingBuilder
appBuilder.Logging
   .AddOpenTelemetry(options=> options.IncludeFormattedMessage = true)
   .AddConsoleExporter();
```

```csharp
// Configure OTel via OpenTelemetryBuilder
appBuilder.Services
   .AddOpenTelemetry()
   .WithLogging(builder => builder
      .ConfigureLoggerOptions(options => options.IncludeFormattedMessage = true)
      .AddConsoleExporter());
```

```csharp
// Configure OTel via OpenTelemetryBuilder
appBuilder.Services
   .AddOpenTelemetry()
   .WithLogging(builder => builder.AddConsoleExporter());

// Configure ILogger options via Options API
appBuilder.Services.Configure<OpenTelemetryLoggerOptions>(options => options.IncludeFormattedMessage = true);
```

```csharp
// Configure OTel via ILoggingBuilder
appBuilder.Logging
   .AddOpenTelemetry().AddConsoleExporter());

// Configure ILogger options via Options API
appBuilder.Services.Configure<OpenTelemetryLoggerOptions>(options => options.IncludeFormattedMessage = true);
```

## Considerations

Today you can do this:

```csharp
appBuilder.Logging.AddOpenTelemetry().AddEventSource();
```

Which is to chain calls on the `ILoggerBuilder`.

The signature of `OpenTelemetryLoggingBuilder` has `OpenTelemetryLoggingBuilder : LoggerProviderBuilder, ILoggingBuilder`. The reason for implementing `ILoggingBuilder` is so that the above code does not break on upgrade.

If users update their code like this...

```csharp
appBuilder.Logging
   .AddOpenTelemetry().AddConsoleExporter()
   .AddEventSource(); // This won't compile because AddConsoleExporter breaks the chain
```

Basically they will have to reorder things.

```csharp
appBuilder.Logging
   .AddEventSource()
   .AddOpenTelemetry().AddConsoleExporter();
```

Or

```csharp
appBuilder.Logging.AddOpenTelemetry().AddConsoleExporter();
appBuilder.Logging.AddEventSource()   
```

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
