### PR TITLE
[AOT] Annotate APIs which call `IServiceCollection.TryAddSingleton` for trim compatibility

### DIFF
--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/Logs/OpenTelemetryDependencyInjectionLoggerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/Logs/OpenTelemetryDependencyInjectionLoggerProviderBuilderExtensions.cs
@@ -14,6 +14,9 @@
 // limitations under the License.
 // </copyright>
 
+#if NET6_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpenTelemetry.Internal;
@@ -35,7 +38,11 @@ public static class OpenTelemetryDependencyInjectionLoggerProviderBuilderExtensi
     /// <typeparam name="T">Instrumentation type.</typeparam>
     /// <param name="loggerProviderBuilder"><see cref="LoggerProviderBuilder"/>.</param>
     /// <returns>The supplied <see cref="LoggerProviderBuilder"/> for chaining.</returns>
-    public static LoggerProviderBuilder AddInstrumentation<T>(this LoggerProviderBuilder loggerProviderBuilder)
+    public static LoggerProviderBuilder AddInstrumentation<
+#if NET6_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+        T>(this LoggerProviderBuilder loggerProviderBuilder)
         where T : class
     {
         loggerProviderBuilder.ConfigureServices(services => services.TryAddSingleton<T>());

--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/Metrics/OpenTelemetryDependencyInjectionMeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/Metrics/OpenTelemetryDependencyInjectionMeterProviderBuilderExtensions.cs
@@ -14,6 +14,9 @@
 // limitations under the License.
 // </copyright>
 
+#if NET6_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpenTelemetry.Internal;
@@ -35,7 +38,11 @@ public static class OpenTelemetryDependencyInjectionMeterProviderBuilderExtensio
     /// <typeparam name="T">Instrumentation type.</typeparam>
     /// <param name="meterProviderBuilder"><see cref="MeterProviderBuilder"/>.</param>
     /// <returns>The supplied <see cref="MeterProviderBuilder"/> for chaining.</returns>
-    public static MeterProviderBuilder AddInstrumentation<T>(this MeterProviderBuilder meterProviderBuilder)
+    public static MeterProviderBuilder AddInstrumentation<
+#if NET6_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+        T>(this MeterProviderBuilder meterProviderBuilder)
         where T : class
     {
         meterProviderBuilder.ConfigureServices(services => services.TryAddSingleton<T>());

--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/Trace/OpenTelemetryDependencyInjectionTracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/Trace/OpenTelemetryDependencyInjectionTracerProviderBuilderExtensions.cs
@@ -14,6 +14,9 @@
 // limitations under the License.
 // </copyright>
 
+#if NET6_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpenTelemetry.Internal;
@@ -35,7 +38,11 @@ public static class OpenTelemetryDependencyInjectionTracerProviderBuilderExtensi
     /// <typeparam name="T">Instrumentation type.</typeparam>
     /// <param name="tracerProviderBuilder"><see cref="TracerProviderBuilder"/>.</param>
     /// <returns>The supplied <see cref="TracerProviderBuilder"/> for chaining.</returns>
-    public static TracerProviderBuilder AddInstrumentation<T>(this TracerProviderBuilder tracerProviderBuilder)
+    public static TracerProviderBuilder AddInstrumentation<
+#if NET6_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+        T>(this TracerProviderBuilder tracerProviderBuilder)
         where T : class
     {
         tracerProviderBuilder.ConfigureServices(services => services.TryAddSingleton<T>());

--- a/src/OpenTelemetry/Logs/Builder/LoggerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Logs/Builder/LoggerProviderBuilderExtensions.cs
@@ -16,6 +16,9 @@
 
 #nullable enable
 
+#if NET6_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpenTelemetry.Internal;
@@ -105,7 +108,11 @@ public static class LoggerProviderBuilderExtensions
     /// <typeparam name="T">Processor type.</typeparam>
     /// <param name="loggerProviderBuilder"><see cref="LoggerProviderBuilder"/>.</param>
     /// <returns>The supplied <see cref="LoggerProviderBuilder"/> for chaining.</returns>
-    public static LoggerProviderBuilder AddProcessor<T>(this LoggerProviderBuilder loggerProviderBuilder)
+    public static LoggerProviderBuilder AddProcessor<
+#if NET6_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+        T>(this LoggerProviderBuilder loggerProviderBuilder)
         where T : BaseProcessor<LogRecord>
     {
         loggerProviderBuilder.ConfigureServices(services => services.TryAddSingleton<T>());

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderExtensions.cs
@@ -16,6 +16,9 @@
 
 #nullable enable
 
+#if NET6_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Diagnostics.Metrics;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.DependencyInjection;
@@ -61,7 +64,11 @@ public static class MeterProviderBuilderExtensions
     /// <typeparam name="T">Reader type.</typeparam>
     /// <param name="meterProviderBuilder"><see cref="MeterProviderBuilder"/>.</param>
     /// <returns>The supplied <see cref="MeterProviderBuilder"/> for chaining.</returns>
-    public static MeterProviderBuilder AddReader<T>(this MeterProviderBuilder meterProviderBuilder)
+    public static MeterProviderBuilder AddReader<
+#if NET6_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+        T>(this MeterProviderBuilder meterProviderBuilder)
         where T : MetricReader
     {
         meterProviderBuilder.ConfigureServices(services => services.TryAddSingleton<T>());

--- a/src/OpenTelemetry/Trace/Builder/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Trace/Builder/TracerProviderBuilderExtensions.cs
@@ -17,6 +17,9 @@
 #nullable enable
 
 using System.Diagnostics;
+#if NET6_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpenTelemetry.Internal;
@@ -80,7 +83,11 @@ public static class TracerProviderBuilderExtensions
     /// <typeparam name="T">Sampler type.</typeparam>
     /// <param name="tracerProviderBuilder"><see cref="TracerProviderBuilder"/>.</param>
     /// <returns>The supplied <see cref="TracerProviderBuilder"/> for chaining.</returns>
-    public static TracerProviderBuilder SetSampler<T>(this TracerProviderBuilder tracerProviderBuilder)
+    public static TracerProviderBuilder SetSampler<
+#if NET6_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+        T>(this TracerProviderBuilder tracerProviderBuilder)
         where T : Sampler
     {
         tracerProviderBuilder.ConfigureServices(services => services.TryAddSingleton<T>());
@@ -196,7 +203,11 @@ public static class TracerProviderBuilderExtensions
     /// <typeparam name="T">Processor type.</typeparam>
     /// <param name="tracerProviderBuilder"><see cref="TracerProviderBuilder"/>.</param>
     /// <returns>The supplied <see cref="TracerProviderBuilder"/> for chaining.</returns>
-    public static TracerProviderBuilder AddProcessor<T>(this TracerProviderBuilder tracerProviderBuilder)
+    public static TracerProviderBuilder AddProcessor<
+#if NET6_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+        T>(this TracerProviderBuilder tracerProviderBuilder)
         where T : BaseProcessor<Activity>
     {
         tracerProviderBuilder.ConfigureServices(services => services.TryAddSingleton<T>());


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-dotnet/issues/3429

`IServiceCollection.TryAddSingleton<T>` has trim annotation on `T`, this needs to be propagated to the caller to make it trim compatible.

This change just propagates the annotation to the signature of the method calling the `TryAddSingleton`. The trim tooling will make sure that the annotation is fulfilled by the caller of the OTel public methods with this change.

Note that these changes don't affect the outcome of the `EnsureAotCompatibility` test. This is because that test uses .NET 7 AOT compiler which has a bug and it doesn't report the warning it should have in these cases. Running the same test as a Trim compatibility test instead (`/p:PublishAot=false /p:PublishTrimmed=true`) will show warnings for each of the change in this PR. The .NET 8 version of the AOT compiler is fixed and will also report these warnings, so we need to fix these for both trimming and AOT compatibility.

I'd be open to adding a `EnsureTrimCompatibility` test, but it will make CI slower as it takes similar amount of time to the AOT compatibility test which is already causing CI slowdowns. @Yun-Ting has been discussing possibility of moving the AOT test into its own CI leg, adding the trim test there would be much less disruptive.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)

@Yun-Ting @eerhardt 