### PR TITLE
Fix issue of multiple instances of OpenTelemetry-Sdk EventSource being created

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/ConsoleExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleExporter.cs
@@ -24,13 +24,17 @@ namespace OpenTelemetry.Exporter
         protected ConsoleExporter(ConsoleExporterOptions options)
         {
             this.options = options ?? new ConsoleExporterOptions();
+            ConsoleTagTransformer.LogUnsupportedAttributeType = (string tagValueType, string tagKey) =>
+            {
+                this.WriteLine($"Unsupported attribute type {tagValueType} for {tagKey}.");
+            };
         }
 
         protected void WriteLine(string message)
         {
             if (this.options.Targets.HasFlag(ConsoleExporterOutputTargets.Console))
             {
-                System.Console.WriteLine(message);
+                Console.WriteLine(message);
             }
 
             if (this.options.Targets.HasFlag(ConsoleExporterOutputTargets.Debug))

--- a/src/OpenTelemetry.Exporter.Console/OpenTelemetry.Exporter.Console.csproj
+++ b/src/OpenTelemetry.Exporter.Console/OpenTelemetry.Exporter.Console.csproj
@@ -28,7 +28,6 @@
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\ExceptionExtensions.cs" Link="Includes\ExceptionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\SpanAttributeConstants.cs" Link="Includes\SpanAttributeConstants.cs" />
-    <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\OpenTelemetrySdkEventSource.cs" Link="Includes\OpenTelemetrySdkEventSource.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\PeriodicExportingMetricReaderHelper.cs" Link="Includes\PeriodicExportingMetricReaderHelper.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\TagTransformer.cs" Link="Includes\TagTransformer.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\Shims\UnconditionalSuppressMessageAttribute.cs" Link="Includes\UnconditionalSuppressMessageAttribute.cs" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerExporterEventSource.cs
@@ -41,5 +41,17 @@ namespace OpenTelemetry.Exporter.Jaeger.Implementation
         {
             this.WriteEvent(1, exception);
         }
+
+        [Event(2, Message = "Unsupported attribute type '{0}' for '{1}'. Attribute will not be exported.", Level = EventLevel.Warning)]
+        public void UnsupportedAttributeType(string type, string key)
+        {
+            this.WriteEvent(2, type.ToString(), key);
+        }
+
+        [Event(3, Message = "{0} environment variable has an invalid value: '{1}'", Level = EventLevel.Warning)]
+        public void InvalidEnvironmentVariable(string key, string value)
+        {
+            this.WriteEvent(3, key, value);
+        }
     }
 }

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
@@ -71,6 +71,16 @@ namespace OpenTelemetry.Exporter
                 throw new NotSupportedException();
             }
 
+            JaegerTagTransformer.LogUnsupportedAttributeType = (string tagValueType, string tagKey) =>
+            {
+                JaegerExporterEventSource.Log.UnsupportedAttributeType(tagValueType, tagKey);
+            };
+
+            ConfigurationExtensions.LogInvalidEnvironmentVariable = (string key, string value) =>
+            {
+                JaegerExporterEventSource.Log.InvalidEnvironmentVariable(key, value);
+            };
+
             this.client = client;
             this.batchWriter = protocolFactory.GetProtocol(this.maxPayloadSizeInBytes * 2);
             this.spanWriter = protocolFactory.GetProtocol(this.maxPayloadSizeInBytes);

--- a/src/OpenTelemetry.Exporter.Jaeger/OpenTelemetry.Exporter.Jaeger.csproj
+++ b/src/OpenTelemetry.Exporter.Jaeger/OpenTelemetry.Exporter.Jaeger.csproj
@@ -23,7 +23,6 @@
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\StatusHelper.cs" Link="Includes\StatusHelper.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\EnvironmentVariables\*.cs" Link="Includes\EnvironmentVariables\%(Filename).cs" />
-    <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\OpenTelemetrySdkEventSource.cs" Link="Includes\OpenTelemetrySdkEventSource.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\Options\*.cs" Link="Includes\Options\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\PooledList.cs" Link="Includes\PooledList.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\PeerServiceResolver.cs" Link="Includes\PeerServiceResolver.cs" />

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OpenTelemetryProtocolExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OpenTelemetryProtocolExporterEventSource.cs
@@ -78,5 +78,17 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation
         {
             this.WriteEvent(9, exceptionMessage);
         }
+
+        [Event(10, Message = "Unsupported attribute type '{0}' for '{1}'. Attribute will not be exported.", Level = EventLevel.Warning)]
+        public void UnsupportedAttributeType(string type, string key)
+        {
+            this.WriteEvent(10, type.ToString(), key);
+        }
+
+        [Event(11, Message = "{0} environment variable has an invalid value: '{1}'", Level = EventLevel.Warning)]
+        public void InvalidEnvironmentVariable(string key, string value)
+        {
+            this.WriteEvent(11, key, value);
+        }
     }
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj
@@ -29,7 +29,6 @@
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\StatusHelper.cs" Link="Includes\StatusHelper.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\EnvironmentVariables\*.cs" Link="Includes\EnvironmentVariables\%(Filename).cs" />
-    <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\OpenTelemetrySdkEventSource.cs" Link="Includes\OpenTelemetrySdkEventSource.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\Options\*.cs" Link="Includes\Options\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\PeriodicExportingMetricReaderHelper.cs" Link="Includes\PeriodicExportingMetricReaderHelper.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\PeerServiceResolver.cs" Link="Includes\PeerServiceResolver.cs" />

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporter.cs
@@ -17,6 +17,7 @@
 using System.Diagnostics;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
+using OpenTelemetry.Internal;
 using OpenTelemetry.Logs;
 using OtlpCollector = OpenTelemetry.Proto.Collector.Logs.V1;
 using OtlpResource = OpenTelemetry.Proto.Resource.V1;
@@ -58,6 +59,16 @@ namespace OpenTelemetry.Exporter
             Debug.Assert(sdkLimitOptions != null, "sdkLimitOptions was null");
 
             this.sdkLimitOptions = sdkLimitOptions;
+
+            OtlpKeyValueTransformer.LogUnsupportedAttributeType = (string tagValueType, string tagKey) =>
+            {
+                OpenTelemetryProtocolExporterEventSource.Log.UnsupportedAttributeType(tagValueType, tagKey);
+            };
+
+            ConfigurationExtensions.LogInvalidEnvironmentVariable = (string key, string value) =>
+            {
+                OpenTelemetryProtocolExporterEventSource.Log.InvalidEnvironmentVariable(key, value);
+            };
 
             if (exportClient != null)
             {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporter.cs
@@ -16,6 +16,7 @@
 
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
+using OpenTelemetry.Internal;
 using OpenTelemetry.Metrics;
 using OtlpCollector = OpenTelemetry.Proto.Collector.Metrics.V1;
 using OtlpResource = OpenTelemetry.Proto.Resource.V1;
@@ -48,6 +49,16 @@ namespace OpenTelemetry.Exporter
         /// <param name="exportClient">Client used for sending export request.</param>
         internal OtlpMetricExporter(OtlpExporterOptions options, IExportClient<OtlpCollector.ExportMetricsServiceRequest> exportClient = null)
         {
+            OtlpKeyValueTransformer.LogUnsupportedAttributeType = (string tagValueType, string tagKey) =>
+            {
+                OpenTelemetryProtocolExporterEventSource.Log.UnsupportedAttributeType(tagValueType, tagKey);
+            };
+
+            ConfigurationExtensions.LogInvalidEnvironmentVariable = (string key, string value) =>
+            {
+                OpenTelemetryProtocolExporterEventSource.Log.InvalidEnvironmentVariable(key, value);
+            };
+
             if (exportClient != null)
             {
                 this.exportClient = exportClient;

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporter.cs
@@ -17,6 +17,7 @@
 using System.Diagnostics;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
+using OpenTelemetry.Internal;
 using OtlpCollector = OpenTelemetry.Proto.Collector.Trace.V1;
 using OtlpResource = OpenTelemetry.Proto.Resource.V1;
 
@@ -57,6 +58,16 @@ namespace OpenTelemetry.Exporter
             Debug.Assert(sdkLimitOptions != null, "sdkLimitOptions was null");
 
             this.sdkLimitOptions = sdkLimitOptions;
+
+            OtlpKeyValueTransformer.LogUnsupportedAttributeType = (string tagValueType, string tagKey) =>
+            {
+                OpenTelemetryProtocolExporterEventSource.Log.UnsupportedAttributeType(tagValueType, tagKey);
+            };
+
+            ConfigurationExtensions.LogInvalidEnvironmentVariable = (string key, string value) =>
+            {
+                OpenTelemetryProtocolExporterEventSource.Log.InvalidEnvironmentVariable(key, value);
+            };
 
             if (exportClient != null)
             {

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinExporterEventSource.cs
@@ -41,5 +41,17 @@ namespace OpenTelemetry.Exporter.Zipkin.Implementation
         {
             this.WriteEvent(1, exception);
         }
+
+        [Event(2, Message = "Unsupported attribute type '{0}' for '{1}'. Attribute will not be exported.", Level = EventLevel.Warning)]
+        public void UnsupportedAttributeType(string type, string key)
+        {
+            this.WriteEvent(2, type.ToString(), key);
+        }
+
+        [Event(3, Message = "{0} environment variable has an invalid value: '{1}'", Level = EventLevel.Warning)]
+        public void InvalidEnvironmentVariable(string key, string value)
+        {
+            this.WriteEvent(3, key, value);
+        }
     }
 }

--- a/src/OpenTelemetry.Exporter.Zipkin/OpenTelemetry.Exporter.Zipkin.csproj
+++ b/src/OpenTelemetry.Exporter.Zipkin/OpenTelemetry.Exporter.Zipkin.csproj
@@ -18,7 +18,6 @@
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\StatusHelper.cs" Link="Includes\StatusHelper.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Api\Internal\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\EnvironmentVariables\*.cs" Link="Includes\EnvironmentVariables\%(Filename).cs" />
-    <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\OpenTelemetrySdkEventSource.cs" Link="Includes\OpenTelemetrySdkEventSource.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\Options\*.cs" Link="Includes\Options\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\PooledList.cs" Link="Includes\PooledList.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry\Internal\PeerServiceResolver.cs" Link="Includes\PeerServiceResolver.cs" />

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporter.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporter.cs
@@ -50,6 +50,16 @@ namespace OpenTelemetry.Exporter
             this.options = options;
             this.maxPayloadSizeInBytes = (!options.MaxPayloadSizeInBytes.HasValue || options.MaxPayloadSizeInBytes <= 0) ? ZipkinExporterOptions.DefaultMaxPayloadSizeInBytes : options.MaxPayloadSizeInBytes.Value;
             this.httpClient = client ?? options.HttpClientFactory?.Invoke() ?? throw new InvalidOperationException("ZipkinExporter was missing HttpClientFactory or it returned null.");
+
+            ZipkinTagTransformer.LogUnsupportedAttributeType = (string tagValueType, string tagKey) =>
+            {
+                ZipkinExporterEventSource.Log.UnsupportedAttributeType(tagValueType, tagKey);
+            };
+
+            ConfigurationExtensions.LogInvalidEnvironmentVariable = (string key, string value) =>
+            {
+                ZipkinExporterEventSource.Log.InvalidEnvironmentVariable(key, value);
+            };
         }
 
         internal ZipkinEndpoint LocalEndpoint { get; private set; }

--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -270,12 +270,6 @@ namespace OpenTelemetry.Internal
             this.WriteEvent(41, instrumentName, meterName, reason, fix);
         }
 
-        [Event(42, Message = "Unsupported attribute type '{0}' for '{1}'. Attribute will not be exported.", Level = EventLevel.Warning)]
-        public void UnsupportedAttributeType(string type, string key)
-        {
-            this.WriteEvent(42, type.ToString(), key);
-        }
-
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "Parameters to this method are primitive and are trimmer safe.")]
         [Event(43, Message = "ForceFlush invoked for processor type '{0}' returned result '{1}'.", Level = EventLevel.Verbose)]
         public void ProcessorForceFlushInvoked(string processorType, bool result)

--- a/src/OpenTelemetry/Internal/Options/ConfigurationExtensions.cs
+++ b/src/OpenTelemetry/Internal/Options/ConfigurationExtensions.cs
@@ -30,6 +30,8 @@ namespace OpenTelemetry.Internal;
 
 internal static class ConfigurationExtensions
 {
+    public static Action<string, string>? LogInvalidEnvironmentVariable = null;
+
     public delegate bool TryParseFunc<T>(
         string value,
 #if !NETFRAMEWORK && !NETSTANDARD2_0
@@ -66,7 +68,7 @@ internal static class ConfigurationExtensions
 
         if (!Uri.TryCreate(stringValue, UriKind.Absolute, out value))
         {
-            OpenTelemetrySdkEventSource.Log.InvalidEnvironmentVariable(key, stringValue);
+            LogInvalidEnvironmentVariable?.Invoke(key, stringValue!);
             return false;
         }
 
@@ -86,7 +88,7 @@ internal static class ConfigurationExtensions
 
         if (!int.TryParse(stringValue, NumberStyles.None, CultureInfo.InvariantCulture, out value))
         {
-            OpenTelemetrySdkEventSource.Log.InvalidEnvironmentVariable(key, stringValue);
+            LogInvalidEnvironmentVariable?.Invoke(key, stringValue!);
             return false;
         }
 
@@ -110,7 +112,7 @@ internal static class ConfigurationExtensions
 
         if (!tryParseFunc(stringValue!, out value))
         {
-            OpenTelemetrySdkEventSource.Log.InvalidEnvironmentVariable(key, stringValue);
+            LogInvalidEnvironmentVariable?.Invoke(key, stringValue!);
             return false;
         }
 

--- a/src/OpenTelemetry/Internal/TagTransformer.cs
+++ b/src/OpenTelemetry/Internal/TagTransformer.cs
@@ -18,6 +18,8 @@ namespace OpenTelemetry.Internal;
 
 internal abstract class TagTransformer<T>
 {
+    public static Action<string, string> LogUnsupportedAttributeType = null;
+
     public bool TryTransformTag(KeyValuePair<string, object> tag, out T result, int? maxLength = null)
     {
         if (tag.Value == null)
@@ -58,7 +60,7 @@ internal abstract class TagTransformer<T>
                     // If an exception is thrown when calling ToString
                     // on any element of the array, then the entire array value
                     // is ignored.
-                    OpenTelemetrySdkEventSource.Log.UnsupportedAttributeType(tag.Value.GetType().ToString(), tag.Key);
+                    LogUnsupportedAttributeType?.Invoke(tag.Value.GetType().ToString(), tag.Key);
                     result = default;
                     return false;
                 }
@@ -79,7 +81,7 @@ internal abstract class TagTransformer<T>
                 catch
                 {
                     // If ToString throws an exception then the tag is ignored.
-                    OpenTelemetrySdkEventSource.Log.UnsupportedAttributeType(tag.Value.GetType().ToString(), tag.Key);
+                    LogUnsupportedAttributeType?.Invoke(tag.Value.GetType().ToString(), tag.Key);
                     result = default;
                     return false;
                 }


### PR DESCRIPTION
Fixes #4516

No other projects other than the SDK project should use `OpenTelemetry-Sdk` EventSource. Currently, we have multiple projects that link to `OpenTelemetrySdkEventSource` which is causing users to run into the error: `An instance of
  EventSource with Guid {guid} already exists.` Moreover, it doesn't make sense for other components to log messages using SDK's EventSource. These components should use their own dedicated EventSource for that.

## Changes
- Remove compilation of `OpenTelemetrySdkEventSource` from other projects
- Update `TagTransformer` and `ConfigurationExtensions` to allow components to use their custom EventSource to log warnings

## Merge requirement checklist
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
