### PR TITLE
Add api-version support

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Added [api-versioning](https://github.com/dotnet/aspnet-api-versioning/wiki) support
+  [#2967](https://github.com/open-telemetry/opentelemetry-dotnet/issues/2967), [4525](https://github.com/open-telemetry/opentelemetry-dotnet/issues/4525)
+
 ## 1.5.0-rc.1
 
 Released 2023-May-25

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -4,5 +4,7 @@
     <PackageVersion Update="Grpc.Tools" Version="[2.44.0,3.0)" />
     <PackageVersion Update="Microsoft.Extensions.Logging" Version="[6.0.0,)" />
     <PackageVersion Update="System.Text.Json" Version="6.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
   </ItemGroup>
 </Project>

--- a/test/TestApp.AspNetCore/Controllers/ChildActivityController.cs
+++ b/test/TestApp.AspNetCore/Controllers/ChildActivityController.cs
@@ -20,8 +20,10 @@ using OpenTelemetry;
 
 namespace TestApp.AspNetCore.Controllers
 {
+    [ApiController]
     public class ChildActivityController : Controller
     {
+        [ApiVersionNeutral]
         [HttpGet]
         [Route("api/GetChildActivityTraceContext")]
         public Dictionary<string, string> GetChildActivityTraceContext()

--- a/test/TestApp.AspNetCore/Controllers/V1/ApiVersioningController.cs
+++ b/test/TestApp.AspNetCore/Controllers/V1/ApiVersioningController.cs
@@ -1,4 +1,4 @@
-// <copyright file="ErrorController.cs" company="OpenTelemetry Authors">
+// <copyright file="ValuesController.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,18 +15,27 @@
 // </copyright>
 using Microsoft.AspNetCore.Mvc;
 
-namespace TestApp.AspNetCore.Controllers
+namespace TestApp.AspNetCore.Controllers.V1
 {
     [ApiController]
-    [ApiVersionNeutral]
-    [Route("api/[controller]")]
-    public class ErrorController : Controller
+    [Route("api/v{version:apiVersion}/[controller]")]
+    [ApiVersion("1.0")]
+    public class ApiVersioningController : Controller
     {
-        // GET api/error
+        // GET api/v1/apiVersion
         [HttpGet]
+        [MapToApiVersion("1.0")]
         public string Get()
         {
-            throw new Exception("something's wrong!");
+            return "version 1";
+        }
+
+        // GET api/v1/apiVersion/42
+        [HttpGet("{id}")]
+        [MapToApiVersion("1.0")]
+        public string Get(int id)
+        {
+            return $"version 1 (id = {id})";
         }
     }
 }

--- a/test/TestApp.AspNetCore/Controllers/V2/ApiVersioningController.cs
+++ b/test/TestApp.AspNetCore/Controllers/V2/ApiVersioningController.cs
@@ -1,4 +1,4 @@
-// <copyright file="ErrorController.cs" company="OpenTelemetry Authors">
+// <copyright file="ValuesController.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,18 +15,27 @@
 // </copyright>
 using Microsoft.AspNetCore.Mvc;
 
-namespace TestApp.AspNetCore.Controllers
+namespace TestApp.AspNetCore.Controllers.V2
 {
     [ApiController]
-    [ApiVersionNeutral]
-    [Route("api/[controller]")]
-    public class ErrorController : Controller
+    [Route("api/v{version:apiVersion}/[controller]")]
+    [ApiVersion("2.0")]
+    public class ApiVersioningController : Controller
     {
-        // GET api/error
+        // GET api/v2/apiVersion
         [HttpGet]
+        [MapToApiVersion("2.0")]
         public string Get()
         {
-            throw new Exception("something's wrong!");
+            return "version 2";
+        }
+
+        // GET api/v2/apiVersion/42
+        [HttpGet("{id}")]
+        [MapToApiVersion("2.0")]
+        public string Get(int id)
+        {
+            return $"version 2 (id = {id})";
         }
     }
 }

--- a/test/TestApp.AspNetCore/Controllers/ValuesController.cs
+++ b/test/TestApp.AspNetCore/Controllers/ValuesController.cs
@@ -17,6 +17,8 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace TestApp.AspNetCore.Controllers
 {
+    [ApiController]
+    [ApiVersionNeutral]
     [Route("api/[controller]")]
     public class ValuesController : Controller
     {

--- a/test/TestApp.AspNetCore/Swagger/ConfigureSwaggerOptions.cs
+++ b/test/TestApp.AspNetCore/Swagger/ConfigureSwaggerOptions.cs
@@ -1,0 +1,61 @@
+// <copyright file="ConfigureSwaggerOptions.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.Extensions.Options;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace TestApp.AspNetCore.Swagger
+{
+    public sealed class ConfigureSwaggerOptions : IConfigureNamedOptions<SwaggerGenOptions>
+    {
+        private readonly IApiVersionDescriptionProvider provider;
+
+        public ConfigureSwaggerOptions(IApiVersionDescriptionProvider provider)
+        {
+            this.provider = provider ?? throw new ArgumentNullException(nameof(provider));
+        }
+
+        public void Configure(string? name, SwaggerGenOptions options)
+        {
+            this.Configure(options);
+        }
+
+        public void Configure(SwaggerGenOptions options)
+        {
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            // Add swagger document for every API version discovered
+            foreach (var description in this.provider.ApiVersionDescriptions)
+            {
+                options.SwaggerDoc(description.GroupName, CreateApiVersion(description));
+            }
+        }
+
+        private static OpenApiInfo CreateApiVersion(ApiVersionDescription description)
+        {
+            return new OpenApiInfo
+            {
+                Title = "TestApp.AspNetCore",
+                Version = description.ApiVersion.ToString(),
+            };
+        }
+    }
+}

--- a/test/TestApp.AspNetCore/TestApp.AspNetCore.csproj
+++ b/test/TestApp.AspNetCore/TestApp.AspNetCore.csproj
@@ -5,6 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
   </ItemGroup>
 


### PR DESCRIPTION
When using a versioned API with `Microsoft.AspNetCore.Mvc.Versioning` nuget package, the `{version:apiVersion}` is not replaced with the real controller version.

Discussion issue #2967 & #4525

## Changes

- Update `OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs` in order to replace `{version:apiVersion}` url segment with the real controller version.
- Add ApiVersioning support & ApiVersioningControllers in `TestApp.AspNetCore` project

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes

This is my first PR here, hope all is fine :)
Any feedback about my proposal is welcome.