### PR TITLE
SemanticConventions: update link to v1.21.0 tag

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Updated [Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/http/http-spans.md).
-  to v1.21.0. This library can emit either old, new, or both attributes.
+* Updated Semantic Conventions to [v1.21.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/http/http-spans.md).
+  This library can emit either old, new, or both attributes.
   Users can control which attributes are emitted by setting the environment
   variable `OTEL_SEMCONV_STABILITY_OPT_IN`.
   ([#4537](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4537))

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Updated [Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md).
+* Updated [Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/http/http-spans.md).
   to v1.21.0. This library can emit either old, new, or both attributes.
   Users can control which attributes are emitted by setting the environment
   variable `OTEL_SEMCONV_STABILITY_OPT_IN`.

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -229,7 +229,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
                     }
                 }
 
-                // see the spec https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md
+                // see the spec https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/http/http-spans.md
                 if (this.emitNewAttributes)
                 {
                     if (request.Host.HasValue)

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInMetricsListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInMetricsListener.cs
@@ -103,7 +103,7 @@ namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation
                     }
                 }
 
-                // see the spec https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md
+                // see the spec https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/http/http-spans.md
                 if (this.emitNewAttributes)
                 {
                     tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeNetworkProtocolVersion, HttpTagHelper.GetFlavorTagValueFromProtocol(context.Request.Protocol)));

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 ## Unreleased
 
-* Updated [Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/rpc/rpc-spans.md)
-  to v1.21.0. This library can emit either old, new, or both attributes.
-  Users can control which attributes are emitted by setting the environment
-  variable `OTEL_SEMCONV_STABILITY_OPT_IN`.
-  ([#4658](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4658))
-
 ## 1.5.0-beta.1
 
 Released 2023-Jun-05

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+* Updated [Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/rpc/rpc-spans.md)
+  to v1.21.0. This library can emit either old, new, or both attributes.
+  Users can control which attributes are emitted by setting the environment
+  variable `OTEL_SEMCONV_STABILITY_OPT_IN`.
+  ([#4658](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4658))
+
 ## 1.5.0-beta.1
 
 Released 2023-Jun-05

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Updated [Http Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md).
+* Updated [Http Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/http/http-spans.md).
   to v1.21.0. This library can emit either old, new, or both attributes.
   Users can control which attributes are emitted by setting the environment
   variable `OTEL_SEMCONV_STABILITY_OPT_IN`.

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Updated [Http Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/http/http-spans.md).
-  to v1.21.0. This library can emit either old, new, or both attributes.
+* Updated Semantic Conventions to [v1.21.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/http/http-spans.md).
+  This library can emit either old, new, or both attributes.
   Users can control which attributes are emitted by setting the environment
   variable `OTEL_SEMCONV_STABILITY_OPT_IN`.
   ([#4538](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4538))

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -179,7 +179,7 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
                     activity.SetTag(SemanticConventions.AttributeHttpFlavor, HttpTagHelper.GetFlavorTagValueFromProtocolVersion(request.Version));
                 }
 
-                // see the spec https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md
+                // see the spec https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/http/http-spans.md
                 if (this.emitNewAttributes)
                 {
                     activity.SetTag(SemanticConventions.AttributeHttpRequestMethod, HttpTagHelper.GetNameForHttpMethod(request.Method));

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
@@ -79,7 +79,7 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
                         }
                     }
 
-                    // see the spec https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md
+                    // see the spec https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/http/http-spans.md
                     if (this.emitNewAttributes)
                     {
                         tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpRequestMethod, HttpTagHelper.GetNameForHttpMethod(request.Method)));

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
@@ -129,7 +129,7 @@ namespace OpenTelemetry.Instrumentation.Http.Implementation
                     activity.SetTag(SemanticConventions.AttributeHttpFlavor, HttpTagHelper.GetFlavorTagValueFromProtocolVersion(request.ProtocolVersion));
                 }
 
-                // see the spec https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md
+                // see the spec https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/http/http-spans.md
                 if (emitNewAttributes)
                 {
                     activity.SetTag(SemanticConventions.AttributeHttpRequestMethod, request.Method);

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-* Updated [Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/database/database-spans.md)
-  to v1.21.0. This library can emit either old, new, or both attributes.
+* Updated Semantic Conventions to [v1.21.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/database/database-spans.md)
+  This library can emit either old, new, or both attributes.
   Users can control which attributes are emitted by setting the environment
   variable `OTEL_SEMCONV_STABILITY_OPT_IN`.
   ([#4644](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4644))

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Updated [Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md)
+* Updated [Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/database/database-spans.md)
   to v1.21.0. This library can emit either old, new, or both attributes.
   Users can control which attributes are emitted by setting the environment
   variable `OTEL_SEMCONV_STABILITY_OPT_IN`.

--- a/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentationOptions.cs
@@ -331,7 +331,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient
                     }
                 }
 
-                // see the spec https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md
+                // see the spec https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/database/database-spans.md
                 if (this.emitNewAttributes)
                 {
                     if (!string.IsNullOrEmpty(connectionDetails.ServerHostName))

--- a/src/Shared/HttpSemanticConventionHelper.cs
+++ b/src/Shared/HttpSemanticConventionHelper.cs
@@ -28,7 +28,7 @@ namespace OpenTelemetry.Internal;
 /// Due to a breaking change in the semantic convention, affected instrumentation libraries
 /// must inspect an environment variable to determine which attributes to emit.
 /// This is expected to be removed when the instrumentation libraries reach Stable.
-/// <see href="https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md"/>.
+/// <see href="https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/http/http-spans.md"/>.
 /// </remarks>
 internal static class HttpSemanticConventionHelper
 {

--- a/src/Shared/SemanticConventions.cs
+++ b/src/Shared/SemanticConventions.cs
@@ -112,8 +112,8 @@ namespace OpenTelemetry.Trace
         public const string AttributeExceptionStacktrace = "exception.stacktrace";
 
         // v1.21.0 (unreleased as of this commit)
-        // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md
-        // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md
+        // https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/http/http-spans.md
+        // https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/database/database-spans.md
         public const string AttributeHttpRequestMethod = "http.request.method"; // replaces: "http.method" (AttributeHttpMethod)
         public const string AttributeHttpResponseStatusCode = "http.response.status_code"; // replaces: "http.status_code" (AttributeHttpStatusCode)
         public const string AttributeNetworkProtocolVersion = "network.protocol.version"; // replaces: "http.flavor" (AttributeHttpFlavor)

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestActivitySourceTestsDupe.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestActivitySourceTestsDupe.netfx.cs
@@ -35,7 +35,7 @@ using static OpenTelemetry.Internal.HttpSemanticConventionHelper;
 namespace OpenTelemetry.Instrumentation.Http.Tests
 {
     // Tests for v1.21.0 Semantic Conventions for Http spans
-    // see the spec https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md
+    // see the spec https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/http/http-spans.md
     // These tests emit both the new and older attributes.
     // This test class can be deleted when this library is GA.
     public class HttpWebRequestActivitySourceTestsDupe : IDisposable

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestActivitySourceTestsNew.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestActivitySourceTestsNew.netfx.cs
@@ -35,7 +35,7 @@ using static OpenTelemetry.Internal.HttpSemanticConventionHelper;
 namespace OpenTelemetry.Instrumentation.Http.Tests
 {
     // Tests for v1.21.0 Semantic Conventions for Http spans
-    // see the spec https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md
+    // see the spec https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/http/http-spans.md
     // These tests emit the new attributes.
     // This test class can replace the other class when this library is GA.
     public class HttpWebRequestActivitySourceTestsNew : IDisposable

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientInstrumentationOptionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientInstrumentationOptionsTests.cs
@@ -106,7 +106,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests
         }
 
         // Tests for v1.21.0 Semantic Conventions for database client calls.
-        // see the spec https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md
+        // see the spec https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/database/database-spans.md
         // This test emits the new attributes.
         // This test method can replace the other (old) test method when this library is GA.
         [Theory]
@@ -151,7 +151,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient.Tests
         }
 
         // Tests for v1.21.0 Semantic Conventions for database client calls.
-        // see the spec https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md
+        // see the spec https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/database/database-spans.md
         // This test emits both the new and older attributes.
         // This test method can be deleted when this library is GA.
         [Theory]


### PR DESCRIPTION
Design discussion issue #4484

## Changes
- Update all semantic convention links to the v1.21.0 tag.
  The semantic-conventions repo completed their first release of v1.21.0.
  I would rather link to a tagged version of the specs than the main branch.

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
