### PR TITLE
Update OpenTelemetry.Shims.OpenTracing to use file scoped namespaces

### DIFF
--- a/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
@@ -19,96 +19,95 @@ using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
 using OpenTracing;
 
-namespace OpenTelemetry.Shims.OpenTracing
+namespace OpenTelemetry.Shims.OpenTracing;
+
+internal sealed class ScopeManagerShim : IScopeManager
 {
-    internal sealed class ScopeManagerShim : IScopeManager
+    private static readonly ConditionalWeakTable<TelemetrySpan, IScope> SpanScopeTable = new();
+
+    private readonly Tracer tracer;
+
+#if DEBUG
+    private int spanScopeTableCount;
+#endif
+
+    public ScopeManagerShim(Tracer tracer)
     {
-        private static readonly ConditionalWeakTable<TelemetrySpan, IScope> SpanScopeTable = new();
+        Guard.ThrowIfNull(tracer);
 
-        private readonly Tracer tracer;
+        this.tracer = tracer;
+    }
 
 #if DEBUG
-        private int spanScopeTableCount;
+    public int SpanScopeTableCount => this.spanScopeTableCount;
 #endif
 
-        public ScopeManagerShim(Tracer tracer)
+    /// <inheritdoc/>
+    public IScope Active
+    {
+        get
         {
-            Guard.ThrowIfNull(tracer);
+            var currentSpan = Tracer.CurrentSpan;
+            if (currentSpan == null || !currentSpan.Context.IsValid)
+            {
+                return null;
+            }
 
-            this.tracer = tracer;
+            if (SpanScopeTable.TryGetValue(currentSpan, out var openTracingScope))
+            {
+                return openTracingScope;
+            }
+
+            return new ScopeInstrumentation(currentSpan);
         }
+    }
 
+    /// <inheritdoc/>
+    public IScope Activate(ISpan span, bool finishSpanOnDispose)
+    {
+        var shim = Guard.ThrowIfNotOfType<SpanShim>(span);
+
+        var scope = Tracer.WithSpan(shim.Span);
+
+        var instrumentation = new ScopeInstrumentation(
+            shim.Span,
+            () =>
+            {
+                var removed = SpanScopeTable.Remove(shim.Span);
 #if DEBUG
-        public int SpanScopeTableCount => this.spanScopeTableCount;
+                if (removed)
+                {
+                    Interlocked.Decrement(ref this.spanScopeTableCount);
+                }
 #endif
+                scope.Dispose();
+            });
+
+        SpanScopeTable.Add(shim.Span, instrumentation);
+#if DEBUG
+        Interlocked.Increment(ref this.spanScopeTableCount);
+#endif
+
+        return instrumentation;
+    }
+
+    private sealed class ScopeInstrumentation : IScope
+    {
+        private readonly Action disposeAction;
+
+        public ScopeInstrumentation(TelemetrySpan span, Action disposeAction = null)
+        {
+            this.Span = new SpanShim(span);
+            this.disposeAction = disposeAction;
+        }
 
         /// <inheritdoc/>
-        public IScope Active
-        {
-            get
-            {
-                var currentSpan = Tracer.CurrentSpan;
-                if (currentSpan == null || !currentSpan.Context.IsValid)
-                {
-                    return null;
-                }
-
-                if (SpanScopeTable.TryGetValue(currentSpan, out var openTracingScope))
-                {
-                    return openTracingScope;
-                }
-
-                return new ScopeInstrumentation(currentSpan);
-            }
-        }
+        public ISpan Span { get; }
 
         /// <inheritdoc/>
-        public IScope Activate(ISpan span, bool finishSpanOnDispose)
+        public void Dispose()
         {
-            var shim = Guard.ThrowIfNotOfType<SpanShim>(span);
-
-            var scope = Tracer.WithSpan(shim.Span);
-
-            var instrumentation = new ScopeInstrumentation(
-                shim.Span,
-                () =>
-                {
-                    var removed = SpanScopeTable.Remove(shim.Span);
-#if DEBUG
-                    if (removed)
-                    {
-                        Interlocked.Decrement(ref this.spanScopeTableCount);
-                    }
-#endif
-                    scope.Dispose();
-                });
-
-            SpanScopeTable.Add(shim.Span, instrumentation);
-#if DEBUG
-            Interlocked.Increment(ref this.spanScopeTableCount);
-#endif
-
-            return instrumentation;
-        }
-
-        private sealed class ScopeInstrumentation : IScope
-        {
-            private readonly Action disposeAction;
-
-            public ScopeInstrumentation(TelemetrySpan span, Action disposeAction = null)
-            {
-                this.Span = new SpanShim(span);
-                this.disposeAction = disposeAction;
-            }
-
-            /// <inheritdoc/>
-            public ISpan Span { get; }
-
-            /// <inheritdoc/>
-            public void Dispose()
-            {
-                this.disposeAction?.Invoke();
-            }
+            this.disposeAction?.Invoke();
         }
     }
 }

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanBuilderShim.cs
@@ -18,306 +18,305 @@ using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
 using OpenTracing;
 
-namespace OpenTelemetry.Shims.OpenTracing
+namespace OpenTelemetry.Shims.OpenTracing;
+
+/// <summary>
+/// Adapts OpenTracing ISpanBuilder to an underlying OpenTelemetry ISpanBuilder.
+/// </summary>
+/// <remarks>Instances of this class are not thread-safe.</remarks>
+/// <seealso cref="ISpanBuilder" />
+internal sealed class SpanBuilderShim : ISpanBuilder
 {
     /// <summary>
-    /// Adapts OpenTracing ISpanBuilder to an underlying OpenTelemetry ISpanBuilder.
+    /// The tracer.
     /// </summary>
-    /// <remarks>Instances of this class are not thread-safe.</remarks>
-    /// <seealso cref="ISpanBuilder" />
-    internal sealed class SpanBuilderShim : ISpanBuilder
+    private readonly Tracer tracer;
+
+    /// <summary>
+    /// The span name.
+    /// </summary>
+    private readonly string spanName;
+
+    /// <summary>
+    /// The OpenTelemetry links. These correspond loosely to OpenTracing references.
+    /// </summary>
+    private readonly List<Link> links = new();
+
+    /// <summary>
+    /// The OpenTelemetry attributes. These correspond to OpenTracing Tags.
+    /// </summary>
+    private readonly List<KeyValuePair<string, object>> attributes = new();
+
+    /// <summary>
+    /// The parent as an TelemetrySpan, if any.
+    /// </summary>
+    private TelemetrySpan parentSpan;
+
+    /// <summary>
+    /// The parent as an SpanContext, if any.
+    /// </summary>
+    private SpanContext parentSpanContext;
+
+    /// <summary>
+    /// The explicit start time, if any.
+    /// </summary>
+    private DateTimeOffset? explicitStartTime;
+
+    private bool ignoreActiveSpan;
+
+    private SpanKind spanKind;
+
+    private bool error;
+
+    public SpanBuilderShim(Tracer tracer, string spanName)
     {
-        /// <summary>
-        /// The tracer.
-        /// </summary>
-        private readonly Tracer tracer;
+        Guard.ThrowIfNull(tracer);
+        Guard.ThrowIfNull(spanName);
 
-        /// <summary>
-        /// The span name.
-        /// </summary>
-        private readonly string spanName;
+        this.tracer = tracer;
+        this.spanName = spanName;
+        this.ScopeManager = new ScopeManagerShim(this.tracer);
+    }
 
-        /// <summary>
-        /// The OpenTelemetry links. These correspond loosely to OpenTracing references.
-        /// </summary>
-        private readonly List<Link> links = new();
+    private IScopeManager ScopeManager { get; }
 
-        /// <summary>
-        /// The OpenTelemetry attributes. These correspond to OpenTracing Tags.
-        /// </summary>
-        private readonly List<KeyValuePair<string, object>> attributes = new();
+    private bool ParentSet => this.parentSpan != null || this.parentSpanContext.IsValid;
 
-        /// <summary>
-        /// The parent as an TelemetrySpan, if any.
-        /// </summary>
-        private TelemetrySpan parentSpan;
-
-        /// <summary>
-        /// The parent as an SpanContext, if any.
-        /// </summary>
-        private SpanContext parentSpanContext;
-
-        /// <summary>
-        /// The explicit start time, if any.
-        /// </summary>
-        private DateTimeOffset? explicitStartTime;
-
-        private bool ignoreActiveSpan;
-
-        private SpanKind spanKind;
-
-        private bool error;
-
-        public SpanBuilderShim(Tracer tracer, string spanName)
+    /// <inheritdoc/>
+    public ISpanBuilder AsChildOf(ISpanContext parent)
+    {
+        if (parent == null)
         {
-            Guard.ThrowIfNull(tracer);
-            Guard.ThrowIfNull(spanName);
-
-            this.tracer = tracer;
-            this.spanName = spanName;
-            this.ScopeManager = new ScopeManagerShim(this.tracer);
-        }
-
-        private IScopeManager ScopeManager { get; }
-
-        private bool ParentSet => this.parentSpan != null || this.parentSpanContext.IsValid;
-
-        /// <inheritdoc/>
-        public ISpanBuilder AsChildOf(ISpanContext parent)
-        {
-            if (parent == null)
-            {
-                return this;
-            }
-
-            return this.AddReference(References.ChildOf, parent);
-        }
-
-        /// <inheritdoc/>
-        public ISpanBuilder AsChildOf(ISpan parent)
-        {
-            if (parent == null)
-            {
-                return this;
-            }
-
-            if (!this.ParentSet)
-            {
-                this.parentSpan = GetOpenTelemetrySpan(parent);
-                return this;
-            }
-
-            return this.AsChildOf(parent.Context);
-        }
-
-        /// <inheritdoc/>
-        public ISpanBuilder AddReference(string referenceType, ISpanContext referencedContext)
-        {
-            if (referencedContext == null)
-            {
-                return this;
-            }
-
-            Guard.ThrowIfNull(referenceType);
-
-            // TODO There is no relation between OpenTracing.References (referenceType) and OpenTelemetry Link
-            var actualContext = GetOpenTelemetrySpanContext(referencedContext);
-            if (!this.ParentSet)
-            {
-                this.parentSpanContext = actualContext;
-                return this;
-            }
-            else
-            {
-                this.links.Add(new Link(actualContext));
-            }
-
             return this;
         }
 
-        /// <inheritdoc/>
-        public ISpanBuilder IgnoreActiveSpan()
+        return this.AddReference(References.ChildOf, parent);
+    }
+
+    /// <inheritdoc/>
+    public ISpanBuilder AsChildOf(ISpan parent)
+    {
+        if (parent == null)
         {
-            this.ignoreActiveSpan = true;
             return this;
         }
 
-        /// <inheritdoc/>
-        public ISpan Start()
+        if (!this.ParentSet)
         {
-            TelemetrySpan span = null;
-
-            // If specified, this takes precedence.
-            if (this.ignoreActiveSpan)
-            {
-                span = this.tracer.StartRootSpan(this.spanName, this.spanKind, default, this.links, this.explicitStartTime ?? default);
-            }
-            else if (this.parentSpan != null)
-            {
-                span = this.tracer.StartSpan(this.spanName, this.spanKind, this.parentSpan, default, this.links, this.explicitStartTime ?? default);
-            }
-            else if (this.parentSpanContext.IsValid)
-            {
-                span = this.tracer.StartSpan(this.spanName, this.spanKind, this.parentSpanContext, default, this.links, this.explicitStartTime ?? default);
-            }
-
-            if (span == null)
-            {
-                span = this.tracer.StartSpan(this.spanName, this.spanKind, default(SpanContext), default, null, this.explicitStartTime ?? default);
-            }
-
-            foreach (var kvp in this.attributes)
-            {
-                span.SetAttribute(kvp.Key, kvp.Value.ToString());
-            }
-
-            if (this.error)
-            {
-                span.SetStatus(Status.Error);
-            }
-
-            return new SpanShim(span);
-        }
-
-        /// <inheritdoc/>
-        public IScope StartActive() => this.StartActive(true);
-
-        /// <inheritdoc/>
-        public IScope StartActive(bool finishSpanOnDispose)
-        {
-            var span = this.Start();
-            return this.ScopeManager.Activate(span, finishSpanOnDispose);
-        }
-
-        /// <inheritdoc/>
-        public ISpanBuilder WithStartTimestamp(DateTimeOffset timestamp)
-        {
-            this.explicitStartTime = timestamp;
+            this.parentSpan = GetOpenTelemetrySpan(parent);
             return this;
         }
 
-        /// <inheritdoc/>
-        public ISpanBuilder WithTag(string key, string value)
-        {
-            // see https://opentracing.io/specification/conventions/ for special key handling.
-            if (global::OpenTracing.Tag.Tags.SpanKind.Key.Equals(key, StringComparison.Ordinal))
-            {
-                this.spanKind = value switch
-                {
-                    global::OpenTracing.Tag.Tags.SpanKindClient => SpanKind.Client,
-                    global::OpenTracing.Tag.Tags.SpanKindServer => SpanKind.Server,
-                    global::OpenTracing.Tag.Tags.SpanKindProducer => SpanKind.Producer,
-                    global::OpenTracing.Tag.Tags.SpanKindConsumer => SpanKind.Consumer,
-                    _ => SpanKind.Internal,
-                };
-            }
-            else if (global::OpenTracing.Tag.Tags.Error.Key.Equals(key, StringComparison.Ordinal) && bool.TryParse(value, out var booleanValue))
-            {
-                this.error = booleanValue;
-            }
-            else
-            {
-                // Keys must be non-null.
-                // Null values => string.Empty.
-                if (key != null)
-                {
-                    this.attributes.Add(new KeyValuePair<string, object>(key, value ?? string.Empty));
-                }
-            }
+        return this.AsChildOf(parent.Context);
+    }
 
+    /// <inheritdoc/>
+    public ISpanBuilder AddReference(string referenceType, ISpanContext referencedContext)
+    {
+        if (referencedContext == null)
+        {
             return this;
         }
 
-        /// <inheritdoc/>
-        public ISpanBuilder WithTag(string key, bool value)
-        {
-            if (global::OpenTracing.Tag.Tags.Error.Key.Equals(key, StringComparison.Ordinal))
-            {
-                this.error = value;
-            }
-            else
-            {
-                this.attributes.Add(new KeyValuePair<string, object>(key, value));
-            }
+        Guard.ThrowIfNull(referenceType);
 
+        // TODO There is no relation between OpenTracing.References (referenceType) and OpenTelemetry Link
+        var actualContext = GetOpenTelemetrySpanContext(referencedContext);
+        if (!this.ParentSet)
+        {
+            this.parentSpanContext = actualContext;
             return this;
         }
+        else
+        {
+            this.links.Add(new Link(actualContext));
+        }
 
-        /// <inheritdoc/>
-        public ISpanBuilder WithTag(string key, int value)
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public ISpanBuilder IgnoreActiveSpan()
+    {
+        this.ignoreActiveSpan = true;
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public ISpan Start()
+    {
+        TelemetrySpan span = null;
+
+        // If specified, this takes precedence.
+        if (this.ignoreActiveSpan)
+        {
+            span = this.tracer.StartRootSpan(this.spanName, this.spanKind, default, this.links, this.explicitStartTime ?? default);
+        }
+        else if (this.parentSpan != null)
+        {
+            span = this.tracer.StartSpan(this.spanName, this.spanKind, this.parentSpan, default, this.links, this.explicitStartTime ?? default);
+        }
+        else if (this.parentSpanContext.IsValid)
+        {
+            span = this.tracer.StartSpan(this.spanName, this.spanKind, this.parentSpanContext, default, this.links, this.explicitStartTime ?? default);
+        }
+
+        if (span == null)
+        {
+            span = this.tracer.StartSpan(this.spanName, this.spanKind, default(SpanContext), default, null, this.explicitStartTime ?? default);
+        }
+
+        foreach (var kvp in this.attributes)
+        {
+            span.SetAttribute(kvp.Key, kvp.Value.ToString());
+        }
+
+        if (this.error)
+        {
+            span.SetStatus(Status.Error);
+        }
+
+        return new SpanShim(span);
+    }
+
+    /// <inheritdoc/>
+    public IScope StartActive() => this.StartActive(true);
+
+    /// <inheritdoc/>
+    public IScope StartActive(bool finishSpanOnDispose)
+    {
+        var span = this.Start();
+        return this.ScopeManager.Activate(span, finishSpanOnDispose);
+    }
+
+    /// <inheritdoc/>
+    public ISpanBuilder WithStartTimestamp(DateTimeOffset timestamp)
+    {
+        this.explicitStartTime = timestamp;
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public ISpanBuilder WithTag(string key, string value)
+    {
+        // see https://opentracing.io/specification/conventions/ for special key handling.
+        if (global::OpenTracing.Tag.Tags.SpanKind.Key.Equals(key, StringComparison.Ordinal))
+        {
+            this.spanKind = value switch
+            {
+                global::OpenTracing.Tag.Tags.SpanKindClient => SpanKind.Client,
+                global::OpenTracing.Tag.Tags.SpanKindServer => SpanKind.Server,
+                global::OpenTracing.Tag.Tags.SpanKindProducer => SpanKind.Producer,
+                global::OpenTracing.Tag.Tags.SpanKindConsumer => SpanKind.Consumer,
+                _ => SpanKind.Internal,
+            };
+        }
+        else if (global::OpenTracing.Tag.Tags.Error.Key.Equals(key, StringComparison.Ordinal) && bool.TryParse(value, out var booleanValue))
+        {
+            this.error = booleanValue;
+        }
+        else
+        {
+            // Keys must be non-null.
+            // Null values => string.Empty.
+            if (key != null)
+            {
+                this.attributes.Add(new KeyValuePair<string, object>(key, value ?? string.Empty));
+            }
+        }
+
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public ISpanBuilder WithTag(string key, bool value)
+    {
+        if (global::OpenTracing.Tag.Tags.Error.Key.Equals(key, StringComparison.Ordinal))
+        {
+            this.error = value;
+        }
+        else
         {
             this.attributes.Add(new KeyValuePair<string, object>(key, value));
-            return this;
         }
 
-        /// <inheritdoc/>
-        public ISpanBuilder WithTag(string key, double value)
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public ISpanBuilder WithTag(string key, int value)
+    {
+        this.attributes.Add(new KeyValuePair<string, object>(key, value));
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public ISpanBuilder WithTag(string key, double value)
+    {
+        this.attributes.Add(new KeyValuePair<string, object>(key, value));
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public ISpanBuilder WithTag(global::OpenTracing.Tag.BooleanTag tag, bool value)
+    {
+        Guard.ThrowIfNull(tag?.Key);
+
+        return this.WithTag(tag.Key, value);
+    }
+
+    /// <inheritdoc/>
+    public ISpanBuilder WithTag(global::OpenTracing.Tag.IntOrStringTag tag, string value)
+    {
+        Guard.ThrowIfNull(tag?.Key);
+
+        if (int.TryParse(value, out var result))
         {
-            this.attributes.Add(new KeyValuePair<string, object>(key, value));
-            return this;
+            return this.WithTag(tag.Key, result);
         }
 
-        /// <inheritdoc/>
-        public ISpanBuilder WithTag(global::OpenTracing.Tag.BooleanTag tag, bool value)
-        {
-            Guard.ThrowIfNull(tag?.Key);
+        return this.WithTag(tag.Key, value);
+    }
 
-            return this.WithTag(tag.Key, value);
-        }
+    /// <inheritdoc/>
+    public ISpanBuilder WithTag(global::OpenTracing.Tag.IntTag tag, int value)
+    {
+        Guard.ThrowIfNull(tag?.Key);
 
-        /// <inheritdoc/>
-        public ISpanBuilder WithTag(global::OpenTracing.Tag.IntOrStringTag tag, string value)
-        {
-            Guard.ThrowIfNull(tag?.Key);
+        return this.WithTag(tag.Key, value);
+    }
 
-            if (int.TryParse(value, out var result))
-            {
-                return this.WithTag(tag.Key, result);
-            }
+    /// <inheritdoc/>
+    public ISpanBuilder WithTag(global::OpenTracing.Tag.StringTag tag, string value)
+    {
+        Guard.ThrowIfNull(tag?.Key);
 
-            return this.WithTag(tag.Key, value);
-        }
+        return this.WithTag(tag.Key, value);
+    }
 
-        /// <inheritdoc/>
-        public ISpanBuilder WithTag(global::OpenTracing.Tag.IntTag tag, int value)
-        {
-            Guard.ThrowIfNull(tag?.Key);
+    /// <summary>
+    /// Gets an implementation of OpenTelemetry TelemetrySpan from the OpenTracing ISpan.
+    /// </summary>
+    /// <param name="span">The span.</param>
+    /// <returns>an implementation of OpenTelemetry TelemetrySpan.</returns>
+    /// <exception cref="ArgumentException">span is not a valid SpanShim object.</exception>
+    private static TelemetrySpan GetOpenTelemetrySpan(ISpan span)
+    {
+        var shim = Guard.ThrowIfNotOfType<SpanShim>(span);
 
-            return this.WithTag(tag.Key, value);
-        }
+        return shim.Span;
+    }
 
-        /// <inheritdoc/>
-        public ISpanBuilder WithTag(global::OpenTracing.Tag.StringTag tag, string value)
-        {
-            Guard.ThrowIfNull(tag?.Key);
+    /// <summary>
+    /// Gets the OpenTelemetry SpanContext.
+    /// </summary>
+    /// <param name="spanContext">The span context.</param>
+    /// <returns>the OpenTelemetry SpanContext.</returns>
+    /// <exception cref="ArgumentException">context is not a valid SpanContextShim object.</exception>
+    private static SpanContext GetOpenTelemetrySpanContext(ISpanContext spanContext)
+    {
+        var shim = Guard.ThrowIfNotOfType<SpanContextShim>(spanContext);
 
-            return this.WithTag(tag.Key, value);
-        }
-
-        /// <summary>
-        /// Gets an implementation of OpenTelemetry TelemetrySpan from the OpenTracing ISpan.
-        /// </summary>
-        /// <param name="span">The span.</param>
-        /// <returns>an implementation of OpenTelemetry TelemetrySpan.</returns>
-        /// <exception cref="ArgumentException">span is not a valid SpanShim object.</exception>
-        private static TelemetrySpan GetOpenTelemetrySpan(ISpan span)
-        {
-            var shim = Guard.ThrowIfNotOfType<SpanShim>(span);
-
-            return shim.Span;
-        }
-
-        /// <summary>
-        /// Gets the OpenTelemetry SpanContext.
-        /// </summary>
-        /// <param name="spanContext">The span context.</param>
-        /// <returns>the OpenTelemetry SpanContext.</returns>
-        /// <exception cref="ArgumentException">context is not a valid SpanContextShim object.</exception>
-        private static SpanContext GetOpenTelemetrySpanContext(ISpanContext spanContext)
-        {
-            var shim = Guard.ThrowIfNotOfType<SpanContextShim>(spanContext);
-
-            return shim.SpanContext;
-        }
+        return shim.SpanContext;
     }
 }

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanContextShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanContextShim.cs
@@ -16,29 +16,28 @@
 
 using OpenTracing;
 
-namespace OpenTelemetry.Shims.OpenTracing
-{
-    internal sealed class SpanContextShim : ISpanContext
-    {
-        public SpanContextShim(in Trace.SpanContext spanContext)
-        {
-            if (!spanContext.IsValid)
-            {
-                throw new ArgumentException($"Invalid '{nameof(Trace.SpanContext)}'", nameof(spanContext));
-            }
+namespace OpenTelemetry.Shims.OpenTracing;
 
-            this.SpanContext = spanContext;
+internal sealed class SpanContextShim : ISpanContext
+{
+    public SpanContextShim(in Trace.SpanContext spanContext)
+    {
+        if (!spanContext.IsValid)
+        {
+            throw new ArgumentException($"Invalid '{nameof(Trace.SpanContext)}'", nameof(spanContext));
         }
 
-        public Trace.SpanContext SpanContext { get; private set; }
-
-        /// <inheritdoc/>
-        public string TraceId => this.SpanContext.TraceId.ToString();
-
-        /// <inheritdoc/>
-        public string SpanId => this.SpanContext.SpanId.ToString();
-
-        public IEnumerable<KeyValuePair<string, string>> GetBaggageItems()
-            => Baggage.GetBaggage();
+        this.SpanContext = spanContext;
     }
+
+    public Trace.SpanContext SpanContext { get; private set; }
+
+    /// <inheritdoc/>
+    public string TraceId => this.SpanContext.TraceId.ToString();
+
+    /// <inheritdoc/>
+    public string SpanId => this.SpanContext.SpanId.ToString();
+
+    public IEnumerable<KeyValuePair<string, string>> GetBaggageItems()
+        => Baggage.GetBaggage();
 }

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanContextShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanContextShim.cs
@@ -16,24 +16,23 @@
 
 using OpenTracing;
 
-namespace OpenTelemetry.Shims.OpenTracing
+namespace OpenTelemetry.Shims.OpenTracing;
+
+internal sealed class SpanContextShim : ISpanContext
 {
-    internal sealed class SpanContextShim : ISpanContext
+    public SpanContextShim(in Trace.SpanContext spanContext)
     {
-        public SpanContextShim(in Trace.SpanContext spanContext)
-        {
-            this.SpanContext = spanContext;
-        }
-
-        public Trace.SpanContext SpanContext { get; private set; }
-
-        /// <inheritdoc/>
-        public string TraceId => this.SpanContext.TraceId.ToString();
-
-        /// <inheritdoc/>
-        public string SpanId => this.SpanContext.SpanId.ToString();
-
-        public IEnumerable<KeyValuePair<string, string>> GetBaggageItems()
-            => Baggage.GetBaggage();
+        this.SpanContext = spanContext;
     }
+
+    public Trace.SpanContext SpanContext { get; private set; }
+
+    /// <inheritdoc/>
+    public string TraceId => this.SpanContext.TraceId.ToString();
+
+    /// <inheritdoc/>
+    public string SpanId => this.SpanContext.SpanId.ToString();
+
+    public IEnumerable<KeyValuePair<string, string>> GetBaggageItems()
+        => Baggage.GetBaggage();
 }

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanShim.cs
@@ -18,278 +18,277 @@ using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
 using OpenTracing;
 
-namespace OpenTelemetry.Shims.OpenTracing
+namespace OpenTelemetry.Shims.OpenTracing;
+
+internal sealed class SpanShim : ISpan
 {
-    internal sealed class SpanShim : ISpan
+    /// <summary>
+    /// The default event name if not specified.
+    /// </summary>
+    public const string DefaultEventName = "log";
+
+    private static readonly IReadOnlyCollection<Type> OpenTelemetrySupportedAttributeValueTypes = new List<Type>
     {
-        /// <summary>
-        /// The default event name if not specified.
-        /// </summary>
-        public const string DefaultEventName = "log";
+        typeof(string),
+        typeof(bool),
+        typeof(byte),
+        typeof(short),
+        typeof(int),
+        typeof(long),
+        typeof(float),
+        typeof(double),
+    };
 
-        private static readonly IReadOnlyCollection<Type> OpenTelemetrySupportedAttributeValueTypes = new List<Type>
+    private readonly SpanContextShim spanContextShim;
+
+    public SpanShim(TelemetrySpan span)
+    {
+        Guard.ThrowIfNull(span);
+
+        if (!span.Context.IsValid)
         {
-            typeof(string),
-            typeof(bool),
-            typeof(byte),
-            typeof(short),
-            typeof(int),
-            typeof(long),
-            typeof(float),
-            typeof(double),
-        };
+            throw new ArgumentException($"Invalid '{nameof(SpanContext)}'", nameof(span.Context));
+        }
 
-        private readonly SpanContextShim spanContextShim;
+        this.Span = span;
+        this.spanContextShim = new SpanContextShim(this.Span.Context);
+    }
 
-        public SpanShim(TelemetrySpan span)
+    public ISpanContext Context => this.spanContextShim;
+
+    public TelemetrySpan Span { get; private set; }
+
+    /// <inheritdoc/>
+    public void Finish()
+    {
+        this.Span.End();
+    }
+
+    /// <inheritdoc/>
+    public void Finish(DateTimeOffset finishTimestamp)
+    {
+        this.Span.End(finishTimestamp);
+    }
+
+    /// <inheritdoc/>
+    public string GetBaggageItem(string key)
+        => Baggage.GetBaggage(key);
+
+    /// <inheritdoc/>
+    public ISpan Log(DateTimeOffset timestamp, IEnumerable<KeyValuePair<string, object>> fields)
+    {
+        Guard.ThrowIfNull(fields);
+
+        var payload = ConvertToEventPayload(fields);
+        var eventName = payload.Item1;
+
+        var spanAttributes = new SpanAttributes();
+        foreach (var field in payload.Item2)
         {
-            Guard.ThrowIfNull(span);
-
-            if (!span.Context.IsValid)
+            switch (field.Value)
             {
-                throw new ArgumentException($"Invalid '{nameof(SpanContext)}'", nameof(span.Context));
+                case long value:
+                    spanAttributes.Add(field.Key, value);
+                    break;
+                case long[] value:
+                    spanAttributes.Add(field.Key, value);
+                    break;
+                case bool value:
+                    spanAttributes.Add(field.Key, value);
+                    break;
+                case bool[] value:
+                    spanAttributes.Add(field.Key, value);
+                    break;
+                case double value:
+                    spanAttributes.Add(field.Key, value);
+                    break;
+                case double[] value:
+                    spanAttributes.Add(field.Key, value);
+                    break;
+                case string value:
+                    spanAttributes.Add(field.Key, value);
+                    break;
+                case string[] value:
+                    spanAttributes.Add(field.Key, value);
+                    break;
+
+                default:
+                    break;
+            }
+        }
+
+        if (timestamp == DateTimeOffset.MinValue)
+        {
+            this.Span.AddEvent(eventName, spanAttributes);
+        }
+        else
+        {
+            this.Span.AddEvent(eventName, timestamp, spanAttributes);
+        }
+
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public ISpan Log(IEnumerable<KeyValuePair<string, object>> fields)
+    {
+        return this.Log(DateTimeOffset.MinValue, fields);
+    }
+
+    /// <inheritdoc/>
+    public ISpan Log(string @event)
+    {
+        Guard.ThrowIfNull(@event);
+
+        this.Span.AddEvent(@event);
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public ISpan Log(DateTimeOffset timestamp, string @event)
+    {
+        Guard.ThrowIfNull(@event);
+
+        this.Span.AddEvent(@event, timestamp);
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public ISpan SetBaggageItem(string key, string value)
+    {
+        Baggage.SetBaggage(key, value);
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public ISpan SetOperationName(string operationName)
+    {
+        Guard.ThrowIfNull(operationName);
+
+        this.Span.UpdateName(operationName);
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public ISpan SetTag(string key, string value)
+    {
+        Guard.ThrowIfNull(key);
+
+        this.Span.SetAttribute(key, value);
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public ISpan SetTag(string key, bool value)
+    {
+        Guard.ThrowIfNull(key);
+
+        // Special case the OpenTracing Error Tag
+        // see https://opentracing.io/specification/conventions/
+        if (global::OpenTracing.Tag.Tags.Error.Key.Equals(key, StringComparison.Ordinal))
+        {
+            this.Span.SetStatus(value ? Status.Error : Status.Ok);
+        }
+        else
+        {
+            this.Span.SetAttribute(key, value);
+        }
+
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public ISpan SetTag(string key, int value)
+    {
+        Guard.ThrowIfNull(key);
+
+        this.Span.SetAttribute(key, value);
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public ISpan SetTag(string key, double value)
+    {
+        Guard.ThrowIfNull(key);
+
+        this.Span.SetAttribute(key, value);
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public ISpan SetTag(global::OpenTracing.Tag.BooleanTag tag, bool value)
+    {
+        return this.SetTag(tag?.Key, value);
+    }
+
+    /// <inheritdoc/>
+    public ISpan SetTag(global::OpenTracing.Tag.IntOrStringTag tag, string value)
+    {
+        if (int.TryParse(value, out var result))
+        {
+            return this.SetTag(tag?.Key, result);
+        }
+
+        return this.SetTag(tag?.Key, value);
+    }
+
+    /// <inheritdoc/>
+    public ISpan SetTag(global::OpenTracing.Tag.IntTag tag, int value)
+    {
+        return this.SetTag(tag?.Key, value);
+    }
+
+    /// <inheritdoc/>
+    public ISpan SetTag(global::OpenTracing.Tag.StringTag tag, string value)
+    {
+        return this.SetTag(tag?.Key, value);
+    }
+
+    /// <summary>
+    /// Constructs an OpenTelemetry event payload from an OpenTracing Log key/value map.
+    /// </summary>
+    /// <param name="fields">The fields.</param>
+    /// <returns>A 2-Tuple containing the event name and payload information.</returns>
+    private static Tuple<string, IDictionary<string, object>> ConvertToEventPayload(IEnumerable<KeyValuePair<string, object>> fields)
+    {
+        string eventName = null;
+        var attributes = new Dictionary<string, object>();
+
+        foreach (var field in fields)
+        {
+            // TODO verify null values are NOT allowed.
+            if (field.Value == null)
+            {
+                continue;
             }
 
-            this.Span = span;
-            this.spanContextShim = new SpanContextShim(this.Span.Context);
-        }
-
-        public ISpanContext Context => this.spanContextShim;
-
-        public TelemetrySpan Span { get; private set; }
-
-        /// <inheritdoc/>
-        public void Finish()
-        {
-            this.Span.End();
-        }
-
-        /// <inheritdoc/>
-        public void Finish(DateTimeOffset finishTimestamp)
-        {
-            this.Span.End(finishTimestamp);
-        }
-
-        /// <inheritdoc/>
-        public string GetBaggageItem(string key)
-            => Baggage.GetBaggage(key);
-
-        /// <inheritdoc/>
-        public ISpan Log(DateTimeOffset timestamp, IEnumerable<KeyValuePair<string, object>> fields)
-        {
-            Guard.ThrowIfNull(fields);
-
-            var payload = ConvertToEventPayload(fields);
-            var eventName = payload.Item1;
-
-            var spanAttributes = new SpanAttributes();
-            foreach (var field in payload.Item2)
+            // Duplicate keys must be ignored even though they appear to be allowed in OpenTracing.
+            if (attributes.ContainsKey(field.Key))
             {
-                switch (field.Value)
-                {
-                    case long value:
-                        spanAttributes.Add(field.Key, value);
-                        break;
-                    case long[] value:
-                        spanAttributes.Add(field.Key, value);
-                        break;
-                    case bool value:
-                        spanAttributes.Add(field.Key, value);
-                        break;
-                    case bool[] value:
-                        spanAttributes.Add(field.Key, value);
-                        break;
-                    case double value:
-                        spanAttributes.Add(field.Key, value);
-                        break;
-                    case double[] value:
-                        spanAttributes.Add(field.Key, value);
-                        break;
-                    case string value:
-                        spanAttributes.Add(field.Key, value);
-                        break;
-                    case string[] value:
-                        spanAttributes.Add(field.Key, value);
-                        break;
-
-                    default:
-                        break;
-                }
+                continue;
             }
 
-            if (timestamp == DateTimeOffset.MinValue)
+            if (eventName == null && field.Key.Equals(LogFields.Event, StringComparison.Ordinal) && field.Value is string value)
             {
-                this.Span.AddEvent(eventName, spanAttributes);
+                // This is meant to be the event name
+                eventName = value;
+
+                // We don't want to add the event name as a separate attribute
+                continue;
+            }
+
+            // Supported types are added directly, all other types are converted to strings.
+            if (OpenTelemetrySupportedAttributeValueTypes.Contains(field.Value.GetType()))
+            {
+                attributes.Add(field.Key, field.Value);
             }
             else
             {
-                this.Span.AddEvent(eventName, timestamp, spanAttributes);
+                // TODO should we completely ignore unsupported types?
+                attributes.Add(field.Key, field.Value.ToString());
             }
-
-            return this;
         }
 
-        /// <inheritdoc/>
-        public ISpan Log(IEnumerable<KeyValuePair<string, object>> fields)
-        {
-            return this.Log(DateTimeOffset.MinValue, fields);
-        }
-
-        /// <inheritdoc/>
-        public ISpan Log(string @event)
-        {
-            Guard.ThrowIfNull(@event);
-
-            this.Span.AddEvent(@event);
-            return this;
-        }
-
-        /// <inheritdoc/>
-        public ISpan Log(DateTimeOffset timestamp, string @event)
-        {
-            Guard.ThrowIfNull(@event);
-
-            this.Span.AddEvent(@event, timestamp);
-            return this;
-        }
-
-        /// <inheritdoc/>
-        public ISpan SetBaggageItem(string key, string value)
-        {
-            Baggage.SetBaggage(key, value);
-            return this;
-        }
-
-        /// <inheritdoc/>
-        public ISpan SetOperationName(string operationName)
-        {
-            Guard.ThrowIfNull(operationName);
-
-            this.Span.UpdateName(operationName);
-            return this;
-        }
-
-        /// <inheritdoc/>
-        public ISpan SetTag(string key, string value)
-        {
-            Guard.ThrowIfNull(key);
-
-            this.Span.SetAttribute(key, value);
-            return this;
-        }
-
-        /// <inheritdoc/>
-        public ISpan SetTag(string key, bool value)
-        {
-            Guard.ThrowIfNull(key);
-
-            // Special case the OpenTracing Error Tag
-            // see https://opentracing.io/specification/conventions/
-            if (global::OpenTracing.Tag.Tags.Error.Key.Equals(key, StringComparison.Ordinal))
-            {
-                this.Span.SetStatus(value ? Status.Error : Status.Ok);
-            }
-            else
-            {
-                this.Span.SetAttribute(key, value);
-            }
-
-            return this;
-        }
-
-        /// <inheritdoc/>
-        public ISpan SetTag(string key, int value)
-        {
-            Guard.ThrowIfNull(key);
-
-            this.Span.SetAttribute(key, value);
-            return this;
-        }
-
-        /// <inheritdoc/>
-        public ISpan SetTag(string key, double value)
-        {
-            Guard.ThrowIfNull(key);
-
-            this.Span.SetAttribute(key, value);
-            return this;
-        }
-
-        /// <inheritdoc/>
-        public ISpan SetTag(global::OpenTracing.Tag.BooleanTag tag, bool value)
-        {
-            return this.SetTag(tag?.Key, value);
-        }
-
-        /// <inheritdoc/>
-        public ISpan SetTag(global::OpenTracing.Tag.IntOrStringTag tag, string value)
-        {
-            if (int.TryParse(value, out var result))
-            {
-                return this.SetTag(tag?.Key, result);
-            }
-
-            return this.SetTag(tag?.Key, value);
-        }
-
-        /// <inheritdoc/>
-        public ISpan SetTag(global::OpenTracing.Tag.IntTag tag, int value)
-        {
-            return this.SetTag(tag?.Key, value);
-        }
-
-        /// <inheritdoc/>
-        public ISpan SetTag(global::OpenTracing.Tag.StringTag tag, string value)
-        {
-            return this.SetTag(tag?.Key, value);
-        }
-
-        /// <summary>
-        /// Constructs an OpenTelemetry event payload from an OpenTracing Log key/value map.
-        /// </summary>
-        /// <param name="fields">The fields.</param>
-        /// <returns>A 2-Tuple containing the event name and payload information.</returns>
-        private static Tuple<string, IDictionary<string, object>> ConvertToEventPayload(IEnumerable<KeyValuePair<string, object>> fields)
-        {
-            string eventName = null;
-            var attributes = new Dictionary<string, object>();
-
-            foreach (var field in fields)
-            {
-                // TODO verify null values are NOT allowed.
-                if (field.Value == null)
-                {
-                    continue;
-                }
-
-                // Duplicate keys must be ignored even though they appear to be allowed in OpenTracing.
-                if (attributes.ContainsKey(field.Key))
-                {
-                    continue;
-                }
-
-                if (eventName == null && field.Key.Equals(LogFields.Event, StringComparison.Ordinal) && field.Value is string value)
-                {
-                    // This is meant to be the event name
-                    eventName = value;
-
-                    // We don't want to add the event name as a separate attribute
-                    continue;
-                }
-
-                // Supported types are added directly, all other types are converted to strings.
-                if (OpenTelemetrySupportedAttributeValueTypes.Contains(field.Value.GetType()))
-                {
-                    attributes.Add(field.Key, field.Value);
-                }
-                else
-                {
-                    // TODO should we completely ignore unsupported types?
-                    attributes.Add(field.Key, field.Value.ToString());
-                }
-            }
-
-            return new Tuple<string, IDictionary<string, object>>(eventName ?? DefaultEventName, attributes);
-        }
+        return new Tuple<string, IDictionary<string, object>>(eventName ?? DefaultEventName, attributes);
     }
 }

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanShim.cs
@@ -18,274 +18,273 @@ using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
 using OpenTracing;
 
-namespace OpenTelemetry.Shims.OpenTracing
+namespace OpenTelemetry.Shims.OpenTracing;
+
+internal sealed class SpanShim : ISpan
 {
-    internal sealed class SpanShim : ISpan
+    /// <summary>
+    /// The default event name if not specified.
+    /// </summary>
+    public const string DefaultEventName = "log";
+
+    private static readonly IReadOnlyCollection<Type> OpenTelemetrySupportedAttributeValueTypes = new List<Type>
     {
-        /// <summary>
-        /// The default event name if not specified.
-        /// </summary>
-        public const string DefaultEventName = "log";
+        typeof(string),
+        typeof(bool),
+        typeof(byte),
+        typeof(short),
+        typeof(int),
+        typeof(long),
+        typeof(float),
+        typeof(double),
+    };
 
-        private static readonly IReadOnlyCollection<Type> OpenTelemetrySupportedAttributeValueTypes = new List<Type>
+    private readonly SpanContextShim spanContextShim;
+
+    public SpanShim(TelemetrySpan span)
+    {
+        Guard.ThrowIfNull(span);
+
+        this.Span = span;
+        this.spanContextShim = new SpanContextShim(this.Span.Context);
+    }
+
+    /// <inheritdoc/>
+    public ISpanContext Context => this.spanContextShim;
+
+    public TelemetrySpan Span { get; private set; }
+
+    /// <inheritdoc/>
+    public void Finish()
+    {
+        this.Span.End();
+    }
+
+    /// <inheritdoc/>
+    public void Finish(DateTimeOffset finishTimestamp)
+    {
+        this.Span.End(finishTimestamp);
+    }
+
+    /// <inheritdoc/>
+    public string GetBaggageItem(string key)
+        => Baggage.GetBaggage(key);
+
+    /// <inheritdoc/>
+    public ISpan Log(DateTimeOffset timestamp, IEnumerable<KeyValuePair<string, object>> fields)
+    {
+        Guard.ThrowIfNull(fields);
+
+        var payload = ConvertToEventPayload(fields);
+        var eventName = payload.Item1;
+
+        var spanAttributes = new SpanAttributes();
+        foreach (var field in payload.Item2)
         {
-            typeof(string),
-            typeof(bool),
-            typeof(byte),
-            typeof(short),
-            typeof(int),
-            typeof(long),
-            typeof(float),
-            typeof(double),
-        };
-
-        private readonly SpanContextShim spanContextShim;
-
-        public SpanShim(TelemetrySpan span)
-        {
-            Guard.ThrowIfNull(span);
-
-            this.Span = span;
-            this.spanContextShim = new SpanContextShim(this.Span.Context);
-        }
-
-        /// <inheritdoc/>
-        public ISpanContext Context => this.spanContextShim;
-
-        public TelemetrySpan Span { get; private set; }
-
-        /// <inheritdoc/>
-        public void Finish()
-        {
-            this.Span.End();
-        }
-
-        /// <inheritdoc/>
-        public void Finish(DateTimeOffset finishTimestamp)
-        {
-            this.Span.End(finishTimestamp);
-        }
-
-        /// <inheritdoc/>
-        public string GetBaggageItem(string key)
-            => Baggage.GetBaggage(key);
-
-        /// <inheritdoc/>
-        public ISpan Log(DateTimeOffset timestamp, IEnumerable<KeyValuePair<string, object>> fields)
-        {
-            Guard.ThrowIfNull(fields);
-
-            var payload = ConvertToEventPayload(fields);
-            var eventName = payload.Item1;
-
-            var spanAttributes = new SpanAttributes();
-            foreach (var field in payload.Item2)
+            switch (field.Value)
             {
-                switch (field.Value)
-                {
-                    case long value:
-                        spanAttributes.Add(field.Key, value);
-                        break;
-                    case long[] value:
-                        spanAttributes.Add(field.Key, value);
-                        break;
-                    case bool value:
-                        spanAttributes.Add(field.Key, value);
-                        break;
-                    case bool[] value:
-                        spanAttributes.Add(field.Key, value);
-                        break;
-                    case double value:
-                        spanAttributes.Add(field.Key, value);
-                        break;
-                    case double[] value:
-                        spanAttributes.Add(field.Key, value);
-                        break;
-                    case string value:
-                        spanAttributes.Add(field.Key, value);
-                        break;
-                    case string[] value:
-                        spanAttributes.Add(field.Key, value);
-                        break;
+                case long value:
+                    spanAttributes.Add(field.Key, value);
+                    break;
+                case long[] value:
+                    spanAttributes.Add(field.Key, value);
+                    break;
+                case bool value:
+                    spanAttributes.Add(field.Key, value);
+                    break;
+                case bool[] value:
+                    spanAttributes.Add(field.Key, value);
+                    break;
+                case double value:
+                    spanAttributes.Add(field.Key, value);
+                    break;
+                case double[] value:
+                    spanAttributes.Add(field.Key, value);
+                    break;
+                case string value:
+                    spanAttributes.Add(field.Key, value);
+                    break;
+                case string[] value:
+                    spanAttributes.Add(field.Key, value);
+                    break;
 
-                    default:
-                        break;
-                }
+                default:
+                    break;
+            }
+        }
+
+        if (timestamp == DateTimeOffset.MinValue)
+        {
+            this.Span.AddEvent(eventName, spanAttributes);
+        }
+        else
+        {
+            this.Span.AddEvent(eventName, timestamp, spanAttributes);
+        }
+
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public ISpan Log(IEnumerable<KeyValuePair<string, object>> fields)
+    {
+        return this.Log(DateTimeOffset.MinValue, fields);
+    }
+
+    /// <inheritdoc/>
+    public ISpan Log(string @event)
+    {
+        Guard.ThrowIfNull(@event);
+
+        this.Span.AddEvent(@event);
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public ISpan Log(DateTimeOffset timestamp, string @event)
+    {
+        Guard.ThrowIfNull(@event);
+
+        this.Span.AddEvent(@event, timestamp);
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public ISpan SetBaggageItem(string key, string value)
+    {
+        Baggage.SetBaggage(key, value);
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public ISpan SetOperationName(string operationName)
+    {
+        Guard.ThrowIfNull(operationName);
+
+        this.Span.UpdateName(operationName);
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public ISpan SetTag(string key, string value)
+    {
+        Guard.ThrowIfNull(key);
+
+        this.Span.SetAttribute(key, value);
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public ISpan SetTag(string key, bool value)
+    {
+        Guard.ThrowIfNull(key);
+
+        // Special case the OpenTracing Error Tag
+        // see https://opentracing.io/specification/conventions/
+        if (global::OpenTracing.Tag.Tags.Error.Key.Equals(key, StringComparison.Ordinal))
+        {
+            this.Span.SetStatus(value ? Status.Error : Status.Ok);
+        }
+        else
+        {
+            this.Span.SetAttribute(key, value);
+        }
+
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public ISpan SetTag(string key, int value)
+    {
+        Guard.ThrowIfNull(key);
+
+        this.Span.SetAttribute(key, value);
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public ISpan SetTag(string key, double value)
+    {
+        Guard.ThrowIfNull(key);
+
+        this.Span.SetAttribute(key, value);
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public ISpan SetTag(global::OpenTracing.Tag.BooleanTag tag, bool value)
+    {
+        return this.SetTag(tag?.Key, value);
+    }
+
+    /// <inheritdoc/>
+    public ISpan SetTag(global::OpenTracing.Tag.IntOrStringTag tag, string value)
+    {
+        if (int.TryParse(value, out var result))
+        {
+            return this.SetTag(tag?.Key, result);
+        }
+
+        return this.SetTag(tag?.Key, value);
+    }
+
+    /// <inheritdoc/>
+    public ISpan SetTag(global::OpenTracing.Tag.IntTag tag, int value)
+    {
+        return this.SetTag(tag?.Key, value);
+    }
+
+    /// <inheritdoc/>
+    public ISpan SetTag(global::OpenTracing.Tag.StringTag tag, string value)
+    {
+        return this.SetTag(tag?.Key, value);
+    }
+
+    /// <summary>
+    /// Constructs an OpenTelemetry event payload from an OpenTracing Log key/value map.
+    /// </summary>
+    /// <param name="fields">The fields.</param>
+    /// <returns>A 2-Tuple containing the event name and payload information.</returns>
+    private static Tuple<string, IDictionary<string, object>> ConvertToEventPayload(IEnumerable<KeyValuePair<string, object>> fields)
+    {
+        string eventName = null;
+        var attributes = new Dictionary<string, object>();
+
+        foreach (var field in fields)
+        {
+            // TODO verify null values are NOT allowed.
+            if (field.Value == null)
+            {
+                continue;
             }
 
-            if (timestamp == DateTimeOffset.MinValue)
+            // Duplicate keys must be ignored even though they appear to be allowed in OpenTracing.
+            if (attributes.ContainsKey(field.Key))
             {
-                this.Span.AddEvent(eventName, spanAttributes);
+                continue;
+            }
+
+            if (eventName == null && field.Key.Equals(LogFields.Event, StringComparison.Ordinal) && field.Value is string value)
+            {
+                // This is meant to be the event name
+                eventName = value;
+
+                // We don't want to add the event name as a separate attribute
+                continue;
+            }
+
+            // Supported types are added directly, all other types are converted to strings.
+            if (OpenTelemetrySupportedAttributeValueTypes.Contains(field.Value.GetType()))
+            {
+                attributes.Add(field.Key, field.Value);
             }
             else
             {
-                this.Span.AddEvent(eventName, timestamp, spanAttributes);
+                // TODO should we completely ignore unsupported types?
+                attributes.Add(field.Key, field.Value.ToString());
             }
-
-            return this;
         }
 
-        /// <inheritdoc/>
-        public ISpan Log(IEnumerable<KeyValuePair<string, object>> fields)
-        {
-            return this.Log(DateTimeOffset.MinValue, fields);
-        }
-
-        /// <inheritdoc/>
-        public ISpan Log(string @event)
-        {
-            Guard.ThrowIfNull(@event);
-
-            this.Span.AddEvent(@event);
-            return this;
-        }
-
-        /// <inheritdoc/>
-        public ISpan Log(DateTimeOffset timestamp, string @event)
-        {
-            Guard.ThrowIfNull(@event);
-
-            this.Span.AddEvent(@event, timestamp);
-            return this;
-        }
-
-        /// <inheritdoc/>
-        public ISpan SetBaggageItem(string key, string value)
-        {
-            Baggage.SetBaggage(key, value);
-            return this;
-        }
-
-        /// <inheritdoc/>
-        public ISpan SetOperationName(string operationName)
-        {
-            Guard.ThrowIfNull(operationName);
-
-            this.Span.UpdateName(operationName);
-            return this;
-        }
-
-        /// <inheritdoc/>
-        public ISpan SetTag(string key, string value)
-        {
-            Guard.ThrowIfNull(key);
-
-            this.Span.SetAttribute(key, value);
-            return this;
-        }
-
-        /// <inheritdoc/>
-        public ISpan SetTag(string key, bool value)
-        {
-            Guard.ThrowIfNull(key);
-
-            // Special case the OpenTracing Error Tag
-            // see https://opentracing.io/specification/conventions/
-            if (global::OpenTracing.Tag.Tags.Error.Key.Equals(key, StringComparison.Ordinal))
-            {
-                this.Span.SetStatus(value ? Status.Error : Status.Ok);
-            }
-            else
-            {
-                this.Span.SetAttribute(key, value);
-            }
-
-            return this;
-        }
-
-        /// <inheritdoc/>
-        public ISpan SetTag(string key, int value)
-        {
-            Guard.ThrowIfNull(key);
-
-            this.Span.SetAttribute(key, value);
-            return this;
-        }
-
-        /// <inheritdoc/>
-        public ISpan SetTag(string key, double value)
-        {
-            Guard.ThrowIfNull(key);
-
-            this.Span.SetAttribute(key, value);
-            return this;
-        }
-
-        /// <inheritdoc/>
-        public ISpan SetTag(global::OpenTracing.Tag.BooleanTag tag, bool value)
-        {
-            return this.SetTag(tag?.Key, value);
-        }
-
-        /// <inheritdoc/>
-        public ISpan SetTag(global::OpenTracing.Tag.IntOrStringTag tag, string value)
-        {
-            if (int.TryParse(value, out var result))
-            {
-                return this.SetTag(tag?.Key, result);
-            }
-
-            return this.SetTag(tag?.Key, value);
-        }
-
-        /// <inheritdoc/>
-        public ISpan SetTag(global::OpenTracing.Tag.IntTag tag, int value)
-        {
-            return this.SetTag(tag?.Key, value);
-        }
-
-        /// <inheritdoc/>
-        public ISpan SetTag(global::OpenTracing.Tag.StringTag tag, string value)
-        {
-            return this.SetTag(tag?.Key, value);
-        }
-
-        /// <summary>
-        /// Constructs an OpenTelemetry event payload from an OpenTracing Log key/value map.
-        /// </summary>
-        /// <param name="fields">The fields.</param>
-        /// <returns>A 2-Tuple containing the event name and payload information.</returns>
-        private static Tuple<string, IDictionary<string, object>> ConvertToEventPayload(IEnumerable<KeyValuePair<string, object>> fields)
-        {
-            string eventName = null;
-            var attributes = new Dictionary<string, object>();
-
-            foreach (var field in fields)
-            {
-                // TODO verify null values are NOT allowed.
-                if (field.Value == null)
-                {
-                    continue;
-                }
-
-                // Duplicate keys must be ignored even though they appear to be allowed in OpenTracing.
-                if (attributes.ContainsKey(field.Key))
-                {
-                    continue;
-                }
-
-                if (eventName == null && field.Key.Equals(LogFields.Event, StringComparison.Ordinal) && field.Value is string value)
-                {
-                    // This is meant to be the event name
-                    eventName = value;
-
-                    // We don't want to add the event name as a separate attribute
-                    continue;
-                }
-
-                // Supported types are added directly, all other types are converted to strings.
-                if (OpenTelemetrySupportedAttributeValueTypes.Contains(field.Value.GetType()))
-                {
-                    attributes.Add(field.Key, field.Value);
-                }
-                else
-                {
-                    // TODO should we completely ignore unsupported types?
-                    attributes.Add(field.Key, field.Value.ToString());
-                }
-            }
-
-            return new Tuple<string, IDictionary<string, object>>(eventName ?? DefaultEventName, attributes);
-        }
+        return new Tuple<string, IDictionary<string, object>>(eventName ?? DefaultEventName, attributes);
     }
 }

--- a/src/OpenTelemetry.Shims.OpenTracing/TracerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/TracerShim.cs
@@ -18,91 +18,90 @@ using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Internal;
 using OpenTracing.Propagation;
 
-namespace OpenTelemetry.Shims.OpenTracing
+namespace OpenTelemetry.Shims.OpenTracing;
+
+public class TracerShim : global::OpenTracing.ITracer
 {
-    public class TracerShim : global::OpenTracing.ITracer
+    private readonly Trace.Tracer tracer;
+    private readonly TextMapPropagator propagator;
+
+    public TracerShim(Trace.Tracer tracer, TextMapPropagator textFormat)
     {
-        private readonly Trace.Tracer tracer;
-        private readonly TextMapPropagator propagator;
+        Guard.ThrowIfNull(tracer);
+        Guard.ThrowIfNull(textFormat);
 
-        public TracerShim(Trace.Tracer tracer, TextMapPropagator textFormat)
+        this.tracer = tracer;
+        this.propagator = textFormat;
+        this.ScopeManager = new ScopeManagerShim(this.tracer);
+    }
+
+    /// <inheritdoc/>
+    public global::OpenTracing.IScopeManager ScopeManager { get; private set; }
+
+    /// <inheritdoc/>
+    public global::OpenTracing.ISpan ActiveSpan => this.ScopeManager.Active?.Span;
+
+    /// <inheritdoc/>
+    public global::OpenTracing.ISpanBuilder BuildSpan(string operationName)
+    {
+        return new SpanBuilderShim(this.tracer, operationName);
+    }
+
+    /// <inheritdoc/>
+    public global::OpenTracing.ISpanContext Extract<TCarrier>(IFormat<TCarrier> format, TCarrier carrier)
+    {
+        Guard.ThrowIfNull(format);
+        Guard.ThrowIfNull(carrier);
+
+        PropagationContext propagationContext = default;
+
+        if ((format == BuiltinFormats.TextMap || format == BuiltinFormats.HttpHeaders) && carrier is ITextMap textMapCarrier)
         {
-            Guard.ThrowIfNull(tracer);
-            Guard.ThrowIfNull(textFormat);
+            var carrierMap = new Dictionary<string, IEnumerable<string>>();
 
-            this.tracer = tracer;
-            this.propagator = textFormat;
-            this.ScopeManager = new ScopeManagerShim(this.tracer);
-        }
-
-        /// <inheritdoc/>
-        public global::OpenTracing.IScopeManager ScopeManager { get; private set; }
-
-        /// <inheritdoc/>
-        public global::OpenTracing.ISpan ActiveSpan => this.ScopeManager.Active?.Span;
-
-        /// <inheritdoc/>
-        public global::OpenTracing.ISpanBuilder BuildSpan(string operationName)
-        {
-            return new SpanBuilderShim(this.tracer, operationName);
-        }
-
-        /// <inheritdoc/>
-        public global::OpenTracing.ISpanContext Extract<TCarrier>(IFormat<TCarrier> format, TCarrier carrier)
-        {
-            Guard.ThrowIfNull(format);
-            Guard.ThrowIfNull(carrier);
-
-            PropagationContext propagationContext = default;
-
-            if ((format == BuiltinFormats.TextMap || format == BuiltinFormats.HttpHeaders) && carrier is ITextMap textMapCarrier)
+            foreach (var entry in textMapCarrier)
             {
-                var carrierMap = new Dictionary<string, IEnumerable<string>>();
-
-                foreach (var entry in textMapCarrier)
-                {
-                    carrierMap.Add(entry.Key, new[] { entry.Value });
-                }
-
-                static IEnumerable<string> GetCarrierKeyValue(Dictionary<string, IEnumerable<string>> source, string key)
-                {
-                    if (key == null || !source.TryGetValue(key, out var value))
-                    {
-                        return null;
-                    }
-
-                    return value;
-                }
-
-                propagationContext = this.propagator.Extract(propagationContext, carrierMap, GetCarrierKeyValue);
+                carrierMap.Add(entry.Key, new[] { entry.Value });
             }
 
-            // TODO:
-            //  Not sure what to do here. Really, Baggage should be returned and not set until this ISpanContext is turned into a live Span.
-            //  But that code doesn't seem to exist.
-            // Baggage.Current = propagationContext.Baggage;
+            static IEnumerable<string> GetCarrierKeyValue(Dictionary<string, IEnumerable<string>> source, string key)
+            {
+                if (key == null || !source.TryGetValue(key, out var value))
+                {
+                    return null;
+                }
 
-            return !propagationContext.ActivityContext.IsValid() ? null : new SpanContextShim(new Trace.SpanContext(propagationContext.ActivityContext));
+                return value;
+            }
+
+            propagationContext = this.propagator.Extract(propagationContext, carrierMap, GetCarrierKeyValue);
         }
 
-        /// <inheritdoc/>
-        public void Inject<TCarrier>(
-            global::OpenTracing.ISpanContext spanContext,
-            IFormat<TCarrier> format,
-            TCarrier carrier)
-        {
-            Guard.ThrowIfNull(spanContext);
-            var shim = Guard.ThrowIfNotOfType<SpanContextShim>(spanContext);
-            Guard.ThrowIfNull(format);
-            Guard.ThrowIfNull(carrier);
+        // TODO:
+        //  Not sure what to do here. Really, Baggage should be returned and not set until this ISpanContext is turned into a live Span.
+        //  But that code doesn't seem to exist.
+        // Baggage.Current = propagationContext.Baggage;
 
-            if ((format == BuiltinFormats.TextMap || format == BuiltinFormats.HttpHeaders) && carrier is ITextMap textMapCarrier)
-            {
-                this.propagator.Inject(
-                    new PropagationContext(shim.SpanContext, Baggage.Current),
-                    textMapCarrier,
-                    (instrumentation, key, value) => instrumentation.Set(key, value));
-            }
+        return !propagationContext.ActivityContext.IsValid() ? null : new SpanContextShim(new Trace.SpanContext(propagationContext.ActivityContext));
+    }
+
+    /// <inheritdoc/>
+    public void Inject<TCarrier>(
+        global::OpenTracing.ISpanContext spanContext,
+        IFormat<TCarrier> format,
+        TCarrier carrier)
+    {
+        Guard.ThrowIfNull(spanContext);
+        var shim = Guard.ThrowIfNotOfType<SpanContextShim>(spanContext);
+        Guard.ThrowIfNull(format);
+        Guard.ThrowIfNull(carrier);
+
+        if ((format == BuiltinFormats.TextMap || format == BuiltinFormats.HttpHeaders) && carrier is ITextMap textMapCarrier)
+        {
+            this.propagator.Inject(
+                new PropagationContext(shim.SpanContext, Baggage.Current),
+                textMapCarrier,
+                (instrumentation, key, value) => instrumentation.Set(key, value));
         }
     }
 }

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/IntegrationTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/IntegrationTests.cs
@@ -20,130 +20,129 @@ using OpenTelemetry.Trace;
 using OpenTracing;
 using Xunit;
 
-namespace OpenTelemetry.Shims.OpenTracing.Tests
+namespace OpenTelemetry.Shims.OpenTracing.Tests;
+
+public class IntegrationTests
 {
-    public class IntegrationTests
+    private const string ChildActivitySource = "ChildActivitySource";
+    private const string ParentActivitySource = "ParentActivitySource";
+    private const string ShimTracerName = "OpenTracing.Shim";
+
+    [Theory]
+    [InlineData(SamplingDecision.Drop, SamplingDecision.Drop, SamplingDecision.Drop)]
+    [InlineData(SamplingDecision.Drop, SamplingDecision.RecordAndSample, SamplingDecision.Drop)]
+    [InlineData(SamplingDecision.Drop, SamplingDecision.RecordOnly, SamplingDecision.Drop)]
+    [InlineData(SamplingDecision.RecordOnly, SamplingDecision.RecordAndSample, SamplingDecision.RecordOnly)]
+    [InlineData(SamplingDecision.RecordAndSample, SamplingDecision.RecordOnly, SamplingDecision.RecordAndSample)]
+    [InlineData(SamplingDecision.RecordAndSample, SamplingDecision.Drop, SamplingDecision.RecordAndSample)]
+    public void WithActivities(
+        SamplingDecision parentActivitySamplingDecision,
+        SamplingDecision shimSamplingDecision,
+        SamplingDecision childActivitySamplingDecision)
     {
-        private const string ChildActivitySource = "ChildActivitySource";
-        private const string ParentActivitySource = "ParentActivitySource";
-        private const string ShimTracerName = "OpenTracing.Shim";
+        var exportedSpans = new List<Activity>();
 
-        [Theory]
-        [InlineData(SamplingDecision.Drop, SamplingDecision.Drop, SamplingDecision.Drop)]
-        [InlineData(SamplingDecision.Drop, SamplingDecision.RecordAndSample, SamplingDecision.Drop)]
-        [InlineData(SamplingDecision.Drop, SamplingDecision.RecordOnly, SamplingDecision.Drop)]
-        [InlineData(SamplingDecision.RecordOnly, SamplingDecision.RecordAndSample, SamplingDecision.RecordOnly)]
-        [InlineData(SamplingDecision.RecordAndSample, SamplingDecision.RecordOnly, SamplingDecision.RecordAndSample)]
-        [InlineData(SamplingDecision.RecordAndSample, SamplingDecision.Drop, SamplingDecision.RecordAndSample)]
-        public void WithActivities(
-            SamplingDecision parentActivitySamplingDecision,
-            SamplingDecision shimSamplingDecision,
-            SamplingDecision childActivitySamplingDecision)
+        const string ParentActivityName = "ParentActivity";
+        const string ShimActivityName = "ShimActivity";
+        const string ChildActivityName = "ChildActivity";
+
+        var testSampler = new TestSampler((samplingParameters) =>
+            samplingParameters.Name switch
+            {
+                ParentActivityName => parentActivitySamplingDecision,
+                ShimActivityName => shimSamplingDecision,
+                ChildActivityName => childActivitySamplingDecision,
+                _ => SamplingDecision.Drop,
+            });
+
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddInMemoryExporter(exportedSpans)
+            .SetSampler(testSampler)
+            .When(
+                parentActivitySamplingDecision == SamplingDecision.RecordAndSample,
+                b => b.AddSource(ParentActivitySource))
+            .When(
+                shimSamplingDecision == SamplingDecision.RecordAndSample,
+                b => b.AddSource(ShimTracerName))
+            .When(
+                childActivitySamplingDecision == SamplingDecision.RecordAndSample,
+                b => b.AddSource(ChildActivitySource))
+            .Build();
+
+        ITracer otTracer = new TracerShim(
+            tracerProvider.GetTracer(ShimTracerName),
+            Propagators.DefaultTextMapPropagator);
+
+        // Real usage requires a call OpenTracing.Util.GlobalTracer.Register(otTracer),
+        // however, that can only happen once per process, we don't do it here so we
+        // can run multiple tests in the same process.
+
+        using var parentActivitySource = new ActivitySource(ParentActivitySource);
+        using var childActivitySource = new ActivitySource(ChildActivitySource);
+
+        using (var parentActivity = parentActivitySource.StartActivity(ParentActivityName))
         {
-            var exportedSpans = new List<Activity>();
-
-            const string ParentActivityName = "ParentActivity";
-            const string ShimActivityName = "ShimActivity";
-            const string ChildActivityName = "ChildActivity";
-
-            var testSampler = new TestSampler((samplingParameters) =>
-                samplingParameters.Name switch
-                {
-                    ParentActivityName => parentActivitySamplingDecision,
-                    ShimActivityName => shimSamplingDecision,
-                    ChildActivityName => childActivitySamplingDecision,
-                    _ => SamplingDecision.Drop,
-                });
-
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-                .AddInMemoryExporter(exportedSpans)
-                .SetSampler(testSampler)
-                .When(
-                    parentActivitySamplingDecision == SamplingDecision.RecordAndSample,
-                    b => b.AddSource(ParentActivitySource))
-                .When(
-                    shimSamplingDecision == SamplingDecision.RecordAndSample,
-                    b => b.AddSource(ShimTracerName))
-                .When(
-                    childActivitySamplingDecision == SamplingDecision.RecordAndSample,
-                    b => b.AddSource(ChildActivitySource))
-                .Build();
-
-            ITracer otTracer = new TracerShim(
-                tracerProvider.GetTracer(ShimTracerName),
-                Propagators.DefaultTextMapPropagator);
-
-            // Real usage requires a call OpenTracing.Util.GlobalTracer.Register(otTracer),
-            // however, that can only happen once per process, we don't do it here so we
-            // can run multiple tests in the same process.
-
-            using var parentActivitySource = new ActivitySource(ParentActivitySource);
-            using var childActivitySource = new ActivitySource(ChildActivitySource);
-
-            using (var parentActivity = parentActivitySource.StartActivity(ParentActivityName))
+            using (IScope parentScope = otTracer.BuildSpan(ShimActivityName).StartActive())
             {
-                using (IScope parentScope = otTracer.BuildSpan(ShimActivityName).StartActive())
-                {
-                    parentScope.Span.SetTag("parent", true);
+                parentScope.Span.SetTag("parent", true);
 
-                    using var childActivity = childActivitySource.StartActivity(ChildActivityName);
-                }
-            }
-
-            var expectedExportedSpans = new string[]
-                {
-                    childActivitySamplingDecision == SamplingDecision.RecordAndSample ? ChildActivityName : null,
-                    shimSamplingDecision == SamplingDecision.RecordAndSample ? ShimActivityName : null,
-                    parentActivitySamplingDecision == SamplingDecision.RecordAndSample ? ParentActivityName : null,
-                }
-                .Where(s => s is not null)
-                .ToList();
-
-            for (int i = 0; i < expectedExportedSpans.Count; i++)
-            {
-                Assert.Equal(expectedExportedSpans[i], exportedSpans[i].DisplayName);
-            }
-
-            if (childActivitySamplingDecision == SamplingDecision.RecordAndSample)
-            {
-                if (shimSamplingDecision == SamplingDecision.RecordAndSample)
-                {
-                    Assert.Same(exportedSpans[1], exportedSpans[0].Parent);
-                }
+                using var childActivity = childActivitySource.StartActivity(ChildActivityName);
             }
         }
 
-        private class TestSampler : Sampler
-        {
-            private readonly Func<SamplingParameters, SamplingDecision> shouldSampleDelegate;
-
-            public TestSampler(Func<SamplingParameters, SamplingDecision> shouldSampleDelegate)
+        var expectedExportedSpans = new string[]
             {
-                this.shouldSampleDelegate = shouldSampleDelegate;
+                childActivitySamplingDecision == SamplingDecision.RecordAndSample ? ChildActivityName : null,
+                shimSamplingDecision == SamplingDecision.RecordAndSample ? ShimActivityName : null,
+                parentActivitySamplingDecision == SamplingDecision.RecordAndSample ? ParentActivityName : null,
             }
+            .Where(s => s is not null)
+            .ToList();
 
-            public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
+        for (int i = 0; i < expectedExportedSpans.Count; i++)
+        {
+            Assert.Equal(expectedExportedSpans[i], exportedSpans[i].DisplayName);
+        }
+
+        if (childActivitySamplingDecision == SamplingDecision.RecordAndSample)
+        {
+            if (shimSamplingDecision == SamplingDecision.RecordAndSample)
             {
-                return new SamplingResult(this.shouldSampleDelegate(samplingParameters));
+                Assert.Same(exportedSpans[1], exportedSpans[0].Parent);
             }
         }
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "Local use only")]
-    internal static class ConditionalTracerProviderBuilderExtension
+    private class TestSampler : Sampler
     {
-        public static TracerProviderBuilder When(
-            this TracerProviderBuilder builder,
-            bool condition,
-            Func<TracerProviderBuilder, TracerProviderBuilder> conditionalDelegate)
-        {
-            if (condition)
-            {
-                builder = conditionalDelegate(builder);
-            }
+        private readonly Func<SamplingParameters, SamplingDecision> shouldSampleDelegate;
 
-            return builder;
+        public TestSampler(Func<SamplingParameters, SamplingDecision> shouldSampleDelegate)
+        {
+            this.shouldSampleDelegate = shouldSampleDelegate;
         }
+
+        public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
+        {
+            return new SamplingResult(this.shouldSampleDelegate(samplingParameters));
+        }
+    }
+}
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "Local use only")]
+internal static class ConditionalTracerProviderBuilderExtension
+{
+    public static TracerProviderBuilder When(
+        this TracerProviderBuilder builder,
+        bool condition,
+        Func<TracerProviderBuilder, TracerProviderBuilder> conditionalDelegate)
+    {
+        if (condition)
+        {
+            builder = conditionalDelegate(builder);
+        }
+
+        return builder;
     }
 }

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/ListenAndSampleAllActivitySources.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/ListenAndSampleAllActivitySources.cs
@@ -17,33 +17,32 @@
 using System.Diagnostics;
 using Xunit;
 
-namespace OpenTelemetry.Shims.OpenTracing.Tests
+namespace OpenTelemetry.Shims.OpenTracing.Tests;
+
+[CollectionDefinition(nameof(ListenAndSampleAllActivitySources))]
+public sealed class ListenAndSampleAllActivitySources : ICollectionFixture<ListenAndSampleAllActivitySources.Fixture>
 {
-    [CollectionDefinition(nameof(ListenAndSampleAllActivitySources))]
-    public sealed class ListenAndSampleAllActivitySources : ICollectionFixture<ListenAndSampleAllActivitySources.Fixture>
+    public sealed class Fixture : IDisposable
     {
-        public sealed class Fixture : IDisposable
+        private readonly ActivityListener listener;
+
+        public Fixture()
         {
-            private readonly ActivityListener listener;
+            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+            Activity.ForceDefaultIdFormat = true;
 
-            public Fixture()
+            this.listener = new ActivityListener
             {
-                Activity.DefaultIdFormat = ActivityIdFormat.W3C;
-                Activity.ForceDefaultIdFormat = true;
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
+            };
 
-                this.listener = new ActivityListener
-                {
-                    ShouldListenTo = _ => true,
-                    Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
-                };
+            ActivitySource.AddActivityListener(this.listener);
+        }
 
-                ActivitySource.AddActivityListener(this.listener);
-            }
-
-            public void Dispose()
-            {
-                this.listener.Dispose();
-            }
+        public void Dispose()
+        {
+            this.listener.Dispose();
         }
     }
 }

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/ScopeManagerShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/ScopeManagerShimTests.cs
@@ -19,74 +19,73 @@ using Moq;
 using OpenTelemetry.Trace;
 using Xunit;
 
-namespace OpenTelemetry.Shims.OpenTracing.Tests
+namespace OpenTelemetry.Shims.OpenTracing.Tests;
+
+[Collection(nameof(ListenAndSampleAllActivitySources))]
+public class ScopeManagerShimTests
 {
-    [Collection(nameof(ListenAndSampleAllActivitySources))]
-    public class ScopeManagerShimTests
+    private const string SpanName = "MySpanName/1";
+    private const string TracerName = "defaultactivitysource";
+
+    [Fact]
+    public void CtorArgumentValidation()
     {
-        private const string SpanName = "MySpanName/1";
-        private const string TracerName = "defaultactivitysource";
+        Assert.Throws<ArgumentNullException>(() => new ScopeManagerShim(null));
+    }
 
-        [Fact]
-        public void CtorArgumentValidation()
+    [Fact]
+    public void Active_IsNull()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new ScopeManagerShim(tracer);
+
+        Assert.Null(Activity.Current);
+        Assert.Null(shim.Active);
+    }
+
+    [Fact]
+    public void Active_IsNotNull()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new ScopeManagerShim(tracer);
+        var openTracingSpan = new SpanShim(tracer.StartSpan(SpanName));
+
+        var scope = shim.Activate(openTracingSpan, true);
+        Assert.NotNull(scope);
+
+        var activeScope = shim.Active;
+        Assert.Equal(scope.Span.Context.SpanId, activeScope.Span.Context.SpanId);
+        openTracingSpan.Finish();
+    }
+
+    [Fact]
+    public void Activate_SpanMustBeShim()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new ScopeManagerShim(tracer);
+
+        Assert.Throws<InvalidCastException>(() => shim.Activate(new Mock<global::OpenTracing.ISpan>().Object, true));
+    }
+
+    [Fact]
+    public void Activate()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new ScopeManagerShim(tracer);
+        var spanShim = new SpanShim(tracer.StartSpan(SpanName));
+
+        using (shim.Activate(spanShim, true))
         {
-            Assert.Throws<ArgumentNullException>(() => new ScopeManagerShim(null));
-        }
-
-        [Fact]
-        public void Active_IsNull()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new ScopeManagerShim(tracer);
-
-            Assert.Null(Activity.Current);
-            Assert.Null(shim.Active);
-        }
-
-        [Fact]
-        public void Active_IsNotNull()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new ScopeManagerShim(tracer);
-            var openTracingSpan = new SpanShim(tracer.StartSpan(SpanName));
-
-            var scope = shim.Activate(openTracingSpan, true);
-            Assert.NotNull(scope);
-
-            var activeScope = shim.Active;
-            Assert.Equal(scope.Span.Context.SpanId, activeScope.Span.Context.SpanId);
-            openTracingSpan.Finish();
-        }
-
-        [Fact]
-        public void Activate_SpanMustBeShim()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new ScopeManagerShim(tracer);
-
-            Assert.Throws<InvalidCastException>(() => shim.Activate(new Mock<global::OpenTracing.ISpan>().Object, true));
-        }
-
-        [Fact]
-        public void Activate()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new ScopeManagerShim(tracer);
-            var spanShim = new SpanShim(tracer.StartSpan(SpanName));
-
-            using (shim.Activate(spanShim, true))
-            {
 #if DEBUG
-                Assert.Equal(1, shim.SpanScopeTableCount);
+            Assert.Equal(1, shim.SpanScopeTableCount);
 #endif
-            }
+        }
 
 #if DEBUG
-            Assert.Equal(0, shim.SpanScopeTableCount);
+        Assert.Equal(0, shim.SpanScopeTableCount);
 #endif
 
-            spanShim.Finish();
-            Assert.NotEqual(default, spanShim.Span.Activity.Duration);
-        }
+        spanShim.Finish();
+        Assert.NotEqual(default, spanShim.Span.Activity.Duration);
     }
 }

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/ScopeManagerShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/ScopeManagerShimTests.cs
@@ -19,87 +19,86 @@ using Moq;
 using OpenTelemetry.Trace;
 using Xunit;
 
-namespace OpenTelemetry.Shims.OpenTracing.Tests
+namespace OpenTelemetry.Shims.OpenTracing.Tests;
+
+public class ScopeManagerShimTests
 {
-    public class ScopeManagerShimTests
+    private const string SpanName = "MySpanName/1";
+    private const string TracerName = "defaultactivitysource";
+
+    static ScopeManagerShimTests()
     {
-        private const string SpanName = "MySpanName/1";
-        private const string TracerName = "defaultactivitysource";
+        Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+        Activity.ForceDefaultIdFormat = true;
 
-        static ScopeManagerShimTests()
+        var listener = new ActivityListener
         {
-            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
-            Activity.ForceDefaultIdFormat = true;
+            ShouldListenTo = _ => true,
+            Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
+        };
 
-            var listener = new ActivityListener
-            {
-                ShouldListenTo = _ => true,
-                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
-            };
+        ActivitySource.AddActivityListener(listener);
+    }
 
-            ActivitySource.AddActivityListener(listener);
-        }
+    [Fact]
+    public void CtorArgumentValidation()
+    {
+        Assert.Throws<ArgumentNullException>(() => new ScopeManagerShim(null));
+    }
 
-        [Fact]
-        public void CtorArgumentValidation()
+    [Fact]
+    public void Active_IsNull()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new ScopeManagerShim(tracer);
+
+        Assert.Null(Activity.Current);
+        Assert.Null(shim.Active);
+    }
+
+    [Fact]
+    public void Active_IsNotNull()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new ScopeManagerShim(tracer);
+        var openTracingSpan = new SpanShim(tracer.StartSpan(SpanName));
+
+        var scope = shim.Activate(openTracingSpan, true);
+        Assert.NotNull(scope);
+
+        var activeScope = shim.Active;
+        Assert.Equal(scope.Span.Context.SpanId, activeScope.Span.Context.SpanId);
+        openTracingSpan.Finish();
+    }
+
+    [Fact]
+    public void Activate_SpanMustBeShim()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new ScopeManagerShim(tracer);
+
+        Assert.Throws<InvalidCastException>(() => shim.Activate(new Mock<global::OpenTracing.ISpan>().Object, true));
+    }
+
+    [Fact]
+    public void Activate()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new ScopeManagerShim(tracer);
+        var spanShim = new SpanShim(tracer.StartSpan(SpanName));
+
+        using (shim.Activate(spanShim, true))
         {
-            Assert.Throws<ArgumentNullException>(() => new ScopeManagerShim(null));
-        }
-
-        [Fact]
-        public void Active_IsNull()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new ScopeManagerShim(tracer);
-
-            Assert.Null(Activity.Current);
-            Assert.Null(shim.Active);
-        }
-
-        [Fact]
-        public void Active_IsNotNull()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new ScopeManagerShim(tracer);
-            var openTracingSpan = new SpanShim(tracer.StartSpan(SpanName));
-
-            var scope = shim.Activate(openTracingSpan, true);
-            Assert.NotNull(scope);
-
-            var activeScope = shim.Active;
-            Assert.Equal(scope.Span.Context.SpanId, activeScope.Span.Context.SpanId);
-            openTracingSpan.Finish();
-        }
-
-        [Fact]
-        public void Activate_SpanMustBeShim()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new ScopeManagerShim(tracer);
-
-            Assert.Throws<InvalidCastException>(() => shim.Activate(new Mock<global::OpenTracing.ISpan>().Object, true));
-        }
-
-        [Fact]
-        public void Activate()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new ScopeManagerShim(tracer);
-            var spanShim = new SpanShim(tracer.StartSpan(SpanName));
-
-            using (shim.Activate(spanShim, true))
-            {
 #if DEBUG
-                Assert.Equal(1, shim.SpanScopeTableCount);
+            Assert.Equal(1, shim.SpanScopeTableCount);
 #endif
-            }
+        }
 
 #if DEBUG
-            Assert.Equal(0, shim.SpanScopeTableCount);
+        Assert.Equal(0, shim.SpanScopeTableCount);
 #endif
 
-            spanShim.Finish();
-            Assert.NotEqual(default, spanShim.Span.Activity.Duration);
-        }
+        spanShim.Finish();
+        Assert.NotEqual(default, spanShim.Span.Activity.Duration);
     }
 }

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanBuilderShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanBuilderShimTests.cs
@@ -18,325 +18,324 @@ using System.Diagnostics;
 using OpenTelemetry.Trace;
 using Xunit;
 
-namespace OpenTelemetry.Shims.OpenTracing.Tests
+namespace OpenTelemetry.Shims.OpenTracing.Tests;
+
+[Collection(nameof(ListenAndSampleAllActivitySources))]
+public class SpanBuilderShimTests
 {
-    [Collection(nameof(ListenAndSampleAllActivitySources))]
-    public class SpanBuilderShimTests
+    private const string SpanName1 = "MySpanName/1";
+    private const string SpanName2 = "MySpanName/2";
+    private const string TracerName = "defaultactivitysource";
+
+    [Fact]
+    public void CtorArgumentValidation()
     {
-        private const string SpanName1 = "MySpanName/1";
-        private const string SpanName2 = "MySpanName/2";
-        private const string TracerName = "defaultactivitysource";
-
-        [Fact]
-        public void CtorArgumentValidation()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            Assert.Throws<ArgumentNullException>(() => new SpanBuilderShim(null, "foo"));
-            Assert.Throws<ArgumentNullException>(() => new SpanBuilderShim(tracer, null));
-        }
-
-        [Fact]
-        public void IgnoreActiveSpan()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-
-            // Add a parent. The shim requires that the ISpan implementation be a SpanShim
-            shim.AsChildOf(new SpanShim(tracer.StartSpan(SpanName1)));
-
-            // Set to Ignore
-            shim.IgnoreActiveSpan();
-
-            // build
-            var spanShim = (SpanShim)shim.Start();
-
-            Assert.Equal("foo", spanShim.Span.Activity.OperationName);
-        }
-
-        [Fact]
-        public void StartWithExplicitTimestamp()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-
-            var startTimestamp = DateTimeOffset.Now;
-            shim.WithStartTimestamp(startTimestamp);
-
-            // build
-            var spanShim = (SpanShim)shim.Start();
-
-            Assert.Equal(startTimestamp, spanShim.Span.Activity.StartTimeUtc);
-        }
-
-        [Fact]
-        public void AsChildOf_WithNullSpan()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-
-            // Add a null parent
-            shim.AsChildOf((global::OpenTracing.ISpan)null);
-
-            // build
-            var spanShim = (SpanShim)shim.Start();
-
-            Assert.Equal("foo", spanShim.Span.Activity.OperationName);
-            Assert.Null(spanShim.Span.Activity.Parent);
-        }
-
-        [Fact]
-        public void AsChildOf_WithSpan()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-
-            // Add a parent.
-            var span = new SpanShim(tracer.StartSpan(SpanName1));
-            shim.AsChildOf(span);
-
-            // build
-            var spanShim = (SpanShim)shim.Start();
-
-            Assert.Equal("foo", spanShim.Span.Activity.OperationName);
-            Assert.NotNull(spanShim.Span.Activity.ParentId);
-        }
-
-        [Fact]
-        public void Start_ActivityOperationRootSpanChecks()
-        {
-            // Create an activity
-            using var activity = new Activity("foo")
-                .SetIdFormat(ActivityIdFormat.W3C)
-                .Start();
-
-            // matching root operation name
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-            var spanShim1 = (SpanShim)shim.Start();
-
-            Assert.Equal("foo", spanShim1.Span.Activity.OperationName);
-
-            // mis-matched root operation name
-            shim = new SpanBuilderShim(tracer, "foo");
-            var spanShim2 = (SpanShim)shim.Start();
-
-            Assert.Equal("foo", spanShim2.Span.Activity.OperationName);
-            Assert.Equal(spanShim1.Context.TraceId, spanShim2.Context.TraceId);
-        }
-
-        [Fact]
-        public void AsChildOf_MultipleCallsWithSpan()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        Assert.Throws<ArgumentNullException>(() => new SpanBuilderShim(null, "foo"));
+        Assert.Throws<ArgumentNullException>(() => new SpanBuilderShim(tracer, null));
+    }
+
+    [Fact]
+    public void IgnoreActiveSpan()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        // Add a parent. The shim requires that the ISpan implementation be a SpanShim
+        shim.AsChildOf(new SpanShim(tracer.StartSpan(SpanName1)));
+
+        // Set to Ignore
+        shim.IgnoreActiveSpan();
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
+
+        Assert.Equal("foo", spanShim.Span.Activity.OperationName);
+    }
+
+    [Fact]
+    public void StartWithExplicitTimestamp()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        var startTimestamp = DateTimeOffset.Now;
+        shim.WithStartTimestamp(startTimestamp);
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
+
+        Assert.Equal(startTimestamp, spanShim.Span.Activity.StartTimeUtc);
+    }
+
+    [Fact]
+    public void AsChildOf_WithNullSpan()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        // Add a null parent
+        shim.AsChildOf((global::OpenTracing.ISpan)null);
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
+
+        Assert.Equal("foo", spanShim.Span.Activity.OperationName);
+        Assert.Null(spanShim.Span.Activity.Parent);
+    }
+
+    [Fact]
+    public void AsChildOf_WithSpan()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        // Add a parent.
+        var span = new SpanShim(tracer.StartSpan(SpanName1));
+        shim.AsChildOf(span);
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
+
+        Assert.Equal("foo", spanShim.Span.Activity.OperationName);
+        Assert.NotNull(spanShim.Span.Activity.ParentId);
+    }
+
+    [Fact]
+    public void Start_ActivityOperationRootSpanChecks()
+    {
+        // Create an activity
+        using var activity = new Activity("foo")
+            .SetIdFormat(ActivityIdFormat.W3C)
+            .Start();
+
+        // matching root operation name
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+        var spanShim1 = (SpanShim)shim.Start();
+
+        Assert.Equal("foo", spanShim1.Span.Activity.OperationName);
+
+        // mis-matched root operation name
+        shim = new SpanBuilderShim(tracer, "foo");
+        var spanShim2 = (SpanShim)shim.Start();
+
+        Assert.Equal("foo", spanShim2.Span.Activity.OperationName);
+        Assert.Equal(spanShim1.Context.TraceId, spanShim2.Context.TraceId);
+    }
+
+    [Fact]
+    public void AsChildOf_MultipleCallsWithSpan()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        // Multiple calls
+        var span1 = new SpanShim(tracer.StartSpan(SpanName1));
+        var span2 = new SpanShim(tracer.StartSpan(SpanName2));
+        shim.AsChildOf(span1);
+        shim.AsChildOf(span2);
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
+
+        Assert.Equal("foo", spanShim.Span.Activity.OperationName);
+        Assert.Contains(spanShim.Context.TraceId, spanShim.Span.Activity.TraceId.ToHexString());
 
-            // Multiple calls
-            var span1 = new SpanShim(tracer.StartSpan(SpanName1));
-            var span2 = new SpanShim(tracer.StartSpan(SpanName2));
-            shim.AsChildOf(span1);
-            shim.AsChildOf(span2);
+        // TODO: Check for multi level parenting
+    }
 
-            // build
-            var spanShim = (SpanShim)shim.Start();
-
-            Assert.Equal("foo", spanShim.Span.Activity.OperationName);
-            Assert.Contains(spanShim.Context.TraceId, spanShim.Span.Activity.TraceId.ToHexString());
+    [Fact]
+    public void AsChildOf_WithNullSpanContext()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
 
-            // TODO: Check for multi level parenting
-        }
+        // Add a null parent
+        shim.AsChildOf((global::OpenTracing.ISpanContext)null);
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
 
-        [Fact]
-        public void AsChildOf_WithNullSpanContext()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
+        // should be no parent.
+        Assert.Null(spanShim.Span.Activity.Parent);
+    }
 
-            // Add a null parent
-            shim.AsChildOf((global::OpenTracing.ISpanContext)null);
-
-            // build
-            var spanShim = (SpanShim)shim.Start();
+    [Fact]
+    public void AsChildOfWithSpanContext()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
 
-            // should be no parent.
-            Assert.Null(spanShim.Span.Activity.Parent);
-        }
+        // Add a parent
+        var spanContext = SpanContextShimTests.GetSpanContextShim();
+        _ = shim.AsChildOf(spanContext);
 
-        [Fact]
-        public void AsChildOfWithSpanContext()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
+        // build
+        var spanShim = (SpanShim)shim.Start();
 
-            // Add a parent
-            var spanContext = SpanContextShimTests.GetSpanContextShim();
-            _ = shim.AsChildOf(spanContext);
+        Assert.NotNull(spanShim.Span.Activity.ParentId);
+    }
 
-            // build
-            var spanShim = (SpanShim)shim.Start();
+    [Fact]
+    public void AsChildOf_MultipleCallsWithSpanContext()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
 
-            Assert.NotNull(spanShim.Span.Activity.ParentId);
-        }
+        // Multiple calls
+        var spanContext1 = SpanContextShimTests.GetSpanContextShim();
+        var spanContext2 = SpanContextShimTests.GetSpanContextShim();
 
-        [Fact]
-        public void AsChildOf_MultipleCallsWithSpanContext()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-
-            // Multiple calls
-            var spanContext1 = SpanContextShimTests.GetSpanContextShim();
-            var spanContext2 = SpanContextShimTests.GetSpanContextShim();
-
-            // Add parent context
-            shim.AsChildOf(spanContext1);
-
-            // Adds as link as parent context already exists
-            shim.AsChildOf(spanContext2);
-
-            // build
-            var spanShim = (SpanShim)shim.Start();
-
-            Assert.Equal("foo", spanShim.Span.Activity.OperationName);
-            Assert.Contains(spanContext1.TraceId, spanShim.Span.Activity.ParentId);
-            Assert.Equal(spanContext2.SpanId, spanShim.Span.Activity.Links.First().Context.SpanId.ToHexString());
-        }
-
-        [Fact]
-        public void WithTag_KeyIsSpanKindStringValue()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-
-            shim.WithTag(global::OpenTracing.Tag.Tags.SpanKind.Key, global::OpenTracing.Tag.Tags.SpanKindClient);
-
-            // build
-            var spanShim = (SpanShim)shim.Start();
-
-            // Not an attribute
-            Assert.Empty(spanShim.Span.Activity.Tags);
-            Assert.Equal("foo", spanShim.Span.Activity.OperationName);
-            Assert.Equal(ActivityKind.Client, spanShim.Span.Activity.Kind);
-        }
-
-        [Fact]
-        public void WithTag_KeyIsErrorStringValue()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-
-            shim.WithTag(global::OpenTracing.Tag.Tags.Error.Key, "true");
-
-            // build
-            var spanShim = (SpanShim)shim.Start();
-
-            // Span status should be set
-            Assert.Equal(Status.Error, spanShim.Span.Activity.GetStatus());
-        }
-
-        [Fact]
-        public void WithTag_KeyIsNullStringValue()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-
-            shim.WithTag((string)null, "unused");
-
-            // build
-            var spanShim = (SpanShim)shim.Start();
-
-            // Null key was ignored
-            Assert.Empty(spanShim.Span.Activity.Tags);
-        }
-
-        [Fact]
-        public void WithTag_ValueIsNullStringValue()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-
-            shim.WithTag("foo", null);
-
-            // build
-            var spanShim = (SpanShim)shim.Start();
-
-            // Null value was turned into string.empty
-            Assert.Equal("foo", spanShim.Span.Activity.Tags.First().Key);
-            Assert.Equal(string.Empty, spanShim.Span.Activity.Tags.First().Value);
-        }
-
-        [Fact]
-        public void WithTag_KeyIsErrorBoolValue()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-
-            shim.WithTag(global::OpenTracing.Tag.Tags.Error.Key, true);
-
-            // build
-            var spanShim = (SpanShim)shim.Start();
-
-            // Span status should be set
-            Assert.Equal(Status.Error, spanShim.Span.Activity.GetStatus());
-        }
-
-        [Fact]
-        public void WithTag_VariousValueTypes()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-
-            shim.WithTag("foo", "unused");
-            shim.WithTag("bar", false);
-            shim.WithTag("baz", 1);
-            shim.WithTag("bizzle", 1D);
-            shim.WithTag(new global::OpenTracing.Tag.BooleanTag("shnizzle"), true);
-            shim.WithTag(new global::OpenTracing.Tag.IntOrStringTag("febrizzle"), "unused");
-            shim.WithTag(new global::OpenTracing.Tag.StringTag("mobizzle"), "unused");
-
-            // build
-            var spanShim = (SpanShim)shim.Start();
-
-            // Just verify the count
-            Assert.Equal(7, spanShim.Span.Activity.Tags.Count());
-        }
-
-        [Fact]
-        public void Start()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-
-            // build
-            var span = shim.Start() as SpanShim;
-
-            // Just check the return value is a SpanShim and that the underlying OpenTelemetry Span.
-            // There is nothing left to verify because the rest of the tests were already calling .Start() prior to verification.
-            Assert.NotNull(span);
-            Assert.Equal("foo", span.Span.Activity.OperationName);
-        }
-
-        [Fact]
-        public void Start_UnderAspNetCoreInstrumentation()
-        {
-            // Simulate a span from AspNetCore instrumentation as parent.
-            using var source = new ActivitySource("Microsoft.AspNetCore.Hosting.HttpRequestIn");
-            using var parentSpan = source.StartActivity("OTelParent");
-            Assert.NotNull(parentSpan);
-
-            // Start the OpenTracing span.
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var builderShim = new SpanBuilderShim(tracer, "foo");
-            var spanShim = builderShim.StartActive().Span as SpanShim;
-            Assert.NotNull(spanShim);
-
-            var telemetrySpan = spanShim.Span;
-            Assert.Same(telemetrySpan.Activity, Activity.Current);
-            Assert.Same(parentSpan, telemetrySpan.Activity.Parent);
-
-            // Dispose the spanShim.Span and ensure correct state for Activity.Current
-            spanShim.Span.Dispose();
-
-            Assert.Same(parentSpan, Activity.Current);
-        }
+        // Add parent context
+        shim.AsChildOf(spanContext1);
+
+        // Adds as link as parent context already exists
+        shim.AsChildOf(spanContext2);
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
+
+        Assert.Equal("foo", spanShim.Span.Activity.OperationName);
+        Assert.Contains(spanContext1.TraceId, spanShim.Span.Activity.ParentId);
+        Assert.Equal(spanContext2.SpanId, spanShim.Span.Activity.Links.First().Context.SpanId.ToHexString());
+    }
+
+    [Fact]
+    public void WithTag_KeyIsSpanKindStringValue()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        shim.WithTag(global::OpenTracing.Tag.Tags.SpanKind.Key, global::OpenTracing.Tag.Tags.SpanKindClient);
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
+
+        // Not an attribute
+        Assert.Empty(spanShim.Span.Activity.Tags);
+        Assert.Equal("foo", spanShim.Span.Activity.OperationName);
+        Assert.Equal(ActivityKind.Client, spanShim.Span.Activity.Kind);
+    }
+
+    [Fact]
+    public void WithTag_KeyIsErrorStringValue()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        shim.WithTag(global::OpenTracing.Tag.Tags.Error.Key, "true");
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
+
+        // Span status should be set
+        Assert.Equal(Status.Error, spanShim.Span.Activity.GetStatus());
+    }
+
+    [Fact]
+    public void WithTag_KeyIsNullStringValue()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        shim.WithTag((string)null, "unused");
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
+
+        // Null key was ignored
+        Assert.Empty(spanShim.Span.Activity.Tags);
+    }
+
+    [Fact]
+    public void WithTag_ValueIsNullStringValue()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        shim.WithTag("foo", null);
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
+
+        // Null value was turned into string.empty
+        Assert.Equal("foo", spanShim.Span.Activity.Tags.First().Key);
+        Assert.Equal(string.Empty, spanShim.Span.Activity.Tags.First().Value);
+    }
+
+    [Fact]
+    public void WithTag_KeyIsErrorBoolValue()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        shim.WithTag(global::OpenTracing.Tag.Tags.Error.Key, true);
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
+
+        // Span status should be set
+        Assert.Equal(Status.Error, spanShim.Span.Activity.GetStatus());
+    }
+
+    [Fact]
+    public void WithTag_VariousValueTypes()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        shim.WithTag("foo", "unused");
+        shim.WithTag("bar", false);
+        shim.WithTag("baz", 1);
+        shim.WithTag("bizzle", 1D);
+        shim.WithTag(new global::OpenTracing.Tag.BooleanTag("shnizzle"), true);
+        shim.WithTag(new global::OpenTracing.Tag.IntOrStringTag("febrizzle"), "unused");
+        shim.WithTag(new global::OpenTracing.Tag.StringTag("mobizzle"), "unused");
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
+
+        // Just verify the count
+        Assert.Equal(7, spanShim.Span.Activity.Tags.Count());
+    }
+
+    [Fact]
+    public void Start()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        // build
+        var span = shim.Start() as SpanShim;
+
+        // Just check the return value is a SpanShim and that the underlying OpenTelemetry Span.
+        // There is nothing left to verify because the rest of the tests were already calling .Start() prior to verification.
+        Assert.NotNull(span);
+        Assert.Equal("foo", span.Span.Activity.OperationName);
+    }
+
+    [Fact]
+    public void Start_UnderAspNetCoreInstrumentation()
+    {
+        // Simulate a span from AspNetCore instrumentation as parent.
+        using var source = new ActivitySource("Microsoft.AspNetCore.Hosting.HttpRequestIn");
+        using var parentSpan = source.StartActivity("OTelParent");
+        Assert.NotNull(parentSpan);
+
+        // Start the OpenTracing span.
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var builderShim = new SpanBuilderShim(tracer, "foo");
+        var spanShim = builderShim.StartActive().Span as SpanShim;
+        Assert.NotNull(spanShim);
+
+        var telemetrySpan = spanShim.Span;
+        Assert.Same(telemetrySpan.Activity, Activity.Current);
+        Assert.Same(parentSpan, telemetrySpan.Activity.Parent);
+
+        // Dispose the spanShim.Span and ensure correct state for Activity.Current
+        spanShim.Span.Dispose();
+
+        Assert.Same(parentSpan, Activity.Current);
     }
 }

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanBuilderShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanBuilderShimTests.cs
@@ -18,338 +18,337 @@ using System.Diagnostics;
 using OpenTelemetry.Trace;
 using Xunit;
 
-namespace OpenTelemetry.Shims.OpenTracing.Tests
+namespace OpenTelemetry.Shims.OpenTracing.Tests;
+
+public class SpanBuilderShimTests
 {
-    public class SpanBuilderShimTests
+    private const string SpanName1 = "MySpanName/1";
+    private const string SpanName2 = "MySpanName/2";
+    private const string TracerName = "defaultactivitysource";
+
+    static SpanBuilderShimTests()
     {
-        private const string SpanName1 = "MySpanName/1";
-        private const string SpanName2 = "MySpanName/2";
-        private const string TracerName = "defaultactivitysource";
+        Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+        Activity.ForceDefaultIdFormat = true;
 
-        static SpanBuilderShimTests()
+        var listener = new ActivityListener
         {
-            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
-            Activity.ForceDefaultIdFormat = true;
-
-            var listener = new ActivityListener
-            {
-                ShouldListenTo = _ => true,
-                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
-            };
-
-            ActivitySource.AddActivityListener(listener);
-        }
-
-        [Fact]
-        public void CtorArgumentValidation()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            Assert.Throws<ArgumentNullException>(() => new SpanBuilderShim(null, "foo"));
-            Assert.Throws<ArgumentNullException>(() => new SpanBuilderShim(tracer, null));
-        }
-
-        [Fact]
-        public void IgnoreActiveSpan()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-
-            // Add a parent. The shim requires that the ISpan implementation be a SpanShim
-            shim.AsChildOf(new SpanShim(tracer.StartSpan(SpanName1)));
-
-            // Set to Ignore
-            shim.IgnoreActiveSpan();
-
-            // build
-            var spanShim = (SpanShim)shim.Start();
-
-            Assert.Equal("foo", spanShim.Span.Activity.OperationName);
-        }
-
-        [Fact]
-        public void StartWithExplicitTimestamp()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-
-            var startTimestamp = DateTimeOffset.Now;
-            shim.WithStartTimestamp(startTimestamp);
-
-            // build
-            var spanShim = (SpanShim)shim.Start();
-
-            Assert.Equal(startTimestamp, spanShim.Span.Activity.StartTimeUtc);
-        }
-
-        [Fact]
-        public void AsChildOf_WithNullSpan()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-
-            // Add a null parent
-            shim.AsChildOf((global::OpenTracing.ISpan)null);
-
-            // build
-            var spanShim = (SpanShim)shim.Start();
-
-            Assert.Equal("foo", spanShim.Span.Activity.OperationName);
-            Assert.Null(spanShim.Span.Activity.Parent);
-        }
-
-        [Fact]
-        public void AsChildOf_WithSpan()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-
-            // Add a parent.
-            var span = new SpanShim(tracer.StartSpan(SpanName1));
-            shim.AsChildOf(span);
-
-            // build
-            var spanShim = (SpanShim)shim.Start();
-
-            Assert.Equal("foo", spanShim.Span.Activity.OperationName);
-            Assert.NotNull(spanShim.Span.Activity.ParentId);
-        }
-
-        [Fact]
-        public void Start_ActivityOperationRootSpanChecks()
-        {
-            // Create an activity
-            using var activity = new Activity("foo")
-                .SetIdFormat(ActivityIdFormat.W3C)
-                .Start();
-
-            // matching root operation name
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-            var spanShim1 = (SpanShim)shim.Start();
-
-            Assert.Equal("foo", spanShim1.Span.Activity.OperationName);
-
-            // mis-matched root operation name
-            shim = new SpanBuilderShim(tracer, "foo");
-            var spanShim2 = (SpanShim)shim.Start();
+            ShouldListenTo = _ => true,
+            Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
+        };
+
+        ActivitySource.AddActivityListener(listener);
+    }
+
+    [Fact]
+    public void CtorArgumentValidation()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        Assert.Throws<ArgumentNullException>(() => new SpanBuilderShim(null, "foo"));
+        Assert.Throws<ArgumentNullException>(() => new SpanBuilderShim(tracer, null));
+    }
+
+    [Fact]
+    public void IgnoreActiveSpan()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        // Add a parent. The shim requires that the ISpan implementation be a SpanShim
+        shim.AsChildOf(new SpanShim(tracer.StartSpan(SpanName1)));
+
+        // Set to Ignore
+        shim.IgnoreActiveSpan();
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
+
+        Assert.Equal("foo", spanShim.Span.Activity.OperationName);
+    }
+
+    [Fact]
+    public void StartWithExplicitTimestamp()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        var startTimestamp = DateTimeOffset.Now;
+        shim.WithStartTimestamp(startTimestamp);
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
+
+        Assert.Equal(startTimestamp, spanShim.Span.Activity.StartTimeUtc);
+    }
+
+    [Fact]
+    public void AsChildOf_WithNullSpan()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        // Add a null parent
+        shim.AsChildOf((global::OpenTracing.ISpan)null);
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
+
+        Assert.Equal("foo", spanShim.Span.Activity.OperationName);
+        Assert.Null(spanShim.Span.Activity.Parent);
+    }
+
+    [Fact]
+    public void AsChildOf_WithSpan()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        // Add a parent.
+        var span = new SpanShim(tracer.StartSpan(SpanName1));
+        shim.AsChildOf(span);
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
+
+        Assert.Equal("foo", spanShim.Span.Activity.OperationName);
+        Assert.NotNull(spanShim.Span.Activity.ParentId);
+    }
+
+    [Fact]
+    public void Start_ActivityOperationRootSpanChecks()
+    {
+        // Create an activity
+        using var activity = new Activity("foo")
+            .SetIdFormat(ActivityIdFormat.W3C)
+            .Start();
+
+        // matching root operation name
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+        var spanShim1 = (SpanShim)shim.Start();
+
+        Assert.Equal("foo", spanShim1.Span.Activity.OperationName);
+
+        // mis-matched root operation name
+        shim = new SpanBuilderShim(tracer, "foo");
+        var spanShim2 = (SpanShim)shim.Start();
+
+        Assert.Equal("foo", spanShim2.Span.Activity.OperationName);
+        Assert.Equal(spanShim1.Context.TraceId, spanShim2.Context.TraceId);
+    }
+
+    [Fact]
+    public void AsChildOf_MultipleCallsWithSpan()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        // Multiple calls
+        var span1 = new SpanShim(tracer.StartSpan(SpanName1));
+        var span2 = new SpanShim(tracer.StartSpan(SpanName2));
+        shim.AsChildOf(span1);
+        shim.AsChildOf(span2);
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
+
+        Assert.Equal("foo", spanShim.Span.Activity.OperationName);
+        Assert.Contains(spanShim.Context.TraceId, spanShim.Span.Activity.TraceId.ToHexString());
+
+        // TODO: Check for multi level parenting
+    }
 
-            Assert.Equal("foo", spanShim2.Span.Activity.OperationName);
-            Assert.Equal(spanShim1.Context.TraceId, spanShim2.Context.TraceId);
-        }
-
-        [Fact]
-        public void AsChildOf_MultipleCallsWithSpan()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
+    [Fact]
+    public void AsChildOf_WithNullSpanContext()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        // Add a null parent
+        shim.AsChildOf((global::OpenTracing.ISpanContext)null);
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
 
-            // Multiple calls
-            var span1 = new SpanShim(tracer.StartSpan(SpanName1));
-            var span2 = new SpanShim(tracer.StartSpan(SpanName2));
-            shim.AsChildOf(span1);
-            shim.AsChildOf(span2);
+        // should be no parent.
+        Assert.Null(spanShim.Span.Activity.Parent);
+    }
 
-            // build
-            var spanShim = (SpanShim)shim.Start();
-
-            Assert.Equal("foo", spanShim.Span.Activity.OperationName);
-            Assert.Contains(spanShim.Context.TraceId, spanShim.Span.Activity.TraceId.ToHexString());
+    [Fact]
+    public void AsChildOfWithSpanContext()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        // Add a parent
+        var spanContext = SpanContextShimTests.GetSpanContextShim();
+        _ = shim.AsChildOf(spanContext);
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
+
+        Assert.NotNull(spanShim.Span.Activity.ParentId);
+    }
 
-            // TODO: Check for multi level parenting
-        }
-
-        [Fact]
-        public void AsChildOf_WithNullSpanContext()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-
-            // Add a null parent
-            shim.AsChildOf((global::OpenTracing.ISpanContext)null);
-
-            // build
-            var spanShim = (SpanShim)shim.Start();
-
-            // should be no parent.
-            Assert.Null(spanShim.Span.Activity.Parent);
-        }
-
-        [Fact]
-        public void AsChildOfWithSpanContext()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-
-            // Add a parent
-            var spanContext = SpanContextShimTests.GetSpanContextShim();
-            _ = shim.AsChildOf(spanContext);
-
-            // build
-            var spanShim = (SpanShim)shim.Start();
-
-            Assert.NotNull(spanShim.Span.Activity.ParentId);
-        }
-
-        [Fact]
-        public void AsChildOf_MultipleCallsWithSpanContext()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-
-            // Multiple calls
-            var spanContext1 = SpanContextShimTests.GetSpanContextShim();
-            var spanContext2 = SpanContextShimTests.GetSpanContextShim();
-
-            // Add parent context
-            shim.AsChildOf(spanContext1);
-
-            // Adds as link as parent context already exists
-            shim.AsChildOf(spanContext2);
-
-            // build
-            var spanShim = (SpanShim)shim.Start();
-
-            Assert.Equal("foo", spanShim.Span.Activity.OperationName);
-            Assert.Contains(spanContext1.TraceId, spanShim.Span.Activity.ParentId);
-            Assert.Equal(spanContext2.SpanId, spanShim.Span.Activity.Links.First().Context.SpanId.ToHexString());
-        }
-
-        [Fact]
-        public void WithTag_KeyIsSpanKindStringValue()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-
-            shim.WithTag(global::OpenTracing.Tag.Tags.SpanKind.Key, global::OpenTracing.Tag.Tags.SpanKindClient);
-
-            // build
-            var spanShim = (SpanShim)shim.Start();
-
-            // Not an attribute
-            Assert.Empty(spanShim.Span.Activity.Tags);
-            Assert.Equal("foo", spanShim.Span.Activity.OperationName);
-            Assert.Equal(ActivityKind.Client, spanShim.Span.Activity.Kind);
-        }
-
-        [Fact]
-        public void WithTag_KeyIsErrorStringValue()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-
-            shim.WithTag(global::OpenTracing.Tag.Tags.Error.Key, "true");
-
-            // build
-            var spanShim = (SpanShim)shim.Start();
-
-            // Span status should be set
-            Assert.Equal(Status.Error, spanShim.Span.Activity.GetStatus());
-        }
-
-        [Fact]
-        public void WithTag_KeyIsNullStringValue()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-
-            shim.WithTag((string)null, "unused");
-
-            // build
-            var spanShim = (SpanShim)shim.Start();
-
-            // Null key was ignored
-            Assert.Empty(spanShim.Span.Activity.Tags);
-        }
-
-        [Fact]
-        public void WithTag_ValueIsNullStringValue()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-
-            shim.WithTag("foo", null);
-
-            // build
-            var spanShim = (SpanShim)shim.Start();
-
-            // Null value was turned into string.empty
-            Assert.Equal("foo", spanShim.Span.Activity.Tags.First().Key);
-            Assert.Equal(string.Empty, spanShim.Span.Activity.Tags.First().Value);
-        }
-
-        [Fact]
-        public void WithTag_KeyIsErrorBoolValue()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-
-            shim.WithTag(global::OpenTracing.Tag.Tags.Error.Key, true);
-
-            // build
-            var spanShim = (SpanShim)shim.Start();
-
-            // Span status should be set
-            Assert.Equal(Status.Error, spanShim.Span.Activity.GetStatus());
-        }
-
-        [Fact]
-        public void WithTag_VariousValueTypes()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-
-            shim.WithTag("foo", "unused");
-            shim.WithTag("bar", false);
-            shim.WithTag("baz", 1);
-            shim.WithTag("bizzle", 1D);
-            shim.WithTag(new global::OpenTracing.Tag.BooleanTag("shnizzle"), true);
-            shim.WithTag(new global::OpenTracing.Tag.IntOrStringTag("febrizzle"), "unused");
-            shim.WithTag(new global::OpenTracing.Tag.StringTag("mobizzle"), "unused");
-
-            // build
-            var spanShim = (SpanShim)shim.Start();
-
-            // Just verify the count
-            Assert.Equal(7, spanShim.Span.Activity.Tags.Count());
-        }
-
-        [Fact]
-        public void Start()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanBuilderShim(tracer, "foo");
-
-            // build
-            var span = shim.Start() as SpanShim;
-
-            // Just check the return value is a SpanShim and that the underlying OpenTelemetry Span.
-            // There is nothing left to verify because the rest of the tests were already calling .Start() prior to verification.
-            Assert.NotNull(span);
-            Assert.Equal("foo", span.Span.Activity.OperationName);
-        }
-
-        [Fact]
-        public void Start_UnderAspNetCoreInstrumentation()
-        {
-            // Simulate a span from AspNetCore instrumentation as parent.
-            using var source = new ActivitySource("Microsoft.AspNetCore.Hosting.HttpRequestIn");
-            using var parentSpan = source.StartActivity("OTelParent");
-            Assert.NotNull(parentSpan);
-
-            // Start the OpenTracing span.
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var builderShim = new SpanBuilderShim(tracer, "foo");
-            var spanShim = builderShim.StartActive().Span as SpanShim;
-            Assert.NotNull(spanShim);
-
-            var telemetrySpan = spanShim.Span;
-            Assert.Same(telemetrySpan.Activity, Activity.Current);
-            Assert.Same(parentSpan, telemetrySpan.Activity.Parent);
-
-            // Dispose the spanShim.Span and ensure correct state for Activity.Current
-            spanShim.Span.Dispose();
-
-            Assert.Same(parentSpan, Activity.Current);
-        }
+    [Fact]
+    public void AsChildOf_MultipleCallsWithSpanContext()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        // Multiple calls
+        var spanContext1 = SpanContextShimTests.GetSpanContextShim();
+        var spanContext2 = SpanContextShimTests.GetSpanContextShim();
+
+        // Add parent context
+        shim.AsChildOf(spanContext1);
+
+        // Adds as link as parent context already exists
+        shim.AsChildOf(spanContext2);
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
+
+        Assert.Equal("foo", spanShim.Span.Activity.OperationName);
+        Assert.Contains(spanContext1.TraceId, spanShim.Span.Activity.ParentId);
+        Assert.Equal(spanContext2.SpanId, spanShim.Span.Activity.Links.First().Context.SpanId.ToHexString());
+    }
+
+    [Fact]
+    public void WithTag_KeyIsSpanKindStringValue()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        shim.WithTag(global::OpenTracing.Tag.Tags.SpanKind.Key, global::OpenTracing.Tag.Tags.SpanKindClient);
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
+
+        // Not an attribute
+        Assert.Empty(spanShim.Span.Activity.Tags);
+        Assert.Equal("foo", spanShim.Span.Activity.OperationName);
+        Assert.Equal(ActivityKind.Client, spanShim.Span.Activity.Kind);
+    }
+
+    [Fact]
+    public void WithTag_KeyIsErrorStringValue()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        shim.WithTag(global::OpenTracing.Tag.Tags.Error.Key, "true");
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
+
+        // Span status should be set
+        Assert.Equal(Status.Error, spanShim.Span.Activity.GetStatus());
+    }
+
+    [Fact]
+    public void WithTag_KeyIsNullStringValue()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        shim.WithTag((string)null, "unused");
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
+
+        // Null key was ignored
+        Assert.Empty(spanShim.Span.Activity.Tags);
+    }
+
+    [Fact]
+    public void WithTag_ValueIsNullStringValue()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        shim.WithTag("foo", null);
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
+
+        // Null value was turned into string.empty
+        Assert.Equal("foo", spanShim.Span.Activity.Tags.First().Key);
+        Assert.Equal(string.Empty, spanShim.Span.Activity.Tags.First().Value);
+    }
+
+    [Fact]
+    public void WithTag_KeyIsErrorBoolValue()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        shim.WithTag(global::OpenTracing.Tag.Tags.Error.Key, true);
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
+
+        // Span status should be set
+        Assert.Equal(Status.Error, spanShim.Span.Activity.GetStatus());
+    }
+
+    [Fact]
+    public void WithTag_VariousValueTypes()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        shim.WithTag("foo", "unused");
+        shim.WithTag("bar", false);
+        shim.WithTag("baz", 1);
+        shim.WithTag("bizzle", 1D);
+        shim.WithTag(new global::OpenTracing.Tag.BooleanTag("shnizzle"), true);
+        shim.WithTag(new global::OpenTracing.Tag.IntOrStringTag("febrizzle"), "unused");
+        shim.WithTag(new global::OpenTracing.Tag.StringTag("mobizzle"), "unused");
+
+        // build
+        var spanShim = (SpanShim)shim.Start();
+
+        // Just verify the count
+        Assert.Equal(7, spanShim.Span.Activity.Tags.Count());
+    }
+
+    [Fact]
+    public void Start()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanBuilderShim(tracer, "foo");
+
+        // build
+        var span = shim.Start() as SpanShim;
+
+        // Just check the return value is a SpanShim and that the underlying OpenTelemetry Span.
+        // There is nothing left to verify because the rest of the tests were already calling .Start() prior to verification.
+        Assert.NotNull(span);
+        Assert.Equal("foo", span.Span.Activity.OperationName);
+    }
+
+    [Fact]
+    public void Start_UnderAspNetCoreInstrumentation()
+    {
+        // Simulate a span from AspNetCore instrumentation as parent.
+        using var source = new ActivitySource("Microsoft.AspNetCore.Hosting.HttpRequestIn");
+        using var parentSpan = source.StartActivity("OTelParent");
+        Assert.NotNull(parentSpan);
+
+        // Start the OpenTracing span.
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var builderShim = new SpanBuilderShim(tracer, "foo");
+        var spanShim = builderShim.StartActive().Span as SpanShim;
+        Assert.NotNull(spanShim);
+
+        var telemetrySpan = spanShim.Span;
+        Assert.Same(telemetrySpan.Activity, Activity.Current);
+        Assert.Same(parentSpan, telemetrySpan.Activity.Parent);
+
+        // Dispose the spanShim.Span and ensure correct state for Activity.Current
+        spanShim.Span.Dispose();
+
+        Assert.Same(parentSpan, Activity.Current);
     }
 }

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanContextShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanContextShimTests.cs
@@ -18,44 +18,43 @@ using System.Diagnostics;
 using OpenTelemetry.Trace;
 using Xunit;
 
-namespace OpenTelemetry.Shims.OpenTracing.Tests
+namespace OpenTelemetry.Shims.OpenTracing.Tests;
+
+public class SpanContextShimTests
 {
-    public class SpanContextShimTests
+    [Fact]
+    public void CtorArgumentValidation()
     {
-        [Fact]
-        public void CtorArgumentValidation()
-        {
-            Assert.Throws<ArgumentException>(() => new SpanContextShim(default));
-            Assert.Throws<ArgumentException>(() => new SpanContextShim(new SpanContext(default, default, ActivityTraceFlags.None)));
-        }
+        Assert.Throws<ArgumentException>(() => new SpanContextShim(default));
+        Assert.Throws<ArgumentException>(() => new SpanContextShim(new SpanContext(default, default, ActivityTraceFlags.None)));
+    }
 
-        [Fact]
-        public void GetTraceId()
-        {
-            var shim = GetSpanContextShim();
+    [Fact]
+    public void GetTraceId()
+    {
+        var shim = GetSpanContextShim();
 
-            Assert.Equal(shim.TraceId.ToString(), shim.TraceId);
-        }
+        Assert.Equal(shim.TraceId.ToString(), shim.TraceId);
+    }
 
-        [Fact]
-        public void GetSpanId()
-        {
-            var shim = GetSpanContextShim();
+    [Fact]
+    public void GetSpanId()
+    {
+        var shim = GetSpanContextShim();
 
-            Assert.Equal(shim.SpanId.ToString(), shim.SpanId);
-        }
+        Assert.Equal(shim.SpanId.ToString(), shim.SpanId);
+    }
 
-        [Fact]
-        public void GetBaggage()
-        {
-            var shim = GetSpanContextShim();
-            var baggage = shim.GetBaggageItems();
-            Assert.Empty(baggage);
-        }
+    [Fact]
+    public void GetBaggage()
+    {
+        var shim = GetSpanContextShim();
+        var baggage = shim.GetBaggageItems();
+        Assert.Empty(baggage);
+    }
 
-        internal static SpanContextShim GetSpanContextShim()
-        {
-            return new SpanContextShim(new SpanContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.None));
-        }
+    internal static SpanContextShim GetSpanContextShim()
+    {
+        return new SpanContextShim(new SpanContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.None));
     }
 }

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanContextShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanContextShimTests.cs
@@ -18,37 +18,36 @@ using System.Diagnostics;
 using OpenTelemetry.Trace;
 using Xunit;
 
-namespace OpenTelemetry.Shims.OpenTracing.Tests
+namespace OpenTelemetry.Shims.OpenTracing.Tests;
+
+public class SpanContextShimTests
 {
-    public class SpanContextShimTests
+    [Fact]
+    public void GetTraceId()
     {
-        [Fact]
-        public void GetTraceId()
-        {
-            var shim = GetSpanContextShim();
+        var shim = GetSpanContextShim();
 
-            Assert.Equal(shim.TraceId.ToString(), shim.TraceId);
-        }
+        Assert.Equal(shim.TraceId.ToString(), shim.TraceId);
+    }
 
-        [Fact]
-        public void GetSpanId()
-        {
-            var shim = GetSpanContextShim();
+    [Fact]
+    public void GetSpanId()
+    {
+        var shim = GetSpanContextShim();
 
-            Assert.Equal(shim.SpanId.ToString(), shim.SpanId);
-        }
+        Assert.Equal(shim.SpanId.ToString(), shim.SpanId);
+    }
 
-        [Fact]
-        public void GetBaggage()
-        {
-            var shim = GetSpanContextShim();
-            var baggage = shim.GetBaggageItems();
-            Assert.Empty(baggage);
-        }
+    [Fact]
+    public void GetBaggage()
+    {
+        var shim = GetSpanContextShim();
+        var baggage = shim.GetBaggageItems();
+        Assert.Empty(baggage);
+    }
 
-        internal static SpanContextShim GetSpanContextShim()
-        {
-            return new SpanContextShim(new SpanContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.None));
-        }
+    internal static SpanContextShim GetSpanContextShim()
+    {
+        return new SpanContextShim(new SpanContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.None));
     }
 }

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
@@ -18,315 +18,314 @@ using OpenTelemetry.Trace;
 using OpenTracing.Tag;
 using Xunit;
 
-namespace OpenTelemetry.Shims.OpenTracing.Tests
+namespace OpenTelemetry.Shims.OpenTracing.Tests;
+
+[Collection(nameof(ListenAndSampleAllActivitySources))]
+public class SpanShimTests
 {
-    [Collection(nameof(ListenAndSampleAllActivitySources))]
-    public class SpanShimTests
+    private const string SpanName = "MySpanName/1";
+    private const string TracerName = "defaultactivitysource";
+
+    [Fact]
+    public void CtorArgumentValidation()
     {
-        private const string SpanName = "MySpanName/1";
-        private const string TracerName = "defaultactivitysource";
+        Assert.Throws<ArgumentNullException>(() => new SpanShim(null));
+    }
 
-        [Fact]
-        public void CtorArgumentValidation()
-        {
-            Assert.Throws<ArgumentNullException>(() => new SpanShim(null));
-        }
+    [Fact]
+    public void SpanContextIsNotNull()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanShim(tracer.StartSpan(SpanName));
 
-        [Fact]
-        public void SpanContextIsNotNull()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanShim(tracer.StartSpan(SpanName));
+        // ISpanContext validation handled in a separate test class
+        Assert.NotNull(shim.Context);
+    }
 
-            // ISpanContext validation handled in a separate test class
-            Assert.NotNull(shim.Context);
-        }
+    [Fact]
+    public void FinishSpan()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanShim(tracer.StartSpan(SpanName));
 
-        [Fact]
-        public void FinishSpan()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanShim(tracer.StartSpan(SpanName));
+        shim.Finish();
 
-            shim.Finish();
+        Assert.NotEqual(default, shim.Span.Activity.Duration);
+    }
 
-            Assert.NotEqual(default, shim.Span.Activity.Duration);
-        }
-
-        [Fact]
-        public void FinishSpanUsingSpecificTimestamp()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanShim(tracer.StartSpan(SpanName));
+    [Fact]
+    public void FinishSpanUsingSpecificTimestamp()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanShim(tracer.StartSpan(SpanName));
 
 #if NETFRAMEWORK
-            // Under the hood the Activity start time uses DateTime.UtcNow, which
-            // doesn't have the same precision as DateTimeOffset.UtcNow on the .NET Framework.
-            // Add a sleep big enough to ensure that the test doesn't break due to the
-            // low resolution of DateTime.UtcNow on the .NET Framework.
-            Thread.Sleep(TimeSpan.FromMilliseconds(20));
+        // Under the hood the Activity start time uses DateTime.UtcNow, which
+        // doesn't have the same precision as DateTimeOffset.UtcNow on the .NET Framework.
+        // Add a sleep big enough to ensure that the test doesn't break due to the
+        // low resolution of DateTime.UtcNow on the .NET Framework.
+        Thread.Sleep(TimeSpan.FromMilliseconds(20));
 #endif
 
-            var endTime = DateTimeOffset.UtcNow;
-            shim.Finish(endTime);
+        var endTime = DateTimeOffset.UtcNow;
+        shim.Finish(endTime);
 
-            Assert.Equal(endTime - shim.Span.Activity.StartTimeUtc, shim.Span.Activity.Duration);
-        }
+        Assert.Equal(endTime - shim.Span.Activity.StartTimeUtc, shim.Span.Activity.Duration);
+    }
 
-        [Fact]
-        public void SetOperationName()
+    [Fact]
+    public void SetOperationName()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanShim(tracer.StartSpan(SpanName));
+
+        // parameter validation
+        Assert.Throws<ArgumentNullException>(() => shim.SetOperationName(null));
+
+        shim.SetOperationName("bar");
+        Assert.Equal("bar", shim.Span.Activity.DisplayName);
+    }
+
+    [Fact]
+    public void GetBaggageItem()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanShim(tracer.StartSpan(SpanName));
+
+        // parameter validation
+        Assert.Throws<ArgumentException>(() => shim.GetBaggageItem(null));
+
+        // TODO - Method not implemented
+    }
+
+    [Fact]
+    public void Log()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanShim(tracer.StartSpan(SpanName));
+
+        shim.Log("foo");
+
+        Assert.Single(shim.Span.Activity.Events);
+        var first = shim.Span.Activity.Events.First();
+        Assert.Equal("foo", first.Name);
+        Assert.False(first.Tags.Any());
+    }
+
+    [Fact]
+    public void LogWithExplicitTimestamp()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanShim(tracer.StartSpan(SpanName));
+
+        var now = DateTimeOffset.UtcNow;
+        shim.Log(now, "foo");
+
+        Assert.Single(shim.Span.Activity.Events);
+        var first = shim.Span.Activity.Events.First();
+        Assert.Equal("foo", first.Name);
+        Assert.Equal(now, first.Timestamp);
+        Assert.False(first.Tags.Any());
+    }
+
+    [Fact]
+    public void LogUsingFields()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanShim(tracer.StartSpan(SpanName));
+
+        Assert.Throws<ArgumentNullException>(() => shim.Log((IEnumerable<KeyValuePair<string, object>>)null));
+
+        shim.Log(new List<KeyValuePair<string, object>>
         {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanShim(tracer.StartSpan(SpanName));
+            new KeyValuePair<string, object>("foo", "bar"),
+        });
 
-            // parameter validation
-            Assert.Throws<ArgumentNullException>(() => shim.SetOperationName(null));
-
-            shim.SetOperationName("bar");
-            Assert.Equal("bar", shim.Span.Activity.DisplayName);
-        }
-
-        [Fact]
-        public void GetBaggageItem()
+        // "event" is a special event name
+        shim.Log(new List<KeyValuePair<string, object>>
         {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanShim(tracer.StartSpan(SpanName));
+            new KeyValuePair<string, object>("event", "foo"),
+        });
 
-            // parameter validation
-            Assert.Throws<ArgumentException>(() => shim.GetBaggageItem(null));
+        var first = shim.Span.Activity.Events.FirstOrDefault();
+        var last = shim.Span.Activity.Events.LastOrDefault();
 
-            // TODO - Method not implemented
-        }
+        Assert.Equal(2, shim.Span.Activity.Events.Count());
 
-        [Fact]
-        public void Log()
+        Assert.Equal(SpanShim.DefaultEventName, first.Name);
+        Assert.True(first.Tags.Any());
+
+        Assert.Equal("foo", last.Name);
+        Assert.False(last.Tags.Any());
+    }
+
+    [Fact]
+    public void LogUsingFieldsWithExplicitTimestamp()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanShim(tracer.StartSpan(SpanName));
+
+        Assert.Throws<ArgumentNullException>(() => shim.Log((IEnumerable<KeyValuePair<string, object>>)null));
+        var now = DateTimeOffset.UtcNow;
+
+        shim.Log(now, new List<KeyValuePair<string, object>>
         {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanShim(tracer.StartSpan(SpanName));
+            new KeyValuePair<string, object>("foo", "bar"),
+        });
 
-            shim.Log("foo");
-
-            Assert.Single(shim.Span.Activity.Events);
-            var first = shim.Span.Activity.Events.First();
-            Assert.Equal("foo", first.Name);
-            Assert.False(first.Tags.Any());
-        }
-
-        [Fact]
-        public void LogWithExplicitTimestamp()
+        // "event" is a special event name
+        shim.Log(now, new List<KeyValuePair<string, object>>
         {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanShim(tracer.StartSpan(SpanName));
+            new KeyValuePair<string, object>("event", "foo"),
+        });
 
-            var now = DateTimeOffset.UtcNow;
-            shim.Log(now, "foo");
+        Assert.Equal(2, shim.Span.Activity.Events.Count());
+        var first = shim.Span.Activity.Events.First();
+        var last = shim.Span.Activity.Events.Last();
 
-            Assert.Single(shim.Span.Activity.Events);
-            var first = shim.Span.Activity.Events.First();
-            Assert.Equal("foo", first.Name);
-            Assert.Equal(now, first.Timestamp);
-            Assert.False(first.Tags.Any());
-        }
+        Assert.Equal(SpanShim.DefaultEventName, first.Name);
+        Assert.True(first.Tags.Any());
+        Assert.Equal(now, first.Timestamp);
 
-        [Fact]
-        public void LogUsingFields()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanShim(tracer.StartSpan(SpanName));
+        Assert.Equal("foo", last.Name);
+        Assert.False(last.Tags.Any());
+        Assert.Equal(now, last.Timestamp);
+    }
 
-            Assert.Throws<ArgumentNullException>(() => shim.Log((IEnumerable<KeyValuePair<string, object>>)null));
+    [Fact]
+    public void SetTagStringValue()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanShim(tracer.StartSpan(SpanName));
 
-            shim.Log(new List<KeyValuePair<string, object>>
-            {
-                new KeyValuePair<string, object>("foo", "bar"),
-            });
+        Assert.Throws<ArgumentNullException>(() => shim.SetTag((string)null, "foo"));
 
-            // "event" is a special event name
-            shim.Log(new List<KeyValuePair<string, object>>
-            {
-                new KeyValuePair<string, object>("event", "foo"),
-            });
+        shim.SetTag("foo", "bar");
 
-            var first = shim.Span.Activity.Events.FirstOrDefault();
-            var last = shim.Span.Activity.Events.LastOrDefault();
+        Assert.Single(shim.Span.Activity.Tags);
+        Assert.Equal("foo", shim.Span.Activity.Tags.First().Key);
+        Assert.Equal("bar", shim.Span.Activity.Tags.First().Value);
+    }
 
-            Assert.Equal(2, shim.Span.Activity.Events.Count());
+    [Fact]
+    public void SetTagBoolValue()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanShim(tracer.StartSpan(SpanName));
 
-            Assert.Equal(SpanShim.DefaultEventName, first.Name);
-            Assert.True(first.Tags.Any());
+        Assert.Throws<ArgumentNullException>(() => shim.SetTag((string)null, true));
 
-            Assert.Equal("foo", last.Name);
-            Assert.False(last.Tags.Any());
-        }
+        shim.SetTag("foo", true);
+        shim.SetTag(Tags.Error.Key, true);
 
-        [Fact]
-        public void LogUsingFieldsWithExplicitTimestamp()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanShim(tracer.StartSpan(SpanName));
+        Assert.Equal("foo", shim.Span.Activity.TagObjects.First().Key);
+        Assert.True((bool)shim.Span.Activity.TagObjects.First().Value);
 
-            Assert.Throws<ArgumentNullException>(() => shim.Log((IEnumerable<KeyValuePair<string, object>>)null));
-            var now = DateTimeOffset.UtcNow;
+        // A boolean tag named "error" is a special case that must be checked
+        Assert.Equal(Status.Error, shim.Span.Activity.GetStatus());
 
-            shim.Log(now, new List<KeyValuePair<string, object>>
-            {
-                new KeyValuePair<string, object>("foo", "bar"),
-            });
+        shim.SetTag(Tags.Error.Key, false);
+        Assert.Equal(Status.Ok, shim.Span.Activity.GetStatus());
+    }
 
-            // "event" is a special event name
-            shim.Log(now, new List<KeyValuePair<string, object>>
-            {
-                new KeyValuePair<string, object>("event", "foo"),
-            });
+    [Fact]
+    public void SetTagIntValue()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanShim(tracer.StartSpan(SpanName));
 
-            Assert.Equal(2, shim.Span.Activity.Events.Count());
-            var first = shim.Span.Activity.Events.First();
-            var last = shim.Span.Activity.Events.Last();
+        Assert.Throws<ArgumentNullException>(() => shim.SetTag((string)null, 1));
 
-            Assert.Equal(SpanShim.DefaultEventName, first.Name);
-            Assert.True(first.Tags.Any());
-            Assert.Equal(now, first.Timestamp);
+        shim.SetTag("foo", 1);
 
-            Assert.Equal("foo", last.Name);
-            Assert.False(last.Tags.Any());
-            Assert.Equal(now, last.Timestamp);
-        }
+        Assert.Single(shim.Span.Activity.TagObjects);
+        Assert.Equal("foo", shim.Span.Activity.TagObjects.First().Key);
+        Assert.Equal(1L, (int)shim.Span.Activity.TagObjects.First().Value);
+    }
 
-        [Fact]
-        public void SetTagStringValue()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanShim(tracer.StartSpan(SpanName));
+    [Fact]
+    public void SetTagDoubleValue()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanShim(tracer.StartSpan(SpanName));
 
-            Assert.Throws<ArgumentNullException>(() => shim.SetTag((string)null, "foo"));
+        Assert.Throws<ArgumentNullException>(() => shim.SetTag(null, 1D));
 
-            shim.SetTag("foo", "bar");
+        shim.SetTag("foo", 1D);
 
-            Assert.Single(shim.Span.Activity.Tags);
-            Assert.Equal("foo", shim.Span.Activity.Tags.First().Key);
-            Assert.Equal("bar", shim.Span.Activity.Tags.First().Value);
-        }
+        Assert.Single(shim.Span.Activity.TagObjects);
+        Assert.Equal("foo", shim.Span.Activity.TagObjects.First().Key);
+        Assert.Equal(1, (double)shim.Span.Activity.TagObjects.First().Value);
+    }
 
-        [Fact]
-        public void SetTagBoolValue()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanShim(tracer.StartSpan(SpanName));
+    [Fact]
+    public void SetTagBooleanTagValue()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanShim(tracer.StartSpan(SpanName));
 
-            Assert.Throws<ArgumentNullException>(() => shim.SetTag((string)null, true));
+        Assert.Throws<ArgumentNullException>(() => shim.SetTag((BooleanTag)null, true));
 
-            shim.SetTag("foo", true);
-            shim.SetTag(Tags.Error.Key, true);
+        shim.SetTag(new BooleanTag("foo"), true);
+        shim.SetTag(new BooleanTag(Tags.Error.Key), true);
 
-            Assert.Equal("foo", shim.Span.Activity.TagObjects.First().Key);
-            Assert.True((bool)shim.Span.Activity.TagObjects.First().Value);
+        Assert.Equal("foo", shim.Span.Activity.TagObjects.First().Key);
+        Assert.True((bool)shim.Span.Activity.TagObjects.First().Value);
 
-            // A boolean tag named "error" is a special case that must be checked
-            Assert.Equal(Status.Error, shim.Span.Activity.GetStatus());
+        // A boolean tag named "error" is a special case that must be checked
+        Assert.Equal(Status.Error, shim.Span.Activity.GetStatus());
 
-            shim.SetTag(Tags.Error.Key, false);
-            Assert.Equal(Status.Ok, shim.Span.Activity.GetStatus());
-        }
+        shim.SetTag(Tags.Error.Key, false);
+        Assert.Equal(Status.Ok, shim.Span.Activity.GetStatus());
+    }
 
-        [Fact]
-        public void SetTagIntValue()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanShim(tracer.StartSpan(SpanName));
+    [Fact]
+    public void SetTagStringTagValue()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanShim(tracer.StartSpan(SpanName));
 
-            Assert.Throws<ArgumentNullException>(() => shim.SetTag((string)null, 1));
+        Assert.Throws<ArgumentNullException>(() => shim.SetTag((StringTag)null, "foo"));
 
-            shim.SetTag("foo", 1);
+        shim.SetTag(new StringTag("foo"), "bar");
 
-            Assert.Single(shim.Span.Activity.TagObjects);
-            Assert.Equal("foo", shim.Span.Activity.TagObjects.First().Key);
-            Assert.Equal(1L, (int)shim.Span.Activity.TagObjects.First().Value);
-        }
+        Assert.Single(shim.Span.Activity.Tags);
+        Assert.Equal("foo", shim.Span.Activity.Tags.First().Key);
+        Assert.Equal("bar", shim.Span.Activity.Tags.First().Value);
+    }
 
-        [Fact]
-        public void SetTagDoubleValue()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanShim(tracer.StartSpan(SpanName));
+    [Fact]
+    public void SetTagIntTagValue()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanShim(tracer.StartSpan(SpanName));
 
-            Assert.Throws<ArgumentNullException>(() => shim.SetTag(null, 1D));
+        Assert.Throws<ArgumentNullException>(() => shim.SetTag((IntTag)null, 1));
 
-            shim.SetTag("foo", 1D);
+        shim.SetTag(new IntTag("foo"), 1);
 
-            Assert.Single(shim.Span.Activity.TagObjects);
-            Assert.Equal("foo", shim.Span.Activity.TagObjects.First().Key);
-            Assert.Equal(1, (double)shim.Span.Activity.TagObjects.First().Value);
-        }
+        Assert.Single(shim.Span.Activity.TagObjects);
+        Assert.Equal("foo", shim.Span.Activity.TagObjects.First().Key);
+        Assert.Equal(1L, (int)shim.Span.Activity.TagObjects.First().Value);
+    }
 
-        [Fact]
-        public void SetTagBooleanTagValue()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanShim(tracer.StartSpan(SpanName));
+    [Fact]
+    public void SetTagIntOrStringTagValue()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new SpanShim(tracer.StartSpan(SpanName));
 
-            Assert.Throws<ArgumentNullException>(() => shim.SetTag((BooleanTag)null, true));
+        Assert.Throws<ArgumentNullException>(() => shim.SetTag((IntOrStringTag)null, "foo"));
 
-            shim.SetTag(new BooleanTag("foo"), true);
-            shim.SetTag(new BooleanTag(Tags.Error.Key), true);
+        shim.SetTag(new IntOrStringTag("foo"), 1);
+        shim.SetTag(new IntOrStringTag("bar"), "baz");
 
-            Assert.Equal("foo", shim.Span.Activity.TagObjects.First().Key);
-            Assert.True((bool)shim.Span.Activity.TagObjects.First().Value);
+        Assert.Equal(2, shim.Span.Activity.TagObjects.Count());
 
-            // A boolean tag named "error" is a special case that must be checked
-            Assert.Equal(Status.Error, shim.Span.Activity.GetStatus());
+        Assert.Equal("foo", shim.Span.Activity.TagObjects.First().Key);
+        Assert.Equal(1L, (int)shim.Span.Activity.TagObjects.First().Value);
 
-            shim.SetTag(Tags.Error.Key, false);
-            Assert.Equal(Status.Ok, shim.Span.Activity.GetStatus());
-        }
-
-        [Fact]
-        public void SetTagStringTagValue()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanShim(tracer.StartSpan(SpanName));
-
-            Assert.Throws<ArgumentNullException>(() => shim.SetTag((StringTag)null, "foo"));
-
-            shim.SetTag(new StringTag("foo"), "bar");
-
-            Assert.Single(shim.Span.Activity.Tags);
-            Assert.Equal("foo", shim.Span.Activity.Tags.First().Key);
-            Assert.Equal("bar", shim.Span.Activity.Tags.First().Value);
-        }
-
-        [Fact]
-        public void SetTagIntTagValue()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanShim(tracer.StartSpan(SpanName));
-
-            Assert.Throws<ArgumentNullException>(() => shim.SetTag((IntTag)null, 1));
-
-            shim.SetTag(new IntTag("foo"), 1);
-
-            Assert.Single(shim.Span.Activity.TagObjects);
-            Assert.Equal("foo", shim.Span.Activity.TagObjects.First().Key);
-            Assert.Equal(1L, (int)shim.Span.Activity.TagObjects.First().Value);
-        }
-
-        [Fact]
-        public void SetTagIntOrStringTagValue()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new SpanShim(tracer.StartSpan(SpanName));
-
-            Assert.Throws<ArgumentNullException>(() => shim.SetTag((IntOrStringTag)null, "foo"));
-
-            shim.SetTag(new IntOrStringTag("foo"), 1);
-            shim.SetTag(new IntOrStringTag("bar"), "baz");
-
-            Assert.Equal(2, shim.Span.Activity.TagObjects.Count());
-
-            Assert.Equal("foo", shim.Span.Activity.TagObjects.First().Key);
-            Assert.Equal(1L, (int)shim.Span.Activity.TagObjects.First().Value);
-
-            Assert.Equal("bar", shim.Span.Activity.TagObjects.Last().Key);
-            Assert.Equal("baz", shim.Span.Activity.TagObjects.Last().Value);
-        }
+        Assert.Equal("bar", shim.Span.Activity.TagObjects.Last().Key);
+        Assert.Equal("baz", shim.Span.Activity.TagObjects.Last().Value);
     }
 }

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/TracerShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/TracerShimTests.cs
@@ -23,193 +23,192 @@ using OpenTracing;
 using OpenTracing.Propagation;
 using Xunit;
 
-namespace OpenTelemetry.Shims.OpenTracing.Tests
+namespace OpenTelemetry.Shims.OpenTracing.Tests;
+
+public class TracerShimTests
 {
-    public class TracerShimTests
+    private const string TracerName = "defaultactivitysource";
+
+    [Fact]
+    public void CtorArgumentValidation()
     {
-        private const string TracerName = "defaultactivitysource";
+        // null tracer and text format
+        Assert.Throws<ArgumentNullException>(() => new TracerShim(null, null));
 
-        [Fact]
-        public void CtorArgumentValidation()
+        // null tracer
+        Assert.Throws<ArgumentNullException>(() => new TracerShim(null, new TraceContextPropagator()));
+
+        // null context format
+        var tracerMock = new Mock<Tracer>();
+        Assert.Throws<ArgumentNullException>(() => new TracerShim(TracerProvider.Default.GetTracer("test"), null));
+    }
+
+    [Fact]
+    public void ScopeManager_NotNull()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new TracerShim(tracer, new TraceContextPropagator());
+
+        // Internals of the ScopeManagerShim tested elsewhere
+        Assert.NotNull(shim.ScopeManager as ScopeManagerShim);
+    }
+
+    [Fact]
+    public void BuildSpan_NotNull()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new TracerShim(tracer, new TraceContextPropagator());
+
+        // Internals of the SpanBuilderShim tested elsewhere
+        Assert.NotNull(shim.BuildSpan("foo") as SpanBuilderShim);
+    }
+
+    [Fact]
+    public void Inject_ArgumentValidation()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new TracerShim(tracer, new TraceContextPropagator());
+
+        var spanContextShim = new SpanContextShim(new SpanContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.None));
+        var mockFormat = new Mock<IFormat<ITextMap>>();
+        var mockCarrier = new Mock<ITextMap>();
+
+        Assert.Throws<ArgumentNullException>(() => shim.Inject(null, mockFormat.Object, mockCarrier.Object));
+        Assert.Throws<InvalidCastException>(() => shim.Inject(new Mock<ISpanContext>().Object, mockFormat.Object, mockCarrier.Object));
+        Assert.Throws<ArgumentNullException>(() => shim.Inject(spanContextShim, null, mockCarrier.Object));
+        Assert.Throws<ArgumentNullException>(() => shim.Inject(spanContextShim, mockFormat.Object, null));
+    }
+
+    [Fact]
+    public void Inject_UnknownFormatIgnored()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new TracerShim(tracer, new TraceContextPropagator());
+
+        var spanContextShim = new SpanContextShim(new SpanContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded));
+
+        // Only two specific types of ITextMap are supported, and neither is a Mock.
+        var mockCarrier = new Mock<ITextMap>();
+        shim.Inject(spanContextShim, new Mock<IFormat<ITextMap>>().Object, mockCarrier.Object);
+
+        // Verify that the carrier mock was never called.
+        mockCarrier.Verify(x => x.Set(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void Extract_ArgumentValidation()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new TracerShim(tracer, new TraceContextPropagator());
+
+        Assert.Throws<ArgumentNullException>(() => shim.Extract(null, new Mock<ITextMap>().Object));
+        Assert.Throws<ArgumentNullException>(() => shim.Extract(new Mock<IFormat<ITextMap>>().Object, null));
+    }
+
+    [Fact]
+    public void Extract_UnknownFormatIgnored()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new TracerShim(tracer, new TraceContextPropagator());
+
+        var spanContextShim = new SpanContextShim(new SpanContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.None));
+
+        // Only two specific types of ITextMap are supported, and neither is a Mock.
+        var mockCarrier = new Mock<ITextMap>();
+        var context = shim.Extract(new Mock<IFormat<ITextMap>>().Object, mockCarrier.Object);
+
+        // Verify that the carrier mock was never called.
+        mockCarrier.Verify(x => x.GetEnumerator(), Times.Never);
+    }
+
+    [Fact]
+    public void Extract_InvalidTraceParent()
+    {
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new TracerShim(tracer, new TraceContextPropagator());
+
+        var mockCarrier = new Mock<ITextMap>();
+
+        // The ProxyTracer uses OpenTelemetry.Context.Propagation.TraceContextPropagator, so we need to satisfy the traceparent key at the least
+        var carrierMap = new Dictionary<string, string>
         {
-            // null tracer and text format
-            Assert.Throws<ArgumentNullException>(() => new TracerShim(null, null));
+            // This is an invalid traceparent value
+            { "traceparent", "unused" },
+        };
 
-            // null tracer
-            Assert.Throws<ArgumentNullException>(() => new TracerShim(null, new TraceContextPropagator()));
+        mockCarrier.Setup(x => x.GetEnumerator()).Returns(carrierMap.GetEnumerator());
+        var spanContextShim = shim.Extract(BuiltinFormats.TextMap, mockCarrier.Object) as SpanContextShim;
 
-            // null context format
-            var tracerMock = new Mock<Tracer>();
-            Assert.Throws<ArgumentNullException>(() => new TracerShim(TracerProvider.Default.GetTracer("test"), null));
+        // Verify that the carrier was called
+        mockCarrier.Verify(x => x.GetEnumerator(), Times.Once);
+
+        Assert.Null(spanContextShim);
+    }
+
+    [Fact]
+    public void InjectExtract_TextMap_Ok()
+    {
+        var carrier = new TextMapCarrier();
+
+        var spanContextShim = new SpanContextShim(new SpanContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.None));
+
+        var format = new TraceContextPropagator();
+
+        var tracer = TracerProvider.Default.GetTracer(TracerName);
+        var shim = new TracerShim(tracer, format);
+
+        // first inject
+        shim.Inject(spanContextShim, BuiltinFormats.TextMap, carrier);
+
+        // then extract
+        var extractedSpanContext = shim.Extract(BuiltinFormats.TextMap, carrier);
+
+        AssertOpenTracerSpanContextEqual(spanContextShim, extractedSpanContext);
+    }
+
+    private static void AssertOpenTracerSpanContextEqual(ISpanContext source, ISpanContext target)
+    {
+        Assert.Equal(source.TraceId, target.TraceId);
+        Assert.Equal(source.SpanId, target.SpanId);
+
+        // TODO BaggageItems are not implemented yet.
+    }
+
+    /// <summary>
+    /// Simple ITextMap implementation used for the inject/extract tests.
+    /// </summary>
+    /// <seealso cref="OpenTracing.Propagation.ITextMap" />
+    private class TextMapCarrier : ITextMap
+    {
+        private readonly Dictionary<string, string> map = new();
+
+        public IDictionary<string, string> Map => this.map;
+
+        public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => this.map.GetEnumerator();
+
+        public void Set(string key, string value)
+        {
+            this.map[key] = value;
         }
 
-        [Fact]
-        public void ScopeManager_NotNull()
+        IEnumerator IEnumerable.GetEnumerator() => this.map.GetEnumerator();
+    }
+
+    /// <summary>
+    /// Simple IBinary implementation used for the inject/extract tests.
+    /// </summary>
+    /// <seealso cref="OpenTracing.Propagation.IBinary" />
+    private class BinaryCarrier : IBinary
+    {
+        private readonly MemoryStream carrierStream = new();
+
+        public MemoryStream Get() => this.carrierStream;
+
+        public void Set(MemoryStream stream)
         {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new TracerShim(tracer, new TraceContextPropagator());
-
-            // Internals of the ScopeManagerShim tested elsewhere
-            Assert.NotNull(shim.ScopeManager as ScopeManagerShim);
-        }
-
-        [Fact]
-        public void BuildSpan_NotNull()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new TracerShim(tracer, new TraceContextPropagator());
-
-            // Internals of the SpanBuilderShim tested elsewhere
-            Assert.NotNull(shim.BuildSpan("foo") as SpanBuilderShim);
-        }
-
-        [Fact]
-        public void Inject_ArgumentValidation()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new TracerShim(tracer, new TraceContextPropagator());
-
-            var spanContextShim = new SpanContextShim(new SpanContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.None));
-            var mockFormat = new Mock<IFormat<ITextMap>>();
-            var mockCarrier = new Mock<ITextMap>();
-
-            Assert.Throws<ArgumentNullException>(() => shim.Inject(null, mockFormat.Object, mockCarrier.Object));
-            Assert.Throws<InvalidCastException>(() => shim.Inject(new Mock<ISpanContext>().Object, mockFormat.Object, mockCarrier.Object));
-            Assert.Throws<ArgumentNullException>(() => shim.Inject(spanContextShim, null, mockCarrier.Object));
-            Assert.Throws<ArgumentNullException>(() => shim.Inject(spanContextShim, mockFormat.Object, null));
-        }
-
-        [Fact]
-        public void Inject_UnknownFormatIgnored()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new TracerShim(tracer, new TraceContextPropagator());
-
-            var spanContextShim = new SpanContextShim(new SpanContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded));
-
-            // Only two specific types of ITextMap are supported, and neither is a Mock.
-            var mockCarrier = new Mock<ITextMap>();
-            shim.Inject(spanContextShim, new Mock<IFormat<ITextMap>>().Object, mockCarrier.Object);
-
-            // Verify that the carrier mock was never called.
-            mockCarrier.Verify(x => x.Set(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-        }
-
-        [Fact]
-        public void Extract_ArgumentValidation()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new TracerShim(tracer, new TraceContextPropagator());
-
-            Assert.Throws<ArgumentNullException>(() => shim.Extract(null, new Mock<ITextMap>().Object));
-            Assert.Throws<ArgumentNullException>(() => shim.Extract(new Mock<IFormat<ITextMap>>().Object, null));
-        }
-
-        [Fact]
-        public void Extract_UnknownFormatIgnored()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new TracerShim(tracer, new TraceContextPropagator());
-
-            var spanContextShim = new SpanContextShim(new SpanContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.None));
-
-            // Only two specific types of ITextMap are supported, and neither is a Mock.
-            var mockCarrier = new Mock<ITextMap>();
-            var context = shim.Extract(new Mock<IFormat<ITextMap>>().Object, mockCarrier.Object);
-
-            // Verify that the carrier mock was never called.
-            mockCarrier.Verify(x => x.GetEnumerator(), Times.Never);
-        }
-
-        [Fact]
-        public void Extract_InvalidTraceParent()
-        {
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new TracerShim(tracer, new TraceContextPropagator());
-
-            var mockCarrier = new Mock<ITextMap>();
-
-            // The ProxyTracer uses OpenTelemetry.Context.Propagation.TraceContextPropagator, so we need to satisfy the traceparent key at the least
-            var carrierMap = new Dictionary<string, string>
-            {
-                // This is an invalid traceparent value
-                { "traceparent", "unused" },
-            };
-
-            mockCarrier.Setup(x => x.GetEnumerator()).Returns(carrierMap.GetEnumerator());
-            var spanContextShim = shim.Extract(BuiltinFormats.TextMap, mockCarrier.Object) as SpanContextShim;
-
-            // Verify that the carrier was called
-            mockCarrier.Verify(x => x.GetEnumerator(), Times.Once);
-
-            Assert.Null(spanContextShim);
-        }
-
-        [Fact]
-        public void InjectExtract_TextMap_Ok()
-        {
-            var carrier = new TextMapCarrier();
-
-            var spanContextShim = new SpanContextShim(new SpanContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.None));
-
-            var format = new TraceContextPropagator();
-
-            var tracer = TracerProvider.Default.GetTracer(TracerName);
-            var shim = new TracerShim(tracer, format);
-
-            // first inject
-            shim.Inject(spanContextShim, BuiltinFormats.TextMap, carrier);
-
-            // then extract
-            var extractedSpanContext = shim.Extract(BuiltinFormats.TextMap, carrier);
-
-            AssertOpenTracerSpanContextEqual(spanContextShim, extractedSpanContext);
-        }
-
-        private static void AssertOpenTracerSpanContextEqual(ISpanContext source, ISpanContext target)
-        {
-            Assert.Equal(source.TraceId, target.TraceId);
-            Assert.Equal(source.SpanId, target.SpanId);
-
-            // TODO BaggageItems are not implemented yet.
-        }
-
-        /// <summary>
-        /// Simple ITextMap implementation used for the inject/extract tests.
-        /// </summary>
-        /// <seealso cref="OpenTracing.Propagation.ITextMap" />
-        private class TextMapCarrier : ITextMap
-        {
-            private readonly Dictionary<string, string> map = new();
-
-            public IDictionary<string, string> Map => this.map;
-
-            public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => this.map.GetEnumerator();
-
-            public void Set(string key, string value)
-            {
-                this.map[key] = value;
-            }
-
-            IEnumerator IEnumerable.GetEnumerator() => this.map.GetEnumerator();
-        }
-
-        /// <summary>
-        /// Simple IBinary implementation used for the inject/extract tests.
-        /// </summary>
-        /// <seealso cref="OpenTracing.Propagation.IBinary" />
-        private class BinaryCarrier : IBinary
-        {
-            private readonly MemoryStream carrierStream = new();
-
-            public MemoryStream Get() => this.carrierStream;
-
-            public void Set(MemoryStream stream)
-            {
-                this.carrierStream.SetLength(stream.Length);
-                this.carrierStream.Seek(0, SeekOrigin.Begin);
-                stream.CopyTo(this.carrierStream, (int)this.carrierStream.Length);
-            }
+            this.carrierStream.SetLength(stream.Length);
+            this.carrierStream.Seek(0, SeekOrigin.Begin);
+            stream.CopyTo(this.carrierStream, (int)this.carrierStream.Length);
         }
     }
 }


### PR DESCRIPTION
Towards #4640 

## Changes

Update projects OpenTelemetry.Shims.OpenTracing and OpenTelemetry.Shims.OpenTracing.Tests to use file scoped namespaces.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [X] Changes in public API reviewed (if applicable)
