### PR TITLE
[di] Expose a detached TracerProviderBuilder extension on IServiceCollection which may modify services.

### DIFF
--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+static OpenTelemetry.Trace.OpenTelemetryDependencyInjectionTracingServiceCollectionExtensions.ConfigureOpenTelemetryTracerProvider(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<OpenTelemetry.Trace.TracerProviderBuilder!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+static OpenTelemetry.Trace.OpenTelemetryDependencyInjectionTracingServiceCollectionExtensions.ConfigureOpenTelemetryTracerProvider(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<OpenTelemetry.Trace.TracerProviderBuilder!>! configure) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
@@ -8,6 +8,12 @@
   `TracerProvider`.
   ([#4468](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4468))
 
+* Added an `IServiceCollection.ConfigureOpenTelemetryTracerProvider` overload
+  which may be used to configure `TracerProviderBuilder`s while the
+  `IServiceCollection` is modifiable (before the `IServiceProvider` has been
+  created).
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.5.0-alpha.2
 
 Released 2023-Mar-31

--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
@@ -12,7 +12,7 @@
   which may be used to configure `TracerProviderBuilder`s while the
   `IServiceCollection` is modifiable (before the `IServiceProvider` has been
   created).
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#4508](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4508))
 
 ## 1.5.0-alpha.2
 

--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/Trace/OpenTelemetryDependencyInjectionTracingServiceCollectionExtensions.cs
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/Trace/OpenTelemetryDependencyInjectionTracingServiceCollectionExtensions.cs
@@ -35,13 +35,12 @@ public static class OpenTelemetryDependencyInjectionTracingServiceCollectionExte
     /// Each registered configuration action will be applied
     /// sequentially.</item>
     /// <item>A <see cref="TracerProvider"/> will NOT be created automatically
-    /// using this method. To begin collecting metrics use the
+    /// using this method. To begin collecting traces use the
     /// <c>IServiceCollection.AddOpenTelemetry</c> extension in the
     /// <c>OpenTelemetry.Extensions.Hosting</c> package.</item>
     /// </list>
     /// </remarks>
-    /// <param name="services">The <see cref="IServiceCollection" /> to add
-    /// services to.</param>
+    /// <param name="services"><see cref="IServiceCollection" />.</param>
     /// <param name="configure">Callback action to configure the <see
     /// cref="TracerProviderBuilder"/>.</param>
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls
@@ -70,7 +69,7 @@ public static class OpenTelemetryDependencyInjectionTracingServiceCollectionExte
     /// Each registered configuration action will be applied
     /// sequentially.</item>
     /// <item>A <see cref="TracerProvider"/> will NOT be created automatically
-    /// using this method. To begin collecting metrics use the
+    /// using this method. To begin collecting traces use the
     /// <c>IServiceCollection.AddOpenTelemetry</c> extension in the
     /// <c>OpenTelemetry.Extensions.Hosting</c> package.</item>
     /// <item>The supplied configuration delegate is called once the <see
@@ -81,8 +80,7 @@ public static class OpenTelemetryDependencyInjectionTracingServiceCollectionExte
     /// delegate.</item>
     /// </list>
     /// </remarks>
-    /// <param name="services">The <see cref="IServiceCollection" /> to add
-    /// services to.</param>
+    /// <param name="services"><see cref="IServiceCollection" />.</param>
     /// <param name="configure">Callback action to configure the <see
     /// cref="TracerProviderBuilder"/>.</param>
     /// <returns>The <see cref="IServiceCollection"/> so that additional calls

--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/Trace/OpenTelemetryDependencyInjectionTracingServiceCollectionExtensions.cs
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/Trace/OpenTelemetryDependencyInjectionTracingServiceCollectionExtensions.cs
@@ -26,9 +26,7 @@ public static class OpenTelemetryDependencyInjectionTracingServiceCollectionExte
 {
     /// <summary>
     /// Registers an action used to configure the OpenTelemetry <see
-    /// cref="TracerProviderBuilder"/> used to create the <see
-    /// cref="TracerProvider"/> for the <see cref="IServiceCollection"/> being
-    /// configured.
+    /// cref="TracerProviderBuilder"/>.
     /// </summary>
     /// <remarks>
     /// Notes:
@@ -36,7 +34,7 @@ public static class OpenTelemetryDependencyInjectionTracingServiceCollectionExte
     /// <item>This is safe to be called multiple times and by library authors.
     /// Each registered configuration action will be applied
     /// sequentially.</item>
-    /// <item>A <see cref="TracerProvider"/> will not be created automatically
+    /// <item>A <see cref="TracerProvider"/> will NOT be created automatically
     /// using this method. To begin collecting metrics use the
     /// <c>IServiceCollection.AddOpenTelemetry</c> extension in the
     /// <c>OpenTelemetry.Extensions.Hosting</c> package.</item>
@@ -50,20 +48,56 @@ public static class OpenTelemetryDependencyInjectionTracingServiceCollectionExte
     /// can be chained.</returns>
     public static IServiceCollection ConfigureOpenTelemetryTracerProvider(
         this IServiceCollection services,
-        Action<IServiceProvider, TracerProviderBuilder> configure)
+        Action<TracerProviderBuilder> configure)
     {
-        RegisterBuildAction(services, configure);
+        Guard.ThrowIfNull(services);
+        Guard.ThrowIfNull(configure);
+
+        configure(new TracerProviderServiceCollectionBuilder(services));
 
         return services;
     }
 
-    private static void RegisterBuildAction(IServiceCollection services, Action<IServiceProvider, TracerProviderBuilder> configure)
+    /// <summary>
+    /// Registers an action used to configure the OpenTelemetry <see
+    /// cref="TracerProviderBuilder"/> once the <see cref="IServiceProvider"/>
+    /// is available.
+    /// </summary>
+    /// <remarks>
+    /// Notes:
+    /// <list type="bullet">
+    /// <item>This is safe to be called multiple times and by library authors.
+    /// Each registered configuration action will be applied
+    /// sequentially.</item>
+    /// <item>A <see cref="TracerProvider"/> will NOT be created automatically
+    /// using this method. To begin collecting metrics use the
+    /// <c>IServiceCollection.AddOpenTelemetry</c> extension in the
+    /// <c>OpenTelemetry.Extensions.Hosting</c> package.</item>
+    /// <item>The supplied configuration delegate is called once the <see
+    /// cref="IServiceProvider"/> is available. Services may NOT be added to a
+    /// <see cref="TracerProviderBuilder"/> once the <see
+    /// cref="IServiceProvider"/> has been created. Many helper extensions
+    /// register services and may throw if invoked inside the configuration
+    /// delegate.</item>
+    /// </list>
+    /// </remarks>
+    /// <param name="services">The <see cref="IServiceCollection" /> to add
+    /// services to.</param>
+    /// <param name="configure">Callback action to configure the <see
+    /// cref="TracerProviderBuilder"/>.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that additional calls
+    /// can be chained.</returns>
+    public static IServiceCollection ConfigureOpenTelemetryTracerProvider(
+        this IServiceCollection services,
+        Action<IServiceProvider, TracerProviderBuilder> configure)
     {
         Guard.ThrowIfNull(services);
         Guard.ThrowIfNull(configure);
 
         services.AddSingleton<IConfigureTracerProviderBuilder>(
             new ConfigureTracerProviderBuilderCallbackWrapper(configure));
+
+        return services;
     }
 
     private sealed class ConfigureTracerProviderBuilderCallbackWrapper : IConfigureTracerProviderBuilder

--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/Trace/TracerProviderServiceCollectionBuilder.cs
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/Trace/TracerProviderServiceCollectionBuilder.cs
@@ -19,7 +19,7 @@ using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Trace;
 
-internal class TracerProviderServiceCollectionBuilder : TracerProviderBuilder, ITracerProviderBuilder
+internal sealed class TracerProviderServiceCollectionBuilder : TracerProviderBuilder, ITracerProviderBuilder
 {
     public TracerProviderServiceCollectionBuilder(IServiceCollection services)
     {

--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/Trace/TracerProviderServiceCollectionBuilder.cs
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/Trace/TracerProviderServiceCollectionBuilder.cs
@@ -1,0 +1,107 @@
+// <copyright file="TracerProviderServiceCollectionBuilder.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Trace;
+
+internal class TracerProviderServiceCollectionBuilder : TracerProviderBuilder, ITracerProviderBuilder
+{
+    public TracerProviderServiceCollectionBuilder(IServiceCollection services)
+    {
+        services.ConfigureOpenTelemetryTracerProvider((sp, builder) => this.Services = null);
+
+        this.Services = services;
+    }
+
+    public IServiceCollection? Services { get; set; }
+
+    public TracerProvider? Provider => null;
+
+    /// <inheritdoc />
+    public override TracerProviderBuilder AddInstrumentation<TInstrumentation>(Func<TInstrumentation> instrumentationFactory)
+    {
+        Guard.ThrowIfNull(instrumentationFactory);
+
+        this.ConfigureBuilderInternal((sp, builder) =>
+        {
+            builder.AddInstrumentation(instrumentationFactory);
+        });
+
+        return this;
+    }
+
+    /// <inheritdoc />
+    public override TracerProviderBuilder AddSource(params string[] names)
+    {
+        Guard.ThrowIfNull(names);
+
+        this.ConfigureBuilderInternal((sp, builder) =>
+        {
+            builder.AddSource(names);
+        });
+
+        return this;
+    }
+
+    /// <inheritdoc />
+    public override TracerProviderBuilder AddLegacySource(string operationName)
+    {
+        Guard.ThrowIfNullOrWhitespace(operationName);
+
+        this.ConfigureBuilderInternal((sp, builder) =>
+        {
+            builder.AddLegacySource(operationName);
+        });
+
+        return this;
+    }
+
+    /// <inheritdoc />
+    public TracerProviderBuilder ConfigureServices(Action<IServiceCollection> configure)
+        => this.ConfigureServicesInternal(configure);
+
+    /// <inheritdoc cref="IDeferredTracerProviderBuilder.Configure" />
+    public TracerProviderBuilder ConfigureBuilder(Action<IServiceProvider, TracerProviderBuilder> configure)
+        => this.ConfigureBuilderInternal(configure);
+
+    /// <inheritdoc />
+    TracerProviderBuilder IDeferredTracerProviderBuilder.Configure(Action<IServiceProvider, TracerProviderBuilder> configure)
+        => this.ConfigureBuilderInternal(configure);
+
+    private TracerProviderBuilder ConfigureBuilderInternal(Action<IServiceProvider, TracerProviderBuilder> configure)
+    {
+        var services = this.Services
+            ?? throw new NotSupportedException("Builder cannot be configured during TracerProvider construction.");
+
+        services.ConfigureOpenTelemetryTracerProvider(configure);
+
+        return this;
+    }
+
+    private TracerProviderBuilder ConfigureServicesInternal(Action<IServiceCollection> configure)
+    {
+        Guard.ThrowIfNull(configure);
+
+        var services = this.Services
+            ?? throw new NotSupportedException("Services cannot be configured during TracerProvider construction.");
+
+        configure(services);
+
+        return this;
+    }
+}


### PR DESCRIPTION
Fixes #4503

## Changes

* Adds an overload to the `IServiceCollection.ConfigureOpenTelemetryTracerProvider` extension which doesn't require `IServiceProvider` and allows for `IServiceCollection` modification.

## Public API Changes

```diff
namespace OpenTelemetry.Trace
{
   public static class OpenTelemetryDependencyInjectionTracingServiceCollectionExtensions
   {
+     public static IServiceCollection ConfigureOpenTelemetryTracerProvider(this IServiceCollection services, Action<TracerProviderBuilder> configure) {}
   }
}
```

## Details

We have this pattern for configuring providers using the `IServiceCollection`: https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/trace/extending-the-sdk#iservicecollection-extension-methods

We refer to this as "detached" configuration.

Today the API passes the `IServiceProvider` to the configuration delegate.

This type of stuff will work fine:

```csharp
services.ConfigureOpenTelemetryTracerProvider((sp, builder) =>
{
   builder.AddSource("MyLibrary");
   builder.AddProcessor(sp.GetRequiredService<MyProcessor>());
});
```

This will throw a NotSupportedException:

```csharp
services.ConfigureOpenTelemetryTracerProvider((sp, builder) =>
{
   builder.ConfigureServices(services => {}); // Throws
   builder.AddProcessor<MyProcessor>(); // Throws
});
```

The reason for that is once the `IServiceProvider` is available, we can no longer add services.

#4503 shows some users want to do detached things but don't really care about the `IServiceProvider`.

```csharp
services.ConfigureOpenTelemetryTracerProvider((sp, builder) => 
   builder.AddOtlpExporter()); // Throws because AddOtlpExporter registers services
```

What this PR does is add a detached extension which may modify services.

```csharp
services.ConfigureOpenTelemetryTracerProvider(builder => 
   builder.AddOtlpExporter()); // Works using this new API
```

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
