### PR TITLE
Console exporter: Display exponential histogram boundaries

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -146,8 +146,21 @@ namespace OpenTelemetry.Exporter
                         }
                         else
                         {
-                            // TODO: Consider how/if to display buckets for exponential histograms.
-                            bucketsBuilder.AppendLine("Buckets are not displayed for exponential histograms.");
+                            var exponentialHistogramData = metricPoint.GetExponentialHistogramData();
+                            var scale = exponentialHistogramData.Scale;
+
+                            if (exponentialHistogramData.ZeroCount != 0)
+                            {
+                                bucketsBuilder.AppendLine($"Zero Bucket, Count: {exponentialHistogramData.ZeroCount}");
+                            }
+
+                            var offset = exponentialHistogramData.PositiveBuckets.Offset;
+                            foreach (var bucketCount in exponentialHistogramData.PositiveBuckets)
+                            {
+                                var lowerBound = Base2ExponentialBucketHistogram.LowerBoundary(offset, scale).ToString(CultureInfo.InvariantCulture);
+                                var upperBound = Base2ExponentialBucketHistogram.LowerBoundary(++offset, scale).ToString(CultureInfo.InvariantCulture);
+                                bucketsBuilder.AppendLine($"Bucket ({lowerBound}, {upperBound}], Count: {bucketCount}");
+                            }
                         }
 
                         valueDisplay = bucketsBuilder.ToString();

--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -151,7 +151,7 @@ namespace OpenTelemetry.Exporter
 
                             if (exponentialHistogramData.ZeroCount != 0)
                             {
-                                bucketsBuilder.AppendLine($"Zero Bucket, Count: {exponentialHistogramData.ZeroCount}");
+                                bucketsBuilder.AppendLine($"Zero Bucket:{exponentialHistogramData.ZeroCount}");
                             }
 
                             var offset = exponentialHistogramData.PositiveBuckets.Offset;
@@ -159,7 +159,7 @@ namespace OpenTelemetry.Exporter
                             {
                                 var lowerBound = Base2ExponentialBucketHistogram.LowerBoundary(offset, scale).ToString(CultureInfo.InvariantCulture);
                                 var upperBound = Base2ExponentialBucketHistogram.LowerBoundary(++offset, scale).ToString(CultureInfo.InvariantCulture);
-                                bucketsBuilder.AppendLine($"Bucket ({lowerBound}, {upperBound}], Count: {bucketCount}");
+                                bucketsBuilder.AppendLine($"({lowerBound}, {upperBound}]:{bucketCount}");
                             }
                         }
 

--- a/src/OpenTelemetry.Exporter.Console/OpenTelemetry.Exporter.Console.csproj
+++ b/src/OpenTelemetry.Exporter.Console/OpenTelemetry.Exporter.Console.csproj
@@ -28,6 +28,7 @@
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\OpenTelemetrySdkEventSource.cs" Link="Includes\OpenTelemetrySdkEventSource.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\PeriodicExportingMetricReaderHelper.cs" Link="Includes\PeriodicExportingMetricReaderHelper.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\TagTransformer.cs" Link="Includes\TagTransformer.cs" />
+    <Compile Include="$(RepoRoot)\src\OpenTelemetry\Metrics\Base2ExponentialBucketHistogram.LowerBoundary.cs" Link="Includes\Base2ExponentialBucketHistogram.LowerBoundary.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\ExceptionExtensions.cs" Link="Includes\ExceptionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\SpanAttributeConstants.cs" Link="Includes\SpanAttributeConstants.cs" />


### PR DESCRIPTION
Reopening #4344

The `LowerBoundary` implementation used in this PR was separately implemented in #4465.`LowerBoundary` just as with the inverse `MapToIndex` can result in some precision loss at positive scales, so recorded values very close to a bucket boundary may not be accurately mapped.

### Example Code

```csharp
var histogram = meter.CreateHistogram<double>("histogram");
histogram.Record(0);
histogram.Record(1000);
histogram.Record(1000.01);
```

### Output from console exporter

```text
Export histogram, Meter: TestMeter
(2023-05-18T19:08:04.9403420Z, 2023-05-18T19:08:04.9464400Z] ExponentialHistogram
Value: Sum: 2000.01 Count: 3 Min: 0 Max: 1000.01 
Zero Bucket:1
(999.9998532010651, 1000.0005142378502]:1
(1000.0005142378502, 1000.0011752750722]:0
(1000.0011752750722, 1000.0018363127313]:0
(1000.0018363127313, 1000.0024973508272]:0
(1000.0024973508272, 1000.0031583893601]:0
(1000.0031583893601, 1000.0038194283301]:0
(1000.0038194283301, 1000.004480467737]:0
(1000.004480467737, 1000.0051415075809]:0
(1000.0051415075809, 1000.0058025478617]:0
(1000.0058025478617, 1000.0064635885795]:0
(1000.0064635885795, 1000.0071246297343]:0
(1000.0071246297343, 1000.007785671326]:0
(1000.007785671326, 1000.0084467133548]:0
(1000.0084467133548, 1000.0091077558196]:0
(1000.0091077558196, 1000.0097687987222]:0
(1000.0097687987222, 1000.010429842062]:1
```