### PR TITLE
[api-logs] Removed default parameter from the EmitLog API

### DIFF
--- a/src/OpenTelemetry.Api/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -1,8 +1,9 @@
-abstract OpenTelemetry.Logs.Logger.EmitLog(in OpenTelemetry.Logs.LogRecordData data, in OpenTelemetry.Logs.LogRecordAttributeList attributes = default(OpenTelemetry.Logs.LogRecordAttributeList)) -> void
+abstract OpenTelemetry.Logs.Logger.EmitLog(in OpenTelemetry.Logs.LogRecordData data, in OpenTelemetry.Logs.LogRecordAttributeList attributes) -> void
 abstract OpenTelemetry.Logs.LoggerProviderBuilder.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation!>! instrumentationFactory) -> OpenTelemetry.Logs.LoggerProviderBuilder!
 OpenTelemetry.Logs.IDeferredLoggerProviderBuilder
 OpenTelemetry.Logs.IDeferredLoggerProviderBuilder.Configure(System.Action<System.IServiceProvider!, OpenTelemetry.Logs.LoggerProviderBuilder!>! configure) -> OpenTelemetry.Logs.LoggerProviderBuilder!
 OpenTelemetry.Logs.Logger
+OpenTelemetry.Logs.Logger.EmitLog(in OpenTelemetry.Logs.LogRecordData data) -> void
 OpenTelemetry.Logs.Logger.Logger(string? name) -> void
 OpenTelemetry.Logs.Logger.Name.get -> string!
 OpenTelemetry.Logs.Logger.Version.get -> string?

--- a/src/OpenTelemetry.Api/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,8 +1,9 @@
-abstract OpenTelemetry.Logs.Logger.EmitLog(in OpenTelemetry.Logs.LogRecordData data, in OpenTelemetry.Logs.LogRecordAttributeList attributes = default(OpenTelemetry.Logs.LogRecordAttributeList)) -> void
+abstract OpenTelemetry.Logs.Logger.EmitLog(in OpenTelemetry.Logs.LogRecordData data, in OpenTelemetry.Logs.LogRecordAttributeList attributes) -> void
 abstract OpenTelemetry.Logs.LoggerProviderBuilder.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation!>! instrumentationFactory) -> OpenTelemetry.Logs.LoggerProviderBuilder!
 OpenTelemetry.Logs.IDeferredLoggerProviderBuilder
 OpenTelemetry.Logs.IDeferredLoggerProviderBuilder.Configure(System.Action<System.IServiceProvider!, OpenTelemetry.Logs.LoggerProviderBuilder!>! configure) -> OpenTelemetry.Logs.LoggerProviderBuilder!
 OpenTelemetry.Logs.Logger
+OpenTelemetry.Logs.Logger.EmitLog(in OpenTelemetry.Logs.LogRecordData data) -> void
 OpenTelemetry.Logs.Logger.Logger(string? name) -> void
 OpenTelemetry.Logs.Logger.Name.get -> string!
 OpenTelemetry.Logs.Logger.Version.get -> string?

--- a/src/OpenTelemetry.Api/Logs/Logger.cs
+++ b/src/OpenTelemetry.Api/Logs/Logger.cs
@@ -48,10 +48,17 @@ public abstract class Logger
     /// Emit a log.
     /// </summary>
     /// <param name="data"><see cref="LogRecordData"/>.</param>
+    public void EmitLog(in LogRecordData data)
+        => this.EmitLog(in data, default);
+
+    /// <summary>
+    /// Emit a log.
+    /// </summary>
+    /// <param name="data"><see cref="LogRecordData"/>.</param>
     /// <param name="attributes"><see cref="LogRecordAttributeList"/>.</param>
     public abstract void EmitLog(
         in LogRecordData data,
-        in LogRecordAttributeList attributes = default);
+        in LogRecordAttributeList attributes);
 
     internal void SetInstrumentationScope(
         string? version)

--- a/src/OpenTelemetry.Api/Logs/NoopLogger.cs
+++ b/src/OpenTelemetry.Api/Logs/NoopLogger.cs
@@ -27,7 +27,7 @@ internal sealed class NoopLogger : Logger
 
     public override void EmitLog(
         in LogRecordData data,
-        in LogRecordAttributeList attributes = default)
+        in LogRecordAttributeList attributes)
     {
     }
 }

--- a/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLogger.cs
+++ b/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLogger.cs
@@ -268,7 +268,7 @@ internal sealed class OpenTelemetryLogger : ILogger
         public static LoggerInstrumentationScope Instance { get; }
             = new("OpenTelemetry", typeof(OpenTelemetryLogger).Assembly.GetName().Version?.ToString() ?? "1.0.0");
 
-        public override void EmitLog(in LogRecordData data, in LogRecordAttributeList attributes = default)
+        public override void EmitLog(in LogRecordData data, in LogRecordAttributeList attributes)
             => throw new NotSupportedException();
     }
 }

--- a/src/OpenTelemetry/Logs/LoggerSdk.cs
+++ b/src/OpenTelemetry/Logs/LoggerSdk.cs
@@ -38,7 +38,7 @@ internal sealed class LoggerSdk : Logger
     }
 
     /// <inheritdoc />
-    public override void EmitLog(in LogRecordData data, in LogRecordAttributeList attributes = default)
+    public override void EmitLog(in LogRecordData data, in LogRecordAttributeList attributes)
     {
         var provider = this.loggerProvider;
         var processor = provider.Processor;

--- a/test/OpenTelemetry.Api.Tests/Logs/LoggerProviderTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Logs/LoggerProviderTests.cs
@@ -82,7 +82,7 @@ public sealed class LoggerProviderTests
         {
         }
 
-        public override void EmitLog(in LogRecordData data, in LogRecordAttributeList attributes = default)
+        public override void EmitLog(in LogRecordData data, in LogRecordAttributeList attributes)
         {
         }
     }


### PR DESCRIPTION
Relates to #4433

See https://github.com/open-telemetry/opentelemetry-dotnet/pull/4552#discussion_r1222102263

## Changes

* Updates the `EmitLog` API so that it doesn't use default parameters

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
