### PR TITLE
[Performance] added `SpanAttributes.Add(string,object)` method for deferred `string`-ification

### DIFF
--- a/src/OpenTelemetry.Api/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -78,3 +78,4 @@ OpenTelemetry.Logs.LogRecordSeverityExtensions
 static OpenTelemetry.Logs.LogRecordAttributeList.CreateFromEnumerable(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, object?>>! attributes) -> OpenTelemetry.Logs.LogRecordAttributeList
 static OpenTelemetry.Logs.LogRecordSeverityExtensions.ToShortName(this OpenTelemetry.Logs.LogRecordSeverity logRecordSeverity) -> string!
 virtual OpenTelemetry.Logs.LoggerProvider.TryCreateLogger(string? name, out OpenTelemetry.Logs.Logger? logger) -> bool
+~OpenTelemetry.Trace.SpanAttributes.Add(string key, object value) -> void

--- a/src/OpenTelemetry.Api/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -222,6 +222,7 @@ virtual OpenTelemetry.Logs.LoggerProvider.TryCreateLogger(string? name, out Open
 ~OpenTelemetry.Trace.SpanAttributes.Add(string key, double[] values) -> void
 ~OpenTelemetry.Trace.SpanAttributes.Add(string key, long value) -> void
 ~OpenTelemetry.Trace.SpanAttributes.Add(string key, long[] values) -> void
+~OpenTelemetry.Trace.SpanAttributes.Add(string key, object value) -> void
 ~OpenTelemetry.Trace.SpanAttributes.Add(string key, string value) -> void
 ~OpenTelemetry.Trace.SpanAttributes.Add(string key, string[] values) -> void
 ~OpenTelemetry.Trace.SpanAttributes.SpanAttributes(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>> attributes) -> void

--- a/src/OpenTelemetry.Api/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -78,3 +78,4 @@ OpenTelemetry.Logs.LogRecordSeverityExtensions
 static OpenTelemetry.Logs.LogRecordAttributeList.CreateFromEnumerable(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, object?>>! attributes) -> OpenTelemetry.Logs.LogRecordAttributeList
 static OpenTelemetry.Logs.LogRecordSeverityExtensions.ToShortName(this OpenTelemetry.Logs.LogRecordSeverity logRecordSeverity) -> string!
 virtual OpenTelemetry.Logs.LoggerProvider.TryCreateLogger(string? name, out OpenTelemetry.Logs.Logger? logger) -> bool
+~OpenTelemetry.Trace.SpanAttributes.Add(string key, object value) -> void

--- a/src/OpenTelemetry.Api/Trace/SpanAttributes.cs
+++ b/src/OpenTelemetry.Api/Trace/SpanAttributes.cs
@@ -130,6 +130,16 @@ public class SpanAttributes
         this.AddInternal(key, values);
     }
 
+    /// <summary>
+    /// Add entry to the attributes.
+    /// </summary>
+    /// <param name="key">Entry key.</param>
+    /// <param name="value">Entry value.</param>
+    public void Add(string key, object value)
+    {
+        this.AddInternal(key, value);
+    }
+
     private void AddInternal(string key, object value)
     {
         Guard.ThrowIfNull(key);

--- a/test/OpenTelemetry.Api.Tests/Trace/SpanAttributesTest.cs
+++ b/test/OpenTelemetry.Api.Tests/Trace/SpanAttributesTest.cs
@@ -43,7 +43,9 @@ public class SpanAttributesTest
         spanAttribute.Add("key_long", 1);
         spanAttribute.Add("key_a_long", new long[] { 1 });
 
-        Assert.Equal(8, spanAttribute.Attributes.Count);
+        spanAttribute.Add("key_object", new object());
+
+        Assert.Equal(9, spanAttribute.Attributes.Count);
     }
 
     [Fact]


### PR DESCRIPTION
## Changes

This is a performance fix aimed at making it possible to defer `string`-ification of complex types until the `Activity` is being processed by the OTel pipeline.

This type of performance work is possible when working directly on `System.Diagnostics.ActivityTagsCollection`, but not when working with `OpenTelemetry.Api.Trace.SpanAttributes`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
