### PR TITLE
Add Copyrights for libraries

### DIFF
--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -67,6 +67,7 @@
     <PackageProjectUrl>https://opentelemetry.io</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Authors>OpenTelemetry Authors</Authors>
+    <Copyright>Copyright The OpenTelemetry Authors</Copyright>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
   </PropertyGroup>
 


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/2781

## Changes

Copyrights for libraries based on https://github.com/open-telemetry/community/blob/01862046dbaf16e5bb7fad2c3f89f1614772d307/CONTRIBUTING.md?plain=1#L38-L41

After changes - Before changes
![image](https://github.com/open-telemetry/opentelemetry-dotnet/assets/5972917/ba16fdd7-fa0f-4b4d-b6cf-d071acc003d5)

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
