### PR TITLE
[sdk-1.5.0-hotfix] Fix LogRecord.State being null when TState matches known interfaces

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -10,7 +10,7 @@ Released 2023-Jun-23
   previously set to a valid value when
   `OpenTelemetryLoggerOptions.ParseStateValues` is `false` and states implement
   `IReadOnlyList` or `IEnumerable` of `KeyValuePair<string, object>`s.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#4609](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4609))
 
 ## 1.5.0
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## 1.5.1
+
+Released 2023-Jun-23
+
+* Fixed a breaking change causing `LogRecord.State` to be `null` where it was
+  previously set to a valid value when
+  `OpenTelemetryLoggerOptions.ParseStateValues` is `false` and states implement
+  `IReadOnlyList` or `IEnumerable` of `KeyValuePair<string, object>`s.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.5.0
 
 Released 2023-Jun-05

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-## 1.5.1
-
-Released 2023-Jun-23
-
 * Fixed a breaking change causing `LogRecord.State` to be `null` where it was
   previously set to a valid value when
   `OpenTelemetryLoggerOptions.ParseStateValues` is `false` and states implement

--- a/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLogger.cs
+++ b/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLogger.cs
@@ -155,7 +155,8 @@ internal sealed class OpenTelemetryLogger : ILogger
         bool includeAttributes,
         bool parseStateValues)
     {
-        if (!includeAttributes)
+        if (!includeAttributes
+            || (!typeof(TState).IsValueType && state is null))
         {
             iLoggerData.State = null;
             return null;
@@ -195,7 +196,7 @@ internal sealed class OpenTelemetryLogger : ILogger
                 return attributeStorage;
             }
         }
-        else if (!parseStateValues || state is null)
+        else if (!parseStateValues)
         {
             return null;
         }

--- a/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLogger.cs
+++ b/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLogger.cs
@@ -204,7 +204,7 @@ internal sealed class OpenTelemetryLogger : ILogger
         {
             try
             {
-                PropertyDescriptorCollection itemProperties = TypeDescriptor.GetProperties(state);
+                PropertyDescriptorCollection itemProperties = TypeDescriptor.GetProperties(state!);
 
                 var attributeStorage = logRecord.AttributeStorage ??= new List<KeyValuePair<string, object?>>(itemProperties.Count);
 

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
@@ -65,7 +65,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
             Assert.Single(logRecords);
             var logRecord = logRecords[0];
 #pragma warning disable CS0618 // Type or member is obsolete
-            Assert.Null(logRecord.State);
+            Assert.NotNull(logRecord.State);
 #pragma warning restore CS0618 // Type or member is obsolete
             Assert.NotNull(logRecord.Attributes);
         }

--- a/test/OpenTelemetry.Tests/Logs/LogRecordTest.cs
+++ b/test/OpenTelemetry.Tests/Logs/LogRecordTest.cs
@@ -82,7 +82,7 @@ namespace OpenTelemetry.Logs.Tests
             const string message = "Hello, World!";
             logger.LogInformation(message);
 
-            Assert.Null(exportedItems[0].State);
+            Assert.NotNull(exportedItems[0].State);
 
             var attributes = exportedItems[0].Attributes;
             Assert.NotNull(attributes);
@@ -113,7 +113,7 @@ namespace OpenTelemetry.Logs.Tests
             var message = $"Hello from potato {0.99}.";
             logger.LogInformation(message);
 
-            Assert.Null(exportedItems[0].State);
+            Assert.NotNull(exportedItems[0].State);
 
             var attributes = exportedItems[0].Attributes;
             Assert.NotNull(attributes);
@@ -143,7 +143,7 @@ namespace OpenTelemetry.Logs.Tests
             const string message = "Hello from {name} {price}.";
             logger.LogInformation(message, "tomato", 2.99);
 
-            Assert.Null(exportedItems[0].State);
+            Assert.NotNull(exportedItems[0].State);
 
             var attributes = exportedItems[0].Attributes;
             Assert.NotNull(attributes);
@@ -185,7 +185,7 @@ namespace OpenTelemetry.Logs.Tests
             var food = new Food { Name = "artichoke", Price = 3.99 };
             logger.LogInformation("{food}", food);
 
-            Assert.Null(exportedItems[0].State);
+            Assert.NotNull(exportedItems[0].State);
 
             var attributes = exportedItems[0].Attributes;
             Assert.NotNull(attributes);
@@ -226,7 +226,7 @@ namespace OpenTelemetry.Logs.Tests
             var anonymousType = new { Name = "pumpkin", Price = 5.99 };
             logger.LogInformation("{food}", anonymousType);
 
-            Assert.Null(exportedItems[0].State);
+            Assert.NotNull(exportedItems[0].State);
 
             var attributes = exportedItems[0].Attributes;
             Assert.NotNull(attributes);
@@ -271,7 +271,7 @@ namespace OpenTelemetry.Logs.Tests
             };
             logger.LogInformation("{food}", food);
 
-            Assert.Null(exportedItems[0].State);
+            Assert.NotNull(exportedItems[0].State);
 
             var attributes = exportedItems[0].Attributes;
             Assert.NotNull(attributes);
@@ -321,7 +321,13 @@ namespace OpenTelemetry.Logs.Tests
             const string message = "Exception Occurred";
             logger.LogInformation(exception, message);
 
-            Assert.Null(exportedItems[0].State);
+            Assert.NotNull(exportedItems[0].State);
+
+            var state = exportedItems[0].State;
+            var itemCount = state.GetType().GetProperty("Count").GetValue(state);
+
+            // state only has {OriginalFormat}
+            Assert.Equal(1, itemCount);
 
             var attributes = exportedItems[0].Attributes;
             Assert.NotNull(attributes);
@@ -334,6 +340,7 @@ namespace OpenTelemetry.Logs.Tests
             Assert.Equal(exceptionMessage, loggedException.Message);
 
             Assert.Equal(message, exportedItems[0].Body);
+            Assert.Equal(message, state.ToString());
             Assert.Null(exportedItems[0].FormattedMessage);
         }
 
@@ -711,7 +718,14 @@ namespace OpenTelemetry.Logs.Tests
             var logRecord = exportedItems[0];
 
             Assert.NotNull(logRecord.StateValues);
-            Assert.Null(logRecord.State);
+            if (parseStateValues)
+            {
+                Assert.Null(logRecord.State);
+            }
+            else
+            {
+                Assert.NotNull(logRecord.State);
+            }
 
             Assert.NotNull(logRecord.StateValues);
             Assert.Equal(3, logRecord.StateValues.Count);
@@ -725,7 +739,14 @@ namespace OpenTelemetry.Logs.Tests
             logRecord = exportedItems[1];
 
             Assert.NotNull(logRecord.StateValues);
-            Assert.Null(logRecord.State);
+            if (parseStateValues)
+            {
+                Assert.Null(logRecord.State);
+            }
+            else
+            {
+                Assert.NotNull(logRecord.State);
+            }
 
             Assert.NotNull(logRecord.StateValues);
             Assert.Equal(4, logRecord.StateValues.Count);


### PR DESCRIPTION
**Note: This PR is targeting main-1.5.0 branch.**

## Changes

* Restores 1.4.0 logic for `LogRecord.State` handling.

## Details

1.5.0 tweaked `OpenTelemetryLoggerOptions.ParseStateValues` so that if logged `TState` is `IReadOnlyList` or `IEnumerable` of `KeyValuePair<string, object>` we automatically set `LogRecord.Attributes` \ `LogRecord.StateValues` and leave `LogRecord.State` = `null`. The idea with that is exporters were coded like this...

```csharp
if (logRecord.StateValues != null)
{
    attributes = logRecord.StateValues;
}
else
{
    attributes = logRecord.State as IReadOnlyList<KeyValuePair<string, object>>;
}
```

What was reported is an exporter doing this...

```csharp
var attributes = (IReadOnlyCollection<KeyValuePair<string, object>>)logRecord.State;
```

Which throws a NRE with the new logic.

In order to preserve the above logic this PR puts back handling of `LogRecord.State` so that it is always set so long as `OpenTelemetryLoggerOptions.ParseStateValues == false` ([the previous behavior](https://github.com/open-telemetry/opentelemetry-dotnet/blob/c9052ef7655b8c9b210500f48ac2a521acf63d66/src/OpenTelemetry/Logs/OpenTelemetryLogger.cs#L62)).

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
