### PR TITLE
[sdk-logs] LoggerProvider + ILogger cohabitation extensions

### DIFF
--- a/src/OpenTelemetry/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -22,6 +22,9 @@ OpenTelemetry.Metrics.ExemplarFilter.ExemplarFilter() -> void
 OpenTelemetry.Metrics.MetricPoint.GetExemplars() -> OpenTelemetry.Metrics.Exemplar[]!
 OpenTelemetry.Metrics.TraceBasedExemplarFilter
 OpenTelemetry.Metrics.TraceBasedExemplarFilter.TraceBasedExemplarFilter() -> void
+static Microsoft.Extensions.Logging.OpenTelemetryLoggingExtensions.ConfigureOpenTelemetry(this Microsoft.Extensions.Logging.ILoggingBuilder! builder, System.Action<OpenTelemetry.Logs.LoggerProviderBuilder!>! configure) -> Microsoft.Extensions.Logging.ILoggingBuilder!
+static OpenTelemetry.Logs.LoggerProviderBuilderExtensions.AddILogger(this OpenTelemetry.Logs.LoggerProviderBuilder! loggerProviderBuilder) -> OpenTelemetry.Logs.LoggerProviderBuilder!
+static OpenTelemetry.Logs.LoggerProviderBuilderExtensions.AddILogger(this OpenTelemetry.Logs.LoggerProviderBuilder! loggerProviderBuilder, System.Action<OpenTelemetry.Logs.OpenTelemetryLoggerOptions!>! configure) -> OpenTelemetry.Logs.LoggerProviderBuilder!
 static OpenTelemetry.Logs.LoggerProviderBuilderExtensions.AddProcessor(this OpenTelemetry.Logs.LoggerProviderBuilder! loggerProviderBuilder, OpenTelemetry.BaseProcessor<OpenTelemetry.Logs.LogRecord!>! processor) -> OpenTelemetry.Logs.LoggerProviderBuilder!
 static OpenTelemetry.Logs.LoggerProviderBuilderExtensions.AddProcessor(this OpenTelemetry.Logs.LoggerProviderBuilder! loggerProviderBuilder, System.Func<System.IServiceProvider!, OpenTelemetry.BaseProcessor<OpenTelemetry.Logs.LogRecord!>!>! implementationFactory) -> OpenTelemetry.Logs.LoggerProviderBuilder!
 static OpenTelemetry.Logs.LoggerProviderBuilderExtensions.AddProcessor<T>(this OpenTelemetry.Logs.LoggerProviderBuilder! loggerProviderBuilder) -> OpenTelemetry.Logs.LoggerProviderBuilder!

--- a/src/OpenTelemetry/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -22,6 +22,9 @@ OpenTelemetry.Metrics.ExemplarFilter.ExemplarFilter() -> void
 OpenTelemetry.Metrics.MetricPoint.GetExemplars() -> OpenTelemetry.Metrics.Exemplar[]!
 OpenTelemetry.Metrics.TraceBasedExemplarFilter
 OpenTelemetry.Metrics.TraceBasedExemplarFilter.TraceBasedExemplarFilter() -> void
+static Microsoft.Extensions.Logging.OpenTelemetryLoggingExtensions.ConfigureOpenTelemetry(this Microsoft.Extensions.Logging.ILoggingBuilder! builder, System.Action<OpenTelemetry.Logs.LoggerProviderBuilder!>! configure) -> Microsoft.Extensions.Logging.ILoggingBuilder!
+static OpenTelemetry.Logs.LoggerProviderBuilderExtensions.AddILogger(this OpenTelemetry.Logs.LoggerProviderBuilder! loggerProviderBuilder) -> OpenTelemetry.Logs.LoggerProviderBuilder!
+static OpenTelemetry.Logs.LoggerProviderBuilderExtensions.AddILogger(this OpenTelemetry.Logs.LoggerProviderBuilder! loggerProviderBuilder, System.Action<OpenTelemetry.Logs.OpenTelemetryLoggerOptions!>! configure) -> OpenTelemetry.Logs.LoggerProviderBuilder!
 static OpenTelemetry.Logs.LoggerProviderBuilderExtensions.AddProcessor(this OpenTelemetry.Logs.LoggerProviderBuilder! loggerProviderBuilder, OpenTelemetry.BaseProcessor<OpenTelemetry.Logs.LogRecord!>! processor) -> OpenTelemetry.Logs.LoggerProviderBuilder!
 static OpenTelemetry.Logs.LoggerProviderBuilderExtensions.AddProcessor(this OpenTelemetry.Logs.LoggerProviderBuilder! loggerProviderBuilder, System.Func<System.IServiceProvider!, OpenTelemetry.BaseProcessor<OpenTelemetry.Logs.LogRecord!>!>! implementationFactory) -> OpenTelemetry.Logs.LoggerProviderBuilder!
 static OpenTelemetry.Logs.LoggerProviderBuilderExtensions.AddProcessor<T>(this OpenTelemetry.Logs.LoggerProviderBuilder! loggerProviderBuilder) -> OpenTelemetry.Logs.LoggerProviderBuilder!

--- a/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -22,6 +22,9 @@ OpenTelemetry.Metrics.ExemplarFilter.ExemplarFilter() -> void
 OpenTelemetry.Metrics.MetricPoint.GetExemplars() -> OpenTelemetry.Metrics.Exemplar[]!
 OpenTelemetry.Metrics.TraceBasedExemplarFilter
 OpenTelemetry.Metrics.TraceBasedExemplarFilter.TraceBasedExemplarFilter() -> void
+static Microsoft.Extensions.Logging.OpenTelemetryLoggingExtensions.ConfigureOpenTelemetry(this Microsoft.Extensions.Logging.ILoggingBuilder! builder, System.Action<OpenTelemetry.Logs.LoggerProviderBuilder!>! configure) -> Microsoft.Extensions.Logging.ILoggingBuilder!
+static OpenTelemetry.Logs.LoggerProviderBuilderExtensions.AddILogger(this OpenTelemetry.Logs.LoggerProviderBuilder! loggerProviderBuilder) -> OpenTelemetry.Logs.LoggerProviderBuilder!
+static OpenTelemetry.Logs.LoggerProviderBuilderExtensions.AddILogger(this OpenTelemetry.Logs.LoggerProviderBuilder! loggerProviderBuilder, System.Action<OpenTelemetry.Logs.OpenTelemetryLoggerOptions!>! configure) -> OpenTelemetry.Logs.LoggerProviderBuilder!
 static OpenTelemetry.Logs.LoggerProviderBuilderExtensions.AddProcessor(this OpenTelemetry.Logs.LoggerProviderBuilder! loggerProviderBuilder, OpenTelemetry.BaseProcessor<OpenTelemetry.Logs.LogRecord!>! processor) -> OpenTelemetry.Logs.LoggerProviderBuilder!
 static OpenTelemetry.Logs.LoggerProviderBuilderExtensions.AddProcessor(this OpenTelemetry.Logs.LoggerProviderBuilder! loggerProviderBuilder, System.Func<System.IServiceProvider!, OpenTelemetry.BaseProcessor<OpenTelemetry.Logs.LogRecord!>!>! implementationFactory) -> OpenTelemetry.Logs.LoggerProviderBuilder!
 static OpenTelemetry.Logs.LoggerProviderBuilderExtensions.AddProcessor<T>(this OpenTelemetry.Logs.LoggerProviderBuilder! loggerProviderBuilder) -> OpenTelemetry.Logs.LoggerProviderBuilder!

--- a/src/OpenTelemetry/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/netstandard2.1/PublicAPI.Unshipped.txt
@@ -22,6 +22,9 @@ OpenTelemetry.Metrics.ExemplarFilter.ExemplarFilter() -> void
 OpenTelemetry.Metrics.MetricPoint.GetExemplars() -> OpenTelemetry.Metrics.Exemplar[]!
 OpenTelemetry.Metrics.TraceBasedExemplarFilter
 OpenTelemetry.Metrics.TraceBasedExemplarFilter.TraceBasedExemplarFilter() -> void
+static Microsoft.Extensions.Logging.OpenTelemetryLoggingExtensions.ConfigureOpenTelemetry(this Microsoft.Extensions.Logging.ILoggingBuilder! builder, System.Action<OpenTelemetry.Logs.LoggerProviderBuilder!>! configure) -> Microsoft.Extensions.Logging.ILoggingBuilder!
+static OpenTelemetry.Logs.LoggerProviderBuilderExtensions.AddILogger(this OpenTelemetry.Logs.LoggerProviderBuilder! loggerProviderBuilder) -> OpenTelemetry.Logs.LoggerProviderBuilder!
+static OpenTelemetry.Logs.LoggerProviderBuilderExtensions.AddILogger(this OpenTelemetry.Logs.LoggerProviderBuilder! loggerProviderBuilder, System.Action<OpenTelemetry.Logs.OpenTelemetryLoggerOptions!>! configure) -> OpenTelemetry.Logs.LoggerProviderBuilder!
 static OpenTelemetry.Logs.LoggerProviderBuilderExtensions.AddProcessor(this OpenTelemetry.Logs.LoggerProviderBuilder! loggerProviderBuilder, OpenTelemetry.BaseProcessor<OpenTelemetry.Logs.LogRecord!>! processor) -> OpenTelemetry.Logs.LoggerProviderBuilder!
 static OpenTelemetry.Logs.LoggerProviderBuilderExtensions.AddProcessor(this OpenTelemetry.Logs.LoggerProviderBuilder! loggerProviderBuilder, System.Func<System.IServiceProvider!, OpenTelemetry.BaseProcessor<OpenTelemetry.Logs.LogRecord!>!>! implementationFactory) -> OpenTelemetry.Logs.LoggerProviderBuilder!
 static OpenTelemetry.Logs.LoggerProviderBuilderExtensions.AddProcessor<T>(this OpenTelemetry.Logs.LoggerProviderBuilder! loggerProviderBuilder) -> OpenTelemetry.Logs.LoggerProviderBuilder!

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -22,6 +22,15 @@
   provided during Logger creation.
   ([#4433](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4433))
 
+* Added `LoggerProviderBuilder.AddILogger` extension to turn on `ILogger`
+  integration when setting up a `LoggerProvider` directly.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
+* Added `ILoggingBuilder.ConfigureOpenTelemetry` extension to configure the
+  `LoggerProvider` used by `ILogger` when configuring logging using the
+  Microsoft.Extensions.Logging API.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.5.0
 
 Released 2023-Jun-05

--- a/src/OpenTelemetry/Logs/Builder/LoggerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Logs/Builder/LoggerProviderBuilderExtensions.cs
@@ -18,6 +18,7 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Resources;
 
@@ -140,6 +141,46 @@ public static class LoggerProviderBuilderExtensions
                 loggerProviderBuilderSdk.AddProcessor(implementationFactory(sp));
             }
         });
+
+        return loggerProviderBuilder;
+    }
+
+    /// <summary>
+    /// Adds <see cref="ILogger"/> integration to the builder.
+    /// </summary>
+    /// <remarks>
+    /// Note: Calling <see cref="AddILogger(LoggerProviderBuilder)"/> turns on
+    /// <c>Microsoft.Extensions.Logging</c> services in the <see
+    /// cref="IServiceCollection"/> used by the <see
+    /// cref="LoggerProviderBuilder"/>. It calls <see
+    /// cref="OpenTelemetryLoggingExtensions.AddOpenTelemetry(ILoggingBuilder)"/>
+    /// to register an <see cref="ILoggerProvider"/> named 'OpenTelemetry' which
+    /// will be used by the <see cref="ILoggerFactory"/>.
+    /// </remarks>
+    /// <param name="loggerProviderBuilder"><see
+    /// cref="LoggerProviderBuilder"/>.</param>
+    /// <returns>The supplied <see cref="LoggerProviderBuilder"/> for
+    /// chaining.</returns>
+    public static LoggerProviderBuilder AddILogger(
+        this LoggerProviderBuilder loggerProviderBuilder)
+        => AddILogger(loggerProviderBuilder, o => { });
+
+    /// <summary><inheritdoc cref="AddILogger(LoggerProviderBuilder)"/></summary>
+    /// <remarks><inheritdoc cref="AddILogger(LoggerProviderBuilder)" path="/remarks"/></remarks>
+    /// <param name="loggerProviderBuilder"><see
+    /// cref="LoggerProviderBuilder"/>.</param>
+    /// <param name="configure">Delegate action for configuring ILogger
+    /// integration options.</param>
+    /// <returns>The supplied <see cref="LoggerProviderBuilder"/> for
+    /// chaining.</returns>
+    public static LoggerProviderBuilder AddILogger(
+        this LoggerProviderBuilder loggerProviderBuilder,
+        Action<OpenTelemetryLoggerOptions> configure)
+    {
+        Guard.ThrowIfNull(configure);
+
+        loggerProviderBuilder.ConfigureServices(services =>
+            services.AddLogging(logging => logging.AddOpenTelemetry(configure)));
 
         return loggerProviderBuilder;
     }

--- a/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggingExtensions.cs
+++ b/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggingExtensions.cs
@@ -32,12 +32,20 @@ namespace Microsoft.Extensions.Logging;
 public static class OpenTelemetryLoggingExtensions
 {
     /// <summary>
-    /// Adds an OpenTelemetry logger named 'OpenTelemetry' to the <see cref="ILoggerFactory"/>.
+    /// Adds an <see cref="ILoggerProvider"/> named 'OpenTelemetry' to the
+    /// factory which will emit log messages into a <see
+    /// cref="LoggerProvider"/>.
     /// </summary>
     /// <remarks>
-    /// Note: This is safe to be called multiple times and by library
-    /// authors. Only a single <see cref="OpenTelemetryLoggerProvider"/>
-    /// will be created for a given <see cref="IServiceCollection"/>.
+    /// Notes:
+    /// <list type="bullet">
+    /// <item>This is safe to be called multiple times and by library authors.
+    /// Only a single <see cref="OpenTelemetryLoggerProvider"/> will be created
+    /// for a given <see cref="IServiceCollection"/>.</item>
+    /// <item>To configure the <see cref="LoggerProvider"/> used by the <see
+    /// cref="OpenTelemetryLoggerProvider"/> call <see
+    /// cref="ConfigureOpenTelemetry"/>.</item>
+    /// </list>
     /// </remarks>
     /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
     /// <returns>The supplied <see cref="ILoggingBuilder"/> for call chaining.</returns>
@@ -82,7 +90,7 @@ public static class OpenTelemetryLoggingExtensions
     }
 
     /// <summary>
-    /// Adds an OpenTelemetry logger named 'OpenTelemetry' to the <see cref="ILoggerFactory"/>.
+    /// <inheritdoc cref="AddOpenTelemetry(ILoggingBuilder)"/>
     /// </summary>
     /// <remarks><inheritdoc cref="AddOpenTelemetry(ILoggingBuilder)" path="/remarks"/></remarks>
     /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
@@ -98,5 +106,35 @@ public static class OpenTelemetryLoggingExtensions
         }
 
         return AddOpenTelemetry(builder);
+    }
+
+    /// <summary>
+    /// Registers an action used to configure the OpenTelemetry <see
+    /// cref="LoggerProviderBuilder"/>.
+    /// </summary>
+    /// <remarks>
+    /// Notes:
+    /// <list type="bullet">
+    /// <item>This is safe to be called multiple times and by library authors.
+    /// Each registered configuration action will be applied
+    /// sequentially.</item>
+    /// <item>A <see cref="LoggerProvider"/> will NOT be created automatically
+    /// using this method. To begin collecting logs call
+    /// <see cref="AddOpenTelemetry(ILoggingBuilder)"/>.</item>
+    /// </list>
+    /// </remarks>
+    /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
+    /// <param name="configure">Callback action to configure the <see
+    /// cref="LoggerProviderBuilder"/>.</param>
+    /// <returns>The supplied <see cref="ILoggingBuilder"/> for call chaining.</returns>
+    public static ILoggingBuilder ConfigureOpenTelemetry(
+        this ILoggingBuilder builder,
+        Action<LoggerProviderBuilder> configure)
+    {
+        Guard.ThrowIfNull(builder);
+
+        builder.Services.ConfigureOpenTelemetryLoggerProvider(configure);
+
+        return builder;
     }
 }


### PR DESCRIPTION
Relates to #4433

## Changes

* Adds `LoggerProviderBuilder.AddILogger` and `ILoggingBuilder.ConfigureOpenTelemetry` extensions
 
## Details

The goal of this PR is to make nice setting up logging using whatever style the user prefers. These might change before shipping stable but the goal is to get something working so we can ship a preview/alpha.

### Scenario 1: Using hosting API

```csharp
appBuilder.Services.AddOpenTelemetry()
   .WithLogging(logging => logging
      .AddILogger(options => options.IncludeFormattedMessage = true)
      .AddConsoleExporter());
```

### Scenario 2: Using ILogger API

```csharp
appBuilder.Logging
   .AddOpenTelemetry(options => options.IncludeFormattedMessage = true)
   .ConfigureOpenTelemetry(builder => builder.AddConsoleExporter());
);
```

### Scenario 3: Using LoggerFactory API

```csharp
LoggerFactory.Create(builder => builder
   .AddOpenTelemetry(options => options.IncludeFormattedMessage = true)
   .ConfigureOpenTelemetry(logging => logging.AddConsoleExporter());
```

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
