### PR TITLE
Remove property related to CodeCoverage from Common.props

### DIFF
--- a/build/Common.nonprod.props
+++ b/build/Common.nonprod.props
@@ -25,6 +25,10 @@
     <ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <MicrosoftCodeCoveragePkgVer>[17.4.1]</MicrosoftCodeCoveragePkgVer>
+  </PropertyGroup>
+
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>

--- a/build/Common.nonprod.props
+++ b/build/Common.nonprod.props
@@ -25,10 +25,6 @@
     <ProduceReferenceAssemblyInOutDir>true</ProduceReferenceAssemblyInOutDir>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <MicrosoftCodeCoveragePkgVer>[17.4.1]</MicrosoftCodeCoveragePkgVer>
-  </PropertyGroup>
-
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>

--- a/build/Common.props
+++ b/build/Common.props
@@ -26,7 +26,6 @@
       Please sort alphabetically.
       Refer to https://docs.microsoft.com/nuget/concepts/package-versioning for semver syntax.
     -->
-    <MicrosoftCodeCoveragePkgVer>[17.4.1]</MicrosoftCodeCoveragePkgVer>
     <OTelPreviousStableVer>1.5.0</OTelPreviousStableVer>
     <SerilogPkgVer>[2.8.0,3.0)</SerilogPkgVer>
     <SystemCollectionsImmutablePkgVer>1.4.0</SystemCollectionsImmutablePkgVer>

--- a/build/process-codecoverage.ps1
+++ b/build/process-codecoverage.ps1
@@ -1,4 +1,4 @@
-[xml]$commonProps = Get-Content -Path $PSScriptRoot\Common.props
+[xml]$commonProps = Get-Content -Path $PSScriptRoot\Common.nonprod.props
 $microsoftCodeCoveragePkgVer = [string]$commonProps.Project.PropertyGroup.MicrosoftCodeCoveragePkgVer # This is collected in the format: "[16.10.0]"
 $microsoftCodeCoveragePkgVer = $microsoftCodeCoveragePkgVer.Trim();
 $microsoftCodeCoveragePkgVer = $microsoftCodeCoveragePkgVer.SubString(1, $microsoftCodeCoveragePkgVer.Length - 2) # Removing square brackets

--- a/build/process-codecoverage.ps1
+++ b/build/process-codecoverage.ps1
@@ -1,7 +1,11 @@
-[xml]$commonProps = Get-Content -Path $PSScriptRoot\Common.nonprod.props
-$microsoftCodeCoveragePkgVer = [string]$commonProps.Project.PropertyGroup.MicrosoftCodeCoveragePkgVer # This is collected in the format: "[16.10.0]"
+$rootDirectory = Split-Path $PSScriptRoot -Parent
+[xml]$commonProps = Get-Content -Path $rootDirectory\Directory.Packages.props
+
+$packages = $commonProps.Project.ItemGroup.PackageVersion
+$microsoftCodeCoveragePkgVer = [string]($packages | Where-Object {$_.Include -eq "Microsoft.CodeCoverage"}).Version # This is collected in the format: "[17.4.1]"
 $microsoftCodeCoveragePkgVer = $microsoftCodeCoveragePkgVer.Trim();
 $microsoftCodeCoveragePkgVer = $microsoftCodeCoveragePkgVer.SubString(1, $microsoftCodeCoveragePkgVer.Length - 2) # Removing square brackets
+
 $files = Get-ChildItem "TestResults" -Filter "*.coverage" -Recurse
 Write-Host $env:USERPROFILE
 foreach ($file in $files)


### PR DESCRIPTION
## Changes
- Remove property related to CodeCoverage from `Common.props`
- Update `process-codecoverage.ps1` to fetch the package version from `build/Directory.packages.props`