### PR TITLE
[AOT] Resolve Trimming warnings in ActivityInstrumentationHelper

### DIFF
--- a/src/OpenTelemetry/Internal/ActivityInstrumentationHelper.cs
+++ b/src/OpenTelemetry/Internal/ActivityInstrumentationHelper.cs
@@ -16,6 +16,7 @@
 
 using System.Diagnostics;
 using System.Linq.Expressions;
+using System.Reflection;
 #pragma warning restore IDE0005
 
 namespace OpenTelemetry.Instrumentation
@@ -29,7 +30,8 @@ namespace OpenTelemetry.Instrumentation
         {
             ParameterExpression instance = Expression.Parameter(typeof(Activity), "instance");
             ParameterExpression propertyValue = Expression.Parameter(typeof(ActivitySource), "propertyValue");
-            var body = Expression.Assign(Expression.Property(instance, "Source"), propertyValue);
+            PropertyInfo sourcePropertyInfo = typeof(Activity).GetProperty("Source");
+            var body = Expression.Assign(Expression.Property(instance, sourcePropertyInfo), propertyValue);
             return Expression.Lambda<Action<Activity, ActivitySource>>(body, instance, propertyValue).Compile();
         }
 
@@ -37,7 +39,8 @@ namespace OpenTelemetry.Instrumentation
         {
             ParameterExpression instance = Expression.Parameter(typeof(Activity), "instance");
             ParameterExpression propertyValue = Expression.Parameter(typeof(ActivityKind), "propertyValue");
-            var body = Expression.Assign(Expression.Property(instance, "Kind"), propertyValue);
+            PropertyInfo kindPropertyInfo = typeof(Activity).GetProperty("Kind");
+            var body = Expression.Assign(Expression.Property(instance, kindPropertyInfo), propertyValue);
             return Expression.Lambda<Action<Activity, ActivityKind>>(body, instance, propertyValue).Compile();
         }
     }

--- a/test/OpenTelemetry.AotCompatibility.Tests/AotCompatibilityTests.cs
+++ b/test/OpenTelemetry.AotCompatibility.Tests/AotCompatibilityTests.cs
@@ -85,7 +85,7 @@ namespace OpenTelemetry.AotCompatibility.Tests
             Assert.True(process.ExitCode == 0, "Publishing the AotCompatibility app failed. See test output for more details.");
 
             var warnings = expectedOutput.ToString().Split('\n', '\r').Where(line => line.Contains("warning IL"));
-            Assert.Equal(58, warnings.Count());
+            Assert.Equal(48, warnings.Count());
         }
     }
 }


### PR DESCRIPTION
The trimming tool can't tell which type Expression.Property(Expression, string propertyName) refers to, so it isn't able to preserve the referenced property.

The workaround is to explicitly reference the PropertyInfo from the static type, which the trimmer can see and knows to preserve the property.

Contributes to #3429

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
