### PR TITLE
Make OtlpExporterOptions.HttpClientFactory work with GRPC protocol

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -157,6 +157,37 @@ namespace OpenTelemetry.Exporter
         /// </summary>
         public BatchExportProcessorOptions<Activity> BatchExportProcessorOptions { get; set; }
 
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
+        /// <summary>
+        /// Gets or sets the factory function called to create the <see
+        /// cref="HttpClient"/> instance that will be used at runtime to
+        /// transmit telemetry over HTTP. The returned instance will be reused
+        /// for all export invocations.
+        /// </summary>
+        /// <remarks>
+        /// Notes:
+        /// <list type="bullet">
+        /// <item>The default behavior when using the <see
+        /// cref="OtlpTraceExporterHelperExtensions.AddOtlpExporter(TracerProviderBuilder,
+        /// Action{OtlpExporterOptions})"/> extension is if an <a
+        /// href="https://docs.microsoft.com/dotnet/api/system.net.http.ihttpclientfactory">IHttpClientFactory</a>
+        /// instance can be resolved through the application <see
+        /// cref="IServiceProvider"/> then an <see cref="HttpClient"/> will be
+        /// created through the factory with the name "OtlpTraceExporter"
+        /// otherwise an <see cref="HttpClient"/> will be instantiated
+        /// directly.</item>
+        /// <item>The default behavior when using the <see
+        /// cref="OtlpMetricExporterExtensions.AddOtlpExporter(MeterProviderBuilder,
+        /// Action{OtlpExporterOptions})"/> extension is if an <a
+        /// href="https://docs.microsoft.com/dotnet/api/system.net.http.ihttpclientfactory">IHttpClientFactory</a>
+        /// instance can be resolved through the application <see
+        /// cref="IServiceProvider"/> then an <see cref="HttpClient"/> will be
+        /// created through the factory with the name "OtlpMetricExporter"
+        /// otherwise an <see cref="HttpClient"/> will be instantiated
+        /// directly.</item>
+        /// </list>
+        /// </remarks>
+#else
         /// <summary>
         /// Gets or sets the factory function called to create the <see
         /// cref="HttpClient"/> instance that will be used at runtime to
@@ -188,6 +219,7 @@ namespace OpenTelemetry.Exporter
         /// directly.</item>
         /// </list>
         /// </remarks>
+#endif
         public Func<HttpClient> HttpClientFactory { get; set; }
 
         /// <summary>

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
@@ -43,7 +43,11 @@ namespace OpenTelemetry.Exporter
             }
 
 #if NETSTANDARD2_1 || NET6_0_OR_GREATER
-            return GrpcChannel.ForAddress(options.Endpoint);
+            return GrpcChannel.ForAddress(options.Endpoint, new GrpcChannelOptions
+            {
+                HttpClient = options.HttpClientFactory?.Invoke()
+                    ?? throw new InvalidOperationException("OtlpExporterOptions was missing HttpClientFactory or it returned null."),
+            });
 #else
             ChannelCredentials channelCredentials;
             if (options.Endpoint.Scheme == Uri.UriSchemeHttps)
@@ -130,7 +134,10 @@ namespace OpenTelemetry.Exporter
         public static void TryEnableIHttpClientFactoryIntegration(this OtlpExporterOptions options, IServiceProvider serviceProvider, string httpClientName)
         {
             if (serviceProvider != null
+#if NETSTANDARD2_1 || NET6_0_OR_GREATER
+#else
                 && options.Protocol == OtlpExportProtocol.HttpProtobuf
+#endif
                 && options.HttpClientFactory == options.DefaultHttpClientFactory)
             {
                 options.HttpClientFactory = () =>


### PR DESCRIPTION
Fixes #2120, #2009
Design discussion issue #3393

## Changes
The purpose is to make it possible to control how `HttpClient` is created when using GRPC protocol. A common use case is to submit a client certificate, for example, to use with mTLS. The changes include:
* Makes `OtlpExporterOptions.HttpClientFactory` option work with `OtlpExportProtocol.Grpc` protocol, instead of just `OtlpExportProtocol.HttpProtobuf`.  
* The `HttpClient` instance is created once when the channel is created, and it is passed to `GrpcChannelOptions`.      
* In addition, the use of `IHttpClientFactory` is also supported for GRPC in much the same way it is for HttpProtobuf. 

### Usage
The following code shows how to setup client certificate with this option enabled.
```c#
Services.AddOpenTelemetry().WithTracing(b =>
{
  b.AddOtlpExporter(expoterOpts=>{
    expoterOpts.Protocol = OtlpExportProtocol.Grpc;
    expoterOpts.HttpClientFactory = CreateOTLPHttpClient;
  });
});

private static HttpClient CreateOTLPHttpClient()
{
  var handler = new HttpClientHandler
  {
    ClientCertificateOptions = ClientCertificateOption.Manual,
    // use this to disable peer validation
    ServerCertificateCustomValidationCallback =HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
  };
  handler.ClientCertificates.Add(new X509Certificate2("mycert.pfx"));

  return new HttpClient(handler, true);
}
```

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable) (N/A)
