### PR TITLE
Resolve CVE-2023-32731

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageVersion Include="Google.Protobuf" Version="[3.19.4,4.0)" />
     <PackageVersion Include="Grpc" Version="[2.44.0,3.0)" />
-    <PackageVersion Include="Grpc.Net.Client" Version="[2.45.0,3.0)" />
+    <PackageVersion Include="Grpc.Net.Client" Version="[2.52.0,3.0)" />
     <PackageVersion Include="Grpc.Tools" Version="[2.44.0,3.0)" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.1.1,6.0)" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Features" Version="[2.1.1,6.0)" />

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -14,12 +14,18 @@
   for instructions to enable exemplars.
   ([#4553](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4553))
 
-* Updated Grpc.Net.Client to v2.45 to fix unobserved exception
+* Updated Grpc.Net.Client to `2.45.0` to fix unobserved exception
   from failed calls.
   ([#4573](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4573))
 
 * Updated to support `Severity` and `SeverityText` when exporting `LogRecord`s.
   ([#4568](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4568))
+
+* Updated Grpc.Net.Client to `2.52.0` to address the vulnerability reported by
+  CVE-2023-32731. Refer to
+  [https://github.com/grpc/grpc/pull/32309](https://github.com/grpc/grpc/pull/32309)
+  for more details.
+  ([#TBD](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TBD))
 
 ## 1.5.1
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -25,7 +25,7 @@
   CVE-2023-32731. Refer to
   [https://github.com/grpc/grpc/pull/32309](https://github.com/grpc/grpc/pull/32309)
   for more details.
-  ([#TBD](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TBD))
+  ([#4647](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4647))
 
 ## 1.5.1
 


### PR DESCRIPTION
When gRPC HTTP2 stack raised a header size exceeded error, it skipped parsing the rest of the HPACK frame. This caused any HPACK table mutations to also be skipped, resulting in a desynchronization of HPACK tables between sender and receiver. If leveraged, say, between a proxy and a backend, this could lead to requests from the proxy being interpreted as containing headers from different proxy clients - leading to an information leak that can be used for privilege escalation or data exfiltration.

https://github.com/grpc/grpc/pull/32309