### PR TITLE
[inmemory-exporter] Add extension on LoggerProviderBuilder

### DIFF
--- a/src/OpenTelemetry.Api/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Api/AssemblyInfo.cs
@@ -20,6 +20,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("OpenTelemetry.Api.ProviderBuilderExtensions" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry.Api.ProviderBuilderExtensions.Tests" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry.Api.Tests" + AssemblyInfo.PublicKey)]
+[assembly: InternalsVisibleTo("OpenTelemetry.Exporter.InMemory" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry.Extensions.Hosting" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry.Extensions.Hosting.Tests" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry.Shims.OpenTracing.Tests" + AssemblyInfo.PublicKey)]

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterLoggingExtensions.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterLoggingExtensions.cs
@@ -26,25 +26,48 @@ namespace OpenTelemetry.Logs
         /// </summary>
         /// <param name="loggerOptions"><see cref="OpenTelemetryLoggerOptions"/> options to use.</param>
         /// <param name="exportedItems">Collection which will be populated with the exported <see cref="LogRecord"/>.</param>
-        /// <returns>The instance of <see cref="OpenTelemetryLoggerOptions"/> to chain the calls.</returns>
-        public static OpenTelemetryLoggerOptions AddInMemoryExporter(this OpenTelemetryLoggerOptions loggerOptions, ICollection<LogRecord> exportedItems)
+        /// <returns>The supplied instance of <see cref="OpenTelemetryLoggerOptions"/> to chain the calls.</returns>
+        /// todo: [Obsolete("Call LoggerProviderBuilder.AddInMemoryExporter instead this method will be removed in a future version.")]
+        public static OpenTelemetryLoggerOptions AddInMemoryExporter(
+            this OpenTelemetryLoggerOptions loggerOptions,
+            ICollection<LogRecord> exportedItems)
         {
             Guard.ThrowIfNull(loggerOptions);
             Guard.ThrowIfNull(exportedItems);
 
-            var logExporter = new InMemoryExporter<LogRecord>(
-                exportFunc: (in Batch<LogRecord> batch) => ExportLogRecord(in batch, exportedItems));
+            var logExporter = BuildExporter(exportedItems);
 
-            return loggerOptions.AddProcessor(new SimpleLogRecordExportProcessor(logExporter));
+            return loggerOptions.AddProcessor(
+                new SimpleLogRecordExportProcessor(logExporter));
+        }
+
+        /// <summary>
+        /// Adds InMemory exporter to the LoggerProviderBuilder.
+        /// </summary>
+        /// <param name="loggerProviderBuilder"><see cref="LoggerProviderBuilder"/>.</param>
+        /// <param name="exportedItems">Collection which will be populated with the exported <see cref="LogRecord"/>.</param>
+        /// <returns>The supplied instance of <see cref="LoggerProviderBuilder"/> to chain the calls.</returns>
+        internal static LoggerProviderBuilder AddInMemoryExporter(
+            this LoggerProviderBuilder loggerProviderBuilder,
+            ICollection<LogRecord> exportedItems)
+        {
+            Guard.ThrowIfNull(loggerProviderBuilder);
+            Guard.ThrowIfNull(exportedItems);
+
+            var logExporter = BuildExporter(exportedItems);
+
+            return loggerProviderBuilder.AddProcessor(
+                new SimpleLogRecordExportProcessor(logExporter));
+        }
+
+        private static InMemoryExporter<LogRecord> BuildExporter(ICollection<LogRecord> exportedItems)
+        {
+            return new InMemoryExporter<LogRecord>(
+                exportFunc: (in Batch<LogRecord> batch) => ExportLogRecord(in batch, exportedItems));
         }
 
         private static ExportResult ExportLogRecord(in Batch<LogRecord> batch, ICollection<LogRecord> exportedItems)
         {
-            if (exportedItems == null)
-            {
-                return ExportResult.Failure;
-            }
-
             foreach (var log in batch)
             {
                 exportedItems.Add(log.Copy());

--- a/src/OpenTelemetry.Exporter.InMemory/OpenTelemetry.Exporter.InMemory.csproj
+++ b/src/OpenTelemetry.Exporter.InMemory/OpenTelemetry.Exporter.InMemory.csproj
@@ -20,7 +20,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Note: OpenTelemetry.Exporter.InMemory temporarily sees OpenTelemetry.Api internals for LoggerProviderBuilder
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\Guard.cs" Link="Includes\Guard.cs" />
+    -->
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Relates to #4433

## Changes

* Adds an extension for registering `InMemoryExporter` against a `LoggerProviderBuilder` instance

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
