### PR TITLE
Enable public API check on non-Windows development environments

### DIFF
--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -7,7 +7,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
 
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Condition=" $(OS) == 'Windows_NT'">
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
Similar to https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1086
https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1071/files#r1137611657


## Changes
- Enable public API check on non-Windows development environments
