### PR TITLE
Update project OpenTelemetry.Exporter.Jaeger to use file scoped namespaces

### DIFF
--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/IJaegerClient.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/IJaegerClient.cs
@@ -14,16 +14,15 @@
 // limitations under the License.
 // </copyright>
 
-namespace OpenTelemetry.Exporter.Jaeger.Implementation
+namespace OpenTelemetry.Exporter.Jaeger.Implementation;
+
+internal interface IJaegerClient : IDisposable
 {
-    internal interface IJaegerClient : IDisposable
-    {
-        bool Connected { get; }
+    bool Connected { get; }
 
-        void Connect();
+    void Connect();
 
-        void Close();
+    void Close();
 
-        int Send(byte[] buffer, int offset, int count);
-    }
+    int Send(byte[] buffer, int offset, int count);
 }

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/Int128.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/Int128.cs
@@ -17,47 +17,46 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 
-namespace OpenTelemetry.Exporter.Jaeger.Implementation
+namespace OpenTelemetry.Exporter.Jaeger.Implementation;
+
+internal readonly struct Int128
 {
-    internal readonly struct Int128
+    public static Int128 Empty;
+
+    private const int SpanIdBytes = 8;
+    private const int TraceIdBytes = 16;
+
+    public Int128(ActivitySpanId spanId)
     {
-        public static Int128 Empty;
+        Span<byte> bytes = stackalloc byte[SpanIdBytes];
+        spanId.CopyTo(bytes);
 
-        private const int SpanIdBytes = 8;
-        private const int TraceIdBytes = 16;
-
-        public Int128(ActivitySpanId spanId)
+        if (BitConverter.IsLittleEndian)
         {
-            Span<byte> bytes = stackalloc byte[SpanIdBytes];
-            spanId.CopyTo(bytes);
-
-            if (BitConverter.IsLittleEndian)
-            {
-                bytes.Reverse();
-            }
-
-            var longs = MemoryMarshal.Cast<byte, long>(bytes);
-            this.High = 0;
-            this.Low = longs[0];
+            bytes.Reverse();
         }
 
-        public Int128(ActivityTraceId traceId)
-        {
-            Span<byte> bytes = stackalloc byte[TraceIdBytes];
-            traceId.CopyTo(bytes);
-
-            if (BitConverter.IsLittleEndian)
-            {
-                bytes.Reverse();
-            }
-
-            var longs = MemoryMarshal.Cast<byte, long>(bytes);
-            this.High = BitConverter.IsLittleEndian ? longs[1] : longs[0];
-            this.Low = BitConverter.IsLittleEndian ? longs[0] : longs[1];
-        }
-
-        public long High { get; }
-
-        public long Low { get; }
+        var longs = MemoryMarshal.Cast<byte, long>(bytes);
+        this.High = 0;
+        this.Low = longs[0];
     }
+
+    public Int128(ActivityTraceId traceId)
+    {
+        Span<byte> bytes = stackalloc byte[TraceIdBytes];
+        traceId.CopyTo(bytes);
+
+        if (BitConverter.IsLittleEndian)
+        {
+            bytes.Reverse();
+        }
+
+        var longs = MemoryMarshal.Cast<byte, long>(bytes);
+        this.High = BitConverter.IsLittleEndian ? longs[1] : longs[0];
+        this.Low = BitConverter.IsLittleEndian ? longs[0] : longs[1];
+    }
+
+    public long High { get; }
+
+    public long Low { get; }
 }

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerActivityExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerActivityExtensions.cs
@@ -19,357 +19,356 @@ using System.Runtime.CompilerServices;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
 
-namespace OpenTelemetry.Exporter.Jaeger.Implementation
+namespace OpenTelemetry.Exporter.Jaeger.Implementation;
+
+internal static class JaegerActivityExtensions
 {
-    internal static class JaegerActivityExtensions
+    internal const string JaegerErrorFlagTagName = "error";
+
+    private const int DaysPerYear = 365;
+
+    // Number of days in 4 years
+    private const int DaysPer4Years = (DaysPerYear * 4) + 1;       // 1461
+
+    // Number of days in 100 years
+    private const int DaysPer100Years = (DaysPer4Years * 25) - 1;  // 36524
+
+    // Number of days in 400 years
+    private const int DaysPer400Years = (DaysPer100Years * 4) + 1; // 146097
+
+    // Number of days from 1/1/0001 to 12/31/1969
+    private const int DaysTo1970 = (DaysPer400Years * 4) + (DaysPer100Years * 3) + (DaysPer4Years * 17) + DaysPerYear; // 719,162
+
+    private const long UnixEpochTicks = DaysTo1970 * TimeSpan.TicksPerDay;
+    private const long TicksPerMicrosecond = TimeSpan.TicksPerMillisecond / 1000;
+    private const long UnixEpochMicroseconds = UnixEpochTicks / TicksPerMicrosecond; // 62,135,596,800,000,000
+
+    public static JaegerSpan ToJaegerSpan(this Activity activity)
     {
-        internal const string JaegerErrorFlagTagName = "error";
-
-        private const int DaysPerYear = 365;
-
-        // Number of days in 4 years
-        private const int DaysPer4Years = (DaysPerYear * 4) + 1;       // 1461
-
-        // Number of days in 100 years
-        private const int DaysPer100Years = (DaysPer4Years * 25) - 1;  // 36524
-
-        // Number of days in 400 years
-        private const int DaysPer400Years = (DaysPer100Years * 4) + 1; // 146097
-
-        // Number of days from 1/1/0001 to 12/31/1969
-        private const int DaysTo1970 = (DaysPer400Years * 4) + (DaysPer100Years * 3) + (DaysPer4Years * 17) + DaysPerYear; // 719,162
-
-        private const long UnixEpochTicks = DaysTo1970 * TimeSpan.TicksPerDay;
-        private const long TicksPerMicrosecond = TimeSpan.TicksPerMillisecond / 1000;
-        private const long UnixEpochMicroseconds = UnixEpochTicks / TicksPerMicrosecond; // 62,135,596,800,000,000
-
-        public static JaegerSpan ToJaegerSpan(this Activity activity)
+        var jaegerTags = new TagEnumerationState
         {
-            var jaegerTags = new TagEnumerationState
-            {
-                Tags = PooledList<JaegerTag>.Create(),
-            };
+            Tags = PooledList<JaegerTag>.Create(),
+        };
 
-            jaegerTags.EnumerateTags(activity);
+        jaegerTags.EnumerateTags(activity);
 
-            if (activity.Status != ActivityStatusCode.Unset)
-            {
-                if (activity.Status == ActivityStatusCode.Ok)
-                {
-                    PooledList<JaegerTag>.Add(
-                        ref jaegerTags.Tags,
-                        new JaegerTag(SpanAttributeConstants.StatusCodeKey, JaegerTagType.STRING, vStr: "OK"));
-                }
-                else
-                {
-                    PooledList<JaegerTag>.Add(
-                        ref jaegerTags.Tags,
-                        new JaegerTag(SpanAttributeConstants.StatusCodeKey, JaegerTagType.STRING, vStr: "ERROR"));
-
-                    PooledList<JaegerTag>.Add(
-                        ref jaegerTags.Tags,
-                        new JaegerTag(JaegerErrorFlagTagName, JaegerTagType.BOOL, vBool: true));
-
-                    PooledList<JaegerTag>.Add(
-                        ref jaegerTags.Tags,
-                        new JaegerTag(SpanAttributeConstants.StatusDescriptionKey, JaegerTagType.STRING, vStr: activity.StatusDescription ?? string.Empty));
-                }
-            }
-            else if (jaegerTags.StatusCode.HasValue && jaegerTags.StatusCode != StatusCode.Unset)
+        if (activity.Status != ActivityStatusCode.Unset)
+        {
+            if (activity.Status == ActivityStatusCode.Ok)
             {
                 PooledList<JaegerTag>.Add(
-                        ref jaegerTags.Tags,
-                        new JaegerTag(
-                            SpanAttributeConstants.StatusCodeKey,
-                            JaegerTagType.STRING,
-                            vStr: StatusHelper.GetTagValueForStatusCode(jaegerTags.StatusCode.Value)));
+                    ref jaegerTags.Tags,
+                    new JaegerTag(SpanAttributeConstants.StatusCodeKey, JaegerTagType.STRING, vStr: "OK"));
+            }
+            else
+            {
+                PooledList<JaegerTag>.Add(
+                    ref jaegerTags.Tags,
+                    new JaegerTag(SpanAttributeConstants.StatusCodeKey, JaegerTagType.STRING, vStr: "ERROR"));
 
-                if (jaegerTags.StatusCode == StatusCode.Error)
-                {
-                    PooledList<JaegerTag>.Add(
-                        ref jaegerTags.Tags,
-                        new JaegerTag(JaegerErrorFlagTagName, JaegerTagType.BOOL, vBool: true));
+                PooledList<JaegerTag>.Add(
+                    ref jaegerTags.Tags,
+                    new JaegerTag(JaegerErrorFlagTagName, JaegerTagType.BOOL, vBool: true));
 
-                    PooledList<JaegerTag>.Add(
-                        ref jaegerTags.Tags,
-                        new JaegerTag(SpanAttributeConstants.StatusDescriptionKey, JaegerTagType.STRING, vStr: jaegerTags.StatusDescription ?? string.Empty));
-                }
+                PooledList<JaegerTag>.Add(
+                    ref jaegerTags.Tags,
+                    new JaegerTag(SpanAttributeConstants.StatusDescriptionKey, JaegerTagType.STRING, vStr: activity.StatusDescription ?? string.Empty));
+            }
+        }
+        else if (jaegerTags.StatusCode.HasValue && jaegerTags.StatusCode != StatusCode.Unset)
+        {
+            PooledList<JaegerTag>.Add(
+                    ref jaegerTags.Tags,
+                    new JaegerTag(
+                        SpanAttributeConstants.StatusCodeKey,
+                        JaegerTagType.STRING,
+                        vStr: StatusHelper.GetTagValueForStatusCode(jaegerTags.StatusCode.Value)));
+
+            if (jaegerTags.StatusCode == StatusCode.Error)
+            {
+                PooledList<JaegerTag>.Add(
+                    ref jaegerTags.Tags,
+                    new JaegerTag(JaegerErrorFlagTagName, JaegerTagType.BOOL, vBool: true));
+
+                PooledList<JaegerTag>.Add(
+                    ref jaegerTags.Tags,
+                    new JaegerTag(SpanAttributeConstants.StatusDescriptionKey, JaegerTagType.STRING, vStr: jaegerTags.StatusDescription ?? string.Empty));
+            }
+        }
+
+        string peerServiceName = null;
+        if (activity.Kind == ActivityKind.Client || activity.Kind == ActivityKind.Producer)
+        {
+            PeerServiceResolver.Resolve(ref jaegerTags, out peerServiceName, out bool addAsTag);
+
+            if (peerServiceName != null && addAsTag)
+            {
+                PooledList<JaegerTag>.Add(ref jaegerTags.Tags, new JaegerTag(SemanticConventions.AttributePeerService, JaegerTagType.STRING, vStr: peerServiceName));
+            }
+        }
+
+        // The Span.Kind must translate into a tag.
+        // See https://opentracing.io/specification/conventions/
+        if (activity.Kind != ActivityKind.Internal)
+        {
+            string spanKind = null;
+
+            if (activity.Kind == ActivityKind.Server)
+            {
+                spanKind = "server";
+            }
+            else if (activity.Kind == ActivityKind.Client)
+            {
+                spanKind = "client";
+            }
+            else if (activity.Kind == ActivityKind.Consumer)
+            {
+                spanKind = "consumer";
+            }
+            else if (activity.Kind == ActivityKind.Producer)
+            {
+                spanKind = "producer";
             }
 
-            string peerServiceName = null;
-            if (activity.Kind == ActivityKind.Client || activity.Kind == ActivityKind.Producer)
+            if (spanKind != null)
             {
-                PeerServiceResolver.Resolve(ref jaegerTags, out peerServiceName, out bool addAsTag);
-
-                if (peerServiceName != null && addAsTag)
-                {
-                    PooledList<JaegerTag>.Add(ref jaegerTags.Tags, new JaegerTag(SemanticConventions.AttributePeerService, JaegerTagType.STRING, vStr: peerServiceName));
-                }
+                PooledList<JaegerTag>.Add(ref jaegerTags.Tags, new JaegerTag("span.kind", JaegerTagType.STRING, vStr: spanKind));
             }
+        }
 
-            // The Span.Kind must translate into a tag.
-            // See https://opentracing.io/specification/conventions/
-            if (activity.Kind != ActivityKind.Internal)
+        var activitySource = activity.Source;
+        if (!string.IsNullOrEmpty(activitySource.Name))
+        {
+            PooledList<JaegerTag>.Add(ref jaegerTags.Tags, new JaegerTag("otel.library.name", JaegerTagType.STRING, vStr: activitySource.Name));
+            if (!string.IsNullOrEmpty(activitySource.Version))
             {
-                string spanKind = null;
-
-                if (activity.Kind == ActivityKind.Server)
-                {
-                    spanKind = "server";
-                }
-                else if (activity.Kind == ActivityKind.Client)
-                {
-                    spanKind = "client";
-                }
-                else if (activity.Kind == ActivityKind.Consumer)
-                {
-                    spanKind = "consumer";
-                }
-                else if (activity.Kind == ActivityKind.Producer)
-                {
-                    spanKind = "producer";
-                }
-
-                if (spanKind != null)
-                {
-                    PooledList<JaegerTag>.Add(ref jaegerTags.Tags, new JaegerTag("span.kind", JaegerTagType.STRING, vStr: spanKind));
-                }
+                PooledList<JaegerTag>.Add(ref jaegerTags.Tags, new JaegerTag("otel.library.version", JaegerTagType.STRING, vStr: activitySource.Version));
             }
+        }
 
-            var activitySource = activity.Source;
-            if (!string.IsNullOrEmpty(activitySource.Name))
+        var traceId = Int128.Empty;
+        var spanId = Int128.Empty;
+        var parentSpanId = Int128.Empty;
+
+        if (activity.IdFormat == ActivityIdFormat.W3C)
+        {
+            // TODO: The check above should be enforced by the usage of the exporter. Perhaps enforce at higher-level.
+            traceId = new Int128(activity.TraceId);
+            spanId = new Int128(activity.SpanId);
+            if (activity.ParentSpanId != default)
             {
-                PooledList<JaegerTag>.Add(ref jaegerTags.Tags, new JaegerTag("otel.library.name", JaegerTagType.STRING, vStr: activitySource.Name));
-                if (!string.IsNullOrEmpty(activitySource.Version))
-                {
-                    PooledList<JaegerTag>.Add(ref jaegerTags.Tags, new JaegerTag("otel.library.version", JaegerTagType.STRING, vStr: activitySource.Version));
-                }
+                parentSpanId = new Int128(activity.ParentSpanId);
             }
+        }
 
-            var traceId = Int128.Empty;
-            var spanId = Int128.Empty;
-            var parentSpanId = Int128.Empty;
+        return new JaegerSpan(
+            peerServiceName: peerServiceName,
+            traceIdLow: traceId.Low,
+            traceIdHigh: traceId.High,
+            spanId: spanId.Low,
+            parentSpanId: parentSpanId.Low,
+            operationName: activity.DisplayName,
+            flags: (activity.Context.TraceFlags & ActivityTraceFlags.Recorded) > 0 ? 0x1 : 0,
+            startTime: ToEpochMicroseconds(activity.StartTimeUtc),
+            duration: activity.Duration.Ticks / TicksPerMicrosecond,
+            references: activity.ToJaegerSpanRefs(),
+            tags: jaegerTags.Tags,
+            logs: activity.ToJaegerLogs());
+    }
 
-            if (activity.IdFormat == ActivityIdFormat.W3C)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static PooledList<JaegerSpanRef> ToJaegerSpanRefs(this Activity activity)
+    {
+        LinkEnumerationState references = default;
+
+        references.EnumerateLinks(activity);
+
+        return references.SpanRefs;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static PooledList<JaegerLog> ToJaegerLogs(this Activity activity)
+    {
+        EventEnumerationState logs = default;
+
+        logs.EnumerateEvents(activity);
+
+        return logs.Logs;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static JaegerLog ToJaegerLog(this in ActivityEvent timedEvent)
+    {
+        var jaegerTags = new EventTagsEnumerationState
+        {
+            Tags = PooledList<JaegerTag>.Create(),
+        };
+
+        jaegerTags.EnumerateTags(in timedEvent);
+
+        if (!jaegerTags.HasEvent)
+        {
+            // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/jaeger.md#events
+            PooledList<JaegerTag>.Add(ref jaegerTags.Tags, new JaegerTag("event", JaegerTagType.STRING, vStr: timedEvent.Name));
+        }
+
+        // TODO: Use the same function as JaegerConversionExtensions or check that the perf here is acceptable.
+        return new JaegerLog(timedEvent.Timestamp.ToEpochMicroseconds(), jaegerTags.Tags);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static JaegerSpanRef ToJaegerSpanRef(this in ActivityLink link)
+    {
+        var traceId = new Int128(link.Context.TraceId);
+        var spanId = new Int128(link.Context.SpanId);
+
+        // Assume FOLLOWS_FROM for links, mirrored from Java: https://github.com/open-telemetry/opentelemetry-java/pull/481#discussion_r312577862
+        var refType = JaegerSpanRefType.FOLLOWS_FROM;
+
+        return new JaegerSpanRef(refType, traceId.Low, traceId.High, spanId.Low);
+    }
+
+    public static long ToEpochMicroseconds(this DateTime utcDateTime)
+    {
+        // Truncate sub-microsecond precision before offsetting by the Unix Epoch to avoid
+        // the last digit being off by one for dates that result in negative Unix times
+        long microseconds = utcDateTime.Ticks / TicksPerMicrosecond;
+        return microseconds - UnixEpochMicroseconds;
+    }
+
+    public static long ToEpochMicroseconds(this DateTimeOffset timestamp)
+    {
+        // Truncate sub-microsecond precision before offsetting by the Unix Epoch to avoid
+        // the last digit being off by one for dates that result in negative Unix times
+        long microseconds = timestamp.UtcDateTime.Ticks / TicksPerMicrosecond;
+        return microseconds - UnixEpochMicroseconds;
+    }
+
+    private struct TagEnumerationState : PeerServiceResolver.IPeerServiceState
+    {
+        public PooledList<JaegerTag> Tags;
+
+        public string PeerService { get; set; }
+
+        public int? PeerServicePriority { get; set; }
+
+        public string HostName { get; set; }
+
+        public string IpAddress { get; set; }
+
+        public long Port { get; set; }
+
+        public StatusCode? StatusCode { get; set; }
+
+        public string StatusDescription { get; set; }
+
+        public void EnumerateTags(Activity activity)
+        {
+            foreach (ref readonly var tag in activity.EnumerateTagObjects())
             {
-                // TODO: The check above should be enforced by the usage of the exporter. Perhaps enforce at higher-level.
-                traceId = new Int128(activity.TraceId);
-                spanId = new Int128(activity.SpanId);
-                if (activity.ParentSpanId != default)
+                if (tag.Value != null)
                 {
-                    parentSpanId = new Int128(activity.ParentSpanId);
-                }
-            }
+                    var key = tag.Key;
 
-            return new JaegerSpan(
-                peerServiceName: peerServiceName,
-                traceIdLow: traceId.Low,
-                traceIdHigh: traceId.High,
-                spanId: spanId.Low,
-                parentSpanId: parentSpanId.Low,
-                operationName: activity.DisplayName,
-                flags: (activity.Context.TraceFlags & ActivityTraceFlags.Recorded) > 0 ? 0x1 : 0,
-                startTime: ToEpochMicroseconds(activity.StartTimeUtc),
-                duration: activity.Duration.Ticks / TicksPerMicrosecond,
-                references: activity.ToJaegerSpanRefs(),
-                tags: jaegerTags.Tags,
-                logs: activity.ToJaegerLogs());
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static PooledList<JaegerSpanRef> ToJaegerSpanRefs(this Activity activity)
-        {
-            LinkEnumerationState references = default;
-
-            references.EnumerateLinks(activity);
-
-            return references.SpanRefs;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static PooledList<JaegerLog> ToJaegerLogs(this Activity activity)
-        {
-            EventEnumerationState logs = default;
-
-            logs.EnumerateEvents(activity);
-
-            return logs.Logs;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static JaegerLog ToJaegerLog(this in ActivityEvent timedEvent)
-        {
-            var jaegerTags = new EventTagsEnumerationState
-            {
-                Tags = PooledList<JaegerTag>.Create(),
-            };
-
-            jaegerTags.EnumerateTags(in timedEvent);
-
-            if (!jaegerTags.HasEvent)
-            {
-                // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/jaeger.md#events
-                PooledList<JaegerTag>.Add(ref jaegerTags.Tags, new JaegerTag("event", JaegerTagType.STRING, vStr: timedEvent.Name));
-            }
-
-            // TODO: Use the same function as JaegerConversionExtensions or check that the perf here is acceptable.
-            return new JaegerLog(timedEvent.Timestamp.ToEpochMicroseconds(), jaegerTags.Tags);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static JaegerSpanRef ToJaegerSpanRef(this in ActivityLink link)
-        {
-            var traceId = new Int128(link.Context.TraceId);
-            var spanId = new Int128(link.Context.SpanId);
-
-            // Assume FOLLOWS_FROM for links, mirrored from Java: https://github.com/open-telemetry/opentelemetry-java/pull/481#discussion_r312577862
-            var refType = JaegerSpanRefType.FOLLOWS_FROM;
-
-            return new JaegerSpanRef(refType, traceId.Low, traceId.High, spanId.Low);
-        }
-
-        public static long ToEpochMicroseconds(this DateTime utcDateTime)
-        {
-            // Truncate sub-microsecond precision before offsetting by the Unix Epoch to avoid
-            // the last digit being off by one for dates that result in negative Unix times
-            long microseconds = utcDateTime.Ticks / TicksPerMicrosecond;
-            return microseconds - UnixEpochMicroseconds;
-        }
-
-        public static long ToEpochMicroseconds(this DateTimeOffset timestamp)
-        {
-            // Truncate sub-microsecond precision before offsetting by the Unix Epoch to avoid
-            // the last digit being off by one for dates that result in negative Unix times
-            long microseconds = timestamp.UtcDateTime.Ticks / TicksPerMicrosecond;
-            return microseconds - UnixEpochMicroseconds;
-        }
-
-        private struct TagEnumerationState : PeerServiceResolver.IPeerServiceState
-        {
-            public PooledList<JaegerTag> Tags;
-
-            public string PeerService { get; set; }
-
-            public int? PeerServicePriority { get; set; }
-
-            public string HostName { get; set; }
-
-            public string IpAddress { get; set; }
-
-            public long Port { get; set; }
-
-            public StatusCode? StatusCode { get; set; }
-
-            public string StatusDescription { get; set; }
-
-            public void EnumerateTags(Activity activity)
-            {
-                foreach (ref readonly var tag in activity.EnumerateTagObjects())
-                {
-                    if (tag.Value != null)
+                    if (!JaegerTagTransformer.Instance.TryTransformTag(tag, out var jaegerTag))
                     {
-                        var key = tag.Key;
+                        continue;
+                    }
 
-                        if (!JaegerTagTransformer.Instance.TryTransformTag(tag, out var jaegerTag))
+                    if (jaegerTag.VStr != null)
+                    {
+                        PeerServiceResolver.InspectTag(ref this, key, jaegerTag.VStr);
+
+                        if (key == SpanAttributeConstants.StatusCodeKey)
                         {
+                            StatusCode? statusCode = StatusHelper.GetStatusCodeForTagValue(jaegerTag.VStr);
+                            this.StatusCode = statusCode;
                             continue;
                         }
-
-                        if (jaegerTag.VStr != null)
+                        else if (key == SpanAttributeConstants.StatusDescriptionKey)
                         {
-                            PeerServiceResolver.InspectTag(ref this, key, jaegerTag.VStr);
-
-                            if (key == SpanAttributeConstants.StatusCodeKey)
-                            {
-                                StatusCode? statusCode = StatusHelper.GetStatusCodeForTagValue(jaegerTag.VStr);
-                                this.StatusCode = statusCode;
-                                continue;
-                            }
-                            else if (key == SpanAttributeConstants.StatusDescriptionKey)
-                            {
-                                this.StatusDescription = jaegerTag.VStr;
-                                continue;
-                            }
+                            this.StatusDescription = jaegerTag.VStr;
+                            continue;
                         }
-                        else if (jaegerTag.VLong.HasValue)
-                        {
-                            PeerServiceResolver.InspectTag(ref this, key, jaegerTag.VLong.Value);
-                        }
-
-                        PooledList<JaegerTag>.Add(ref this.Tags, jaegerTag);
                     }
+                    else if (jaegerTag.VLong.HasValue)
+                    {
+                        PeerServiceResolver.InspectTag(ref this, key, jaegerTag.VLong.Value);
+                    }
+
+                    PooledList<JaegerTag>.Add(ref this.Tags, jaegerTag);
                 }
             }
         }
+    }
 
-        private struct LinkEnumerationState
+    private struct LinkEnumerationState
+    {
+        public bool Created;
+
+        public PooledList<JaegerSpanRef> SpanRefs;
+
+        public void EnumerateLinks(Activity activity)
         {
-            public bool Created;
+            var enumerator = activity.EnumerateLinks();
 
-            public PooledList<JaegerSpanRef> SpanRefs;
-
-            public void EnumerateLinks(Activity activity)
+            if (enumerator.MoveNext())
             {
-                var enumerator = activity.EnumerateLinks();
+                this.SpanRefs = PooledList<JaegerSpanRef>.Create();
+                this.Created = true;
 
-                if (enumerator.MoveNext())
+                do
                 {
-                    this.SpanRefs = PooledList<JaegerSpanRef>.Create();
-                    this.Created = true;
-
-                    do
-                    {
-                        ref readonly var link = ref enumerator.Current;
-                        PooledList<JaegerSpanRef>.Add(ref this.SpanRefs, link.ToJaegerSpanRef());
-                    }
-                    while (enumerator.MoveNext());
+                    ref readonly var link = ref enumerator.Current;
+                    PooledList<JaegerSpanRef>.Add(ref this.SpanRefs, link.ToJaegerSpanRef());
                 }
+                while (enumerator.MoveNext());
             }
         }
+    }
 
-        private struct EventEnumerationState
+    private struct EventEnumerationState
+    {
+        public bool Created;
+
+        public PooledList<JaegerLog> Logs;
+
+        public void EnumerateEvents(Activity activity)
         {
-            public bool Created;
+            var enumerator = activity.EnumerateEvents();
 
-            public PooledList<JaegerLog> Logs;
-
-            public void EnumerateEvents(Activity activity)
+            if (enumerator.MoveNext())
             {
-                var enumerator = activity.EnumerateEvents();
+                this.Logs = PooledList<JaegerLog>.Create();
+                this.Created = true;
 
-                if (enumerator.MoveNext())
+                do
                 {
-                    this.Logs = PooledList<JaegerLog>.Create();
-                    this.Created = true;
-
-                    do
-                    {
-                        ref readonly var @event = ref enumerator.Current;
-                        PooledList<JaegerLog>.Add(ref this.Logs, @event.ToJaegerLog());
-                    }
-                    while (enumerator.MoveNext());
+                    ref readonly var @event = ref enumerator.Current;
+                    PooledList<JaegerLog>.Add(ref this.Logs, @event.ToJaegerLog());
                 }
+                while (enumerator.MoveNext());
             }
         }
+    }
 
-        private struct EventTagsEnumerationState
+    private struct EventTagsEnumerationState
+    {
+        public PooledList<JaegerTag> Tags;
+
+        public bool HasEvent;
+
+        public void EnumerateTags(in ActivityEvent @event)
         {
-            public PooledList<JaegerTag> Tags;
-
-            public bool HasEvent;
-
-            public void EnumerateTags(in ActivityEvent @event)
+            foreach (ref readonly var tag in @event.EnumerateTagObjects())
             {
-                foreach (ref readonly var tag in @event.EnumerateTagObjects())
+                if (JaegerTagTransformer.Instance.TryTransformTag(tag, out var result))
                 {
-                    if (JaegerTagTransformer.Instance.TryTransformTag(tag, out var result))
-                    {
-                        PooledList<JaegerTag>.Add(ref this.Tags, result);
+                    PooledList<JaegerTag>.Add(ref this.Tags, result);
 
-                        if (tag.Key == "event")
-                        {
-                            this.HasEvent = true;
-                        }
+                    if (tag.Key == "event")
+                    {
+                        this.HasEvent = true;
                     }
                 }
             }

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerExporterEventSource.cs
@@ -17,41 +17,40 @@
 using System.Diagnostics.Tracing;
 using OpenTelemetry.Internal;
 
-namespace OpenTelemetry.Exporter.Jaeger.Implementation
+namespace OpenTelemetry.Exporter.Jaeger.Implementation;
+
+/// <summary>
+/// EventSource events emitted from the project.
+/// </summary>
+[EventSource(Name = "OpenTelemetry-Exporter-Jaeger")]
+internal sealed class JaegerExporterEventSource : EventSource
 {
-    /// <summary>
-    /// EventSource events emitted from the project.
-    /// </summary>
-    [EventSource(Name = "OpenTelemetry-Exporter-Jaeger")]
-    internal sealed class JaegerExporterEventSource : EventSource
+    public static JaegerExporterEventSource Log = new();
+
+    [NonEvent]
+    public void FailedExport(Exception ex)
     {
-        public static JaegerExporterEventSource Log = new();
-
-        [NonEvent]
-        public void FailedExport(Exception ex)
+        if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
         {
-            if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
-            {
-                this.FailedExport(ex.ToInvariantString());
-            }
+            this.FailedExport(ex.ToInvariantString());
         }
+    }
 
-        [Event(1, Message = "Failed to send spans: '{0}'", Level = EventLevel.Error)]
-        public void FailedExport(string exception)
-        {
-            this.WriteEvent(1, exception);
-        }
+    [Event(1, Message = "Failed to send spans: '{0}'", Level = EventLevel.Error)]
+    public void FailedExport(string exception)
+    {
+        this.WriteEvent(1, exception);
+    }
 
-        [Event(2, Message = "Unsupported attribute type '{0}' for '{1}'. Attribute will not be exported.", Level = EventLevel.Warning)]
-        public void UnsupportedAttributeType(string type, string key)
-        {
-            this.WriteEvent(2, type.ToString(), key);
-        }
+    [Event(2, Message = "Unsupported attribute type '{0}' for '{1}'. Attribute will not be exported.", Level = EventLevel.Warning)]
+    public void UnsupportedAttributeType(string type, string key)
+    {
+        this.WriteEvent(2, type.ToString(), key);
+    }
 
-        [Event(3, Message = "{0} environment variable has an invalid value: '{1}'", Level = EventLevel.Warning)]
-        public void InvalidEnvironmentVariable(string key, string value)
-        {
-            this.WriteEvent(3, key, value);
-        }
+    [Event(3, Message = "{0} environment variable has an invalid value: '{1}'", Level = EventLevel.Warning)]
+    public void InvalidEnvironmentVariable(string key, string value)
+    {
+        this.WriteEvent(3, key, value);
     }
 }

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerExporterException.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerExporterException.cs
@@ -14,17 +14,16 @@
 // limitations under the License.
 // </copyright>
 
-namespace OpenTelemetry.Exporter.Jaeger.Implementation
-{
+namespace OpenTelemetry.Exporter.Jaeger.Implementation;
+
 #pragma warning disable CA1032 // Implement standard exception constructors
 #pragma warning disable CA1064 // Exceptions should be public
-    internal sealed class JaegerExporterException : Exception
+internal sealed class JaegerExporterException : Exception
 #pragma warning restore CA1064 // Exceptions should be public
 #pragma warning restore CA1032 // Implement standard exception constructors
+{
+    public JaegerExporterException(string message, Exception originalException)
+        : base(message, originalException)
     {
-        public JaegerExporterException(string message, Exception originalException)
-            : base(message, originalException)
-        {
-        }
     }
 }

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerSpan.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerSpan.cs
@@ -19,261 +19,260 @@ using OpenTelemetry.Internal;
 using Thrift.Protocol;
 using Thrift.Protocol.Entities;
 
-namespace OpenTelemetry.Exporter.Jaeger.Implementation
+namespace OpenTelemetry.Exporter.Jaeger.Implementation;
+
+internal readonly struct JaegerSpan : TUnionBase
 {
-    internal readonly struct JaegerSpan : TUnionBase
+    public JaegerSpan(
+        string peerServiceName,
+        long traceIdLow,
+        long traceIdHigh,
+        long spanId,
+        long parentSpanId,
+        string operationName,
+        int flags,
+        long startTime,
+        long duration,
+        in PooledList<JaegerSpanRef> references,
+        in PooledList<JaegerTag> tags,
+        in PooledList<JaegerLog> logs)
     {
-        public JaegerSpan(
-            string peerServiceName,
-            long traceIdLow,
-            long traceIdHigh,
-            long spanId,
-            long parentSpanId,
-            string operationName,
-            int flags,
-            long startTime,
-            long duration,
-            in PooledList<JaegerSpanRef> references,
-            in PooledList<JaegerTag> tags,
-            in PooledList<JaegerLog> logs)
+        this.PeerServiceName = peerServiceName;
+        this.TraceIdLow = traceIdLow;
+        this.TraceIdHigh = traceIdHigh;
+        this.SpanId = spanId;
+        this.ParentSpanId = parentSpanId;
+        this.OperationName = operationName;
+        this.Flags = flags;
+        this.StartTime = startTime;
+        this.Duration = duration;
+        this.References = references;
+        this.Tags = tags;
+        this.Logs = logs;
+    }
+
+    public string PeerServiceName { get; }
+
+    public long TraceIdLow { get; }
+
+    public long TraceIdHigh { get; }
+
+    public long SpanId { get; }
+
+    public long ParentSpanId { get; }
+
+    public string OperationName { get; }
+
+    public PooledList<JaegerSpanRef> References { get; }
+
+    public int Flags { get; }
+
+    public long StartTime { get; }
+
+    public long Duration { get; }
+
+    public PooledList<JaegerTag> Tags { get; }
+
+    public PooledList<JaegerLog> Logs { get; }
+
+    public void Write(TProtocol oprot)
+    {
+        oprot.IncrementRecursionDepth();
+        try
         {
-            this.PeerServiceName = peerServiceName;
-            this.TraceIdLow = traceIdLow;
-            this.TraceIdHigh = traceIdHigh;
-            this.SpanId = spanId;
-            this.ParentSpanId = parentSpanId;
-            this.OperationName = operationName;
-            this.Flags = flags;
-            this.StartTime = startTime;
-            this.Duration = duration;
-            this.References = references;
-            this.Tags = tags;
-            this.Logs = logs;
-        }
+            var struc = new TStruct("Span");
+            oprot.WriteStructBegin(struc);
 
-        public string PeerServiceName { get; }
-
-        public long TraceIdLow { get; }
-
-        public long TraceIdHigh { get; }
-
-        public long SpanId { get; }
-
-        public long ParentSpanId { get; }
-
-        public string OperationName { get; }
-
-        public PooledList<JaegerSpanRef> References { get; }
-
-        public int Flags { get; }
-
-        public long StartTime { get; }
-
-        public long Duration { get; }
-
-        public PooledList<JaegerTag> Tags { get; }
-
-        public PooledList<JaegerLog> Logs { get; }
-
-        public void Write(TProtocol oprot)
-        {
-            oprot.IncrementRecursionDepth();
-            try
+            var field = new TField
             {
-                var struc = new TStruct("Span");
-                oprot.WriteStructBegin(struc);
+                Name = "traceIdLow",
+                Type = TType.I64,
+                ID = 1,
+            };
 
-                var field = new TField
-                {
-                    Name = "traceIdLow",
-                    Type = TType.I64,
-                    ID = 1,
-                };
+            oprot.WriteFieldBegin(field);
+            oprot.WriteI64(this.TraceIdLow);
+            oprot.WriteFieldEnd();
 
-                oprot.WriteFieldBegin(field);
-                oprot.WriteI64(this.TraceIdLow);
-                oprot.WriteFieldEnd();
+            field.Name = "traceIdHigh";
+            field.Type = TType.I64;
+            field.ID = 2;
 
-                field.Name = "traceIdHigh";
-                field.Type = TType.I64;
-                field.ID = 2;
+            oprot.WriteFieldBegin(field);
+            oprot.WriteI64(this.TraceIdHigh);
+            oprot.WriteFieldEnd();
 
-                oprot.WriteFieldBegin(field);
-                oprot.WriteI64(this.TraceIdHigh);
-                oprot.WriteFieldEnd();
+            field.Name = "spanId";
+            field.Type = TType.I64;
+            field.ID = 3;
 
-                field.Name = "spanId";
-                field.Type = TType.I64;
-                field.ID = 3;
+            oprot.WriteFieldBegin(field);
+            oprot.WriteI64(this.SpanId);
+            oprot.WriteFieldEnd();
 
-                oprot.WriteFieldBegin(field);
-                oprot.WriteI64(this.SpanId);
-                oprot.WriteFieldEnd();
+            field.Name = "parentSpanId";
+            field.Type = TType.I64;
+            field.ID = 4;
 
-                field.Name = "parentSpanId";
-                field.Type = TType.I64;
-                field.ID = 4;
+            oprot.WriteFieldBegin(field);
+            oprot.WriteI64(this.ParentSpanId);
+            oprot.WriteFieldEnd();
 
-                oprot.WriteFieldBegin(field);
-                oprot.WriteI64(this.ParentSpanId);
-                oprot.WriteFieldEnd();
+            field.Name = "operationName";
+            field.Type = TType.String;
+            field.ID = 5;
 
-                field.Name = "operationName";
-                field.Type = TType.String;
-                field.ID = 5;
+            oprot.WriteFieldBegin(field);
+            oprot.WriteString(this.OperationName);
+            oprot.WriteFieldEnd();
 
-                oprot.WriteFieldBegin(field);
-                oprot.WriteString(this.OperationName);
-                oprot.WriteFieldEnd();
-
-                if (!this.References.IsEmpty)
-                {
-                    field.Name = "references";
-                    field.Type = TType.List;
-                    field.ID = 6;
-                    oprot.WriteFieldBegin(field);
-                    {
-                        oprot.WriteListBegin(new TList(TType.Struct, this.References.Count));
-
-                        for (int i = 0; i < this.References.Count; i++)
-                        {
-                            this.References[i].Write(oprot);
-                        }
-
-                        oprot.WriteListEnd();
-                    }
-
-                    oprot.WriteFieldEnd();
-                }
-
-                field.Name = "flags";
-                field.Type = TType.I32;
-                field.ID = 7;
-
-                oprot.WriteFieldBegin(field);
-                oprot.WriteI32(this.Flags);
-                oprot.WriteFieldEnd();
-
-                field.Name = "startTime";
-                field.Type = TType.I64;
-                field.ID = 8;
-
-                oprot.WriteFieldBegin(field);
-                oprot.WriteI64(this.StartTime);
-                oprot.WriteFieldEnd();
-
-                field.Name = "duration";
-                field.Type = TType.I64;
-                field.ID = 9;
-
-                oprot.WriteFieldBegin(field);
-                oprot.WriteI64(this.Duration);
-                oprot.WriteFieldEnd();
-
-                if (!this.Tags.IsEmpty)
-                {
-                    field.Name = "JaegerTags";
-                    field.Type = TType.List;
-                    field.ID = 10;
-
-                    oprot.WriteFieldBegin(field);
-                    {
-                        oprot.WriteListBegin(new TList(TType.Struct, this.Tags.Count));
-
-                        for (int i = 0; i < this.Tags.Count; i++)
-                        {
-                            this.Tags[i].Write(oprot);
-                        }
-
-                        oprot.WriteListEnd();
-                    }
-
-                    oprot.WriteFieldEnd();
-                }
-
-                if (!this.Logs.IsEmpty)
-                {
-                    field.Name = "logs";
-                    field.Type = TType.List;
-                    field.ID = 11;
-                    oprot.WriteFieldBegin(field);
-                    {
-                        oprot.WriteListBegin(new TList(TType.Struct, this.Logs.Count));
-
-                        for (int i = 0; i < this.Logs.Count; i++)
-                        {
-                            this.Logs[i].Write(oprot);
-                        }
-
-                        oprot.WriteListEnd();
-                    }
-
-                    oprot.WriteFieldEnd();
-                }
-
-                oprot.WriteFieldStop();
-                oprot.WriteStructEnd();
-            }
-            finally
-            {
-                oprot.DecrementRecursionDepth();
-            }
-        }
-
-        public void Return()
-        {
-            this.References.Return();
-            this.Tags.Return();
-            if (!this.Logs.IsEmpty)
-            {
-                for (int i = 0; i < this.Logs.Count; i++)
-                {
-                    this.Logs[i].Fields.Return();
-                }
-
-                this.Logs.Return();
-            }
-        }
-
-        public override string ToString()
-        {
-            var sb = new StringBuilder("Span(");
-            sb.Append(", TraceIdLow: ");
-            sb.Append(this.TraceIdLow);
-            sb.Append(", TraceIdHigh: ");
-            sb.Append(this.TraceIdHigh);
-            sb.Append(", SpanId: ");
-            sb.Append(this.SpanId);
-            sb.Append(", ParentSpanId: ");
-            sb.Append(this.ParentSpanId);
-            sb.Append(", OperationName: ");
-            sb.Append(this.OperationName);
             if (!this.References.IsEmpty)
             {
-                sb.Append(", References: ");
-                sb.Append(this.References);
+                field.Name = "references";
+                field.Type = TType.List;
+                field.ID = 6;
+                oprot.WriteFieldBegin(field);
+                {
+                    oprot.WriteListBegin(new TList(TType.Struct, this.References.Count));
+
+                    for (int i = 0; i < this.References.Count; i++)
+                    {
+                        this.References[i].Write(oprot);
+                    }
+
+                    oprot.WriteListEnd();
+                }
+
+                oprot.WriteFieldEnd();
             }
 
-            sb.Append(", Flags: ");
-            sb.Append(this.Flags);
-            sb.Append(", StartTime: ");
-            sb.Append(this.StartTime);
-            sb.Append(", Duration: ");
-            sb.Append(this.Duration);
+            field.Name = "flags";
+            field.Type = TType.I32;
+            field.ID = 7;
+
+            oprot.WriteFieldBegin(field);
+            oprot.WriteI32(this.Flags);
+            oprot.WriteFieldEnd();
+
+            field.Name = "startTime";
+            field.Type = TType.I64;
+            field.ID = 8;
+
+            oprot.WriteFieldBegin(field);
+            oprot.WriteI64(this.StartTime);
+            oprot.WriteFieldEnd();
+
+            field.Name = "duration";
+            field.Type = TType.I64;
+            field.ID = 9;
+
+            oprot.WriteFieldBegin(field);
+            oprot.WriteI64(this.Duration);
+            oprot.WriteFieldEnd();
+
             if (!this.Tags.IsEmpty)
             {
-                sb.Append(", JaegerTags: ");
-                sb.Append(this.Tags);
+                field.Name = "JaegerTags";
+                field.Type = TType.List;
+                field.ID = 10;
+
+                oprot.WriteFieldBegin(field);
+                {
+                    oprot.WriteListBegin(new TList(TType.Struct, this.Tags.Count));
+
+                    for (int i = 0; i < this.Tags.Count; i++)
+                    {
+                        this.Tags[i].Write(oprot);
+                    }
+
+                    oprot.WriteListEnd();
+                }
+
+                oprot.WriteFieldEnd();
             }
 
             if (!this.Logs.IsEmpty)
             {
-                sb.Append(", Logs: ");
-                sb.Append(this.Logs);
+                field.Name = "logs";
+                field.Type = TType.List;
+                field.ID = 11;
+                oprot.WriteFieldBegin(field);
+                {
+                    oprot.WriteListBegin(new TList(TType.Struct, this.Logs.Count));
+
+                    for (int i = 0; i < this.Logs.Count; i++)
+                    {
+                        this.Logs[i].Write(oprot);
+                    }
+
+                    oprot.WriteListEnd();
+                }
+
+                oprot.WriteFieldEnd();
             }
 
-            sb.Append(')');
-            return sb.ToString();
+            oprot.WriteFieldStop();
+            oprot.WriteStructEnd();
         }
+        finally
+        {
+            oprot.DecrementRecursionDepth();
+        }
+    }
+
+    public void Return()
+    {
+        this.References.Return();
+        this.Tags.Return();
+        if (!this.Logs.IsEmpty)
+        {
+            for (int i = 0; i < this.Logs.Count; i++)
+            {
+                this.Logs[i].Fields.Return();
+            }
+
+            this.Logs.Return();
+        }
+    }
+
+    public override string ToString()
+    {
+        var sb = new StringBuilder("Span(");
+        sb.Append(", TraceIdLow: ");
+        sb.Append(this.TraceIdLow);
+        sb.Append(", TraceIdHigh: ");
+        sb.Append(this.TraceIdHigh);
+        sb.Append(", SpanId: ");
+        sb.Append(this.SpanId);
+        sb.Append(", ParentSpanId: ");
+        sb.Append(this.ParentSpanId);
+        sb.Append(", OperationName: ");
+        sb.Append(this.OperationName);
+        if (!this.References.IsEmpty)
+        {
+            sb.Append(", References: ");
+            sb.Append(this.References);
+        }
+
+        sb.Append(", Flags: ");
+        sb.Append(this.Flags);
+        sb.Append(", StartTime: ");
+        sb.Append(this.StartTime);
+        sb.Append(", Duration: ");
+        sb.Append(this.Duration);
+        if (!this.Tags.IsEmpty)
+        {
+            sb.Append(", JaegerTags: ");
+            sb.Append(this.Tags);
+        }
+
+        if (!this.Logs.IsEmpty)
+        {
+            sb.Append(", Logs: ");
+            sb.Append(this.Logs);
+        }
+
+        sb.Append(')');
+        return sb.ToString();
     }
 }

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerSpanRef.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerSpanRef.cs
@@ -18,94 +18,93 @@ using System.Text;
 using Thrift.Protocol;
 using Thrift.Protocol.Entities;
 
-namespace OpenTelemetry.Exporter.Jaeger.Implementation
+namespace OpenTelemetry.Exporter.Jaeger.Implementation;
+
+internal readonly struct JaegerSpanRef : TUnionBase
 {
-    internal readonly struct JaegerSpanRef : TUnionBase
+    public JaegerSpanRef(JaegerSpanRefType refType, long traceIdLow, long traceIdHigh, long spanId)
     {
-        public JaegerSpanRef(JaegerSpanRefType refType, long traceIdLow, long traceIdHigh, long spanId)
+        this.RefType = refType;
+        this.TraceIdLow = traceIdLow;
+        this.TraceIdHigh = traceIdHigh;
+        this.SpanId = spanId;
+    }
+
+    public JaegerSpanRefType RefType { get; }
+
+    public long TraceIdLow { get; }
+
+    public long TraceIdHigh { get; }
+
+    public long SpanId { get; }
+
+    public void Write(TProtocol oprot)
+    {
+        oprot.IncrementRecursionDepth();
+        try
         {
-            this.RefType = refType;
-            this.TraceIdLow = traceIdLow;
-            this.TraceIdHigh = traceIdHigh;
-            this.SpanId = spanId;
-        }
+            var struc = new TStruct("SpanRef");
+            oprot.WriteStructBegin(struc);
 
-        public JaegerSpanRefType RefType { get; }
-
-        public long TraceIdLow { get; }
-
-        public long TraceIdHigh { get; }
-
-        public long SpanId { get; }
-
-        public void Write(TProtocol oprot)
-        {
-            oprot.IncrementRecursionDepth();
-            try
+            var field = new TField
             {
-                var struc = new TStruct("SpanRef");
-                oprot.WriteStructBegin(struc);
+                Name = "refType",
+                Type = TType.I32,
+                ID = 1,
+            };
 
-                var field = new TField
-                {
-                    Name = "refType",
-                    Type = TType.I32,
-                    ID = 1,
-                };
+            oprot.WriteFieldBegin(field);
+            oprot.WriteI32((int)this.RefType);
+            oprot.WriteFieldEnd();
 
-                oprot.WriteFieldBegin(field);
-                oprot.WriteI32((int)this.RefType);
-                oprot.WriteFieldEnd();
+            field.Name = "traceIdLow";
+            field.Type = TType.I64;
+            field.ID = 2;
 
-                field.Name = "traceIdLow";
-                field.Type = TType.I64;
-                field.ID = 2;
+            oprot.WriteFieldBegin(field);
+            oprot.WriteI64(this.TraceIdLow);
+            oprot.WriteFieldEnd();
 
-                oprot.WriteFieldBegin(field);
-                oprot.WriteI64(this.TraceIdLow);
-                oprot.WriteFieldEnd();
+            field.Name = "traceIdHigh";
+            field.Type = TType.I64;
+            field.ID = 3;
 
-                field.Name = "traceIdHigh";
-                field.Type = TType.I64;
-                field.ID = 3;
+            oprot.WriteFieldBegin(field);
+            oprot.WriteI64(this.TraceIdHigh);
+            oprot.WriteFieldEnd();
 
-                oprot.WriteFieldBegin(field);
-                oprot.WriteI64(this.TraceIdHigh);
-                oprot.WriteFieldEnd();
+            field.Name = "spanId";
+            field.Type = TType.I64;
+            field.ID = 4;
 
-                field.Name = "spanId";
-                field.Type = TType.I64;
-                field.ID = 4;
-
-                oprot.WriteFieldBegin(field);
-                oprot.WriteI64(this.SpanId);
-                oprot.WriteFieldEnd();
-                oprot.WriteFieldStop();
-                oprot.WriteStructEnd();
-            }
-            finally
-            {
-                oprot.DecrementRecursionDepth();
-            }
+            oprot.WriteFieldBegin(field);
+            oprot.WriteI64(this.SpanId);
+            oprot.WriteFieldEnd();
+            oprot.WriteFieldStop();
+            oprot.WriteStructEnd();
         }
-
-        /// <summary>
-        /// <seealso cref="JaegerSpanRefType"/>
-        /// </summary>
-        /// <returns>A string representation of the object.</returns>
-        public override string ToString()
+        finally
         {
-            var sb = new StringBuilder("SpanRef(");
-            sb.Append(", RefType: ");
-            sb.Append(this.RefType);
-            sb.Append(", TraceIdLow: ");
-            sb.Append(this.TraceIdLow);
-            sb.Append(", TraceIdHigh: ");
-            sb.Append(this.TraceIdHigh);
-            sb.Append(", SpanId: ");
-            sb.Append(this.SpanId);
-            sb.Append(')');
-            return sb.ToString();
+            oprot.DecrementRecursionDepth();
         }
+    }
+
+    /// <summary>
+    /// <seealso cref="JaegerSpanRefType"/>
+    /// </summary>
+    /// <returns>A string representation of the object.</returns>
+    public override string ToString()
+    {
+        var sb = new StringBuilder("SpanRef(");
+        sb.Append(", RefType: ");
+        sb.Append(this.RefType);
+        sb.Append(", TraceIdLow: ");
+        sb.Append(this.TraceIdLow);
+        sb.Append(", TraceIdHigh: ");
+        sb.Append(this.TraceIdHigh);
+        sb.Append(", SpanId: ");
+        sb.Append(this.SpanId);
+        sb.Append(')');
+        return sb.ToString();
     }
 }

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerSpanRefType.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerSpanRefType.cs
@@ -14,21 +14,20 @@
 // limitations under the License.
 // </copyright>
 
-namespace OpenTelemetry.Exporter.Jaeger.Implementation
+namespace OpenTelemetry.Exporter.Jaeger.Implementation;
+
+/// <summary>
+/// Represents the different types of Jaeger Spans.
+/// </summary>
+internal enum JaegerSpanRefType
 {
     /// <summary>
-    /// Represents the different types of Jaeger Spans.
+    /// A child span.
     /// </summary>
-    internal enum JaegerSpanRefType
-    {
-        /// <summary>
-        /// A child span.
-        /// </summary>
-        CHILD_OF = 0,
+    CHILD_OF = 0,
 
-        /// <summary>
-        /// A sibling span.
-        /// </summary>
-        FOLLOWS_FROM = 1,
-    }
+    /// <summary>
+    /// A sibling span.
+    /// </summary>
+    FOLLOWS_FROM = 1,
 }

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerTag.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerTag.cs
@@ -18,164 +18,163 @@ using System.Text;
 using Thrift.Protocol;
 using Thrift.Protocol.Entities;
 
-namespace OpenTelemetry.Exporter.Jaeger.Implementation
+namespace OpenTelemetry.Exporter.Jaeger.Implementation;
+
+internal readonly struct JaegerTag : TUnionBase
 {
-    internal readonly struct JaegerTag : TUnionBase
+    public JaegerTag(
+        string key,
+        JaegerTagType vType,
+        string vStr = null,
+        double? vDouble = null,
+        bool? vBool = null,
+        long? vLong = null,
+        byte[] vBinary = null)
     {
-        public JaegerTag(
-            string key,
-            JaegerTagType vType,
-            string vStr = null,
-            double? vDouble = null,
-            bool? vBool = null,
-            long? vLong = null,
-            byte[] vBinary = null)
+        this.Key = key;
+        this.VType = vType;
+
+        this.VStr = vStr;
+        this.VDouble = vDouble;
+        this.VBool = vBool;
+        this.VLong = vLong;
+        this.VBinary = vBinary;
+    }
+
+    public string Key { get; }
+
+    public JaegerTagType VType { get; }
+
+    public string VStr { get; }
+
+    public double? VDouble { get; }
+
+    public bool? VBool { get; }
+
+    public long? VLong { get; }
+
+    public byte[] VBinary { get; }
+
+    public void Write(TProtocol oprot)
+    {
+        oprot.IncrementRecursionDepth();
+        try
         {
-            this.Key = key;
-            this.VType = vType;
+            var struc = new TStruct("Tag");
+            oprot.WriteStructBegin(struc);
 
-            this.VStr = vStr;
-            this.VDouble = vDouble;
-            this.VBool = vBool;
-            this.VLong = vLong;
-            this.VBinary = vBinary;
-        }
-
-        public string Key { get; }
-
-        public JaegerTagType VType { get; }
-
-        public string VStr { get; }
-
-        public double? VDouble { get; }
-
-        public bool? VBool { get; }
-
-        public long? VLong { get; }
-
-        public byte[] VBinary { get; }
-
-        public void Write(TProtocol oprot)
-        {
-            oprot.IncrementRecursionDepth();
-            try
+            var field = new TField
             {
-                var struc = new TStruct("Tag");
-                oprot.WriteStructBegin(struc);
+                Name = "key",
+                Type = TType.String,
+                ID = 1,
+            };
 
-                var field = new TField
-                {
-                    Name = "key",
-                    Type = TType.String,
-                    ID = 1,
-                };
+            oprot.WriteFieldBegin(field);
+            oprot.WriteString(this.Key);
+            oprot.WriteFieldEnd();
 
-                oprot.WriteFieldBegin(field);
-                oprot.WriteString(this.Key);
-                oprot.WriteFieldEnd();
+            field.Name = "vType";
+            field.Type = TType.I32;
+            field.ID = 2;
 
-                field.Name = "vType";
-                field.Type = TType.I32;
-                field.ID = 2;
+            oprot.WriteFieldBegin(field);
+            oprot.WriteI32((int)this.VType);
+            oprot.WriteFieldEnd();
 
-                oprot.WriteFieldBegin(field);
-                oprot.WriteI32((int)this.VType);
-                oprot.WriteFieldEnd();
-
-                if (this.VStr != null)
-                {
-                    field.Name = "vStr";
-                    field.Type = TType.String;
-                    field.ID = 3;
-                    oprot.WriteFieldBegin(field);
-                    oprot.WriteString(this.VStr);
-                    oprot.WriteFieldEnd();
-                }
-                else if (this.VDouble.HasValue)
-                {
-                    field.Name = "vDouble";
-                    field.Type = TType.Double;
-                    field.ID = 4;
-                    oprot.WriteFieldBegin(field);
-                    oprot.WriteDouble(this.VDouble.Value);
-                    oprot.WriteFieldEnd();
-                }
-                else if (this.VBool.HasValue)
-                {
-                    field.Name = "vBool";
-                    field.Type = TType.Bool;
-                    field.ID = 5;
-                    oprot.WriteFieldBegin(field);
-                    oprot.WriteBool(this.VBool.Value);
-                    oprot.WriteFieldEnd();
-                }
-                else if (this.VLong.HasValue)
-                {
-                    field.Name = "vLong";
-                    field.Type = TType.I64;
-                    field.ID = 6;
-                    oprot.WriteFieldBegin(field);
-                    oprot.WriteI64(this.VLong.Value);
-                    oprot.WriteFieldEnd();
-                }
-                else if (this.VBinary != null)
-                {
-                    field.Name = "vBinary";
-                    field.Type = TType.String;
-                    field.ID = 7;
-                    oprot.WriteFieldBegin(field);
-                    oprot.WriteBinary(this.VBinary, 0, this.VBinary.Length);
-                    oprot.WriteFieldEnd();
-                }
-
-                oprot.WriteFieldStop();
-                oprot.WriteStructEnd();
-            }
-            finally
-            {
-                oprot.DecrementRecursionDepth();
-            }
-        }
-
-        public override string ToString()
-        {
-            var sb = new StringBuilder("Tag(");
-            sb.Append(", Key: ");
-            sb.Append(this.Key);
-            sb.Append(", VType: ");
-            sb.Append(this.VType);
             if (this.VStr != null)
             {
-                sb.Append(", VStr: ");
-                sb.Append(this.VStr);
+                field.Name = "vStr";
+                field.Type = TType.String;
+                field.ID = 3;
+                oprot.WriteFieldBegin(field);
+                oprot.WriteString(this.VStr);
+                oprot.WriteFieldEnd();
             }
-
-            if (this.VDouble.HasValue)
+            else if (this.VDouble.HasValue)
             {
-                sb.Append(", VDouble: ");
-                sb.Append(this.VDouble);
+                field.Name = "vDouble";
+                field.Type = TType.Double;
+                field.ID = 4;
+                oprot.WriteFieldBegin(field);
+                oprot.WriteDouble(this.VDouble.Value);
+                oprot.WriteFieldEnd();
             }
-
-            if (this.VBool.HasValue)
+            else if (this.VBool.HasValue)
             {
-                sb.Append(", VBool: ");
-                sb.Append(this.VBool);
+                field.Name = "vBool";
+                field.Type = TType.Bool;
+                field.ID = 5;
+                oprot.WriteFieldBegin(field);
+                oprot.WriteBool(this.VBool.Value);
+                oprot.WriteFieldEnd();
             }
-
-            if (this.VLong.HasValue)
+            else if (this.VLong.HasValue)
             {
-                sb.Append(", VLong: ");
-                sb.Append(this.VLong);
+                field.Name = "vLong";
+                field.Type = TType.I64;
+                field.ID = 6;
+                oprot.WriteFieldBegin(field);
+                oprot.WriteI64(this.VLong.Value);
+                oprot.WriteFieldEnd();
             }
-
-            if (this.VBinary != null)
+            else if (this.VBinary != null)
             {
-                sb.Append(", VBinary: ");
-                sb.Append(this.VBinary);
+                field.Name = "vBinary";
+                field.Type = TType.String;
+                field.ID = 7;
+                oprot.WriteFieldBegin(field);
+                oprot.WriteBinary(this.VBinary, 0, this.VBinary.Length);
+                oprot.WriteFieldEnd();
             }
 
-            sb.Append(')');
-            return sb.ToString();
+            oprot.WriteFieldStop();
+            oprot.WriteStructEnd();
         }
+        finally
+        {
+            oprot.DecrementRecursionDepth();
+        }
+    }
+
+    public override string ToString()
+    {
+        var sb = new StringBuilder("Tag(");
+        sb.Append(", Key: ");
+        sb.Append(this.Key);
+        sb.Append(", VType: ");
+        sb.Append(this.VType);
+        if (this.VStr != null)
+        {
+            sb.Append(", VStr: ");
+            sb.Append(this.VStr);
+        }
+
+        if (this.VDouble.HasValue)
+        {
+            sb.Append(", VDouble: ");
+            sb.Append(this.VDouble);
+        }
+
+        if (this.VBool.HasValue)
+        {
+            sb.Append(", VBool: ");
+            sb.Append(this.VBool);
+        }
+
+        if (this.VLong.HasValue)
+        {
+            sb.Append(", VLong: ");
+            sb.Append(this.VLong);
+        }
+
+        if (this.VBinary != null)
+        {
+            sb.Append(", VBinary: ");
+            sb.Append(this.VBinary);
+        }
+
+        sb.Append(')');
+        return sb.ToString();
     }
 }

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerTagType.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerTagType.cs
@@ -14,36 +14,35 @@
 // limitations under the License.
 // </copyright>
 
-namespace OpenTelemetry.Exporter.Jaeger.Implementation
+namespace OpenTelemetry.Exporter.Jaeger.Implementation;
+
+/// <summary>
+/// Indicates the data type of a Jaeger tag.
+/// </summary>
+internal enum JaegerTagType
 {
     /// <summary>
-    /// Indicates the data type of a Jaeger tag.
+    /// Tag contains a string.
     /// </summary>
-    internal enum JaegerTagType
-    {
-        /// <summary>
-        /// Tag contains a string.
-        /// </summary>
-        STRING = 0,
+    STRING = 0,
 
-        /// <summary>
-        /// Tag contains a double.
-        /// </summary>
-        DOUBLE = 1,
+    /// <summary>
+    /// Tag contains a double.
+    /// </summary>
+    DOUBLE = 1,
 
-        /// <summary>
-        /// Tag contains a boolean.
-        /// </summary>
-        BOOL = 2,
+    /// <summary>
+    /// Tag contains a boolean.
+    /// </summary>
+    BOOL = 2,
 
-        /// <summary>
-        /// Tag contains a long.
-        /// </summary>
-        LONG = 3,
+    /// <summary>
+    /// Tag contains a long.
+    /// </summary>
+    LONG = 3,
 
-        /// <summary>
-        /// Tag contains binary data.
-        /// </summary>
-        BINARY = 4,
-    }
+    /// <summary>
+    /// Tag contains binary data.
+    /// </summary>
+    BINARY = 4,
 }

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpClient.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/JaegerUdpClient.cs
@@ -16,44 +16,43 @@
 
 using System.Net.Sockets;
 
-namespace OpenTelemetry.Exporter.Jaeger.Implementation
+namespace OpenTelemetry.Exporter.Jaeger.Implementation;
+
+internal sealed class JaegerUdpClient : IJaegerClient
 {
-    internal sealed class JaegerUdpClient : IJaegerClient
+    private readonly string host;
+    private readonly int port;
+    private readonly UdpClient client;
+    private bool disposed;
+
+    public JaegerUdpClient(string host, int port)
     {
-        private readonly string host;
-        private readonly int port;
-        private readonly UdpClient client;
-        private bool disposed;
+        this.host = host;
+        this.port = port;
+        this.client = new UdpClient();
+    }
 
-        public JaegerUdpClient(string host, int port)
+    public bool Connected => this.client.Client.Connected;
+
+    public void Close() => this.client.Close();
+
+    public void Connect() => this.client.Connect(this.host, this.port);
+
+    public int Send(byte[] buffer, int offset, int count)
+    {
+        return this.client.Client.Send(buffer, offset, count, SocketFlags.None);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (this.disposed)
         {
-            this.host = host;
-            this.port = port;
-            this.client = new UdpClient();
+            return;
         }
 
-        public bool Connected => this.client.Client.Connected;
+        this.client.Dispose();
 
-        public void Close() => this.client.Close();
-
-        public void Connect() => this.client.Connect(this.host, this.port);
-
-        public int Send(byte[] buffer, int offset, int count)
-        {
-            return this.client.Client.Send(buffer, offset, count, SocketFlags.None);
-        }
-
-        /// <inheritdoc/>
-        public void Dispose()
-        {
-            if (this.disposed)
-            {
-                return;
-            }
-
-            this.client.Dispose();
-
-            this.disposed = true;
-        }
+        this.disposed = true;
     }
 }

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/Process.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/Process.cs
@@ -18,78 +18,77 @@ using System.Text;
 using Thrift.Protocol;
 using Thrift.Protocol.Entities;
 
-namespace OpenTelemetry.Exporter.Jaeger.Implementation
+namespace OpenTelemetry.Exporter.Jaeger.Implementation;
+
+internal sealed class Process
 {
-    internal sealed class Process
+    public string ServiceName { get; set; }
+
+    public Dictionary<string, JaegerTag> Tags { get; set; }
+
+    public override string ToString()
     {
-        public string ServiceName { get; set; }
+        var sb = new StringBuilder("Process(");
+        sb.Append(", ServiceName: ");
+        sb.Append(this.ServiceName);
 
-        public Dictionary<string, JaegerTag> Tags { get; set; }
-
-        public override string ToString()
+        if (this.Tags != null)
         {
-            var sb = new StringBuilder("Process(");
-            sb.Append(", ServiceName: ");
-            sb.Append(this.ServiceName);
+            sb.Append(", Tags: ");
+            sb.Append(this.Tags);
+        }
+
+        sb.Append(')');
+        return sb.ToString();
+    }
+
+    public void Write(TProtocol oprot)
+    {
+        oprot.IncrementRecursionDepth();
+
+        try
+        {
+            var struc = new TStruct("Process");
+            oprot.WriteStructBegin(struc);
+
+            var field = new TField
+            {
+                Name = "serviceName",
+                Type = TType.String,
+                ID = 1,
+            };
+
+            oprot.WriteFieldBegin(field);
+            oprot.WriteString(this.ServiceName);
+            oprot.WriteFieldEnd();
 
             if (this.Tags != null)
             {
-                sb.Append(", Tags: ");
-                sb.Append(this.Tags);
-            }
-
-            sb.Append(')');
-            return sb.ToString();
-        }
-
-        public void Write(TProtocol oprot)
-        {
-            oprot.IncrementRecursionDepth();
-
-            try
-            {
-                var struc = new TStruct("Process");
-                oprot.WriteStructBegin(struc);
-
-                var field = new TField
-                {
-                    Name = "serviceName",
-                    Type = TType.String,
-                    ID = 1,
-                };
+                field.Name = "tags";
+                field.Type = TType.List;
+                field.ID = 2;
 
                 oprot.WriteFieldBegin(field);
-                oprot.WriteString(this.ServiceName);
-                oprot.WriteFieldEnd();
-
-                if (this.Tags != null)
                 {
-                    field.Name = "tags";
-                    field.Type = TType.List;
-                    field.ID = 2;
+                    oprot.WriteListBegin(new TList(TType.Struct, this.Tags.Count));
 
-                    oprot.WriteFieldBegin(field);
+                    foreach (var jt in this.Tags)
                     {
-                        oprot.WriteListBegin(new TList(TType.Struct, this.Tags.Count));
-
-                        foreach (var jt in this.Tags)
-                        {
-                            jt.Value.Write(oprot);
-                        }
-
-                        oprot.WriteListEnd();
+                        jt.Value.Write(oprot);
                     }
 
-                    oprot.WriteFieldEnd();
+                    oprot.WriteListEnd();
                 }
 
-                oprot.WriteFieldStop();
-                oprot.WriteStructEnd();
+                oprot.WriteFieldEnd();
             }
-            finally
-            {
-                oprot.DecrementRecursionDepth();
-            }
+
+            oprot.WriteFieldStop();
+            oprot.WriteStructEnd();
+        }
+        finally
+        {
+            oprot.DecrementRecursionDepth();
         }
     }
 }

--- a/src/OpenTelemetry.Exporter.Jaeger/Implementation/ShimExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/Implementation/ShimExtensions.cs
@@ -15,22 +15,21 @@
 // </copyright>
 
 #if NETSTANDARD2_0 || NETFRAMEWORK
-namespace System
-{
-    internal static class ShimExtensions
-    {
-        public static byte[] ToArray(this ArraySegment<byte> arraySegment)
-        {
-            int count = arraySegment.Count;
-            if (count == 0)
-            {
-                return Array.Empty<byte>();
-            }
+namespace System;
 
-            var array = new byte[count];
-            Array.Copy(arraySegment.Array, arraySegment.Offset, array, 0, count);
-            return array;
+internal static class ShimExtensions
+{
+    public static byte[] ToArray(this ArraySegment<byte> arraySegment)
+    {
+        int count = arraySegment.Count;
+        if (count == 0)
+        {
+            return Array.Empty<byte>();
         }
+
+        var array = new byte[count];
+        Array.Copy(arraySegment.Array, arraySegment.Offset, array, 0, count);
+        return array;
     }
 }
 #endif

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExportProtocol.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExportProtocol.cs
@@ -14,27 +14,26 @@
 // limitations under the License.
 // </copyright>
 
-namespace OpenTelemetry.Exporter
+namespace OpenTelemetry.Exporter;
+
+/// <summary>
+/// Defines the exporter protocols supported by the <see cref="JaegerExporter"/>.
+/// </summary>
+public enum JaegerExportProtocol : byte
 {
     /// <summary>
-    /// Defines the exporter protocols supported by the <see cref="JaegerExporter"/>.
+    /// Compact thrift protocol over UDP.
     /// </summary>
-    public enum JaegerExportProtocol : byte
-    {
-        /// <summary>
-        /// Compact thrift protocol over UDP.
-        /// </summary>
-        /// <remarks>
-        /// Note: Supported by Jaeger Agents only.
-        /// </remarks>
-        UdpCompactThrift = 0,
+    /// <remarks>
+    /// Note: Supported by Jaeger Agents only.
+    /// </remarks>
+    UdpCompactThrift = 0,
 
-        /// <summary>
-        /// Binary thrift protocol over HTTP.
-        /// </summary>
-        /// <remarks>
-        /// Note: Supported by Jaeger Collectors only.
-        /// </remarks>
-        HttpBinaryThrift = 1,
-    }
+    /// <summary>
+    /// Binary thrift protocol over HTTP.
+    /// </summary>
+    /// <remarks>
+    /// Note: Supported by Jaeger Collectors only.
+    /// </remarks>
+    HttpBinaryThrift = 1,
 }

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporter.cs
@@ -22,267 +22,266 @@ using OpenTelemetry.Resources;
 using Thrift.Protocol;
 using Process = OpenTelemetry.Exporter.Jaeger.Implementation.Process;
 
-namespace OpenTelemetry.Exporter
+namespace OpenTelemetry.Exporter;
+
+public class JaegerExporter : BaseExporter<Activity>
 {
-    public class JaegerExporter : BaseExporter<Activity>
+    internal uint NumberOfSpansInCurrentBatch;
+
+    private readonly byte[] uInt32Storage = new byte[8];
+    private readonly int maxPayloadSizeInBytes;
+    private readonly IJaegerClient client;
+    private readonly TProtocol batchWriter;
+    private readonly TProtocol spanWriter;
+    private readonly bool sendUsingEmitBatchArgs;
+    private int minimumBatchSizeInBytes;
+    private int currentBatchSizeInBytes;
+    private int spanStartPosition;
+    private uint sequenceId;
+    private bool disposed;
+
+    public JaegerExporter(JaegerExporterOptions options)
+        : this(options, null)
     {
-        internal uint NumberOfSpansInCurrentBatch;
+    }
 
-        private readonly byte[] uInt32Storage = new byte[8];
-        private readonly int maxPayloadSizeInBytes;
-        private readonly IJaegerClient client;
-        private readonly TProtocol batchWriter;
-        private readonly TProtocol spanWriter;
-        private readonly bool sendUsingEmitBatchArgs;
-        private int minimumBatchSizeInBytes;
-        private int currentBatchSizeInBytes;
-        private int spanStartPosition;
-        private uint sequenceId;
-        private bool disposed;
+    internal JaegerExporter(JaegerExporterOptions options, TProtocolFactory protocolFactory = null, IJaegerClient client = null)
+    {
+        Guard.ThrowIfNull(options);
 
-        public JaegerExporter(JaegerExporterOptions options)
-            : this(options, null)
+        this.maxPayloadSizeInBytes = (!options.MaxPayloadSizeInBytes.HasValue || options.MaxPayloadSizeInBytes <= 0)
+            ? JaegerExporterOptions.DefaultMaxPayloadSizeInBytes
+            : options.MaxPayloadSizeInBytes.Value;
+
+        if (options.Protocol == JaegerExportProtocol.UdpCompactThrift)
         {
+            protocolFactory ??= new TCompactProtocol.Factory();
+            client ??= new JaegerUdpClient(options.AgentHost, options.AgentPort);
+            this.sendUsingEmitBatchArgs = true;
+        }
+        else if (options.Protocol == JaegerExportProtocol.HttpBinaryThrift)
+        {
+            protocolFactory ??= new TBinaryProtocol.Factory();
+            client ??= new JaegerHttpClient(
+                options.Endpoint,
+                options.HttpClientFactory?.Invoke() ?? throw new InvalidOperationException("JaegerExporterOptions was missing HttpClientFactory or it returned null."));
+        }
+        else
+        {
+            throw new NotSupportedException();
         }
 
-        internal JaegerExporter(JaegerExporterOptions options, TProtocolFactory protocolFactory = null, IJaegerClient client = null)
+        JaegerTagTransformer.LogUnsupportedAttributeType = (string tagValueType, string tagKey) =>
         {
-            Guard.ThrowIfNull(options);
+            JaegerExporterEventSource.Log.UnsupportedAttributeType(tagValueType, tagKey);
+        };
 
-            this.maxPayloadSizeInBytes = (!options.MaxPayloadSizeInBytes.HasValue || options.MaxPayloadSizeInBytes <= 0)
-                ? JaegerExporterOptions.DefaultMaxPayloadSizeInBytes
-                : options.MaxPayloadSizeInBytes.Value;
+        ConfigurationExtensions.LogInvalidEnvironmentVariable = (string key, string value) =>
+        {
+            JaegerExporterEventSource.Log.InvalidEnvironmentVariable(key, value);
+        };
 
-            if (options.Protocol == JaegerExportProtocol.UdpCompactThrift)
+        this.client = client;
+        this.batchWriter = protocolFactory.GetProtocol(this.maxPayloadSizeInBytes * 2);
+        this.spanWriter = protocolFactory.GetProtocol(this.maxPayloadSizeInBytes);
+
+        this.Process = new();
+
+        client.Connect();
+    }
+
+    internal Process Process { get; }
+
+    internal EmitBatchArgs EmitBatchArgs { get; private set; }
+
+    internal Batch Batch { get; private set; }
+
+    /// <inheritdoc/>
+    public override ExportResult Export(in Batch<Activity> activityBatch)
+    {
+        try
+        {
+            if (this.Batch == null)
             {
-                protocolFactory ??= new TCompactProtocol.Factory();
-                client ??= new JaegerUdpClient(options.AgentHost, options.AgentPort);
-                this.sendUsingEmitBatchArgs = true;
+                this.SetResourceAndInitializeBatch(this.ParentProvider.GetResource());
             }
-            else if (options.Protocol == JaegerExportProtocol.HttpBinaryThrift)
+
+            foreach (var activity in activityBatch)
             {
-                protocolFactory ??= new TBinaryProtocol.Factory();
-                client ??= new JaegerHttpClient(
-                    options.Endpoint,
-                    options.HttpClientFactory?.Invoke() ?? throw new InvalidOperationException("JaegerExporterOptions was missing HttpClientFactory or it returned null."));
-            }
-            else
-            {
-                throw new NotSupportedException();
+                var jaegerSpan = activity.ToJaegerSpan();
+                this.AppendSpan(jaegerSpan);
+                jaegerSpan.Return();
             }
 
-            JaegerTagTransformer.LogUnsupportedAttributeType = (string tagValueType, string tagKey) =>
+            this.SendCurrentBatch();
+
+            return ExportResult.Success;
+        }
+        catch (Exception ex)
+        {
+            JaegerExporterEventSource.Log.FailedExport(ex);
+
+            return ExportResult.Failure;
+        }
+    }
+
+    internal void SetResourceAndInitializeBatch(Resource resource)
+    {
+        Guard.ThrowIfNull(resource);
+
+        var process = this.Process;
+
+        string serviceName = null;
+        string serviceNamespace = null;
+        foreach (var label in resource.Attributes)
+        {
+            string key = label.Key;
+
+            if (label.Value is string strVal)
             {
-                JaegerExporterEventSource.Log.UnsupportedAttributeType(tagValueType, tagKey);
-            };
+                switch (key)
+                {
+                    case ResourceSemanticConventions.AttributeServiceName:
+                        serviceName = strVal;
+                        continue;
+                    case ResourceSemanticConventions.AttributeServiceNamespace:
+                        serviceNamespace = strVal;
+                        continue;
+                }
+            }
 
-            ConfigurationExtensions.LogInvalidEnvironmentVariable = (string key, string value) =>
+            if (JaegerTagTransformer.Instance.TryTransformTag(label, out var result))
             {
-                JaegerExporterEventSource.Log.InvalidEnvironmentVariable(key, value);
-            };
+                if (process.Tags == null)
+                {
+                    process.Tags = new Dictionary<string, JaegerTag>();
+                }
 
-            this.client = client;
-            this.batchWriter = protocolFactory.GetProtocol(this.maxPayloadSizeInBytes * 2);
-            this.spanWriter = protocolFactory.GetProtocol(this.maxPayloadSizeInBytes);
-
-            this.Process = new();
-
-            client.Connect();
+                process.Tags[key] = result;
+            }
         }
 
-        internal Process Process { get; }
-
-        internal EmitBatchArgs EmitBatchArgs { get; private set; }
-
-        internal Batch Batch { get; private set; }
-
-        /// <inheritdoc/>
-        public override ExportResult Export(in Batch<Activity> activityBatch)
+        if (!string.IsNullOrWhiteSpace(serviceName))
         {
-            try
+            serviceName = string.IsNullOrEmpty(serviceNamespace)
+                ? serviceName
+                : serviceNamespace + "." + serviceName;
+        }
+        else
+        {
+            serviceName = (string)this.ParentProvider.GetDefaultResource().Attributes.FirstOrDefault(
+                pair => pair.Key == ResourceSemanticConventions.AttributeServiceName).Value;
+        }
+
+        process.ServiceName = serviceName;
+
+        this.Batch = new Batch(process, this.batchWriter);
+        if (this.sendUsingEmitBatchArgs)
+        {
+            this.EmitBatchArgs = new EmitBatchArgs(this.batchWriter);
+            this.Batch.SpanCountPosition += this.EmitBatchArgs.EmitBatchArgsBeginMessage.Length;
+            this.batchWriter.WriteRaw(this.EmitBatchArgs.EmitBatchArgsBeginMessage);
+        }
+
+        this.batchWriter.WriteRaw(this.Batch.BatchBeginMessage);
+        this.spanStartPosition = this.batchWriter.Position;
+
+        this.minimumBatchSizeInBytes = this.EmitBatchArgs?.MinimumMessageSize ?? 0
+            + this.Batch.MinimumMessageSize;
+
+        this.ResetBatch();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void AppendSpan(JaegerSpan jaegerSpan)
+    {
+        jaegerSpan.Write(this.spanWriter);
+        try
+        {
+            var spanTotalBytesNeeded = this.spanWriter.Length;
+
+            if (this.NumberOfSpansInCurrentBatch > 0
+                && this.currentBatchSizeInBytes + spanTotalBytesNeeded >= this.maxPayloadSizeInBytes)
             {
-                if (this.Batch == null)
-                {
-                    this.SetResourceAndInitializeBatch(this.ParentProvider.GetResource());
-                }
-
-                foreach (var activity in activityBatch)
-                {
-                    var jaegerSpan = activity.ToJaegerSpan();
-                    this.AppendSpan(jaegerSpan);
-                    jaegerSpan.Return();
-                }
-
                 this.SendCurrentBatch();
-
-                return ExportResult.Success;
             }
-            catch (Exception ex)
-            {
-                JaegerExporterEventSource.Log.FailedExport(ex);
 
-                return ExportResult.Failure;
-            }
+            var spanData = this.spanWriter.WrittenData;
+            this.batchWriter.WriteRaw(spanData);
+
+            this.NumberOfSpansInCurrentBatch++;
+            this.currentBatchSizeInBytes += spanTotalBytesNeeded;
         }
-
-        internal void SetResourceAndInitializeBatch(Resource resource)
+        finally
         {
-            Guard.ThrowIfNull(resource);
+            this.spanWriter.Clear();
+        }
+    }
 
-            var process = this.Process;
+    internal void SendCurrentBatch()
+    {
+        try
+        {
+            this.batchWriter.WriteRaw(this.Batch.BatchEndMessage);
 
-            string serviceName = null;
-            string serviceNamespace = null;
-            foreach (var label in resource.Attributes)
-            {
-                string key = label.Key;
-
-                if (label.Value is string strVal)
-                {
-                    switch (key)
-                    {
-                        case ResourceSemanticConventions.AttributeServiceName:
-                            serviceName = strVal;
-                            continue;
-                        case ResourceSemanticConventions.AttributeServiceNamespace:
-                            serviceNamespace = strVal;
-                            continue;
-                    }
-                }
-
-                if (JaegerTagTransformer.Instance.TryTransformTag(label, out var result))
-                {
-                    if (process.Tags == null)
-                    {
-                        process.Tags = new Dictionary<string, JaegerTag>();
-                    }
-
-                    process.Tags[key] = result;
-                }
-            }
-
-            if (!string.IsNullOrWhiteSpace(serviceName))
-            {
-                serviceName = string.IsNullOrEmpty(serviceNamespace)
-                    ? serviceName
-                    : serviceNamespace + "." + serviceName;
-            }
-            else
-            {
-                serviceName = (string)this.ParentProvider.GetDefaultResource().Attributes.FirstOrDefault(
-                    pair => pair.Key == ResourceSemanticConventions.AttributeServiceName).Value;
-            }
-
-            process.ServiceName = serviceName;
-
-            this.Batch = new Batch(process, this.batchWriter);
             if (this.sendUsingEmitBatchArgs)
             {
-                this.EmitBatchArgs = new EmitBatchArgs(this.batchWriter);
-                this.Batch.SpanCountPosition += this.EmitBatchArgs.EmitBatchArgsBeginMessage.Length;
-                this.batchWriter.WriteRaw(this.EmitBatchArgs.EmitBatchArgsBeginMessage);
+                this.batchWriter.WriteRaw(this.EmitBatchArgs.EmitBatchArgsEndMessage);
+
+                this.WriteUInt32AtPosition(this.EmitBatchArgs.SeqIdPosition, ++this.sequenceId);
             }
 
-            this.batchWriter.WriteRaw(this.Batch.BatchBeginMessage);
-            this.spanStartPosition = this.batchWriter.Position;
+            this.WriteUInt32AtPosition(this.Batch.SpanCountPosition, this.NumberOfSpansInCurrentBatch);
 
-            this.minimumBatchSizeInBytes = this.EmitBatchArgs?.MinimumMessageSize ?? 0
-                + this.Batch.MinimumMessageSize;
+            var writtenData = this.batchWriter.WrittenData;
 
+            this.client.Send(writtenData.Array, writtenData.Offset, writtenData.Count);
+        }
+        finally
+        {
             this.ResetBatch();
         }
+    }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void AppendSpan(JaegerSpan jaegerSpan)
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (!this.disposed)
         {
-            jaegerSpan.Write(this.spanWriter);
-            try
+            if (disposing)
             {
-                var spanTotalBytesNeeded = this.spanWriter.Length;
-
-                if (this.NumberOfSpansInCurrentBatch > 0
-                    && this.currentBatchSizeInBytes + spanTotalBytesNeeded >= this.maxPayloadSizeInBytes)
+                try
                 {
-                    this.SendCurrentBatch();
+                    this.client.Close();
+                }
+                catch
+                {
                 }
 
-                var spanData = this.spanWriter.WrittenData;
-                this.batchWriter.WriteRaw(spanData);
-
-                this.NumberOfSpansInCurrentBatch++;
-                this.currentBatchSizeInBytes += spanTotalBytesNeeded;
-            }
-            finally
-            {
-                this.spanWriter.Clear();
-            }
-        }
-
-        internal void SendCurrentBatch()
-        {
-            try
-            {
-                this.batchWriter.WriteRaw(this.Batch.BatchEndMessage);
-
-                if (this.sendUsingEmitBatchArgs)
-                {
-                    this.batchWriter.WriteRaw(this.EmitBatchArgs.EmitBatchArgsEndMessage);
-
-                    this.WriteUInt32AtPosition(this.EmitBatchArgs.SeqIdPosition, ++this.sequenceId);
-                }
-
-                this.WriteUInt32AtPosition(this.Batch.SpanCountPosition, this.NumberOfSpansInCurrentBatch);
-
-                var writtenData = this.batchWriter.WrittenData;
-
-                this.client.Send(writtenData.Array, writtenData.Offset, writtenData.Count);
-            }
-            finally
-            {
-                this.ResetBatch();
-            }
-        }
-
-        /// <inheritdoc/>
-        protected override void Dispose(bool disposing)
-        {
-            if (!this.disposed)
-            {
-                if (disposing)
-                {
-                    try
-                    {
-                        this.client.Close();
-                    }
-                    catch
-                    {
-                    }
-
-                    this.client.Dispose();
-                    this.batchWriter.Dispose();
-                    this.spanWriter.Dispose();
-                }
-
-                this.disposed = true;
+                this.client.Dispose();
+                this.batchWriter.Dispose();
+                this.spanWriter.Dispose();
             }
 
-            base.Dispose(disposing);
+            this.disposed = true;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void WriteUInt32AtPosition(int position, uint value)
-        {
-            this.batchWriter.Position = position;
-            int numberOfBytes = this.batchWriter.WriteUI32(value, this.uInt32Storage);
-            this.batchWriter.WriteRaw(this.uInt32Storage, 0, numberOfBytes);
-        }
+        base.Dispose(disposing);
+    }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void ResetBatch()
-        {
-            this.currentBatchSizeInBytes = this.minimumBatchSizeInBytes;
-            this.NumberOfSpansInCurrentBatch = 0;
-            this.batchWriter.Clear(this.spanStartPosition);
-        }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void WriteUInt32AtPosition(int position, uint value)
+    {
+        this.batchWriter.Position = position;
+        int numberOfBytes = this.batchWriter.WriteUI32(value, this.uInt32Storage);
+        this.batchWriter.WriteRaw(this.uInt32Storage, 0, numberOfBytes);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void ResetBatch()
+    {
+        this.currentBatchSizeInBytes = this.minimumBatchSizeInBytes;
+        this.NumberOfSpansInCurrentBatch = 0;
+        this.batchWriter.Clear(this.spanStartPosition);
     }
 }

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterHelperExtensions.cs
@@ -24,114 +24,113 @@ using Microsoft.Extensions.Options;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Internal;
 
-namespace OpenTelemetry.Trace
+namespace OpenTelemetry.Trace;
+
+/// <summary>
+/// Extension methods to simplify registering a Jaeger exporter.
+/// </summary>
+public static class JaegerExporterHelperExtensions
 {
     /// <summary>
-    /// Extension methods to simplify registering a Jaeger exporter.
+    /// Adds Jaeger exporter to the TracerProvider.
     /// </summary>
-    public static class JaegerExporterHelperExtensions
+    /// <param name="builder"><see cref="TracerProviderBuilder"/> builder to use.</param>
+    /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
+    public static TracerProviderBuilder AddJaegerExporter(this TracerProviderBuilder builder)
+        => AddJaegerExporter(builder, name: null, configure: null);
+
+    /// <summary>
+    /// Adds Jaeger exporter to the TracerProvider.
+    /// </summary>
+    /// <param name="builder"><see cref="TracerProviderBuilder"/> builder to use.</param>
+    /// <param name="configure">Callback action for configuring <see cref="JaegerExporterOptions"/>.</param>
+    /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
+    public static TracerProviderBuilder AddJaegerExporter(this TracerProviderBuilder builder, Action<JaegerExporterOptions> configure)
+        => AddJaegerExporter(builder, name: null, configure);
+
+    /// <summary>
+    /// Adds Jaeger exporter to the TracerProvider.
+    /// </summary>
+    /// <param name="builder"><see cref="TracerProviderBuilder"/> builder to use.</param>
+    /// <param name="name">Name which is used when retrieving options.</param>
+    /// <param name="configure">Callback action for configuring <see cref="JaegerExporterOptions"/>.</param>
+    /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
+    public static TracerProviderBuilder AddJaegerExporter(
+        this TracerProviderBuilder builder,
+        string name,
+        Action<JaegerExporterOptions> configure)
     {
-        /// <summary>
-        /// Adds Jaeger exporter to the TracerProvider.
-        /// </summary>
-        /// <param name="builder"><see cref="TracerProviderBuilder"/> builder to use.</param>
-        /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
-        public static TracerProviderBuilder AddJaegerExporter(this TracerProviderBuilder builder)
-            => AddJaegerExporter(builder, name: null, configure: null);
+        Guard.ThrowIfNull(builder);
 
-        /// <summary>
-        /// Adds Jaeger exporter to the TracerProvider.
-        /// </summary>
-        /// <param name="builder"><see cref="TracerProviderBuilder"/> builder to use.</param>
-        /// <param name="configure">Callback action for configuring <see cref="JaegerExporterOptions"/>.</param>
-        /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
-        public static TracerProviderBuilder AddJaegerExporter(this TracerProviderBuilder builder, Action<JaegerExporterOptions> configure)
-            => AddJaegerExporter(builder, name: null, configure);
+        name ??= Options.DefaultName;
 
-        /// <summary>
-        /// Adds Jaeger exporter to the TracerProvider.
-        /// </summary>
-        /// <param name="builder"><see cref="TracerProviderBuilder"/> builder to use.</param>
-        /// <param name="name">Name which is used when retrieving options.</param>
-        /// <param name="configure">Callback action for configuring <see cref="JaegerExporterOptions"/>.</param>
-        /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
-        public static TracerProviderBuilder AddJaegerExporter(
-            this TracerProviderBuilder builder,
-            string name,
-            Action<JaegerExporterOptions> configure)
+        builder.ConfigureServices(services =>
         {
-            Guard.ThrowIfNull(builder);
-
-            name ??= Options.DefaultName;
-
-            builder.ConfigureServices(services =>
+            if (configure != null)
             {
-                if (configure != null)
-                {
-                    services.Configure(name, configure);
-                }
+                services.Configure(name, configure);
+            }
 
-                services.RegisterOptionsFactory(
-                    (sp, configuration, name) => new JaegerExporterOptions(
-                        configuration,
-                        sp.GetRequiredService<IOptionsMonitor<BatchExportActivityProcessorOptions>>().Get(name)));
-            });
+            services.RegisterOptionsFactory(
+                (sp, configuration, name) => new JaegerExporterOptions(
+                    configuration,
+                    sp.GetRequiredService<IOptionsMonitor<BatchExportActivityProcessorOptions>>().Get(name)));
+        });
 
-            return builder.AddProcessor(sp =>
-            {
-                var options = sp.GetRequiredService<IOptionsMonitor<JaegerExporterOptions>>().Get(name);
-
-                return BuildJaegerExporterProcessor(options, sp);
-            });
-        }
-
-        private static BaseProcessor<Activity> BuildJaegerExporterProcessor(
-            JaegerExporterOptions options,
-            IServiceProvider serviceProvider)
+        return builder.AddProcessor(sp =>
         {
-            if (options.Protocol == JaegerExportProtocol.HttpBinaryThrift
-                && options.HttpClientFactory == JaegerExporterOptions.DefaultHttpClientFactory)
+            var options = sp.GetRequiredService<IOptionsMonitor<JaegerExporterOptions>>().Get(name);
+
+            return BuildJaegerExporterProcessor(options, sp);
+        });
+    }
+
+    private static BaseProcessor<Activity> BuildJaegerExporterProcessor(
+        JaegerExporterOptions options,
+        IServiceProvider serviceProvider)
+    {
+        if (options.Protocol == JaegerExportProtocol.HttpBinaryThrift
+            && options.HttpClientFactory == JaegerExporterOptions.DefaultHttpClientFactory)
+        {
+            options.HttpClientFactory = () =>
             {
-                options.HttpClientFactory = () =>
+                Type httpClientFactoryType = Type.GetType("System.Net.Http.IHttpClientFactory, Microsoft.Extensions.Http", throwOnError: false);
+                if (httpClientFactoryType != null)
                 {
-                    Type httpClientFactoryType = Type.GetType("System.Net.Http.IHttpClientFactory, Microsoft.Extensions.Http", throwOnError: false);
-                    if (httpClientFactoryType != null)
+                    object httpClientFactory = serviceProvider.GetService(httpClientFactoryType);
+                    if (httpClientFactory != null)
                     {
-                        object httpClientFactory = serviceProvider.GetService(httpClientFactoryType);
-                        if (httpClientFactory != null)
+                        MethodInfo createClientMethod = httpClientFactoryType.GetMethod(
+                            "CreateClient",
+                            BindingFlags.Public | BindingFlags.Instance,
+                            binder: null,
+                            new Type[] { typeof(string) },
+                            modifiers: null);
+                        if (createClientMethod != null)
                         {
-                            MethodInfo createClientMethod = httpClientFactoryType.GetMethod(
-                                "CreateClient",
-                                BindingFlags.Public | BindingFlags.Instance,
-                                binder: null,
-                                new Type[] { typeof(string) },
-                                modifiers: null);
-                            if (createClientMethod != null)
-                            {
-                                return (HttpClient)createClientMethod.Invoke(httpClientFactory, new object[] { "JaegerExporter" });
-                            }
+                            return (HttpClient)createClientMethod.Invoke(httpClientFactory, new object[] { "JaegerExporter" });
                         }
                     }
+                }
 
-                    return new HttpClient();
-                };
-            }
+                return new HttpClient();
+            };
+        }
 
-            var jaegerExporter = new JaegerExporter(options);
+        var jaegerExporter = new JaegerExporter(options);
 
-            if (options.ExportProcessorType == ExportProcessorType.Simple)
-            {
-                return new SimpleActivityExportProcessor(jaegerExporter);
-            }
-            else
-            {
-                return new BatchActivityExportProcessor(
-                    jaegerExporter,
-                    options.BatchExportProcessorOptions.MaxQueueSize,
-                    options.BatchExportProcessorOptions.ScheduledDelayMilliseconds,
-                    options.BatchExportProcessorOptions.ExporterTimeoutMilliseconds,
-                    options.BatchExportProcessorOptions.MaxExportBatchSize);
-            }
+        if (options.ExportProcessorType == ExportProcessorType.Simple)
+        {
+            return new SimpleActivityExportProcessor(jaegerExporter);
+        }
+        else
+        {
+            return new BatchActivityExportProcessor(
+                jaegerExporter,
+                options.BatchExportProcessorOptions.MaxQueueSize,
+                options.BatchExportProcessorOptions.ScheduledDelayMilliseconds,
+                options.BatchExportProcessorOptions.ExporterTimeoutMilliseconds,
+                options.BatchExportProcessorOptions.MaxExportBatchSize);
         }
     }
 }

--- a/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Jaeger/JaegerExporterOptions.cs
@@ -22,125 +22,124 @@ using Microsoft.Extensions.Configuration;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
 
-namespace OpenTelemetry.Exporter
+namespace OpenTelemetry.Exporter;
+
+/// <summary>
+/// Jaeger exporter options.
+/// OTEL_EXPORTER_JAEGER_AGENT_HOST, OTEL_EXPORTER_JAEGER_AGENT_PORT
+/// environment variables are parsed during object construction.
+/// </summary>
+public class JaegerExporterOptions
 {
+    internal const int DefaultMaxPayloadSizeInBytes = 4096;
+
+    internal const string OTelProtocolEnvVarKey = "OTEL_EXPORTER_JAEGER_PROTOCOL";
+    internal const string OTelAgentHostEnvVarKey = "OTEL_EXPORTER_JAEGER_AGENT_HOST";
+    internal const string OTelAgentPortEnvVarKey = "OTEL_EXPORTER_JAEGER_AGENT_PORT";
+    internal const string OTelEndpointEnvVarKey = "OTEL_EXPORTER_JAEGER_ENDPOINT";
+    internal const string DefaultJaegerEndpoint = "http://localhost:14268/api/traces";
+
+    internal static readonly Func<HttpClient> DefaultHttpClientFactory = () => new HttpClient();
+
     /// <summary>
-    /// Jaeger exporter options.
-    /// OTEL_EXPORTER_JAEGER_AGENT_HOST, OTEL_EXPORTER_JAEGER_AGENT_PORT
-    /// environment variables are parsed during object construction.
+    /// Initializes a new instance of the <see cref="JaegerExporterOptions"/> class.
     /// </summary>
-    public class JaegerExporterOptions
+    public JaegerExporterOptions()
+        : this(new ConfigurationBuilder().AddEnvironmentVariables().Build(), new())
     {
-        internal const int DefaultMaxPayloadSizeInBytes = 4096;
-
-        internal const string OTelProtocolEnvVarKey = "OTEL_EXPORTER_JAEGER_PROTOCOL";
-        internal const string OTelAgentHostEnvVarKey = "OTEL_EXPORTER_JAEGER_AGENT_HOST";
-        internal const string OTelAgentPortEnvVarKey = "OTEL_EXPORTER_JAEGER_AGENT_PORT";
-        internal const string OTelEndpointEnvVarKey = "OTEL_EXPORTER_JAEGER_ENDPOINT";
-        internal const string DefaultJaegerEndpoint = "http://localhost:14268/api/traces";
-
-        internal static readonly Func<HttpClient> DefaultHttpClientFactory = () => new HttpClient();
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="JaegerExporterOptions"/> class.
-        /// </summary>
-        public JaegerExporterOptions()
-            : this(new ConfigurationBuilder().AddEnvironmentVariables().Build(), new())
-        {
-        }
-
-        internal JaegerExporterOptions(
-            IConfiguration configuration,
-            BatchExportActivityProcessorOptions defaultBatchOptions)
-        {
-            Debug.Assert(configuration != null, "configuration was null");
-            Debug.Assert(defaultBatchOptions != null, "defaultBatchOptions was null");
-
-            if (configuration.TryGetValue<JaegerExportProtocol>(
-                OTelProtocolEnvVarKey,
-                JaegerExporterProtocolParser.TryParse,
-                out var protocol))
-            {
-                this.Protocol = protocol;
-            }
-
-            if (configuration.TryGetStringValue(OTelAgentHostEnvVarKey, out var agentHost))
-            {
-                this.AgentHost = agentHost;
-            }
-
-            if (configuration.TryGetIntValue(OTelAgentPortEnvVarKey, out var agentPort))
-            {
-                this.AgentPort = agentPort;
-            }
-
-            if (configuration.TryGetUriValue(OTelEndpointEnvVarKey, out var endpoint))
-            {
-                this.Endpoint = endpoint;
-            }
-
-            this.BatchExportProcessorOptions = defaultBatchOptions;
-        }
-
-        /// <summary>
-        /// Gets or sets the <see cref="JaegerExportProtocol"/> to use when
-        /// communicating to Jaeger. Default value: <see
-        /// cref="JaegerExportProtocol.UdpCompactThrift"/>.
-        /// </summary>
-        public JaegerExportProtocol Protocol { get; set; } = JaegerExportProtocol.UdpCompactThrift;
-
-        /// <summary>
-        /// Gets or sets the Jaeger agent host. Default value: localhost.
-        /// </summary>
-        public string AgentHost { get; set; } = "localhost";
-
-        /// <summary>
-        /// Gets or sets the Jaeger agent port. Default value: 6831.
-        /// </summary>
-        public int AgentPort { get; set; } = 6831;
-
-        /// <summary>
-        /// Gets or sets the Jaeger HTTP endpoint. Default value: "http://localhost:14268/api/traces".
-        /// Typically https://jaeger-server-name:14268/api/traces.
-        /// </summary>
-        public Uri Endpoint { get; set; } = new Uri(DefaultJaegerEndpoint);
-
-        /// <summary>
-        /// Gets or sets the maximum payload size in bytes. Default value: 4096.
-        /// </summary>
-        public int? MaxPayloadSizeInBytes { get; set; } = DefaultMaxPayloadSizeInBytes;
-
-        /// <summary>
-        /// Gets or sets the export processor type to be used with Jaeger Exporter. The default value is <see cref="ExportProcessorType.Batch"/>.
-        /// </summary>
-        public ExportProcessorType ExportProcessorType { get; set; } = ExportProcessorType.Batch;
-
-        /// <summary>
-        /// Gets or sets the BatchExportProcessor options. Ignored unless ExportProcessorType is BatchExporter.
-        /// </summary>
-        public BatchExportProcessorOptions<Activity> BatchExportProcessorOptions { get; set; }
-
-        /// <summary>
-        /// Gets or sets the factory function called to create the <see
-        /// cref="HttpClient"/> instance that will be used at runtime to
-        /// transmit spans over HTTP. The returned instance will be reused for
-        /// all export invocations.
-        /// </summary>
-        /// <remarks>
-        /// Notes:
-        /// <list type="bullet">
-        /// <item>This is only invoked for the <see
-        /// cref="JaegerExportProtocol.HttpBinaryThrift"/> protocol.</item>
-        /// <item>The default behavior when using the <see
-        /// cref="JaegerExporterHelperExtensions.AddJaegerExporter(TracerProviderBuilder,
-        /// Action{JaegerExporterOptions})"/> extension is if an <a
-        /// href="https://docs.microsoft.com/dotnet/api/system.net.http.ihttpclientfactory">IHttpClientFactory</a>
-        /// instance can be resolved through the application <see
-        /// cref="IServiceProvider"/> then an <see cref="HttpClient"/> will be
-        /// created through the factory with the name "JaegerExporter" otherwise
-        /// an <see cref="HttpClient"/> will be instantiated directly.</item>
-        /// </list>
-        /// </remarks>
-        public Func<HttpClient> HttpClientFactory { get; set; } = DefaultHttpClientFactory;
     }
+
+    internal JaegerExporterOptions(
+        IConfiguration configuration,
+        BatchExportActivityProcessorOptions defaultBatchOptions)
+    {
+        Debug.Assert(configuration != null, "configuration was null");
+        Debug.Assert(defaultBatchOptions != null, "defaultBatchOptions was null");
+
+        if (configuration.TryGetValue<JaegerExportProtocol>(
+            OTelProtocolEnvVarKey,
+            JaegerExporterProtocolParser.TryParse,
+            out var protocol))
+        {
+            this.Protocol = protocol;
+        }
+
+        if (configuration.TryGetStringValue(OTelAgentHostEnvVarKey, out var agentHost))
+        {
+            this.AgentHost = agentHost;
+        }
+
+        if (configuration.TryGetIntValue(OTelAgentPortEnvVarKey, out var agentPort))
+        {
+            this.AgentPort = agentPort;
+        }
+
+        if (configuration.TryGetUriValue(OTelEndpointEnvVarKey, out var endpoint))
+        {
+            this.Endpoint = endpoint;
+        }
+
+        this.BatchExportProcessorOptions = defaultBatchOptions;
+    }
+
+    /// <summary>
+    /// Gets or sets the <see cref="JaegerExportProtocol"/> to use when
+    /// communicating to Jaeger. Default value: <see
+    /// cref="JaegerExportProtocol.UdpCompactThrift"/>.
+    /// </summary>
+    public JaegerExportProtocol Protocol { get; set; } = JaegerExportProtocol.UdpCompactThrift;
+
+    /// <summary>
+    /// Gets or sets the Jaeger agent host. Default value: localhost.
+    /// </summary>
+    public string AgentHost { get; set; } = "localhost";
+
+    /// <summary>
+    /// Gets or sets the Jaeger agent port. Default value: 6831.
+    /// </summary>
+    public int AgentPort { get; set; } = 6831;
+
+    /// <summary>
+    /// Gets or sets the Jaeger HTTP endpoint. Default value: "http://localhost:14268/api/traces".
+    /// Typically https://jaeger-server-name:14268/api/traces.
+    /// </summary>
+    public Uri Endpoint { get; set; } = new Uri(DefaultJaegerEndpoint);
+
+    /// <summary>
+    /// Gets or sets the maximum payload size in bytes. Default value: 4096.
+    /// </summary>
+    public int? MaxPayloadSizeInBytes { get; set; } = DefaultMaxPayloadSizeInBytes;
+
+    /// <summary>
+    /// Gets or sets the export processor type to be used with Jaeger Exporter. The default value is <see cref="ExportProcessorType.Batch"/>.
+    /// </summary>
+    public ExportProcessorType ExportProcessorType { get; set; } = ExportProcessorType.Batch;
+
+    /// <summary>
+    /// Gets or sets the BatchExportProcessor options. Ignored unless ExportProcessorType is BatchExporter.
+    /// </summary>
+    public BatchExportProcessorOptions<Activity> BatchExportProcessorOptions { get; set; }
+
+    /// <summary>
+    /// Gets or sets the factory function called to create the <see
+    /// cref="HttpClient"/> instance that will be used at runtime to
+    /// transmit spans over HTTP. The returned instance will be reused for
+    /// all export invocations.
+    /// </summary>
+    /// <remarks>
+    /// Notes:
+    /// <list type="bullet">
+    /// <item>This is only invoked for the <see
+    /// cref="JaegerExportProtocol.HttpBinaryThrift"/> protocol.</item>
+    /// <item>The default behavior when using the <see
+    /// cref="JaegerExporterHelperExtensions.AddJaegerExporter(TracerProviderBuilder,
+    /// Action{JaegerExporterOptions})"/> extension is if an <a
+    /// href="https://docs.microsoft.com/dotnet/api/system.net.http.ihttpclientfactory">IHttpClientFactory</a>
+    /// instance can be resolved through the application <see
+    /// cref="IServiceProvider"/> then an <see cref="HttpClient"/> will be
+    /// created through the factory with the name "JaegerExporter" otherwise
+    /// an <see cref="HttpClient"/> will be instantiated directly.</item>
+    /// </list>
+    /// </remarks>
+    public Func<HttpClient> HttpClientFactory { get; set; } = DefaultHttpClientFactory;
 }

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/EventSourceTest.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/EventSourceTest.cs
@@ -18,14 +18,13 @@ using OpenTelemetry.Exporter.Jaeger.Implementation;
 using OpenTelemetry.Tests;
 using Xunit;
 
-namespace OpenTelemetry.Exporter.Jaeger.Tests
+namespace OpenTelemetry.Exporter.Jaeger.Tests;
+
+public class EventSourceTest
 {
-    public class EventSourceTest
+    [Fact]
+    public void EventSourceTest_JaegerExporterEventSource()
     {
-        [Fact]
-        public void EventSourceTest_JaegerExporterEventSource()
-        {
-            EventSourceTestHelper.MethodsAreImplementedConsistentlyWithTheirAttributes(JaegerExporterEventSource.Log);
-        }
+        EventSourceTestHelper.MethodsAreImplementedConsistentlyWithTheirAttributes(JaegerExporterEventSource.Log);
     }
 }

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/Int128Test.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/Int128Test.cs
@@ -17,18 +17,17 @@
 using System.Diagnostics;
 using Xunit;
 
-namespace OpenTelemetry.Exporter.Jaeger.Implementation.Tests
-{
-    public class Int128Test
-    {
-        [Fact]
-        public void Int128ConversionWorksAsExpected()
-        {
-            var id = ActivityTraceId.CreateFromBytes(new byte[] { 0x1a, 0x0f, 0x54, 0x63, 0x25, 0xa8, 0x56, 0x43, 0x1a, 0x4c, 0x24, 0xea, 0xa8, 0x60, 0xb0, 0xe8 });
-            var int128 = new Int128(id);
+namespace OpenTelemetry.Exporter.Jaeger.Implementation.Tests;
 
-            Assert.Equal(unchecked(0x1a0f546325a85643), int128.High);
-            Assert.Equal(unchecked(0x1a4c24eaa860b0e8), int128.Low);
-        }
+public class Int128Test
+{
+    [Fact]
+    public void Int128ConversionWorksAsExpected()
+    {
+        var id = ActivityTraceId.CreateFromBytes(new byte[] { 0x1a, 0x0f, 0x54, 0x63, 0x25, 0xa8, 0x56, 0x43, 0x1a, 0x4c, 0x24, 0xea, 0xa8, 0x60, 0xb0, 0xe8 });
+        var int128 = new Int128(id);
+
+        Assert.Equal(unchecked(0x1a0f546325a85643), int128.High);
+        Assert.Equal(unchecked(0x1a4c24eaa860b0e8), int128.Low);
     }
 }

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerActivityConversionTest.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/Implementation/JaegerActivityConversionTest.cs
@@ -20,843 +20,842 @@ using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using Xunit;
 
-namespace OpenTelemetry.Exporter.Jaeger.Implementation.Tests
+namespace OpenTelemetry.Exporter.Jaeger.Implementation.Tests;
+
+public class JaegerActivityConversionTest
 {
-    public class JaegerActivityConversionTest
+    static JaegerActivityConversionTest()
     {
-        static JaegerActivityConversionTest()
-        {
-            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
-            Activity.ForceDefaultIdFormat = true;
+        Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+        Activity.ForceDefaultIdFormat = true;
 
-            var listener = new ActivityListener
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = _ => true,
+            Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
+        };
+
+        ActivitySource.AddActivityListener(listener);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void JaegerActivityConverterTest_ConvertActivityToJaegerSpan_AllPropertiesSet(bool isRootSpan)
+    {
+        using var activity = CreateTestActivity(isRootSpan: isRootSpan);
+        var traceIdAsInt = new Int128(activity.Context.TraceId);
+        var spanIdAsInt = new Int128(activity.Context.SpanId);
+        var linkTraceIdAsInt = new Int128(activity.Links.Single().Context.TraceId);
+        var linkSpanIdAsInt = new Int128(activity.Links.Single().Context.SpanId);
+
+        var jaegerSpan = activity.ToJaegerSpan();
+
+        Assert.Equal("Name", jaegerSpan.OperationName);
+        Assert.Equal(2, jaegerSpan.Logs.Count);
+
+        Assert.Equal(traceIdAsInt.High, jaegerSpan.TraceIdHigh);
+        Assert.Equal(traceIdAsInt.Low, jaegerSpan.TraceIdLow);
+        Assert.Equal(spanIdAsInt.Low, jaegerSpan.SpanId);
+        Assert.Equal(new Int128(activity.ParentSpanId).Low, jaegerSpan.ParentSpanId);
+
+        Assert.Equal(activity.Links.Count(), jaegerSpan.References.Count);
+        var references = jaegerSpan.References.ToArray();
+        var jaegerRef = references[0];
+        Assert.Equal(linkTraceIdAsInt.High, jaegerRef.TraceIdHigh);
+        Assert.Equal(linkTraceIdAsInt.Low, jaegerRef.TraceIdLow);
+        Assert.Equal(linkSpanIdAsInt.Low, jaegerRef.SpanId);
+
+        Assert.Equal(0x1, jaegerSpan.Flags);
+
+        Assert.Equal(activity.StartTimeUtc.ToEpochMicroseconds(), jaegerSpan.StartTime);
+        Assert.Equal(TimeSpanToMicroseconds(activity.Duration), jaegerSpan.Duration);
+
+        var tags = jaegerSpan.Tags.ToArray();
+        var tag = tags[0];
+        Assert.Equal(JaegerTagType.STRING, tag.VType);
+        Assert.Equal("stringKey", tag.Key);
+        Assert.Equal("value", tag.VStr);
+        tag = tags[1];
+        Assert.Equal(JaegerTagType.LONG, tag.VType);
+        Assert.Equal("longKey", tag.Key);
+        Assert.Equal(1, tag.VLong);
+        tag = tags[2];
+        Assert.Equal(JaegerTagType.LONG, tag.VType);
+        Assert.Equal("longKey2", tag.Key);
+        Assert.Equal(1, tag.VLong);
+        tag = tags[3];
+        Assert.Equal(JaegerTagType.DOUBLE, tag.VType);
+        Assert.Equal("doubleKey", tag.Key);
+        Assert.Equal(1, tag.VDouble);
+        tag = tags[4];
+        Assert.Equal(JaegerTagType.DOUBLE, tag.VType);
+        Assert.Equal("doubleKey2", tag.Key);
+        Assert.Equal(1, tag.VDouble);
+        tag = tags[5];
+        Assert.Equal(JaegerTagType.BOOL, tag.VType);
+        Assert.Equal("boolKey", tag.Key);
+        Assert.Equal(true, tag.VBool);
+
+        var logs = jaegerSpan.Logs.ToArray();
+        var jaegerLog = logs[0];
+        Assert.Equal(activity.Events.First().Timestamp.ToEpochMicroseconds(), jaegerLog.Timestamp);
+        Assert.Equal(3, jaegerLog.Fields.Count);
+        var eventFields = jaegerLog.Fields.ToArray();
+        var eventField = eventFields[0];
+        Assert.Equal("key", eventField.Key);
+        Assert.Equal("value", eventField.VStr);
+        eventField = eventFields[1];
+        Assert.Equal("string_array", eventField.Key);
+        Assert.Equal(@"[""a"",""b""]", eventField.VStr);
+        eventField = eventFields[2];
+        Assert.Equal("event", eventField.Key);
+        Assert.Equal("Event1", eventField.VStr);
+
+        Assert.Equal(activity.Events.First().Timestamp.ToEpochMicroseconds(), jaegerLog.Timestamp);
+
+        jaegerLog = logs[1];
+        Assert.Equal(2, jaegerLog.Fields.Count);
+        eventFields = jaegerLog.Fields.ToArray();
+        eventField = eventFields[0];
+        Assert.Equal("key", eventField.Key);
+        Assert.Equal("value", eventField.VStr);
+        eventField = eventFields[1];
+        Assert.Equal("event", eventField.Key);
+        Assert.Equal("Event2", eventField.VStr);
+    }
+
+    [Fact]
+    public void JaegerActivityConverterTest_ConvertActivityToJaegerSpan_NoAttributes()
+    {
+        using var activity = CreateTestActivity(setAttributes: false);
+        var traceIdAsInt = new Int128(activity.Context.TraceId);
+        var spanIdAsInt = new Int128(activity.Context.SpanId);
+        var linkTraceIdAsInt = new Int128(activity.Links.Single().Context.TraceId);
+        var linkSpanIdAsInt = new Int128(activity.Links.Single().Context.SpanId);
+
+        var jaegerSpan = activity.ToJaegerSpan();
+
+        Assert.Equal("Name", jaegerSpan.OperationName);
+        Assert.Equal(2, jaegerSpan.Logs.Count);
+
+        Assert.Equal(traceIdAsInt.High, jaegerSpan.TraceIdHigh);
+        Assert.Equal(traceIdAsInt.Low, jaegerSpan.TraceIdLow);
+        Assert.Equal(spanIdAsInt.Low, jaegerSpan.SpanId);
+        Assert.Equal(new Int128(activity.ParentSpanId).Low, jaegerSpan.ParentSpanId);
+
+        Assert.Equal(activity.Links.Count(), jaegerSpan.References.Count);
+        var references = jaegerSpan.References.ToArray();
+        var jaegerRef = references[0];
+        Assert.Equal(linkTraceIdAsInt.High, jaegerRef.TraceIdHigh);
+        Assert.Equal(linkTraceIdAsInt.Low, jaegerRef.TraceIdLow);
+        Assert.Equal(linkSpanIdAsInt.Low, jaegerRef.SpanId);
+
+        Assert.Equal(0x1, jaegerSpan.Flags);
+
+        Assert.Equal(activity.StartTimeUtc.ToEpochMicroseconds(), jaegerSpan.StartTime);
+        Assert.Equal(TimeSpanToMicroseconds(activity.Duration), jaegerSpan.Duration);
+
+        // 2 tags: span.kind & library.name.
+        Assert.Equal(2, jaegerSpan.Tags.Count);
+
+        var logs = jaegerSpan.Logs.ToArray();
+        var jaegerLog = logs[0];
+        Assert.Equal(activity.Events.First().Timestamp.ToEpochMicroseconds(), jaegerLog.Timestamp);
+        Assert.Equal(3, jaegerLog.Fields.Count);
+        var eventFields = jaegerLog.Fields.ToArray();
+        var eventField = eventFields[0];
+        Assert.Equal("key", eventField.Key);
+        Assert.Equal("value", eventField.VStr);
+        eventField = eventFields[2];
+        Assert.Equal("event", eventField.Key);
+        Assert.Equal("Event1", eventField.VStr);
+
+        Assert.Equal(activity.Events.First().Timestamp.ToEpochMicroseconds(), jaegerLog.Timestamp);
+
+        jaegerLog = logs[1];
+        Assert.Equal(2, jaegerLog.Fields.Count);
+        eventFields = jaegerLog.Fields.ToArray();
+        eventField = eventFields[0];
+        Assert.Equal("key", eventField.Key);
+        Assert.Equal("value", eventField.VStr);
+        eventField = eventFields[1];
+        Assert.Equal("event", eventField.Key);
+        Assert.Equal("Event2", eventField.VStr);
+    }
+
+    [Fact]
+    public void JaegerActivityConverterTest_ConvertActivityToJaegerSpan_NoEvents()
+    {
+        using var activity = CreateTestActivity(addEvents: false);
+        var traceIdAsInt = new Int128(activity.Context.TraceId);
+        var spanIdAsInt = new Int128(activity.Context.SpanId);
+        var linkTraceIdAsInt = new Int128(activity.Links.Single().Context.TraceId);
+        var linkSpanIdAsInt = new Int128(activity.Links.Single().Context.SpanId);
+
+        var jaegerSpan = activity.ToJaegerSpan();
+
+        Assert.Equal("Name", jaegerSpan.OperationName);
+        Assert.Empty(jaegerSpan.Logs);
+
+        Assert.Equal(traceIdAsInt.High, jaegerSpan.TraceIdHigh);
+        Assert.Equal(traceIdAsInt.Low, jaegerSpan.TraceIdLow);
+        Assert.Equal(spanIdAsInt.Low, jaegerSpan.SpanId);
+        Assert.Equal(new Int128(activity.ParentSpanId).Low, jaegerSpan.ParentSpanId);
+
+        Assert.Equal(activity.Links.Count(), jaegerSpan.References.Count);
+        var references = jaegerSpan.References.ToArray();
+        var jaegerRef = references[0];
+        Assert.Equal(linkTraceIdAsInt.High, jaegerRef.TraceIdHigh);
+        Assert.Equal(linkTraceIdAsInt.Low, jaegerRef.TraceIdLow);
+        Assert.Equal(linkSpanIdAsInt.Low, jaegerRef.SpanId);
+
+        Assert.Equal(0x1, jaegerSpan.Flags);
+
+        Assert.Equal(activity.StartTimeUtc.ToEpochMicroseconds(), jaegerSpan.StartTime);
+        Assert.Equal(TimeSpanToMicroseconds(activity.Duration), jaegerSpan.Duration);
+
+        var tags = jaegerSpan.Tags.ToArray();
+        var tag = tags[0];
+        Assert.Equal(JaegerTagType.STRING, tag.VType);
+        Assert.Equal("stringKey", tag.Key);
+        Assert.Equal("value", tag.VStr);
+        tag = tags[1];
+        Assert.Equal(JaegerTagType.LONG, tag.VType);
+        Assert.Equal("longKey", tag.Key);
+        Assert.Equal(1, tag.VLong);
+        tag = tags[2];
+        Assert.Equal(JaegerTagType.LONG, tag.VType);
+        Assert.Equal("longKey2", tag.Key);
+        Assert.Equal(1, tag.VLong);
+        tag = tags[3];
+        Assert.Equal(JaegerTagType.DOUBLE, tag.VType);
+        Assert.Equal("doubleKey", tag.Key);
+        Assert.Equal(1, tag.VDouble);
+        tag = tags[4];
+        Assert.Equal(JaegerTagType.DOUBLE, tag.VType);
+        Assert.Equal("doubleKey2", tag.Key);
+        Assert.Equal(1, tag.VDouble);
+        tag = tags[5];
+        Assert.Equal(JaegerTagType.BOOL, tag.VType);
+        Assert.Equal("boolKey", tag.Key);
+        Assert.Equal(true, tag.VBool);
+    }
+
+    [Fact]
+    public void JaegerActivityConverterTest_ConvertActivityToJaegerSpan_NoLinks()
+    {
+        using var activity = CreateTestActivity(addLinks: false, ticksToAdd: 8000);
+        var traceIdAsInt = new Int128(activity.Context.TraceId);
+        var spanIdAsInt = new Int128(activity.Context.SpanId);
+
+        var jaegerSpan = activity.ToJaegerSpan();
+
+        Assert.Equal("Name", jaegerSpan.OperationName);
+        Assert.Equal(2, jaegerSpan.Logs.Count);
+
+        Assert.Equal(traceIdAsInt.High, jaegerSpan.TraceIdHigh);
+        Assert.Equal(traceIdAsInt.Low, jaegerSpan.TraceIdLow);
+        Assert.Equal(spanIdAsInt.Low, jaegerSpan.SpanId);
+        Assert.Equal(new Int128(activity.ParentSpanId).Low, jaegerSpan.ParentSpanId);
+
+        Assert.Empty(jaegerSpan.References);
+
+        Assert.Equal(0x1, jaegerSpan.Flags);
+
+        Assert.Equal(activity.StartTimeUtc.ToEpochMicroseconds(), jaegerSpan.StartTime);
+        Assert.Equal(TimeSpanToMicroseconds(activity.Duration), jaegerSpan.Duration);
+
+        var tags = jaegerSpan.Tags.ToArray();
+        var tag = tags[0];
+        Assert.Equal(JaegerTagType.STRING, tag.VType);
+        Assert.Equal("stringKey", tag.Key);
+        Assert.Equal("value", tag.VStr);
+        tag = tags[1];
+        Assert.Equal(JaegerTagType.LONG, tag.VType);
+        Assert.Equal("longKey", tag.Key);
+        Assert.Equal(1, tag.VLong);
+        tag = tags[2];
+        Assert.Equal(JaegerTagType.LONG, tag.VType);
+        Assert.Equal("longKey2", tag.Key);
+        Assert.Equal(1, tag.VLong);
+        tag = tags[3];
+        Assert.Equal(JaegerTagType.DOUBLE, tag.VType);
+        Assert.Equal("doubleKey", tag.Key);
+        Assert.Equal(1, tag.VDouble);
+        tag = tags[4];
+        Assert.Equal(JaegerTagType.DOUBLE, tag.VType);
+        Assert.Equal("doubleKey2", tag.Key);
+        Assert.Equal(1, tag.VDouble);
+        tag = tags[5];
+        Assert.Equal(JaegerTagType.BOOL, tag.VType);
+        Assert.Equal("boolKey", tag.Key);
+        Assert.Equal(true, tag.VBool);
+
+        tag = tags[6];
+        Assert.Equal(JaegerTagType.STRING, tag.VType);
+        Assert.Equal("int_array", tag.Key);
+        Assert.Equal(System.Text.Json.JsonSerializer.Serialize(new[] { 1, 2 }), tag.VStr);
+
+        tag = tags[7];
+        Assert.Equal(JaegerTagType.STRING, tag.VType);
+        Assert.Equal("bool_array", tag.Key);
+        Assert.Equal(System.Text.Json.JsonSerializer.Serialize(new[] { true, false }), tag.VStr);
+
+        tag = tags[8];
+        Assert.Equal(JaegerTagType.STRING, tag.VType);
+        Assert.Equal("double_array", tag.Key);
+        Assert.Equal(System.Text.Json.JsonSerializer.Serialize(new[] { 1, 1.1 }), tag.VStr);
+
+        tag = tags[9];
+        Assert.Equal(JaegerTagType.STRING, tag.VType);
+        Assert.Equal("string_array", tag.Key);
+        Assert.Equal(System.Text.Json.JsonSerializer.Serialize(new[] { "a", "b" }), tag.VStr);
+
+        tag = tags[10];
+        Assert.Equal(JaegerTagType.STRING, tag.VType);
+        Assert.Equal("obj_array", tag.Key);
+        Assert.Equal(System.Text.Json.JsonSerializer.Serialize(new[] { 1.ToString(), false.ToString(), new object().ToString(), "string", string.Empty, null }), tag.VStr);
+
+        // The second to last tag should be span.kind in this case
+        tag = tags[tags.Length - 2];
+        Assert.Equal(JaegerTagType.STRING, tag.VType);
+        Assert.Equal("span.kind", tag.Key);
+        Assert.Equal("client", tag.VStr);
+
+        // The last tag should be library.name in this case
+        tag = tags[tags.Length - 1];
+        Assert.Equal(JaegerTagType.STRING, tag.VType);
+        Assert.Equal("otel.library.name", tag.Key);
+        Assert.Equal(nameof(CreateTestActivity), tag.VStr);
+
+        var logs = jaegerSpan.Logs.ToArray();
+        var jaegerLog = logs[0];
+        Assert.Equal(activity.Events.First().Timestamp.ToEpochMicroseconds(), jaegerLog.Timestamp);
+        Assert.Equal(3, jaegerLog.Fields.Count);
+        var eventFields = jaegerLog.Fields.ToArray();
+        var eventField = eventFields[0];
+        Assert.Equal("key", eventField.Key);
+        Assert.Equal("value", eventField.VStr);
+        eventField = eventFields[2];
+        Assert.Equal("event", eventField.Key);
+        Assert.Equal("Event1", eventField.VStr);
+        Assert.Equal(activity.Events.First().Timestamp.ToEpochMicroseconds(), jaegerLog.Timestamp);
+
+        jaegerLog = logs[1];
+        Assert.Equal(2, jaegerLog.Fields.Count);
+        eventFields = jaegerLog.Fields.ToArray();
+        eventField = eventFields[0];
+        Assert.Equal("key", eventField.Key);
+        Assert.Equal("value", eventField.VStr);
+        eventField = eventFields[1];
+        Assert.Equal("event", eventField.Key);
+        Assert.Equal("Event2", eventField.VStr);
+    }
+
+    [Fact]
+    public void JaegerActivityConverterTest_GenerateJaegerSpan_RemoteEndpointOmittedByDefault()
+    {
+        // Arrange
+        using var span = CreateTestActivity();
+
+        // Act
+        var jaegerSpan = span.ToJaegerSpan();
+
+        // Assert
+        Assert.DoesNotContain(jaegerSpan.Tags, t => t.Key == "peer.service");
+    }
+
+    [Fact]
+    public void JaegerActivityConverterTest_GenerateJaegerSpan_RemoteEndpointResolution()
+    {
+        // Arrange
+        using var span = CreateTestActivity(
+            additionalAttributes: new Dictionary<string, object>
             {
-                ShouldListenTo = _ => true,
-                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
-            };
-
-            ActivitySource.AddActivityListener(listener);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void JaegerActivityConverterTest_ConvertActivityToJaegerSpan_AllPropertiesSet(bool isRootSpan)
-        {
-            using var activity = CreateTestActivity(isRootSpan: isRootSpan);
-            var traceIdAsInt = new Int128(activity.Context.TraceId);
-            var spanIdAsInt = new Int128(activity.Context.SpanId);
-            var linkTraceIdAsInt = new Int128(activity.Links.Single().Context.TraceId);
-            var linkSpanIdAsInt = new Int128(activity.Links.Single().Context.SpanId);
-
-            var jaegerSpan = activity.ToJaegerSpan();
-
-            Assert.Equal("Name", jaegerSpan.OperationName);
-            Assert.Equal(2, jaegerSpan.Logs.Count);
-
-            Assert.Equal(traceIdAsInt.High, jaegerSpan.TraceIdHigh);
-            Assert.Equal(traceIdAsInt.Low, jaegerSpan.TraceIdLow);
-            Assert.Equal(spanIdAsInt.Low, jaegerSpan.SpanId);
-            Assert.Equal(new Int128(activity.ParentSpanId).Low, jaegerSpan.ParentSpanId);
-
-            Assert.Equal(activity.Links.Count(), jaegerSpan.References.Count);
-            var references = jaegerSpan.References.ToArray();
-            var jaegerRef = references[0];
-            Assert.Equal(linkTraceIdAsInt.High, jaegerRef.TraceIdHigh);
-            Assert.Equal(linkTraceIdAsInt.Low, jaegerRef.TraceIdLow);
-            Assert.Equal(linkSpanIdAsInt.Low, jaegerRef.SpanId);
-
-            Assert.Equal(0x1, jaegerSpan.Flags);
-
-            Assert.Equal(activity.StartTimeUtc.ToEpochMicroseconds(), jaegerSpan.StartTime);
-            Assert.Equal(TimeSpanToMicroseconds(activity.Duration), jaegerSpan.Duration);
-
-            var tags = jaegerSpan.Tags.ToArray();
-            var tag = tags[0];
-            Assert.Equal(JaegerTagType.STRING, tag.VType);
-            Assert.Equal("stringKey", tag.Key);
-            Assert.Equal("value", tag.VStr);
-            tag = tags[1];
-            Assert.Equal(JaegerTagType.LONG, tag.VType);
-            Assert.Equal("longKey", tag.Key);
-            Assert.Equal(1, tag.VLong);
-            tag = tags[2];
-            Assert.Equal(JaegerTagType.LONG, tag.VType);
-            Assert.Equal("longKey2", tag.Key);
-            Assert.Equal(1, tag.VLong);
-            tag = tags[3];
-            Assert.Equal(JaegerTagType.DOUBLE, tag.VType);
-            Assert.Equal("doubleKey", tag.Key);
-            Assert.Equal(1, tag.VDouble);
-            tag = tags[4];
-            Assert.Equal(JaegerTagType.DOUBLE, tag.VType);
-            Assert.Equal("doubleKey2", tag.Key);
-            Assert.Equal(1, tag.VDouble);
-            tag = tags[5];
-            Assert.Equal(JaegerTagType.BOOL, tag.VType);
-            Assert.Equal("boolKey", tag.Key);
-            Assert.Equal(true, tag.VBool);
-
-            var logs = jaegerSpan.Logs.ToArray();
-            var jaegerLog = logs[0];
-            Assert.Equal(activity.Events.First().Timestamp.ToEpochMicroseconds(), jaegerLog.Timestamp);
-            Assert.Equal(3, jaegerLog.Fields.Count);
-            var eventFields = jaegerLog.Fields.ToArray();
-            var eventField = eventFields[0];
-            Assert.Equal("key", eventField.Key);
-            Assert.Equal("value", eventField.VStr);
-            eventField = eventFields[1];
-            Assert.Equal("string_array", eventField.Key);
-            Assert.Equal(@"[""a"",""b""]", eventField.VStr);
-            eventField = eventFields[2];
-            Assert.Equal("event", eventField.Key);
-            Assert.Equal("Event1", eventField.VStr);
-
-            Assert.Equal(activity.Events.First().Timestamp.ToEpochMicroseconds(), jaegerLog.Timestamp);
-
-            jaegerLog = logs[1];
-            Assert.Equal(2, jaegerLog.Fields.Count);
-            eventFields = jaegerLog.Fields.ToArray();
-            eventField = eventFields[0];
-            Assert.Equal("key", eventField.Key);
-            Assert.Equal("value", eventField.VStr);
-            eventField = eventFields[1];
-            Assert.Equal("event", eventField.Key);
-            Assert.Equal("Event2", eventField.VStr);
-        }
-
-        [Fact]
-        public void JaegerActivityConverterTest_ConvertActivityToJaegerSpan_NoAttributes()
-        {
-            using var activity = CreateTestActivity(setAttributes: false);
-            var traceIdAsInt = new Int128(activity.Context.TraceId);
-            var spanIdAsInt = new Int128(activity.Context.SpanId);
-            var linkTraceIdAsInt = new Int128(activity.Links.Single().Context.TraceId);
-            var linkSpanIdAsInt = new Int128(activity.Links.Single().Context.SpanId);
-
-            var jaegerSpan = activity.ToJaegerSpan();
-
-            Assert.Equal("Name", jaegerSpan.OperationName);
-            Assert.Equal(2, jaegerSpan.Logs.Count);
-
-            Assert.Equal(traceIdAsInt.High, jaegerSpan.TraceIdHigh);
-            Assert.Equal(traceIdAsInt.Low, jaegerSpan.TraceIdLow);
-            Assert.Equal(spanIdAsInt.Low, jaegerSpan.SpanId);
-            Assert.Equal(new Int128(activity.ParentSpanId).Low, jaegerSpan.ParentSpanId);
-
-            Assert.Equal(activity.Links.Count(), jaegerSpan.References.Count);
-            var references = jaegerSpan.References.ToArray();
-            var jaegerRef = references[0];
-            Assert.Equal(linkTraceIdAsInt.High, jaegerRef.TraceIdHigh);
-            Assert.Equal(linkTraceIdAsInt.Low, jaegerRef.TraceIdLow);
-            Assert.Equal(linkSpanIdAsInt.Low, jaegerRef.SpanId);
-
-            Assert.Equal(0x1, jaegerSpan.Flags);
-
-            Assert.Equal(activity.StartTimeUtc.ToEpochMicroseconds(), jaegerSpan.StartTime);
-            Assert.Equal(TimeSpanToMicroseconds(activity.Duration), jaegerSpan.Duration);
-
-            // 2 tags: span.kind & library.name.
-            Assert.Equal(2, jaegerSpan.Tags.Count);
-
-            var logs = jaegerSpan.Logs.ToArray();
-            var jaegerLog = logs[0];
-            Assert.Equal(activity.Events.First().Timestamp.ToEpochMicroseconds(), jaegerLog.Timestamp);
-            Assert.Equal(3, jaegerLog.Fields.Count);
-            var eventFields = jaegerLog.Fields.ToArray();
-            var eventField = eventFields[0];
-            Assert.Equal("key", eventField.Key);
-            Assert.Equal("value", eventField.VStr);
-            eventField = eventFields[2];
-            Assert.Equal("event", eventField.Key);
-            Assert.Equal("Event1", eventField.VStr);
-
-            Assert.Equal(activity.Events.First().Timestamp.ToEpochMicroseconds(), jaegerLog.Timestamp);
-
-            jaegerLog = logs[1];
-            Assert.Equal(2, jaegerLog.Fields.Count);
-            eventFields = jaegerLog.Fields.ToArray();
-            eventField = eventFields[0];
-            Assert.Equal("key", eventField.Key);
-            Assert.Equal("value", eventField.VStr);
-            eventField = eventFields[1];
-            Assert.Equal("event", eventField.Key);
-            Assert.Equal("Event2", eventField.VStr);
-        }
-
-        [Fact]
-        public void JaegerActivityConverterTest_ConvertActivityToJaegerSpan_NoEvents()
-        {
-            using var activity = CreateTestActivity(addEvents: false);
-            var traceIdAsInt = new Int128(activity.Context.TraceId);
-            var spanIdAsInt = new Int128(activity.Context.SpanId);
-            var linkTraceIdAsInt = new Int128(activity.Links.Single().Context.TraceId);
-            var linkSpanIdAsInt = new Int128(activity.Links.Single().Context.SpanId);
-
-            var jaegerSpan = activity.ToJaegerSpan();
-
-            Assert.Equal("Name", jaegerSpan.OperationName);
-            Assert.Empty(jaegerSpan.Logs);
-
-            Assert.Equal(traceIdAsInt.High, jaegerSpan.TraceIdHigh);
-            Assert.Equal(traceIdAsInt.Low, jaegerSpan.TraceIdLow);
-            Assert.Equal(spanIdAsInt.Low, jaegerSpan.SpanId);
-            Assert.Equal(new Int128(activity.ParentSpanId).Low, jaegerSpan.ParentSpanId);
-
-            Assert.Equal(activity.Links.Count(), jaegerSpan.References.Count);
-            var references = jaegerSpan.References.ToArray();
-            var jaegerRef = references[0];
-            Assert.Equal(linkTraceIdAsInt.High, jaegerRef.TraceIdHigh);
-            Assert.Equal(linkTraceIdAsInt.Low, jaegerRef.TraceIdLow);
-            Assert.Equal(linkSpanIdAsInt.Low, jaegerRef.SpanId);
-
-            Assert.Equal(0x1, jaegerSpan.Flags);
-
-            Assert.Equal(activity.StartTimeUtc.ToEpochMicroseconds(), jaegerSpan.StartTime);
-            Assert.Equal(TimeSpanToMicroseconds(activity.Duration), jaegerSpan.Duration);
-
-            var tags = jaegerSpan.Tags.ToArray();
-            var tag = tags[0];
-            Assert.Equal(JaegerTagType.STRING, tag.VType);
-            Assert.Equal("stringKey", tag.Key);
-            Assert.Equal("value", tag.VStr);
-            tag = tags[1];
-            Assert.Equal(JaegerTagType.LONG, tag.VType);
-            Assert.Equal("longKey", tag.Key);
-            Assert.Equal(1, tag.VLong);
-            tag = tags[2];
-            Assert.Equal(JaegerTagType.LONG, tag.VType);
-            Assert.Equal("longKey2", tag.Key);
-            Assert.Equal(1, tag.VLong);
-            tag = tags[3];
-            Assert.Equal(JaegerTagType.DOUBLE, tag.VType);
-            Assert.Equal("doubleKey", tag.Key);
-            Assert.Equal(1, tag.VDouble);
-            tag = tags[4];
-            Assert.Equal(JaegerTagType.DOUBLE, tag.VType);
-            Assert.Equal("doubleKey2", tag.Key);
-            Assert.Equal(1, tag.VDouble);
-            tag = tags[5];
-            Assert.Equal(JaegerTagType.BOOL, tag.VType);
-            Assert.Equal("boolKey", tag.Key);
-            Assert.Equal(true, tag.VBool);
-        }
-
-        [Fact]
-        public void JaegerActivityConverterTest_ConvertActivityToJaegerSpan_NoLinks()
-        {
-            using var activity = CreateTestActivity(addLinks: false, ticksToAdd: 8000);
-            var traceIdAsInt = new Int128(activity.Context.TraceId);
-            var spanIdAsInt = new Int128(activity.Context.SpanId);
-
-            var jaegerSpan = activity.ToJaegerSpan();
-
-            Assert.Equal("Name", jaegerSpan.OperationName);
-            Assert.Equal(2, jaegerSpan.Logs.Count);
-
-            Assert.Equal(traceIdAsInt.High, jaegerSpan.TraceIdHigh);
-            Assert.Equal(traceIdAsInt.Low, jaegerSpan.TraceIdLow);
-            Assert.Equal(spanIdAsInt.Low, jaegerSpan.SpanId);
-            Assert.Equal(new Int128(activity.ParentSpanId).Low, jaegerSpan.ParentSpanId);
-
-            Assert.Empty(jaegerSpan.References);
-
-            Assert.Equal(0x1, jaegerSpan.Flags);
-
-            Assert.Equal(activity.StartTimeUtc.ToEpochMicroseconds(), jaegerSpan.StartTime);
-            Assert.Equal(TimeSpanToMicroseconds(activity.Duration), jaegerSpan.Duration);
-
-            var tags = jaegerSpan.Tags.ToArray();
-            var tag = tags[0];
-            Assert.Equal(JaegerTagType.STRING, tag.VType);
-            Assert.Equal("stringKey", tag.Key);
-            Assert.Equal("value", tag.VStr);
-            tag = tags[1];
-            Assert.Equal(JaegerTagType.LONG, tag.VType);
-            Assert.Equal("longKey", tag.Key);
-            Assert.Equal(1, tag.VLong);
-            tag = tags[2];
-            Assert.Equal(JaegerTagType.LONG, tag.VType);
-            Assert.Equal("longKey2", tag.Key);
-            Assert.Equal(1, tag.VLong);
-            tag = tags[3];
-            Assert.Equal(JaegerTagType.DOUBLE, tag.VType);
-            Assert.Equal("doubleKey", tag.Key);
-            Assert.Equal(1, tag.VDouble);
-            tag = tags[4];
-            Assert.Equal(JaegerTagType.DOUBLE, tag.VType);
-            Assert.Equal("doubleKey2", tag.Key);
-            Assert.Equal(1, tag.VDouble);
-            tag = tags[5];
-            Assert.Equal(JaegerTagType.BOOL, tag.VType);
-            Assert.Equal("boolKey", tag.Key);
-            Assert.Equal(true, tag.VBool);
-
-            tag = tags[6];
-            Assert.Equal(JaegerTagType.STRING, tag.VType);
-            Assert.Equal("int_array", tag.Key);
-            Assert.Equal(System.Text.Json.JsonSerializer.Serialize(new[] { 1, 2 }), tag.VStr);
-
-            tag = tags[7];
-            Assert.Equal(JaegerTagType.STRING, tag.VType);
-            Assert.Equal("bool_array", tag.Key);
-            Assert.Equal(System.Text.Json.JsonSerializer.Serialize(new[] { true, false }), tag.VStr);
-
-            tag = tags[8];
-            Assert.Equal(JaegerTagType.STRING, tag.VType);
-            Assert.Equal("double_array", tag.Key);
-            Assert.Equal(System.Text.Json.JsonSerializer.Serialize(new[] { 1, 1.1 }), tag.VStr);
-
-            tag = tags[9];
-            Assert.Equal(JaegerTagType.STRING, tag.VType);
-            Assert.Equal("string_array", tag.Key);
-            Assert.Equal(System.Text.Json.JsonSerializer.Serialize(new[] { "a", "b" }), tag.VStr);
-
-            tag = tags[10];
-            Assert.Equal(JaegerTagType.STRING, tag.VType);
-            Assert.Equal("obj_array", tag.Key);
-            Assert.Equal(System.Text.Json.JsonSerializer.Serialize(new[] { 1.ToString(), false.ToString(), new object().ToString(), "string", string.Empty, null }), tag.VStr);
-
-            // The second to last tag should be span.kind in this case
-            tag = tags[tags.Length - 2];
-            Assert.Equal(JaegerTagType.STRING, tag.VType);
-            Assert.Equal("span.kind", tag.Key);
-            Assert.Equal("client", tag.VStr);
-
-            // The last tag should be library.name in this case
-            tag = tags[tags.Length - 1];
-            Assert.Equal(JaegerTagType.STRING, tag.VType);
-            Assert.Equal("otel.library.name", tag.Key);
-            Assert.Equal(nameof(CreateTestActivity), tag.VStr);
-
-            var logs = jaegerSpan.Logs.ToArray();
-            var jaegerLog = logs[0];
-            Assert.Equal(activity.Events.First().Timestamp.ToEpochMicroseconds(), jaegerLog.Timestamp);
-            Assert.Equal(3, jaegerLog.Fields.Count);
-            var eventFields = jaegerLog.Fields.ToArray();
-            var eventField = eventFields[0];
-            Assert.Equal("key", eventField.Key);
-            Assert.Equal("value", eventField.VStr);
-            eventField = eventFields[2];
-            Assert.Equal("event", eventField.Key);
-            Assert.Equal("Event1", eventField.VStr);
-            Assert.Equal(activity.Events.First().Timestamp.ToEpochMicroseconds(), jaegerLog.Timestamp);
-
-            jaegerLog = logs[1];
-            Assert.Equal(2, jaegerLog.Fields.Count);
-            eventFields = jaegerLog.Fields.ToArray();
-            eventField = eventFields[0];
-            Assert.Equal("key", eventField.Key);
-            Assert.Equal("value", eventField.VStr);
-            eventField = eventFields[1];
-            Assert.Equal("event", eventField.Key);
-            Assert.Equal("Event2", eventField.VStr);
-        }
-
-        [Fact]
-        public void JaegerActivityConverterTest_GenerateJaegerSpan_RemoteEndpointOmittedByDefault()
-        {
-            // Arrange
-            using var span = CreateTestActivity();
-
-            // Act
-            var jaegerSpan = span.ToJaegerSpan();
-
-            // Assert
-            Assert.DoesNotContain(jaegerSpan.Tags, t => t.Key == "peer.service");
-        }
-
-        [Fact]
-        public void JaegerActivityConverterTest_GenerateJaegerSpan_RemoteEndpointResolution()
-        {
-            // Arrange
-            using var span = CreateTestActivity(
-                additionalAttributes: new Dictionary<string, object>
-                {
-                    ["net.peer.name"] = "RemoteServiceName",
-                });
-
-            // Act
-            var jaegerSpan = span.ToJaegerSpan();
-
-            // Assert
-            Assert.Contains(jaegerSpan.Tags, t => t.Key == "peer.service");
-            Assert.Equal("RemoteServiceName", jaegerSpan.Tags.First(t => t.Key == "peer.service").VStr);
-        }
-
-        [Fact]
-        public void JaegerActivityConverterTest_GenerateJaegerSpan_PeerServiceNameIgnoredForServerSpan()
-        {
-            // Arrange
-            using var span = CreateTestActivity(
-                additionalAttributes: new Dictionary<string, object>
-                {
-                    ["http.host"] = "DiscardedRemoteServiceName",
-                },
-                kind: ActivityKind.Server);
-
-            // Act
-            var jaegerSpan = span.ToJaegerSpan();
-
-            // Assert
-            Assert.Null(jaegerSpan.PeerServiceName);
-            Assert.Empty(jaegerSpan.Tags.Where(t => t.Key == "peer.service"));
-        }
-
-        [Theory]
-        [MemberData(nameof(RemoteEndpointPriorityTestCase.GetTestCases), MemberType = typeof(RemoteEndpointPriorityTestCase))]
-        public void JaegerActivityConverterTest_GenerateJaegerSpan_RemoteEndpointResolutionPriority(RemoteEndpointPriorityTestCase testCase)
-        {
-            // Arrange
-            using var activity = CreateTestActivity(additionalAttributes: testCase.RemoteEndpointAttributes);
-
-            // Act
-            var jaegerSpan = activity.ToJaegerSpan();
-
-            // Assert
-            var tags = jaegerSpan.Tags.Where(t => t.Key == "peer.service");
-            Assert.Single(tags);
-            var tag = tags.First();
-            Assert.Equal(testCase.ExpectedResult, tag.VStr);
-        }
-
-        [Fact]
-        public void JaegerActivityConverterTest_NullTagValueTest()
-        {
-            // Arrange
-            using var activity = CreateTestActivity(additionalAttributes: new Dictionary<string, object> { ["nullTag"] = null });
-
-            // Act
-            var jaegerSpan = activity.ToJaegerSpan();
-
-            // Assert
-            Assert.DoesNotContain(jaegerSpan.Tags, t => t.Key == "nullTag");
-        }
-
-        [Theory]
-        [InlineData(StatusCode.Unset, "unset", "")]
-        [InlineData(StatusCode.Ok, "Ok", "")]
-        [InlineData(StatusCode.Error, "ERROR", "error description")]
-        [InlineData(StatusCode.Unset, "iNvAlId", "")]
-        public void JaegerActivityConverterTest_Status_ErrorFlagTest(StatusCode expectedStatusCode, string statusCodeTagValue, string statusDescription)
-        {
-            // Arrange
-            using var activity = CreateTestActivity();
-            activity.SetTag(SpanAttributeConstants.StatusCodeKey, statusCodeTagValue);
-            activity.SetTag(SpanAttributeConstants.StatusDescriptionKey, statusDescription);
-
-            // Act
-            var jaegerSpan = activity.ToJaegerSpan();
-
-            // Assert
-
-            Assert.Equal(expectedStatusCode, activity.GetStatus().StatusCode);
-
-            if (expectedStatusCode == StatusCode.Unset)
+                ["net.peer.name"] = "RemoteServiceName",
+            });
+
+        // Act
+        var jaegerSpan = span.ToJaegerSpan();
+
+        // Assert
+        Assert.Contains(jaegerSpan.Tags, t => t.Key == "peer.service");
+        Assert.Equal("RemoteServiceName", jaegerSpan.Tags.First(t => t.Key == "peer.service").VStr);
+    }
+
+    [Fact]
+    public void JaegerActivityConverterTest_GenerateJaegerSpan_PeerServiceNameIgnoredForServerSpan()
+    {
+        // Arrange
+        using var span = CreateTestActivity(
+            additionalAttributes: new Dictionary<string, object>
             {
-                Assert.DoesNotContain(jaegerSpan.Tags, t => t.Key == SpanAttributeConstants.StatusCodeKey);
-            }
-            else
-            {
-                Assert.Equal(
-                    StatusHelper.GetTagValueForStatusCode(expectedStatusCode),
-                    jaegerSpan.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.StatusCodeKey).VStr);
-            }
+                ["http.host"] = "DiscardedRemoteServiceName",
+            },
+            kind: ActivityKind.Server);
 
-            if (expectedStatusCode == StatusCode.Error)
-            {
-                Assert.Contains(
-                    jaegerSpan.Tags, t =>
-                    t.Key == JaegerActivityExtensions.JaegerErrorFlagTagName &&
-                    t.VType == JaegerTagType.BOOL && (t.VBool ?? false));
-                Assert.Contains(
-                    jaegerSpan.Tags, t =>
-                    t.Key == SpanAttributeConstants.StatusDescriptionKey &&
-                    t.VType == JaegerTagType.STRING && t.VStr.Equals(statusDescription));
-            }
-            else
-            {
-                Assert.DoesNotContain(jaegerSpan.Tags, t => t.Key == JaegerActivityExtensions.JaegerErrorFlagTagName);
-            }
+        // Act
+        var jaegerSpan = span.ToJaegerSpan();
+
+        // Assert
+        Assert.Null(jaegerSpan.PeerServiceName);
+        Assert.Empty(jaegerSpan.Tags.Where(t => t.Key == "peer.service"));
+    }
+
+    [Theory]
+    [MemberData(nameof(RemoteEndpointPriorityTestCase.GetTestCases), MemberType = typeof(RemoteEndpointPriorityTestCase))]
+    public void JaegerActivityConverterTest_GenerateJaegerSpan_RemoteEndpointResolutionPriority(RemoteEndpointPriorityTestCase testCase)
+    {
+        // Arrange
+        using var activity = CreateTestActivity(additionalAttributes: testCase.RemoteEndpointAttributes);
+
+        // Act
+        var jaegerSpan = activity.ToJaegerSpan();
+
+        // Assert
+        var tags = jaegerSpan.Tags.Where(t => t.Key == "peer.service");
+        Assert.Single(tags);
+        var tag = tags.First();
+        Assert.Equal(testCase.ExpectedResult, tag.VStr);
+    }
+
+    [Fact]
+    public void JaegerActivityConverterTest_NullTagValueTest()
+    {
+        // Arrange
+        using var activity = CreateTestActivity(additionalAttributes: new Dictionary<string, object> { ["nullTag"] = null });
+
+        // Act
+        var jaegerSpan = activity.ToJaegerSpan();
+
+        // Assert
+        Assert.DoesNotContain(jaegerSpan.Tags, t => t.Key == "nullTag");
+    }
+
+    [Theory]
+    [InlineData(StatusCode.Unset, "unset", "")]
+    [InlineData(StatusCode.Ok, "Ok", "")]
+    [InlineData(StatusCode.Error, "ERROR", "error description")]
+    [InlineData(StatusCode.Unset, "iNvAlId", "")]
+    public void JaegerActivityConverterTest_Status_ErrorFlagTest(StatusCode expectedStatusCode, string statusCodeTagValue, string statusDescription)
+    {
+        // Arrange
+        using var activity = CreateTestActivity();
+        activity.SetTag(SpanAttributeConstants.StatusCodeKey, statusCodeTagValue);
+        activity.SetTag(SpanAttributeConstants.StatusDescriptionKey, statusDescription);
+
+        // Act
+        var jaegerSpan = activity.ToJaegerSpan();
+
+        // Assert
+
+        Assert.Equal(expectedStatusCode, activity.GetStatus().StatusCode);
+
+        if (expectedStatusCode == StatusCode.Unset)
+        {
+            Assert.DoesNotContain(jaegerSpan.Tags, t => t.Key == SpanAttributeConstants.StatusCodeKey);
+        }
+        else
+        {
+            Assert.Equal(
+                StatusHelper.GetTagValueForStatusCode(expectedStatusCode),
+                jaegerSpan.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.StatusCodeKey).VStr);
         }
 
-        [Theory]
-        [InlineData(ActivityStatusCode.Unset)]
-        [InlineData(ActivityStatusCode.Ok)]
-        [InlineData(ActivityStatusCode.Error)]
-        public void ToJaegerSpan_Activity_Status_And_StatusDescription_is_Set(ActivityStatusCode expectedStatusCode)
+        if (expectedStatusCode == StatusCode.Error)
         {
-            // Arrange
-            using var activity = CreateTestActivity();
-            activity.SetStatus(expectedStatusCode);
-
-            // Act
-            var jaegerSpan = activity.ToJaegerSpan();
-
-            // Assert
-            if (expectedStatusCode == ActivityStatusCode.Unset)
-            {
-                Assert.DoesNotContain(jaegerSpan.Tags, t => t.Key == SpanAttributeConstants.StatusCodeKey);
-            }
-            else if (expectedStatusCode == ActivityStatusCode.Ok)
-            {
-                Assert.Equal("OK", jaegerSpan.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.StatusCodeKey).VStr);
-            }
-
-            // expectedStatusCode is Error
-            else
-            {
-                Assert.Equal("ERROR", jaegerSpan.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.StatusCodeKey).VStr);
-            }
-
-            if (expectedStatusCode == ActivityStatusCode.Error)
-            {
-                Assert.Contains(
-                    jaegerSpan.Tags, t =>
-                    t.Key == JaegerActivityExtensions.JaegerErrorFlagTagName &&
-                    t.VType == JaegerTagType.BOOL && (t.VBool ?? false));
-            }
-            else
-            {
-                Assert.DoesNotContain(
-                    jaegerSpan.Tags, t =>
-                    t.Key == JaegerActivityExtensions.JaegerErrorFlagTagName);
-            }
-        }
-
-        [Fact]
-        public void ActivityStatus_Takes_precedence_Over_Status_Tags_ActivityStatusCodeIsOk()
-        {
-            // Arrange.
-            using var activity = CreateTestActivity();
-            const string TagDescriptionOnError = "Description when TagStatusCode is Error.";
-            activity.SetStatus(ActivityStatusCode.Ok);
-            activity.SetTag(SpanAttributeConstants.StatusCodeKey, "ERROR");
-            activity.SetTag(SpanAttributeConstants.StatusDescriptionKey, TagDescriptionOnError);
-
-            // Enrich activity with additional tags.
-            activity.SetTag("myCustomTag", "myCustomTagValue");
-
-            // Act.
-            var jaegerSpan = activity.ToJaegerSpan();
-
-            // Assert.
-            Assert.Equal("OK", jaegerSpan.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.StatusCodeKey).VStr);
-
-            Assert.Contains(jaegerSpan.Tags, t => t.Key == "otel.status_code" && t.VStr == "OK");
-            Assert.DoesNotContain(jaegerSpan.Tags, t => t.Key == "otel.status_code" && t.VStr == "ERROR");
-            Assert.DoesNotContain(jaegerSpan.Tags, t => t.Key == JaegerActivityExtensions.JaegerErrorFlagTagName);
-            Assert.DoesNotContain(jaegerSpan.Tags, t => t.Key == SpanAttributeConstants.StatusDescriptionKey &&
-                                    t.VType == JaegerTagType.STRING && t.VStr.Equals(TagDescriptionOnError));
-
-            // Ensure additional Activity tags were being converted.
-            Assert.Contains(jaegerSpan.Tags, t => t.Key == "myCustomTag" && t.VStr == "myCustomTagValue");
-        }
-
-        [Fact]
-        public void ActivityStatus_Takes_precedence_Over_Status_Tags_ActivityStatusCodeIsError()
-        {
-            // Arrange.
-            using var activity = CreateTestActivity();
-            const string StatusDescriptionOnError = "Description when ActivityStatusCode is Error.";
-            activity.SetStatus(ActivityStatusCode.Error, StatusDescriptionOnError);
-            activity.SetTag(SpanAttributeConstants.StatusCodeKey, "OK");
-
-            // Enrich activity with additional tags.
-            activity.SetTag("myCustomTag", "myCustomTagValue");
-
-            // Act.
-            var jaegerSpan = activity.ToJaegerSpan();
-
-            // Assert.
-            Assert.Contains(jaegerSpan.Tags, t => t.Key == "otel.status_code" && t.VStr == "ERROR");
-            Assert.Contains(jaegerSpan.Tags, t => t.Key == JaegerActivityExtensions.JaegerErrorFlagTagName);
-            Assert.Contains(jaegerSpan.Tags, t => t.Key == SpanAttributeConstants.StatusDescriptionKey &&
-                        t.VType == JaegerTagType.STRING && t.VStr.Equals(StatusDescriptionOnError));
-
-            Assert.DoesNotContain(jaegerSpan.Tags, t => t.Key == "otel.status_code" && t.VStr == "OK");
-
-            // Ensure additional Activity tags were being converted.
-            Assert.Contains(jaegerSpan.Tags, t => t.Key == "myCustomTag" && t.VStr == "myCustomTagValue");
-        }
-
-        [Fact]
-        public void ActivityDescription_Takes_precedence_Over_Status_Tags_When_ActivityStatusCodeIsError()
-        {
-            // Arrange.
-            using var activity = CreateTestActivity();
-
-            const string StatusDescriptionOnError = "Description when ActivityStatusCode is Error.";
-            const string TagDescriptionOnError = "Description when TagStatusCode is Error.";
-            activity.SetStatus(ActivityStatusCode.Error, StatusDescriptionOnError);
-            activity.SetTag(SpanAttributeConstants.StatusCodeKey, "ERROR");
-            activity.SetTag(SpanAttributeConstants.StatusDescriptionKey, TagDescriptionOnError);
-
-            // Enrich activity with additional tags.
-            activity.SetTag("myCustomTag", "myCustomTagValue");
-
-            // Act.
-            var jaegerSpan = activity.ToJaegerSpan();
-
-            // Assert.
-            Assert.Equal("ERROR", jaegerSpan.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.StatusCodeKey).VStr);
-
             Assert.Contains(
                 jaegerSpan.Tags, t =>
                 t.Key == JaegerActivityExtensions.JaegerErrorFlagTagName &&
                 t.VType == JaegerTagType.BOOL && (t.VBool ?? false));
-
             Assert.Contains(
                 jaegerSpan.Tags, t =>
                 t.Key == SpanAttributeConstants.StatusDescriptionKey &&
-                t.VType == JaegerTagType.STRING && t.VStr.Equals(StatusDescriptionOnError));
+                t.VType == JaegerTagType.STRING && t.VStr.Equals(statusDescription));
+        }
+        else
+        {
+            Assert.DoesNotContain(jaegerSpan.Tags, t => t.Key == JaegerActivityExtensions.JaegerErrorFlagTagName);
+        }
+    }
 
-            // Ensure additional Activity tags were being converted.
-            Assert.Contains(jaegerSpan.Tags, t => t.Key == "myCustomTag" && t.VStr == "myCustomTagValue");
+    [Theory]
+    [InlineData(ActivityStatusCode.Unset)]
+    [InlineData(ActivityStatusCode.Ok)]
+    [InlineData(ActivityStatusCode.Error)]
+    public void ToJaegerSpan_Activity_Status_And_StatusDescription_is_Set(ActivityStatusCode expectedStatusCode)
+    {
+        // Arrange
+        using var activity = CreateTestActivity();
+        activity.SetStatus(expectedStatusCode);
+
+        // Act
+        var jaegerSpan = activity.ToJaegerSpan();
+
+        // Assert
+        if (expectedStatusCode == ActivityStatusCode.Unset)
+        {
+            Assert.DoesNotContain(jaegerSpan.Tags, t => t.Key == SpanAttributeConstants.StatusCodeKey);
+        }
+        else if (expectedStatusCode == ActivityStatusCode.Ok)
+        {
+            Assert.Equal("OK", jaegerSpan.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.StatusCodeKey).VStr);
         }
 
-        internal static Activity CreateTestActivity(
-            bool setAttributes = true,
-            Dictionary<string, object> additionalAttributes = null,
-            bool addEvents = true,
-            bool addLinks = true,
-            Resource resource = null,
-            ActivityKind kind = ActivityKind.Client,
-            bool isRootSpan = false,
-            Status? status = null,
-            long ticksToAdd = 60 * TimeSpan.TicksPerSecond)
+        // expectedStatusCode is Error
+        else
         {
-            var startTimestamp = DateTime.UtcNow;
-            var endTimestamp = startTimestamp.AddTicks(ticksToAdd);
-            var eventTimestamp = DateTime.UtcNow;
-            var traceId = ActivityTraceId.CreateFromString("e8ea7e9ac72de94e91fabc613f9686b2".AsSpan());
+            Assert.Equal("ERROR", jaegerSpan.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.StatusCodeKey).VStr);
+        }
 
-            var parentSpanId = isRootSpan ? default : ActivitySpanId.CreateFromBytes(new byte[] { 12, 23, 34, 45, 56, 67, 78, 89 });
+        if (expectedStatusCode == ActivityStatusCode.Error)
+        {
+            Assert.Contains(
+                jaegerSpan.Tags, t =>
+                t.Key == JaegerActivityExtensions.JaegerErrorFlagTagName &&
+                t.VType == JaegerTagType.BOOL && (t.VBool ?? false));
+        }
+        else
+        {
+            Assert.DoesNotContain(
+                jaegerSpan.Tags, t =>
+                t.Key == JaegerActivityExtensions.JaegerErrorFlagTagName);
+        }
+    }
 
-            var attributes = new Dictionary<string, object>
+    [Fact]
+    public void ActivityStatus_Takes_precedence_Over_Status_Tags_ActivityStatusCodeIsOk()
+    {
+        // Arrange.
+        using var activity = CreateTestActivity();
+        const string TagDescriptionOnError = "Description when TagStatusCode is Error.";
+        activity.SetStatus(ActivityStatusCode.Ok);
+        activity.SetTag(SpanAttributeConstants.StatusCodeKey, "ERROR");
+        activity.SetTag(SpanAttributeConstants.StatusDescriptionKey, TagDescriptionOnError);
+
+        // Enrich activity with additional tags.
+        activity.SetTag("myCustomTag", "myCustomTagValue");
+
+        // Act.
+        var jaegerSpan = activity.ToJaegerSpan();
+
+        // Assert.
+        Assert.Equal("OK", jaegerSpan.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.StatusCodeKey).VStr);
+
+        Assert.Contains(jaegerSpan.Tags, t => t.Key == "otel.status_code" && t.VStr == "OK");
+        Assert.DoesNotContain(jaegerSpan.Tags, t => t.Key == "otel.status_code" && t.VStr == "ERROR");
+        Assert.DoesNotContain(jaegerSpan.Tags, t => t.Key == JaegerActivityExtensions.JaegerErrorFlagTagName);
+        Assert.DoesNotContain(jaegerSpan.Tags, t => t.Key == SpanAttributeConstants.StatusDescriptionKey &&
+                                t.VType == JaegerTagType.STRING && t.VStr.Equals(TagDescriptionOnError));
+
+        // Ensure additional Activity tags were being converted.
+        Assert.Contains(jaegerSpan.Tags, t => t.Key == "myCustomTag" && t.VStr == "myCustomTagValue");
+    }
+
+    [Fact]
+    public void ActivityStatus_Takes_precedence_Over_Status_Tags_ActivityStatusCodeIsError()
+    {
+        // Arrange.
+        using var activity = CreateTestActivity();
+        const string StatusDescriptionOnError = "Description when ActivityStatusCode is Error.";
+        activity.SetStatus(ActivityStatusCode.Error, StatusDescriptionOnError);
+        activity.SetTag(SpanAttributeConstants.StatusCodeKey, "OK");
+
+        // Enrich activity with additional tags.
+        activity.SetTag("myCustomTag", "myCustomTagValue");
+
+        // Act.
+        var jaegerSpan = activity.ToJaegerSpan();
+
+        // Assert.
+        Assert.Contains(jaegerSpan.Tags, t => t.Key == "otel.status_code" && t.VStr == "ERROR");
+        Assert.Contains(jaegerSpan.Tags, t => t.Key == JaegerActivityExtensions.JaegerErrorFlagTagName);
+        Assert.Contains(jaegerSpan.Tags, t => t.Key == SpanAttributeConstants.StatusDescriptionKey &&
+                    t.VType == JaegerTagType.STRING && t.VStr.Equals(StatusDescriptionOnError));
+
+        Assert.DoesNotContain(jaegerSpan.Tags, t => t.Key == "otel.status_code" && t.VStr == "OK");
+
+        // Ensure additional Activity tags were being converted.
+        Assert.Contains(jaegerSpan.Tags, t => t.Key == "myCustomTag" && t.VStr == "myCustomTagValue");
+    }
+
+    [Fact]
+    public void ActivityDescription_Takes_precedence_Over_Status_Tags_When_ActivityStatusCodeIsError()
+    {
+        // Arrange.
+        using var activity = CreateTestActivity();
+
+        const string StatusDescriptionOnError = "Description when ActivityStatusCode is Error.";
+        const string TagDescriptionOnError = "Description when TagStatusCode is Error.";
+        activity.SetStatus(ActivityStatusCode.Error, StatusDescriptionOnError);
+        activity.SetTag(SpanAttributeConstants.StatusCodeKey, "ERROR");
+        activity.SetTag(SpanAttributeConstants.StatusDescriptionKey, TagDescriptionOnError);
+
+        // Enrich activity with additional tags.
+        activity.SetTag("myCustomTag", "myCustomTagValue");
+
+        // Act.
+        var jaegerSpan = activity.ToJaegerSpan();
+
+        // Assert.
+        Assert.Equal("ERROR", jaegerSpan.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.StatusCodeKey).VStr);
+
+        Assert.Contains(
+            jaegerSpan.Tags, t =>
+            t.Key == JaegerActivityExtensions.JaegerErrorFlagTagName &&
+            t.VType == JaegerTagType.BOOL && (t.VBool ?? false));
+
+        Assert.Contains(
+            jaegerSpan.Tags, t =>
+            t.Key == SpanAttributeConstants.StatusDescriptionKey &&
+            t.VType == JaegerTagType.STRING && t.VStr.Equals(StatusDescriptionOnError));
+
+        // Ensure additional Activity tags were being converted.
+        Assert.Contains(jaegerSpan.Tags, t => t.Key == "myCustomTag" && t.VStr == "myCustomTagValue");
+    }
+
+    internal static Activity CreateTestActivity(
+        bool setAttributes = true,
+        Dictionary<string, object> additionalAttributes = null,
+        bool addEvents = true,
+        bool addLinks = true,
+        Resource resource = null,
+        ActivityKind kind = ActivityKind.Client,
+        bool isRootSpan = false,
+        Status? status = null,
+        long ticksToAdd = 60 * TimeSpan.TicksPerSecond)
+    {
+        var startTimestamp = DateTime.UtcNow;
+        var endTimestamp = startTimestamp.AddTicks(ticksToAdd);
+        var eventTimestamp = DateTime.UtcNow;
+        var traceId = ActivityTraceId.CreateFromString("e8ea7e9ac72de94e91fabc613f9686b2".AsSpan());
+
+        var parentSpanId = isRootSpan ? default : ActivitySpanId.CreateFromBytes(new byte[] { 12, 23, 34, 45, 56, 67, 78, 89 });
+
+        var attributes = new Dictionary<string, object>
+        {
+            { "exceptionFromToString", new MyToStringMethodThrowsAnException() },
+            { "exceptionFromToStringInArray", new MyToStringMethodThrowsAnException[] { new MyToStringMethodThrowsAnException() } },
+            { "stringKey", "value" },
+            { "longKey", 1L },
+            { "longKey2", 1 },
+            { "doubleKey", 1D },
+            { "doubleKey2", 1F },
+            { "boolKey", true },
+            { "int_array", new int[] { 1, 2 } },
+            { "bool_array", new bool[] { true, false } },
+            { "double_array", new double[] { 1.0, 1.1 } },
+            { "string_array", new string[] { "a", "b" } },
+            { "obj_array", new object[] { 1, false, new object(), "string", string.Empty, null } },
+        };
+        if (additionalAttributes != null)
+        {
+            foreach (var attribute in additionalAttributes)
             {
-                { "exceptionFromToString", new MyToStringMethodThrowsAnException() },
-                { "exceptionFromToStringInArray", new MyToStringMethodThrowsAnException[] { new MyToStringMethodThrowsAnException() } },
-                { "stringKey", "value" },
-                { "longKey", 1L },
-                { "longKey2", 1 },
-                { "doubleKey", 1D },
-                { "doubleKey2", 1F },
-                { "boolKey", true },
-                { "int_array", new int[] { 1, 2 } },
-                { "bool_array", new bool[] { true, false } },
-                { "double_array", new double[] { 1.0, 1.1 } },
-                { "string_array", new string[] { "a", "b" } },
-                { "obj_array", new object[] { 1, false, new object(), "string", string.Empty, null } },
-            };
-            if (additionalAttributes != null)
-            {
-                foreach (var attribute in additionalAttributes)
+                attributes.Add(attribute.Key, attribute.Value);
+            }
+        }
+
+        var events = new List<ActivityEvent>
+        {
+            new ActivityEvent(
+                "Event1",
+                eventTimestamp,
+                new ActivityTagsCollection(new Dictionary<string, object>
                 {
-                    attributes.Add(attribute.Key, attribute.Value);
+                    { "key", "value" },
+                    { "string_array", new string[] { "a", "b" } },
+                })),
+            new ActivityEvent(
+                "Event2",
+                eventTimestamp,
+                new ActivityTagsCollection(new Dictionary<string, object>
+                {
+                    { "key", "value" },
+                })),
+        };
+
+        var linkedSpanId = ActivitySpanId.CreateFromString("888915b6286b9c41".AsSpan());
+
+        using var activitySource = new ActivitySource(nameof(CreateTestActivity));
+
+        var tags = setAttributes ?
+                attributes
+                : null;
+        var links = addLinks ?
+                new[]
+                {
+                    new ActivityLink(new ActivityContext(
+                        traceId,
+                        linkedSpanId,
+                        ActivityTraceFlags.Recorded)),
                 }
-            }
+                : null;
 
-            var events = new List<ActivityEvent>
+        using var activity = activitySource.StartActivity(
+            "Name",
+            kind,
+            parentContext: new ActivityContext(traceId, parentSpanId, ActivityTraceFlags.Recorded),
+            tags,
+            links,
+            startTime: startTimestamp);
+
+        if (addEvents)
+        {
+            foreach (var evnt in events)
             {
-                new ActivityEvent(
-                    "Event1",
-                    eventTimestamp,
-                    new ActivityTagsCollection(new Dictionary<string, object>
+                activity.AddEvent(evnt);
+            }
+        }
+
+        if (status.HasValue)
+        {
+            activity.SetStatus(status.Value);
+        }
+
+        activity.SetEndTime(endTimestamp);
+        activity.Stop();
+
+        return activity;
+    }
+
+    private static long TimeSpanToMicroseconds(TimeSpan timeSpan)
+    {
+        return timeSpan.Ticks / (TimeSpan.TicksPerMillisecond / 1000);
+    }
+
+    public class RemoteEndpointPriorityTestCase
+    {
+        public string Name { get; set; }
+
+        public string ExpectedResult { get; set; }
+
+        public Dictionary<string, object> RemoteEndpointAttributes { get; set; }
+
+        public static IEnumerable<object[]> GetTestCases()
+        {
+            yield return new object[]
+            {
+                new RemoteEndpointPriorityTestCase
+                {
+                    Name = "Highest priority name = net.peer.name",
+                    ExpectedResult = "RemoteServiceName",
+                    RemoteEndpointAttributes = new Dictionary<string, object>
                     {
-                        { "key", "value" },
-                        { "string_array", new string[] { "a", "b" } },
-                    })),
-                new ActivityEvent(
-                    "Event2",
-                    eventTimestamp,
-                    new ActivityTagsCollection(new Dictionary<string, object>
-                    {
-                        { "key", "value" },
-                    })),
+                        ["http.host"] = "DiscardedRemoteServiceName",
+                        ["net.peer.name"] = "RemoteServiceName",
+                        ["peer.hostname"] = "DiscardedRemoteServiceName",
+                    },
+                },
             };
 
-            var linkedSpanId = ActivitySpanId.CreateFromString("888915b6286b9c41".AsSpan());
-
-            using var activitySource = new ActivitySource(nameof(CreateTestActivity));
-
-            var tags = setAttributes ?
-                    attributes
-                    : null;
-            var links = addLinks ?
-                    new[]
-                    {
-                        new ActivityLink(new ActivityContext(
-                            traceId,
-                            linkedSpanId,
-                            ActivityTraceFlags.Recorded)),
-                    }
-                    : null;
-
-            using var activity = activitySource.StartActivity(
-                "Name",
-                kind,
-                parentContext: new ActivityContext(traceId, parentSpanId, ActivityTraceFlags.Recorded),
-                tags,
-                links,
-                startTime: startTimestamp);
-
-            if (addEvents)
+            yield return new object[]
             {
-                foreach (var evnt in events)
+                new RemoteEndpointPriorityTestCase
                 {
-                    activity.AddEvent(evnt);
-                }
-            }
+                    Name = "Highest priority name = SemanticConventions.AttributePeerService",
+                    ExpectedResult = "RemoteServiceName",
+                    RemoteEndpointAttributes = new Dictionary<string, object>
+                    {
+                        [SemanticConventions.AttributePeerService] = "RemoteServiceName",
+                        ["http.host"] = "DiscardedRemoteServiceName",
+                        ["net.peer.name"] = "DiscardedRemoteServiceName",
+                        ["net.peer.port"] = "1234",
+                        ["peer.hostname"] = "DiscardedRemoteServiceName",
+                    },
+                },
+            };
 
-            if (status.HasValue)
+            yield return new object[]
             {
-                activity.SetStatus(status.Value);
-            }
+                new RemoteEndpointPriorityTestCase
+                {
+                    Name = "Only has net.peer.name and net.peer.port",
+                    ExpectedResult = "RemoteServiceName:1234",
+                    RemoteEndpointAttributes = new Dictionary<string, object>
+                    {
+                        ["net.peer.name"] = "RemoteServiceName",
+                        ["net.peer.port"] = "1234",
+                    },
+                },
+            };
 
-            activity.SetEndTime(endTimestamp);
-            activity.Stop();
+            yield return new object[]
+            {
+                new RemoteEndpointPriorityTestCase
+                {
+                    Name = "net.peer.port is an int",
+                    ExpectedResult = "RemoteServiceName:1234",
+                    RemoteEndpointAttributes = new Dictionary<string, object>
+                    {
+                        ["net.peer.name"] = "RemoteServiceName",
+                        ["net.peer.port"] = 1234,
+                    },
+                },
+            };
 
-            return activity;
+            yield return new object[]
+            {
+                new RemoteEndpointPriorityTestCase
+                {
+                    Name = "Has net.peer.name and net.peer.port",
+                    ExpectedResult = "RemoteServiceName:1234",
+                    RemoteEndpointAttributes = new Dictionary<string, object>
+                    {
+                        ["http.host"] = "DiscardedRemoteServiceName",
+                        ["net.peer.name"] = "RemoteServiceName",
+                        ["net.peer.port"] = "1234",
+                        ["peer.hostname"] = "DiscardedRemoteServiceName",
+                    },
+                },
+            };
+
+            yield return new object[]
+            {
+                new RemoteEndpointPriorityTestCase
+                {
+                    Name = "Has net.peer.ip and net.peer.port",
+                    ExpectedResult = "1.2.3.4:1234",
+                    RemoteEndpointAttributes = new Dictionary<string, object>
+                    {
+                        ["http.host"] = "DiscardedRemoteServiceName",
+                        ["net.peer.ip"] = "1.2.3.4",
+                        ["net.peer.port"] = "1234",
+                        ["peer.hostname"] = "DiscardedRemoteServiceName",
+                    },
+                },
+            };
+
+            yield return new object[]
+            {
+                new RemoteEndpointPriorityTestCase
+                {
+                    Name = "Has net.peer.name, net.peer.ip, and net.peer.port",
+                    ExpectedResult = "RemoteServiceName:1234",
+                    RemoteEndpointAttributes = new Dictionary<string, object>
+                    {
+                        ["http.host"] = "DiscardedRemoteServiceName",
+                        ["net.peer.name"] = "RemoteServiceName",
+                        ["net.peer.ip"] = "1.2.3.4",
+                        ["net.peer.port"] = "1234",
+                        ["peer.hostname"] = "DiscardedRemoteServiceName",
+                    },
+                },
+            };
         }
 
-        private static long TimeSpanToMicroseconds(TimeSpan timeSpan)
+        public override string ToString()
         {
-            return timeSpan.Ticks / (TimeSpan.TicksPerMillisecond / 1000);
+            return this.Name;
         }
+    }
 
-        public class RemoteEndpointPriorityTestCase
+    private class MyToStringMethodThrowsAnException
+    {
+        public override string ToString()
         {
-            public string Name { get; set; }
-
-            public string ExpectedResult { get; set; }
-
-            public Dictionary<string, object> RemoteEndpointAttributes { get; set; }
-
-            public static IEnumerable<object[]> GetTestCases()
-            {
-                yield return new object[]
-                {
-                    new RemoteEndpointPriorityTestCase
-                    {
-                        Name = "Highest priority name = net.peer.name",
-                        ExpectedResult = "RemoteServiceName",
-                        RemoteEndpointAttributes = new Dictionary<string, object>
-                        {
-                            ["http.host"] = "DiscardedRemoteServiceName",
-                            ["net.peer.name"] = "RemoteServiceName",
-                            ["peer.hostname"] = "DiscardedRemoteServiceName",
-                        },
-                    },
-                };
-
-                yield return new object[]
-                {
-                    new RemoteEndpointPriorityTestCase
-                    {
-                        Name = "Highest priority name = SemanticConventions.AttributePeerService",
-                        ExpectedResult = "RemoteServiceName",
-                        RemoteEndpointAttributes = new Dictionary<string, object>
-                        {
-                            [SemanticConventions.AttributePeerService] = "RemoteServiceName",
-                            ["http.host"] = "DiscardedRemoteServiceName",
-                            ["net.peer.name"] = "DiscardedRemoteServiceName",
-                            ["net.peer.port"] = "1234",
-                            ["peer.hostname"] = "DiscardedRemoteServiceName",
-                        },
-                    },
-                };
-
-                yield return new object[]
-                {
-                    new RemoteEndpointPriorityTestCase
-                    {
-                        Name = "Only has net.peer.name and net.peer.port",
-                        ExpectedResult = "RemoteServiceName:1234",
-                        RemoteEndpointAttributes = new Dictionary<string, object>
-                        {
-                            ["net.peer.name"] = "RemoteServiceName",
-                            ["net.peer.port"] = "1234",
-                        },
-                    },
-                };
-
-                yield return new object[]
-                {
-                    new RemoteEndpointPriorityTestCase
-                    {
-                        Name = "net.peer.port is an int",
-                        ExpectedResult = "RemoteServiceName:1234",
-                        RemoteEndpointAttributes = new Dictionary<string, object>
-                        {
-                            ["net.peer.name"] = "RemoteServiceName",
-                            ["net.peer.port"] = 1234,
-                        },
-                    },
-                };
-
-                yield return new object[]
-                {
-                    new RemoteEndpointPriorityTestCase
-                    {
-                        Name = "Has net.peer.name and net.peer.port",
-                        ExpectedResult = "RemoteServiceName:1234",
-                        RemoteEndpointAttributes = new Dictionary<string, object>
-                        {
-                            ["http.host"] = "DiscardedRemoteServiceName",
-                            ["net.peer.name"] = "RemoteServiceName",
-                            ["net.peer.port"] = "1234",
-                            ["peer.hostname"] = "DiscardedRemoteServiceName",
-                        },
-                    },
-                };
-
-                yield return new object[]
-                {
-                    new RemoteEndpointPriorityTestCase
-                    {
-                        Name = "Has net.peer.ip and net.peer.port",
-                        ExpectedResult = "1.2.3.4:1234",
-                        RemoteEndpointAttributes = new Dictionary<string, object>
-                        {
-                            ["http.host"] = "DiscardedRemoteServiceName",
-                            ["net.peer.ip"] = "1.2.3.4",
-                            ["net.peer.port"] = "1234",
-                            ["peer.hostname"] = "DiscardedRemoteServiceName",
-                        },
-                    },
-                };
-
-                yield return new object[]
-                {
-                    new RemoteEndpointPriorityTestCase
-                    {
-                        Name = "Has net.peer.name, net.peer.ip, and net.peer.port",
-                        ExpectedResult = "RemoteServiceName:1234",
-                        RemoteEndpointAttributes = new Dictionary<string, object>
-                        {
-                            ["http.host"] = "DiscardedRemoteServiceName",
-                            ["net.peer.name"] = "RemoteServiceName",
-                            ["net.peer.ip"] = "1.2.3.4",
-                            ["net.peer.port"] = "1234",
-                            ["peer.hostname"] = "DiscardedRemoteServiceName",
-                        },
-                    },
-                };
-            }
-
-            public override string ToString()
-            {
-                return this.Name;
-            }
-        }
-
-        private class MyToStringMethodThrowsAnException
-        {
-            public override string ToString()
-            {
-                throw new Exception("Nope.");
-            }
+            throw new Exception("Nope.");
         }
     }
 }

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterOptionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterOptionsTests.cs
@@ -20,138 +20,137 @@ using Microsoft.Extensions.Options;
 using OpenTelemetry.Trace;
 using Xunit;
 
-namespace OpenTelemetry.Exporter.Jaeger.Tests
+namespace OpenTelemetry.Exporter.Jaeger.Tests;
+
+public class JaegerExporterOptionsTests : IDisposable
 {
-    public class JaegerExporterOptionsTests : IDisposable
+    public JaegerExporterOptionsTests()
     {
-        public JaegerExporterOptionsTests()
+        ClearEnvVars();
+    }
+
+    public void Dispose()
+    {
+        ClearEnvVars();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void JaegerExporterOptions_Defaults()
+    {
+        var options = new JaegerExporterOptions();
+
+        Assert.Equal("localhost", options.AgentHost);
+        Assert.Equal(6831, options.AgentPort);
+        Assert.Equal(4096, options.MaxPayloadSizeInBytes);
+        Assert.Equal(ExportProcessorType.Batch, options.ExportProcessorType);
+        Assert.Equal(JaegerExportProtocol.UdpCompactThrift, options.Protocol);
+        Assert.Equal(JaegerExporterOptions.DefaultJaegerEndpoint, options.Endpoint.ToString());
+    }
+
+    [Fact]
+    public void JaegerExporterOptions_EnvironmentVariableOverride()
+    {
+        Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelAgentHostEnvVarKey, "jaeger-host");
+        Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelAgentPortEnvVarKey, "123");
+        Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelProtocolEnvVarKey, "http/thrift.binary");
+        Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelEndpointEnvVarKey, "http://custom-endpoint:12345");
+
+        var options = new JaegerExporterOptions();
+
+        Assert.Equal("jaeger-host", options.AgentHost);
+        Assert.Equal(123, options.AgentPort);
+        Assert.Equal(JaegerExportProtocol.HttpBinaryThrift, options.Protocol);
+        Assert.Equal(new Uri("http://custom-endpoint:12345"), options.Endpoint);
+    }
+
+    [Fact]
+    public void JaegerExporterOptions_InvalidEnvironmentVariableOverride()
+    {
+        Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelAgentPortEnvVarKey, "invalid");
+        Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelProtocolEnvVarKey, "invalid");
+
+        var options = new JaegerExporterOptions();
+
+        Assert.Equal("localhost", options.AgentHost);
+        Assert.Equal(default(JaegerExportProtocol), options.Protocol);
+    }
+
+    [Fact]
+    public void JaegerExporterOptions_SetterOverridesEnvironmentVariable()
+    {
+        Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelAgentHostEnvVarKey, "envvar-host");
+
+        var options = new JaegerExporterOptions
         {
-            ClearEnvVars();
-        }
+            AgentHost = "incode-host",
+        };
 
-        public void Dispose()
+        Assert.Equal("incode-host", options.AgentHost);
+    }
+
+    [Fact]
+    public void JaegerExporterOptions_EnvironmentVariableNames()
+    {
+        Assert.Equal("OTEL_EXPORTER_JAEGER_PROTOCOL", JaegerExporterOptions.OTelProtocolEnvVarKey);
+        Assert.Equal("OTEL_EXPORTER_JAEGER_AGENT_HOST", JaegerExporterOptions.OTelAgentHostEnvVarKey);
+        Assert.Equal("OTEL_EXPORTER_JAEGER_AGENT_PORT", JaegerExporterOptions.OTelAgentPortEnvVarKey);
+        Assert.Equal("OTEL_EXPORTER_JAEGER_ENDPOINT", JaegerExporterOptions.OTelEndpointEnvVarKey);
+    }
+
+    [Fact]
+    public void JaegerExporterOptions_FromConfigurationTest()
+    {
+        var values = new Dictionary<string, string>()
         {
-            ClearEnvVars();
-            GC.SuppressFinalize(this);
-        }
+            [JaegerExporterOptions.OTelProtocolEnvVarKey] = "http/thrift.binary",
+            [JaegerExporterOptions.OTelAgentHostEnvVarKey] = "jaeger-host",
+            [JaegerExporterOptions.OTelAgentPortEnvVarKey] = "123",
+            [JaegerExporterOptions.OTelEndpointEnvVarKey] = "http://custom-endpoint:12345",
+            ["OTEL_BSP_MAX_QUEUE_SIZE"] = "18",
+            ["OTEL_BSP_MAX_EXPORT_BATCH_SIZE"] = "2",
+            ["Jaeger:BatchExportProcessorOptions:MaxExportBatchSize"] = "5",
+        };
 
-        [Fact]
-        public void JaegerExporterOptions_Defaults()
-        {
-            var options = new JaegerExporterOptions();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
 
-            Assert.Equal("localhost", options.AgentHost);
-            Assert.Equal(6831, options.AgentPort);
-            Assert.Equal(4096, options.MaxPayloadSizeInBytes);
-            Assert.Equal(ExportProcessorType.Batch, options.ExportProcessorType);
-            Assert.Equal(JaegerExportProtocol.UdpCompactThrift, options.Protocol);
-            Assert.Equal(JaegerExporterOptions.DefaultJaegerEndpoint, options.Endpoint.ToString());
-        }
+        IServiceCollection services = null;
 
-        [Fact]
-        public void JaegerExporterOptions_EnvironmentVariableOverride()
-        {
-            Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelAgentHostEnvVarKey, "jaeger-host");
-            Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelAgentPortEnvVarKey, "123");
-            Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelProtocolEnvVarKey, "http/thrift.binary");
-            Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelEndpointEnvVarKey, "http://custom-endpoint:12345");
-
-            var options = new JaegerExporterOptions();
-
-            Assert.Equal("jaeger-host", options.AgentHost);
-            Assert.Equal(123, options.AgentPort);
-            Assert.Equal(JaegerExportProtocol.HttpBinaryThrift, options.Protocol);
-            Assert.Equal(new Uri("http://custom-endpoint:12345"), options.Endpoint);
-        }
-
-        [Fact]
-        public void JaegerExporterOptions_InvalidEnvironmentVariableOverride()
-        {
-            Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelAgentPortEnvVarKey, "invalid");
-            Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelProtocolEnvVarKey, "invalid");
-
-            var options = new JaegerExporterOptions();
-
-            Assert.Equal("localhost", options.AgentHost);
-            Assert.Equal(default(JaegerExportProtocol), options.Protocol);
-        }
-
-        [Fact]
-        public void JaegerExporterOptions_SetterOverridesEnvironmentVariable()
-        {
-            Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelAgentHostEnvVarKey, "envvar-host");
-
-            var options = new JaegerExporterOptions
+        using var provider = Sdk.CreateTracerProviderBuilder()
+            .ConfigureServices(s =>
             {
-                AgentHost = "incode-host",
-            };
+                services = s;
+                services.AddSingleton<IConfiguration>(configuration);
+                services.Configure<JaegerExporterOptions>(configuration.GetSection("Jaeger"));
+            })
+            .AddJaegerExporter()
+            .Build();
 
-            Assert.Equal("incode-host", options.AgentHost);
-        }
+        Assert.NotNull(services);
 
-        [Fact]
-        public void JaegerExporterOptions_EnvironmentVariableNames()
-        {
-            Assert.Equal("OTEL_EXPORTER_JAEGER_PROTOCOL", JaegerExporterOptions.OTelProtocolEnvVarKey);
-            Assert.Equal("OTEL_EXPORTER_JAEGER_AGENT_HOST", JaegerExporterOptions.OTelAgentHostEnvVarKey);
-            Assert.Equal("OTEL_EXPORTER_JAEGER_AGENT_PORT", JaegerExporterOptions.OTelAgentPortEnvVarKey);
-            Assert.Equal("OTEL_EXPORTER_JAEGER_ENDPOINT", JaegerExporterOptions.OTelEndpointEnvVarKey);
-        }
+        using var serviceProvider = services.BuildServiceProvider();
 
-        [Fact]
-        public void JaegerExporterOptions_FromConfigurationTest()
-        {
-            var values = new Dictionary<string, string>()
-            {
-                [JaegerExporterOptions.OTelProtocolEnvVarKey] = "http/thrift.binary",
-                [JaegerExporterOptions.OTelAgentHostEnvVarKey] = "jaeger-host",
-                [JaegerExporterOptions.OTelAgentPortEnvVarKey] = "123",
-                [JaegerExporterOptions.OTelEndpointEnvVarKey] = "http://custom-endpoint:12345",
-                ["OTEL_BSP_MAX_QUEUE_SIZE"] = "18",
-                ["OTEL_BSP_MAX_EXPORT_BATCH_SIZE"] = "2",
-                ["Jaeger:BatchExportProcessorOptions:MaxExportBatchSize"] = "5",
-            };
+        var options = serviceProvider.GetRequiredService<IOptionsMonitor<JaegerExporterOptions>>().CurrentValue;
 
-            var configuration = new ConfigurationBuilder()
-                .AddInMemoryCollection(values)
-                .Build();
+        Assert.Equal("jaeger-host", options.AgentHost);
+        Assert.Equal(123, options.AgentPort);
+        Assert.Equal(JaegerExportProtocol.HttpBinaryThrift, options.Protocol);
+        Assert.Equal(new Uri("http://custom-endpoint:12345"), options.Endpoint);
+        Assert.Equal(18, options.BatchExportProcessorOptions.MaxQueueSize);
 
-            IServiceCollection services = null;
+        // Note:
+        //  1. OTEL_BSP_MAX_EXPORT_BATCH_SIZE is processed in BatchExportActivityProcessorOptions ctor and sets MaxExportBatchSize to 2.
+        //  2. Jaeger:BatchExportProcessorOptions:MaxExportBatchSize is processed by options binder after ctor and sets MaxExportBatchSize to 5.
+        Assert.Equal(5, options.BatchExportProcessorOptions.MaxExportBatchSize);
+    }
 
-            using var provider = Sdk.CreateTracerProviderBuilder()
-                .ConfigureServices(s =>
-                {
-                    services = s;
-                    services.AddSingleton<IConfiguration>(configuration);
-                    services.Configure<JaegerExporterOptions>(configuration.GetSection("Jaeger"));
-                })
-                .AddJaegerExporter()
-                .Build();
-
-            Assert.NotNull(services);
-
-            using var serviceProvider = services.BuildServiceProvider();
-
-            var options = serviceProvider.GetRequiredService<IOptionsMonitor<JaegerExporterOptions>>().CurrentValue;
-
-            Assert.Equal("jaeger-host", options.AgentHost);
-            Assert.Equal(123, options.AgentPort);
-            Assert.Equal(JaegerExportProtocol.HttpBinaryThrift, options.Protocol);
-            Assert.Equal(new Uri("http://custom-endpoint:12345"), options.Endpoint);
-            Assert.Equal(18, options.BatchExportProcessorOptions.MaxQueueSize);
-
-            // Note:
-            //  1. OTEL_BSP_MAX_EXPORT_BATCH_SIZE is processed in BatchExportActivityProcessorOptions ctor and sets MaxExportBatchSize to 2.
-            //  2. Jaeger:BatchExportProcessorOptions:MaxExportBatchSize is processed by options binder after ctor and sets MaxExportBatchSize to 5.
-            Assert.Equal(5, options.BatchExportProcessorOptions.MaxExportBatchSize);
-        }
-
-        private static void ClearEnvVars()
-        {
-            Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelProtocolEnvVarKey, null);
-            Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelAgentHostEnvVarKey, null);
-            Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelAgentPortEnvVarKey, null);
-            Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelEndpointEnvVarKey, null);
-        }
+    private static void ClearEnvVars()
+    {
+        Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelProtocolEnvVarKey, null);
+        Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelAgentHostEnvVarKey, null);
+        Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelAgentPortEnvVarKey, null);
+        Environment.SetEnvironmentVariable(JaegerExporterOptions.OTelEndpointEnvVarKey, null);
     }
 }

--- a/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Jaeger.Tests/JaegerExporterTests.cs
@@ -26,401 +26,400 @@ using OpenTelemetry.Trace;
 using Thrift.Protocol;
 using Xunit;
 
-namespace OpenTelemetry.Exporter.Jaeger.Tests
+namespace OpenTelemetry.Exporter.Jaeger.Tests;
+
+public class JaegerExporterTests
 {
-    public class JaegerExporterTests
+    [Fact]
+    public void AddJaegerExporterNamedOptionsSupported()
     {
-        [Fact]
-        public void AddJaegerExporterNamedOptionsSupported()
-        {
-            int defaultExporterOptionsConfigureOptionsInvocations = 0;
-            int namedExporterOptionsConfigureOptionsInvocations = 0;
+        int defaultExporterOptionsConfigureOptionsInvocations = 0;
+        int namedExporterOptionsConfigureOptionsInvocations = 0;
 
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-                .ConfigureServices(services =>
-                {
-                    services.Configure<JaegerExporterOptions>(o => defaultExporterOptionsConfigureOptionsInvocations++);
-
-                    services.Configure<JaegerExporterOptions>("Exporter2", o => namedExporterOptionsConfigureOptionsInvocations++);
-                })
-                .AddJaegerExporter()
-                .AddJaegerExporter("Exporter2", o => { })
-                .Build();
-
-            Assert.Equal(1, defaultExporterOptionsConfigureOptionsInvocations);
-            Assert.Equal(1, namedExporterOptionsConfigureOptionsInvocations);
-        }
-
-        [Fact]
-        public void JaegerExporter_BadArgs()
-        {
-            TracerProviderBuilder builder = null;
-            Assert.Throws<ArgumentNullException>(() => builder.AddJaegerExporter());
-        }
-
-        [Fact]
-        public void JaegerTraceExporter_ctor_NullServiceNameAllowed()
-        {
-            using var jaegerTraceExporter = new JaegerExporter(new JaegerExporterOptions());
-            Assert.NotNull(jaegerTraceExporter);
-        }
-
-        [Fact]
-        public void UserHttpFactoryCalled()
-        {
-            JaegerExporterOptions options = new JaegerExporterOptions();
-
-            var defaultFactory = options.HttpClientFactory;
-
-            int invocations = 0;
-            options.Protocol = JaegerExportProtocol.HttpBinaryThrift;
-            options.HttpClientFactory = () =>
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .ConfigureServices(services =>
             {
-                invocations++;
-                return defaultFactory();
-            };
+                services.Configure<JaegerExporterOptions>(o => defaultExporterOptionsConfigureOptionsInvocations++);
 
-            using (var exporter = new JaegerExporter(options))
-            {
-                Assert.Equal(1, invocations);
-            }
+                services.Configure<JaegerExporterOptions>("Exporter2", o => namedExporterOptionsConfigureOptionsInvocations++);
+            })
+            .AddJaegerExporter()
+            .AddJaegerExporter("Exporter2", o => { })
+            .Build();
 
-            using (var provider = Sdk.CreateTracerProviderBuilder()
-                .AddJaegerExporter(o =>
-                {
-                    o.Protocol = JaegerExportProtocol.HttpBinaryThrift;
-                    o.HttpClientFactory = options.HttpClientFactory;
-                })
-                .Build())
-            {
-                Assert.Equal(2, invocations);
-            }
+        Assert.Equal(1, defaultExporterOptionsConfigureOptionsInvocations);
+        Assert.Equal(1, namedExporterOptionsConfigureOptionsInvocations);
+    }
 
-            options.HttpClientFactory = null;
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                using var exporter = new JaegerExporter(options);
-            });
+    [Fact]
+    public void JaegerExporter_BadArgs()
+    {
+        TracerProviderBuilder builder = null;
+        Assert.Throws<ArgumentNullException>(() => builder.AddJaegerExporter());
+    }
 
-            options.HttpClientFactory = () => null;
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                using var exporter = new JaegerExporter(options);
-            });
-        }
+    [Fact]
+    public void JaegerTraceExporter_ctor_NullServiceNameAllowed()
+    {
+        using var jaegerTraceExporter = new JaegerExporter(new JaegerExporterOptions());
+        Assert.NotNull(jaegerTraceExporter);
+    }
 
-        [Fact]
-        public void ServiceProviderHttpClientFactoryInvoked()
+    [Fact]
+    public void UserHttpFactoryCalled()
+    {
+        JaegerExporterOptions options = new JaegerExporterOptions();
+
+        var defaultFactory = options.HttpClientFactory;
+
+        int invocations = 0;
+        options.Protocol = JaegerExportProtocol.HttpBinaryThrift;
+        options.HttpClientFactory = () =>
         {
-            IServiceCollection services = new ServiceCollection();
+            invocations++;
+            return defaultFactory();
+        };
 
-            services.AddHttpClient();
-
-            int invocations = 0;
-
-            services.AddHttpClient("JaegerExporter", configureClient: (client) => invocations++);
-
-            services.AddOpenTelemetry().WithTracing(builder => builder
-                .AddJaegerExporter(o => o.Protocol = JaegerExportProtocol.HttpBinaryThrift));
-
-            using var serviceProvider = services.BuildServiceProvider();
-
-            var tracerProvider = serviceProvider.GetRequiredService<TracerProvider>();
-
+        using (var exporter = new JaegerExporter(options))
+        {
             Assert.Equal(1, invocations);
         }
 
-        [Theory]
-        [InlineData("/api/traces")]
-        [InlineData("/foo/bar")]
-        [InlineData("/")]
-        public void HttpClient_Posts_To_Configured_Endpoint(string uriPath)
+        using (var provider = Sdk.CreateTracerProviderBuilder()
+            .AddJaegerExporter(o =>
+            {
+                o.Protocol = JaegerExportProtocol.HttpBinaryThrift;
+                o.HttpClientFactory = options.HttpClientFactory;
+            })
+            .Build())
         {
-            // Arrange
-            ConcurrentDictionary<Guid, string> responses = new ConcurrentDictionary<Guid, string>();
-            using var testServer = TestHttpServer.RunServer(
-                context =>
+            Assert.Equal(2, invocations);
+        }
+
+        options.HttpClientFactory = null;
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            using var exporter = new JaegerExporter(options);
+        });
+
+        options.HttpClientFactory = () => null;
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            using var exporter = new JaegerExporter(options);
+        });
+    }
+
+    [Fact]
+    public void ServiceProviderHttpClientFactoryInvoked()
+    {
+        IServiceCollection services = new ServiceCollection();
+
+        services.AddHttpClient();
+
+        int invocations = 0;
+
+        services.AddHttpClient("JaegerExporter", configureClient: (client) => invocations++);
+
+        services.AddOpenTelemetry().WithTracing(builder => builder
+            .AddJaegerExporter(o => o.Protocol = JaegerExportProtocol.HttpBinaryThrift));
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var tracerProvider = serviceProvider.GetRequiredService<TracerProvider>();
+
+        Assert.Equal(1, invocations);
+    }
+
+    [Theory]
+    [InlineData("/api/traces")]
+    [InlineData("/foo/bar")]
+    [InlineData("/")]
+    public void HttpClient_Posts_To_Configured_Endpoint(string uriPath)
+    {
+        // Arrange
+        ConcurrentDictionary<Guid, string> responses = new ConcurrentDictionary<Guid, string>();
+        using var testServer = TestHttpServer.RunServer(
+            context =>
+            {
+                context.Response.StatusCode = 200;
+
+                using StreamReader readStream = new StreamReader(context.Request.InputStream);
+
+                string requestContent = readStream.ReadToEnd();
+
+                responses.TryAdd(
+                    Guid.Parse(context.Request.QueryString["requestId"]),
+                    context.Request.Url.LocalPath);
+
+                context.Response.OutputStream.Close();
+            },
+            out var testServerHost,
+            out var testServerPort);
+
+        var requestId = Guid.NewGuid();
+        var options = new JaegerExporterOptions
+        {
+            Endpoint = new Uri($"http://{testServerHost}:{testServerPort}{uriPath}?requestId={requestId}"),
+            Protocol = JaegerExportProtocol.HttpBinaryThrift,
+            ExportProcessorType = ExportProcessorType.Simple,
+        };
+
+        using var jaegerExporter = new JaegerExporter(options);
+
+        // Act
+        jaegerExporter.SetResourceAndInitializeBatch(Resource.Empty);
+        jaegerExporter.AppendSpan(CreateTestJaegerSpan());
+        jaegerExporter.SendCurrentBatch();
+
+        // Assert
+        Assert.True(responses.ContainsKey(requestId));
+        Assert.Equal(uriPath, responses[requestId]);
+    }
+
+    [Fact]
+    public void JaegerTraceExporter_SetResource_UpdatesServiceName()
+    {
+        using var jaegerTraceExporter = new JaegerExporter(new JaegerExporterOptions());
+        var process = jaegerTraceExporter.Process;
+
+        jaegerTraceExporter.SetResourceAndInitializeBatch(Resource.Empty);
+
+        Assert.StartsWith("unknown_service:", process.ServiceName);
+
+        jaegerTraceExporter.SetResourceAndInitializeBatch(ResourceBuilder.CreateEmpty().AddService("MyService").Build());
+
+        Assert.Equal("MyService", process.ServiceName);
+
+        jaegerTraceExporter.SetResourceAndInitializeBatch(ResourceBuilder.CreateEmpty().AddService("MyService", "MyNamespace").Build());
+
+        Assert.Equal("MyNamespace.MyService", process.ServiceName);
+    }
+
+    [Fact]
+    public void JaegerTraceExporter_SetResource_CreatesTags()
+    {
+        using var jaegerTraceExporter = new JaegerExporter(new JaegerExporterOptions());
+        var process = jaegerTraceExporter.Process;
+
+        jaegerTraceExporter.SetResourceAndInitializeBatch(ResourceBuilder.CreateEmpty().AddAttributes(new Dictionary<string, object>
+        {
+            ["Tag"] = "value",
+        }).Build());
+
+        Assert.NotNull(process.Tags);
+        Assert.Single(process.Tags);
+        Assert.Equal("value", process.Tags["Tag"].VStr);
+    }
+
+    [Fact]
+    public void JaegerTraceExporter_SetResource_CombinesTags()
+    {
+        using var jaegerTraceExporter = new JaegerExporter(new JaegerExporterOptions());
+        var process = jaegerTraceExporter.Process;
+
+        JaegerTagTransformer.Instance.TryTransformTag(new KeyValuePair<string, object>("Tag1", "value1"), out var result);
+        process.Tags = new Dictionary<string, JaegerTag> { ["Tag1"] = result };
+
+        jaegerTraceExporter.SetResourceAndInitializeBatch(ResourceBuilder.CreateEmpty().AddAttributes(new Dictionary<string, object>
+        {
+            ["Tag2"] = "value2",
+        }).Build());
+
+        Assert.NotNull(process.Tags);
+        Assert.Equal(2, process.Tags.Count);
+        Assert.Equal("value1", process.Tags["Tag1"].VStr);
+        Assert.Equal("value2", process.Tags["Tag2"].VStr);
+    }
+
+    [Fact]
+    public void JaegerTraceExporter_SetResource_IgnoreServiceResources()
+    {
+        using var jaegerTraceExporter = new JaegerExporter(new JaegerExporterOptions());
+        var process = jaegerTraceExporter.Process;
+
+        jaegerTraceExporter.SetResourceAndInitializeBatch(ResourceBuilder.CreateEmpty().AddAttributes(new Dictionary<string, object>
+        {
+            [ResourceSemanticConventions.AttributeServiceName] = "servicename",
+            [ResourceSemanticConventions.AttributeServiceNamespace] = "servicenamespace",
+        }).Build());
+
+        Assert.Null(process.Tags);
+    }
+
+    [Fact]
+    public void JaegerTraceExporter_SetResource_UpdatesServiceNameFromIConfiguration()
+    {
+        var tracerProviderBuilder = Sdk.CreateTracerProviderBuilder()
+            .ConfigureServices(services =>
+            {
+                Dictionary<string, string> configuration = new()
                 {
-                    context.Response.StatusCode = 200;
+                    ["OTEL_SERVICE_NAME"] = "myservicename",
+                };
 
-                    using StreamReader readStream = new StreamReader(context.Request.InputStream);
+                services.AddSingleton<IConfiguration>(
+                    new ConfigurationBuilder().AddInMemoryCollection(configuration).Build());
+            });
 
-                    string requestContent = readStream.ReadToEnd();
+        var jaegerTraceExporter = new JaegerExporter(new JaegerExporterOptions());
 
-                    responses.TryAdd(
-                        Guid.Parse(context.Request.QueryString["requestId"]),
-                        context.Request.Url.LocalPath);
+        tracerProviderBuilder.AddProcessor(new BatchActivityExportProcessor(jaegerTraceExporter));
 
-                    context.Response.OutputStream.Close();
-                },
-                out var testServerHost,
-                out var testServerPort);
+        using var provider = tracerProviderBuilder.Build();
 
-            var requestId = Guid.NewGuid();
-            var options = new JaegerExporterOptions
-            {
-                Endpoint = new Uri($"http://{testServerHost}:{testServerPort}{uriPath}?requestId={requestId}"),
-                Protocol = JaegerExportProtocol.HttpBinaryThrift,
-                ExportProcessorType = ExportProcessorType.Simple,
-            };
+        var process = jaegerTraceExporter.Process;
 
-            using var jaegerExporter = new JaegerExporter(options);
+        jaegerTraceExporter.SetResourceAndInitializeBatch(Resource.Empty);
 
-            // Act
-            jaegerExporter.SetResourceAndInitializeBatch(Resource.Empty);
-            jaegerExporter.AppendSpan(CreateTestJaegerSpan());
-            jaegerExporter.SendCurrentBatch();
+        Assert.Equal("myservicename", process.ServiceName);
+    }
 
-            // Assert
-            Assert.True(responses.ContainsKey(requestId));
-            Assert.Equal(uriPath, responses[requestId]);
-        }
+    [Fact]
+    public void JaegerTraceExporter_BuildBatchesToTransmit_FlushedBatch()
+    {
+        // Arrange
+        using var jaegerExporter = new JaegerExporter(new JaegerExporterOptions { MaxPayloadSizeInBytes = 1500 });
+        jaegerExporter.SetResourceAndInitializeBatch(Resource.Empty);
 
-        [Fact]
-        public void JaegerTraceExporter_SetResource_UpdatesServiceName()
+        // Act
+        jaegerExporter.AppendSpan(CreateTestJaegerSpan());
+        jaegerExporter.AppendSpan(CreateTestJaegerSpan());
+        jaegerExporter.AppendSpan(CreateTestJaegerSpan());
+
+        // Assert
+        Assert.Equal(1U, jaegerExporter.NumberOfSpansInCurrentBatch);
+    }
+
+    [Theory]
+    [InlineData("Compact", 1500)]
+    [InlineData("Binary", 2200)]
+    public void JaegerTraceExporter_SpansSplitToBatches_SpansIncludedInBatches(string protocolType, int maxPayloadSizeInBytes)
+    {
+        TProtocolFactory protocolFactory = protocolType == "Compact"
+            ? new TCompactProtocol.Factory()
+            : new TBinaryProtocol.Factory();
+        var client = new TestJaegerClient();
+
+        // Arrange
+        using var jaegerExporter = new JaegerExporter(
+            new JaegerExporterOptions { MaxPayloadSizeInBytes = maxPayloadSizeInBytes },
+            protocolFactory,
+            client);
+        jaegerExporter.SetResourceAndInitializeBatch(Resource.Empty);
+
+        // Create six spans, each taking more space than the previous one
+        var spans = new JaegerSpan[6];
+        for (int i = 0; i < 6; i++)
         {
-            using var jaegerTraceExporter = new JaegerExporter(new JaegerExporterOptions());
-            var process = jaegerTraceExporter.Process;
-
-            jaegerTraceExporter.SetResourceAndInitializeBatch(Resource.Empty);
-
-            Assert.StartsWith("unknown_service:", process.ServiceName);
-
-            jaegerTraceExporter.SetResourceAndInitializeBatch(ResourceBuilder.CreateEmpty().AddService("MyService").Build());
-
-            Assert.Equal("MyService", process.ServiceName);
-
-            jaegerTraceExporter.SetResourceAndInitializeBatch(ResourceBuilder.CreateEmpty().AddService("MyService", "MyNamespace").Build());
-
-            Assert.Equal("MyNamespace.MyService", process.ServiceName);
-        }
-
-        [Fact]
-        public void JaegerTraceExporter_SetResource_CreatesTags()
-        {
-            using var jaegerTraceExporter = new JaegerExporter(new JaegerExporterOptions());
-            var process = jaegerTraceExporter.Process;
-
-            jaegerTraceExporter.SetResourceAndInitializeBatch(ResourceBuilder.CreateEmpty().AddAttributes(new Dictionary<string, object>
-            {
-                ["Tag"] = "value",
-            }).Build());
-
-            Assert.NotNull(process.Tags);
-            Assert.Single(process.Tags);
-            Assert.Equal("value", process.Tags["Tag"].VStr);
-        }
-
-        [Fact]
-        public void JaegerTraceExporter_SetResource_CombinesTags()
-        {
-            using var jaegerTraceExporter = new JaegerExporter(new JaegerExporterOptions());
-            var process = jaegerTraceExporter.Process;
-
-            JaegerTagTransformer.Instance.TryTransformTag(new KeyValuePair<string, object>("Tag1", "value1"), out var result);
-            process.Tags = new Dictionary<string, JaegerTag> { ["Tag1"] = result };
-
-            jaegerTraceExporter.SetResourceAndInitializeBatch(ResourceBuilder.CreateEmpty().AddAttributes(new Dictionary<string, object>
-            {
-                ["Tag2"] = "value2",
-            }).Build());
-
-            Assert.NotNull(process.Tags);
-            Assert.Equal(2, process.Tags.Count);
-            Assert.Equal("value1", process.Tags["Tag1"].VStr);
-            Assert.Equal("value2", process.Tags["Tag2"].VStr);
-        }
-
-        [Fact]
-        public void JaegerTraceExporter_SetResource_IgnoreServiceResources()
-        {
-            using var jaegerTraceExporter = new JaegerExporter(new JaegerExporterOptions());
-            var process = jaegerTraceExporter.Process;
-
-            jaegerTraceExporter.SetResourceAndInitializeBatch(ResourceBuilder.CreateEmpty().AddAttributes(new Dictionary<string, object>
-            {
-                [ResourceSemanticConventions.AttributeServiceName] = "servicename",
-                [ResourceSemanticConventions.AttributeServiceNamespace] = "servicenamespace",
-            }).Build());
-
-            Assert.Null(process.Tags);
-        }
-
-        [Fact]
-        public void JaegerTraceExporter_SetResource_UpdatesServiceNameFromIConfiguration()
-        {
-            var tracerProviderBuilder = Sdk.CreateTracerProviderBuilder()
-                .ConfigureServices(services =>
+            spans[i] = CreateTestJaegerSpan(
+                additionalAttributes: new Dictionary<string, object>
                 {
-                    Dictionary<string, string> configuration = new()
-                    {
-                        ["OTEL_SERVICE_NAME"] = "myservicename",
-                    };
-
-                    services.AddSingleton<IConfiguration>(
-                        new ConfigurationBuilder().AddInMemoryCollection(configuration).Build());
+                    ["foo"] = new string('_', 10 * i),
                 });
-
-            var jaegerTraceExporter = new JaegerExporter(new JaegerExporterOptions());
-
-            tracerProviderBuilder.AddProcessor(new BatchActivityExportProcessor(jaegerTraceExporter));
-
-            using var provider = tracerProviderBuilder.Build();
-
-            var process = jaegerTraceExporter.Process;
-
-            jaegerTraceExporter.SetResourceAndInitializeBatch(Resource.Empty);
-
-            Assert.Equal("myservicename", process.ServiceName);
         }
 
-        [Fact]
-        public void JaegerTraceExporter_BuildBatchesToTransmit_FlushedBatch()
+        var protocol = protocolFactory.GetProtocol();
+        var serializedSpans = spans.Select(s =>
         {
-            // Arrange
-            using var jaegerExporter = new JaegerExporter(new JaegerExporterOptions { MaxPayloadSizeInBytes = 1500 });
-            jaegerExporter.SetResourceAndInitializeBatch(Resource.Empty);
+            s.Write(protocol);
+            var data = protocol.WrittenData.ToArray();
+            protocol.Clear();
+            return data;
+        }).ToArray();
 
-            // Act
-            jaegerExporter.AppendSpan(CreateTestJaegerSpan());
-            jaegerExporter.AppendSpan(CreateTestJaegerSpan());
-            jaegerExporter.AppendSpan(CreateTestJaegerSpan());
-
-            // Assert
-            Assert.Equal(1U, jaegerExporter.NumberOfSpansInCurrentBatch);
+        // Act
+        var sentBatches = new List<byte[]>();
+        foreach (var span in spans)
+        {
+            jaegerExporter.AppendSpan(span);
+            var sentBatch = client.LastWrittenData;
+            if (sentBatch != null)
+            {
+                sentBatches.Add(sentBatch);
+                client.LastWrittenData = null;
+            }
         }
 
-        [Theory]
-        [InlineData("Compact", 1500)]
-        [InlineData("Binary", 2200)]
-        public void JaegerTraceExporter_SpansSplitToBatches_SpansIncludedInBatches(string protocolType, int maxPayloadSizeInBytes)
+        // Assert
+
+        // Appending the six spans will send two batches with the first four spans
+        Assert.Equal(2, sentBatches.Count);
+        Assert.True(
+            ContainsSequence(sentBatches[0], serializedSpans[0]),
+            "Expected span data not found in sent batch");
+        Assert.True(
+            ContainsSequence(sentBatches[0], serializedSpans[1]),
+            "Expected span data not found in sent batch");
+
+        Assert.True(
+            ContainsSequence(sentBatches[1], serializedSpans[2]),
+            "Expected span data not found in sent batch");
+        Assert.True(
+            ContainsSequence(sentBatches[1], serializedSpans[3]),
+            "Expected span data not found in sent batch");
+
+        // jaegerExporter.Batch should contain the two remaining spans
+        Assert.Equal(2U, jaegerExporter.NumberOfSpansInCurrentBatch);
+        jaegerExporter.SendCurrentBatch();
+        Assert.True(client.LastWrittenData != null);
+        var serializedBatch = client.LastWrittenData;
+        Assert.True(
+            ContainsSequence(serializedBatch, serializedSpans[4]),
+            "Expected span data not found in unsent batch");
+        Assert.True(
+            ContainsSequence(serializedBatch, serializedSpans[5]),
+            "Expected span data not found in unsent batch");
+    }
+
+    internal static JaegerSpan CreateTestJaegerSpan(
+        bool setAttributes = true,
+        Dictionary<string, object> additionalAttributes = null,
+        bool addEvents = true,
+        bool addLinks = true,
+        Resource resource = null,
+        ActivityKind kind = ActivityKind.Client)
+    {
+        return JaegerActivityConversionTest
+            .CreateTestActivity(
+                setAttributes, additionalAttributes, addEvents, addLinks, resource, kind)
+            .ToJaegerSpan();
+    }
+
+    private static bool ContainsSequence(byte[] source, byte[] pattern)
+    {
+        for (var start = 0; start < (source.Length - pattern.Length + 1); start++)
         {
-            TProtocolFactory protocolFactory = protocolType == "Compact"
-                ? new TCompactProtocol.Factory()
-                : new TBinaryProtocol.Factory();
-            var client = new TestJaegerClient();
-
-            // Arrange
-            using var jaegerExporter = new JaegerExporter(
-                new JaegerExporterOptions { MaxPayloadSizeInBytes = maxPayloadSizeInBytes },
-                protocolFactory,
-                client);
-            jaegerExporter.SetResourceAndInitializeBatch(Resource.Empty);
-
-            // Create six spans, each taking more space than the previous one
-            var spans = new JaegerSpan[6];
-            for (int i = 0; i < 6; i++)
+            if (source.Skip(start).Take(pattern.Length).SequenceEqual(pattern))
             {
-                spans[i] = CreateTestJaegerSpan(
-                    additionalAttributes: new Dictionary<string, object>
-                    {
-                        ["foo"] = new string('_', 10 * i),
-                    });
+                return true;
             }
-
-            var protocol = protocolFactory.GetProtocol();
-            var serializedSpans = spans.Select(s =>
-            {
-                s.Write(protocol);
-                var data = protocol.WrittenData.ToArray();
-                protocol.Clear();
-                return data;
-            }).ToArray();
-
-            // Act
-            var sentBatches = new List<byte[]>();
-            foreach (var span in spans)
-            {
-                jaegerExporter.AppendSpan(span);
-                var sentBatch = client.LastWrittenData;
-                if (sentBatch != null)
-                {
-                    sentBatches.Add(sentBatch);
-                    client.LastWrittenData = null;
-                }
-            }
-
-            // Assert
-
-            // Appending the six spans will send two batches with the first four spans
-            Assert.Equal(2, sentBatches.Count);
-            Assert.True(
-                ContainsSequence(sentBatches[0], serializedSpans[0]),
-                "Expected span data not found in sent batch");
-            Assert.True(
-                ContainsSequence(sentBatches[0], serializedSpans[1]),
-                "Expected span data not found in sent batch");
-
-            Assert.True(
-                ContainsSequence(sentBatches[1], serializedSpans[2]),
-                "Expected span data not found in sent batch");
-            Assert.True(
-                ContainsSequence(sentBatches[1], serializedSpans[3]),
-                "Expected span data not found in sent batch");
-
-            // jaegerExporter.Batch should contain the two remaining spans
-            Assert.Equal(2U, jaegerExporter.NumberOfSpansInCurrentBatch);
-            jaegerExporter.SendCurrentBatch();
-            Assert.True(client.LastWrittenData != null);
-            var serializedBatch = client.LastWrittenData;
-            Assert.True(
-                ContainsSequence(serializedBatch, serializedSpans[4]),
-                "Expected span data not found in unsent batch");
-            Assert.True(
-                ContainsSequence(serializedBatch, serializedSpans[5]),
-                "Expected span data not found in unsent batch");
         }
 
-        internal static JaegerSpan CreateTestJaegerSpan(
-            bool setAttributes = true,
-            Dictionary<string, object> additionalAttributes = null,
-            bool addEvents = true,
-            bool addLinks = true,
-            Resource resource = null,
-            ActivityKind kind = ActivityKind.Client)
+        return false;
+    }
+
+    private sealed class TestJaegerClient : IJaegerClient
+    {
+        public bool Connected => true;
+
+        public byte[] LastWrittenData { get; set; }
+
+        public void Close()
         {
-            return JaegerActivityConversionTest
-                .CreateTestActivity(
-                    setAttributes, additionalAttributes, addEvents, addLinks, resource, kind)
-                .ToJaegerSpan();
         }
 
-        private static bool ContainsSequence(byte[] source, byte[] pattern)
+        public void Connect()
         {
-            for (var start = 0; start < (source.Length - pattern.Length + 1); start++)
-            {
-                if (source.Skip(start).Take(pattern.Length).SequenceEqual(pattern))
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
 
-        private sealed class TestJaegerClient : IJaegerClient
+        public void Dispose()
         {
-            public bool Connected => true;
+        }
 
-            public byte[] LastWrittenData { get; set; }
-
-            public void Close()
-            {
-            }
-
-            public void Connect()
-            {
-            }
-
-            public void Dispose()
-            {
-            }
-
-            public int Send(byte[] buffer, int offset, int count)
-            {
-                this.LastWrittenData = new ArraySegment<byte>(buffer, offset, count).ToArray();
-                return count;
-            }
+        public int Send(byte[] buffer, int offset, int count)
+        {
+            this.LastWrittenData = new ArraySegment<byte>(buffer, offset, count).ToArray();
+            return count;
         }
     }
 }


### PR DESCRIPTION
Towards #4640 

## Changes

Update projects OpenTelemetry.Exporter.Jaeger and OpenTelemetry.Exporter.Jaeger.Tests to use file scoped namespaces.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [X] Changes in public API reviewed (if applicable)
