### PR TITLE
[hosting-logs] Don't register ILogger when calling WithLogging

### DIFF
--- a/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryBuilder.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryBuilder.cs
@@ -15,7 +15,6 @@
 // </copyright>
 
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
@@ -141,15 +140,9 @@ public sealed class OpenTelemetryBuilder
     /// Adds logging services into the builder.
     /// </summary>
     /// <remarks>
-    /// Notes:
-    /// <list type="bullet">
-    /// <item>This is safe to be called multiple times and by library authors.
+    /// Note: This is safe to be called multiple times and by library authors.
     /// Only a single <see cref="LoggerProvider"/> will be created for a given
-    /// <see cref="IServiceCollection"/>.</item>
-    /// <item>This operation enables <see cref="ILogger"/> integration
-    /// automatically by calling <see
-    /// cref="OpenTelemetryLoggingExtensions.AddOpenTelemetry(ILoggingBuilder)"/>.</item>
-    /// </list>
+    /// <see cref="IServiceCollection"/>.
     /// </remarks>
     /// <returns>The supplied <see cref="OpenTelemetryBuilder"/> for chaining
     /// calls.</returns>
@@ -167,9 +160,6 @@ public sealed class OpenTelemetryBuilder
     internal OpenTelemetryBuilder WithLogging(Action<LoggerProviderBuilder> configure)
     {
         Guard.ThrowIfNull(configure);
-
-        // Note: This enables ILogger integration
-        this.Services.AddLogging().AddOpenTelemetry();
 
         var builder = new LoggerProviderBuilderBase(this.Services);
 


### PR DESCRIPTION
Relates to #4433

## Changes

* Removes the auto-registration of OTel `ILoggerProvider` when calling `WithLogging`

## Details

@alanwest and I felt like this behavior needed more discussion.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
