### PR TITLE
[sdk-debug] Add EventWrittenEventArgs.Level to the EventListener debug output

### DIFF
--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -358,7 +358,7 @@ namespace OpenTelemetry.Internal
                     message = e.Message;
                 }
 
-                Debug.WriteLine($"{e.EventSource.Name} - EventId: [{e.EventId}], EventName: [{e.EventName}], Message: [{message}]");
+                Debug.WriteLine($"{e.EventSource.Name} - Level: [{e.Level}], EventId: [{e.EventId}], EventName: [{e.EventName}], Message: [{message}]");
             }
         }
 #endif


### PR DESCRIPTION
## Changes

I was helping a user trying to debug the SDK using the [self-diagnostic feature](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry#self-diagnostics). They were listening at the _Warning_ level and not seeing anything super useful. In order to recommend a good level to them I added the information to our debug output when running locally so I could see everything. Opening this PR because I thought it might be generally useful to have by default in there for everyone working in the repo.