### PR TITLE
Opentracing shim noop cases

### DIFF
--- a/src/OpenTelemetry.Shims.OpenTracing/CHANGELOG.md
+++ b/src/OpenTelemetry.Shims.OpenTracing/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Fix: Do not raise `ArgumentException` if `Activity` behind the shim span
+  has an invalid context.
+  ([#2787](https://github.com/open-telemetry/opentelemetry-dotnet/issues/2787))
+
 ## 1.5.0-beta.1
 
 Released 2023-Jun-05

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanContextShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanContextShim.cs
@@ -22,11 +22,6 @@ namespace OpenTelemetry.Shims.OpenTracing
     {
         public SpanContextShim(in Trace.SpanContext spanContext)
         {
-            if (!spanContext.IsValid)
-            {
-                throw new ArgumentException($"Invalid '{nameof(Trace.SpanContext)}'", nameof(spanContext));
-            }
-
             this.SpanContext = spanContext;
         }
 

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanShim.cs
@@ -45,15 +45,11 @@ namespace OpenTelemetry.Shims.OpenTracing
         {
             Guard.ThrowIfNull(span);
 
-            if (!span.Context.IsValid)
-            {
-                throw new ArgumentException($"Invalid '{nameof(SpanContext)}'", nameof(span.Context));
-            }
-
             this.Span = span;
             this.spanContextShim = new SpanContextShim(this.Span.Context);
         }
 
+        /// <inheritdoc/>
         public ISpanContext Context => this.spanContextShim;
 
         public TelemetrySpan Span { get; private set; }

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/IntegrationTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/IntegrationTests.cs
@@ -1,0 +1,193 @@
+// <copyright file="IntegrationTests.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Diagnostics;
+using OpenTelemetry.Context.Propagation;
+using OpenTelemetry.Trace;
+using OpenTracing;
+using Xunit;
+
+namespace OpenTelemetry.Shims.OpenTracing.Tests
+{
+    public class IntegrationTests
+    {
+        private const string ChildActivitySource = "ChildActivitySource";
+        private const string ParentActivitySource = "ParentActivitySource";
+        private const string ShimTracerName = "OpenTracing.Shim";
+
+        [Theory(Skip = "Known Activate bug")]
+        [InlineData(false, 0)]
+        [InlineData(true, 2)]
+        public void ActiveSpanViaShim(bool listenToShim, int expectedExportedSpansCount)
+        {
+            var exportedSpans = new List<Activity>();
+
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                .SetSampler(listenToShim ? new AlwaysOnSampler() : new AlwaysOffSampler())
+                .When(
+                    listenToShim,
+                    b => b.AddSource(ShimTracerName))
+                .Build();
+
+            ITracer otTracer = new TracerShim(
+                tracerProvider.GetTracer(ShimTracerName),
+                Propagators.DefaultTextMapPropagator);
+
+            // Real usage requires a call OpenTracing.Util.GlobalTracer.Register(otTracer),
+            // however, that can only happen once per process, we don't do it here so we
+            // can run multiple tests in the same process.
+
+            using (IScope parentScope = otTracer.BuildSpan("Parent").StartActive())
+            {
+                parentScope.Span.SetTag("parent", true);
+
+                // Create a child span using the ScopeManager
+                var otScopeManager = otTracer.ScopeManager;
+                Assert.NotNull(otScopeManager);
+
+                var otSpan = otTracer.BuildSpan("Child")
+                    .WithTag("parent", false)
+                    .Start();
+                using IScope childScope = otScopeManager.Activate(otSpan, finishSpanOnDispose: true);
+            }
+
+            Assert.Equal(expectedExportedSpansCount, exportedSpans.Count);
+            if (expectedExportedSpansCount > 0)
+            {
+                Assert.Equal("Child", exportedSpans[0].DisplayName);
+                Assert.Equal("Parent", exportedSpans[1].DisplayName);
+            }
+        }
+
+        [Theory]
+        [InlineData(SamplingDecision.Drop, SamplingDecision.Drop, SamplingDecision.Drop)]
+        [InlineData(SamplingDecision.Drop, SamplingDecision.RecordAndSample, SamplingDecision.Drop)]
+        [InlineData(SamplingDecision.Drop, SamplingDecision.RecordOnly, SamplingDecision.Drop)]
+        [InlineData(SamplingDecision.RecordOnly, SamplingDecision.RecordAndSample, SamplingDecision.RecordOnly)]
+        [InlineData(SamplingDecision.RecordAndSample, SamplingDecision.RecordOnly, SamplingDecision.RecordAndSample)]
+        [InlineData(SamplingDecision.RecordAndSample, SamplingDecision.Drop, SamplingDecision.RecordAndSample)]
+        public void WithActivities(
+            SamplingDecision parentActivitySamplingDecision,
+            SamplingDecision shimSamplingDecision,
+            SamplingDecision childActivitySamplingDecision)
+        {
+            var exportedSpans = new List<Activity>();
+
+            const string ParentActivityName = "ParentActivity";
+            const string ShimActivityName = "ShimActivity";
+            const string ChildActivityName = "ChildActivity";
+
+            var testSampler = new TestSampler((samplingParameters) =>
+                samplingParameters.Name switch
+                {
+                    ParentActivityName => parentActivitySamplingDecision,
+                    ShimActivityName => shimSamplingDecision,
+                    ChildActivityName => childActivitySamplingDecision,
+                    _ => SamplingDecision.Drop,
+                });
+
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                .AddInMemoryExporter(exportedSpans)
+                .SetSampler(testSampler)
+                .When(
+                    parentActivitySamplingDecision == SamplingDecision.RecordAndSample,
+                    b => b.AddSource(ParentActivitySource))
+                .When(
+                    shimSamplingDecision == SamplingDecision.RecordAndSample,
+                    b => b.AddSource(ShimTracerName))
+                .When(
+                    childActivitySamplingDecision == SamplingDecision.RecordAndSample,
+                    b => b.AddSource(ChildActivitySource))
+                .Build();
+
+            ITracer otTracer = new TracerShim(
+                tracerProvider.GetTracer(ShimTracerName),
+                Propagators.DefaultTextMapPropagator);
+
+            // Real usage requires a call OpenTracing.Util.GlobalTracer.Register(otTracer),
+            // however, that can only happen once per process, we don't do it here so we
+            // can run multiple tests in the same process.
+
+            using var parentActivitySource = new ActivitySource(ParentActivitySource);
+            using var childActivitySource = new ActivitySource(ChildActivitySource);
+
+            using (var parentActivity = parentActivitySource.StartActivity(ParentActivityName))
+            {
+                using (IScope parentScope = otTracer.BuildSpan(ShimActivityName).StartActive())
+                {
+                    parentScope.Span.SetTag("parent", true);
+
+                    using var childActivity = childActivitySource.StartActivity(ChildActivityName);
+                }
+            }
+
+            var expectedExportedSpans = new string[]
+                {
+                    childActivitySamplingDecision == SamplingDecision.RecordAndSample ? ChildActivityName : null,
+                    shimSamplingDecision == SamplingDecision.RecordAndSample ? ShimActivityName : null,
+                    parentActivitySamplingDecision == SamplingDecision.RecordAndSample ? ParentActivityName : null,
+                }
+                .Where(s => s is not null)
+                .ToList();
+
+            for (int i = 0; i < expectedExportedSpans.Count; i++)
+            {
+                Assert.Equal(expectedExportedSpans[i], exportedSpans[i].DisplayName);
+            }
+
+            if (childActivitySamplingDecision == SamplingDecision.RecordAndSample)
+            {
+                if (shimSamplingDecision == SamplingDecision.RecordAndSample)
+                {
+                    Assert.Same(exportedSpans[1], exportedSpans[0].Parent);
+                }
+            }
+        }
+
+        private class TestSampler : Sampler
+        {
+            private readonly Func<SamplingParameters, SamplingDecision> shouldSampleDelegate;
+
+            public TestSampler(Func<SamplingParameters, SamplingDecision> shouldSampleDelegate)
+            {
+                this.shouldSampleDelegate = shouldSampleDelegate;
+            }
+
+            public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
+            {
+                return new SamplingResult(this.shouldSampleDelegate(samplingParameters));
+            }
+        }
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "Local use only")]
+    internal static class ConditionalTracerProviderBuilderExtension
+    {
+        public static TracerProviderBuilder When(
+            this TracerProviderBuilder builder,
+            bool condition,
+            Func<TracerProviderBuilder, TracerProviderBuilder> conditionalDelegate)
+        {
+            if (condition)
+            {
+                builder = conditionalDelegate(builder);
+            }
+
+            return builder;
+        }
+    }
+}

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/ListenAndSampleAllActivitySources.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/ListenAndSampleAllActivitySources.cs
@@ -1,0 +1,49 @@
+// <copyright file="ListenAndSampleAllActivitySources.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Diagnostics;
+using Xunit;
+
+namespace OpenTelemetry.Shims.OpenTracing.Tests
+{
+    [CollectionDefinition("ListenAndSampleAllActivitySources")]
+    public class ListenAndSampleAllActivitySources : ICollectionFixture<ListenAndSampleAllActivitySources.Fixture>
+    {
+        public class Fixture : IDisposable
+        {
+            private readonly ActivityListener listener;
+
+            public Fixture()
+            {
+                Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+                Activity.ForceDefaultIdFormat = true;
+
+                this.listener = new ActivityListener
+                {
+                    ShouldListenTo = _ => true,
+                    Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
+                };
+
+                ActivitySource.AddActivityListener(this.listener);
+            }
+
+            public void Dispose()
+            {
+                this.listener.Dispose();
+            }
+        }
+    }
+}

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/ListenAndSampleAllActivitySources.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/ListenAndSampleAllActivitySources.cs
@@ -19,10 +19,10 @@ using Xunit;
 
 namespace OpenTelemetry.Shims.OpenTracing.Tests
 {
-    [CollectionDefinition("ListenAndSampleAllActivitySources")]
-    public class ListenAndSampleAllActivitySources : ICollectionFixture<ListenAndSampleAllActivitySources.Fixture>
+    [CollectionDefinition(nameof(ListenAndSampleAllActivitySources))]
+    public sealed class ListenAndSampleAllActivitySources : ICollectionFixture<ListenAndSampleAllActivitySources.Fixture>
     {
-        public class Fixture : IDisposable
+        public sealed class Fixture : IDisposable
         {
             private readonly ActivityListener listener;
 

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/OpenTelemetry.Shims.OpenTracing.Tests.csproj
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/OpenTelemetry.Shims.OpenTracing.Tests.csproj
@@ -19,6 +19,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry\OpenTelemetry.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.InMemory\OpenTelemetry.Exporter.InMemory.csproj" />
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Shims.OpenTracing\OpenTelemetry.Shims.OpenTracing.csproj" />
   </ItemGroup>
 </Project>

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/OpenTelemetry.Shims.OpenTracing.Tests.csproj
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/OpenTelemetry.Shims.OpenTracing.Tests.csproj
@@ -3,7 +3,7 @@
     <Description>Unit test project for OpenTelemetry.Shims.OpenTracing</Description>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
     <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
-
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <!-- this is temporary. will remove in future PR. -->
     <Nullable>disable</Nullable>
   </PropertyGroup>

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/ScopeManagerShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/ScopeManagerShimTests.cs
@@ -21,7 +21,7 @@ using Xunit;
 
 namespace OpenTelemetry.Shims.OpenTracing.Tests
 {
-    [Collection("ListenAndSampleAllActivitySources")]
+    [Collection(nameof(ListenAndSampleAllActivitySources))]
     public class ScopeManagerShimTests
     {
         private const string SpanName = "MySpanName/1";

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/ScopeManagerShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/ScopeManagerShimTests.cs
@@ -21,24 +21,11 @@ using Xunit;
 
 namespace OpenTelemetry.Shims.OpenTracing.Tests
 {
+    [Collection("ListenAndSampleAllActivitySources")]
     public class ScopeManagerShimTests
     {
         private const string SpanName = "MySpanName/1";
         private const string TracerName = "defaultactivitysource";
-
-        static ScopeManagerShimTests()
-        {
-            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
-            Activity.ForceDefaultIdFormat = true;
-
-            var listener = new ActivityListener
-            {
-                ShouldListenTo = _ => true,
-                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
-            };
-
-            ActivitySource.AddActivityListener(listener);
-        }
 
         [Fact]
         public void CtorArgumentValidation()

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanBuilderShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanBuilderShimTests.cs
@@ -20,7 +20,7 @@ using Xunit;
 
 namespace OpenTelemetry.Shims.OpenTracing.Tests
 {
-    [Collection("ListenAndSampleAllActivitySources")]
+    [Collection(nameof(ListenAndSampleAllActivitySources))]
     public class SpanBuilderShimTests
     {
         private const string SpanName1 = "MySpanName/1";

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanBuilderShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanBuilderShimTests.cs
@@ -20,25 +20,12 @@ using Xunit;
 
 namespace OpenTelemetry.Shims.OpenTracing.Tests
 {
+    [Collection("ListenAndSampleAllActivitySources")]
     public class SpanBuilderShimTests
     {
         private const string SpanName1 = "MySpanName/1";
         private const string SpanName2 = "MySpanName/2";
         private const string TracerName = "defaultactivitysource";
-
-        static SpanBuilderShimTests()
-        {
-            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
-            Activity.ForceDefaultIdFormat = true;
-
-            var listener = new ActivityListener
-            {
-                ShouldListenTo = _ => true,
-                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
-            };
-
-            ActivitySource.AddActivityListener(listener);
-        }
 
         [Fact]
         public void CtorArgumentValidation()

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanContextShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanContextShimTests.cs
@@ -23,13 +23,6 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
     public class SpanContextShimTests
     {
         [Fact]
-        public void CtorArgumentValidation()
-        {
-            Assert.Throws<ArgumentException>(() => new SpanContextShim(default));
-            Assert.Throws<ArgumentException>(() => new SpanContextShim(new SpanContext(default, default, ActivityTraceFlags.None)));
-        }
-
-        [Fact]
         public void GetTraceId()
         {
             var shim = GetSpanContextShim();

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
@@ -20,7 +20,7 @@ using Xunit;
 
 namespace OpenTelemetry.Shims.OpenTracing.Tests
 {
-    [Collection("ListenAndSampleAllActivitySources")]
+    [Collection(nameof(ListenAndSampleAllActivitySources))]
     public class SpanShimTests
     {
         private const string SpanName = "MySpanName/1";

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
@@ -59,6 +59,14 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests
             var tracer = TracerProvider.Default.GetTracer(TracerName);
             var shim = new SpanShim(tracer.StartSpan(SpanName));
 
+#if NETFRAMEWORK
+            // Under the hood the Activity start time uses DateTime.UtcNow, which
+            // doesn't have the same precision as DateTimeOffset.UtcNow on the .NET Framework.
+            // Add a sleep big enough to ensure that the test doesn't break due to the
+            // low resolution of DateTime.UtcNow on the .NET Framework.
+            Thread.Sleep(TimeSpan.FromMilliseconds(20));
+#endif
+
             var endTime = DateTimeOffset.UtcNow;
             shim.Finish(endTime);
 

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
@@ -14,31 +14,17 @@
 // limitations under the License.
 // </copyright>
 
-using System.Diagnostics;
 using OpenTelemetry.Trace;
 using OpenTracing.Tag;
 using Xunit;
 
 namespace OpenTelemetry.Shims.OpenTracing.Tests
 {
+    [Collection("ListenAndSampleAllActivitySources")]
     public class SpanShimTests
     {
         private const string SpanName = "MySpanName/1";
         private const string TracerName = "defaultactivitysource";
-
-        static SpanShimTests()
-        {
-            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
-            Activity.ForceDefaultIdFormat = true;
-
-            var listener = new ActivityListener
-            {
-                ShouldListenTo = _ => true,
-                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
-            };
-
-            ActivitySource.AddActivityListener(listener);
-        }
 
         [Fact]
         public void CtorArgumentValidation()


### PR DESCRIPTION
Fixes #2787

## Changes

* Since the `TelemetrySpan.NoopInstance` has an invalid span context the shim should not raise an exception: it is an expected scenario.
* Added integration tests for the shim, interacting with `Activity` and various sampling configurations to prevent similar regressions in the future.
* Enabled the shim tests against net462.
* Refactored the configuration of listeners in the tests, so different tests could have different configurations.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
