### PR TITLE
[Sdk] TracerProviderBuilderBase chained/fluent call fix

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -6,7 +6,7 @@
   [#4508](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4508) in
   1.5.0-rc.1 which caused the "Build" extension to return `null` when performing
   chained/fluent calls.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#4529](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4529))
 
 ## 1.5.0-rc.1
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+* Fixed a bug introduced by
+  [#4508](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4508) in
+  1.5.0-rc.1 which caused the "Build" extension to return `null` when performing
+  chained/fluent calls.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.5.0-rc.1
 
 Released 2023-May-25

--- a/src/OpenTelemetry/Trace/Builder/TracerProviderBuilderBase.cs
+++ b/src/OpenTelemetry/Trace/Builder/TracerProviderBuilderBase.cs
@@ -90,11 +90,19 @@ public class TracerProviderBuilderBase : TracerProviderBuilder, ITracerProviderB
 
     /// <inheritdoc />
     TracerProviderBuilder ITracerProviderBuilder.ConfigureServices(Action<IServiceCollection> configure)
-        => this.innerBuilder.ConfigureServices(configure);
+    {
+        this.innerBuilder.ConfigureServices(configure);
+
+        return this;
+    }
 
     /// <inheritdoc />
     TracerProviderBuilder IDeferredTracerProviderBuilder.Configure(Action<IServiceProvider, TracerProviderBuilder> configure)
-        => this.innerBuilder.ConfigureBuilder(configure);
+    {
+        this.innerBuilder.ConfigureBuilder(configure);
+
+        return this;
+    }
 
     internal TracerProvider InvokeBuild()
         => this.Build();
@@ -115,7 +123,7 @@ public class TracerProviderBuilderBase : TracerProviderBuilder, ITracerProviderB
         Guard.ThrowIfNullOrWhitespace(instrumentationVersion);
         Guard.ThrowIfNull(instrumentationFactory);
 
-        return this.innerBuilder.ConfigureBuilder((sp, builder) =>
+        this.innerBuilder.ConfigureBuilder((sp, builder) =>
         {
             if (builder is TracerProviderBuilderSdk tracerProviderBuilderState)
             {
@@ -125,6 +133,8 @@ public class TracerProviderBuilderBase : TracerProviderBuilder, ITracerProviderB
                     instrumentationFactory);
             }
         });
+
+        return this;
     }
 
     /// <summary>
@@ -138,12 +148,8 @@ public class TracerProviderBuilderBase : TracerProviderBuilder, ITracerProviderB
             throw new NotSupportedException("A TracerProviderBuilder bound to external service cannot be built directly. Access the TracerProvider using the application IServiceProvider instead.");
         }
 
-        var services = this.innerBuilder.Services;
-
-        if (services == null)
-        {
-            throw new NotSupportedException("TracerProviderBuilder build method cannot be called multiple times.");
-        }
+        var services = this.innerBuilder.Services
+            ?? throw new NotSupportedException("TracerProviderBuilder build method cannot be called multiple times.");
 
         this.innerBuilder.Services = null;
 


### PR DESCRIPTION
Relates to #4508

## Changes

* Fixes a bug introduced on #4508 that the caused the type of builder to change which broke the `Build` extension [expecting the type to be TracerProviderBuilderBase](https://github.com/open-telemetry/opentelemetry-dotnet/blob/64df5e3df8db55e4da482e577c3524b53213f4b2/src/OpenTelemetry/Trace/Builder/TracerProviderBuilderExtensions.cs#L245).

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes

