### PR TITLE
[console-logs] Expose LoggerProviderBuilder extension

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Console/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+static OpenTelemetry.Logs.ConsoleExporterLoggingExtensions.AddConsoleExporter(this OpenTelemetry.Logs.LoggerProviderBuilder loggerProviderBuilder) -> OpenTelemetry.Logs.LoggerProviderBuilder
+static OpenTelemetry.Logs.ConsoleExporterLoggingExtensions.AddConsoleExporter(this OpenTelemetry.Logs.LoggerProviderBuilder loggerProviderBuilder, string name, System.Action<OpenTelemetry.Exporter.ConsoleExporterOptions> configure) -> OpenTelemetry.Logs.LoggerProviderBuilder
+static OpenTelemetry.Logs.ConsoleExporterLoggingExtensions.AddConsoleExporter(this OpenTelemetry.Logs.LoggerProviderBuilder loggerProviderBuilder, System.Action<OpenTelemetry.Exporter.ConsoleExporterOptions> configure) -> OpenTelemetry.Logs.LoggerProviderBuilder

--- a/src/OpenTelemetry.Exporter.Console/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Console/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+static OpenTelemetry.Logs.ConsoleExporterLoggingExtensions.AddConsoleExporter(this OpenTelemetry.Logs.LoggerProviderBuilder loggerProviderBuilder) -> OpenTelemetry.Logs.LoggerProviderBuilder
+static OpenTelemetry.Logs.ConsoleExporterLoggingExtensions.AddConsoleExporter(this OpenTelemetry.Logs.LoggerProviderBuilder loggerProviderBuilder, string name, System.Action<OpenTelemetry.Exporter.ConsoleExporterOptions> configure) -> OpenTelemetry.Logs.LoggerProviderBuilder
+static OpenTelemetry.Logs.ConsoleExporterLoggingExtensions.AddConsoleExporter(this OpenTelemetry.Logs.LoggerProviderBuilder loggerProviderBuilder, System.Action<OpenTelemetry.Exporter.ConsoleExporterOptions> configure) -> OpenTelemetry.Logs.LoggerProviderBuilder

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -10,6 +10,9 @@
   `ILogger.LogLevel` when exporting `LogRecord` instances.
   ([#4568](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4568))
 
+* Added `LoggerProviderBuilder.AddConsoleExporter` registration extension.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.5.0
 
 Released 2023-Jun-05

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -11,7 +11,7 @@
   ([#4568](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4568))
 
 * Added `LoggerProviderBuilder.AddConsoleExporter` registration extension.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#4583](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4583))
 
 ## 1.5.0
 

--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporterLoggingExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporterLoggingExtensions.cs
@@ -53,7 +53,7 @@ namespace OpenTelemetry.Logs
         /// </summary>
         /// <param name="loggerProviderBuilder"><see cref="LoggerProviderBuilder"/>.</param>
         /// <returns>The supplied instance of <see cref="LoggerProviderBuilder"/> to chain the calls.</returns>
-        internal static LoggerProviderBuilder AddConsoleExporter(
+        public static LoggerProviderBuilder AddConsoleExporter(
             this LoggerProviderBuilder loggerProviderBuilder)
             => AddConsoleExporter(loggerProviderBuilder, name: null, configure: null);
 
@@ -63,7 +63,7 @@ namespace OpenTelemetry.Logs
         /// <param name="loggerProviderBuilder"><see cref="LoggerProviderBuilder"/>.</param>
         /// <param name="configure">Callback action for configuring <see cref="ConsoleExporterOptions"/>.</param>
         /// <returns>The supplied instance of <see cref="LoggerProviderBuilder"/> to chain the calls.</returns>
-        internal static LoggerProviderBuilder AddConsoleExporter(
+        public static LoggerProviderBuilder AddConsoleExporter(
             this LoggerProviderBuilder loggerProviderBuilder,
             Action<ConsoleExporterOptions> configure)
             => AddConsoleExporter(loggerProviderBuilder, name: null, configure);
@@ -75,7 +75,7 @@ namespace OpenTelemetry.Logs
         /// <param name="name">Name which is used when retrieving options.</param>
         /// <param name="configure">Callback action for configuring <see cref="ConsoleExporterOptions"/>.</param>
         /// <returns>The supplied instance of <see cref="LoggerProviderBuilder"/> to chain the calls.</returns>
-        internal static LoggerProviderBuilder AddConsoleExporter(
+        public static LoggerProviderBuilder AddConsoleExporter(
             this LoggerProviderBuilder loggerProviderBuilder,
             string name,
             Action<ConsoleExporterOptions> configure)


### PR DESCRIPTION
Relates to #4433

## Changes

* Exposes the `LoggerProviderBuilder.AddConsoleExporter` extension

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
