### PR TITLE
Update OpenTelemetry.Exporter.Zipkin to use filescoped namespaces

### DIFF
--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinActivityConversionExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinActivityConversionExtensions.cs
@@ -19,261 +19,260 @@ using System.Diagnostics;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
 
-namespace OpenTelemetry.Exporter.Zipkin.Implementation
+namespace OpenTelemetry.Exporter.Zipkin.Implementation;
+
+internal static class ZipkinActivityConversionExtensions
 {
-    internal static class ZipkinActivityConversionExtensions
+    internal const string ZipkinErrorFlagTagName = "error";
+    private const long TicksPerMicrosecond = TimeSpan.TicksPerMillisecond / 1000;
+    private const long UnixEpochTicks = 621355968000000000L; // = DateTimeOffset.FromUnixTimeMilliseconds(0).Ticks
+    private const long UnixEpochMicroseconds = UnixEpochTicks / TicksPerMicrosecond;
+
+    private static readonly ConcurrentDictionary<(string, int), ZipkinEndpoint> RemoteEndpointCache = new();
+
+    internal static ZipkinSpan ToZipkinSpan(this Activity activity, ZipkinEndpoint localEndpoint, bool useShortTraceIds = false)
     {
-        internal const string ZipkinErrorFlagTagName = "error";
-        private const long TicksPerMicrosecond = TimeSpan.TicksPerMillisecond / 1000;
-        private const long UnixEpochTicks = 621355968000000000L; // = DateTimeOffset.FromUnixTimeMilliseconds(0).Ticks
-        private const long UnixEpochMicroseconds = UnixEpochTicks / TicksPerMicrosecond;
+        var context = activity.Context;
 
-        private static readonly ConcurrentDictionary<(string, int), ZipkinEndpoint> RemoteEndpointCache = new();
+        string parentId = activity.ParentSpanId == default ?
+            null
+            : EncodeSpanId(activity.ParentSpanId);
 
-        internal static ZipkinSpan ToZipkinSpan(this Activity activity, ZipkinEndpoint localEndpoint, bool useShortTraceIds = false)
+        var tagState = new TagEnumerationState
         {
-            var context = activity.Context;
+            Tags = PooledList<KeyValuePair<string, object>>.Create(),
+        };
 
-            string parentId = activity.ParentSpanId == default ?
-                null
-                : EncodeSpanId(activity.ParentSpanId);
+        tagState.EnumerateTags(activity);
 
-            var tagState = new TagEnumerationState
+        // When status is set on Activity using the native Status field in activity,
+        // which was first introduced in System.Diagnostic.DiagnosticSource 6.0.0.
+        if (activity.Status != ActivityStatusCode.Unset)
+        {
+            if (activity.Status == ActivityStatusCode.Ok)
             {
-                Tags = PooledList<KeyValuePair<string, object>>.Create(),
-            };
-
-            tagState.EnumerateTags(activity);
-
-            // When status is set on Activity using the native Status field in activity,
-            // which was first introduced in System.Diagnostic.DiagnosticSource 6.0.0.
-            if (activity.Status != ActivityStatusCode.Unset)
-            {
-                if (activity.Status == ActivityStatusCode.Ok)
-                {
-                    PooledList<KeyValuePair<string, object>>.Add(
-                    ref tagState.Tags,
-                    new KeyValuePair<string, object>(
-                        SpanAttributeConstants.StatusCodeKey,
-                        "OK"));
-                }
-
-                // activity.Status is Error
-                else
-                {
-                    PooledList<KeyValuePair<string, object>>.Add(
-                        ref tagState.Tags,
-                        new KeyValuePair<string, object>(
-                            SpanAttributeConstants.StatusCodeKey,
-                            "ERROR"));
-
-                    // Error flag rule from https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/zipkin.md#status
-                    PooledList<KeyValuePair<string, object>>.Add(
-                        ref tagState.Tags,
-                        new KeyValuePair<string, object>(
-                            ZipkinErrorFlagTagName,
-                            activity.StatusDescription ?? string.Empty));
-                }
+                PooledList<KeyValuePair<string, object>>.Add(
+                ref tagState.Tags,
+                new KeyValuePair<string, object>(
+                    SpanAttributeConstants.StatusCodeKey,
+                    "OK"));
             }
 
-            // In the case when both activity status and status tag were set,
-            // activity status takes precedence over status tag.
-            else if (tagState.StatusCode.HasValue && tagState.StatusCode != StatusCode.Unset)
+            // activity.Status is Error
+            else
             {
                 PooledList<KeyValuePair<string, object>>.Add(
                     ref tagState.Tags,
                     new KeyValuePair<string, object>(
                         SpanAttributeConstants.StatusCodeKey,
-                        StatusHelper.GetTagValueForStatusCode(tagState.StatusCode.Value)));
+                        "ERROR"));
 
                 // Error flag rule from https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/zipkin.md#status
-                if (tagState.StatusCode == StatusCode.Error)
+                PooledList<KeyValuePair<string, object>>.Add(
+                    ref tagState.Tags,
+                    new KeyValuePair<string, object>(
+                        ZipkinErrorFlagTagName,
+                        activity.StatusDescription ?? string.Empty));
+            }
+        }
+
+        // In the case when both activity status and status tag were set,
+        // activity status takes precedence over status tag.
+        else if (tagState.StatusCode.HasValue && tagState.StatusCode != StatusCode.Unset)
+        {
+            PooledList<KeyValuePair<string, object>>.Add(
+                ref tagState.Tags,
+                new KeyValuePair<string, object>(
+                    SpanAttributeConstants.StatusCodeKey,
+                    StatusHelper.GetTagValueForStatusCode(tagState.StatusCode.Value)));
+
+            // Error flag rule from https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/zipkin.md#status
+            if (tagState.StatusCode == StatusCode.Error)
+            {
+                PooledList<KeyValuePair<string, object>>.Add(
+                    ref tagState.Tags,
+                    new KeyValuePair<string, object>(
+                        ZipkinErrorFlagTagName,
+                        tagState.StatusDescription ?? string.Empty));
+            }
+        }
+
+        var activitySource = activity.Source;
+        if (!string.IsNullOrEmpty(activitySource.Name))
+        {
+            PooledList<KeyValuePair<string, object>>.Add(ref tagState.Tags, new KeyValuePair<string, object>("otel.library.name", activitySource.Name));
+            if (!string.IsNullOrEmpty(activitySource.Version))
+            {
+                PooledList<KeyValuePair<string, object>>.Add(ref tagState.Tags, new KeyValuePair<string, object>("otel.library.version", activitySource.Version));
+            }
+        }
+
+        ZipkinEndpoint remoteEndpoint = null;
+        if (activity.Kind == ActivityKind.Client || activity.Kind == ActivityKind.Producer)
+        {
+            PeerServiceResolver.Resolve(ref tagState, out string peerServiceName, out bool addAsTag);
+
+            if (peerServiceName != null)
+            {
+                remoteEndpoint = RemoteEndpointCache.GetOrAdd((peerServiceName, default), ZipkinEndpoint.Create);
+                if (addAsTag)
                 {
-                    PooledList<KeyValuePair<string, object>>.Add(
-                        ref tagState.Tags,
-                        new KeyValuePair<string, object>(
-                            ZipkinErrorFlagTagName,
-                            tagState.StatusDescription ?? string.Empty));
+                    PooledList<KeyValuePair<string, object>>.Add(ref tagState.Tags, new KeyValuePair<string, object>(SemanticConventions.AttributePeerService, peerServiceName));
                 }
             }
+        }
 
-            var activitySource = activity.Source;
-            if (!string.IsNullOrEmpty(activitySource.Name))
+        EventEnumerationState eventState = default;
+        eventState.EnumerateEvents(activity);
+
+        return new ZipkinSpan(
+            EncodeTraceId(context.TraceId, useShortTraceIds),
+            parentId,
+            EncodeSpanId(context.SpanId),
+            ToActivityKind(activity),
+            activity.DisplayName,
+            activity.StartTimeUtc.ToEpochMicroseconds(),
+            duration: activity.Duration.ToEpochMicroseconds(),
+            localEndpoint,
+            remoteEndpoint,
+            eventState.Annotations,
+            tagState.Tags,
+            null,
+            null);
+    }
+
+    internal static string EncodeSpanId(ActivitySpanId spanId)
+    {
+        return spanId.ToHexString();
+    }
+
+    internal static long ToEpochMicroseconds(this DateTimeOffset dateTimeOffset)
+    {
+        // Truncate sub-microsecond precision before offsetting by the Unix Epoch to avoid
+        // the last digit being off by one for dates that result in negative Unix times
+        long microseconds = dateTimeOffset.Ticks / TicksPerMicrosecond;
+        return microseconds - UnixEpochMicroseconds;
+    }
+
+    internal static long ToEpochMicroseconds(this TimeSpan timeSpan)
+    {
+        return timeSpan.Ticks / TicksPerMicrosecond;
+    }
+
+    internal static long ToEpochMicroseconds(this DateTime utcDateTime)
+    {
+        // Truncate sub-microsecond precision before offsetting by the Unix Epoch to avoid
+        // the last digit being off by one for dates that result in negative Unix times
+        long microseconds = utcDateTime.Ticks / TicksPerMicrosecond;
+        return microseconds - UnixEpochMicroseconds;
+    }
+
+    private static string EncodeTraceId(ActivityTraceId traceId, bool useShortTraceIds)
+    {
+        var id = traceId.ToHexString();
+
+        if (id.Length > 16 && useShortTraceIds)
+        {
+            id = id.Substring(id.Length - 16, 16);
+        }
+
+        return id;
+    }
+
+    private static string ToActivityKind(Activity activity)
+    {
+        return activity.Kind switch
+        {
+            ActivityKind.Server => "SERVER",
+            ActivityKind.Producer => "PRODUCER",
+            ActivityKind.Consumer => "CONSUMER",
+            ActivityKind.Client => "CLIENT",
+            _ => null,
+        };
+    }
+
+    internal struct TagEnumerationState : PeerServiceResolver.IPeerServiceState
+    {
+        public PooledList<KeyValuePair<string, object>> Tags;
+
+        public string PeerService { get; set; }
+
+        public int? PeerServicePriority { get; set; }
+
+        public string HostName { get; set; }
+
+        public string IpAddress { get; set; }
+
+        public long Port { get; set; }
+
+        public StatusCode? StatusCode { get; set; }
+
+        public string StatusDescription { get; set; }
+
+        public void EnumerateTags(Activity activity)
+        {
+            foreach (ref readonly var tag in activity.EnumerateTagObjects())
             {
-                PooledList<KeyValuePair<string, object>>.Add(ref tagState.Tags, new KeyValuePair<string, object>("otel.library.name", activitySource.Name));
-                if (!string.IsNullOrEmpty(activitySource.Version))
+                if (tag.Value == null)
                 {
-                    PooledList<KeyValuePair<string, object>>.Add(ref tagState.Tags, new KeyValuePair<string, object>("otel.library.version", activitySource.Version));
+                    continue;
                 }
-            }
 
-            ZipkinEndpoint remoteEndpoint = null;
-            if (activity.Kind == ActivityKind.Client || activity.Kind == ActivityKind.Producer)
-            {
-                PeerServiceResolver.Resolve(ref tagState, out string peerServiceName, out bool addAsTag);
+                string key = tag.Key;
 
-                if (peerServiceName != null)
+                if (tag.Value is string strVal)
                 {
-                    remoteEndpoint = RemoteEndpointCache.GetOrAdd((peerServiceName, default), ZipkinEndpoint.Create);
-                    if (addAsTag)
+                    PeerServiceResolver.InspectTag(ref this, key, strVal);
+
+                    if (key == SpanAttributeConstants.StatusCodeKey)
                     {
-                        PooledList<KeyValuePair<string, object>>.Add(ref tagState.Tags, new KeyValuePair<string, object>(SemanticConventions.AttributePeerService, peerServiceName));
-                    }
-                }
-            }
-
-            EventEnumerationState eventState = default;
-            eventState.EnumerateEvents(activity);
-
-            return new ZipkinSpan(
-                EncodeTraceId(context.TraceId, useShortTraceIds),
-                parentId,
-                EncodeSpanId(context.SpanId),
-                ToActivityKind(activity),
-                activity.DisplayName,
-                activity.StartTimeUtc.ToEpochMicroseconds(),
-                duration: activity.Duration.ToEpochMicroseconds(),
-                localEndpoint,
-                remoteEndpoint,
-                eventState.Annotations,
-                tagState.Tags,
-                null,
-                null);
-        }
-
-        internal static string EncodeSpanId(ActivitySpanId spanId)
-        {
-            return spanId.ToHexString();
-        }
-
-        internal static long ToEpochMicroseconds(this DateTimeOffset dateTimeOffset)
-        {
-            // Truncate sub-microsecond precision before offsetting by the Unix Epoch to avoid
-            // the last digit being off by one for dates that result in negative Unix times
-            long microseconds = dateTimeOffset.Ticks / TicksPerMicrosecond;
-            return microseconds - UnixEpochMicroseconds;
-        }
-
-        internal static long ToEpochMicroseconds(this TimeSpan timeSpan)
-        {
-            return timeSpan.Ticks / TicksPerMicrosecond;
-        }
-
-        internal static long ToEpochMicroseconds(this DateTime utcDateTime)
-        {
-            // Truncate sub-microsecond precision before offsetting by the Unix Epoch to avoid
-            // the last digit being off by one for dates that result in negative Unix times
-            long microseconds = utcDateTime.Ticks / TicksPerMicrosecond;
-            return microseconds - UnixEpochMicroseconds;
-        }
-
-        private static string EncodeTraceId(ActivityTraceId traceId, bool useShortTraceIds)
-        {
-            var id = traceId.ToHexString();
-
-            if (id.Length > 16 && useShortTraceIds)
-            {
-                id = id.Substring(id.Length - 16, 16);
-            }
-
-            return id;
-        }
-
-        private static string ToActivityKind(Activity activity)
-        {
-            return activity.Kind switch
-            {
-                ActivityKind.Server => "SERVER",
-                ActivityKind.Producer => "PRODUCER",
-                ActivityKind.Consumer => "CONSUMER",
-                ActivityKind.Client => "CLIENT",
-                _ => null,
-            };
-        }
-
-        internal struct TagEnumerationState : PeerServiceResolver.IPeerServiceState
-        {
-            public PooledList<KeyValuePair<string, object>> Tags;
-
-            public string PeerService { get; set; }
-
-            public int? PeerServicePriority { get; set; }
-
-            public string HostName { get; set; }
-
-            public string IpAddress { get; set; }
-
-            public long Port { get; set; }
-
-            public StatusCode? StatusCode { get; set; }
-
-            public string StatusDescription { get; set; }
-
-            public void EnumerateTags(Activity activity)
-            {
-                foreach (ref readonly var tag in activity.EnumerateTagObjects())
-                {
-                    if (tag.Value == null)
-                    {
+                        this.StatusCode = StatusHelper.GetStatusCodeForTagValue(strVal);
                         continue;
                     }
-
-                    string key = tag.Key;
-
-                    if (tag.Value is string strVal)
+                    else if (key == SpanAttributeConstants.StatusDescriptionKey)
                     {
-                        PeerServiceResolver.InspectTag(ref this, key, strVal);
-
-                        if (key == SpanAttributeConstants.StatusCodeKey)
-                        {
-                            this.StatusCode = StatusHelper.GetStatusCodeForTagValue(strVal);
-                            continue;
-                        }
-                        else if (key == SpanAttributeConstants.StatusDescriptionKey)
-                        {
-                            // Description is sent as `error` but only if StatusCode is Error. See: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/zipkin.md#status
-                            this.StatusDescription = strVal;
-                            continue;
-                        }
-                        else if (key == ZipkinErrorFlagTagName)
-                        {
-                            // Ignore `error` tag if it exists, it will be added based on StatusCode + StatusDescription.
-                            continue;
-                        }
+                        // Description is sent as `error` but only if StatusCode is Error. See: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/zipkin.md#status
+                        this.StatusDescription = strVal;
+                        continue;
                     }
-                    else if (tag.Value is int intVal && tag.Key == SemanticConventions.AttributeNetPeerPort)
+                    else if (key == ZipkinErrorFlagTagName)
                     {
-                        PeerServiceResolver.InspectTag(ref this, key, intVal);
+                        // Ignore `error` tag if it exists, it will be added based on StatusCode + StatusDescription.
+                        continue;
                     }
-
-                    PooledList<KeyValuePair<string, object>>.Add(ref this.Tags, tag);
                 }
+                else if (tag.Value is int intVal && tag.Key == SemanticConventions.AttributeNetPeerPort)
+                {
+                    PeerServiceResolver.InspectTag(ref this, key, intVal);
+                }
+
+                PooledList<KeyValuePair<string, object>>.Add(ref this.Tags, tag);
             }
         }
+    }
 
-        private struct EventEnumerationState
+    private struct EventEnumerationState
+    {
+        public bool Created;
+
+        public PooledList<ZipkinAnnotation> Annotations;
+
+        public void EnumerateEvents(Activity activity)
         {
-            public bool Created;
+            var enumerator = activity.EnumerateEvents();
 
-            public PooledList<ZipkinAnnotation> Annotations;
-
-            public void EnumerateEvents(Activity activity)
+            if (enumerator.MoveNext())
             {
-                var enumerator = activity.EnumerateEvents();
+                this.Annotations = PooledList<ZipkinAnnotation>.Create();
+                this.Created = true;
 
-                if (enumerator.MoveNext())
+                do
                 {
-                    this.Annotations = PooledList<ZipkinAnnotation>.Create();
-                    this.Created = true;
+                    ref readonly var @event = ref enumerator.Current;
 
-                    do
-                    {
-                        ref readonly var @event = ref enumerator.Current;
-
-                        PooledList<ZipkinAnnotation>.Add(ref this.Annotations, new ZipkinAnnotation(@event.Timestamp.ToEpochMicroseconds(), @event.Name));
-                    }
-                    while (enumerator.MoveNext());
+                    PooledList<ZipkinAnnotation>.Add(ref this.Annotations, new ZipkinAnnotation(@event.Timestamp.ToEpochMicroseconds(), @event.Name));
                 }
+                while (enumerator.MoveNext());
             }
         }
     }

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinAnnotation.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinAnnotation.cs
@@ -13,20 +13,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
-namespace OpenTelemetry.Exporter.Zipkin.Implementation
+namespace OpenTelemetry.Exporter.Zipkin.Implementation;
+
+internal readonly struct ZipkinAnnotation
 {
-    internal readonly struct ZipkinAnnotation
+    public ZipkinAnnotation(
+        long timestamp,
+        string value)
     {
-        public ZipkinAnnotation(
-            long timestamp,
-            string value)
-        {
-            this.Timestamp = timestamp;
-            this.Value = value;
-        }
-
-        public long Timestamp { get; }
-
-        public string Value { get; }
+        this.Timestamp = timestamp;
+        this.Value = value;
     }
+
+    public long Timestamp { get; }
+
+    public string Value { get; }
 }

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinEndpoint.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinEndpoint.cs
@@ -16,88 +16,87 @@
 
 using System.Text.Json;
 
-namespace OpenTelemetry.Exporter.Zipkin.Implementation
+namespace OpenTelemetry.Exporter.Zipkin.Implementation;
+
+internal sealed class ZipkinEndpoint
 {
-    internal sealed class ZipkinEndpoint
+    public ZipkinEndpoint(string serviceName)
+        : this(serviceName, null, null, null, null)
     {
-        public ZipkinEndpoint(string serviceName)
-            : this(serviceName, null, null, null, null)
+    }
+
+    public ZipkinEndpoint(
+        string serviceName,
+        string ipv4,
+        string ipv6,
+        int? port,
+        Dictionary<string, object> tags)
+    {
+        this.ServiceName = serviceName;
+        this.Ipv4 = ipv4;
+        this.Ipv6 = ipv6;
+        this.Port = port;
+        this.Tags = tags;
+    }
+
+    public string ServiceName { get; }
+
+    public string Ipv4 { get; }
+
+    public string Ipv6 { get; }
+
+    public int? Port { get; }
+
+    public Dictionary<string, object> Tags { get; }
+
+    public static ZipkinEndpoint Create(string serviceName)
+    {
+        return new ZipkinEndpoint(serviceName);
+    }
+
+    public static ZipkinEndpoint Create((string Name, int Port) serviceNameAndPort)
+    {
+        var serviceName = serviceNameAndPort.Port == default
+            ? serviceNameAndPort.Name
+            : $"{serviceNameAndPort.Name}:{serviceNameAndPort.Port}";
+
+        return new ZipkinEndpoint(serviceName);
+    }
+
+    public ZipkinEndpoint Clone(string serviceName)
+    {
+        return new ZipkinEndpoint(
+            serviceName,
+            this.Ipv4,
+            this.Ipv6,
+            this.Port,
+            this.Tags);
+    }
+
+    public void Write(Utf8JsonWriter writer)
+    {
+        writer.WriteStartObject();
+
+        if (this.ServiceName != null)
         {
+            writer.WriteString(ZipkinSpanJsonHelper.ServiceNamePropertyName, this.ServiceName);
         }
 
-        public ZipkinEndpoint(
-            string serviceName,
-            string ipv4,
-            string ipv6,
-            int? port,
-            Dictionary<string, object> tags)
+        if (this.Ipv4 != null)
         {
-            this.ServiceName = serviceName;
-            this.Ipv4 = ipv4;
-            this.Ipv6 = ipv6;
-            this.Port = port;
-            this.Tags = tags;
+            writer.WriteString(ZipkinSpanJsonHelper.Ipv4PropertyName, this.Ipv4);
         }
 
-        public string ServiceName { get; }
-
-        public string Ipv4 { get; }
-
-        public string Ipv6 { get; }
-
-        public int? Port { get; }
-
-        public Dictionary<string, object> Tags { get; }
-
-        public static ZipkinEndpoint Create(string serviceName)
+        if (this.Ipv6 != null)
         {
-            return new ZipkinEndpoint(serviceName);
+            writer.WriteString(ZipkinSpanJsonHelper.Ipv6PropertyName, this.Ipv6);
         }
 
-        public static ZipkinEndpoint Create((string Name, int Port) serviceNameAndPort)
+        if (this.Port.HasValue)
         {
-            var serviceName = serviceNameAndPort.Port == default
-                ? serviceNameAndPort.Name
-                : $"{serviceNameAndPort.Name}:{serviceNameAndPort.Port}";
-
-            return new ZipkinEndpoint(serviceName);
+            writer.WriteNumber(ZipkinSpanJsonHelper.PortPropertyName, this.Port.Value);
         }
 
-        public ZipkinEndpoint Clone(string serviceName)
-        {
-            return new ZipkinEndpoint(
-                serviceName,
-                this.Ipv4,
-                this.Ipv6,
-                this.Port,
-                this.Tags);
-        }
-
-        public void Write(Utf8JsonWriter writer)
-        {
-            writer.WriteStartObject();
-
-            if (this.ServiceName != null)
-            {
-                writer.WriteString(ZipkinSpanJsonHelper.ServiceNamePropertyName, this.ServiceName);
-            }
-
-            if (this.Ipv4 != null)
-            {
-                writer.WriteString(ZipkinSpanJsonHelper.Ipv4PropertyName, this.Ipv4);
-            }
-
-            if (this.Ipv6 != null)
-            {
-                writer.WriteString(ZipkinSpanJsonHelper.Ipv6PropertyName, this.Ipv6);
-            }
-
-            if (this.Port.HasValue)
-            {
-                writer.WriteNumber(ZipkinSpanJsonHelper.PortPropertyName, this.Port.Value);
-            }
-
-            writer.WriteEndObject();
-        }
+        writer.WriteEndObject();
     }
 }

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinExporterEventSource.cs
@@ -17,41 +17,40 @@
 using System.Diagnostics.Tracing;
 using OpenTelemetry.Internal;
 
-namespace OpenTelemetry.Exporter.Zipkin.Implementation
+namespace OpenTelemetry.Exporter.Zipkin.Implementation;
+
+/// <summary>
+/// EventSource events emitted from the project.
+/// </summary>
+[EventSource(Name = "OpenTelemetry-Exporter-Zipkin")]
+internal sealed class ZipkinExporterEventSource : EventSource
 {
-    /// <summary>
-    /// EventSource events emitted from the project.
-    /// </summary>
-    [EventSource(Name = "OpenTelemetry-Exporter-Zipkin")]
-    internal sealed class ZipkinExporterEventSource : EventSource
+    public static ZipkinExporterEventSource Log = new();
+
+    [NonEvent]
+    public void FailedExport(Exception ex)
     {
-        public static ZipkinExporterEventSource Log = new();
-
-        [NonEvent]
-        public void FailedExport(Exception ex)
+        if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
         {
-            if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
-            {
-                this.FailedExport(ex.ToInvariantString());
-            }
+            this.FailedExport(ex.ToInvariantString());
         }
+    }
 
-        [Event(1, Message = "Failed to export activities: '{0}'", Level = EventLevel.Error)]
-        public void FailedExport(string exception)
-        {
-            this.WriteEvent(1, exception);
-        }
+    [Event(1, Message = "Failed to export activities: '{0}'", Level = EventLevel.Error)]
+    public void FailedExport(string exception)
+    {
+        this.WriteEvent(1, exception);
+    }
 
-        [Event(2, Message = "Unsupported attribute type '{0}' for '{1}'. Attribute will not be exported.", Level = EventLevel.Warning)]
-        public void UnsupportedAttributeType(string type, string key)
-        {
-            this.WriteEvent(2, type.ToString(), key);
-        }
+    [Event(2, Message = "Unsupported attribute type '{0}' for '{1}'. Attribute will not be exported.", Level = EventLevel.Warning)]
+    public void UnsupportedAttributeType(string type, string key)
+    {
+        this.WriteEvent(2, type.ToString(), key);
+    }
 
-        [Event(3, Message = "{0} environment variable has an invalid value: '{1}'", Level = EventLevel.Warning)]
-        public void InvalidEnvironmentVariable(string key, string value)
-        {
-            this.WriteEvent(3, key, value);
-        }
+    [Event(3, Message = "{0} environment variable has an invalid value: '{1}'", Level = EventLevel.Warning)]
+    public void InvalidEnvironmentVariable(string key, string value)
+    {
+        this.WriteEvent(3, key, value);
     }
 }

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinSpan.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinSpan.cs
@@ -18,185 +18,184 @@ using System.Globalization;
 using System.Text.Json;
 using OpenTelemetry.Internal;
 
-namespace OpenTelemetry.Exporter.Zipkin.Implementation
+namespace OpenTelemetry.Exporter.Zipkin.Implementation;
+
+internal readonly struct ZipkinSpan
 {
-    internal readonly struct ZipkinSpan
+    public ZipkinSpan(
+        string traceId,
+        string parentId,
+        string id,
+        string kind,
+        string name,
+        long? timestamp,
+        long? duration,
+        ZipkinEndpoint localEndpoint,
+        ZipkinEndpoint remoteEndpoint,
+        in PooledList<ZipkinAnnotation> annotations,
+        in PooledList<KeyValuePair<string, object>> tags,
+        bool? debug,
+        bool? shared)
     {
-        public ZipkinSpan(
-            string traceId,
-            string parentId,
-            string id,
-            string kind,
-            string name,
-            long? timestamp,
-            long? duration,
-            ZipkinEndpoint localEndpoint,
-            ZipkinEndpoint remoteEndpoint,
-            in PooledList<ZipkinAnnotation> annotations,
-            in PooledList<KeyValuePair<string, object>> tags,
-            bool? debug,
-            bool? shared)
-        {
-            Guard.ThrowIfNullOrWhitespace(traceId);
-            Guard.ThrowIfNullOrWhitespace(id);
+        Guard.ThrowIfNullOrWhitespace(traceId);
+        Guard.ThrowIfNullOrWhitespace(id);
 
-            this.TraceId = traceId;
-            this.ParentId = parentId;
-            this.Id = id;
-            this.Kind = kind;
-            this.Name = name;
-            this.Timestamp = timestamp;
-            this.Duration = duration;
-            this.LocalEndpoint = localEndpoint;
-            this.RemoteEndpoint = remoteEndpoint;
-            this.Annotations = annotations;
-            this.Tags = tags;
-            this.Debug = debug;
-            this.Shared = shared;
+        this.TraceId = traceId;
+        this.ParentId = parentId;
+        this.Id = id;
+        this.Kind = kind;
+        this.Name = name;
+        this.Timestamp = timestamp;
+        this.Duration = duration;
+        this.LocalEndpoint = localEndpoint;
+        this.RemoteEndpoint = remoteEndpoint;
+        this.Annotations = annotations;
+        this.Tags = tags;
+        this.Debug = debug;
+        this.Shared = shared;
+    }
+
+    public string TraceId { get; }
+
+    public string ParentId { get; }
+
+    public string Id { get; }
+
+    public string Kind { get; }
+
+    public string Name { get; }
+
+    public long? Timestamp { get; }
+
+    public long? Duration { get; }
+
+    public ZipkinEndpoint LocalEndpoint { get; }
+
+    public ZipkinEndpoint RemoteEndpoint { get; }
+
+    public PooledList<ZipkinAnnotation> Annotations { get; }
+
+    public PooledList<KeyValuePair<string, object>> Tags { get; }
+
+    public bool? Debug { get; }
+
+    public bool? Shared { get; }
+
+    public void Return()
+    {
+        this.Annotations.Return();
+        this.Tags.Return();
+    }
+
+    public void Write(Utf8JsonWriter writer)
+    {
+        writer.WriteStartObject();
+
+        writer.WriteString(ZipkinSpanJsonHelper.TraceIdPropertyName, this.TraceId);
+
+        if (this.Name != null)
+        {
+            writer.WriteString(ZipkinSpanJsonHelper.NamePropertyName, this.Name);
         }
 
-        public string TraceId { get; }
-
-        public string ParentId { get; }
-
-        public string Id { get; }
-
-        public string Kind { get; }
-
-        public string Name { get; }
-
-        public long? Timestamp { get; }
-
-        public long? Duration { get; }
-
-        public ZipkinEndpoint LocalEndpoint { get; }
-
-        public ZipkinEndpoint RemoteEndpoint { get; }
-
-        public PooledList<ZipkinAnnotation> Annotations { get; }
-
-        public PooledList<KeyValuePair<string, object>> Tags { get; }
-
-        public bool? Debug { get; }
-
-        public bool? Shared { get; }
-
-        public void Return()
+        if (this.ParentId != null)
         {
-            this.Annotations.Return();
-            this.Tags.Return();
+            writer.WriteString(ZipkinSpanJsonHelper.ParentIdPropertyName, this.ParentId);
         }
 
-        public void Write(Utf8JsonWriter writer)
+        writer.WriteString(ZipkinSpanJsonHelper.IdPropertyName, this.Id);
+
+        if (this.Kind != null)
         {
-            writer.WriteStartObject();
+            writer.WriteString(ZipkinSpanJsonHelper.KindPropertyName, this.Kind);
+        }
 
-            writer.WriteString(ZipkinSpanJsonHelper.TraceIdPropertyName, this.TraceId);
+        if (this.Timestamp.HasValue)
+        {
+            writer.WriteNumber(ZipkinSpanJsonHelper.TimestampPropertyName, this.Timestamp.Value);
+        }
 
-            if (this.Name != null)
+        if (this.Duration.HasValue)
+        {
+            writer.WriteNumber(ZipkinSpanJsonHelper.DurationPropertyName, this.Duration.Value);
+        }
+
+        if (this.Debug.HasValue)
+        {
+            writer.WriteBoolean(ZipkinSpanJsonHelper.DebugPropertyName, this.Debug.Value);
+        }
+
+        if (this.Shared.HasValue)
+        {
+            writer.WriteBoolean(ZipkinSpanJsonHelper.SharedPropertyName, this.Shared.Value);
+        }
+
+        if (this.LocalEndpoint != null)
+        {
+            writer.WritePropertyName(ZipkinSpanJsonHelper.LocalEndpointPropertyName);
+            this.LocalEndpoint.Write(writer);
+        }
+
+        if (this.RemoteEndpoint != null)
+        {
+            writer.WritePropertyName(ZipkinSpanJsonHelper.RemoteEndpointPropertyName);
+            this.RemoteEndpoint.Write(writer);
+        }
+
+        if (!this.Annotations.IsEmpty)
+        {
+            writer.WritePropertyName(ZipkinSpanJsonHelper.AnnotationsPropertyName);
+            writer.WriteStartArray();
+
+            foreach (var annotation in this.Annotations)
             {
-                writer.WriteString(ZipkinSpanJsonHelper.NamePropertyName, this.Name);
-            }
-
-            if (this.ParentId != null)
-            {
-                writer.WriteString(ZipkinSpanJsonHelper.ParentIdPropertyName, this.ParentId);
-            }
-
-            writer.WriteString(ZipkinSpanJsonHelper.IdPropertyName, this.Id);
-
-            if (this.Kind != null)
-            {
-                writer.WriteString(ZipkinSpanJsonHelper.KindPropertyName, this.Kind);
-            }
-
-            if (this.Timestamp.HasValue)
-            {
-                writer.WriteNumber(ZipkinSpanJsonHelper.TimestampPropertyName, this.Timestamp.Value);
-            }
-
-            if (this.Duration.HasValue)
-            {
-                writer.WriteNumber(ZipkinSpanJsonHelper.DurationPropertyName, this.Duration.Value);
-            }
-
-            if (this.Debug.HasValue)
-            {
-                writer.WriteBoolean(ZipkinSpanJsonHelper.DebugPropertyName, this.Debug.Value);
-            }
-
-            if (this.Shared.HasValue)
-            {
-                writer.WriteBoolean(ZipkinSpanJsonHelper.SharedPropertyName, this.Shared.Value);
-            }
-
-            if (this.LocalEndpoint != null)
-            {
-                writer.WritePropertyName(ZipkinSpanJsonHelper.LocalEndpointPropertyName);
-                this.LocalEndpoint.Write(writer);
-            }
-
-            if (this.RemoteEndpoint != null)
-            {
-                writer.WritePropertyName(ZipkinSpanJsonHelper.RemoteEndpointPropertyName);
-                this.RemoteEndpoint.Write(writer);
-            }
-
-            if (!this.Annotations.IsEmpty)
-            {
-                writer.WritePropertyName(ZipkinSpanJsonHelper.AnnotationsPropertyName);
-                writer.WriteStartArray();
-
-                foreach (var annotation in this.Annotations)
-                {
-                    writer.WriteStartObject();
-
-                    writer.WriteNumber(ZipkinSpanJsonHelper.TimestampPropertyName, annotation.Timestamp);
-
-                    writer.WriteString(ZipkinSpanJsonHelper.ValuePropertyName, annotation.Value);
-
-                    writer.WriteEndObject();
-                }
-
-                writer.WriteEndArray();
-            }
-
-            if (!this.Tags.IsEmpty || this.LocalEndpoint.Tags != null)
-            {
-                writer.WritePropertyName(ZipkinSpanJsonHelper.TagsPropertyName);
                 writer.WriteStartObject();
 
-                // this will be used when we convert int, double, int[], double[] to string
-                var originalUICulture = Thread.CurrentThread.CurrentUICulture;
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+                writer.WriteNumber(ZipkinSpanJsonHelper.TimestampPropertyName, annotation.Timestamp);
 
-                try
-                {
-                    foreach (var tag in this.LocalEndpoint.Tags ?? Enumerable.Empty<KeyValuePair<string, object>>())
-                    {
-                        if (ZipkinTagTransformer.Instance.TryTransformTag(tag, out var result))
-                        {
-                            writer.WriteString(tag.Key, result);
-                        }
-                    }
-
-                    foreach (var tag in this.Tags)
-                    {
-                        if (ZipkinTagTransformer.Instance.TryTransformTag(tag, out var result))
-                        {
-                            writer.WriteString(tag.Key, result);
-                        }
-                    }
-                }
-                finally
-                {
-                    Thread.CurrentThread.CurrentUICulture = originalUICulture;
-                }
+                writer.WriteString(ZipkinSpanJsonHelper.ValuePropertyName, annotation.Value);
 
                 writer.WriteEndObject();
             }
 
+            writer.WriteEndArray();
+        }
+
+        if (!this.Tags.IsEmpty || this.LocalEndpoint.Tags != null)
+        {
+            writer.WritePropertyName(ZipkinSpanJsonHelper.TagsPropertyName);
+            writer.WriteStartObject();
+
+            // this will be used when we convert int, double, int[], double[] to string
+            var originalUICulture = Thread.CurrentThread.CurrentUICulture;
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+
+            try
+            {
+                foreach (var tag in this.LocalEndpoint.Tags ?? Enumerable.Empty<KeyValuePair<string, object>>())
+                {
+                    if (ZipkinTagTransformer.Instance.TryTransformTag(tag, out var result))
+                    {
+                        writer.WriteString(tag.Key, result);
+                    }
+                }
+
+                foreach (var tag in this.Tags)
+                {
+                    if (ZipkinTagTransformer.Instance.TryTransformTag(tag, out var result))
+                    {
+                        writer.WriteString(tag.Key, result);
+                    }
+                }
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentUICulture = originalUICulture;
+            }
+
             writer.WriteEndObject();
         }
+
+        writer.WriteEndObject();
     }
 }

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinSpanJsonHelper.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinSpanJsonHelper.cs
@@ -16,44 +16,43 @@
 
 using System.Text.Json;
 
-namespace OpenTelemetry.Exporter.Zipkin.Implementation
+namespace OpenTelemetry.Exporter.Zipkin.Implementation;
+
+internal static class ZipkinSpanJsonHelper
 {
-    internal static class ZipkinSpanJsonHelper
-    {
-        public static readonly JsonEncodedText TraceIdPropertyName = JsonEncodedText.Encode("traceId");
+    public static readonly JsonEncodedText TraceIdPropertyName = JsonEncodedText.Encode("traceId");
 
-        public static readonly JsonEncodedText NamePropertyName = JsonEncodedText.Encode("name");
+    public static readonly JsonEncodedText NamePropertyName = JsonEncodedText.Encode("name");
 
-        public static readonly JsonEncodedText ParentIdPropertyName = JsonEncodedText.Encode("parentId");
+    public static readonly JsonEncodedText ParentIdPropertyName = JsonEncodedText.Encode("parentId");
 
-        public static readonly JsonEncodedText IdPropertyName = JsonEncodedText.Encode("id");
+    public static readonly JsonEncodedText IdPropertyName = JsonEncodedText.Encode("id");
 
-        public static readonly JsonEncodedText KindPropertyName = JsonEncodedText.Encode("kind");
+    public static readonly JsonEncodedText KindPropertyName = JsonEncodedText.Encode("kind");
 
-        public static readonly JsonEncodedText TimestampPropertyName = JsonEncodedText.Encode("timestamp");
+    public static readonly JsonEncodedText TimestampPropertyName = JsonEncodedText.Encode("timestamp");
 
-        public static readonly JsonEncodedText DurationPropertyName = JsonEncodedText.Encode("duration");
+    public static readonly JsonEncodedText DurationPropertyName = JsonEncodedText.Encode("duration");
 
-        public static readonly JsonEncodedText DebugPropertyName = JsonEncodedText.Encode("debug");
+    public static readonly JsonEncodedText DebugPropertyName = JsonEncodedText.Encode("debug");
 
-        public static readonly JsonEncodedText SharedPropertyName = JsonEncodedText.Encode("shared");
+    public static readonly JsonEncodedText SharedPropertyName = JsonEncodedText.Encode("shared");
 
-        public static readonly JsonEncodedText LocalEndpointPropertyName = JsonEncodedText.Encode("localEndpoint");
+    public static readonly JsonEncodedText LocalEndpointPropertyName = JsonEncodedText.Encode("localEndpoint");
 
-        public static readonly JsonEncodedText RemoteEndpointPropertyName = JsonEncodedText.Encode("remoteEndpoint");
+    public static readonly JsonEncodedText RemoteEndpointPropertyName = JsonEncodedText.Encode("remoteEndpoint");
 
-        public static readonly JsonEncodedText AnnotationsPropertyName = JsonEncodedText.Encode("annotations");
+    public static readonly JsonEncodedText AnnotationsPropertyName = JsonEncodedText.Encode("annotations");
 
-        public static readonly JsonEncodedText ValuePropertyName = JsonEncodedText.Encode("value");
+    public static readonly JsonEncodedText ValuePropertyName = JsonEncodedText.Encode("value");
 
-        public static readonly JsonEncodedText TagsPropertyName = JsonEncodedText.Encode("tags");
+    public static readonly JsonEncodedText TagsPropertyName = JsonEncodedText.Encode("tags");
 
-        public static readonly JsonEncodedText ServiceNamePropertyName = JsonEncodedText.Encode("serviceName");
+    public static readonly JsonEncodedText ServiceNamePropertyName = JsonEncodedText.Encode("serviceName");
 
-        public static readonly JsonEncodedText Ipv4PropertyName = JsonEncodedText.Encode("ipv4");
+    public static readonly JsonEncodedText Ipv4PropertyName = JsonEncodedText.Encode("ipv4");
 
-        public static readonly JsonEncodedText Ipv6PropertyName = JsonEncodedText.Encode("ipv6");
+    public static readonly JsonEncodedText Ipv6PropertyName = JsonEncodedText.Encode("ipv6");
 
-        public static readonly JsonEncodedText PortPropertyName = JsonEncodedText.Encode("port");
-    }
+    public static readonly JsonEncodedText PortPropertyName = JsonEncodedText.Encode("port");
 }

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporterOptions.cs
@@ -22,87 +22,86 @@ using Microsoft.Extensions.Configuration;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
 
-namespace OpenTelemetry.Exporter
+namespace OpenTelemetry.Exporter;
+
+/// <summary>
+/// Zipkin span exporter options.
+/// OTEL_EXPORTER_ZIPKIN_ENDPOINT
+/// environment variables are parsed during object construction.
+/// </summary>
+public sealed class ZipkinExporterOptions
 {
+    internal const int DefaultMaxPayloadSizeInBytes = 4096;
+    internal const string ZipkinEndpointEnvVar = "OTEL_EXPORTER_ZIPKIN_ENDPOINT";
+    internal const string DefaultZipkinEndpoint = "http://localhost:9411/api/v2/spans";
+
+    internal static readonly Func<HttpClient> DefaultHttpClientFactory = () => new HttpClient();
+
     /// <summary>
-    /// Zipkin span exporter options.
-    /// OTEL_EXPORTER_ZIPKIN_ENDPOINT
-    /// environment variables are parsed during object construction.
+    /// Initializes a new instance of the <see cref="ZipkinExporterOptions"/> class.
+    /// Initializes zipkin endpoint.
     /// </summary>
-    public sealed class ZipkinExporterOptions
+    public ZipkinExporterOptions()
+         : this(new ConfigurationBuilder().AddEnvironmentVariables().Build(), new())
     {
-        internal const int DefaultMaxPayloadSizeInBytes = 4096;
-        internal const string ZipkinEndpointEnvVar = "OTEL_EXPORTER_ZIPKIN_ENDPOINT";
-        internal const string DefaultZipkinEndpoint = "http://localhost:9411/api/v2/spans";
-
-        internal static readonly Func<HttpClient> DefaultHttpClientFactory = () => new HttpClient();
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ZipkinExporterOptions"/> class.
-        /// Initializes zipkin endpoint.
-        /// </summary>
-        public ZipkinExporterOptions()
-             : this(new ConfigurationBuilder().AddEnvironmentVariables().Build(), new())
-        {
-        }
-
-        internal ZipkinExporterOptions(
-            IConfiguration configuration,
-            BatchExportActivityProcessorOptions defaultBatchOptions)
-        {
-            Debug.Assert(configuration != null, "configuration was null");
-            Debug.Assert(defaultBatchOptions != null, "defaultBatchOptions was null");
-
-            if (configuration.TryGetUriValue(ZipkinEndpointEnvVar, out var endpoint))
-            {
-                this.Endpoint = endpoint;
-            }
-
-            this.BatchExportProcessorOptions = defaultBatchOptions;
-        }
-
-        /// <summary>
-        /// Gets or sets Zipkin endpoint address. See https://zipkin.io/zipkin-api/#/default/post_spans.
-        /// Typically https://zipkin-server-name:9411/api/v2/spans.
-        /// </summary>
-        public Uri Endpoint { get; set; } = new Uri(DefaultZipkinEndpoint);
-
-        /// <summary>
-        /// Gets or sets a value indicating whether short trace id should be used.
-        /// </summary>
-        public bool UseShortTraceIds { get; set; }
-
-        /// <summary>
-        /// Gets or sets the maximum payload size in bytes. Default value: 4096.
-        /// </summary>
-        public int? MaxPayloadSizeInBytes { get; set; } = DefaultMaxPayloadSizeInBytes;
-
-        /// <summary>
-        /// Gets or sets the export processor type to be used with Zipkin Exporter. The default value is <see cref="ExportProcessorType.Batch"/>.
-        /// </summary>
-        public ExportProcessorType ExportProcessorType { get; set; } = ExportProcessorType.Batch;
-
-        /// <summary>
-        /// Gets or sets the BatchExportProcessor options. Ignored unless ExportProcessorType is BatchExporter.
-        /// </summary>
-        public BatchExportProcessorOptions<Activity> BatchExportProcessorOptions { get; set; }
-
-        /// <summary>
-        /// Gets or sets the factory function called to create the <see
-        /// cref="HttpClient"/> instance that will be used at runtime to
-        /// transmit spans over HTTP. The returned instance will be reused for
-        /// all export invocations.
-        /// </summary>
-        /// <remarks>
-        /// Note: The default behavior when using the <see
-        /// cref="ZipkinExporterHelperExtensions.AddZipkinExporter(TracerProviderBuilder,
-        /// Action{ZipkinExporterOptions})"/> extension is if an <a
-        /// href="https://docs.microsoft.com/dotnet/api/system.net.http.ihttpclientfactory">IHttpClientFactory</a>
-        /// instance can be resolved through the application <see
-        /// cref="IServiceProvider"/> then an <see cref="HttpClient"/> will be
-        /// created through the factory with the name "ZipkinExporter" otherwise
-        /// an <see cref="HttpClient"/> will be instantiated directly.
-        /// </remarks>
-        public Func<HttpClient> HttpClientFactory { get; set; } = DefaultHttpClientFactory;
     }
+
+    internal ZipkinExporterOptions(
+        IConfiguration configuration,
+        BatchExportActivityProcessorOptions defaultBatchOptions)
+    {
+        Debug.Assert(configuration != null, "configuration was null");
+        Debug.Assert(defaultBatchOptions != null, "defaultBatchOptions was null");
+
+        if (configuration.TryGetUriValue(ZipkinEndpointEnvVar, out var endpoint))
+        {
+            this.Endpoint = endpoint;
+        }
+
+        this.BatchExportProcessorOptions = defaultBatchOptions;
+    }
+
+    /// <summary>
+    /// Gets or sets Zipkin endpoint address. See https://zipkin.io/zipkin-api/#/default/post_spans.
+    /// Typically https://zipkin-server-name:9411/api/v2/spans.
+    /// </summary>
+    public Uri Endpoint { get; set; } = new Uri(DefaultZipkinEndpoint);
+
+    /// <summary>
+    /// Gets or sets a value indicating whether short trace id should be used.
+    /// </summary>
+    public bool UseShortTraceIds { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum payload size in bytes. Default value: 4096.
+    /// </summary>
+    public int? MaxPayloadSizeInBytes { get; set; } = DefaultMaxPayloadSizeInBytes;
+
+    /// <summary>
+    /// Gets or sets the export processor type to be used with Zipkin Exporter. The default value is <see cref="ExportProcessorType.Batch"/>.
+    /// </summary>
+    public ExportProcessorType ExportProcessorType { get; set; } = ExportProcessorType.Batch;
+
+    /// <summary>
+    /// Gets or sets the BatchExportProcessor options. Ignored unless ExportProcessorType is BatchExporter.
+    /// </summary>
+    public BatchExportProcessorOptions<Activity> BatchExportProcessorOptions { get; set; }
+
+    /// <summary>
+    /// Gets or sets the factory function called to create the <see
+    /// cref="HttpClient"/> instance that will be used at runtime to
+    /// transmit spans over HTTP. The returned instance will be reused for
+    /// all export invocations.
+    /// </summary>
+    /// <remarks>
+    /// Note: The default behavior when using the <see
+    /// cref="ZipkinExporterHelperExtensions.AddZipkinExporter(TracerProviderBuilder,
+    /// Action{ZipkinExporterOptions})"/> extension is if an <a
+    /// href="https://docs.microsoft.com/dotnet/api/system.net.http.ihttpclientfactory">IHttpClientFactory</a>
+    /// instance can be resolved through the application <see
+    /// cref="IServiceProvider"/> then an <see cref="HttpClient"/> will be
+    /// created through the factory with the name "ZipkinExporter" otherwise
+    /// an <see cref="HttpClient"/> will be instantiated directly.
+    /// </remarks>
+    public Func<HttpClient> HttpClientFactory { get; set; } = DefaultHttpClientFactory;
 }

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/EventSourceTest.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/EventSourceTest.cs
@@ -18,14 +18,13 @@ using OpenTelemetry.Exporter.Zipkin.Implementation;
 using OpenTelemetry.Tests;
 using Xunit;
 
-namespace OpenTelemetry.Exporter.Zipkin.Tests
+namespace OpenTelemetry.Exporter.Zipkin.Tests;
+
+public class EventSourceTest
 {
-    public class EventSourceTest
+    [Fact]
+    public void EventSourceTest_ZipkinExporterEventSource()
     {
-        [Fact]
-        public void EventSourceTest_ZipkinExporterEventSource()
-        {
-            EventSourceTestHelper.MethodsAreImplementedConsistentlyWithTheirAttributes(ZipkinExporterEventSource.Log);
-        }
+        EventSourceTestHelper.MethodsAreImplementedConsistentlyWithTheirAttributes(ZipkinExporterEventSource.Log);
     }
 }

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionExtensionsTest.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionExtensionsTest.cs
@@ -19,49 +19,48 @@ using OpenTelemetry.Internal;
 using Xunit;
 using static OpenTelemetry.Exporter.Zipkin.Implementation.ZipkinActivityConversionExtensions;
 
-namespace OpenTelemetry.Exporter.Zipkin.Implementation.Tests
+namespace OpenTelemetry.Exporter.Zipkin.Implementation.Tests;
+
+public class ZipkinActivityConversionExtensionsTest
 {
-    public class ZipkinActivityConversionExtensionsTest
+    [Theory]
+    [InlineData("int", 1)]
+    [InlineData("string", "s")]
+    [InlineData("bool", true)]
+    [InlineData("double", 1.0)]
+    public void CheckProcessTag(string key, object value)
     {
-        [Theory]
-        [InlineData("int", 1)]
-        [InlineData("string", "s")]
-        [InlineData("bool", true)]
-        [InlineData("double", 1.0)]
-        public void CheckProcessTag(string key, object value)
+        var attributeEnumerationState = new TagEnumerationState
         {
-            var attributeEnumerationState = new TagEnumerationState
-            {
-                Tags = PooledList<KeyValuePair<string, object>>.Create(),
-            };
+            Tags = PooledList<KeyValuePair<string, object>>.Create(),
+        };
 
-            using var activity = new Activity("TestActivity");
-            activity.SetTag(key, value);
+        using var activity = new Activity("TestActivity");
+        activity.SetTag(key, value);
 
-            attributeEnumerationState.EnumerateTags(activity);
+        attributeEnumerationState.EnumerateTags(activity);
 
-            Assert.Equal(key, attributeEnumerationState.Tags[0].Key);
-            Assert.Equal(value, attributeEnumerationState.Tags[0].Value);
-        }
+        Assert.Equal(key, attributeEnumerationState.Tags[0].Key);
+        Assert.Equal(value, attributeEnumerationState.Tags[0].Value);
+    }
 
-        [Theory]
-        [InlineData("int", null)]
-        [InlineData("string", null)]
-        [InlineData("bool", null)]
-        [InlineData("double", null)]
-        public void CheckNullValueProcessTag(string key, object value)
+    [Theory]
+    [InlineData("int", null)]
+    [InlineData("string", null)]
+    [InlineData("bool", null)]
+    [InlineData("double", null)]
+    public void CheckNullValueProcessTag(string key, object value)
+    {
+        var attributeEnumerationState = new TagEnumerationState
         {
-            var attributeEnumerationState = new TagEnumerationState
-            {
-                Tags = PooledList<KeyValuePair<string, object>>.Create(),
-            };
+            Tags = PooledList<KeyValuePair<string, object>>.Create(),
+        };
 
-            using var activity = new Activity("TestActivity");
-            activity.SetTag(key, value);
+        using var activity = new Activity("TestActivity");
+        activity.SetTag(key, value);
 
-            attributeEnumerationState.EnumerateTags(activity);
+        attributeEnumerationState.EnumerateTags(activity);
 
-            Assert.Empty(attributeEnumerationState.Tags);
-        }
+        Assert.Empty(attributeEnumerationState.Tags);
     }
 }

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionTest.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionTest.cs
@@ -20,250 +20,249 @@ using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
 using Xunit;
 
-namespace OpenTelemetry.Exporter.Zipkin.Implementation.Tests
+namespace OpenTelemetry.Exporter.Zipkin.Implementation.Tests;
+
+public class ZipkinActivityConversionTest
 {
-    public class ZipkinActivityConversionTest
+    private const string ZipkinSpanName = "Name";
+    private static readonly ZipkinEndpoint DefaultZipkinEndpoint = new("TestService");
+
+    [Fact]
+    public void ToZipkinSpan_AllPropertiesSet()
     {
-        private const string ZipkinSpanName = "Name";
-        private static readonly ZipkinEndpoint DefaultZipkinEndpoint = new("TestService");
+        // Arrange
+        using var activity = ZipkinExporterTests.CreateTestActivity();
 
-        [Fact]
-        public void ToZipkinSpan_AllPropertiesSet()
+        // Act & Assert
+        var zipkinSpan = activity.ToZipkinSpan(DefaultZipkinEndpoint);
+
+        Assert.Equal(ZipkinSpanName, zipkinSpan.Name);
+
+        Assert.Equal(activity.TraceId.ToHexString(), zipkinSpan.TraceId);
+        Assert.Equal(activity.SpanId.ToHexString(), zipkinSpan.Id);
+
+        Assert.Equal(activity.StartTimeUtc.ToEpochMicroseconds(), zipkinSpan.Timestamp);
+        Assert.Equal((long)(activity.Duration.TotalMilliseconds * 1000), zipkinSpan.Duration);
+
+        int counter = 0;
+        var tagsArray = zipkinSpan.Tags.ToArray();
+
+        foreach (var tags in activity.TagObjects)
         {
-            // Arrange
-            using var activity = ZipkinExporterTests.CreateTestActivity();
-
-            // Act & Assert
-            var zipkinSpan = activity.ToZipkinSpan(DefaultZipkinEndpoint);
-
-            Assert.Equal(ZipkinSpanName, zipkinSpan.Name);
-
-            Assert.Equal(activity.TraceId.ToHexString(), zipkinSpan.TraceId);
-            Assert.Equal(activity.SpanId.ToHexString(), zipkinSpan.Id);
-
-            Assert.Equal(activity.StartTimeUtc.ToEpochMicroseconds(), zipkinSpan.Timestamp);
-            Assert.Equal((long)(activity.Duration.TotalMilliseconds * 1000), zipkinSpan.Duration);
-
-            int counter = 0;
-            var tagsArray = zipkinSpan.Tags.ToArray();
-
-            foreach (var tags in activity.TagObjects)
-            {
-                Assert.Equal(tagsArray[counter].Key, tags.Key);
-                Assert.Equal(tagsArray[counter++].Value, tags.Value);
-            }
-
-            foreach (var annotation in zipkinSpan.Annotations)
-            {
-                // Timestamp is same in both events
-                Assert.Equal(activity.Events.First().Timestamp.ToEpochMicroseconds(), annotation.Timestamp);
-            }
+            Assert.Equal(tagsArray[counter].Key, tags.Key);
+            Assert.Equal(tagsArray[counter++].Value, tags.Value);
         }
 
-        [Fact]
-        public void ToZipkinSpan_NoEvents()
+        foreach (var annotation in zipkinSpan.Annotations)
         {
-            // Arrange
-            using var activity = ZipkinExporterTests.CreateTestActivity(addEvents: false);
+            // Timestamp is same in both events
+            Assert.Equal(activity.Events.First().Timestamp.ToEpochMicroseconds(), annotation.Timestamp);
+        }
+    }
 
-            // Act & Assert
-            var zipkinSpan = activity.ToZipkinSpan(DefaultZipkinEndpoint);
+    [Fact]
+    public void ToZipkinSpan_NoEvents()
+    {
+        // Arrange
+        using var activity = ZipkinExporterTests.CreateTestActivity(addEvents: false);
 
-            Assert.Equal(ZipkinSpanName, zipkinSpan.Name);
-            Assert.Empty(zipkinSpan.Annotations);
-            Assert.Equal(activity.TraceId.ToHexString(), zipkinSpan.TraceId);
-            Assert.Equal(activity.SpanId.ToHexString(), zipkinSpan.Id);
+        // Act & Assert
+        var zipkinSpan = activity.ToZipkinSpan(DefaultZipkinEndpoint);
 
-            int counter = 0;
-            var tagsArray = zipkinSpan.Tags.ToArray();
+        Assert.Equal(ZipkinSpanName, zipkinSpan.Name);
+        Assert.Empty(zipkinSpan.Annotations);
+        Assert.Equal(activity.TraceId.ToHexString(), zipkinSpan.TraceId);
+        Assert.Equal(activity.SpanId.ToHexString(), zipkinSpan.Id);
 
-            foreach (var tags in activity.TagObjects)
-            {
-                Assert.Equal(tagsArray[counter].Key, tags.Key);
-                Assert.Equal(tagsArray[counter++].Value, tags.Value);
-            }
+        int counter = 0;
+        var tagsArray = zipkinSpan.Tags.ToArray();
 
-            Assert.Equal(activity.StartTimeUtc.ToEpochMicroseconds(), zipkinSpan.Timestamp);
-            Assert.Equal((long)activity.Duration.TotalMilliseconds * 1000, zipkinSpan.Duration);
+        foreach (var tags in activity.TagObjects)
+        {
+            Assert.Equal(tagsArray[counter].Key, tags.Key);
+            Assert.Equal(tagsArray[counter++].Value, tags.Value);
         }
 
-        [Theory]
-        [InlineData(StatusCode.Unset, "unset")]
-        [InlineData(StatusCode.Ok, "Ok")]
-        [InlineData(StatusCode.Error, "ERROR")]
-        [InlineData(StatusCode.Unset, "iNvAlId")]
-        public void ToZipkinSpan_Status_ErrorFlagTest(StatusCode expectedStatusCode, string statusCodeTagValue)
+        Assert.Equal(activity.StartTimeUtc.ToEpochMicroseconds(), zipkinSpan.Timestamp);
+        Assert.Equal((long)activity.Duration.TotalMilliseconds * 1000, zipkinSpan.Duration);
+    }
+
+    [Theory]
+    [InlineData(StatusCode.Unset, "unset")]
+    [InlineData(StatusCode.Ok, "Ok")]
+    [InlineData(StatusCode.Error, "ERROR")]
+    [InlineData(StatusCode.Unset, "iNvAlId")]
+    public void ToZipkinSpan_Status_ErrorFlagTest(StatusCode expectedStatusCode, string statusCodeTagValue)
+    {
+        // Arrange
+        using var activity = ZipkinExporterTests.CreateTestActivity();
+        activity.SetTag(SpanAttributeConstants.StatusCodeKey, statusCodeTagValue);
+
+        // Act
+        var zipkinSpan = activity.ToZipkinSpan(DefaultZipkinEndpoint);
+
+        // Assert
+
+        Assert.Equal(expectedStatusCode, activity.GetStatus().StatusCode);
+
+        if (expectedStatusCode == StatusCode.Unset)
         {
-            // Arrange
-            using var activity = ZipkinExporterTests.CreateTestActivity();
-            activity.SetTag(SpanAttributeConstants.StatusCodeKey, statusCodeTagValue);
-
-            // Act
-            var zipkinSpan = activity.ToZipkinSpan(DefaultZipkinEndpoint);
-
-            // Assert
-
-            Assert.Equal(expectedStatusCode, activity.GetStatus().StatusCode);
-
-            if (expectedStatusCode == StatusCode.Unset)
-            {
-                Assert.DoesNotContain(zipkinSpan.Tags, t => t.Key == SpanAttributeConstants.StatusCodeKey);
-            }
-            else
-            {
-                Assert.Equal(
-                    StatusHelper.GetTagValueForStatusCode(expectedStatusCode),
-                    zipkinSpan.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.StatusCodeKey).Value);
-            }
-
-            if (expectedStatusCode == StatusCode.Error)
-            {
-                Assert.Contains(zipkinSpan.Tags, t => t.Key == "error" && (string)t.Value == string.Empty);
-            }
-            else
-            {
-                Assert.DoesNotContain(zipkinSpan.Tags, t => t.Key == "error");
-            }
+            Assert.DoesNotContain(zipkinSpan.Tags, t => t.Key == SpanAttributeConstants.StatusCodeKey);
+        }
+        else
+        {
+            Assert.Equal(
+                StatusHelper.GetTagValueForStatusCode(expectedStatusCode),
+                zipkinSpan.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.StatusCodeKey).Value);
         }
 
-        [Theory]
-        [InlineData(ActivityStatusCode.Unset)]
-        [InlineData(ActivityStatusCode.Ok)]
-        [InlineData(ActivityStatusCode.Error)]
-        public void ToZipkinSpan_Activity_Status_And_StatusDescription_is_Set(ActivityStatusCode expectedStatusCode)
+        if (expectedStatusCode == StatusCode.Error)
         {
-            // Arrange.
-            const string description = "Description when ActivityStatusCode is Error.";
-            using var activity = ZipkinExporterTests.CreateTestActivity();
-            activity.SetStatus(expectedStatusCode, description);
-
-            // Act.
-            var zipkinSpan = activity.ToZipkinSpan(DefaultZipkinEndpoint);
-
-            // Assert.
-            if (expectedStatusCode == ActivityStatusCode.Unset)
-            {
-                Assert.DoesNotContain(zipkinSpan.Tags, t => t.Key == SpanAttributeConstants.StatusCodeKey);
-            }
-            else if (expectedStatusCode == ActivityStatusCode.Ok)
-            {
-                Assert.Equal("OK", zipkinSpan.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.StatusCodeKey).Value);
-            }
-
-            // expectedStatusCode is Error
-            else
-            {
-                Assert.Equal("ERROR", zipkinSpan.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.StatusCodeKey).Value);
-            }
-
-            if (expectedStatusCode == ActivityStatusCode.Error)
-            {
-                Assert.Contains(
-                    zipkinSpan.Tags, t =>
-                    t.Key == ZipkinActivityConversionExtensions.ZipkinErrorFlagTagName &&
-                    (string)t.Value == description);
-            }
-            else
-            {
-                Assert.DoesNotContain(
-                    zipkinSpan.Tags, t =>
-                    t.Key == ZipkinActivityConversionExtensions.ZipkinErrorFlagTagName);
-            }
+            Assert.Contains(zipkinSpan.Tags, t => t.Key == "error" && (string)t.Value == string.Empty);
         }
-
-        [Fact]
-        public void ActivityStatus_Takes_precedence_Over_Status_Tags_ActivityStatusCodeIsOk()
+        else
         {
-            // Arrange.
-            using var activity = ZipkinExporterTests.CreateTestActivity();
-            activity.SetStatus(ActivityStatusCode.Ok);
-            activity.SetTag(SpanAttributeConstants.StatusCodeKey, "ERROR");
+            Assert.DoesNotContain(zipkinSpan.Tags, t => t.Key == "error");
+        }
+    }
 
-            // Enrich activity with additional tags.
-            activity.SetTag("myCustomTag", "myCustomTagValue");
+    [Theory]
+    [InlineData(ActivityStatusCode.Unset)]
+    [InlineData(ActivityStatusCode.Ok)]
+    [InlineData(ActivityStatusCode.Error)]
+    public void ToZipkinSpan_Activity_Status_And_StatusDescription_is_Set(ActivityStatusCode expectedStatusCode)
+    {
+        // Arrange.
+        const string description = "Description when ActivityStatusCode is Error.";
+        using var activity = ZipkinExporterTests.CreateTestActivity();
+        activity.SetStatus(expectedStatusCode, description);
 
-            // Act.
-            var zipkinSpan = activity.ToZipkinSpan(DefaultZipkinEndpoint);
+        // Act.
+        var zipkinSpan = activity.ToZipkinSpan(DefaultZipkinEndpoint);
 
-            // Assert.
+        // Assert.
+        if (expectedStatusCode == ActivityStatusCode.Unset)
+        {
+            Assert.DoesNotContain(zipkinSpan.Tags, t => t.Key == SpanAttributeConstants.StatusCodeKey);
+        }
+        else if (expectedStatusCode == ActivityStatusCode.Ok)
+        {
             Assert.Equal("OK", zipkinSpan.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.StatusCodeKey).Value);
-
-            Assert.Contains(zipkinSpan.Tags, t => t.Key == "otel.status_code" && (string)t.Value == "OK");
-            Assert.DoesNotContain(zipkinSpan.Tags, t => t.Key == "otel.status_code" && (string)t.Value == "ERROR");
-
-            // Ensure additional Activity tags were being converted.
-            Assert.Contains(zipkinSpan.Tags, t => t.Key == "myCustomTag" && (string)t.Value == "myCustomTagValue");
-            Assert.DoesNotContain(zipkinSpan.Tags, t => t.Key == ZipkinActivityConversionExtensions.ZipkinErrorFlagTagName);
         }
 
-        [Fact]
-        public void ActivityStatus_Takes_precedence_Over_Status_Tags_ActivityStatusCodeIsError()
+        // expectedStatusCode is Error
+        else
         {
-            // Arrange.
-            using var activity = ZipkinExporterTests.CreateTestActivity();
-
-            const string StatusDescriptionOnError = "Description when ActivityStatusCode is Error.";
-            const string TagDescriptionOnError = "Description when TagStatusCode is Error.";
-            activity.SetStatus(ActivityStatusCode.Error, StatusDescriptionOnError);
-            activity.SetTag(SpanAttributeConstants.StatusCodeKey, "ERROR");
-            activity.SetTag(SpanAttributeConstants.StatusDescriptionKey, TagDescriptionOnError);
-
-            // Enrich activity with additional tags.
-            activity.SetTag("myCustomTag", "myCustomTagValue");
-
-            // Act.
-            var zipkinSpan = activity.ToZipkinSpan(DefaultZipkinEndpoint);
-
-            // Assert.
             Assert.Equal("ERROR", zipkinSpan.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.StatusCodeKey).Value);
+        }
 
-            // ActivityStatusDescription takes higher precedence.
+        if (expectedStatusCode == ActivityStatusCode.Error)
+        {
             Assert.Contains(
                 zipkinSpan.Tags, t =>
                 t.Key == ZipkinActivityConversionExtensions.ZipkinErrorFlagTagName &&
-                (string)t.Value == StatusDescriptionOnError);
-            Assert.DoesNotContain(
-                zipkinSpan.Tags, t =>
-                t.Key == ZipkinActivityConversionExtensions.ZipkinErrorFlagTagName &&
-                (string)t.Value == TagDescriptionOnError);
-
-            // Ensure additional Activity tags were being converted.
-            Assert.Contains(zipkinSpan.Tags, t => t.Key == "myCustomTag" && (string)t.Value == "myCustomTagValue");
+                (string)t.Value == description);
         }
-
-        [Fact]
-        public void ActivityStatus_Takes_precedence_Over_Status_Tags_ActivityStatusCodeIsError_SettingTagFirst()
+        else
         {
-            // Arrange.
-            using var activity = ZipkinExporterTests.CreateTestActivity();
-
-            const string StatusDescriptionOnError = "Description when ActivityStatusCode is Error.";
-            const string TagDescriptionOnError = "Description when TagStatusCode is Error.";
-            activity.SetTag(SpanAttributeConstants.StatusCodeKey, "ERROR");
-            activity.SetTag(SpanAttributeConstants.StatusDescriptionKey, TagDescriptionOnError);
-            activity.SetStatus(ActivityStatusCode.Error, StatusDescriptionOnError);
-
-            // Enrich activity with additional tags.
-            activity.SetTag("myCustomTag", "myCustomTagValue");
-
-            // Act.
-            var zipkinSpan = activity.ToZipkinSpan(DefaultZipkinEndpoint);
-
-            // Assert.
-            Assert.Equal("ERROR", zipkinSpan.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.StatusCodeKey).Value);
-
-            // ActivityStatusDescription takes higher precedence.
-            Assert.Contains(
-                zipkinSpan.Tags, t =>
-                t.Key == ZipkinActivityConversionExtensions.ZipkinErrorFlagTagName &&
-                (string)t.Value == StatusDescriptionOnError);
             Assert.DoesNotContain(
                 zipkinSpan.Tags, t =>
-                t.Key == ZipkinActivityConversionExtensions.ZipkinErrorFlagTagName &&
-                (string)t.Value == TagDescriptionOnError);
-
-            // Ensure additional Activity tags were being converted.
-            Assert.Contains(zipkinSpan.Tags, t => t.Key == "myCustomTag" && (string)t.Value == "myCustomTagValue");
+                t.Key == ZipkinActivityConversionExtensions.ZipkinErrorFlagTagName);
         }
+    }
+
+    [Fact]
+    public void ActivityStatus_Takes_precedence_Over_Status_Tags_ActivityStatusCodeIsOk()
+    {
+        // Arrange.
+        using var activity = ZipkinExporterTests.CreateTestActivity();
+        activity.SetStatus(ActivityStatusCode.Ok);
+        activity.SetTag(SpanAttributeConstants.StatusCodeKey, "ERROR");
+
+        // Enrich activity with additional tags.
+        activity.SetTag("myCustomTag", "myCustomTagValue");
+
+        // Act.
+        var zipkinSpan = activity.ToZipkinSpan(DefaultZipkinEndpoint);
+
+        // Assert.
+        Assert.Equal("OK", zipkinSpan.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.StatusCodeKey).Value);
+
+        Assert.Contains(zipkinSpan.Tags, t => t.Key == "otel.status_code" && (string)t.Value == "OK");
+        Assert.DoesNotContain(zipkinSpan.Tags, t => t.Key == "otel.status_code" && (string)t.Value == "ERROR");
+
+        // Ensure additional Activity tags were being converted.
+        Assert.Contains(zipkinSpan.Tags, t => t.Key == "myCustomTag" && (string)t.Value == "myCustomTagValue");
+        Assert.DoesNotContain(zipkinSpan.Tags, t => t.Key == ZipkinActivityConversionExtensions.ZipkinErrorFlagTagName);
+    }
+
+    [Fact]
+    public void ActivityStatus_Takes_precedence_Over_Status_Tags_ActivityStatusCodeIsError()
+    {
+        // Arrange.
+        using var activity = ZipkinExporterTests.CreateTestActivity();
+
+        const string StatusDescriptionOnError = "Description when ActivityStatusCode is Error.";
+        const string TagDescriptionOnError = "Description when TagStatusCode is Error.";
+        activity.SetStatus(ActivityStatusCode.Error, StatusDescriptionOnError);
+        activity.SetTag(SpanAttributeConstants.StatusCodeKey, "ERROR");
+        activity.SetTag(SpanAttributeConstants.StatusDescriptionKey, TagDescriptionOnError);
+
+        // Enrich activity with additional tags.
+        activity.SetTag("myCustomTag", "myCustomTagValue");
+
+        // Act.
+        var zipkinSpan = activity.ToZipkinSpan(DefaultZipkinEndpoint);
+
+        // Assert.
+        Assert.Equal("ERROR", zipkinSpan.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.StatusCodeKey).Value);
+
+        // ActivityStatusDescription takes higher precedence.
+        Assert.Contains(
+            zipkinSpan.Tags, t =>
+            t.Key == ZipkinActivityConversionExtensions.ZipkinErrorFlagTagName &&
+            (string)t.Value == StatusDescriptionOnError);
+        Assert.DoesNotContain(
+            zipkinSpan.Tags, t =>
+            t.Key == ZipkinActivityConversionExtensions.ZipkinErrorFlagTagName &&
+            (string)t.Value == TagDescriptionOnError);
+
+        // Ensure additional Activity tags were being converted.
+        Assert.Contains(zipkinSpan.Tags, t => t.Key == "myCustomTag" && (string)t.Value == "myCustomTagValue");
+    }
+
+    [Fact]
+    public void ActivityStatus_Takes_precedence_Over_Status_Tags_ActivityStatusCodeIsError_SettingTagFirst()
+    {
+        // Arrange.
+        using var activity = ZipkinExporterTests.CreateTestActivity();
+
+        const string StatusDescriptionOnError = "Description when ActivityStatusCode is Error.";
+        const string TagDescriptionOnError = "Description when TagStatusCode is Error.";
+        activity.SetTag(SpanAttributeConstants.StatusCodeKey, "ERROR");
+        activity.SetTag(SpanAttributeConstants.StatusDescriptionKey, TagDescriptionOnError);
+        activity.SetStatus(ActivityStatusCode.Error, StatusDescriptionOnError);
+
+        // Enrich activity with additional tags.
+        activity.SetTag("myCustomTag", "myCustomTagValue");
+
+        // Act.
+        var zipkinSpan = activity.ToZipkinSpan(DefaultZipkinEndpoint);
+
+        // Assert.
+        Assert.Equal("ERROR", zipkinSpan.Tags.FirstOrDefault(t => t.Key == SpanAttributeConstants.StatusCodeKey).Value);
+
+        // ActivityStatusDescription takes higher precedence.
+        Assert.Contains(
+            zipkinSpan.Tags, t =>
+            t.Key == ZipkinActivityConversionExtensions.ZipkinErrorFlagTagName &&
+            (string)t.Value == StatusDescriptionOnError);
+        Assert.DoesNotContain(
+            zipkinSpan.Tags, t =>
+            t.Key == ZipkinActivityConversionExtensions.ZipkinErrorFlagTagName &&
+            (string)t.Value == TagDescriptionOnError);
+
+        // Ensure additional Activity tags were being converted.
+        Assert.Contains(zipkinSpan.Tags, t => t.Key == "myCustomTag" && (string)t.Value == "myCustomTagValue");
     }
 }

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
@@ -27,516 +27,515 @@ using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
 using Xunit;
 
-namespace OpenTelemetry.Exporter.Zipkin.Tests
+namespace OpenTelemetry.Exporter.Zipkin.Tests;
+
+public class ZipkinExporterTests : IDisposable
 {
-    public class ZipkinExporterTests : IDisposable
+    private const string TraceId = "e8ea7e9ac72de94e91fabc613f9686b2";
+    private static readonly ConcurrentDictionary<Guid, string> Responses = new();
+
+    private readonly IDisposable testServer;
+    private readonly string testServerHost;
+    private readonly int testServerPort;
+
+    static ZipkinExporterTests()
     {
-        private const string TraceId = "e8ea7e9ac72de94e91fabc613f9686b2";
-        private static readonly ConcurrentDictionary<Guid, string> Responses = new();
+        Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+        Activity.ForceDefaultIdFormat = true;
 
-        private readonly IDisposable testServer;
-        private readonly string testServerHost;
-        private readonly int testServerPort;
-
-        static ZipkinExporterTests()
+        var listener = new ActivityListener
         {
-            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
-            Activity.ForceDefaultIdFormat = true;
+            ShouldListenTo = _ => true,
+            Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
+        };
 
-            var listener = new ActivityListener
+        ActivitySource.AddActivityListener(listener);
+    }
+
+    public ZipkinExporterTests()
+    {
+        this.testServer = TestHttpServer.RunServer(
+            ctx => ProcessServerRequest(ctx),
+            out this.testServerHost,
+            out this.testServerPort);
+
+        static void ProcessServerRequest(HttpListenerContext context)
+        {
+            context.Response.StatusCode = 200;
+
+            using StreamReader readStream = new StreamReader(context.Request.InputStream);
+
+            string requestContent = readStream.ReadToEnd();
+
+            Responses.TryAdd(
+                Guid.Parse(context.Request.QueryString["requestId"]),
+                requestContent);
+
+            context.Response.OutputStream.Close();
+        }
+    }
+
+    public void Dispose()
+    {
+        this.testServer.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void AddAddZipkinExporterNamedOptionsSupported()
+    {
+        int defaultExporterOptionsConfigureOptionsInvocations = 0;
+        int namedExporterOptionsConfigureOptionsInvocations = 0;
+
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .ConfigureServices(services =>
             {
-                ShouldListenTo = _ => true,
-                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
+                services.Configure<ZipkinExporterOptions>(o => defaultExporterOptionsConfigureOptionsInvocations++);
+
+                services.Configure<ZipkinExporterOptions>("Exporter2", o => namedExporterOptionsConfigureOptionsInvocations++);
+            })
+            .AddZipkinExporter()
+            .AddZipkinExporter("Exporter2", o => { })
+            .Build();
+
+        Assert.Equal(1, defaultExporterOptionsConfigureOptionsInvocations);
+        Assert.Equal(1, namedExporterOptionsConfigureOptionsInvocations);
+    }
+
+    [Fact]
+    public void BadArgs()
+    {
+        TracerProviderBuilder builder = null;
+        Assert.Throws<ArgumentNullException>(() => builder.AddZipkinExporter());
+    }
+
+    [Fact]
+    public void SuppressesInstrumentation()
+    {
+        const string ActivitySourceName = "zipkin.test";
+        Guid requestId = Guid.NewGuid();
+        TestActivityProcessor testActivityProcessor = new TestActivityProcessor();
+
+        int endCalledCount = 0;
+
+        testActivityProcessor.EndAction =
+            (a) =>
+            {
+                endCalledCount++;
             };
 
-            ActivitySource.AddActivityListener(listener);
-        }
-
-        public ZipkinExporterTests()
+        var exporterOptions = new ZipkinExporterOptions
         {
-            this.testServer = TestHttpServer.RunServer(
-                ctx => ProcessServerRequest(ctx),
-                out this.testServerHost,
-                out this.testServerPort);
+            Endpoint = new Uri($"http://{this.testServerHost}:{this.testServerPort}/api/v2/spans?requestId={requestId}"),
+        };
+        using var zipkinExporter = new ZipkinExporter(exporterOptions);
+        using var exportActivityProcessor = new BatchActivityExportProcessor(zipkinExporter);
 
-            static void ProcessServerRequest(HttpListenerContext context)
-            {
-                context.Response.StatusCode = 200;
+        var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource(ActivitySourceName)
+            .AddProcessor(testActivityProcessor)
+            .AddProcessor(exportActivityProcessor)
+            .AddHttpClientInstrumentation()
+            .Build();
 
-                using StreamReader readStream = new StreamReader(context.Request.InputStream);
+        using var source = new ActivitySource(ActivitySourceName);
+        using var activity = source.StartActivity("Test Zipkin Activity");
+        activity?.Stop();
 
-                string requestContent = readStream.ReadToEnd();
+        // We call ForceFlush on the exporter twice, so that in the event
+        // of a regression, this should give any operations performed in
+        // the Zipkin exporter itself enough time to be instrumented and
+        // loop back through the exporter.
+        exportActivityProcessor.ForceFlush();
+        exportActivityProcessor.ForceFlush();
 
-                Responses.TryAdd(
-                    Guid.Parse(context.Request.QueryString["requestId"]),
-                    requestContent);
+        Assert.Equal(1, endCalledCount);
+    }
 
-                context.Response.OutputStream.Close();
-            }
-        }
-
-        public void Dispose()
+    [Fact]
+    public void EndpointConfigurationUsingEnvironmentVariable()
+    {
+        try
         {
-            this.testServer.Dispose();
-            GC.SuppressFinalize(this);
+            Environment.SetEnvironmentVariable(ZipkinExporterOptions.ZipkinEndpointEnvVar, "http://urifromenvironmentvariable");
+
+            var exporterOptions = new ZipkinExporterOptions();
+
+            Assert.Equal(new Uri(Environment.GetEnvironmentVariable(ZipkinExporterOptions.ZipkinEndpointEnvVar)).AbsoluteUri, exporterOptions.Endpoint.AbsoluteUri);
         }
-
-        [Fact]
-        public void AddAddZipkinExporterNamedOptionsSupported()
+        finally
         {
-            int defaultExporterOptionsConfigureOptionsInvocations = 0;
-            int namedExporterOptionsConfigureOptionsInvocations = 0;
-
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-                .ConfigureServices(services =>
-                {
-                    services.Configure<ZipkinExporterOptions>(o => defaultExporterOptionsConfigureOptionsInvocations++);
-
-                    services.Configure<ZipkinExporterOptions>("Exporter2", o => namedExporterOptionsConfigureOptionsInvocations++);
-                })
-                .AddZipkinExporter()
-                .AddZipkinExporter("Exporter2", o => { })
-                .Build();
-
-            Assert.Equal(1, defaultExporterOptionsConfigureOptionsInvocations);
-            Assert.Equal(1, namedExporterOptionsConfigureOptionsInvocations);
+            Environment.SetEnvironmentVariable(ZipkinExporterOptions.ZipkinEndpointEnvVar, null);
         }
+    }
 
-        [Fact]
-        public void BadArgs()
+    [Fact]
+    public void IncodeEndpointConfigTakesPrecedenceOverEnvironmentVariable()
+    {
+        try
         {
-            TracerProviderBuilder builder = null;
-            Assert.Throws<ArgumentNullException>(() => builder.AddZipkinExporter());
-        }
-
-        [Fact]
-        public void SuppressesInstrumentation()
-        {
-            const string ActivitySourceName = "zipkin.test";
-            Guid requestId = Guid.NewGuid();
-            TestActivityProcessor testActivityProcessor = new TestActivityProcessor();
-
-            int endCalledCount = 0;
-
-            testActivityProcessor.EndAction =
-                (a) =>
-                {
-                    endCalledCount++;
-                };
+            Environment.SetEnvironmentVariable(ZipkinExporterOptions.ZipkinEndpointEnvVar, "http://urifromenvironmentvariable");
 
             var exporterOptions = new ZipkinExporterOptions
             {
-                Endpoint = new Uri($"http://{this.testServerHost}:{this.testServerPort}/api/v2/spans?requestId={requestId}"),
-            };
-            using var zipkinExporter = new ZipkinExporter(exporterOptions);
-            using var exportActivityProcessor = new BatchActivityExportProcessor(zipkinExporter);
-
-            var tracerProvider = Sdk.CreateTracerProviderBuilder()
-                .AddSource(ActivitySourceName)
-                .AddProcessor(testActivityProcessor)
-                .AddProcessor(exportActivityProcessor)
-                .AddHttpClientInstrumentation()
-                .Build();
-
-            using var source = new ActivitySource(ActivitySourceName);
-            using var activity = source.StartActivity("Test Zipkin Activity");
-            activity?.Stop();
-
-            // We call ForceFlush on the exporter twice, so that in the event
-            // of a regression, this should give any operations performed in
-            // the Zipkin exporter itself enough time to be instrumented and
-            // loop back through the exporter.
-            exportActivityProcessor.ForceFlush();
-            exportActivityProcessor.ForceFlush();
-
-            Assert.Equal(1, endCalledCount);
-        }
-
-        [Fact]
-        public void EndpointConfigurationUsingEnvironmentVariable()
-        {
-            try
-            {
-                Environment.SetEnvironmentVariable(ZipkinExporterOptions.ZipkinEndpointEnvVar, "http://urifromenvironmentvariable");
-
-                var exporterOptions = new ZipkinExporterOptions();
-
-                Assert.Equal(new Uri(Environment.GetEnvironmentVariable(ZipkinExporterOptions.ZipkinEndpointEnvVar)).AbsoluteUri, exporterOptions.Endpoint.AbsoluteUri);
-            }
-            finally
-            {
-                Environment.SetEnvironmentVariable(ZipkinExporterOptions.ZipkinEndpointEnvVar, null);
-            }
-        }
-
-        [Fact]
-        public void IncodeEndpointConfigTakesPrecedenceOverEnvironmentVariable()
-        {
-            try
-            {
-                Environment.SetEnvironmentVariable(ZipkinExporterOptions.ZipkinEndpointEnvVar, "http://urifromenvironmentvariable");
-
-                var exporterOptions = new ZipkinExporterOptions
-                {
-                    Endpoint = new Uri("http://urifromcode"),
-                };
-
-                Assert.Equal(new Uri("http://urifromcode").AbsoluteUri, exporterOptions.Endpoint.AbsoluteUri);
-            }
-            finally
-            {
-                Environment.SetEnvironmentVariable(ZipkinExporterOptions.ZipkinEndpointEnvVar, null);
-            }
-        }
-
-        [Fact(Skip = "https://github.com/open-telemetry/opentelemetry-dotnet/issues/3690")]
-        public void ErrorGettingUriFromEnvVarSetsDefaultEndpointValue()
-        {
-            try
-            {
-                Environment.SetEnvironmentVariable(ZipkinExporterOptions.ZipkinEndpointEnvVar, "InvalidUri");
-
-                var options = new ZipkinExporterOptions();
-
-                Assert.Equal(new Uri(ZipkinExporterOptions.DefaultZipkinEndpoint), options.Endpoint);
-            }
-            finally
-            {
-                Environment.SetEnvironmentVariable(ZipkinExporterOptions.ZipkinEndpointEnvVar, null);
-            }
-        }
-
-        [Fact]
-        public void EndpointConfigurationUsingIConfiguration()
-        {
-            var values = new Dictionary<string, string>()
-            {
-                [ZipkinExporterOptions.ZipkinEndpointEnvVar] = "http://custom-endpoint:12345",
+                Endpoint = new Uri("http://urifromcode"),
             };
 
-            var configuration = new ConfigurationBuilder()
-                .AddInMemoryCollection(values)
-                .Build();
-
-            var options = new ZipkinExporterOptions(configuration, new());
-
-            Assert.Equal(new Uri("http://custom-endpoint:12345"), options.Endpoint);
+            Assert.Equal(new Uri("http://urifromcode").AbsoluteUri, exporterOptions.Endpoint.AbsoluteUri);
         }
-
-        [Fact]
-        public void UserHttpFactoryCalled()
+        finally
         {
-            ZipkinExporterOptions options = new ZipkinExporterOptions();
-
-            var defaultFactory = options.HttpClientFactory;
-
-            int invocations = 0;
-            options.HttpClientFactory = () =>
-            {
-                invocations++;
-                return defaultFactory();
-            };
-
-            using (var exporter = new ZipkinExporter(options))
-            {
-                Assert.Equal(1, invocations);
-            }
-
-            using (var provider = Sdk.CreateTracerProviderBuilder()
-                .AddZipkinExporter(o => o.HttpClientFactory = options.HttpClientFactory)
-                .Build())
-            {
-                Assert.Equal(2, invocations);
-            }
-
-            using var client = new HttpClient();
-
-            using (var exporter = new ZipkinExporter(options, client))
-            {
-                // Factory not called when client is passed as a param.
-                Assert.Equal(2, invocations);
-            }
-
-            options.HttpClientFactory = null;
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                using var exporter = new ZipkinExporter(options);
-            });
-
-            options.HttpClientFactory = () => null;
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                using var exporter = new ZipkinExporter(options);
-            });
+            Environment.SetEnvironmentVariable(ZipkinExporterOptions.ZipkinEndpointEnvVar, null);
         }
+    }
 
-        [Fact]
-        public void ServiceProviderHttpClientFactoryInvoked()
+    [Fact(Skip = "https://github.com/open-telemetry/opentelemetry-dotnet/issues/3690")]
+    public void ErrorGettingUriFromEnvVarSetsDefaultEndpointValue()
+    {
+        try
         {
-            IServiceCollection services = new ServiceCollection();
+            Environment.SetEnvironmentVariable(ZipkinExporterOptions.ZipkinEndpointEnvVar, "InvalidUri");
 
-            services.AddHttpClient();
+            var options = new ZipkinExporterOptions();
 
-            int invocations = 0;
+            Assert.Equal(new Uri(ZipkinExporterOptions.DefaultZipkinEndpoint), options.Endpoint);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(ZipkinExporterOptions.ZipkinEndpointEnvVar, null);
+        }
+    }
 
-            services.AddHttpClient("ZipkinExporter", configureClient: (client) => invocations++);
+    [Fact]
+    public void EndpointConfigurationUsingIConfiguration()
+    {
+        var values = new Dictionary<string, string>()
+        {
+            [ZipkinExporterOptions.ZipkinEndpointEnvVar] = "http://custom-endpoint:12345",
+        };
 
-            services.AddOpenTelemetry().WithTracing(builder => builder
-                .AddZipkinExporter());
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
 
-            using var serviceProvider = services.BuildServiceProvider();
+        var options = new ZipkinExporterOptions(configuration, new());
 
-            var tracerProvider = serviceProvider.GetRequiredService<TracerProvider>();
+        Assert.Equal(new Uri("http://custom-endpoint:12345"), options.Endpoint);
+    }
 
+    [Fact]
+    public void UserHttpFactoryCalled()
+    {
+        ZipkinExporterOptions options = new ZipkinExporterOptions();
+
+        var defaultFactory = options.HttpClientFactory;
+
+        int invocations = 0;
+        options.HttpClientFactory = () =>
+        {
+            invocations++;
+            return defaultFactory();
+        };
+
+        using (var exporter = new ZipkinExporter(options))
+        {
             Assert.Equal(1, invocations);
         }
 
-        [Fact]
-        public void UpdatesServiceNameFromDefaultResource()
+        using (var provider = Sdk.CreateTracerProviderBuilder()
+            .AddZipkinExporter(o => o.HttpClientFactory = options.HttpClientFactory)
+            .Build())
         {
-            var zipkinExporter = new ZipkinExporter(new ZipkinExporterOptions());
-
-            zipkinExporter.SetLocalEndpointFromResource(Resource.Empty);
-
-            Assert.StartsWith("unknown_service:", zipkinExporter.LocalEndpoint.ServiceName);
+            Assert.Equal(2, invocations);
         }
 
-        [Fact]
-        public void UpdatesServiceNameFromIConfiguration()
+        using var client = new HttpClient();
+
+        using (var exporter = new ZipkinExporter(options, client))
         {
-            var tracerProviderBuilder = Sdk.CreateTracerProviderBuilder()
-                .ConfigureServices(services =>
-                {
-                    Dictionary<string, string> configuration = new()
-                    {
-                        ["OTEL_SERVICE_NAME"] = "myservicename",
-                    };
-
-                    services.AddSingleton<IConfiguration>(
-                        new ConfigurationBuilder().AddInMemoryCollection(configuration).Build());
-                });
-
-            var zipkinExporter = new ZipkinExporter(new ZipkinExporterOptions());
-
-            tracerProviderBuilder.AddProcessor(new BatchActivityExportProcessor(zipkinExporter));
-
-            using var provider = tracerProviderBuilder.Build();
-
-            zipkinExporter.SetLocalEndpointFromResource(Resource.Empty);
-
-            Assert.Equal("myservicename", zipkinExporter.LocalEndpoint.ServiceName);
+            // Factory not called when client is passed as a param.
+            Assert.Equal(2, invocations);
         }
 
-        [Theory]
-        [InlineData(true, false, false)]
-        [InlineData(false, false, false)]
-        [InlineData(false, true, false)]
-        [InlineData(false, false, true)]
-        [InlineData(false, false, false, StatusCode.Ok)]
-        [InlineData(false, false, false, StatusCode.Ok, null, true)]
-        [InlineData(false, false, false, StatusCode.Error)]
-        [InlineData(false, false, false, StatusCode.Error, "Error description")]
-        public void IntegrationTest(
-            bool useShortTraceIds,
-            bool useTestResource,
-            bool isRootSpan,
-            StatusCode statusCode = StatusCode.Unset,
-            string statusDescription = null,
-            bool addErrorTag = false)
+        options.HttpClientFactory = null;
+        Assert.Throws<InvalidOperationException>(() =>
         {
-            var status = statusCode switch
+            using var exporter = new ZipkinExporter(options);
+        });
+
+        options.HttpClientFactory = () => null;
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            using var exporter = new ZipkinExporter(options);
+        });
+    }
+
+    [Fact]
+    public void ServiceProviderHttpClientFactoryInvoked()
+    {
+        IServiceCollection services = new ServiceCollection();
+
+        services.AddHttpClient();
+
+        int invocations = 0;
+
+        services.AddHttpClient("ZipkinExporter", configureClient: (client) => invocations++);
+
+        services.AddOpenTelemetry().WithTracing(builder => builder
+            .AddZipkinExporter());
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var tracerProvider = serviceProvider.GetRequiredService<TracerProvider>();
+
+        Assert.Equal(1, invocations);
+    }
+
+    [Fact]
+    public void UpdatesServiceNameFromDefaultResource()
+    {
+        var zipkinExporter = new ZipkinExporter(new ZipkinExporterOptions());
+
+        zipkinExporter.SetLocalEndpointFromResource(Resource.Empty);
+
+        Assert.StartsWith("unknown_service:", zipkinExporter.LocalEndpoint.ServiceName);
+    }
+
+    [Fact]
+    public void UpdatesServiceNameFromIConfiguration()
+    {
+        var tracerProviderBuilder = Sdk.CreateTracerProviderBuilder()
+            .ConfigureServices(services =>
             {
-                StatusCode.Unset => Status.Unset,
-                StatusCode.Ok => Status.Ok,
-                StatusCode.Error => Status.Error,
-                _ => throw new InvalidOperationException(),
-            };
-
-            if (!string.IsNullOrEmpty(statusDescription))
-            {
-                status = status.WithDescription(statusDescription);
-            }
-
-            Guid requestId = Guid.NewGuid();
-
-            ZipkinExporter exporter = new ZipkinExporter(
-                new ZipkinExporterOptions
+                Dictionary<string, string> configuration = new()
                 {
-                    Endpoint = new Uri($"http://{this.testServerHost}:{this.testServerPort}/api/v2/spans?requestId={requestId}"),
-                    UseShortTraceIds = useShortTraceIds,
-                });
+                    ["OTEL_SERVICE_NAME"] = "myservicename",
+                };
 
-            var serviceName = (string)exporter.ParentProvider.GetDefaultResource().Attributes
-                .Where(pair => pair.Key == ResourceSemanticConventions.AttributeServiceName).FirstOrDefault().Value;
-            var resourceTags = string.Empty;
-            var activity = CreateTestActivity(isRootSpan: isRootSpan, status: status);
-            if (useTestResource)
-            {
-                serviceName = "MyService";
+                services.AddSingleton<IConfiguration>(
+                    new ConfigurationBuilder().AddInMemoryCollection(configuration).Build());
+            });
 
-                exporter.SetLocalEndpointFromResource(ResourceBuilder.CreateEmpty().AddAttributes(new Dictionary<string, object>
-                {
-                    [ResourceSemanticConventions.AttributeServiceName] = serviceName,
-                    ["service.tag"] = "hello world",
-                }).Build());
-            }
-            else
-            {
-                exporter.SetLocalEndpointFromResource(Resource.Empty);
-            }
+        var zipkinExporter = new ZipkinExporter(new ZipkinExporterOptions());
 
-            if (addErrorTag)
-            {
-                activity.SetTag(ZipkinActivityConversionExtensions.ZipkinErrorFlagTagName, "This should be removed.");
-            }
+        tracerProviderBuilder.AddProcessor(new BatchActivityExportProcessor(zipkinExporter));
 
-            var processor = new SimpleActivityExportProcessor(exporter);
+        using var provider = tracerProviderBuilder.Build();
 
-            processor.OnEnd(activity);
+        zipkinExporter.SetLocalEndpointFromResource(Resource.Empty);
 
-            var context = activity.Context;
+        Assert.Equal("myservicename", zipkinExporter.LocalEndpoint.ServiceName);
+    }
 
-            var timestamp = activity.StartTimeUtc.ToEpochMicroseconds();
-            var eventTimestamp = activity.Events.First().Timestamp.ToEpochMicroseconds();
+    [Theory]
+    [InlineData(true, false, false)]
+    [InlineData(false, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(false, false, true)]
+    [InlineData(false, false, false, StatusCode.Ok)]
+    [InlineData(false, false, false, StatusCode.Ok, null, true)]
+    [InlineData(false, false, false, StatusCode.Error)]
+    [InlineData(false, false, false, StatusCode.Error, "Error description")]
+    public void IntegrationTest(
+        bool useShortTraceIds,
+        bool useTestResource,
+        bool isRootSpan,
+        StatusCode statusCode = StatusCode.Unset,
+        string statusDescription = null,
+        bool addErrorTag = false)
+    {
+        var status = statusCode switch
+        {
+            StatusCode.Unset => Status.Unset,
+            StatusCode.Ok => Status.Ok,
+            StatusCode.Error => Status.Error,
+            _ => throw new InvalidOperationException(),
+        };
 
-            StringBuilder ipInformation = new StringBuilder();
-            if (!string.IsNullOrEmpty(exporter.LocalEndpoint.Ipv4))
-            {
-                ipInformation.Append($@",""ipv4"":""{exporter.LocalEndpoint.Ipv4}""");
-            }
-
-            if (!string.IsNullOrEmpty(exporter.LocalEndpoint.Ipv6))
-            {
-                ipInformation.Append($@",""ipv6"":""{exporter.LocalEndpoint.Ipv6}""");
-            }
-
-            var parentId = isRootSpan ? string.Empty : $@"""parentId"":""{ZipkinActivityConversionExtensions.EncodeSpanId(activity.ParentSpanId)}"",";
-
-            var traceId = useShortTraceIds ? TraceId.Substring(TraceId.Length - 16, 16) : TraceId;
-
-            string statusTag;
-            string errorTag = string.Empty;
-            switch (statusCode)
-            {
-                case StatusCode.Ok:
-                    statusTag = $@"""{SpanAttributeConstants.StatusCodeKey}"":""OK"",";
-                    break;
-                case StatusCode.Unset:
-                    statusTag = string.Empty;
-                    break;
-                case StatusCode.Error:
-                    statusTag = $@"""{SpanAttributeConstants.StatusCodeKey}"":""ERROR"",";
-                    errorTag = $@"""{ZipkinActivityConversionExtensions.ZipkinErrorFlagTagName}"":""{statusDescription}"",";
-                    break;
-                default:
-                    throw new NotSupportedException();
-            }
-
-            Assert.Equal(
-                $@"[{{""traceId"":""{traceId}"",""name"":""Name"",{parentId}""id"":""{ZipkinActivityConversionExtensions.EncodeSpanId(context.SpanId)}"",""kind"":""CLIENT"",""timestamp"":{timestamp},""duration"":60000000,""localEndpoint"":{{""serviceName"":""{serviceName}""{ipInformation}}},""remoteEndpoint"":{{""serviceName"":""http://localhost:44312/""}},""annotations"":[{{""timestamp"":{eventTimestamp},""value"":""Event1""}},{{""timestamp"":{eventTimestamp},""value"":""Event2""}}],""tags"":{{{resourceTags}""stringKey"":""value"",""longKey"":""1"",""longKey2"":""1"",""doubleKey"":""1"",""doubleKey2"":""1"",""longArrayKey"":""[1,2]"",""boolKey"":""true"",""boolArrayKey"":""[true,false]"",""http.host"":""http://localhost:44312/"",{statusTag}{errorTag}""otel.library.name"":""CreateTestActivity"",""peer.service"":""http://localhost:44312/""}}}}]",
-                Responses[requestId]);
+        if (!string.IsNullOrEmpty(statusDescription))
+        {
+            status = status.WithDescription(statusDescription);
         }
 
-        internal static Activity CreateTestActivity(
-           bool isRootSpan = false,
-           bool setAttributes = true,
-           Dictionary<string, object> additionalAttributes = null,
-           bool addEvents = true,
-           bool addLinks = true,
-           Resource resource = null,
-           ActivityKind kind = ActivityKind.Client,
-           Status? status = null)
+        Guid requestId = Guid.NewGuid();
+
+        ZipkinExporter exporter = new ZipkinExporter(
+            new ZipkinExporterOptions
+            {
+                Endpoint = new Uri($"http://{this.testServerHost}:{this.testServerPort}/api/v2/spans?requestId={requestId}"),
+                UseShortTraceIds = useShortTraceIds,
+            });
+
+        var serviceName = (string)exporter.ParentProvider.GetDefaultResource().Attributes
+            .Where(pair => pair.Key == ResourceSemanticConventions.AttributeServiceName).FirstOrDefault().Value;
+        var resourceTags = string.Empty;
+        var activity = CreateTestActivity(isRootSpan: isRootSpan, status: status);
+        if (useTestResource)
         {
-            var startTimestamp = DateTime.UtcNow;
-            var endTimestamp = startTimestamp.AddSeconds(60);
-            var eventTimestamp = DateTime.UtcNow;
-            var traceId = ActivityTraceId.CreateFromString("e8ea7e9ac72de94e91fabc613f9686b2".AsSpan());
+            serviceName = "MyService";
 
-            var parentSpanId = isRootSpan ? default : ActivitySpanId.CreateFromBytes(new byte[] { 12, 23, 34, 45, 56, 67, 78, 89 });
+            exporter.SetLocalEndpointFromResource(ResourceBuilder.CreateEmpty().AddAttributes(new Dictionary<string, object>
+            {
+                [ResourceSemanticConventions.AttributeServiceName] = serviceName,
+                ["service.tag"] = "hello world",
+            }).Build());
+        }
+        else
+        {
+            exporter.SetLocalEndpointFromResource(Resource.Empty);
+        }
 
-            var attributes = new Dictionary<string, object>
+        if (addErrorTag)
+        {
+            activity.SetTag(ZipkinActivityConversionExtensions.ZipkinErrorFlagTagName, "This should be removed.");
+        }
+
+        var processor = new SimpleActivityExportProcessor(exporter);
+
+        processor.OnEnd(activity);
+
+        var context = activity.Context;
+
+        var timestamp = activity.StartTimeUtc.ToEpochMicroseconds();
+        var eventTimestamp = activity.Events.First().Timestamp.ToEpochMicroseconds();
+
+        StringBuilder ipInformation = new StringBuilder();
+        if (!string.IsNullOrEmpty(exporter.LocalEndpoint.Ipv4))
+        {
+            ipInformation.Append($@",""ipv4"":""{exporter.LocalEndpoint.Ipv4}""");
+        }
+
+        if (!string.IsNullOrEmpty(exporter.LocalEndpoint.Ipv6))
+        {
+            ipInformation.Append($@",""ipv6"":""{exporter.LocalEndpoint.Ipv6}""");
+        }
+
+        var parentId = isRootSpan ? string.Empty : $@"""parentId"":""{ZipkinActivityConversionExtensions.EncodeSpanId(activity.ParentSpanId)}"",";
+
+        var traceId = useShortTraceIds ? TraceId.Substring(TraceId.Length - 16, 16) : TraceId;
+
+        string statusTag;
+        string errorTag = string.Empty;
+        switch (statusCode)
+        {
+            case StatusCode.Ok:
+                statusTag = $@"""{SpanAttributeConstants.StatusCodeKey}"":""OK"",";
+                break;
+            case StatusCode.Unset:
+                statusTag = string.Empty;
+                break;
+            case StatusCode.Error:
+                statusTag = $@"""{SpanAttributeConstants.StatusCodeKey}"":""ERROR"",";
+                errorTag = $@"""{ZipkinActivityConversionExtensions.ZipkinErrorFlagTagName}"":""{statusDescription}"",";
+                break;
+            default:
+                throw new NotSupportedException();
+        }
+
+        Assert.Equal(
+            $@"[{{""traceId"":""{traceId}"",""name"":""Name"",{parentId}""id"":""{ZipkinActivityConversionExtensions.EncodeSpanId(context.SpanId)}"",""kind"":""CLIENT"",""timestamp"":{timestamp},""duration"":60000000,""localEndpoint"":{{""serviceName"":""{serviceName}""{ipInformation}}},""remoteEndpoint"":{{""serviceName"":""http://localhost:44312/""}},""annotations"":[{{""timestamp"":{eventTimestamp},""value"":""Event1""}},{{""timestamp"":{eventTimestamp},""value"":""Event2""}}],""tags"":{{{resourceTags}""stringKey"":""value"",""longKey"":""1"",""longKey2"":""1"",""doubleKey"":""1"",""doubleKey2"":""1"",""longArrayKey"":""[1,2]"",""boolKey"":""true"",""boolArrayKey"":""[true,false]"",""http.host"":""http://localhost:44312/"",{statusTag}{errorTag}""otel.library.name"":""CreateTestActivity"",""peer.service"":""http://localhost:44312/""}}}}]",
+            Responses[requestId]);
+    }
+
+    internal static Activity CreateTestActivity(
+       bool isRootSpan = false,
+       bool setAttributes = true,
+       Dictionary<string, object> additionalAttributes = null,
+       bool addEvents = true,
+       bool addLinks = true,
+       Resource resource = null,
+       ActivityKind kind = ActivityKind.Client,
+       Status? status = null)
+    {
+        var startTimestamp = DateTime.UtcNow;
+        var endTimestamp = startTimestamp.AddSeconds(60);
+        var eventTimestamp = DateTime.UtcNow;
+        var traceId = ActivityTraceId.CreateFromString("e8ea7e9ac72de94e91fabc613f9686b2".AsSpan());
+
+        var parentSpanId = isRootSpan ? default : ActivitySpanId.CreateFromBytes(new byte[] { 12, 23, 34, 45, 56, 67, 78, 89 });
+
+        var attributes = new Dictionary<string, object>
+        {
+            { "stringKey", "value" },
+            { "longKey", 1L },
+            { "longKey2", 1 },
+            { "doubleKey", 1D },
+            { "doubleKey2", 1F },
+            { "longArrayKey", new long[] { 1, 2 } },
+            { "boolKey", true },
+            { "boolArrayKey", new bool[] { true, false } },
+            { "http.host", "http://localhost:44312/" }, // simulating instrumentation tag adding http.host
+        };
+        if (additionalAttributes != null)
+        {
+            foreach (var attribute in additionalAttributes)
             {
-                { "stringKey", "value" },
-                { "longKey", 1L },
-                { "longKey2", 1 },
-                { "doubleKey", 1D },
-                { "doubleKey2", 1F },
-                { "longArrayKey", new long[] { 1, 2 } },
-                { "boolKey", true },
-                { "boolArrayKey", new bool[] { true, false } },
-                { "http.host", "http://localhost:44312/" }, // simulating instrumentation tag adding http.host
-            };
-            if (additionalAttributes != null)
-            {
-                foreach (var attribute in additionalAttributes)
+                if (!attributes.ContainsKey(attribute.Key))
                 {
-                    if (!attributes.ContainsKey(attribute.Key))
-                    {
-                        attributes.Add(attribute.Key, attribute.Value);
-                    }
+                    attributes.Add(attribute.Key, attribute.Value);
                 }
             }
-
-            var events = new List<ActivityEvent>
-            {
-                new ActivityEvent(
-                    "Event1",
-                    eventTimestamp,
-                    new ActivityTagsCollection(new Dictionary<string, object>
-                    {
-                        { "key", "value" },
-                    })),
-                new ActivityEvent(
-                    "Event2",
-                    eventTimestamp,
-                    new ActivityTagsCollection(new Dictionary<string, object>
-                    {
-                        { "key", "value" },
-                    })),
-            };
-
-            var linkedSpanId = ActivitySpanId.CreateFromString("888915b6286b9c41".AsSpan());
-
-            var activitySource = new ActivitySource(nameof(CreateTestActivity));
-
-            var tags = setAttributes ?
-                    attributes.Select(kvp => new KeyValuePair<string, object>(kvp.Key, kvp.Value))
-                    : null;
-            var links = addLinks ?
-                    new[]
-                    {
-                        new ActivityLink(new ActivityContext(
-                            traceId,
-                            linkedSpanId,
-                            ActivityTraceFlags.Recorded)),
-                    }
-                    : null;
-
-            var activity = activitySource.StartActivity(
-                "Name",
-                kind,
-                parentContext: new ActivityContext(traceId, parentSpanId, ActivityTraceFlags.Recorded),
-                tags,
-                links,
-                startTime: startTimestamp);
-
-            if (addEvents)
-            {
-                foreach (var evnt in events)
-                {
-                    activity.AddEvent(evnt);
-                }
-            }
-
-            if (status.HasValue)
-            {
-                activity.SetStatus(status.Value);
-            }
-
-            activity.SetEndTime(endTimestamp);
-            activity.Stop();
-
-            return activity;
         }
+
+        var events = new List<ActivityEvent>
+        {
+            new ActivityEvent(
+                "Event1",
+                eventTimestamp,
+                new ActivityTagsCollection(new Dictionary<string, object>
+                {
+                    { "key", "value" },
+                })),
+            new ActivityEvent(
+                "Event2",
+                eventTimestamp,
+                new ActivityTagsCollection(new Dictionary<string, object>
+                {
+                    { "key", "value" },
+                })),
+        };
+
+        var linkedSpanId = ActivitySpanId.CreateFromString("888915b6286b9c41".AsSpan());
+
+        var activitySource = new ActivitySource(nameof(CreateTestActivity));
+
+        var tags = setAttributes ?
+                attributes.Select(kvp => new KeyValuePair<string, object>(kvp.Key, kvp.Value))
+                : null;
+        var links = addLinks ?
+                new[]
+                {
+                    new ActivityLink(new ActivityContext(
+                        traceId,
+                        linkedSpanId,
+                        ActivityTraceFlags.Recorded)),
+                }
+                : null;
+
+        var activity = activitySource.StartActivity(
+            "Name",
+            kind,
+            parentContext: new ActivityContext(traceId, parentSpanId, ActivityTraceFlags.Recorded),
+            tags,
+            links,
+            startTime: startTimestamp);
+
+        if (addEvents)
+        {
+            foreach (var evnt in events)
+            {
+                activity.AddEvent(evnt);
+            }
+        }
+
+        if (status.HasValue)
+        {
+            activity.SetStatus(status.Value);
+        }
+
+        activity.SetEndTime(endTimestamp);
+        activity.Stop();
+
+        return activity;
     }
 }


### PR DESCRIPTION
Towards #4640 

## Changes

Update projects OpenTelemetry.Exporter.Zipkin and OpenTelemetry.Exporter.Zipkin.Tests to use file scoped namespaces.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [X] Changes in public API reviewed (if applicable)
