### PR TITLE
[AOT] Resolve ConfigurationExtensions and EventSource warnings

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/AspNetCoreInstrumentationEventSource.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/AspNetCoreInstrumentationEventSource.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 // </copyright>
 
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;
 using OpenTelemetry.Internal;
 
@@ -57,12 +58,14 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
             this.WriteEvent(2, handlerName, eventName, operationName);
         }
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "Parameters to this method are primitive and are trimmer safe.")]
         [Event(3, Message = "Filter threw exception, request will not be collected. HandlerName: '{0}', EventName: '{1}', OperationName: '{2}', Exception: {3}.", Level = EventLevel.Error)]
         public void RequestFilterException(string handlerName, string eventName, string operationName, string exception)
         {
             this.WriteEvent(3, handlerName, eventName, operationName, exception);
         }
 
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "Parameters to this method are primitive and are trimmer safe.")]
         [Event(4, Message = "Enrich threw exception. HandlerName: '{0}', EventName: '{1}', OperationName: '{2}', Exception: {3}.", Level = EventLevel.Warning)]
         public void EnrichmentException(string handlerName, string eventName, string operationName, string exception)
         {

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
@@ -15,6 +15,7 @@
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.GrpcNetClient\StatusCanonicalCode.cs" Link="Includes\StatusCanonicalCode.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\HttpSemanticConventionHelper.cs" Link="Includes\HttpSemanticConventionHelper.cs" />
+    <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\Shims\UnconditionalSuppressMessageAttribute.cs" Link="Includes\UnconditionalSuppressMessageAttribute.cs" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry/Internal/Options/ConfigurationExtensions.cs
+++ b/src/OpenTelemetry/Internal/Options/ConfigurationExtensions.cs
@@ -45,7 +45,7 @@ internal static class ConfigurationExtensions
 #endif
         out string? value)
     {
-        value = configuration.GetValue<string?>(key, null);
+        value = configuration[key] is string configValue ? configValue : null;
 
         return !string.IsNullOrWhiteSpace(value);
     }
@@ -125,7 +125,7 @@ internal static class ConfigurationExtensions
         Debug.Assert(services != null, "services was null");
         Debug.Assert(optionsFactoryFunc != null, "optionsFactoryFunc was null");
 
-        services!.TryAddSingleton<IOptionsFactory<T>>(sp =>
+        services.TryAddSingleton<IOptionsFactory<T>>(sp =>
         {
             return new DelegatingOptionsFactory<T>(
                 (c, n) => optionsFactoryFunc!(c),
@@ -146,7 +146,7 @@ internal static class ConfigurationExtensions
         Debug.Assert(services != null, "services was null");
         Debug.Assert(optionsFactoryFunc != null, "optionsFactoryFunc was null");
 
-        services!.TryAddSingleton<IOptionsFactory<T>>(sp =>
+        services.TryAddSingleton<IOptionsFactory<T>>(sp =>
         {
             return new DelegatingOptionsFactory<T>(
                 (c, n) => optionsFactoryFunc!(sp, c, n),

--- a/test/OpenTelemetry.AotCompatibility.Tests/AotCompatibilityTests.cs
+++ b/test/OpenTelemetry.AotCompatibility.Tests/AotCompatibilityTests.cs
@@ -81,7 +81,7 @@ namespace OpenTelemetry.AotCompatibility.Tests
             process.Start();
             process.BeginOutputReadLine();
 
-            Assert.True(process.WaitForExit(milliseconds: 180_000), "dotnet publish command timed out after 180 seconds.");
+            Assert.True(process.WaitForExit(milliseconds: 240_000), "dotnet publish command timed out after 240 seconds.");
             Assert.True(process.ExitCode == 0, "Publishing the AotCompatibility app failed. See test output for more details.");
 
             var warnings = expectedOutput.ToString().Split('\n', '\r').Where(line => line.Contains("warning IL"));

--- a/test/OpenTelemetry.AotCompatibility.Tests/AotCompatibilityTests.cs
+++ b/test/OpenTelemetry.AotCompatibility.Tests/AotCompatibilityTests.cs
@@ -85,7 +85,7 @@ namespace OpenTelemetry.AotCompatibility.Tests
             Assert.True(process.ExitCode == 0, "Publishing the AotCompatibility app failed. See test output for more details.");
 
             var warnings = expectedOutput.ToString().Split('\n', '\r').Where(line => line.Contains("warning IL"));
-            Assert.Equal(48, warnings.Count());
+            Assert.Equal(43, warnings.Count());
         }
     }
 }


### PR DESCRIPTION
- ConfigurationBinder.GetValue uses Reflection to bind IConfiguration values to strongly typed objects. ConfigurationExtensions.TryGetStringValue was using ConfigurationBinder to get a string value from IConfiguration, which is causing a warning. However, IConfiguration values are already strings, so this is unnecessary. It is also not performant because calling ConfigurationBinder allocates objects and uses TypeDescriptor.

- Additionally, suppress 2 EventSource warnings while I'm making changes.

Contributes to #3429

cc @Yun-Ting @vitek-karas