### PR TITLE
Add back Guard.ThrowIfNull batch options

### DIFF
--- a/src/OpenTelemetry/Logs/LogRecordExportProcessorOptions.cs
+++ b/src/OpenTelemetry/Logs/LogRecordExportProcessorOptions.cs
@@ -17,6 +17,7 @@
 #nullable enable
 
 using System.Diagnostics;
+using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Logs;
 
@@ -25,6 +26,8 @@ namespace OpenTelemetry.Logs;
 /// </summary>
 public class LogRecordExportProcessorOptions
 {
+    private BatchExportLogRecordProcessorOptions batchExportProcessorOptions;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="LogRecordExportProcessorOptions"/> class.
     /// </summary>
@@ -38,7 +41,7 @@ public class LogRecordExportProcessorOptions
     {
         Debug.Assert(defaultBatchExportLogRecordProcessorOptions != null, "defaultBatchExportLogRecordProcessorOptions was null");
 
-        this.BatchExportProcessorOptions = defaultBatchExportLogRecordProcessorOptions ?? new();
+        this.batchExportProcessorOptions = defaultBatchExportLogRecordProcessorOptions ?? new();
     }
 
     /// <summary>
@@ -49,5 +52,13 @@ public class LogRecordExportProcessorOptions
     /// <summary>
     /// Gets or sets the batch export options. Ignored unless <see cref="ExportProcessorType"/> is <see cref="ExportProcessorType.Batch"/>.
     /// </summary>
-    public BatchExportLogRecordProcessorOptions BatchExportProcessorOptions { get; set; }
+    public BatchExportLogRecordProcessorOptions BatchExportProcessorOptions
+    {
+        get => this.batchExportProcessorOptions;
+        set
+        {
+            Guard.ThrowIfNull(value);
+            this.batchExportProcessorOptions = value;
+        }
+    }
 }


### PR DESCRIPTION
@vishweshbankwar oops, sorry, I glossed over this reviewing your update regarding https://github.com/open-telemetry/opentelemetry-dotnet/pull/4575#discussion_r1237328278

Since you made the property not nullable, I think we want to keep the Guard.ThrowIfNull so that it's certain not to be null.