### PR TITLE
Allow suppressing nested activities without dependency on OTel

### DIFF
--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.cs
@@ -318,6 +318,61 @@ namespace OpenTelemetry.Instrumentation.Http.Tests
         }
 
         [Fact]
+        public async Task RespectsSuppressWithActivityProperty()
+        {
+            try
+            {
+                var propagator = new Mock<TextMapPropagator>();
+                propagator.Setup(m => m.Inject(It.IsAny<PropagationContext>(), It.IsAny<HttpRequestMessage>(), It.IsAny<Action<HttpRequestMessage, string, string>>()))
+                    .Callback<PropagationContext, HttpRequestMessage, Action<HttpRequestMessage, string, string>>((context, message, action) =>
+                    {
+                        action(message, "custom_traceparent", $"00/{context.ActivityContext.TraceId}/{context.ActivityContext.SpanId}/01");
+                        action(message, "custom_tracestate", Activity.Current.TraceStateString);
+                    });
+
+                var processor = new Mock<BaseProcessor<Activity>>();
+
+                using var request = new HttpRequestMessage
+                {
+                    RequestUri = new Uri(this.url),
+                    Method = new HttpMethod("GET"),
+                };
+
+                using var parent = new Activity("parent")
+                    .SetIdFormat(ActivityIdFormat.W3C)
+                    .Start();
+                parent.TraceStateString = "k1=v1,k2=v2";
+                parent.ActivityTraceFlags = ActivityTraceFlags.Recorded;
+                parent.SetCustomProperty("otel.suppress_instrumentation", true);
+
+                Sdk.SetDefaultTextMapPropagator(propagator.Object);
+
+                using (Sdk.CreateTracerProviderBuilder()
+                    .AddHttpClientInstrumentation()
+                    .AddProcessor(processor.Object)
+                    .Build())
+                {
+                    using var c = new HttpClient();
+                    await c.SendAsync(request).ConfigureAwait(false);
+                }
+
+                // If suppressed, activity is not emitted and
+                // propagation is also not performed.
+                Assert.Equal(3, processor.Invocations.Count); // SetParentProvider/OnShutdown/Dispose called.
+                Assert.False(request.Headers.Contains("custom_traceparent"));
+                Assert.False(request.Headers.Contains("custom_tracestate"));
+            }
+            finally
+            {
+                Sdk.SetDefaultTextMapPropagator(new CompositeTextMapPropagator(new TextMapPropagator[]
+                {
+                    new TraceContextPropagator(),
+                    new BaggagePropagator(),
+                }));
+            }
+        }
+
+        [Fact]
         public async Task ExportsSpansCreatedForRetries()
         {
             var exportedItems = new List<Activity>();


### PR DESCRIPTION
Demonstrates approach proposed in #4641

## Changes

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
