### PR TITLE
[api-logs] Expose logging artifacts as public

### DIFF
--- a/src/OpenTelemetry.Api/.publicApi/net462/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/net462/PublicAPI.Shipped.txt
@@ -1,44 +1,45 @@
-abstract OpenTelemetry.Context.Propagation.TextMapPropagator.Extract<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> OpenTelemetry.Context.Propagation.PropagationContext
-abstract OpenTelemetry.Context.Propagation.TextMapPropagator.Fields.get -> System.Collections.Generic.ISet<string>
-abstract OpenTelemetry.Context.Propagation.TextMapPropagator.Inject<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
+#nullable enable
+~abstract OpenTelemetry.Context.Propagation.TextMapPropagator.Extract<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> OpenTelemetry.Context.Propagation.PropagationContext
+~abstract OpenTelemetry.Context.Propagation.TextMapPropagator.Fields.get -> System.Collections.Generic.ISet<string>
+~abstract OpenTelemetry.Context.Propagation.TextMapPropagator.Inject<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
 abstract OpenTelemetry.Context.RuntimeContextSlot<T>.Get() -> T
 abstract OpenTelemetry.Context.RuntimeContextSlot<T>.Set(T value) -> void
-abstract OpenTelemetry.Metrics.MeterProviderBuilder.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation> instrumentationFactory) -> OpenTelemetry.Metrics.MeterProviderBuilder
-abstract OpenTelemetry.Metrics.MeterProviderBuilder.AddMeter(params string[] names) -> OpenTelemetry.Metrics.MeterProviderBuilder
-abstract OpenTelemetry.Trace.TracerProviderBuilder.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation> instrumentationFactory) -> OpenTelemetry.Trace.TracerProviderBuilder
-abstract OpenTelemetry.Trace.TracerProviderBuilder.AddLegacySource(string operationName) -> OpenTelemetry.Trace.TracerProviderBuilder
-abstract OpenTelemetry.Trace.TracerProviderBuilder.AddSource(params string[] names) -> OpenTelemetry.Trace.TracerProviderBuilder
+~abstract OpenTelemetry.Metrics.MeterProviderBuilder.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation> instrumentationFactory) -> OpenTelemetry.Metrics.MeterProviderBuilder
+~abstract OpenTelemetry.Metrics.MeterProviderBuilder.AddMeter(params string[] names) -> OpenTelemetry.Metrics.MeterProviderBuilder
+~abstract OpenTelemetry.Trace.TracerProviderBuilder.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation> instrumentationFactory) -> OpenTelemetry.Trace.TracerProviderBuilder
+~abstract OpenTelemetry.Trace.TracerProviderBuilder.AddLegacySource(string operationName) -> OpenTelemetry.Trace.TracerProviderBuilder
+~abstract OpenTelemetry.Trace.TracerProviderBuilder.AddSource(params string[] names) -> OpenTelemetry.Trace.TracerProviderBuilder
 OpenTelemetry.ActivityContextExtensions
 OpenTelemetry.Baggage
 OpenTelemetry.Baggage.Baggage() -> void
 OpenTelemetry.Baggage.ClearBaggage() -> OpenTelemetry.Baggage
 OpenTelemetry.Baggage.Count.get -> int
 OpenTelemetry.Baggage.Equals(OpenTelemetry.Baggage other) -> bool
-OpenTelemetry.Baggage.GetBaggage() -> System.Collections.Generic.IReadOnlyDictionary<string, string>
-OpenTelemetry.Baggage.GetBaggage(string name) -> string
-OpenTelemetry.Baggage.GetEnumerator() -> System.Collections.Generic.Dictionary<string, string>.Enumerator
-OpenTelemetry.Baggage.RemoveBaggage(string name) -> OpenTelemetry.Baggage
-OpenTelemetry.Baggage.SetBaggage(params System.Collections.Generic.KeyValuePair<string, string>[] baggageItems) -> OpenTelemetry.Baggage
-OpenTelemetry.Baggage.SetBaggage(string name, string value) -> OpenTelemetry.Baggage
-OpenTelemetry.Baggage.SetBaggage(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> baggageItems) -> OpenTelemetry.Baggage
+~OpenTelemetry.Baggage.GetBaggage() -> System.Collections.Generic.IReadOnlyDictionary<string, string>
+~OpenTelemetry.Baggage.GetBaggage(string name) -> string
+~OpenTelemetry.Baggage.GetEnumerator() -> System.Collections.Generic.Dictionary<string, string>.Enumerator
+~OpenTelemetry.Baggage.RemoveBaggage(string name) -> OpenTelemetry.Baggage
+~OpenTelemetry.Baggage.SetBaggage(params System.Collections.Generic.KeyValuePair<string, string>[] baggageItems) -> OpenTelemetry.Baggage
+~OpenTelemetry.Baggage.SetBaggage(string name, string value) -> OpenTelemetry.Baggage
+~OpenTelemetry.Baggage.SetBaggage(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> baggageItems) -> OpenTelemetry.Baggage
 OpenTelemetry.BaseProvider
 OpenTelemetry.BaseProvider.~BaseProvider() -> void
 OpenTelemetry.BaseProvider.BaseProvider() -> void
 OpenTelemetry.BaseProvider.Dispose() -> void
 OpenTelemetry.Context.AsyncLocalRuntimeContextSlot<T>
-OpenTelemetry.Context.AsyncLocalRuntimeContextSlot<T>.AsyncLocalRuntimeContextSlot(string name) -> void
-OpenTelemetry.Context.AsyncLocalRuntimeContextSlot<T>.Value.get -> object
-OpenTelemetry.Context.AsyncLocalRuntimeContextSlot<T>.Value.set -> void
+~OpenTelemetry.Context.AsyncLocalRuntimeContextSlot<T>.AsyncLocalRuntimeContextSlot(string name) -> void
+~OpenTelemetry.Context.AsyncLocalRuntimeContextSlot<T>.Value.get -> object
+~OpenTelemetry.Context.AsyncLocalRuntimeContextSlot<T>.Value.set -> void
 OpenTelemetry.Context.IRuntimeContextSlotValueAccessor
-OpenTelemetry.Context.IRuntimeContextSlotValueAccessor.Value.get -> object
-OpenTelemetry.Context.IRuntimeContextSlotValueAccessor.Value.set -> void
+~OpenTelemetry.Context.IRuntimeContextSlotValueAccessor.Value.get -> object
+~OpenTelemetry.Context.IRuntimeContextSlotValueAccessor.Value.set -> void
 OpenTelemetry.Context.Propagation.B3Propagator
 OpenTelemetry.Context.Propagation.B3Propagator.B3Propagator() -> void
 OpenTelemetry.Context.Propagation.B3Propagator.B3Propagator(bool singleHeader) -> void
 OpenTelemetry.Context.Propagation.BaggagePropagator
 OpenTelemetry.Context.Propagation.BaggagePropagator.BaggagePropagator() -> void
 OpenTelemetry.Context.Propagation.CompositeTextMapPropagator
-OpenTelemetry.Context.Propagation.CompositeTextMapPropagator.CompositeTextMapPropagator(System.Collections.Generic.IEnumerable<OpenTelemetry.Context.Propagation.TextMapPropagator> propagators) -> void
+~OpenTelemetry.Context.Propagation.CompositeTextMapPropagator.CompositeTextMapPropagator(System.Collections.Generic.IEnumerable<OpenTelemetry.Context.Propagation.TextMapPropagator> propagators) -> void
 OpenTelemetry.Context.Propagation.PropagationContext
 OpenTelemetry.Context.Propagation.PropagationContext.ActivityContext.get -> System.Diagnostics.ActivityContext
 OpenTelemetry.Context.Propagation.PropagationContext.Baggage.get -> OpenTelemetry.Baggage
@@ -51,56 +52,56 @@ OpenTelemetry.Context.Propagation.TextMapPropagator.TextMapPropagator() -> void
 OpenTelemetry.Context.Propagation.TraceContextPropagator
 OpenTelemetry.Context.Propagation.TraceContextPropagator.TraceContextPropagator() -> void
 OpenTelemetry.Context.RemotingRuntimeContextSlot<T>
-OpenTelemetry.Context.RemotingRuntimeContextSlot<T>.RemotingRuntimeContextSlot(string name) -> void
-OpenTelemetry.Context.RemotingRuntimeContextSlot<T>.Value.get -> object
-OpenTelemetry.Context.RemotingRuntimeContextSlot<T>.Value.set -> void
+~OpenTelemetry.Context.RemotingRuntimeContextSlot<T>.RemotingRuntimeContextSlot(string name) -> void
+~OpenTelemetry.Context.RemotingRuntimeContextSlot<T>.Value.get -> object
+~OpenTelemetry.Context.RemotingRuntimeContextSlot<T>.Value.set -> void
 OpenTelemetry.Context.RuntimeContext
 OpenTelemetry.Context.RuntimeContextSlot<T>
 OpenTelemetry.Context.RuntimeContextSlot<T>.Dispose() -> void
-OpenTelemetry.Context.RuntimeContextSlot<T>.Name.get -> string
-OpenTelemetry.Context.RuntimeContextSlot<T>.RuntimeContextSlot(string name) -> void
+~OpenTelemetry.Context.RuntimeContextSlot<T>.Name.get -> string
+~OpenTelemetry.Context.RuntimeContextSlot<T>.RuntimeContextSlot(string name) -> void
 OpenTelemetry.Context.ThreadLocalRuntimeContextSlot<T>
-OpenTelemetry.Context.ThreadLocalRuntimeContextSlot<T>.ThreadLocalRuntimeContextSlot(string name) -> void
-OpenTelemetry.Context.ThreadLocalRuntimeContextSlot<T>.Value.get -> object
-OpenTelemetry.Context.ThreadLocalRuntimeContextSlot<T>.Value.set -> void
+~OpenTelemetry.Context.ThreadLocalRuntimeContextSlot<T>.ThreadLocalRuntimeContextSlot(string name) -> void
+~OpenTelemetry.Context.ThreadLocalRuntimeContextSlot<T>.Value.get -> object
+~OpenTelemetry.Context.ThreadLocalRuntimeContextSlot<T>.Value.set -> void
 OpenTelemetry.Metrics.IDeferredMeterProviderBuilder
-OpenTelemetry.Metrics.IDeferredMeterProviderBuilder.Configure(System.Action<System.IServiceProvider, OpenTelemetry.Metrics.MeterProviderBuilder> configure) -> OpenTelemetry.Metrics.MeterProviderBuilder
+~OpenTelemetry.Metrics.IDeferredMeterProviderBuilder.Configure(System.Action<System.IServiceProvider, OpenTelemetry.Metrics.MeterProviderBuilder> configure) -> OpenTelemetry.Metrics.MeterProviderBuilder
 OpenTelemetry.Metrics.MeterProvider
 OpenTelemetry.Metrics.MeterProvider.MeterProvider() -> void
 OpenTelemetry.Metrics.MeterProviderBuilder
 OpenTelemetry.Metrics.MeterProviderBuilder.MeterProviderBuilder() -> void
 OpenTelemetry.Trace.ActivityExtensions
 OpenTelemetry.Trace.IDeferredTracerProviderBuilder
-OpenTelemetry.Trace.IDeferredTracerProviderBuilder.Configure(System.Action<System.IServiceProvider, OpenTelemetry.Trace.TracerProviderBuilder> configure) -> OpenTelemetry.Trace.TracerProviderBuilder
+~OpenTelemetry.Trace.IDeferredTracerProviderBuilder.Configure(System.Action<System.IServiceProvider, OpenTelemetry.Trace.TracerProviderBuilder> configure) -> OpenTelemetry.Trace.TracerProviderBuilder
 OpenTelemetry.Trace.Link
-OpenTelemetry.Trace.Link.Attributes.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>
+~OpenTelemetry.Trace.Link.Attributes.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>
 OpenTelemetry.Trace.Link.Context.get -> OpenTelemetry.Trace.SpanContext
 OpenTelemetry.Trace.Link.Equals(OpenTelemetry.Trace.Link other) -> bool
 OpenTelemetry.Trace.Link.Link() -> void
 OpenTelemetry.Trace.Link.Link(in OpenTelemetry.Trace.SpanContext spanContext) -> void
-OpenTelemetry.Trace.Link.Link(in OpenTelemetry.Trace.SpanContext spanContext, OpenTelemetry.Trace.SpanAttributes attributes) -> void
+~OpenTelemetry.Trace.Link.Link(in OpenTelemetry.Trace.SpanContext spanContext, OpenTelemetry.Trace.SpanAttributes attributes) -> void
 OpenTelemetry.Trace.SpanAttributes
-OpenTelemetry.Trace.SpanAttributes.Add(string key, bool value) -> void
-OpenTelemetry.Trace.SpanAttributes.Add(string key, bool[] values) -> void
-OpenTelemetry.Trace.SpanAttributes.Add(string key, double value) -> void
-OpenTelemetry.Trace.SpanAttributes.Add(string key, double[] values) -> void
-OpenTelemetry.Trace.SpanAttributes.Add(string key, long value) -> void
-OpenTelemetry.Trace.SpanAttributes.Add(string key, long[] values) -> void
-OpenTelemetry.Trace.SpanAttributes.Add(string key, string value) -> void
-OpenTelemetry.Trace.SpanAttributes.Add(string key, string[] values) -> void
+~OpenTelemetry.Trace.SpanAttributes.Add(string key, bool value) -> void
+~OpenTelemetry.Trace.SpanAttributes.Add(string key, bool[] values) -> void
+~OpenTelemetry.Trace.SpanAttributes.Add(string key, double value) -> void
+~OpenTelemetry.Trace.SpanAttributes.Add(string key, double[] values) -> void
+~OpenTelemetry.Trace.SpanAttributes.Add(string key, long value) -> void
+~OpenTelemetry.Trace.SpanAttributes.Add(string key, long[] values) -> void
+~OpenTelemetry.Trace.SpanAttributes.Add(string key, string value) -> void
+~OpenTelemetry.Trace.SpanAttributes.Add(string key, string[] values) -> void
 OpenTelemetry.Trace.SpanAttributes.SpanAttributes() -> void
-OpenTelemetry.Trace.SpanAttributes.SpanAttributes(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>> attributes) -> void
+~OpenTelemetry.Trace.SpanAttributes.SpanAttributes(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>> attributes) -> void
 OpenTelemetry.Trace.SpanContext
 OpenTelemetry.Trace.SpanContext.Equals(OpenTelemetry.Trace.SpanContext other) -> bool
 OpenTelemetry.Trace.SpanContext.IsRemote.get -> bool
 OpenTelemetry.Trace.SpanContext.IsValid.get -> bool
 OpenTelemetry.Trace.SpanContext.SpanContext() -> void
 OpenTelemetry.Trace.SpanContext.SpanContext(in System.Diagnostics.ActivityContext activityContext) -> void
-OpenTelemetry.Trace.SpanContext.SpanContext(in System.Diagnostics.ActivityTraceId traceId, in System.Diagnostics.ActivitySpanId spanId, System.Diagnostics.ActivityTraceFlags traceFlags, bool isRemote = false, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> traceState = null) -> void
+~OpenTelemetry.Trace.SpanContext.SpanContext(in System.Diagnostics.ActivityTraceId traceId, in System.Diagnostics.ActivitySpanId spanId, System.Diagnostics.ActivityTraceFlags traceFlags, bool isRemote = false, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> traceState = null) -> void
 OpenTelemetry.Trace.SpanContext.SpanId.get -> System.Diagnostics.ActivitySpanId
 OpenTelemetry.Trace.SpanContext.TraceFlags.get -> System.Diagnostics.ActivityTraceFlags
 OpenTelemetry.Trace.SpanContext.TraceId.get -> System.Diagnostics.ActivityTraceId
-OpenTelemetry.Trace.SpanContext.TraceState.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>
+~OpenTelemetry.Trace.SpanContext.TraceState.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>
 OpenTelemetry.Trace.SpanKind
 OpenTelemetry.Trace.SpanKind.Client = 3 -> OpenTelemetry.Trace.SpanKind
 OpenTelemetry.Trace.SpanKind.Consumer = 5 -> OpenTelemetry.Trace.SpanKind
@@ -108,107 +109,107 @@ OpenTelemetry.Trace.SpanKind.Internal = 1 -> OpenTelemetry.Trace.SpanKind
 OpenTelemetry.Trace.SpanKind.Producer = 4 -> OpenTelemetry.Trace.SpanKind
 OpenTelemetry.Trace.SpanKind.Server = 2 -> OpenTelemetry.Trace.SpanKind
 OpenTelemetry.Trace.Status
-OpenTelemetry.Trace.Status.Description.get -> string
+~OpenTelemetry.Trace.Status.Description.get -> string
 OpenTelemetry.Trace.Status.Equals(OpenTelemetry.Trace.Status other) -> bool
 OpenTelemetry.Trace.Status.Status() -> void
 OpenTelemetry.Trace.Status.StatusCode.get -> OpenTelemetry.Trace.StatusCode
-OpenTelemetry.Trace.Status.WithDescription(string description) -> OpenTelemetry.Trace.Status
+~OpenTelemetry.Trace.Status.WithDescription(string description) -> OpenTelemetry.Trace.Status
 OpenTelemetry.Trace.StatusCode
 OpenTelemetry.Trace.StatusCode.Error = 2 -> OpenTelemetry.Trace.StatusCode
 OpenTelemetry.Trace.StatusCode.Ok = 1 -> OpenTelemetry.Trace.StatusCode
 OpenTelemetry.Trace.StatusCode.Unset = 0 -> OpenTelemetry.Trace.StatusCode
 OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.TelemetrySpan.AddEvent(string name) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.TelemetrySpan.AddEvent(string name, OpenTelemetry.Trace.SpanAttributes attributes) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.TelemetrySpan.AddEvent(string name, System.DateTimeOffset timestamp) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.TelemetrySpan.AddEvent(string name, System.DateTimeOffset timestamp, OpenTelemetry.Trace.SpanAttributes attributes) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.AddEvent(string name) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.AddEvent(string name, OpenTelemetry.Trace.SpanAttributes attributes) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.AddEvent(string name, System.DateTimeOffset timestamp) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.AddEvent(string name, System.DateTimeOffset timestamp, OpenTelemetry.Trace.SpanAttributes attributes) -> OpenTelemetry.Trace.TelemetrySpan
 OpenTelemetry.Trace.TelemetrySpan.Context.get -> OpenTelemetry.Trace.SpanContext
 OpenTelemetry.Trace.TelemetrySpan.Dispose() -> void
 OpenTelemetry.Trace.TelemetrySpan.End() -> void
 OpenTelemetry.Trace.TelemetrySpan.End(System.DateTimeOffset endTimestamp) -> void
 OpenTelemetry.Trace.TelemetrySpan.IsRecording.get -> bool
 OpenTelemetry.Trace.TelemetrySpan.ParentSpanId.get -> System.Diagnostics.ActivitySpanId
-OpenTelemetry.Trace.TelemetrySpan.RecordException(string type, string message, string stacktrace) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.TelemetrySpan.RecordException(System.Exception ex) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, bool value) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, bool[] values) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, double value) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, double[] values) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, int value) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, int[] values) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, string value) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, string[] values) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.RecordException(string type, string message, string stacktrace) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.RecordException(System.Exception ex) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, bool value) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, bool[] values) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, double value) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, double[] values) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, int value) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, int[] values) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, string value) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, string[] values) -> OpenTelemetry.Trace.TelemetrySpan
 OpenTelemetry.Trace.TelemetrySpan.SetStatus(OpenTelemetry.Trace.Status value) -> void
-OpenTelemetry.Trace.TelemetrySpan.UpdateName(string name) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.UpdateName(string name) -> OpenTelemetry.Trace.TelemetrySpan
 OpenTelemetry.Trace.Tracer
-OpenTelemetry.Trace.Tracer.StartActiveSpan(string name, OpenTelemetry.Trace.SpanKind kind = OpenTelemetry.Trace.SpanKind.Internal, in OpenTelemetry.Trace.SpanContext parentContext = default(OpenTelemetry.Trace.SpanContext), OpenTelemetry.Trace.SpanAttributes initialAttributes = null, System.Collections.Generic.IEnumerable<OpenTelemetry.Trace.Link> links = null, System.DateTimeOffset startTime = default(System.DateTimeOffset)) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.Tracer.StartActiveSpan(string name, OpenTelemetry.Trace.SpanKind kind, in OpenTelemetry.Trace.TelemetrySpan parentSpan, OpenTelemetry.Trace.SpanAttributes initialAttributes = null, System.Collections.Generic.IEnumerable<OpenTelemetry.Trace.Link> links = null, System.DateTimeOffset startTime = default(System.DateTimeOffset)) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.Tracer.StartRootSpan(string name, OpenTelemetry.Trace.SpanKind kind = OpenTelemetry.Trace.SpanKind.Internal, OpenTelemetry.Trace.SpanAttributes initialAttributes = null, System.Collections.Generic.IEnumerable<OpenTelemetry.Trace.Link> links = null, System.DateTimeOffset startTime = default(System.DateTimeOffset)) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.Tracer.StartSpan(string name, OpenTelemetry.Trace.SpanKind kind = OpenTelemetry.Trace.SpanKind.Internal, in OpenTelemetry.Trace.SpanContext parentContext = default(OpenTelemetry.Trace.SpanContext), OpenTelemetry.Trace.SpanAttributes initialAttributes = null, System.Collections.Generic.IEnumerable<OpenTelemetry.Trace.Link> links = null, System.DateTimeOffset startTime = default(System.DateTimeOffset)) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.Tracer.StartSpan(string name, OpenTelemetry.Trace.SpanKind kind, in OpenTelemetry.Trace.TelemetrySpan parentSpan, OpenTelemetry.Trace.SpanAttributes initialAttributes = null, System.Collections.Generic.IEnumerable<OpenTelemetry.Trace.Link> links = null, System.DateTimeOffset startTime = default(System.DateTimeOffset)) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.Tracer.StartActiveSpan(string name, OpenTelemetry.Trace.SpanKind kind = OpenTelemetry.Trace.SpanKind.Internal, in OpenTelemetry.Trace.SpanContext parentContext = default(OpenTelemetry.Trace.SpanContext), OpenTelemetry.Trace.SpanAttributes initialAttributes = null, System.Collections.Generic.IEnumerable<OpenTelemetry.Trace.Link> links = null, System.DateTimeOffset startTime = default(System.DateTimeOffset)) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.Tracer.StartActiveSpan(string name, OpenTelemetry.Trace.SpanKind kind, in OpenTelemetry.Trace.TelemetrySpan parentSpan, OpenTelemetry.Trace.SpanAttributes initialAttributes = null, System.Collections.Generic.IEnumerable<OpenTelemetry.Trace.Link> links = null, System.DateTimeOffset startTime = default(System.DateTimeOffset)) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.Tracer.StartRootSpan(string name, OpenTelemetry.Trace.SpanKind kind = OpenTelemetry.Trace.SpanKind.Internal, OpenTelemetry.Trace.SpanAttributes initialAttributes = null, System.Collections.Generic.IEnumerable<OpenTelemetry.Trace.Link> links = null, System.DateTimeOffset startTime = default(System.DateTimeOffset)) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.Tracer.StartSpan(string name, OpenTelemetry.Trace.SpanKind kind = OpenTelemetry.Trace.SpanKind.Internal, in OpenTelemetry.Trace.SpanContext parentContext = default(OpenTelemetry.Trace.SpanContext), OpenTelemetry.Trace.SpanAttributes initialAttributes = null, System.Collections.Generic.IEnumerable<OpenTelemetry.Trace.Link> links = null, System.DateTimeOffset startTime = default(System.DateTimeOffset)) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.Tracer.StartSpan(string name, OpenTelemetry.Trace.SpanKind kind, in OpenTelemetry.Trace.TelemetrySpan parentSpan, OpenTelemetry.Trace.SpanAttributes initialAttributes = null, System.Collections.Generic.IEnumerable<OpenTelemetry.Trace.Link> links = null, System.DateTimeOffset startTime = default(System.DateTimeOffset)) -> OpenTelemetry.Trace.TelemetrySpan
 OpenTelemetry.Trace.TracerProvider
-OpenTelemetry.Trace.TracerProvider.GetTracer(string name, string version = null) -> OpenTelemetry.Trace.Tracer
+~OpenTelemetry.Trace.TracerProvider.GetTracer(string name, string version = null) -> OpenTelemetry.Trace.Tracer
 OpenTelemetry.Trace.TracerProvider.TracerProvider() -> void
 OpenTelemetry.Trace.TracerProviderBuilder
 OpenTelemetry.Trace.TracerProviderBuilder.TracerProviderBuilder() -> void
-override OpenTelemetry.Baggage.Equals(object obj) -> bool
+~override OpenTelemetry.Baggage.Equals(object obj) -> bool
 override OpenTelemetry.Baggage.GetHashCode() -> int
 override OpenTelemetry.Context.AsyncLocalRuntimeContextSlot<T>.Get() -> T
 override OpenTelemetry.Context.AsyncLocalRuntimeContextSlot<T>.Set(T value) -> void
-override OpenTelemetry.Context.Propagation.B3Propagator.Extract<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> OpenTelemetry.Context.Propagation.PropagationContext
-override OpenTelemetry.Context.Propagation.B3Propagator.Fields.get -> System.Collections.Generic.ISet<string>
-override OpenTelemetry.Context.Propagation.B3Propagator.Inject<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
-override OpenTelemetry.Context.Propagation.BaggagePropagator.Extract<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> OpenTelemetry.Context.Propagation.PropagationContext
-override OpenTelemetry.Context.Propagation.BaggagePropagator.Fields.get -> System.Collections.Generic.ISet<string>
-override OpenTelemetry.Context.Propagation.BaggagePropagator.Inject<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
-override OpenTelemetry.Context.Propagation.CompositeTextMapPropagator.Extract<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> OpenTelemetry.Context.Propagation.PropagationContext
-override OpenTelemetry.Context.Propagation.CompositeTextMapPropagator.Fields.get -> System.Collections.Generic.ISet<string>
-override OpenTelemetry.Context.Propagation.CompositeTextMapPropagator.Inject<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
-override OpenTelemetry.Context.Propagation.PropagationContext.Equals(object obj) -> bool
+~override OpenTelemetry.Context.Propagation.B3Propagator.Extract<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> OpenTelemetry.Context.Propagation.PropagationContext
+~override OpenTelemetry.Context.Propagation.B3Propagator.Fields.get -> System.Collections.Generic.ISet<string>
+~override OpenTelemetry.Context.Propagation.B3Propagator.Inject<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
+~override OpenTelemetry.Context.Propagation.BaggagePropagator.Extract<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> OpenTelemetry.Context.Propagation.PropagationContext
+~override OpenTelemetry.Context.Propagation.BaggagePropagator.Fields.get -> System.Collections.Generic.ISet<string>
+~override OpenTelemetry.Context.Propagation.BaggagePropagator.Inject<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
+~override OpenTelemetry.Context.Propagation.CompositeTextMapPropagator.Extract<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> OpenTelemetry.Context.Propagation.PropagationContext
+~override OpenTelemetry.Context.Propagation.CompositeTextMapPropagator.Fields.get -> System.Collections.Generic.ISet<string>
+~override OpenTelemetry.Context.Propagation.CompositeTextMapPropagator.Inject<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
+~override OpenTelemetry.Context.Propagation.PropagationContext.Equals(object obj) -> bool
 override OpenTelemetry.Context.Propagation.PropagationContext.GetHashCode() -> int
-override OpenTelemetry.Context.Propagation.TraceContextPropagator.Extract<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> OpenTelemetry.Context.Propagation.PropagationContext
-override OpenTelemetry.Context.Propagation.TraceContextPropagator.Fields.get -> System.Collections.Generic.ISet<string>
-override OpenTelemetry.Context.Propagation.TraceContextPropagator.Inject<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
+~override OpenTelemetry.Context.Propagation.TraceContextPropagator.Extract<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> OpenTelemetry.Context.Propagation.PropagationContext
+~override OpenTelemetry.Context.Propagation.TraceContextPropagator.Fields.get -> System.Collections.Generic.ISet<string>
+~override OpenTelemetry.Context.Propagation.TraceContextPropagator.Inject<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
 override OpenTelemetry.Context.RemotingRuntimeContextSlot<T>.Get() -> T
 override OpenTelemetry.Context.RemotingRuntimeContextSlot<T>.Set(T value) -> void
 override OpenTelemetry.Context.ThreadLocalRuntimeContextSlot<T>.Dispose(bool disposing) -> void
 override OpenTelemetry.Context.ThreadLocalRuntimeContextSlot<T>.Get() -> T
 override OpenTelemetry.Context.ThreadLocalRuntimeContextSlot<T>.Set(T value) -> void
-override OpenTelemetry.Trace.Link.Equals(object obj) -> bool
+~override OpenTelemetry.Trace.Link.Equals(object obj) -> bool
 override OpenTelemetry.Trace.Link.GetHashCode() -> int
-override OpenTelemetry.Trace.SpanContext.Equals(object obj) -> bool
+~override OpenTelemetry.Trace.SpanContext.Equals(object obj) -> bool
 override OpenTelemetry.Trace.SpanContext.GetHashCode() -> int
-override OpenTelemetry.Trace.Status.Equals(object obj) -> bool
+~override OpenTelemetry.Trace.Status.Equals(object obj) -> bool
 override OpenTelemetry.Trace.Status.GetHashCode() -> int
-override OpenTelemetry.Trace.Status.ToString() -> string
+~override OpenTelemetry.Trace.Status.ToString() -> string
 static OpenTelemetry.ActivityContextExtensions.IsValid(this System.Diagnostics.ActivityContext ctx) -> bool
 static OpenTelemetry.Baggage.ClearBaggage(OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> OpenTelemetry.Baggage
-static OpenTelemetry.Baggage.Create(System.Collections.Generic.Dictionary<string, string> baggageItems = null) -> OpenTelemetry.Baggage
+~static OpenTelemetry.Baggage.Create(System.Collections.Generic.Dictionary<string, string> baggageItems = null) -> OpenTelemetry.Baggage
 static OpenTelemetry.Baggage.Current.get -> OpenTelemetry.Baggage
 static OpenTelemetry.Baggage.Current.set -> void
-static OpenTelemetry.Baggage.GetBaggage(OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> System.Collections.Generic.IReadOnlyDictionary<string, string>
-static OpenTelemetry.Baggage.GetBaggage(string name, OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> string
-static OpenTelemetry.Baggage.GetEnumerator(OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> System.Collections.Generic.Dictionary<string, string>.Enumerator
+~static OpenTelemetry.Baggage.GetBaggage(OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> System.Collections.Generic.IReadOnlyDictionary<string, string>
+~static OpenTelemetry.Baggage.GetBaggage(string name, OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> string
+~static OpenTelemetry.Baggage.GetEnumerator(OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> System.Collections.Generic.Dictionary<string, string>.Enumerator
 static OpenTelemetry.Baggage.operator !=(OpenTelemetry.Baggage left, OpenTelemetry.Baggage right) -> bool
 static OpenTelemetry.Baggage.operator ==(OpenTelemetry.Baggage left, OpenTelemetry.Baggage right) -> bool
-static OpenTelemetry.Baggage.RemoveBaggage(string name, OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> OpenTelemetry.Baggage
-static OpenTelemetry.Baggage.SetBaggage(string name, string value, OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> OpenTelemetry.Baggage
-static OpenTelemetry.Baggage.SetBaggage(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> baggageItems, OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> OpenTelemetry.Baggage
+~static OpenTelemetry.Baggage.RemoveBaggage(string name, OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> OpenTelemetry.Baggage
+~static OpenTelemetry.Baggage.SetBaggage(string name, string value, OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> OpenTelemetry.Baggage
+~static OpenTelemetry.Baggage.SetBaggage(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> baggageItems, OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> OpenTelemetry.Baggage
 static OpenTelemetry.Context.Propagation.PropagationContext.operator !=(OpenTelemetry.Context.Propagation.PropagationContext left, OpenTelemetry.Context.Propagation.PropagationContext right) -> bool
 static OpenTelemetry.Context.Propagation.PropagationContext.operator ==(OpenTelemetry.Context.Propagation.PropagationContext left, OpenTelemetry.Context.Propagation.PropagationContext right) -> bool
-static OpenTelemetry.Context.Propagation.Propagators.DefaultTextMapPropagator.get -> OpenTelemetry.Context.Propagation.TextMapPropagator
-static OpenTelemetry.Context.RuntimeContext.ContextSlotType.get -> System.Type
-static OpenTelemetry.Context.RuntimeContext.ContextSlotType.set -> void
-static OpenTelemetry.Context.RuntimeContext.GetSlot<T>(string slotName) -> OpenTelemetry.Context.RuntimeContextSlot<T>
-static OpenTelemetry.Context.RuntimeContext.GetValue(string slotName) -> object
-static OpenTelemetry.Context.RuntimeContext.GetValue<T>(string slotName) -> T
-static OpenTelemetry.Context.RuntimeContext.RegisterSlot<T>(string slotName) -> OpenTelemetry.Context.RuntimeContextSlot<T>
-static OpenTelemetry.Context.RuntimeContext.SetValue(string slotName, object value) -> void
-static OpenTelemetry.Context.RuntimeContext.SetValue<T>(string slotName, T value) -> void
-static OpenTelemetry.Trace.ActivityExtensions.GetStatus(this System.Diagnostics.Activity activity) -> OpenTelemetry.Trace.Status
-static OpenTelemetry.Trace.ActivityExtensions.RecordException(this System.Diagnostics.Activity activity, System.Exception ex) -> void
-static OpenTelemetry.Trace.ActivityExtensions.RecordException(this System.Diagnostics.Activity activity, System.Exception ex, in System.Diagnostics.TagList tags) -> void
-static OpenTelemetry.Trace.ActivityExtensions.SetStatus(this System.Diagnostics.Activity activity, OpenTelemetry.Trace.Status status) -> void
+~static OpenTelemetry.Context.Propagation.Propagators.DefaultTextMapPropagator.get -> OpenTelemetry.Context.Propagation.TextMapPropagator
+~static OpenTelemetry.Context.RuntimeContext.ContextSlotType.get -> System.Type
+~static OpenTelemetry.Context.RuntimeContext.ContextSlotType.set -> void
+~static OpenTelemetry.Context.RuntimeContext.GetSlot<T>(string slotName) -> OpenTelemetry.Context.RuntimeContextSlot<T>
+~static OpenTelemetry.Context.RuntimeContext.GetValue(string slotName) -> object
+~static OpenTelemetry.Context.RuntimeContext.GetValue<T>(string slotName) -> T
+~static OpenTelemetry.Context.RuntimeContext.RegisterSlot<T>(string slotName) -> OpenTelemetry.Context.RuntimeContextSlot<T>
+~static OpenTelemetry.Context.RuntimeContext.SetValue(string slotName, object value) -> void
+~static OpenTelemetry.Context.RuntimeContext.SetValue<T>(string slotName, T value) -> void
+~static OpenTelemetry.Trace.ActivityExtensions.GetStatus(this System.Diagnostics.Activity activity) -> OpenTelemetry.Trace.Status
+~static OpenTelemetry.Trace.ActivityExtensions.RecordException(this System.Diagnostics.Activity activity, System.Exception ex) -> void
+~static OpenTelemetry.Trace.ActivityExtensions.RecordException(this System.Diagnostics.Activity activity, System.Exception ex, in System.Diagnostics.TagList tags) -> void
+~static OpenTelemetry.Trace.ActivityExtensions.SetStatus(this System.Diagnostics.Activity activity, OpenTelemetry.Trace.Status status) -> void
 static OpenTelemetry.Trace.Link.operator !=(OpenTelemetry.Trace.Link link1, OpenTelemetry.Trace.Link link2) -> bool
 static OpenTelemetry.Trace.Link.operator ==(OpenTelemetry.Trace.Link link1, OpenTelemetry.Trace.Link link2) -> bool
 static OpenTelemetry.Trace.SpanContext.implicit operator System.Diagnostics.ActivityContext(OpenTelemetry.Trace.SpanContext spanContext) -> System.Diagnostics.ActivityContext
@@ -216,9 +217,9 @@ static OpenTelemetry.Trace.SpanContext.operator !=(OpenTelemetry.Trace.SpanConte
 static OpenTelemetry.Trace.SpanContext.operator ==(OpenTelemetry.Trace.SpanContext spanContext1, OpenTelemetry.Trace.SpanContext spanContext2) -> bool
 static OpenTelemetry.Trace.Status.operator !=(OpenTelemetry.Trace.Status status1, OpenTelemetry.Trace.Status status2) -> bool
 static OpenTelemetry.Trace.Status.operator ==(OpenTelemetry.Trace.Status status1, OpenTelemetry.Trace.Status status2) -> bool
-static OpenTelemetry.Trace.Tracer.CurrentSpan.get -> OpenTelemetry.Trace.TelemetrySpan
-static OpenTelemetry.Trace.Tracer.WithSpan(OpenTelemetry.Trace.TelemetrySpan span) -> OpenTelemetry.Trace.TelemetrySpan
-static OpenTelemetry.Trace.TracerProvider.Default.get -> OpenTelemetry.Trace.TracerProvider
+~static OpenTelemetry.Trace.Tracer.CurrentSpan.get -> OpenTelemetry.Trace.TelemetrySpan
+~static OpenTelemetry.Trace.Tracer.WithSpan(OpenTelemetry.Trace.TelemetrySpan span) -> OpenTelemetry.Trace.TelemetrySpan
+~static OpenTelemetry.Trace.TracerProvider.Default.get -> OpenTelemetry.Trace.TracerProvider
 static readonly OpenTelemetry.Trace.Status.Error -> OpenTelemetry.Trace.Status
 static readonly OpenTelemetry.Trace.Status.Ok -> OpenTelemetry.Trace.Status
 static readonly OpenTelemetry.Trace.Status.Unset -> OpenTelemetry.Trace.Status

--- a/src/OpenTelemetry.Api/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,79 @@
+abstract OpenTelemetry.Logs.Logger.EmitLog(in OpenTelemetry.Logs.LogRecordData data, in OpenTelemetry.Logs.LogRecordAttributeList attributes = default(OpenTelemetry.Logs.LogRecordAttributeList)) -> void
+abstract OpenTelemetry.Logs.LoggerProviderBuilder.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation!>! instrumentationFactory) -> OpenTelemetry.Logs.LoggerProviderBuilder!
+OpenTelemetry.Logs.IDeferredLoggerProviderBuilder
+OpenTelemetry.Logs.IDeferredLoggerProviderBuilder.Configure(System.Action<System.IServiceProvider!, OpenTelemetry.Logs.LoggerProviderBuilder!>! configure) -> OpenTelemetry.Logs.LoggerProviderBuilder!
+OpenTelemetry.Logs.Logger
+OpenTelemetry.Logs.Logger.Logger(string? name) -> void
+OpenTelemetry.Logs.Logger.Name.get -> string!
+OpenTelemetry.Logs.Logger.Version.get -> string?
+OpenTelemetry.Logs.LoggerProvider
+OpenTelemetry.Logs.LoggerProvider.GetLogger() -> OpenTelemetry.Logs.Logger!
+OpenTelemetry.Logs.LoggerProvider.GetLogger(string? name) -> OpenTelemetry.Logs.Logger!
+OpenTelemetry.Logs.LoggerProvider.GetLogger(string? name, string? version) -> OpenTelemetry.Logs.Logger!
+OpenTelemetry.Logs.LoggerProvider.LoggerProvider() -> void
+OpenTelemetry.Logs.LoggerProviderBuilder
+OpenTelemetry.Logs.LoggerProviderBuilder.LoggerProviderBuilder() -> void
+OpenTelemetry.Logs.LogRecordAttributeList
+OpenTelemetry.Logs.LogRecordAttributeList.Add(string! key, object? value) -> void
+OpenTelemetry.Logs.LogRecordAttributeList.Add(System.Collections.Generic.KeyValuePair<string!, object?> attribute) -> void
+OpenTelemetry.Logs.LogRecordAttributeList.Clear() -> void
+OpenTelemetry.Logs.LogRecordAttributeList.Count.get -> int
+OpenTelemetry.Logs.LogRecordAttributeList.Enumerator
+OpenTelemetry.Logs.LogRecordAttributeList.Enumerator.Current.get -> System.Collections.Generic.KeyValuePair<string!, object?>
+OpenTelemetry.Logs.LogRecordAttributeList.Enumerator.Dispose() -> void
+OpenTelemetry.Logs.LogRecordAttributeList.Enumerator.Enumerator() -> void
+OpenTelemetry.Logs.LogRecordAttributeList.Enumerator.MoveNext() -> bool
+OpenTelemetry.Logs.LogRecordAttributeList.GetEnumerator() -> OpenTelemetry.Logs.LogRecordAttributeList.Enumerator
+OpenTelemetry.Logs.LogRecordAttributeList.LogRecordAttributeList() -> void
+OpenTelemetry.Logs.LogRecordAttributeList.RecordException(System.Exception! exception) -> void
+OpenTelemetry.Logs.LogRecordAttributeList.this[int index].get -> System.Collections.Generic.KeyValuePair<string!, object?>
+OpenTelemetry.Logs.LogRecordAttributeList.this[int index].set -> void
+OpenTelemetry.Logs.LogRecordAttributeList.this[string! key].set -> void
+OpenTelemetry.Logs.LogRecordData
+OpenTelemetry.Logs.LogRecordData.Body.get -> string?
+OpenTelemetry.Logs.LogRecordData.Body.set -> void
+OpenTelemetry.Logs.LogRecordData.LogRecordData() -> void
+OpenTelemetry.Logs.LogRecordData.LogRecordData(in System.Diagnostics.ActivityContext activityContext) -> void
+OpenTelemetry.Logs.LogRecordData.LogRecordData(System.Diagnostics.Activity? activity) -> void
+OpenTelemetry.Logs.LogRecordData.Severity.get -> OpenTelemetry.Logs.LogRecordSeverity?
+OpenTelemetry.Logs.LogRecordData.Severity.set -> void
+OpenTelemetry.Logs.LogRecordData.SeverityText.get -> string?
+OpenTelemetry.Logs.LogRecordData.SeverityText.set -> void
+OpenTelemetry.Logs.LogRecordData.SpanId.get -> System.Diagnostics.ActivitySpanId
+OpenTelemetry.Logs.LogRecordData.SpanId.set -> void
+OpenTelemetry.Logs.LogRecordData.Timestamp.get -> System.DateTime
+OpenTelemetry.Logs.LogRecordData.Timestamp.set -> void
+OpenTelemetry.Logs.LogRecordData.TraceFlags.get -> System.Diagnostics.ActivityTraceFlags
+OpenTelemetry.Logs.LogRecordData.TraceFlags.set -> void
+OpenTelemetry.Logs.LogRecordData.TraceId.get -> System.Diagnostics.ActivityTraceId
+OpenTelemetry.Logs.LogRecordData.TraceId.set -> void
+OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Debug = 5 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Debug2 = 6 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Debug3 = 7 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Debug4 = 8 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Error = 17 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Error2 = 18 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Error3 = 19 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Error4 = 20 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Fatal = 21 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Fatal2 = 22 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Fatal3 = 23 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Fatal4 = 24 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Info = 9 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Info2 = 10 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Info3 = 11 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Info4 = 12 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Trace = 1 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Trace2 = 2 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Trace3 = 3 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Trace4 = 4 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Unspecified = 0 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Warn = 13 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Warn2 = 14 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Warn3 = 15 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Warn4 = 16 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverityExtensions
+static OpenTelemetry.Logs.LogRecordAttributeList.CreateFromEnumerable(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, object?>>! attributes) -> OpenTelemetry.Logs.LogRecordAttributeList
+static OpenTelemetry.Logs.LogRecordSeverityExtensions.ToShortName(this OpenTelemetry.Logs.LogRecordSeverity logRecordSeverity) -> string!
+virtual OpenTelemetry.Logs.LoggerProvider.TryCreateLogger(string? name, out OpenTelemetry.Logs.Logger? logger) -> bool

--- a/src/OpenTelemetry.Api/.publicApi/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/netstandard2.0/PublicAPI.Shipped.txt
@@ -1,44 +1,45 @@
-abstract OpenTelemetry.Context.Propagation.TextMapPropagator.Extract<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> OpenTelemetry.Context.Propagation.PropagationContext
-abstract OpenTelemetry.Context.Propagation.TextMapPropagator.Fields.get -> System.Collections.Generic.ISet<string>
-abstract OpenTelemetry.Context.Propagation.TextMapPropagator.Inject<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
+#nullable enable
+~abstract OpenTelemetry.Context.Propagation.TextMapPropagator.Extract<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> OpenTelemetry.Context.Propagation.PropagationContext
+~abstract OpenTelemetry.Context.Propagation.TextMapPropagator.Fields.get -> System.Collections.Generic.ISet<string>
+~abstract OpenTelemetry.Context.Propagation.TextMapPropagator.Inject<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
 abstract OpenTelemetry.Context.RuntimeContextSlot<T>.Get() -> T
 abstract OpenTelemetry.Context.RuntimeContextSlot<T>.Set(T value) -> void
-abstract OpenTelemetry.Metrics.MeterProviderBuilder.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation> instrumentationFactory) -> OpenTelemetry.Metrics.MeterProviderBuilder
-abstract OpenTelemetry.Metrics.MeterProviderBuilder.AddMeter(params string[] names) -> OpenTelemetry.Metrics.MeterProviderBuilder
-abstract OpenTelemetry.Trace.TracerProviderBuilder.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation> instrumentationFactory) -> OpenTelemetry.Trace.TracerProviderBuilder
-abstract OpenTelemetry.Trace.TracerProviderBuilder.AddLegacySource(string operationName) -> OpenTelemetry.Trace.TracerProviderBuilder
-abstract OpenTelemetry.Trace.TracerProviderBuilder.AddSource(params string[] names) -> OpenTelemetry.Trace.TracerProviderBuilder
+~abstract OpenTelemetry.Metrics.MeterProviderBuilder.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation> instrumentationFactory) -> OpenTelemetry.Metrics.MeterProviderBuilder
+~abstract OpenTelemetry.Metrics.MeterProviderBuilder.AddMeter(params string[] names) -> OpenTelemetry.Metrics.MeterProviderBuilder
+~abstract OpenTelemetry.Trace.TracerProviderBuilder.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation> instrumentationFactory) -> OpenTelemetry.Trace.TracerProviderBuilder
+~abstract OpenTelemetry.Trace.TracerProviderBuilder.AddLegacySource(string operationName) -> OpenTelemetry.Trace.TracerProviderBuilder
+~abstract OpenTelemetry.Trace.TracerProviderBuilder.AddSource(params string[] names) -> OpenTelemetry.Trace.TracerProviderBuilder
 OpenTelemetry.ActivityContextExtensions
 OpenTelemetry.Baggage
 OpenTelemetry.Baggage.Baggage() -> void
 OpenTelemetry.Baggage.ClearBaggage() -> OpenTelemetry.Baggage
 OpenTelemetry.Baggage.Count.get -> int
 OpenTelemetry.Baggage.Equals(OpenTelemetry.Baggage other) -> bool
-OpenTelemetry.Baggage.GetBaggage() -> System.Collections.Generic.IReadOnlyDictionary<string, string>
-OpenTelemetry.Baggage.GetBaggage(string name) -> string
-OpenTelemetry.Baggage.GetEnumerator() -> System.Collections.Generic.Dictionary<string, string>.Enumerator
-OpenTelemetry.Baggage.RemoveBaggage(string name) -> OpenTelemetry.Baggage
-OpenTelemetry.Baggage.SetBaggage(params System.Collections.Generic.KeyValuePair<string, string>[] baggageItems) -> OpenTelemetry.Baggage
-OpenTelemetry.Baggage.SetBaggage(string name, string value) -> OpenTelemetry.Baggage
-OpenTelemetry.Baggage.SetBaggage(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> baggageItems) -> OpenTelemetry.Baggage
+~OpenTelemetry.Baggage.GetBaggage() -> System.Collections.Generic.IReadOnlyDictionary<string, string>
+~OpenTelemetry.Baggage.GetBaggage(string name) -> string
+~OpenTelemetry.Baggage.GetEnumerator() -> System.Collections.Generic.Dictionary<string, string>.Enumerator
+~OpenTelemetry.Baggage.RemoveBaggage(string name) -> OpenTelemetry.Baggage
+~OpenTelemetry.Baggage.SetBaggage(params System.Collections.Generic.KeyValuePair<string, string>[] baggageItems) -> OpenTelemetry.Baggage
+~OpenTelemetry.Baggage.SetBaggage(string name, string value) -> OpenTelemetry.Baggage
+~OpenTelemetry.Baggage.SetBaggage(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> baggageItems) -> OpenTelemetry.Baggage
 OpenTelemetry.BaseProvider
 OpenTelemetry.BaseProvider.~BaseProvider() -> void
 OpenTelemetry.BaseProvider.BaseProvider() -> void
 OpenTelemetry.BaseProvider.Dispose() -> void
 OpenTelemetry.Context.AsyncLocalRuntimeContextSlot<T>
-OpenTelemetry.Context.AsyncLocalRuntimeContextSlot<T>.AsyncLocalRuntimeContextSlot(string name) -> void
-OpenTelemetry.Context.AsyncLocalRuntimeContextSlot<T>.Value.get -> object
-OpenTelemetry.Context.AsyncLocalRuntimeContextSlot<T>.Value.set -> void
+~OpenTelemetry.Context.AsyncLocalRuntimeContextSlot<T>.AsyncLocalRuntimeContextSlot(string name) -> void
+~OpenTelemetry.Context.AsyncLocalRuntimeContextSlot<T>.Value.get -> object
+~OpenTelemetry.Context.AsyncLocalRuntimeContextSlot<T>.Value.set -> void
 OpenTelemetry.Context.IRuntimeContextSlotValueAccessor
-OpenTelemetry.Context.IRuntimeContextSlotValueAccessor.Value.get -> object
-OpenTelemetry.Context.IRuntimeContextSlotValueAccessor.Value.set -> void
+~OpenTelemetry.Context.IRuntimeContextSlotValueAccessor.Value.get -> object
+~OpenTelemetry.Context.IRuntimeContextSlotValueAccessor.Value.set -> void
 OpenTelemetry.Context.Propagation.B3Propagator
 OpenTelemetry.Context.Propagation.B3Propagator.B3Propagator() -> void
 OpenTelemetry.Context.Propagation.B3Propagator.B3Propagator(bool singleHeader) -> void
 OpenTelemetry.Context.Propagation.BaggagePropagator
 OpenTelemetry.Context.Propagation.BaggagePropagator.BaggagePropagator() -> void
 OpenTelemetry.Context.Propagation.CompositeTextMapPropagator
-OpenTelemetry.Context.Propagation.CompositeTextMapPropagator.CompositeTextMapPropagator(System.Collections.Generic.IEnumerable<OpenTelemetry.Context.Propagation.TextMapPropagator> propagators) -> void
+~OpenTelemetry.Context.Propagation.CompositeTextMapPropagator.CompositeTextMapPropagator(System.Collections.Generic.IEnumerable<OpenTelemetry.Context.Propagation.TextMapPropagator> propagators) -> void
 OpenTelemetry.Context.Propagation.PropagationContext
 OpenTelemetry.Context.Propagation.PropagationContext.ActivityContext.get -> System.Diagnostics.ActivityContext
 OpenTelemetry.Context.Propagation.PropagationContext.Baggage.get -> OpenTelemetry.Baggage
@@ -53,50 +54,50 @@ OpenTelemetry.Context.Propagation.TraceContextPropagator.TraceContextPropagator(
 OpenTelemetry.Context.RuntimeContext
 OpenTelemetry.Context.RuntimeContextSlot<T>
 OpenTelemetry.Context.RuntimeContextSlot<T>.Dispose() -> void
-OpenTelemetry.Context.RuntimeContextSlot<T>.Name.get -> string
-OpenTelemetry.Context.RuntimeContextSlot<T>.RuntimeContextSlot(string name) -> void
+~OpenTelemetry.Context.RuntimeContextSlot<T>.Name.get -> string
+~OpenTelemetry.Context.RuntimeContextSlot<T>.RuntimeContextSlot(string name) -> void
 OpenTelemetry.Context.ThreadLocalRuntimeContextSlot<T>
-OpenTelemetry.Context.ThreadLocalRuntimeContextSlot<T>.ThreadLocalRuntimeContextSlot(string name) -> void
-OpenTelemetry.Context.ThreadLocalRuntimeContextSlot<T>.Value.get -> object
-OpenTelemetry.Context.ThreadLocalRuntimeContextSlot<T>.Value.set -> void
+~OpenTelemetry.Context.ThreadLocalRuntimeContextSlot<T>.ThreadLocalRuntimeContextSlot(string name) -> void
+~OpenTelemetry.Context.ThreadLocalRuntimeContextSlot<T>.Value.get -> object
+~OpenTelemetry.Context.ThreadLocalRuntimeContextSlot<T>.Value.set -> void
 OpenTelemetry.Metrics.IDeferredMeterProviderBuilder
-OpenTelemetry.Metrics.IDeferredMeterProviderBuilder.Configure(System.Action<System.IServiceProvider, OpenTelemetry.Metrics.MeterProviderBuilder> configure) -> OpenTelemetry.Metrics.MeterProviderBuilder
+~OpenTelemetry.Metrics.IDeferredMeterProviderBuilder.Configure(System.Action<System.IServiceProvider, OpenTelemetry.Metrics.MeterProviderBuilder> configure) -> OpenTelemetry.Metrics.MeterProviderBuilder
 OpenTelemetry.Metrics.MeterProvider
 OpenTelemetry.Metrics.MeterProvider.MeterProvider() -> void
 OpenTelemetry.Metrics.MeterProviderBuilder
 OpenTelemetry.Metrics.MeterProviderBuilder.MeterProviderBuilder() -> void
 OpenTelemetry.Trace.ActivityExtensions
 OpenTelemetry.Trace.IDeferredTracerProviderBuilder
-OpenTelemetry.Trace.IDeferredTracerProviderBuilder.Configure(System.Action<System.IServiceProvider, OpenTelemetry.Trace.TracerProviderBuilder> configure) -> OpenTelemetry.Trace.TracerProviderBuilder
+~OpenTelemetry.Trace.IDeferredTracerProviderBuilder.Configure(System.Action<System.IServiceProvider, OpenTelemetry.Trace.TracerProviderBuilder> configure) -> OpenTelemetry.Trace.TracerProviderBuilder
 OpenTelemetry.Trace.Link
-OpenTelemetry.Trace.Link.Attributes.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>
+~OpenTelemetry.Trace.Link.Attributes.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>
 OpenTelemetry.Trace.Link.Context.get -> OpenTelemetry.Trace.SpanContext
 OpenTelemetry.Trace.Link.Equals(OpenTelemetry.Trace.Link other) -> bool
 OpenTelemetry.Trace.Link.Link() -> void
 OpenTelemetry.Trace.Link.Link(in OpenTelemetry.Trace.SpanContext spanContext) -> void
-OpenTelemetry.Trace.Link.Link(in OpenTelemetry.Trace.SpanContext spanContext, OpenTelemetry.Trace.SpanAttributes attributes) -> void
+~OpenTelemetry.Trace.Link.Link(in OpenTelemetry.Trace.SpanContext spanContext, OpenTelemetry.Trace.SpanAttributes attributes) -> void
 OpenTelemetry.Trace.SpanAttributes
-OpenTelemetry.Trace.SpanAttributes.Add(string key, bool value) -> void
-OpenTelemetry.Trace.SpanAttributes.Add(string key, bool[] values) -> void
-OpenTelemetry.Trace.SpanAttributes.Add(string key, double value) -> void
-OpenTelemetry.Trace.SpanAttributes.Add(string key, double[] values) -> void
-OpenTelemetry.Trace.SpanAttributes.Add(string key, long value) -> void
-OpenTelemetry.Trace.SpanAttributes.Add(string key, long[] values) -> void
-OpenTelemetry.Trace.SpanAttributes.Add(string key, string value) -> void
-OpenTelemetry.Trace.SpanAttributes.Add(string key, string[] values) -> void
+~OpenTelemetry.Trace.SpanAttributes.Add(string key, bool value) -> void
+~OpenTelemetry.Trace.SpanAttributes.Add(string key, bool[] values) -> void
+~OpenTelemetry.Trace.SpanAttributes.Add(string key, double value) -> void
+~OpenTelemetry.Trace.SpanAttributes.Add(string key, double[] values) -> void
+~OpenTelemetry.Trace.SpanAttributes.Add(string key, long value) -> void
+~OpenTelemetry.Trace.SpanAttributes.Add(string key, long[] values) -> void
+~OpenTelemetry.Trace.SpanAttributes.Add(string key, string value) -> void
+~OpenTelemetry.Trace.SpanAttributes.Add(string key, string[] values) -> void
 OpenTelemetry.Trace.SpanAttributes.SpanAttributes() -> void
-OpenTelemetry.Trace.SpanAttributes.SpanAttributes(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>> attributes) -> void
+~OpenTelemetry.Trace.SpanAttributes.SpanAttributes(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>> attributes) -> void
 OpenTelemetry.Trace.SpanContext
 OpenTelemetry.Trace.SpanContext.Equals(OpenTelemetry.Trace.SpanContext other) -> bool
 OpenTelemetry.Trace.SpanContext.IsRemote.get -> bool
 OpenTelemetry.Trace.SpanContext.IsValid.get -> bool
 OpenTelemetry.Trace.SpanContext.SpanContext() -> void
 OpenTelemetry.Trace.SpanContext.SpanContext(in System.Diagnostics.ActivityContext activityContext) -> void
-OpenTelemetry.Trace.SpanContext.SpanContext(in System.Diagnostics.ActivityTraceId traceId, in System.Diagnostics.ActivitySpanId spanId, System.Diagnostics.ActivityTraceFlags traceFlags, bool isRemote = false, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> traceState = null) -> void
+~OpenTelemetry.Trace.SpanContext.SpanContext(in System.Diagnostics.ActivityTraceId traceId, in System.Diagnostics.ActivitySpanId spanId, System.Diagnostics.ActivityTraceFlags traceFlags, bool isRemote = false, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> traceState = null) -> void
 OpenTelemetry.Trace.SpanContext.SpanId.get -> System.Diagnostics.ActivitySpanId
 OpenTelemetry.Trace.SpanContext.TraceFlags.get -> System.Diagnostics.ActivityTraceFlags
 OpenTelemetry.Trace.SpanContext.TraceId.get -> System.Diagnostics.ActivityTraceId
-OpenTelemetry.Trace.SpanContext.TraceState.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>
+~OpenTelemetry.Trace.SpanContext.TraceState.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>
 OpenTelemetry.Trace.SpanKind
 OpenTelemetry.Trace.SpanKind.Client = 3 -> OpenTelemetry.Trace.SpanKind
 OpenTelemetry.Trace.SpanKind.Consumer = 5 -> OpenTelemetry.Trace.SpanKind
@@ -104,105 +105,105 @@ OpenTelemetry.Trace.SpanKind.Internal = 1 -> OpenTelemetry.Trace.SpanKind
 OpenTelemetry.Trace.SpanKind.Producer = 4 -> OpenTelemetry.Trace.SpanKind
 OpenTelemetry.Trace.SpanKind.Server = 2 -> OpenTelemetry.Trace.SpanKind
 OpenTelemetry.Trace.Status
-OpenTelemetry.Trace.Status.Description.get -> string
+~OpenTelemetry.Trace.Status.Description.get -> string
 OpenTelemetry.Trace.Status.Equals(OpenTelemetry.Trace.Status other) -> bool
 OpenTelemetry.Trace.Status.Status() -> void
 OpenTelemetry.Trace.Status.StatusCode.get -> OpenTelemetry.Trace.StatusCode
-OpenTelemetry.Trace.Status.WithDescription(string description) -> OpenTelemetry.Trace.Status
+~OpenTelemetry.Trace.Status.WithDescription(string description) -> OpenTelemetry.Trace.Status
 OpenTelemetry.Trace.StatusCode
 OpenTelemetry.Trace.StatusCode.Error = 2 -> OpenTelemetry.Trace.StatusCode
 OpenTelemetry.Trace.StatusCode.Ok = 1 -> OpenTelemetry.Trace.StatusCode
 OpenTelemetry.Trace.StatusCode.Unset = 0 -> OpenTelemetry.Trace.StatusCode
 OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.TelemetrySpan.AddEvent(string name) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.TelemetrySpan.AddEvent(string name, OpenTelemetry.Trace.SpanAttributes attributes) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.TelemetrySpan.AddEvent(string name, System.DateTimeOffset timestamp) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.TelemetrySpan.AddEvent(string name, System.DateTimeOffset timestamp, OpenTelemetry.Trace.SpanAttributes attributes) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.AddEvent(string name) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.AddEvent(string name, OpenTelemetry.Trace.SpanAttributes attributes) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.AddEvent(string name, System.DateTimeOffset timestamp) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.AddEvent(string name, System.DateTimeOffset timestamp, OpenTelemetry.Trace.SpanAttributes attributes) -> OpenTelemetry.Trace.TelemetrySpan
 OpenTelemetry.Trace.TelemetrySpan.Context.get -> OpenTelemetry.Trace.SpanContext
 OpenTelemetry.Trace.TelemetrySpan.Dispose() -> void
 OpenTelemetry.Trace.TelemetrySpan.End() -> void
 OpenTelemetry.Trace.TelemetrySpan.End(System.DateTimeOffset endTimestamp) -> void
 OpenTelemetry.Trace.TelemetrySpan.IsRecording.get -> bool
 OpenTelemetry.Trace.TelemetrySpan.ParentSpanId.get -> System.Diagnostics.ActivitySpanId
-OpenTelemetry.Trace.TelemetrySpan.RecordException(string type, string message, string stacktrace) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.TelemetrySpan.RecordException(System.Exception ex) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, bool value) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, bool[] values) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, double value) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, double[] values) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, int value) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, int[] values) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, string value) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, string[] values) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.RecordException(string type, string message, string stacktrace) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.RecordException(System.Exception ex) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, bool value) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, bool[] values) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, double value) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, double[] values) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, int value) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, int[] values) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, string value) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.SetAttribute(string key, string[] values) -> OpenTelemetry.Trace.TelemetrySpan
 OpenTelemetry.Trace.TelemetrySpan.SetStatus(OpenTelemetry.Trace.Status value) -> void
-OpenTelemetry.Trace.TelemetrySpan.UpdateName(string name) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.TelemetrySpan.UpdateName(string name) -> OpenTelemetry.Trace.TelemetrySpan
 OpenTelemetry.Trace.Tracer
-OpenTelemetry.Trace.Tracer.StartActiveSpan(string name, OpenTelemetry.Trace.SpanKind kind = OpenTelemetry.Trace.SpanKind.Internal, in OpenTelemetry.Trace.SpanContext parentContext = default(OpenTelemetry.Trace.SpanContext), OpenTelemetry.Trace.SpanAttributes initialAttributes = null, System.Collections.Generic.IEnumerable<OpenTelemetry.Trace.Link> links = null, System.DateTimeOffset startTime = default(System.DateTimeOffset)) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.Tracer.StartActiveSpan(string name, OpenTelemetry.Trace.SpanKind kind, in OpenTelemetry.Trace.TelemetrySpan parentSpan, OpenTelemetry.Trace.SpanAttributes initialAttributes = null, System.Collections.Generic.IEnumerable<OpenTelemetry.Trace.Link> links = null, System.DateTimeOffset startTime = default(System.DateTimeOffset)) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.Tracer.StartRootSpan(string name, OpenTelemetry.Trace.SpanKind kind = OpenTelemetry.Trace.SpanKind.Internal, OpenTelemetry.Trace.SpanAttributes initialAttributes = null, System.Collections.Generic.IEnumerable<OpenTelemetry.Trace.Link> links = null, System.DateTimeOffset startTime = default(System.DateTimeOffset)) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.Tracer.StartSpan(string name, OpenTelemetry.Trace.SpanKind kind = OpenTelemetry.Trace.SpanKind.Internal, in OpenTelemetry.Trace.SpanContext parentContext = default(OpenTelemetry.Trace.SpanContext), OpenTelemetry.Trace.SpanAttributes initialAttributes = null, System.Collections.Generic.IEnumerable<OpenTelemetry.Trace.Link> links = null, System.DateTimeOffset startTime = default(System.DateTimeOffset)) -> OpenTelemetry.Trace.TelemetrySpan
-OpenTelemetry.Trace.Tracer.StartSpan(string name, OpenTelemetry.Trace.SpanKind kind, in OpenTelemetry.Trace.TelemetrySpan parentSpan, OpenTelemetry.Trace.SpanAttributes initialAttributes = null, System.Collections.Generic.IEnumerable<OpenTelemetry.Trace.Link> links = null, System.DateTimeOffset startTime = default(System.DateTimeOffset)) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.Tracer.StartActiveSpan(string name, OpenTelemetry.Trace.SpanKind kind = OpenTelemetry.Trace.SpanKind.Internal, in OpenTelemetry.Trace.SpanContext parentContext = default(OpenTelemetry.Trace.SpanContext), OpenTelemetry.Trace.SpanAttributes initialAttributes = null, System.Collections.Generic.IEnumerable<OpenTelemetry.Trace.Link> links = null, System.DateTimeOffset startTime = default(System.DateTimeOffset)) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.Tracer.StartActiveSpan(string name, OpenTelemetry.Trace.SpanKind kind, in OpenTelemetry.Trace.TelemetrySpan parentSpan, OpenTelemetry.Trace.SpanAttributes initialAttributes = null, System.Collections.Generic.IEnumerable<OpenTelemetry.Trace.Link> links = null, System.DateTimeOffset startTime = default(System.DateTimeOffset)) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.Tracer.StartRootSpan(string name, OpenTelemetry.Trace.SpanKind kind = OpenTelemetry.Trace.SpanKind.Internal, OpenTelemetry.Trace.SpanAttributes initialAttributes = null, System.Collections.Generic.IEnumerable<OpenTelemetry.Trace.Link> links = null, System.DateTimeOffset startTime = default(System.DateTimeOffset)) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.Tracer.StartSpan(string name, OpenTelemetry.Trace.SpanKind kind = OpenTelemetry.Trace.SpanKind.Internal, in OpenTelemetry.Trace.SpanContext parentContext = default(OpenTelemetry.Trace.SpanContext), OpenTelemetry.Trace.SpanAttributes initialAttributes = null, System.Collections.Generic.IEnumerable<OpenTelemetry.Trace.Link> links = null, System.DateTimeOffset startTime = default(System.DateTimeOffset)) -> OpenTelemetry.Trace.TelemetrySpan
+~OpenTelemetry.Trace.Tracer.StartSpan(string name, OpenTelemetry.Trace.SpanKind kind, in OpenTelemetry.Trace.TelemetrySpan parentSpan, OpenTelemetry.Trace.SpanAttributes initialAttributes = null, System.Collections.Generic.IEnumerable<OpenTelemetry.Trace.Link> links = null, System.DateTimeOffset startTime = default(System.DateTimeOffset)) -> OpenTelemetry.Trace.TelemetrySpan
 OpenTelemetry.Trace.TracerProvider
-OpenTelemetry.Trace.TracerProvider.GetTracer(string name, string version = null) -> OpenTelemetry.Trace.Tracer
+~OpenTelemetry.Trace.TracerProvider.GetTracer(string name, string version = null) -> OpenTelemetry.Trace.Tracer
 OpenTelemetry.Trace.TracerProvider.TracerProvider() -> void
 OpenTelemetry.Trace.TracerProviderBuilder
 OpenTelemetry.Trace.TracerProviderBuilder.TracerProviderBuilder() -> void
-override OpenTelemetry.Baggage.Equals(object obj) -> bool
+~override OpenTelemetry.Baggage.Equals(object obj) -> bool
 override OpenTelemetry.Baggage.GetHashCode() -> int
 override OpenTelemetry.Context.AsyncLocalRuntimeContextSlot<T>.Get() -> T
 override OpenTelemetry.Context.AsyncLocalRuntimeContextSlot<T>.Set(T value) -> void
-override OpenTelemetry.Context.Propagation.B3Propagator.Extract<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> OpenTelemetry.Context.Propagation.PropagationContext
-override OpenTelemetry.Context.Propagation.B3Propagator.Fields.get -> System.Collections.Generic.ISet<string>
-override OpenTelemetry.Context.Propagation.B3Propagator.Inject<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
-override OpenTelemetry.Context.Propagation.BaggagePropagator.Extract<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> OpenTelemetry.Context.Propagation.PropagationContext
-override OpenTelemetry.Context.Propagation.BaggagePropagator.Fields.get -> System.Collections.Generic.ISet<string>
-override OpenTelemetry.Context.Propagation.BaggagePropagator.Inject<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
-override OpenTelemetry.Context.Propagation.CompositeTextMapPropagator.Extract<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> OpenTelemetry.Context.Propagation.PropagationContext
-override OpenTelemetry.Context.Propagation.CompositeTextMapPropagator.Fields.get -> System.Collections.Generic.ISet<string>
-override OpenTelemetry.Context.Propagation.CompositeTextMapPropagator.Inject<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
-override OpenTelemetry.Context.Propagation.PropagationContext.Equals(object obj) -> bool
+~override OpenTelemetry.Context.Propagation.B3Propagator.Extract<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> OpenTelemetry.Context.Propagation.PropagationContext
+~override OpenTelemetry.Context.Propagation.B3Propagator.Fields.get -> System.Collections.Generic.ISet<string>
+~override OpenTelemetry.Context.Propagation.B3Propagator.Inject<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
+~override OpenTelemetry.Context.Propagation.BaggagePropagator.Extract<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> OpenTelemetry.Context.Propagation.PropagationContext
+~override OpenTelemetry.Context.Propagation.BaggagePropagator.Fields.get -> System.Collections.Generic.ISet<string>
+~override OpenTelemetry.Context.Propagation.BaggagePropagator.Inject<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
+~override OpenTelemetry.Context.Propagation.CompositeTextMapPropagator.Extract<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> OpenTelemetry.Context.Propagation.PropagationContext
+~override OpenTelemetry.Context.Propagation.CompositeTextMapPropagator.Fields.get -> System.Collections.Generic.ISet<string>
+~override OpenTelemetry.Context.Propagation.CompositeTextMapPropagator.Inject<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
+~override OpenTelemetry.Context.Propagation.PropagationContext.Equals(object obj) -> bool
 override OpenTelemetry.Context.Propagation.PropagationContext.GetHashCode() -> int
-override OpenTelemetry.Context.Propagation.TraceContextPropagator.Extract<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> OpenTelemetry.Context.Propagation.PropagationContext
-override OpenTelemetry.Context.Propagation.TraceContextPropagator.Fields.get -> System.Collections.Generic.ISet<string>
-override OpenTelemetry.Context.Propagation.TraceContextPropagator.Inject<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
+~override OpenTelemetry.Context.Propagation.TraceContextPropagator.Extract<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Func<T, string, System.Collections.Generic.IEnumerable<string>> getter) -> OpenTelemetry.Context.Propagation.PropagationContext
+~override OpenTelemetry.Context.Propagation.TraceContextPropagator.Fields.get -> System.Collections.Generic.ISet<string>
+~override OpenTelemetry.Context.Propagation.TraceContextPropagator.Inject<T>(OpenTelemetry.Context.Propagation.PropagationContext context, T carrier, System.Action<T, string, string> setter) -> void
 override OpenTelemetry.Context.ThreadLocalRuntimeContextSlot<T>.Dispose(bool disposing) -> void
 override OpenTelemetry.Context.ThreadLocalRuntimeContextSlot<T>.Get() -> T
 override OpenTelemetry.Context.ThreadLocalRuntimeContextSlot<T>.Set(T value) -> void
-override OpenTelemetry.Trace.Link.Equals(object obj) -> bool
+~override OpenTelemetry.Trace.Link.Equals(object obj) -> bool
 override OpenTelemetry.Trace.Link.GetHashCode() -> int
-override OpenTelemetry.Trace.SpanContext.Equals(object obj) -> bool
+~override OpenTelemetry.Trace.SpanContext.Equals(object obj) -> bool
 override OpenTelemetry.Trace.SpanContext.GetHashCode() -> int
-override OpenTelemetry.Trace.Status.Equals(object obj) -> bool
+~override OpenTelemetry.Trace.Status.Equals(object obj) -> bool
 override OpenTelemetry.Trace.Status.GetHashCode() -> int
-override OpenTelemetry.Trace.Status.ToString() -> string
+~override OpenTelemetry.Trace.Status.ToString() -> string
 static OpenTelemetry.ActivityContextExtensions.IsValid(this System.Diagnostics.ActivityContext ctx) -> bool
 static OpenTelemetry.Baggage.ClearBaggage(OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> OpenTelemetry.Baggage
-static OpenTelemetry.Baggage.Create(System.Collections.Generic.Dictionary<string, string> baggageItems = null) -> OpenTelemetry.Baggage
+~static OpenTelemetry.Baggage.Create(System.Collections.Generic.Dictionary<string, string> baggageItems = null) -> OpenTelemetry.Baggage
 static OpenTelemetry.Baggage.Current.get -> OpenTelemetry.Baggage
 static OpenTelemetry.Baggage.Current.set -> void
-static OpenTelemetry.Baggage.GetBaggage(OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> System.Collections.Generic.IReadOnlyDictionary<string, string>
-static OpenTelemetry.Baggage.GetBaggage(string name, OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> string
-static OpenTelemetry.Baggage.GetEnumerator(OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> System.Collections.Generic.Dictionary<string, string>.Enumerator
+~static OpenTelemetry.Baggage.GetBaggage(OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> System.Collections.Generic.IReadOnlyDictionary<string, string>
+~static OpenTelemetry.Baggage.GetBaggage(string name, OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> string
+~static OpenTelemetry.Baggage.GetEnumerator(OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> System.Collections.Generic.Dictionary<string, string>.Enumerator
 static OpenTelemetry.Baggage.operator !=(OpenTelemetry.Baggage left, OpenTelemetry.Baggage right) -> bool
 static OpenTelemetry.Baggage.operator ==(OpenTelemetry.Baggage left, OpenTelemetry.Baggage right) -> bool
-static OpenTelemetry.Baggage.RemoveBaggage(string name, OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> OpenTelemetry.Baggage
-static OpenTelemetry.Baggage.SetBaggage(string name, string value, OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> OpenTelemetry.Baggage
-static OpenTelemetry.Baggage.SetBaggage(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> baggageItems, OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> OpenTelemetry.Baggage
+~static OpenTelemetry.Baggage.RemoveBaggage(string name, OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> OpenTelemetry.Baggage
+~static OpenTelemetry.Baggage.SetBaggage(string name, string value, OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> OpenTelemetry.Baggage
+~static OpenTelemetry.Baggage.SetBaggage(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> baggageItems, OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> OpenTelemetry.Baggage
 static OpenTelemetry.Context.Propagation.PropagationContext.operator !=(OpenTelemetry.Context.Propagation.PropagationContext left, OpenTelemetry.Context.Propagation.PropagationContext right) -> bool
 static OpenTelemetry.Context.Propagation.PropagationContext.operator ==(OpenTelemetry.Context.Propagation.PropagationContext left, OpenTelemetry.Context.Propagation.PropagationContext right) -> bool
-static OpenTelemetry.Context.Propagation.Propagators.DefaultTextMapPropagator.get -> OpenTelemetry.Context.Propagation.TextMapPropagator
-static OpenTelemetry.Context.RuntimeContext.ContextSlotType.get -> System.Type
-static OpenTelemetry.Context.RuntimeContext.ContextSlotType.set -> void
-static OpenTelemetry.Context.RuntimeContext.GetSlot<T>(string slotName) -> OpenTelemetry.Context.RuntimeContextSlot<T>
-static OpenTelemetry.Context.RuntimeContext.GetValue(string slotName) -> object
-static OpenTelemetry.Context.RuntimeContext.GetValue<T>(string slotName) -> T
-static OpenTelemetry.Context.RuntimeContext.RegisterSlot<T>(string slotName) -> OpenTelemetry.Context.RuntimeContextSlot<T>
-static OpenTelemetry.Context.RuntimeContext.SetValue(string slotName, object value) -> void
-static OpenTelemetry.Context.RuntimeContext.SetValue<T>(string slotName, T value) -> void
-static OpenTelemetry.Trace.ActivityExtensions.GetStatus(this System.Diagnostics.Activity activity) -> OpenTelemetry.Trace.Status
-static OpenTelemetry.Trace.ActivityExtensions.RecordException(this System.Diagnostics.Activity activity, System.Exception ex) -> void
-static OpenTelemetry.Trace.ActivityExtensions.RecordException(this System.Diagnostics.Activity activity, System.Exception ex, in System.Diagnostics.TagList tags) -> void
-static OpenTelemetry.Trace.ActivityExtensions.SetStatus(this System.Diagnostics.Activity activity, OpenTelemetry.Trace.Status status) -> void
+~static OpenTelemetry.Context.Propagation.Propagators.DefaultTextMapPropagator.get -> OpenTelemetry.Context.Propagation.TextMapPropagator
+~static OpenTelemetry.Context.RuntimeContext.ContextSlotType.get -> System.Type
+~static OpenTelemetry.Context.RuntimeContext.ContextSlotType.set -> void
+~static OpenTelemetry.Context.RuntimeContext.GetSlot<T>(string slotName) -> OpenTelemetry.Context.RuntimeContextSlot<T>
+~static OpenTelemetry.Context.RuntimeContext.GetValue(string slotName) -> object
+~static OpenTelemetry.Context.RuntimeContext.GetValue<T>(string slotName) -> T
+~static OpenTelemetry.Context.RuntimeContext.RegisterSlot<T>(string slotName) -> OpenTelemetry.Context.RuntimeContextSlot<T>
+~static OpenTelemetry.Context.RuntimeContext.SetValue(string slotName, object value) -> void
+~static OpenTelemetry.Context.RuntimeContext.SetValue<T>(string slotName, T value) -> void
+~static OpenTelemetry.Trace.ActivityExtensions.GetStatus(this System.Diagnostics.Activity activity) -> OpenTelemetry.Trace.Status
+~static OpenTelemetry.Trace.ActivityExtensions.RecordException(this System.Diagnostics.Activity activity, System.Exception ex) -> void
+~static OpenTelemetry.Trace.ActivityExtensions.RecordException(this System.Diagnostics.Activity activity, System.Exception ex, in System.Diagnostics.TagList tags) -> void
+~static OpenTelemetry.Trace.ActivityExtensions.SetStatus(this System.Diagnostics.Activity activity, OpenTelemetry.Trace.Status status) -> void
 static OpenTelemetry.Trace.Link.operator !=(OpenTelemetry.Trace.Link link1, OpenTelemetry.Trace.Link link2) -> bool
 static OpenTelemetry.Trace.Link.operator ==(OpenTelemetry.Trace.Link link1, OpenTelemetry.Trace.Link link2) -> bool
 static OpenTelemetry.Trace.SpanContext.implicit operator System.Diagnostics.ActivityContext(OpenTelemetry.Trace.SpanContext spanContext) -> System.Diagnostics.ActivityContext
@@ -210,9 +211,9 @@ static OpenTelemetry.Trace.SpanContext.operator !=(OpenTelemetry.Trace.SpanConte
 static OpenTelemetry.Trace.SpanContext.operator ==(OpenTelemetry.Trace.SpanContext spanContext1, OpenTelemetry.Trace.SpanContext spanContext2) -> bool
 static OpenTelemetry.Trace.Status.operator !=(OpenTelemetry.Trace.Status status1, OpenTelemetry.Trace.Status status2) -> bool
 static OpenTelemetry.Trace.Status.operator ==(OpenTelemetry.Trace.Status status1, OpenTelemetry.Trace.Status status2) -> bool
-static OpenTelemetry.Trace.Tracer.CurrentSpan.get -> OpenTelemetry.Trace.TelemetrySpan
-static OpenTelemetry.Trace.Tracer.WithSpan(OpenTelemetry.Trace.TelemetrySpan span) -> OpenTelemetry.Trace.TelemetrySpan
-static OpenTelemetry.Trace.TracerProvider.Default.get -> OpenTelemetry.Trace.TracerProvider
+~static OpenTelemetry.Trace.Tracer.CurrentSpan.get -> OpenTelemetry.Trace.TelemetrySpan
+~static OpenTelemetry.Trace.Tracer.WithSpan(OpenTelemetry.Trace.TelemetrySpan span) -> OpenTelemetry.Trace.TelemetrySpan
+~static OpenTelemetry.Trace.TracerProvider.Default.get -> OpenTelemetry.Trace.TracerProvider
 static readonly OpenTelemetry.Trace.Status.Error -> OpenTelemetry.Trace.Status
 static readonly OpenTelemetry.Trace.Status.Ok -> OpenTelemetry.Trace.Status
 static readonly OpenTelemetry.Trace.Status.Unset -> OpenTelemetry.Trace.Status

--- a/src/OpenTelemetry.Api/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,79 @@
+abstract OpenTelemetry.Logs.Logger.EmitLog(in OpenTelemetry.Logs.LogRecordData data, in OpenTelemetry.Logs.LogRecordAttributeList attributes = default(OpenTelemetry.Logs.LogRecordAttributeList)) -> void
+abstract OpenTelemetry.Logs.LoggerProviderBuilder.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation!>! instrumentationFactory) -> OpenTelemetry.Logs.LoggerProviderBuilder!
+OpenTelemetry.Logs.IDeferredLoggerProviderBuilder
+OpenTelemetry.Logs.IDeferredLoggerProviderBuilder.Configure(System.Action<System.IServiceProvider!, OpenTelemetry.Logs.LoggerProviderBuilder!>! configure) -> OpenTelemetry.Logs.LoggerProviderBuilder!
+OpenTelemetry.Logs.Logger
+OpenTelemetry.Logs.Logger.Logger(string? name) -> void
+OpenTelemetry.Logs.Logger.Name.get -> string!
+OpenTelemetry.Logs.Logger.Version.get -> string?
+OpenTelemetry.Logs.LoggerProvider
+OpenTelemetry.Logs.LoggerProvider.GetLogger() -> OpenTelemetry.Logs.Logger!
+OpenTelemetry.Logs.LoggerProvider.GetLogger(string? name) -> OpenTelemetry.Logs.Logger!
+OpenTelemetry.Logs.LoggerProvider.GetLogger(string? name, string? version) -> OpenTelemetry.Logs.Logger!
+OpenTelemetry.Logs.LoggerProvider.LoggerProvider() -> void
+OpenTelemetry.Logs.LoggerProviderBuilder
+OpenTelemetry.Logs.LoggerProviderBuilder.LoggerProviderBuilder() -> void
+OpenTelemetry.Logs.LogRecordAttributeList
+OpenTelemetry.Logs.LogRecordAttributeList.Add(string! key, object? value) -> void
+OpenTelemetry.Logs.LogRecordAttributeList.Add(System.Collections.Generic.KeyValuePair<string!, object?> attribute) -> void
+OpenTelemetry.Logs.LogRecordAttributeList.Clear() -> void
+OpenTelemetry.Logs.LogRecordAttributeList.Count.get -> int
+OpenTelemetry.Logs.LogRecordAttributeList.Enumerator
+OpenTelemetry.Logs.LogRecordAttributeList.Enumerator.Current.get -> System.Collections.Generic.KeyValuePair<string!, object?>
+OpenTelemetry.Logs.LogRecordAttributeList.Enumerator.Dispose() -> void
+OpenTelemetry.Logs.LogRecordAttributeList.Enumerator.Enumerator() -> void
+OpenTelemetry.Logs.LogRecordAttributeList.Enumerator.MoveNext() -> bool
+OpenTelemetry.Logs.LogRecordAttributeList.GetEnumerator() -> OpenTelemetry.Logs.LogRecordAttributeList.Enumerator
+OpenTelemetry.Logs.LogRecordAttributeList.LogRecordAttributeList() -> void
+OpenTelemetry.Logs.LogRecordAttributeList.RecordException(System.Exception! exception) -> void
+OpenTelemetry.Logs.LogRecordAttributeList.this[int index].get -> System.Collections.Generic.KeyValuePair<string!, object?>
+OpenTelemetry.Logs.LogRecordAttributeList.this[int index].set -> void
+OpenTelemetry.Logs.LogRecordAttributeList.this[string! key].set -> void
+OpenTelemetry.Logs.LogRecordData
+OpenTelemetry.Logs.LogRecordData.Body.get -> string?
+OpenTelemetry.Logs.LogRecordData.Body.set -> void
+OpenTelemetry.Logs.LogRecordData.LogRecordData() -> void
+OpenTelemetry.Logs.LogRecordData.LogRecordData(in System.Diagnostics.ActivityContext activityContext) -> void
+OpenTelemetry.Logs.LogRecordData.LogRecordData(System.Diagnostics.Activity? activity) -> void
+OpenTelemetry.Logs.LogRecordData.Severity.get -> OpenTelemetry.Logs.LogRecordSeverity?
+OpenTelemetry.Logs.LogRecordData.Severity.set -> void
+OpenTelemetry.Logs.LogRecordData.SeverityText.get -> string?
+OpenTelemetry.Logs.LogRecordData.SeverityText.set -> void
+OpenTelemetry.Logs.LogRecordData.SpanId.get -> System.Diagnostics.ActivitySpanId
+OpenTelemetry.Logs.LogRecordData.SpanId.set -> void
+OpenTelemetry.Logs.LogRecordData.Timestamp.get -> System.DateTime
+OpenTelemetry.Logs.LogRecordData.Timestamp.set -> void
+OpenTelemetry.Logs.LogRecordData.TraceFlags.get -> System.Diagnostics.ActivityTraceFlags
+OpenTelemetry.Logs.LogRecordData.TraceFlags.set -> void
+OpenTelemetry.Logs.LogRecordData.TraceId.get -> System.Diagnostics.ActivityTraceId
+OpenTelemetry.Logs.LogRecordData.TraceId.set -> void
+OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Debug = 5 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Debug2 = 6 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Debug3 = 7 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Debug4 = 8 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Error = 17 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Error2 = 18 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Error3 = 19 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Error4 = 20 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Fatal = 21 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Fatal2 = 22 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Fatal3 = 23 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Fatal4 = 24 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Info = 9 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Info2 = 10 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Info3 = 11 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Info4 = 12 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Trace = 1 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Trace2 = 2 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Trace3 = 3 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Trace4 = 4 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Unspecified = 0 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Warn = 13 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Warn2 = 14 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Warn3 = 15 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverity.Warn4 = 16 -> OpenTelemetry.Logs.LogRecordSeverity
+OpenTelemetry.Logs.LogRecordSeverityExtensions
+static OpenTelemetry.Logs.LogRecordAttributeList.CreateFromEnumerable(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, object?>>! attributes) -> OpenTelemetry.Logs.LogRecordAttributeList
+static OpenTelemetry.Logs.LogRecordSeverityExtensions.ToShortName(this OpenTelemetry.Logs.LogRecordSeverity logRecordSeverity) -> string!
+virtual OpenTelemetry.Logs.LoggerProvider.TryCreateLogger(string? name, out OpenTelemetry.Logs.Logger? logger) -> bool

--- a/src/OpenTelemetry.Api/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Api/AssemblyInfo.cs
@@ -18,12 +18,7 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("OpenTelemetry" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry.Api.ProviderBuilderExtensions" + AssemblyInfo.PublicKey)]
-[assembly: InternalsVisibleTo("OpenTelemetry.Api.ProviderBuilderExtensions.Tests" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry.Api.Tests" + AssemblyInfo.PublicKey)]
-[assembly: InternalsVisibleTo("OpenTelemetry.Exporter.Console" + AssemblyInfo.PublicKey)]
-[assembly: InternalsVisibleTo("OpenTelemetry.Exporter.InMemory" + AssemblyInfo.PublicKey)]
-[assembly: InternalsVisibleTo("OpenTelemetry.Extensions.Hosting" + AssemblyInfo.PublicKey)]
-[assembly: InternalsVisibleTo("OpenTelemetry.Extensions.Hosting.Tests" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry.Shims.OpenTracing.Tests" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry.Tests" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2" + AssemblyInfo.MoqPublicKey)]

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -11,6 +11,11 @@
   other than the three types mentioned.
   ([#4542](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4542))
 
+* Added [Logs Bridge
+  API](https://github.com/open-telemetry/opentelemetry-specification/blob/976432b74c565e8a84af3570e9b82cb95e1d844c/specification/logs/bridge-api.md)
+  artifacts.
+  ([#4433](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4433))
+
 ## 1.5.0
 
 Released 2023-Jun-05

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 * Added [Logs Bridge
   API](https://github.com/open-telemetry/opentelemetry-specification/blob/976432b74c565e8a84af3570e9b82cb95e1d844c/specification/logs/bridge-api.md)
-  artifacts.
+  implementation (`LoggerProviderBuilder`, `LoggerProvider`, `Logger`, etc.).
   ([#4433](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4433))
 
 ## 1.5.0

--- a/src/OpenTelemetry.Api/Logs/IDeferredLoggerProviderBuilder.cs
+++ b/src/OpenTelemetry.Api/Logs/IDeferredLoggerProviderBuilder.cs
@@ -23,7 +23,7 @@ namespace OpenTelemetry.Logs;
 /// initialization using an <see cref="IServiceProvider"/> to perform
 /// dependency injection.
 /// </summary>
-internal interface IDeferredLoggerProviderBuilder
+public interface IDeferredLoggerProviderBuilder
 {
     /// <summary>
     /// Register a callback action to configure the <see

--- a/src/OpenTelemetry.Api/Logs/LogRecordAttributeList.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordAttributeList.cs
@@ -27,7 +27,7 @@ namespace OpenTelemetry.Logs;
 /// <summary>
 /// Stores attributes to be added to a log message.
 /// </summary>
-internal struct LogRecordAttributeList : IReadOnlyList<KeyValuePair<string, object?>>
+public struct LogRecordAttributeList : IReadOnlyList<KeyValuePair<string, object?>>
 {
     internal const int OverflowMaxCount = 8;
     internal const int OverflowAdditionalCapacity = 16;

--- a/src/OpenTelemetry.Api/Logs/LogRecordData.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordData.cs
@@ -23,7 +23,7 @@ namespace OpenTelemetry.Logs;
 /// <summary>
 /// Stores details about a log message.
 /// </summary>
-internal struct LogRecordData
+public struct LogRecordData
 {
     internal DateTime TimestampBacking = DateTime.UtcNow;
 

--- a/src/OpenTelemetry.Api/Logs/LogRecordSeverity.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordSeverity.cs
@@ -21,7 +21,7 @@ namespace OpenTelemetry.Logs;
 /// <summary>
 /// Describes the severity level of a log record.
 /// </summary>
-internal enum LogRecordSeverity
+public enum LogRecordSeverity
 {
     /// <summary>Unspecified severity (0).</summary>
     Unspecified = 0,

--- a/src/OpenTelemetry.Api/Logs/LogRecordSeverityExtensions.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordSeverityExtensions.cs
@@ -21,7 +21,7 @@ namespace OpenTelemetry.Logs;
 /// <summary>
 /// Contains extension methods for the <see cref="LogRecordSeverity"/> enum.
 /// </summary>
-internal static class LogRecordSeverityExtensions
+public static class LogRecordSeverityExtensions
 {
     internal const string UnspecifiedShortName = "UNSPECIFIED";
 

--- a/src/OpenTelemetry.Api/Logs/Logger.cs
+++ b/src/OpenTelemetry.Api/Logs/Logger.cs
@@ -21,7 +21,7 @@ namespace OpenTelemetry.Logs;
 /// <summary>
 /// Logger is the class responsible for creating log records.
 /// </summary>
-internal abstract class Logger
+public abstract class Logger
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="Logger"/> class.

--- a/src/OpenTelemetry.Api/Logs/LoggerProvider.cs
+++ b/src/OpenTelemetry.Api/Logs/LoggerProvider.cs
@@ -25,7 +25,7 @@ namespace OpenTelemetry.Logs;
 /// <summary>
 /// LoggerProvider is the entry point of the OpenTelemetry API. It provides access to <see cref="Logger"/>.
 /// </summary>
-internal class LoggerProvider : BaseProvider
+public class LoggerProvider : BaseProvider
 {
     private static readonly NoopLogger NoopLogger = new();
 

--- a/src/OpenTelemetry.Api/Logs/LoggerProviderBuilder.cs
+++ b/src/OpenTelemetry.Api/Logs/LoggerProviderBuilder.cs
@@ -21,7 +21,7 @@ namespace OpenTelemetry.Logs;
 /// <summary>
 /// LoggerProviderBuilder base class.
 /// </summary>
-internal abstract class LoggerProviderBuilder
+public abstract class LoggerProviderBuilder
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="LoggerProviderBuilder"/> class.

--- a/src/OpenTelemetry.Exporter.Console/OpenTelemetry.Exporter.Console.csproj
+++ b/src/OpenTelemetry.Exporter.Console/OpenTelemetry.Exporter.Console.csproj
@@ -25,11 +25,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Note: OpenTelemetry.Exporter.Console temporarily sees OpenTelemetry.Api internals for LoggerProviderBuilder
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\ExceptionExtensions.cs" Link="Includes\ExceptionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\SpanAttributeConstants.cs" Link="Includes\SpanAttributeConstants.cs" />
-    -->
     <!-- Note: OpenTelemetry.Exporter.Console temporarily sees OpenTelemetry internals for LoggerProviderBuilder extensions
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\OpenTelemetrySdkEventSource.cs" Link="Includes\OpenTelemetrySdkEventSource.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\PeriodicExportingMetricReaderHelper.cs" Link="Includes\PeriodicExportingMetricReaderHelper.cs" />

--- a/src/OpenTelemetry.Exporter.InMemory/OpenTelemetry.Exporter.InMemory.csproj
+++ b/src/OpenTelemetry.Exporter.InMemory/OpenTelemetry.Exporter.InMemory.csproj
@@ -20,9 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Note: OpenTelemetry.Exporter.InMemory temporarily sees OpenTelemetry.Api internals for LoggerProviderBuilder
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\Guard.cs" Link="Includes\Guard.cs" />
-    -->
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Extensions.Hosting/AssemblyInfo.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/AssemblyInfo.cs
@@ -19,7 +19,6 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("OpenTelemetry.Extensions.Hosting.Tests" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2" + AssemblyInfo.MoqPublicKey)]
 
-/* Note: OpenTelemetry.Extensions.Hosting temporarily sees OpenTelemetry.Api internals for LoggerProvider
 #if SIGNED
 internal static class AssemblyInfo
 {
@@ -33,4 +32,3 @@ internal static class AssemblyInfo
     public const string MoqPublicKey = "";
 }
 #endif
-*/

--- a/src/OpenTelemetry.Extensions.Hosting/OpenTelemetry.Extensions.Hosting.csproj
+++ b/src/OpenTelemetry.Extensions.Hosting/OpenTelemetry.Extensions.Hosting.csproj
@@ -18,10 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Note: OpenTelemetry.Extensions.Hosting temporarily sees OpenTelemetry.Api internals for LoggerProvider
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\ExceptionExtensions.cs" Link="Includes\ExceptionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\Guard.cs" Link="Includes\Guard.cs" />
-    -->
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Relates to #4433

## Changes

* Exposes the logging artifacts in `OpenTelemetry.Api` and removes the added `InternalsVisibleTo`s

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
