### PR TITLE
[sdk-1.5.0-hotfix] Removed support for parsing custom log states using reflection

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -16,7 +16,7 @@
   [#4334](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4334) and
   has been removed because it makes the OpenTelemetry .NET SDK incompatible with
   native AOT.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#4614](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4614))
 
 ## 1.5.0
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -8,6 +8,16 @@
   `IReadOnlyList` or `IEnumerable` of `KeyValuePair<string, object>`s.
   ([#4609](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4609))
 
+* **Breaking Change** Removed the support for parsing `TState` types passed to
+  the `ILogger.Log<TState>` API when `ParseStateValues` is true and `TState`
+  does not implement either `IReadOnlyList<KeyValuePair<string, object>>` or
+  `IEnumerable<KeyValuePair<string, object>>`. This feature was first introduced
+  in the `1.5.0` stable release with
+  [#4334](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4334) and
+  has been removed because it makes the OpenTelemetry .NET SDK incompatible with
+  native AOT.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.5.0
 
 Released 2023-Jun-05

--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -158,6 +158,17 @@ namespace OpenTelemetry.Internal
             }
         }
 
+        [NonEvent]
+        public void LoggerProcessStateSkipped<TState>()
+        {
+            if (this.IsEnabled(EventLevel.Warning, EventKeywords.All))
+            {
+                this.LoggerProcessStateSkipped(
+                    typeof(TState).FullName!,
+                    "because it does not implement either IReadOnlyList<KeyValuePair<string, object>> or IEnumerable<KeyValuePair<string, object>>");
+            }
+        }
+
         [Event(4, Message = "Unknown error in SpanProcessor event '{0}': '{1}'.", Level = EventLevel.Error)]
         public void SpanProcessorException(string evnt, string ex)
         {
@@ -323,6 +334,12 @@ namespace OpenTelemetry.Internal
         public void LoggerProviderException(string methodName, string ex)
         {
             this.WriteEvent(50, methodName, ex);
+        }
+
+        [Event(51, Message = "Skipped processing log state of type '{0}' {1}.", Level = EventLevel.Warning)]
+        public void LoggerProcessStateSkipped(string type, string reason)
+        {
+            this.WriteEvent(51, type, reason);
         }
 
 #if DEBUG

--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -165,7 +165,7 @@ namespace OpenTelemetry.Internal
             {
                 this.LoggerProcessStateSkipped(
                     typeof(TState).FullName!,
-                    "because it does not implement either IReadOnlyList<KeyValuePair<string, object>> or IEnumerable<KeyValuePair<string, object>>");
+                    "because it does not implement a supported interface (either IReadOnlyList<KeyValuePair<string, object>> or IEnumerable<KeyValuePair<string, object>>)");
             }
         }
 

--- a/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLogger.cs
+++ b/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLogger.cs
@@ -16,7 +16,6 @@
 
 #nullable enable
 
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -207,6 +206,7 @@ internal sealed class OpenTelemetryLogger : ILogger
             // Note: This is to preserve legacy behavior where State is
             // exposed if we didn't parse state.
             iLoggerData.State = state;
+
             return null;
         }
         else
@@ -215,36 +215,9 @@ internal sealed class OpenTelemetryLogger : ILogger
             // have come from the pool and may have State from a prior log.
             iLoggerData.State = null;
 
-            try
-            {
-                PropertyDescriptorCollection itemProperties = TypeDescriptor.GetProperties(state!);
+            OpenTelemetrySdkEventSource.Log.LoggerProcessStateSkipped<TState>();
 
-                var attributeStorage = logRecord.AttributeStorage ??= new List<KeyValuePair<string, object?>>(itemProperties.Count);
-
-                foreach (PropertyDescriptor? itemProperty in itemProperties)
-                {
-                    if (itemProperty == null)
-                    {
-                        continue;
-                    }
-
-                    object? value = itemProperty.GetValue(state);
-                    if (value == null)
-                    {
-                        continue;
-                    }
-
-                    attributeStorage.Add(new KeyValuePair<string, object?>(itemProperty.Name, value));
-                }
-
-                return attributeStorage;
-            }
-            catch (Exception parseException)
-            {
-                OpenTelemetrySdkEventSource.Log.LoggerParseStateException<TState>(parseException);
-
-                return Array.Empty<KeyValuePair<string, object?>>();
-            }
+            return Array.Empty<KeyValuePair<string, object?>>();
         }
     }
 

--- a/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggerOptions.cs
+++ b/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggerOptions.cs
@@ -58,8 +58,8 @@ public class OpenTelemetryLoggerOptions
     /// <remarks>
     /// Notes:
     /// <list type="bullet">
-    /// <item>As of OpenTelemetry 1.5.0 state parsing is handled automatically
-    /// if the state logged implements <see cref="IReadOnlyList{T}"/> or <see
+    /// <item>As of OpenTelemetry v1.5 state parsing is handled automatically if
+    /// the state logged implements <see cref="IReadOnlyList{T}"/> or <see
     /// cref="IEnumerable{T}"/> where <c>T</c> is <c>KeyValuePair&lt;string,
     /// object&gt;</c> than <see cref="LogRecord.Attributes"/> will be set
     /// regardless of the value of <see cref="ParseStateValues"/>.</item>

--- a/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggerOptions.cs
+++ b/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggerOptions.cs
@@ -58,13 +58,21 @@ public class OpenTelemetryLoggerOptions
     /// <remarks>
     /// Notes:
     /// <list type="bullet">
-    /// <item>Parsing is only executed when the state logged does NOT
-    /// implement <see cref="IReadOnlyList{T}"/> or <see
+    /// <item>As of OpenTelemetry 1.5.0 state parsing is handled automatically
+    /// if the state logged implements <see cref="IReadOnlyList{T}"/> or <see
     /// cref="IEnumerable{T}"/> where <c>T</c> is <c>KeyValuePair&lt;string,
-    /// object&gt;</c>.</item>
+    /// object&gt;</c> than <see cref="LogRecord.Attributes"/> will be set
+    /// regardless of the value of <see cref="ParseStateValues"/>.</item>
     /// <item>When <see cref="ParseStateValues"/> is set to <see
     /// langword="true"/> <see cref="LogRecord.State"/> will always be <see
-    /// langword="null"/>.</item>
+    /// langword="null"/>. When <see cref="ParseStateValues"/> is set to <see
+    /// langword="false"/> <see cref="LogRecord.State"/> will always be set to
+    /// the logged state to support legacy exporters which access <see
+    /// cref="LogRecord.State"/> directly. Exporters should NOT access <see
+    /// cref="LogRecord.State"/> directly because is NOT safe and may lead to
+    /// exceptions or incorrect data especially when using batching. Exporters
+    /// should use <see cref="LogRecord.Attributes"/> to safely access any data
+    /// attached to log messages.</item>
     /// </list>
     /// </remarks>
     public bool ParseStateValues { get; set; }

--- a/test/OpenTelemetry.AotCompatibility.Tests/AotCompatibilityTests.cs
+++ b/test/OpenTelemetry.AotCompatibility.Tests/AotCompatibilityTests.cs
@@ -85,7 +85,7 @@ namespace OpenTelemetry.AotCompatibility.Tests
             Assert.True(process.ExitCode == 0, "Publishing the AotCompatibility app failed. See test output for more details.");
 
             var warnings = expectedOutput.ToString().Split('\n', '\r').Where(line => line.Contains("warning IL"));
-            Assert.Equal(43, warnings.Count());
+            Assert.Equal(42, warnings.Count());
         }
     }
 }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
@@ -100,7 +100,11 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
             {
                 Assert.Null(logRecord.State);
                 Assert.NotNull(logRecord.Attributes);
-                Assert.Contains(logRecord.Attributes, kvp => kvp.Key == "propertyA" && (string)kvp.Value == "valueA");
+
+                // Note: We currently do not support parsing custom states which do
+                // not implement the standard interfaces. We return empty attributes
+                // for these.
+                Assert.Empty(logRecord.Attributes);
             }
             else
             {
@@ -140,7 +144,11 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests
             {
                 Assert.Null(logRecord.State);
                 Assert.NotNull(logRecord.Attributes);
-                Assert.Contains(logRecord.Attributes, kvp => kvp.Key == "propertyA" && (string)kvp.Value == "valueA");
+
+                // Note: We currently do not support parsing custom states which do
+                // not implement the standard interfaces. We return empty attributes
+                // for these.
+                Assert.Empty(logRecord.Attributes);
             }
             else
             {

--- a/test/OpenTelemetry.Tests/Logs/LogRecordTest.cs
+++ b/test/OpenTelemetry.Tests/Logs/LogRecordTest.cs
@@ -826,7 +826,7 @@ namespace OpenTelemetry.Logs.Tests
         }
 
         [Fact]
-        public void ParseStateValuesUsingCustomTest()
+        public void ParseStateValuesUsingNonconformingCustomTypeTest()
         {
             using var loggerFactory = InitializeLoggerFactory(out List<LogRecord> exportedItems, configure: options => options.ParseStateValues = true);
             var logger = loggerFactory.CreateLogger<LogRecordTest>();
@@ -848,12 +848,11 @@ namespace OpenTelemetry.Logs.Tests
 
             Assert.Null(logRecord.State);
             Assert.NotNull(logRecord.StateValues);
-            Assert.Equal(1, logRecord.StateValues.Count);
 
-            KeyValuePair<string, object> actualState = logRecord.StateValues[0];
-
-            Assert.Equal("Property", actualState.Key);
-            Assert.Equal("Value", actualState.Value);
+            // Note: We currently do not support parsing custom states which do
+            // not implement the standard interfaces. We return empty attributes
+            // for these.
+            Assert.Empty(logRecord.StateValues);
         }
 
         [Fact]


### PR DESCRIPTION
[Greetings :wave: If you have landed on this PR from the CHANGELOG entry and were using the parsing feature or have a need for such a feature please drop a comment. We have options/ideas for how we could put this feature back in a way that would be compatible with AOT but prioritization of that effort will be based largely on feedback.]

**Note: This PR is targeting main-1.5.0 branch.**

Relates to #4609
See https://github.com/open-telemetry/opentelemetry-dotnet/pull/4609#issuecomment-1604992826

## Changes

* Removes the support for parsing custom states passed to `ILogger.Log<TState>` which do not implement the expected interfaces.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
