### PR TITLE
Update OpenTelemetry.Exporter.InMemory to use file scoped namespaces

### DIFF
--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporter.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporter.cs
@@ -14,67 +14,66 @@
 // limitations under the License.
 // </copyright>
 
-namespace OpenTelemetry.Exporter
+namespace OpenTelemetry.Exporter;
+
+public class InMemoryExporter<T> : BaseExporter<T>
+    where T : class
 {
-    public class InMemoryExporter<T> : BaseExporter<T>
-        where T : class
+    private readonly ICollection<T> exportedItems;
+    private readonly ExportFunc onExport;
+    private bool disposed;
+    private string disposedStackTrace;
+
+    public InMemoryExporter(ICollection<T> exportedItems)
     {
-        private readonly ICollection<T> exportedItems;
-        private readonly ExportFunc onExport;
-        private bool disposed;
-        private string disposedStackTrace;
+        this.exportedItems = exportedItems;
+        this.onExport = this.DefaultExport;
+    }
 
-        public InMemoryExporter(ICollection<T> exportedItems)
+    internal InMemoryExporter(ExportFunc exportFunc)
+    {
+        this.onExport = exportFunc;
+    }
+
+    internal delegate ExportResult ExportFunc(in Batch<T> batch);
+
+    public override ExportResult Export(in Batch<T> batch)
+    {
+        if (this.disposed)
         {
-            this.exportedItems = exportedItems;
-            this.onExport = this.DefaultExport;
+            // Note: In-memory exporter is designed for testing purposes so this error is strategic to surface lifecycle management bugs during development.
+            throw new ObjectDisposedException(
+                this.GetType().Name,
+                $"The in-memory exporter is still being invoked after it has been disposed. This could be the result of invalid lifecycle management of the OpenTelemetry .NET SDK. Dispose was called on the following stack trace:{Environment.NewLine}{this.disposedStackTrace}");
         }
 
-        internal InMemoryExporter(ExportFunc exportFunc)
+        return this.onExport(batch);
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (!this.disposed)
         {
-            this.onExport = exportFunc;
+            this.disposedStackTrace = Environment.StackTrace;
+            this.disposed = true;
         }
 
-        internal delegate ExportResult ExportFunc(in Batch<T> batch);
+        base.Dispose(disposing);
+    }
 
-        public override ExportResult Export(in Batch<T> batch)
+    private ExportResult DefaultExport(in Batch<T> batch)
+    {
+        if (this.exportedItems == null)
         {
-            if (this.disposed)
-            {
-                // Note: In-memory exporter is designed for testing purposes so this error is strategic to surface lifecycle management bugs during development.
-                throw new ObjectDisposedException(
-                    this.GetType().Name,
-                    $"The in-memory exporter is still being invoked after it has been disposed. This could be the result of invalid lifecycle management of the OpenTelemetry .NET SDK. Dispose was called on the following stack trace:{Environment.NewLine}{this.disposedStackTrace}");
-            }
-
-            return this.onExport(batch);
+            return ExportResult.Failure;
         }
 
-        /// <inheritdoc/>
-        protected override void Dispose(bool disposing)
+        foreach (var data in batch)
         {
-            if (!this.disposed)
-            {
-                this.disposedStackTrace = Environment.StackTrace;
-                this.disposed = true;
-            }
-
-            base.Dispose(disposing);
+            this.exportedItems.Add(data);
         }
 
-        private ExportResult DefaultExport(in Batch<T> batch)
-        {
-            if (this.exportedItems == null)
-            {
-                return ExportResult.Failure;
-            }
-
-            foreach (var data in batch)
-            {
-                this.exportedItems.Add(data);
-            }
-
-            return ExportResult.Success;
-        }
+        return ExportResult.Success;
     }
 }

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterHelperExtensions.cs
@@ -18,22 +18,21 @@ using System.Diagnostics;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Internal;
 
-namespace OpenTelemetry.Trace
-{
-    public static class InMemoryExporterHelperExtensions
-    {
-        /// <summary>
-        /// Adds InMemory exporter to the TracerProvider.
-        /// </summary>
-        /// <param name="builder"><see cref="TracerProviderBuilder"/> builder to use.</param>
-        /// <param name="exportedItems">Collection which will be populated with the exported <see cref="Activity"/>.</param>
-        /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
-        public static TracerProviderBuilder AddInMemoryExporter(this TracerProviderBuilder builder, ICollection<Activity> exportedItems)
-        {
-            Guard.ThrowIfNull(builder);
-            Guard.ThrowIfNull(exportedItems);
+namespace OpenTelemetry.Trace;
 
-            return builder.AddProcessor(new SimpleActivityExportProcessor(new InMemoryExporter<Activity>(exportedItems)));
-        }
+public static class InMemoryExporterHelperExtensions
+{
+    /// <summary>
+    /// Adds InMemory exporter to the TracerProvider.
+    /// </summary>
+    /// <param name="builder"><see cref="TracerProviderBuilder"/> builder to use.</param>
+    /// <param name="exportedItems">Collection which will be populated with the exported <see cref="Activity"/>.</param>
+    /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
+    public static TracerProviderBuilder AddInMemoryExporter(this TracerProviderBuilder builder, ICollection<Activity> exportedItems)
+    {
+        Guard.ThrowIfNull(builder);
+        Guard.ThrowIfNull(exportedItems);
+
+        return builder.AddProcessor(new SimpleActivityExportProcessor(new InMemoryExporter<Activity>(exportedItems)));
     }
 }

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterLoggingExtensions.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterLoggingExtensions.cs
@@ -17,63 +17,62 @@
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Internal;
 
-namespace OpenTelemetry.Logs
+namespace OpenTelemetry.Logs;
+
+public static class InMemoryExporterLoggingExtensions
 {
-    public static class InMemoryExporterLoggingExtensions
+    /// <summary>
+    /// Adds InMemory exporter to the OpenTelemetryLoggerOptions.
+    /// </summary>
+    /// <param name="loggerOptions"><see cref="OpenTelemetryLoggerOptions"/> options to use.</param>
+    /// <param name="exportedItems">Collection which will be populated with the exported <see cref="LogRecord"/>.</param>
+    /// <returns>The supplied instance of <see cref="OpenTelemetryLoggerOptions"/> to chain the calls.</returns>
+    /// todo: [Obsolete("Call LoggerProviderBuilder.AddInMemoryExporter instead this method will be removed in a future version.")]
+    public static OpenTelemetryLoggerOptions AddInMemoryExporter(
+        this OpenTelemetryLoggerOptions loggerOptions,
+        ICollection<LogRecord> exportedItems)
     {
-        /// <summary>
-        /// Adds InMemory exporter to the OpenTelemetryLoggerOptions.
-        /// </summary>
-        /// <param name="loggerOptions"><see cref="OpenTelemetryLoggerOptions"/> options to use.</param>
-        /// <param name="exportedItems">Collection which will be populated with the exported <see cref="LogRecord"/>.</param>
-        /// <returns>The supplied instance of <see cref="OpenTelemetryLoggerOptions"/> to chain the calls.</returns>
-        /// todo: [Obsolete("Call LoggerProviderBuilder.AddInMemoryExporter instead this method will be removed in a future version.")]
-        public static OpenTelemetryLoggerOptions AddInMemoryExporter(
-            this OpenTelemetryLoggerOptions loggerOptions,
-            ICollection<LogRecord> exportedItems)
+        Guard.ThrowIfNull(loggerOptions);
+        Guard.ThrowIfNull(exportedItems);
+
+        var logExporter = BuildExporter(exportedItems);
+
+        return loggerOptions.AddProcessor(
+            new SimpleLogRecordExportProcessor(logExporter));
+    }
+
+    /// <summary>
+    /// Adds InMemory exporter to the LoggerProviderBuilder.
+    /// </summary>
+    /// <param name="loggerProviderBuilder"><see cref="LoggerProviderBuilder"/>.</param>
+    /// <param name="exportedItems">Collection which will be populated with the exported <see cref="LogRecord"/>.</param>
+    /// <returns>The supplied instance of <see cref="LoggerProviderBuilder"/> to chain the calls.</returns>
+    public static LoggerProviderBuilder AddInMemoryExporter(
+        this LoggerProviderBuilder loggerProviderBuilder,
+        ICollection<LogRecord> exportedItems)
+    {
+        Guard.ThrowIfNull(loggerProviderBuilder);
+        Guard.ThrowIfNull(exportedItems);
+
+        var logExporter = BuildExporter(exportedItems);
+
+        return loggerProviderBuilder.AddProcessor(
+            new SimpleLogRecordExportProcessor(logExporter));
+    }
+
+    private static InMemoryExporter<LogRecord> BuildExporter(ICollection<LogRecord> exportedItems)
+    {
+        return new InMemoryExporter<LogRecord>(
+            exportFunc: (in Batch<LogRecord> batch) => ExportLogRecord(in batch, exportedItems));
+    }
+
+    private static ExportResult ExportLogRecord(in Batch<LogRecord> batch, ICollection<LogRecord> exportedItems)
+    {
+        foreach (var log in batch)
         {
-            Guard.ThrowIfNull(loggerOptions);
-            Guard.ThrowIfNull(exportedItems);
-
-            var logExporter = BuildExporter(exportedItems);
-
-            return loggerOptions.AddProcessor(
-                new SimpleLogRecordExportProcessor(logExporter));
+            exportedItems.Add(log.Copy());
         }
 
-        /// <summary>
-        /// Adds InMemory exporter to the LoggerProviderBuilder.
-        /// </summary>
-        /// <param name="loggerProviderBuilder"><see cref="LoggerProviderBuilder"/>.</param>
-        /// <param name="exportedItems">Collection which will be populated with the exported <see cref="LogRecord"/>.</param>
-        /// <returns>The supplied instance of <see cref="LoggerProviderBuilder"/> to chain the calls.</returns>
-        public static LoggerProviderBuilder AddInMemoryExporter(
-            this LoggerProviderBuilder loggerProviderBuilder,
-            ICollection<LogRecord> exportedItems)
-        {
-            Guard.ThrowIfNull(loggerProviderBuilder);
-            Guard.ThrowIfNull(exportedItems);
-
-            var logExporter = BuildExporter(exportedItems);
-
-            return loggerProviderBuilder.AddProcessor(
-                new SimpleLogRecordExportProcessor(logExporter));
-        }
-
-        private static InMemoryExporter<LogRecord> BuildExporter(ICollection<LogRecord> exportedItems)
-        {
-            return new InMemoryExporter<LogRecord>(
-                exportFunc: (in Batch<LogRecord> batch) => ExportLogRecord(in batch, exportedItems));
-        }
-
-        private static ExportResult ExportLogRecord(in Batch<LogRecord> batch, ICollection<LogRecord> exportedItems)
-        {
-            foreach (var log in batch)
-            {
-                exportedItems.Add(log.Copy());
-            }
-
-            return ExportResult.Success;
-        }
+        return ExportResult.Success;
     }
 }

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterMetricsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterMetricsExtensions.cs
@@ -19,187 +19,186 @@ using Microsoft.Extensions.Options;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Internal;
 
-namespace OpenTelemetry.Metrics
+namespace OpenTelemetry.Metrics;
+
+/// <summary>
+/// Extension methods to simplify registering of the InMemory exporter.
+/// </summary>
+public static class InMemoryExporterMetricsExtensions
 {
+    private const int DefaultExportIntervalMilliseconds = Timeout.Infinite;
+    private const int DefaultExportTimeoutMilliseconds = Timeout.Infinite;
+
     /// <summary>
-    /// Extension methods to simplify registering of the InMemory exporter.
+    /// Adds InMemory metric exporter to the <see cref="MeterProviderBuilder"/> using default options.
     /// </summary>
-    public static class InMemoryExporterMetricsExtensions
+    /// <remarks>
+    /// Be aware that <see cref="Metric"/> may continue to be updated after export.
+    /// </remarks>
+    /// <param name="builder"><see cref="MeterProviderBuilder"/> builder to use.</param>
+    /// <param name="exportedItems">Collection which will be populated with the exported <see cref="Metric"/>.</param>
+    /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
+    public static MeterProviderBuilder AddInMemoryExporter(this MeterProviderBuilder builder, ICollection<Metric> exportedItems)
+        => AddInMemoryExporter(builder, name: null, exportedItems, configureMetricReader: null);
+
+    /// <summary>
+    /// Adds InMemory metric exporter to the <see cref="MeterProviderBuilder"/>.
+    /// </summary>
+    /// <remarks>
+    /// Be aware that <see cref="Metric"/> may continue to be updated after export.
+    /// </remarks>
+    /// <param name="builder"><see cref="MeterProviderBuilder"/> builder to use.</param>
+    /// <param name="exportedItems">Collection which will be populated with the exported <see cref="Metric"/>.</param>
+    /// <param name="configureMetricReader">Callback action for configuring <see cref="MetricReaderOptions"/>.</param>
+    /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
+    public static MeterProviderBuilder AddInMemoryExporter(
+        this MeterProviderBuilder builder,
+        ICollection<Metric> exportedItems,
+        Action<MetricReaderOptions> configureMetricReader)
+        => AddInMemoryExporter(builder, name: null, exportedItems, configureMetricReader);
+
+    /// <summary>
+    /// Adds InMemory metric exporter to the <see cref="MeterProviderBuilder"/>.
+    /// </summary>
+    /// <remarks>
+    /// Be aware that <see cref="Metric"/> may continue to be updated after export.
+    /// </remarks>
+    /// <param name="builder"><see cref="MeterProviderBuilder"/> builder to use.</param>
+    /// <param name="name">Name which is used when retrieving options.</param>
+    /// <param name="exportedItems">Collection which will be populated with the exported <see cref="Metric"/>.</param>
+    /// <param name="configureMetricReader">Callback action for configuring <see cref="MetricReaderOptions"/>.</param>
+    /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
+    public static MeterProviderBuilder AddInMemoryExporter(
+        this MeterProviderBuilder builder,
+        string name,
+        ICollection<Metric> exportedItems,
+        Action<MetricReaderOptions> configureMetricReader)
     {
-        private const int DefaultExportIntervalMilliseconds = Timeout.Infinite;
-        private const int DefaultExportTimeoutMilliseconds = Timeout.Infinite;
+        Guard.ThrowIfNull(builder);
+        Guard.ThrowIfNull(exportedItems);
 
-        /// <summary>
-        /// Adds InMemory metric exporter to the <see cref="MeterProviderBuilder"/> using default options.
-        /// </summary>
-        /// <remarks>
-        /// Be aware that <see cref="Metric"/> may continue to be updated after export.
-        /// </remarks>
-        /// <param name="builder"><see cref="MeterProviderBuilder"/> builder to use.</param>
-        /// <param name="exportedItems">Collection which will be populated with the exported <see cref="Metric"/>.</param>
-        /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
-        public static MeterProviderBuilder AddInMemoryExporter(this MeterProviderBuilder builder, ICollection<Metric> exportedItems)
-            => AddInMemoryExporter(builder, name: null, exportedItems, configureMetricReader: null);
+        name ??= Options.DefaultName;
 
-        /// <summary>
-        /// Adds InMemory metric exporter to the <see cref="MeterProviderBuilder"/>.
-        /// </summary>
-        /// <remarks>
-        /// Be aware that <see cref="Metric"/> may continue to be updated after export.
-        /// </remarks>
-        /// <param name="builder"><see cref="MeterProviderBuilder"/> builder to use.</param>
-        /// <param name="exportedItems">Collection which will be populated with the exported <see cref="Metric"/>.</param>
-        /// <param name="configureMetricReader">Callback action for configuring <see cref="MetricReaderOptions"/>.</param>
-        /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
-        public static MeterProviderBuilder AddInMemoryExporter(
-            this MeterProviderBuilder builder,
-            ICollection<Metric> exportedItems,
-            Action<MetricReaderOptions> configureMetricReader)
-            => AddInMemoryExporter(builder, name: null, exportedItems, configureMetricReader);
-
-        /// <summary>
-        /// Adds InMemory metric exporter to the <see cref="MeterProviderBuilder"/>.
-        /// </summary>
-        /// <remarks>
-        /// Be aware that <see cref="Metric"/> may continue to be updated after export.
-        /// </remarks>
-        /// <param name="builder"><see cref="MeterProviderBuilder"/> builder to use.</param>
-        /// <param name="name">Name which is used when retrieving options.</param>
-        /// <param name="exportedItems">Collection which will be populated with the exported <see cref="Metric"/>.</param>
-        /// <param name="configureMetricReader">Callback action for configuring <see cref="MetricReaderOptions"/>.</param>
-        /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
-        public static MeterProviderBuilder AddInMemoryExporter(
-            this MeterProviderBuilder builder,
-            string name,
-            ICollection<Metric> exportedItems,
-            Action<MetricReaderOptions> configureMetricReader)
+        if (configureMetricReader != null)
         {
-            Guard.ThrowIfNull(builder);
-            Guard.ThrowIfNull(exportedItems);
-
-            name ??= Options.DefaultName;
-
-            if (configureMetricReader != null)
-            {
-                builder.ConfigureServices(services => services.Configure(name, configureMetricReader));
-            }
-
-            return builder.AddReader(sp =>
-            {
-                var options = sp.GetRequiredService<IOptionsMonitor<MetricReaderOptions>>().Get(name);
-
-                return BuildInMemoryExporterMetricReader(exportedItems, options);
-            });
+            builder.ConfigureServices(services => services.Configure(name, configureMetricReader));
         }
 
-        /// <summary>
-        /// Adds InMemory metric exporter to the <see cref="MeterProviderBuilder"/> using default options.
-        /// The exporter will be setup to export <see cref="MetricSnapshot"/>.
-        /// </summary>
-        /// <remarks>
-        /// Use this if you need a copy of <see cref="Metric"/> that will not be updated after export.
-        /// </remarks>
-        /// <param name="builder"><see cref="MeterProviderBuilder"/> builder to use.</param>
-        /// <param name="exportedItems">Collection which will be populated with the exported <see cref="Metric"/> represented as <see cref="MetricSnapshot"/>.</param>
-        /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
-        public static MeterProviderBuilder AddInMemoryExporter(
-            this MeterProviderBuilder builder,
-            ICollection<MetricSnapshot> exportedItems)
-            => AddInMemoryExporter(builder, name: null, exportedItems, configureMetricReader: null);
-
-        /// <summary>
-        /// Adds InMemory metric exporter to the <see cref="MeterProviderBuilder"/>.
-        /// The exporter will be setup to export <see cref="MetricSnapshot"/>.
-        /// </summary>
-        /// <remarks>
-        /// Use this if you need a copy of <see cref="Metric"/> that will not be updated after export.
-        /// </remarks>
-        /// <param name="builder"><see cref="MeterProviderBuilder"/> builder to use.</param>
-        /// <param name="exportedItems">Collection which will be populated with the exported <see cref="Metric"/> represented as <see cref="MetricSnapshot"/>.</param>
-        /// <param name="configureMetricReader">Callback action for configuring <see cref="MetricReaderOptions"/>.</param>
-        /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
-        public static MeterProviderBuilder AddInMemoryExporter(
-            this MeterProviderBuilder builder,
-            ICollection<MetricSnapshot> exportedItems,
-            Action<MetricReaderOptions> configureMetricReader)
-            => AddInMemoryExporter(builder, name: null, exportedItems, configureMetricReader);
-
-        /// <summary>
-        /// Adds InMemory metric exporter to the <see cref="MeterProviderBuilder"/>.
-        /// The exporter will be setup to export <see cref="MetricSnapshot"/>.
-        /// </summary>
-        /// <remarks>
-        /// Use this if you need a copy of <see cref="Metric"/> that will not be updated after export.
-        /// </remarks>
-        /// <param name="builder"><see cref="MeterProviderBuilder"/> builder to use.</param>
-        /// <param name="name">Name which is used when retrieving options.</param>
-        /// <param name="exportedItems">Collection which will be populated with the exported <see cref="Metric"/> represented as <see cref="MetricSnapshot"/>.</param>
-        /// <param name="configureMetricReader">Callback action for configuring <see cref="MetricReaderOptions"/>.</param>
-        /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
-        public static MeterProviderBuilder AddInMemoryExporter(
-            this MeterProviderBuilder builder,
-            string name,
-            ICollection<MetricSnapshot> exportedItems,
-            Action<MetricReaderOptions> configureMetricReader)
+        return builder.AddReader(sp =>
         {
-            Guard.ThrowIfNull(builder);
-            Guard.ThrowIfNull(exportedItems);
+            var options = sp.GetRequiredService<IOptionsMonitor<MetricReaderOptions>>().Get(name);
 
-            name ??= Options.DefaultName;
+            return BuildInMemoryExporterMetricReader(exportedItems, options);
+        });
+    }
 
-            if (configureMetricReader != null)
-            {
-                builder.ConfigureServices(services => services.Configure(name, configureMetricReader));
-            }
+    /// <summary>
+    /// Adds InMemory metric exporter to the <see cref="MeterProviderBuilder"/> using default options.
+    /// The exporter will be setup to export <see cref="MetricSnapshot"/>.
+    /// </summary>
+    /// <remarks>
+    /// Use this if you need a copy of <see cref="Metric"/> that will not be updated after export.
+    /// </remarks>
+    /// <param name="builder"><see cref="MeterProviderBuilder"/> builder to use.</param>
+    /// <param name="exportedItems">Collection which will be populated with the exported <see cref="Metric"/> represented as <see cref="MetricSnapshot"/>.</param>
+    /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
+    public static MeterProviderBuilder AddInMemoryExporter(
+        this MeterProviderBuilder builder,
+        ICollection<MetricSnapshot> exportedItems)
+        => AddInMemoryExporter(builder, name: null, exportedItems, configureMetricReader: null);
 
-            return builder.AddReader(sp =>
-            {
-                var options = sp.GetRequiredService<IOptionsMonitor<MetricReaderOptions>>().Get(name);
+    /// <summary>
+    /// Adds InMemory metric exporter to the <see cref="MeterProviderBuilder"/>.
+    /// The exporter will be setup to export <see cref="MetricSnapshot"/>.
+    /// </summary>
+    /// <remarks>
+    /// Use this if you need a copy of <see cref="Metric"/> that will not be updated after export.
+    /// </remarks>
+    /// <param name="builder"><see cref="MeterProviderBuilder"/> builder to use.</param>
+    /// <param name="exportedItems">Collection which will be populated with the exported <see cref="Metric"/> represented as <see cref="MetricSnapshot"/>.</param>
+    /// <param name="configureMetricReader">Callback action for configuring <see cref="MetricReaderOptions"/>.</param>
+    /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
+    public static MeterProviderBuilder AddInMemoryExporter(
+        this MeterProviderBuilder builder,
+        ICollection<MetricSnapshot> exportedItems,
+        Action<MetricReaderOptions> configureMetricReader)
+        => AddInMemoryExporter(builder, name: null, exportedItems, configureMetricReader);
 
-                return BuildInMemoryExporterMetricReader(exportedItems, options);
-            });
+    /// <summary>
+    /// Adds InMemory metric exporter to the <see cref="MeterProviderBuilder"/>.
+    /// The exporter will be setup to export <see cref="MetricSnapshot"/>.
+    /// </summary>
+    /// <remarks>
+    /// Use this if you need a copy of <see cref="Metric"/> that will not be updated after export.
+    /// </remarks>
+    /// <param name="builder"><see cref="MeterProviderBuilder"/> builder to use.</param>
+    /// <param name="name">Name which is used when retrieving options.</param>
+    /// <param name="exportedItems">Collection which will be populated with the exported <see cref="Metric"/> represented as <see cref="MetricSnapshot"/>.</param>
+    /// <param name="configureMetricReader">Callback action for configuring <see cref="MetricReaderOptions"/>.</param>
+    /// <returns>The instance of <see cref="MeterProviderBuilder"/> to chain the calls.</returns>
+    public static MeterProviderBuilder AddInMemoryExporter(
+        this MeterProviderBuilder builder,
+        string name,
+        ICollection<MetricSnapshot> exportedItems,
+        Action<MetricReaderOptions> configureMetricReader)
+    {
+        Guard.ThrowIfNull(builder);
+        Guard.ThrowIfNull(exportedItems);
+
+        name ??= Options.DefaultName;
+
+        if (configureMetricReader != null)
+        {
+            builder.ConfigureServices(services => services.Configure(name, configureMetricReader));
         }
 
-        private static MetricReader BuildInMemoryExporterMetricReader(
-            ICollection<Metric> exportedItems,
-            MetricReaderOptions metricReaderOptions)
+        return builder.AddReader(sp =>
         {
-            var metricExporter = new InMemoryExporter<Metric>(exportedItems);
+            var options = sp.GetRequiredService<IOptionsMonitor<MetricReaderOptions>>().Get(name);
 
-            return PeriodicExportingMetricReaderHelper.CreatePeriodicExportingMetricReader(
-                metricExporter,
-                metricReaderOptions,
-                DefaultExportIntervalMilliseconds,
-                DefaultExportTimeoutMilliseconds);
+            return BuildInMemoryExporterMetricReader(exportedItems, options);
+        });
+    }
+
+    private static MetricReader BuildInMemoryExporterMetricReader(
+        ICollection<Metric> exportedItems,
+        MetricReaderOptions metricReaderOptions)
+    {
+        var metricExporter = new InMemoryExporter<Metric>(exportedItems);
+
+        return PeriodicExportingMetricReaderHelper.CreatePeriodicExportingMetricReader(
+            metricExporter,
+            metricReaderOptions,
+            DefaultExportIntervalMilliseconds,
+            DefaultExportTimeoutMilliseconds);
+    }
+
+    private static MetricReader BuildInMemoryExporterMetricReader(
+        ICollection<MetricSnapshot> exportedItems,
+        MetricReaderOptions metricReaderOptions)
+    {
+        var metricExporter = new InMemoryExporter<Metric>(
+            exportFunc: (in Batch<Metric> metricBatch) => ExportMetricSnapshot(in metricBatch, exportedItems));
+
+        return PeriodicExportingMetricReaderHelper.CreatePeriodicExportingMetricReader(
+            metricExporter,
+            metricReaderOptions,
+            DefaultExportIntervalMilliseconds,
+            DefaultExportTimeoutMilliseconds);
+    }
+
+    private static ExportResult ExportMetricSnapshot(in Batch<Metric> batch, ICollection<MetricSnapshot> exportedItems)
+    {
+        if (exportedItems == null)
+        {
+            return ExportResult.Failure;
         }
 
-        private static MetricReader BuildInMemoryExporterMetricReader(
-            ICollection<MetricSnapshot> exportedItems,
-            MetricReaderOptions metricReaderOptions)
+        foreach (var metric in batch)
         {
-            var metricExporter = new InMemoryExporter<Metric>(
-                exportFunc: (in Batch<Metric> metricBatch) => ExportMetricSnapshot(in metricBatch, exportedItems));
-
-            return PeriodicExportingMetricReaderHelper.CreatePeriodicExportingMetricReader(
-                metricExporter,
-                metricReaderOptions,
-                DefaultExportIntervalMilliseconds,
-                DefaultExportTimeoutMilliseconds);
+            exportedItems.Add(new MetricSnapshot(metric));
         }
 
-        private static ExportResult ExportMetricSnapshot(in Batch<Metric> batch, ICollection<MetricSnapshot> exportedItems)
-        {
-            if (exportedItems == null)
-            {
-                return ExportResult.Failure;
-            }
-
-            foreach (var metric in batch)
-            {
-                exportedItems.Add(new MetricSnapshot(metric));
-            }
-
-            return ExportResult.Success;
-        }
+        return ExportResult.Success;
     }
 }

--- a/src/OpenTelemetry.Exporter.InMemory/MetricSnapshot.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/MetricSnapshot.cs
@@ -14,43 +14,42 @@
 // limitations under the License.
 // </copyright>
 
-namespace OpenTelemetry.Metrics
+namespace OpenTelemetry.Metrics;
+
+/// <summary>
+/// This class represents a selective copy of <see cref="Metric"/>.
+/// This contains the minimum fields and properties needed for most
+/// unit testing scenarios.
+/// </summary>
+public class MetricSnapshot
 {
-    /// <summary>
-    /// This class represents a selective copy of <see cref="Metric"/>.
-    /// This contains the minimum fields and properties needed for most
-    /// unit testing scenarios.
-    /// </summary>
-    public class MetricSnapshot
+    private readonly MetricStreamIdentity instrumentIdentity;
+
+    public MetricSnapshot(Metric metric)
     {
-        private readonly MetricStreamIdentity instrumentIdentity;
+        this.instrumentIdentity = metric.InstrumentIdentity;
+        this.MetricType = metric.MetricType;
 
-        public MetricSnapshot(Metric metric)
+        List<MetricPoint> metricPoints = new();
+        foreach (ref readonly var metricPoint in metric.GetMetricPoints())
         {
-            this.instrumentIdentity = metric.InstrumentIdentity;
-            this.MetricType = metric.MetricType;
-
-            List<MetricPoint> metricPoints = new();
-            foreach (ref readonly var metricPoint in metric.GetMetricPoints())
-            {
-                metricPoints.Add(metricPoint.Copy());
-            }
-
-            this.MetricPoints = metricPoints;
+            metricPoints.Add(metricPoint.Copy());
         }
 
-        public string Name => this.instrumentIdentity.InstrumentName;
-
-        public string Description => this.instrumentIdentity.Description;
-
-        public string Unit => this.instrumentIdentity.Unit;
-
-        public string MeterName => this.instrumentIdentity.MeterName;
-
-        public MetricType MetricType { get; }
-
-        public string MeterVersion => this.instrumentIdentity.MeterVersion;
-
-        public IReadOnlyList<MetricPoint> MetricPoints { get; }
+        this.MetricPoints = metricPoints;
     }
+
+    public string Name => this.instrumentIdentity.InstrumentName;
+
+    public string Description => this.instrumentIdentity.Description;
+
+    public string Unit => this.instrumentIdentity.Unit;
+
+    public string MeterName => this.instrumentIdentity.MeterName;
+
+    public MetricType MetricType { get; }
+
+    public string MeterVersion => this.instrumentIdentity.MeterVersion;
+
+    public IReadOnlyList<MetricPoint> MetricPoints { get; }
 }


### PR DESCRIPTION
Towards #4640 

## Changes

Update project OpenTelemetry.Exporter.InMemory to use file scoped namespaces.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [X] Changes in public API reviewed (if applicable)
