### PR TITLE
Retry policy for OTLP/gRPC exporter

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -16,7 +16,7 @@
   [specification](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#failures).
   Retry support is not available in the `netstandard2.0` or `net462`
   targets of the OTLP exporter.
-  ([#TBD](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TBD))
+  ([#4587](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4587))
 
 * Add back support for Exemplars. See [exemplars](../../docs/metrics/customizing-the-sdk/README.md#exemplars)
   for instructions to enable exemplars.

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -10,6 +10,14 @@
   are now included in this package.
   ([#4556](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4556))
 
+* Added support for the OTLP gRPC exporter to retry failed requests due to
+  transient network faults. The status codes that are
+  retried are defined in the
+  [specification](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#failures).
+  Retry support is not available in the `netstandard2.0` or `net462`
+  targets of the OTLP exporter.
+  ([#TBD](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TBD))
+
 * Add back support for Exemplars. See [exemplars](../../docs/metrics/customizing-the-sdk/README.md#exemplars)
   for instructions to enable exemplars.
   ([#4553](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4553))

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
@@ -22,6 +22,7 @@ using Grpc.Core;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
 #if NETSTANDARD2_1 || NET6_0_OR_GREATER
 using Grpc.Net.Client;
+using Grpc.Net.Client.Configuration;
 #endif
 using LogOtlpCollector = OpenTelemetry.Proto.Collector.Logs.V1;
 using MetricsOtlpCollector = OpenTelemetry.Proto.Collector.Metrics.V1;
@@ -43,7 +44,41 @@ namespace OpenTelemetry.Exporter
             }
 
 #if NETSTANDARD2_1 || NET6_0_OR_GREATER
-            return GrpcChannel.ForAddress(options.Endpoint);
+            // The specification does not dictate the parameters of the default retry policy.
+            // These defaults are borrowed from opentelemetry-java.
+            var retryPolicy = new RetryPolicy
+            {
+                // https://github.com/open-telemetry/opentelemetry-java/blob/6f755cc8128f8077643b4990327c22b293c46e45/exporters/otlp/common/src/main/java/io/opentelemetry/exporter/otlp/internal/retry/RetryPolicyBuilder.java#L19-L22
+                MaxAttempts = 5,
+                InitialBackoff = TimeSpan.FromSeconds(1),
+                MaxBackoff = TimeSpan.FromSeconds(5),
+                BackoffMultiplier = 1.5,
+
+                // https://github.com/open-telemetry/opentelemetry-java/commit/6f755cc8128f8077643b4990327c22b293c46e45#diff-2d25b543bc2c5a13e495895b6f6a2db80e1167bbe3387024cb917efda35a99acR24-R34
+                RetryableStatusCodes =
+                {
+                    StatusCode.Cancelled,
+                    StatusCode.DeadlineExceeded,
+                    StatusCode.ResourceExhausted,
+                    StatusCode.Aborted,
+                    StatusCode.OutOfRange,
+                    StatusCode.Unavailable,
+                    StatusCode.DataLoss,
+                },
+            };
+
+            var methodConfig = new MethodConfig
+            {
+                // MethodName.Default applies the retry policy to all methods called by this channel.
+                Names = { MethodName.Default },
+                RetryPolicy = retryPolicy,
+            };
+
+            var serviceConfig = new ServiceConfig { MethodConfigs = { methodConfig } };
+
+            var channelOptions = new GrpcChannelOptions { ServiceConfig = serviceConfig };
+
+            return GrpcChannel.ForAddress(options.Endpoint, channelOptions);
 #else
             ChannelCredentials channelCredentials;
             if (options.Endpoint.Scheme == Uri.UriSchemeHttps)

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
@@ -183,6 +183,20 @@ services.AddHttpClient(
 Note: The single instance returned by `HttpClientFactory` is reused by all
 export requests.
 
+## Retry behavior
+
+The OTLP/gRPC exporter targeting `netstandard2.1` and `net6.0` will
+automatically retry failed requests. The
+[specification](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#failures)
+defines which status codes are retriable. The retry policy of exporter
+is to retry a maximum of five times using an exponential backoff strategy.
+The retry policy is not configurable.
+
+The OTLP/HTTP exporter does not automatically retry failed requests. However,
+if you [Configure HttpClient](#configure-httpclient), you can implement a
+retry policy using a framework like
+[Polly](https://learn.microsoft.com/dotnet/architecture/microservices/implement-resilient-applications/implement-http-call-retries-exponential-backoff-polly).
+
 ## Troubleshooting
 
 This component uses an

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/MockCollectorIntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/MockCollectorIntegrationTests.cs
@@ -15,11 +15,7 @@
 // </copyright>
 
 #if !NETFRAMEWORK
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Net.Http;
-using System.Threading.Tasks;
 using Grpc.Core;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -110,7 +106,7 @@ public sealed class MockCollectorIntegrationTests
 
     private class MockCollectorState
     {
-        private Grpc.Core.StatusCode[] statusCodes = { };
+        private Grpc.Core.StatusCode[] statusCodes = Array.Empty<Grpc.Core.StatusCode>();
         private int statusCodeIndex = 0;
 
         public void SetStatusCodes(int[] statusCodes)

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/MockCollectorIntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/MockCollectorIntegrationTests.cs
@@ -29,12 +29,14 @@ using Xunit;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests;
 
-public sealed class MockCollectorIntegrationTests
+public sealed class MockCollectorIntegrationTests : IDisposable
 {
-    [Fact]
-    public async Task TestRecoveryAfterFailedExport()
+    private readonly IHost collectorHost;
+    private readonly HttpClient httpClient;
+
+    public MockCollectorIntegrationTests()
     {
-        using var host = await new HostBuilder()
+        this.collectorHost = new HostBuilder()
            .ConfigureWebHostDefaults(webBuilder => webBuilder
                 .ConfigureKestrel(options =>
                 {
@@ -63,15 +65,25 @@ public sealed class MockCollectorIntegrationTests
                        endpoints.MapGrpcService<MockTraceService>();
                    });
                }))
-           .StartAsync().ConfigureAwait(false);
+           .Start();
 
-        var httpClient = new HttpClient() { BaseAddress = new System.Uri("http://localhost:5050") };
+        this.httpClient = new HttpClient() { BaseAddress = new Uri("http://localhost:5050") };
+    }
 
+    public void Dispose()
+    {
+        this.collectorHost.Dispose();
+        this.httpClient.Dispose();
+    }
+
+    [Fact]
+    public async Task TestRecoveryAfterFailedExport()
+    {
         var codes = new[] { Grpc.Core.StatusCode.Unimplemented, Grpc.Core.StatusCode.OK };
-        await httpClient.GetAsync($"/MockCollector/SetResponseCodes/{string.Join(",", codes.Select(x => (int)x))}").ConfigureAwait(false);
+        await this.httpClient.GetAsync($"/MockCollector/SetResponseCodes/{string.Join(",", codes.Select(x => (int)x))}").ConfigureAwait(false);
 
         var exportResults = new List<ExportResult>();
-        var otlpExporter = new OtlpTraceExporter(new OtlpExporterOptions() { Endpoint = new System.Uri("http://localhost:4317") });
+        var otlpExporter = new OtlpTraceExporter(new OtlpExporterOptions() { Endpoint = new Uri("http://localhost:4317") });
         var delegatingExporter = new DelegatingExporter<Activity>
         {
             OnExportFunc = (batch) =>
@@ -100,8 +112,6 @@ public sealed class MockCollectorIntegrationTests
 
         Assert.Equal(2, exportResults.Count);
         Assert.Equal(ExportResult.Success, exportResults[1]);
-
-        await host.StopAsync().ConfigureAwait(false);
     }
 
     private class MockCollectorState


### PR DESCRIPTION
Implements the retry behavior [described by the specification](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#failures) for the OTLP/gRPC exporter.