### PR TITLE
Support custom header in JaegerPropagator

### DIFF
--- a/src/OpenTelemetry.Extensions.Propagators/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions.Propagators/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+OpenTelemetry.Extensions.Propagators.JaegerPropagator.JaegerPropagator(string jaegerHeader) -> void

--- a/src/OpenTelemetry.Extensions.Propagators/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions.Propagators/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+OpenTelemetry.Extensions.Propagators.JaegerPropagator.JaegerPropagator(string jaegerHeader) -> void

--- a/src/OpenTelemetry.Extensions.Propagators/JaegerPropagator.cs
+++ b/src/OpenTelemetry.Extensions.Propagators/JaegerPropagator.cs
@@ -38,7 +38,7 @@ public class JaegerPropagator : TextMapPropagator
 
     /// <summary>
     /// Initializes a new instance of the <see cref="JaegerPropagator"/> class.
-    /// Uses the default header value uber-trace-id.
+    /// Uses the default header uber-trace-id.
     /// </summary>
     public JaegerPropagator()
         : this("uber-trace-id")

--- a/src/OpenTelemetry.Extensions.Propagators/JaegerPropagator.cs
+++ b/src/OpenTelemetry.Extensions.Propagators/JaegerPropagator.cs
@@ -25,7 +25,6 @@ namespace OpenTelemetry.Extensions.Propagators;
 /// </summary>
 public class JaegerPropagator : TextMapPropagator
 {
-    internal const string JaegerHeader = "uber-trace-id";
     internal const string JaegerDelimiter = ":";
     internal const string JaegerDelimiterEncoded = "%3A"; // while the spec defines the delimiter as a ':', some clients will url encode headers.
     internal const string SampledValue = "1";
@@ -35,8 +34,28 @@ public class JaegerPropagator : TextMapPropagator
     private static readonly int TraceId128BitLength = "0af7651916cd43dd8448eb211c80319c".Length;
     private static readonly int SpanIdLength = "00f067aa0ba902b7".Length;
 
+    private readonly string jaegerHeader;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JaegerPropagator"/> class.
+    /// Uses the default header value uber-trace-id.
+    /// </summary>
+    public JaegerPropagator()
+        : this("uber-trace-id")
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JaegerPropagator"/> class.
+    /// </summary>
+    /// <param name="jaegerHeader">Customization of the jeager header.</param>
+    public JaegerPropagator(string jaegerHeader)
+    {
+        this.jaegerHeader = jaegerHeader;
+    }
+
     /// <inheritdoc/>
-    public override ISet<string> Fields => new HashSet<string> { JaegerHeader };
+    public override ISet<string> Fields => new HashSet<string> { this.jaegerHeader };
 
     /// <inheritdoc/>
     public override PropagationContext Extract<T>(PropagationContext context, T carrier, Func<T, string, IEnumerable<string>> getter)
@@ -61,7 +80,7 @@ public class JaegerPropagator : TextMapPropagator
 
         try
         {
-            var jaegerHeaderCollection = getter(carrier, JaegerHeader);
+            var jaegerHeaderCollection = getter(carrier, this.jaegerHeader);
             var jaegerHeader = jaegerHeaderCollection?.First();
 
             if (string.IsNullOrWhiteSpace(jaegerHeader))
@@ -123,7 +142,7 @@ public class JaegerPropagator : TextMapPropagator
             defaultParentSpanId,
             flags);
 
-        setter(carrier, JaegerHeader, jaegerTrace);
+        setter(carrier, this.jaegerHeader, jaegerTrace);
     }
 
     internal static bool TryExtractTraceContext(string jaegerHeader, out ActivityTraceId traceId, out ActivitySpanId spanId, out ActivityTraceFlags traceOptions)


### PR DESCRIPTION
Fixes #3836 

This PR allows setting a custom jaeger header name in the JaegerPropagator, e.g. _jaeger-trace-id_ instead of _uber-trace-id_.

The outdated C# Client for Jaeger supported a custom header names by providing a method [WithSpanContextKey](https://github.com/jaegertracing/jaeger-client-csharp/blob/a29d3fe4ae16d01d94fd57e4134f065fa5805cac/src/Jaeger.Core/Propagation/TextMapCodec.cs#L156). This PR will add support for that as well. [Link to a test in the C# Client for Jaeger](https://github.com/jaegertracing/jaeger-client-csharp/blob/a29d3fe4ae16d01d94fd57e4134f065fa5805cac/test/Jaeger.Core.Tests/Propagation/TextMapCodecTests.cs#L13) which checks the header "jaeger-trace-id".

## Changes
- Add second constructor which allows changing the jaeger header name
- Add unit tests

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
