### PR TITLE
Semantic Convention changes. correct link and update changelog.

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## Unreleased
 
-* Updated [Http Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.21.0/specification/trace/semantic_conventions/http.md).
-  This library can emit either old, new, or both attributes. Users can control
-  which attributes are emitted by setting the environment variable
-  `OTEL_SEMCONV_STABILITY_OPT_IN`.
+* Updated [Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md).
+  to v1.21.0. This library can emit either old, new, or both attributes.
+  Users can control which attributes are emitted by setting the environment
+  variable `OTEL_SEMCONV_STABILITY_OPT_IN`.
+  ([#4537](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4537))
+  ([#4606](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4606))
 
 * Fixed an issue affecting NET 7.0+. If custom propagation is being used
   and tags are added to an Activity during sampling then that Activity would be dropped.

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -229,7 +229,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
                     }
                 }
 
-                // see the spec https://github.com/open-telemetry/opentelemetry-specification/blob/v1.21.0/specification/trace/semantic_conventions/http.md
+                // see the spec https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md
                 if (this.emitNewAttributes)
                 {
                     if (request.Host.HasValue)

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInMetricsListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInMetricsListener.cs
@@ -103,7 +103,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
                     }
                 }
 
-                // see the spec https://github.com/open-telemetry/opentelemetry-specification/blob/v1.21.0/specification/trace/semantic_conventions/http.md
+                // see the spec https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md
                 if (this.emitNewAttributes)
                 {
                     tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeNetworkProtocolVersion, HttpTagHelper.GetFlavorTagValueFromProtocol(context.Request.Protocol)));

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## Unreleased
 
 * Updated [Http Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md).
-  This library can emit either old, new, or both attributes. Users can control
-  which attributes are emitted by setting the environment variable
-  `OTEL_SEMCONV_STABILITY_OPT_IN`.
+  to v1.21.0. This library can emit either old, new, or both attributes.
+  Users can control which attributes are emitted by setting the environment
+  variable `OTEL_SEMCONV_STABILITY_OPT_IN`.
   ([#4538](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4538))
   ([#4639](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4639))
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## Unreleased
 
-* Updated [Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md).
-  This library can emit either old, new, or both attributes. Users can control
-  which attributes are emitted by setting the environment variable
-  `OTEL_SEMCONV_STABILITY_OPT_IN`.
+* Updated [Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md)
+  to v1.21.0. This library can emit either old, new, or both attributes.
+  Users can control which attributes are emitted by setting the environment
+  variable `OTEL_SEMCONV_STABILITY_OPT_IN`.
   ([#4644](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4644))
 
 ## 1.5.0-beta.1

--- a/src/Shared/HttpSemanticConventionHelper.cs
+++ b/src/Shared/HttpSemanticConventionHelper.cs
@@ -28,7 +28,7 @@ namespace OpenTelemetry.Internal;
 /// Due to a breaking change in the semantic convention, affected instrumentation libraries
 /// must inspect an environment variable to determine which attributes to emit.
 /// This is expected to be removed when the instrumentation libraries reach Stable.
-/// <see href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md"/>.
+/// <see href="https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md"/>.
 /// </remarks>
 internal static class HttpSemanticConventionHelper
 {
@@ -43,7 +43,7 @@ internal static class HttpSemanticConventionHelper
         Old = 0x1,
 
         /// <summary>
-        /// Instructs an instrumentation library to emit the new, stable Http attributes.
+        /// Instructs an instrumentation library to emit the new, v1.21.0 Http attributes.
         /// </summary>
         New = 0x2,
 

--- a/src/Shared/SemanticConventions.cs
+++ b/src/Shared/SemanticConventions.cs
@@ -111,7 +111,9 @@ namespace OpenTelemetry.Trace
         public const string AttributeExceptionMessage = "exception.message";
         public const string AttributeExceptionStacktrace = "exception.stacktrace";
 
-        // Http v1.21.0 https://github.com/open-telemetry/opentelemetry-specification/blob/v1.21.0/specification/trace/semantic_conventions/http.md
+        // v1.21.0 (unreleased as of this commit)
+        // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md
+        // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md
         public const string AttributeHttpRequestMethod = "http.request.method"; // replaces: "http.method" (AttributeHttpMethod)
         public const string AttributeHttpResponseStatusCode = "http.response.status_code"; // replaces: "http.status_code" (AttributeHttpStatusCode)
         public const string AttributeNetworkProtocolVersion = "network.protocol.version"; // replaces: "http.flavor" (AttributeHttpFlavor)


### PR DESCRIPTION
Design discussion issue #4484

## Changes
- correct the link to semantic conventions, using new repo.
- update Changelog with semcon version number
- update Changelog with missing links to PRs.


## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
