### PR TITLE
Update OpenTelemetry.Instrumentation.SqlClient to use filescoped name…

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
@@ -17,25 +17,24 @@ using System.Diagnostics;
 using System.Reflection;
 using OpenTelemetry.Trace;
 
-namespace OpenTelemetry.Instrumentation.SqlClient.Implementation
+namespace OpenTelemetry.Instrumentation.SqlClient.Implementation;
+
+/// <summary>
+/// Helper class to hold common properties used by both SqlClientDiagnosticListener on .NET Core
+/// and SqlEventSourceListener on .NET Framework.
+/// </summary>
+internal sealed class SqlActivitySourceHelper
 {
-    /// <summary>
-    /// Helper class to hold common properties used by both SqlClientDiagnosticListener on .NET Core
-    /// and SqlEventSourceListener on .NET Framework.
-    /// </summary>
-    internal sealed class SqlActivitySourceHelper
+    public const string MicrosoftSqlServerDatabaseSystemName = "mssql";
+
+    public static readonly AssemblyName AssemblyName = typeof(SqlActivitySourceHelper).Assembly.GetName();
+    public static readonly string ActivitySourceName = AssemblyName.Name;
+    public static readonly Version Version = AssemblyName.Version;
+    public static readonly ActivitySource ActivitySource = new(ActivitySourceName, Version.ToString());
+    public static readonly string ActivityName = ActivitySourceName + ".Execute";
+
+    public static readonly IEnumerable<KeyValuePair<string, object>> CreationTags = new[]
     {
-        public const string MicrosoftSqlServerDatabaseSystemName = "mssql";
-
-        public static readonly AssemblyName AssemblyName = typeof(SqlActivitySourceHelper).Assembly.GetName();
-        public static readonly string ActivitySourceName = AssemblyName.Name;
-        public static readonly Version Version = AssemblyName.Version;
-        public static readonly ActivitySource ActivitySource = new(ActivitySourceName, Version.ToString());
-        public static readonly string ActivityName = ActivitySourceName + ".Execute";
-
-        public static readonly IEnumerable<KeyValuePair<string, object>> CreationTags = new[]
-        {
-            new KeyValuePair<string, object>(SemanticConventions.AttributeDbSystem, MicrosoftSqlServerDatabaseSystemName),
-        };
-    }
+        new KeyValuePair<string, object>(SemanticConventions.AttributeDbSystem, MicrosoftSqlServerDatabaseSystemName),
+    };
 }

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
@@ -18,196 +18,195 @@ using System.Data;
 using System.Diagnostics;
 using OpenTelemetry.Trace;
 
-namespace OpenTelemetry.Instrumentation.SqlClient.Implementation
+namespace OpenTelemetry.Instrumentation.SqlClient.Implementation;
+
+internal sealed class SqlClientDiagnosticListener : ListenerHandler
 {
-    internal sealed class SqlClientDiagnosticListener : ListenerHandler
+    public const string SqlDataBeforeExecuteCommand = "System.Data.SqlClient.WriteCommandBefore";
+    public const string SqlMicrosoftBeforeExecuteCommand = "Microsoft.Data.SqlClient.WriteCommandBefore";
+
+    public const string SqlDataAfterExecuteCommand = "System.Data.SqlClient.WriteCommandAfter";
+    public const string SqlMicrosoftAfterExecuteCommand = "Microsoft.Data.SqlClient.WriteCommandAfter";
+
+    public const string SqlDataWriteCommandError = "System.Data.SqlClient.WriteCommandError";
+    public const string SqlMicrosoftWriteCommandError = "Microsoft.Data.SqlClient.WriteCommandError";
+
+    private readonly PropertyFetcher<object> commandFetcher = new("Command");
+    private readonly PropertyFetcher<object> connectionFetcher = new("Connection");
+    private readonly PropertyFetcher<object> dataSourceFetcher = new("DataSource");
+    private readonly PropertyFetcher<object> databaseFetcher = new("Database");
+    private readonly PropertyFetcher<CommandType> commandTypeFetcher = new("CommandType");
+    private readonly PropertyFetcher<object> commandTextFetcher = new("CommandText");
+    private readonly PropertyFetcher<Exception> exceptionFetcher = new("Exception");
+    private readonly SqlClientInstrumentationOptions options;
+
+    public SqlClientDiagnosticListener(string sourceName, SqlClientInstrumentationOptions options)
+        : base(sourceName)
     {
-        public const string SqlDataBeforeExecuteCommand = "System.Data.SqlClient.WriteCommandBefore";
-        public const string SqlMicrosoftBeforeExecuteCommand = "Microsoft.Data.SqlClient.WriteCommandBefore";
+        this.options = options ?? new SqlClientInstrumentationOptions();
+    }
 
-        public const string SqlDataAfterExecuteCommand = "System.Data.SqlClient.WriteCommandAfter";
-        public const string SqlMicrosoftAfterExecuteCommand = "Microsoft.Data.SqlClient.WriteCommandAfter";
+    public override bool SupportsNullActivity => true;
 
-        public const string SqlDataWriteCommandError = "System.Data.SqlClient.WriteCommandError";
-        public const string SqlMicrosoftWriteCommandError = "Microsoft.Data.SqlClient.WriteCommandError";
-
-        private readonly PropertyFetcher<object> commandFetcher = new("Command");
-        private readonly PropertyFetcher<object> connectionFetcher = new("Connection");
-        private readonly PropertyFetcher<object> dataSourceFetcher = new("DataSource");
-        private readonly PropertyFetcher<object> databaseFetcher = new("Database");
-        private readonly PropertyFetcher<CommandType> commandTypeFetcher = new("CommandType");
-        private readonly PropertyFetcher<object> commandTextFetcher = new("CommandText");
-        private readonly PropertyFetcher<Exception> exceptionFetcher = new("Exception");
-        private readonly SqlClientInstrumentationOptions options;
-
-        public SqlClientDiagnosticListener(string sourceName, SqlClientInstrumentationOptions options)
-            : base(sourceName)
+    public override void OnEventWritten(string name, object payload)
+    {
+        var activity = Activity.Current;
+        switch (name)
         {
-            this.options = options ?? new SqlClientInstrumentationOptions();
-        }
+            case SqlDataBeforeExecuteCommand:
+            case SqlMicrosoftBeforeExecuteCommand:
+                {
+                    // SqlClient does not create an Activity. So the activity coming in here will be null or the root span.
+                    activity = SqlActivitySourceHelper.ActivitySource.StartActivity(
+                        SqlActivitySourceHelper.ActivityName,
+                        ActivityKind.Client,
+                        default(ActivityContext),
+                        SqlActivitySourceHelper.CreationTags);
 
-        public override bool SupportsNullActivity => true;
-
-        public override void OnEventWritten(string name, object payload)
-        {
-            var activity = Activity.Current;
-            switch (name)
-            {
-                case SqlDataBeforeExecuteCommand:
-                case SqlMicrosoftBeforeExecuteCommand:
+                    if (activity == null)
                     {
-                        // SqlClient does not create an Activity. So the activity coming in here will be null or the root span.
-                        activity = SqlActivitySourceHelper.ActivitySource.StartActivity(
-                            SqlActivitySourceHelper.ActivityName,
-                            ActivityKind.Client,
-                            default(ActivityContext),
-                            SqlActivitySourceHelper.CreationTags);
+                        // There is no listener or it decided not to sample the current request.
+                        return;
+                    }
 
-                        if (activity == null)
-                        {
-                            // There is no listener or it decided not to sample the current request.
-                            return;
-                        }
+                    _ = this.commandFetcher.TryFetch(payload, out var command);
+                    if (command == null)
+                    {
+                        SqlClientInstrumentationEventSource.Log.NullPayload(nameof(SqlClientDiagnosticListener), name);
+                        activity.Stop();
+                        return;
+                    }
 
-                        _ = this.commandFetcher.TryFetch(payload, out var command);
-                        if (command == null)
+                    if (activity.IsAllDataRequested)
+                    {
+                        try
                         {
-                            SqlClientInstrumentationEventSource.Log.NullPayload(nameof(SqlClientDiagnosticListener), name);
-                            activity.Stop();
-                            return;
-                        }
-
-                        if (activity.IsAllDataRequested)
-                        {
-                            try
+                            if (this.options.Filter?.Invoke(command) == false)
                             {
-                                if (this.options.Filter?.Invoke(command) == false)
-                                {
-                                    SqlClientInstrumentationEventSource.Log.CommandIsFilteredOut(activity.OperationName);
-                                    activity.IsAllDataRequested = false;
-                                    activity.ActivityTraceFlags &= ~ActivityTraceFlags.Recorded;
-                                    return;
-                                }
-                            }
-                            catch (Exception ex)
-                            {
-                                SqlClientInstrumentationEventSource.Log.CommandFilterException(ex);
+                                SqlClientInstrumentationEventSource.Log.CommandIsFilteredOut(activity.OperationName);
                                 activity.IsAllDataRequested = false;
                                 activity.ActivityTraceFlags &= ~ActivityTraceFlags.Recorded;
                                 return;
                             }
+                        }
+                        catch (Exception ex)
+                        {
+                            SqlClientInstrumentationEventSource.Log.CommandFilterException(ex);
+                            activity.IsAllDataRequested = false;
+                            activity.ActivityTraceFlags &= ~ActivityTraceFlags.Recorded;
+                            return;
+                        }
 
-                            _ = this.connectionFetcher.TryFetch(command, out var connection);
-                            _ = this.databaseFetcher.TryFetch(connection, out var database);
+                        _ = this.connectionFetcher.TryFetch(command, out var connection);
+                        _ = this.databaseFetcher.TryFetch(connection, out var database);
 
-                            activity.DisplayName = (string)database;
+                        activity.DisplayName = (string)database;
 
-                            _ = this.dataSourceFetcher.TryFetch(connection, out var dataSource);
-                            _ = this.commandTextFetcher.TryFetch(command, out var commandText);
+                        _ = this.dataSourceFetcher.TryFetch(connection, out var dataSource);
+                        _ = this.commandTextFetcher.TryFetch(command, out var commandText);
 
-                            activity.SetTag(SemanticConventions.AttributeDbName, (string)database);
+                        activity.SetTag(SemanticConventions.AttributeDbName, (string)database);
 
-                            this.options.AddConnectionLevelDetailsToActivity((string)dataSource, activity);
+                        this.options.AddConnectionLevelDetailsToActivity((string)dataSource, activity);
 
-                            if (this.commandTypeFetcher.TryFetch(command, out CommandType commandType))
+                        if (this.commandTypeFetcher.TryFetch(command, out CommandType commandType))
+                        {
+                            switch (commandType)
                             {
-                                switch (commandType)
-                                {
-                                    case CommandType.StoredProcedure:
-                                        activity.SetTag(SpanAttributeConstants.DatabaseStatementTypeKey, nameof(CommandType.StoredProcedure));
-                                        if (this.options.SetDbStatementForStoredProcedure)
-                                        {
-                                            activity.SetTag(SemanticConventions.AttributeDbStatement, (string)commandText);
-                                        }
+                                case CommandType.StoredProcedure:
+                                    activity.SetTag(SpanAttributeConstants.DatabaseStatementTypeKey, nameof(CommandType.StoredProcedure));
+                                    if (this.options.SetDbStatementForStoredProcedure)
+                                    {
+                                        activity.SetTag(SemanticConventions.AttributeDbStatement, (string)commandText);
+                                    }
 
-                                        break;
+                                    break;
 
-                                    case CommandType.Text:
-                                        activity.SetTag(SpanAttributeConstants.DatabaseStatementTypeKey, nameof(CommandType.Text));
-                                        if (this.options.SetDbStatementForText)
-                                        {
-                                            activity.SetTag(SemanticConventions.AttributeDbStatement, (string)commandText);
-                                        }
+                                case CommandType.Text:
+                                    activity.SetTag(SpanAttributeConstants.DatabaseStatementTypeKey, nameof(CommandType.Text));
+                                    if (this.options.SetDbStatementForText)
+                                    {
+                                        activity.SetTag(SemanticConventions.AttributeDbStatement, (string)commandText);
+                                    }
 
-                                        break;
+                                    break;
 
-                                    case CommandType.TableDirect:
-                                        activity.SetTag(SpanAttributeConstants.DatabaseStatementTypeKey, nameof(CommandType.TableDirect));
-                                        break;
-                                }
+                                case CommandType.TableDirect:
+                                    activity.SetTag(SpanAttributeConstants.DatabaseStatementTypeKey, nameof(CommandType.TableDirect));
+                                    break;
                             }
-
-                            try
-                            {
-                                this.options.Enrich?.Invoke(activity, "OnCustom", command);
-                            }
-                            catch (Exception ex)
-                            {
-                                SqlClientInstrumentationEventSource.Log.EnrichmentException(ex);
-                            }
-                        }
-                    }
-
-                    break;
-                case SqlDataAfterExecuteCommand:
-                case SqlMicrosoftAfterExecuteCommand:
-                    {
-                        if (activity == null)
-                        {
-                            SqlClientInstrumentationEventSource.Log.NullActivity(name);
-                            return;
-                        }
-
-                        if (activity.Source != SqlActivitySourceHelper.ActivitySource)
-                        {
-                            return;
-                        }
-
-                        activity.Stop();
-                    }
-
-                    break;
-                case SqlDataWriteCommandError:
-                case SqlMicrosoftWriteCommandError:
-                    {
-                        if (activity == null)
-                        {
-                            SqlClientInstrumentationEventSource.Log.NullActivity(name);
-                            return;
-                        }
-
-                        if (activity.Source != SqlActivitySourceHelper.ActivitySource)
-                        {
-                            return;
                         }
 
                         try
                         {
-                            if (activity.IsAllDataRequested)
-                            {
-                                if (this.exceptionFetcher.TryFetch(payload, out Exception exception) && exception != null)
-                                {
-                                    activity.SetStatus(ActivityStatusCode.Error, exception.Message);
-
-                                    if (this.options.RecordException)
-                                    {
-                                        activity.RecordException(exception);
-                                    }
-                                }
-                                else
-                                {
-                                    SqlClientInstrumentationEventSource.Log.NullPayload(nameof(SqlClientDiagnosticListener), name);
-                                }
-                            }
+                            this.options.Enrich?.Invoke(activity, "OnCustom", command);
                         }
-                        finally
+                        catch (Exception ex)
                         {
-                            activity.Stop();
+                            SqlClientInstrumentationEventSource.Log.EnrichmentException(ex);
                         }
                     }
+                }
 
-                    break;
-            }
+                break;
+            case SqlDataAfterExecuteCommand:
+            case SqlMicrosoftAfterExecuteCommand:
+                {
+                    if (activity == null)
+                    {
+                        SqlClientInstrumentationEventSource.Log.NullActivity(name);
+                        return;
+                    }
+
+                    if (activity.Source != SqlActivitySourceHelper.ActivitySource)
+                    {
+                        return;
+                    }
+
+                    activity.Stop();
+                }
+
+                break;
+            case SqlDataWriteCommandError:
+            case SqlMicrosoftWriteCommandError:
+                {
+                    if (activity == null)
+                    {
+                        SqlClientInstrumentationEventSource.Log.NullActivity(name);
+                        return;
+                    }
+
+                    if (activity.Source != SqlActivitySourceHelper.ActivitySource)
+                    {
+                        return;
+                    }
+
+                    try
+                    {
+                        if (activity.IsAllDataRequested)
+                        {
+                            if (this.exceptionFetcher.TryFetch(payload, out Exception exception) && exception != null)
+                            {
+                                activity.SetStatus(ActivityStatusCode.Error, exception.Message);
+
+                                if (this.options.RecordException)
+                                {
+                                    activity.RecordException(exception);
+                                }
+                            }
+                            else
+                            {
+                                SqlClientInstrumentationEventSource.Log.NullPayload(nameof(SqlClientDiagnosticListener), name);
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        activity.Stop();
+                    }
+                }
+
+                break;
         }
     }
 }

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientInstrumentationEventSource.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientInstrumentationEventSource.cs
@@ -17,83 +17,82 @@
 using System.Diagnostics.Tracing;
 using OpenTelemetry.Internal;
 
-namespace OpenTelemetry.Instrumentation.SqlClient.Implementation
+namespace OpenTelemetry.Instrumentation.SqlClient.Implementation;
+
+/// <summary>
+/// EventSource events emitted from the project.
+/// </summary>
+[EventSource(Name = "OpenTelemetry-Instrumentation-SqlClient")]
+internal sealed class SqlClientInstrumentationEventSource : EventSource
 {
-    /// <summary>
-    /// EventSource events emitted from the project.
-    /// </summary>
-    [EventSource(Name = "OpenTelemetry-Instrumentation-SqlClient")]
-    internal sealed class SqlClientInstrumentationEventSource : EventSource
+    public static SqlClientInstrumentationEventSource Log = new();
+
+    [NonEvent]
+    public void UnknownErrorProcessingEvent(string handlerName, string eventName, Exception ex)
     {
-        public static SqlClientInstrumentationEventSource Log = new();
-
-        [NonEvent]
-        public void UnknownErrorProcessingEvent(string handlerName, string eventName, Exception ex)
+        if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
         {
-            if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
-            {
-                this.UnknownErrorProcessingEvent(handlerName, eventName, ex.ToInvariantString());
-            }
+            this.UnknownErrorProcessingEvent(handlerName, eventName, ex.ToInvariantString());
         }
+    }
 
-        [Event(1, Message = "Unknown error processing event '{1}' from handler '{0}', Exception: {2}", Level = EventLevel.Error)]
-        public void UnknownErrorProcessingEvent(string handlerName, string eventName, string ex)
-        {
-            this.WriteEvent(1, handlerName, eventName, ex);
-        }
+    [Event(1, Message = "Unknown error processing event '{1}' from handler '{0}', Exception: {2}", Level = EventLevel.Error)]
+    public void UnknownErrorProcessingEvent(string handlerName, string eventName, string ex)
+    {
+        this.WriteEvent(1, handlerName, eventName, ex);
+    }
 
-        [Event(2, Message = "Current Activity is NULL in the '{0}' callback. Span will not be recorded.", Level = EventLevel.Warning)]
-        public void NullActivity(string eventName)
-        {
-            this.WriteEvent(2, eventName);
-        }
+    [Event(2, Message = "Current Activity is NULL in the '{0}' callback. Span will not be recorded.", Level = EventLevel.Warning)]
+    public void NullActivity(string eventName)
+    {
+        this.WriteEvent(2, eventName);
+    }
 
-        [Event(3, Message = "Payload is NULL in event '{1}' from handler '{0}', span will not be recorded.", Level = EventLevel.Warning)]
-        public void NullPayload(string handlerName, string eventName)
-        {
-            this.WriteEvent(3, handlerName, eventName);
-        }
+    [Event(3, Message = "Payload is NULL in event '{1}' from handler '{0}', span will not be recorded.", Level = EventLevel.Warning)]
+    public void NullPayload(string handlerName, string eventName)
+    {
+        this.WriteEvent(3, handlerName, eventName);
+    }
 
-        [Event(4, Message = "Payload is invalid in event '{1}' from handler '{0}', span will not be recorded.", Level = EventLevel.Warning)]
-        public void InvalidPayload(string handlerName, string eventName)
-        {
-            this.WriteEvent(4, handlerName, eventName);
-        }
+    [Event(4, Message = "Payload is invalid in event '{1}' from handler '{0}', span will not be recorded.", Level = EventLevel.Warning)]
+    public void InvalidPayload(string handlerName, string eventName)
+    {
+        this.WriteEvent(4, handlerName, eventName);
+    }
 
-        [NonEvent]
-        public void EnrichmentException(Exception ex)
+    [NonEvent]
+    public void EnrichmentException(Exception ex)
+    {
+        if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
         {
-            if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
-            {
-                this.EnrichmentException(ex.ToInvariantString());
-            }
+            this.EnrichmentException(ex.ToInvariantString());
         }
+    }
 
-        [Event(5, Message = "Enrichment threw exception. Exception {0}.", Level = EventLevel.Error)]
-        public void EnrichmentException(string exception)
-        {
-            this.WriteEvent(5, exception);
-        }
+    [Event(5, Message = "Enrichment threw exception. Exception {0}.", Level = EventLevel.Error)]
+    public void EnrichmentException(string exception)
+    {
+        this.WriteEvent(5, exception);
+    }
 
-        [Event(6, Message = "Command is filtered out. Activity {0}", Level = EventLevel.Verbose)]
-        public void CommandIsFilteredOut(string activityName)
-        {
-            this.WriteEvent(6, activityName);
-        }
+    [Event(6, Message = "Command is filtered out. Activity {0}", Level = EventLevel.Verbose)]
+    public void CommandIsFilteredOut(string activityName)
+    {
+        this.WriteEvent(6, activityName);
+    }
 
-        [NonEvent]
-        public void CommandFilterException(Exception ex)
+    [NonEvent]
+    public void CommandFilterException(Exception ex)
+    {
+        if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
         {
-            if (this.IsEnabled(EventLevel.Error, EventKeywords.All))
-            {
-                this.CommandFilterException(ex.ToInvariantString());
-            }
+            this.CommandFilterException(ex.ToInvariantString());
         }
+    }
 
-        [Event(7, Message = "Command filter threw exception. Command will not be collected. Exception {0}.", Level = EventLevel.Error)]
-        public void CommandFilterException(string exception)
-        {
-            this.WriteEvent(7, exception);
-        }
+    [Event(7, Message = "Command filter threw exception. Command will not be collected. Exception {0}.", Level = EventLevel.Error)]
+    public void CommandFilterException(string exception)
+    {
+        this.WriteEvent(7, exception);
     }
 }

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
@@ -19,186 +19,185 @@ using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using OpenTelemetry.Trace;
 
-namespace OpenTelemetry.Instrumentation.SqlClient.Implementation
+namespace OpenTelemetry.Instrumentation.SqlClient.Implementation;
+
+/// <summary>
+/// On .NET Framework, neither System.Data.SqlClient nor Microsoft.Data.SqlClient emit DiagnosticSource events.
+/// Instead they use EventSource:
+/// For System.Data.SqlClient see: <a href="https://github.com/microsoft/referencesource/blob/3b1eaf5203992df69de44c783a3eda37d3d4cd10/System.Data/System/Data/Common/SqlEventSource.cs#L29">reference source</a>.
+/// For Microsoft.Data.SqlClient see: <a href="https://github.com/dotnet/SqlClient/blob/ac8bb3f9132e6c104dc3e307fe2d569daed0776f/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs#L15">SqlClientEventSource</a>.
+///
+/// We hook into these event sources and process their BeginExecute/EndExecute events.
+/// </summary>
+/// <remarks>
+/// Note that before version 2.0.0, Microsoft.Data.SqlClient used
+/// "Microsoft-AdoNet-SystemData" (same as System.Data.SqlClient), but since
+/// 2.0.0 has switched to "Microsoft.Data.SqlClient.EventSource".
+/// </remarks>
+internal sealed class SqlEventSourceListener : EventListener
 {
-    /// <summary>
-    /// On .NET Framework, neither System.Data.SqlClient nor Microsoft.Data.SqlClient emit DiagnosticSource events.
-    /// Instead they use EventSource:
-    /// For System.Data.SqlClient see: <a href="https://github.com/microsoft/referencesource/blob/3b1eaf5203992df69de44c783a3eda37d3d4cd10/System.Data/System/Data/Common/SqlEventSource.cs#L29">reference source</a>.
-    /// For Microsoft.Data.SqlClient see: <a href="https://github.com/dotnet/SqlClient/blob/ac8bb3f9132e6c104dc3e307fe2d569daed0776f/src/Microsoft.Data.SqlClient/src/Microsoft/Data/SqlClient/SqlClientEventSource.cs#L15">SqlClientEventSource</a>.
-    ///
-    /// We hook into these event sources and process their BeginExecute/EndExecute events.
-    /// </summary>
-    /// <remarks>
-    /// Note that before version 2.0.0, Microsoft.Data.SqlClient used
-    /// "Microsoft-AdoNet-SystemData" (same as System.Data.SqlClient), but since
-    /// 2.0.0 has switched to "Microsoft.Data.SqlClient.EventSource".
-    /// </remarks>
-    internal sealed class SqlEventSourceListener : EventListener
+    internal const string AdoNetEventSourceName = "Microsoft-AdoNet-SystemData";
+    internal const string MdsEventSourceName = "Microsoft.Data.SqlClient.EventSource";
+
+    internal const int BeginExecuteEventId = 1;
+    internal const int EndExecuteEventId = 2;
+
+    private readonly SqlClientInstrumentationOptions options;
+    private EventSource adoNetEventSource;
+    private EventSource mdsEventSource;
+
+    public SqlEventSourceListener(SqlClientInstrumentationOptions options = null)
     {
-        internal const string AdoNetEventSourceName = "Microsoft-AdoNet-SystemData";
-        internal const string MdsEventSourceName = "Microsoft.Data.SqlClient.EventSource";
+        this.options = options ?? new SqlClientInstrumentationOptions();
+    }
 
-        internal const int BeginExecuteEventId = 1;
-        internal const int EndExecuteEventId = 2;
-
-        private readonly SqlClientInstrumentationOptions options;
-        private EventSource adoNetEventSource;
-        private EventSource mdsEventSource;
-
-        public SqlEventSourceListener(SqlClientInstrumentationOptions options = null)
+    public override void Dispose()
+    {
+        if (this.adoNetEventSource != null)
         {
-            this.options = options ?? new SqlClientInstrumentationOptions();
+            this.DisableEvents(this.adoNetEventSource);
         }
 
-        public override void Dispose()
+        if (this.mdsEventSource != null)
         {
-            if (this.adoNetEventSource != null)
-            {
-                this.DisableEvents(this.adoNetEventSource);
-            }
-
-            if (this.mdsEventSource != null)
-            {
-                this.DisableEvents(this.mdsEventSource);
-            }
-
-            base.Dispose();
+            this.DisableEvents(this.mdsEventSource);
         }
 
-        protected override void OnEventSourceCreated(EventSource eventSource)
-        {
-            if (eventSource?.Name.StartsWith(AdoNetEventSourceName, StringComparison.Ordinal) == true)
-            {
-                this.adoNetEventSource = eventSource;
-                this.EnableEvents(eventSource, EventLevel.Informational, EventKeywords.All);
-            }
-            else if (eventSource?.Name.StartsWith(MdsEventSourceName, StringComparison.Ordinal) == true)
-            {
-                this.mdsEventSource = eventSource;
-                this.EnableEvents(eventSource, EventLevel.Informational, EventKeywords.All);
-            }
+        base.Dispose();
+    }
 
-            base.OnEventSourceCreated(eventSource);
+    protected override void OnEventSourceCreated(EventSource eventSource)
+    {
+        if (eventSource?.Name.StartsWith(AdoNetEventSourceName, StringComparison.Ordinal) == true)
+        {
+            this.adoNetEventSource = eventSource;
+            this.EnableEvents(eventSource, EventLevel.Informational, EventKeywords.All);
+        }
+        else if (eventSource?.Name.StartsWith(MdsEventSourceName, StringComparison.Ordinal) == true)
+        {
+            this.mdsEventSource = eventSource;
+            this.EnableEvents(eventSource, EventLevel.Informational, EventKeywords.All);
         }
 
-        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        base.OnEventSourceCreated(eventSource);
+    }
+
+    protected override void OnEventWritten(EventWrittenEventArgs eventData)
+    {
+        try
         {
-            try
+            if (eventData.EventId == BeginExecuteEventId)
             {
-                if (eventData.EventId == BeginExecuteEventId)
-                {
-                    this.OnBeginExecute(eventData);
-                }
-                else if (eventData.EventId == EndExecuteEventId)
-                {
-                    this.OnEndExecute(eventData);
-                }
+                this.OnBeginExecute(eventData);
             }
-            catch (Exception exc)
+            else if (eventData.EventId == EndExecuteEventId)
             {
-                SqlClientInstrumentationEventSource.Log.UnknownErrorProcessingEvent(nameof(SqlEventSourceListener), nameof(this.OnEventWritten), exc);
+                this.OnEndExecute(eventData);
             }
         }
-
-        private void OnBeginExecute(EventWrittenEventArgs eventData)
+        catch (Exception exc)
         {
-            /*
-               Expected payload:
-                [0] -> ObjectId
-                [1] -> DataSource
-                [2] -> Database
-                [3] -> CommandText
+            SqlClientInstrumentationEventSource.Log.UnknownErrorProcessingEvent(nameof(SqlEventSourceListener), nameof(this.OnEventWritten), exc);
+        }
+    }
 
-                Note:
-                - For "Microsoft-AdoNet-SystemData" v1.0: [3] CommandText = CommandType == CommandType.StoredProcedure ? CommandText : string.Empty; (so it is set for only StoredProcedure command types)
-                    (https://github.com/dotnet/SqlClient/blob/v1.0.19239.1/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs#L6369)
-                - For "Microsoft-AdoNet-SystemData" v1.1: [3] CommandText = sqlCommand.CommandText (so it is set for all command types)
-                    (https://github.com/dotnet/SqlClient/blob/v1.1.0/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs#L7459)
-                - For "Microsoft.Data.SqlClient.EventSource" v2.0+: [3] CommandText = sqlCommand.CommandText (so it is set for all command types).
-                    (https://github.com/dotnet/SqlClient/blob/f4568ce68da21db3fe88c0e72e1287368aaa1dc8/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs#L6641)
-             */
+    private void OnBeginExecute(EventWrittenEventArgs eventData)
+    {
+        /*
+           Expected payload:
+            [0] -> ObjectId
+            [1] -> DataSource
+            [2] -> Database
+            [3] -> CommandText
 
-            if ((eventData?.Payload?.Count ?? 0) < 4)
+            Note:
+            - For "Microsoft-AdoNet-SystemData" v1.0: [3] CommandText = CommandType == CommandType.StoredProcedure ? CommandText : string.Empty; (so it is set for only StoredProcedure command types)
+                (https://github.com/dotnet/SqlClient/blob/v1.0.19239.1/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs#L6369)
+            - For "Microsoft-AdoNet-SystemData" v1.1: [3] CommandText = sqlCommand.CommandText (so it is set for all command types)
+                (https://github.com/dotnet/SqlClient/blob/v1.1.0/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlClient/SqlCommand.cs#L7459)
+            - For "Microsoft.Data.SqlClient.EventSource" v2.0+: [3] CommandText = sqlCommand.CommandText (so it is set for all command types).
+                (https://github.com/dotnet/SqlClient/blob/f4568ce68da21db3fe88c0e72e1287368aaa1dc8/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlCommand.cs#L6641)
+         */
+
+        if ((eventData?.Payload?.Count ?? 0) < 4)
+        {
+            SqlClientInstrumentationEventSource.Log.InvalidPayload(nameof(SqlEventSourceListener), nameof(this.OnBeginExecute));
+            return;
+        }
+
+        var activity = SqlActivitySourceHelper.ActivitySource.StartActivity(
+            SqlActivitySourceHelper.ActivityName,
+            ActivityKind.Client,
+            default(ActivityContext),
+            SqlActivitySourceHelper.CreationTags);
+
+        if (activity == null)
+        {
+            // There is no listener or it decided not to sample the current request.
+            return;
+        }
+
+        string databaseName = (string)eventData.Payload[2];
+
+        activity.DisplayName = databaseName;
+
+        if (activity.IsAllDataRequested)
+        {
+            activity.SetTag(SemanticConventions.AttributeDbName, databaseName);
+
+            this.options.AddConnectionLevelDetailsToActivity((string)eventData.Payload[1], activity);
+
+            string commandText = (string)eventData.Payload[3];
+            if (!string.IsNullOrEmpty(commandText) && this.options.SetDbStatementForText)
             {
-                SqlClientInstrumentationEventSource.Log.InvalidPayload(nameof(SqlEventSourceListener), nameof(this.OnBeginExecute));
-                return;
+                activity.SetTag(SemanticConventions.AttributeDbStatement, commandText);
             }
+        }
+    }
 
-            var activity = SqlActivitySourceHelper.ActivitySource.StartActivity(
-                SqlActivitySourceHelper.ActivityName,
-                ActivityKind.Client,
-                default(ActivityContext),
-                SqlActivitySourceHelper.CreationTags);
+    private void OnEndExecute(EventWrittenEventArgs eventData)
+    {
+        /*
+           Expected payload:
+            [0] -> ObjectId
+            [1] -> CompositeState bitmask (0b001 -> successFlag, 0b010 -> isSqlExceptionFlag , 0b100 -> synchronousFlag)
+            [2] -> SqlExceptionNumber
+         */
 
-            if (activity == null)
-            {
-                // There is no listener or it decided not to sample the current request.
-                return;
-            }
+        if ((eventData?.Payload?.Count ?? 0) < 3)
+        {
+            SqlClientInstrumentationEventSource.Log.InvalidPayload(nameof(SqlEventSourceListener), nameof(this.OnEndExecute));
+            return;
+        }
 
-            string databaseName = (string)eventData.Payload[2];
+        var activity = Activity.Current;
+        if (activity?.Source != SqlActivitySourceHelper.ActivitySource)
+        {
+            return;
+        }
 
-            activity.DisplayName = databaseName;
-
+        try
+        {
             if (activity.IsAllDataRequested)
             {
-                activity.SetTag(SemanticConventions.AttributeDbName, databaseName);
-
-                this.options.AddConnectionLevelDetailsToActivity((string)eventData.Payload[1], activity);
-
-                string commandText = (string)eventData.Payload[3];
-                if (!string.IsNullOrEmpty(commandText) && this.options.SetDbStatementForText)
+                int compositeState = (int)eventData.Payload[1];
+                if ((compositeState & 0b001) != 0b001)
                 {
-                    activity.SetTag(SemanticConventions.AttributeDbStatement, commandText);
-                }
-            }
-        }
-
-        private void OnEndExecute(EventWrittenEventArgs eventData)
-        {
-            /*
-               Expected payload:
-                [0] -> ObjectId
-                [1] -> CompositeState bitmask (0b001 -> successFlag, 0b010 -> isSqlExceptionFlag , 0b100 -> synchronousFlag)
-                [2] -> SqlExceptionNumber
-             */
-
-            if ((eventData?.Payload?.Count ?? 0) < 3)
-            {
-                SqlClientInstrumentationEventSource.Log.InvalidPayload(nameof(SqlEventSourceListener), nameof(this.OnEndExecute));
-                return;
-            }
-
-            var activity = Activity.Current;
-            if (activity?.Source != SqlActivitySourceHelper.ActivitySource)
-            {
-                return;
-            }
-
-            try
-            {
-                if (activity.IsAllDataRequested)
-                {
-                    int compositeState = (int)eventData.Payload[1];
-                    if ((compositeState & 0b001) != 0b001)
+                    if ((compositeState & 0b010) == 0b010)
                     {
-                        if ((compositeState & 0b010) == 0b010)
-                        {
-                            var errorText = $"SqlExceptionNumber {eventData.Payload[2]} thrown.";
-                            activity.SetStatus(ActivityStatusCode.Error, errorText);
-                        }
-                        else
-                        {
-                            activity.SetStatus(ActivityStatusCode.Error, "Unknown Sql failure.");
-                        }
+                        var errorText = $"SqlExceptionNumber {eventData.Payload[2]} thrown.";
+                        activity.SetStatus(ActivityStatusCode.Error, errorText);
+                    }
+                    else
+                    {
+                        activity.SetStatus(ActivityStatusCode.Error, "Unknown Sql failure.");
                     }
                 }
             }
-            finally
-            {
-                activity.Stop();
-            }
+        }
+        finally
+        {
+            activity.Stop();
         }
     }
 }

--- a/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentation.cs
@@ -16,60 +16,59 @@
 
 using OpenTelemetry.Instrumentation.SqlClient.Implementation;
 
-namespace OpenTelemetry.Instrumentation.SqlClient
+namespace OpenTelemetry.Instrumentation.SqlClient;
+
+/// <summary>
+/// SqlClient instrumentation.
+/// </summary>
+internal sealed class SqlClientInstrumentation : IDisposable
 {
-    /// <summary>
-    /// SqlClient instrumentation.
-    /// </summary>
-    internal sealed class SqlClientInstrumentation : IDisposable
+    internal const string SqlClientDiagnosticListenerName = "SqlClientDiagnosticListener";
+
+#if NETFRAMEWORK
+    private readonly SqlEventSourceListener sqlEventSourceListener;
+#else
+    private static readonly HashSet<string> DiagnosticSourceEvents = new()
     {
-        internal const string SqlClientDiagnosticListenerName = "SqlClientDiagnosticListener";
+        "System.Data.SqlClient.WriteCommandBefore",
+        "Microsoft.Data.SqlClient.WriteCommandBefore",
+        "System.Data.SqlClient.WriteCommandAfter",
+        "Microsoft.Data.SqlClient.WriteCommandAfter",
+        "System.Data.SqlClient.WriteCommandError",
+        "Microsoft.Data.SqlClient.WriteCommandError",
+    };
 
-#if NETFRAMEWORK
-        private readonly SqlEventSourceListener sqlEventSourceListener;
-#else
-        private static readonly HashSet<string> DiagnosticSourceEvents = new()
-        {
-            "System.Data.SqlClient.WriteCommandBefore",
-            "Microsoft.Data.SqlClient.WriteCommandBefore",
-            "System.Data.SqlClient.WriteCommandAfter",
-            "Microsoft.Data.SqlClient.WriteCommandAfter",
-            "System.Data.SqlClient.WriteCommandError",
-            "Microsoft.Data.SqlClient.WriteCommandError",
-        };
+    private readonly Func<string, object, object, bool> isEnabled = (eventName, _, _)
+        => DiagnosticSourceEvents.Contains(eventName);
 
-        private readonly Func<string, object, object, bool> isEnabled = (eventName, _, _)
-            => DiagnosticSourceEvents.Contains(eventName);
-
-        private readonly DiagnosticSourceSubscriber diagnosticSourceSubscriber;
+    private readonly DiagnosticSourceSubscriber diagnosticSourceSubscriber;
 #endif
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SqlClientInstrumentation"/> class.
-        /// </summary>
-        /// <param name="options">Configuration options for sql instrumentation.</param>
-        public SqlClientInstrumentation(
-            SqlClientInstrumentationOptions options = null)
-        {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SqlClientInstrumentation"/> class.
+    /// </summary>
+    /// <param name="options">Configuration options for sql instrumentation.</param>
+    public SqlClientInstrumentation(
+        SqlClientInstrumentationOptions options = null)
+    {
 #if NETFRAMEWORK
-            this.sqlEventSourceListener = new SqlEventSourceListener(options);
+        this.sqlEventSourceListener = new SqlEventSourceListener(options);
 #else
-            this.diagnosticSourceSubscriber = new DiagnosticSourceSubscriber(
-               name => new SqlClientDiagnosticListener(name, options),
-               listener => listener.Name == SqlClientDiagnosticListenerName,
-               this.isEnabled);
-            this.diagnosticSourceSubscriber.Subscribe();
+        this.diagnosticSourceSubscriber = new DiagnosticSourceSubscriber(
+           name => new SqlClientDiagnosticListener(name, options),
+           listener => listener.Name == SqlClientDiagnosticListenerName,
+           this.isEnabled);
+        this.diagnosticSourceSubscriber.Subscribe();
 #endif
-        }
+    }
 
-        /// <inheritdoc/>
-        public void Dispose()
-        {
+    /// <inheritdoc/>
+    public void Dispose()
+    {
 #if NETFRAMEWORK
-            this.sqlEventSourceListener?.Dispose();
+        this.sqlEventSourceListener?.Dispose();
 #else
-            this.diagnosticSourceSubscriber?.Dispose();
+        this.diagnosticSourceSubscriber?.Dispose();
 #endif
-        }
     }
 }

--- a/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentationOptions.cs
@@ -22,345 +22,344 @@ using Microsoft.Extensions.Configuration;
 using OpenTelemetry.Trace;
 using static OpenTelemetry.Internal.HttpSemanticConventionHelper;
 
-namespace OpenTelemetry.Instrumentation.SqlClient
+namespace OpenTelemetry.Instrumentation.SqlClient;
+
+/// <summary>
+/// Options for <see cref="SqlClientInstrumentation"/>.
+/// </summary>
+/// <remarks>
+/// For help and examples see: <a href="https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Instrumentation.SqlClient/README.md#advanced-configuration" />.
+/// </remarks>
+public class SqlClientInstrumentationOptions
 {
+    /*
+     * Match...
+     *  protocol[ ]:[ ]serverName
+     *  serverName
+     *  serverName[ ]\[ ]instanceName
+     *  serverName[ ],[ ]port
+     *  serverName[ ]\[ ]instanceName[ ],[ ]port
+     *
+     * [ ] can be any number of white-space, SQL allows it for some reason.
+     *
+     * Optional "protocol" can be "tcp", "lpc" (shared memory), or "np" (named pipes). See:
+     *  https://docs.microsoft.com/troubleshoot/sql/connect/use-server-name-parameter-connection-string, and
+     *  https://docs.microsoft.com/dotnet/api/system.data.sqlclient.sqlconnection.connectionstring?view=dotnet-plat-ext-5.0
+     *
+     * In case of named pipes the Data Source string can take form of:
+     *  np:serverName\instanceName, or
+     *  np:\\serverName\pipe\pipeName, or
+     *  np:\\serverName\pipe\MSSQL$instanceName\pipeName - in this case a separate regex (see NamedPipeRegex below)
+     *  is used to extract instanceName
+     */
+    private static readonly Regex DataSourceRegex = new("^(.*\\s*:\\s*\\\\{0,2})?(.*?)\\s*(?:[\\\\,]|$)\\s*(.*?)\\s*(?:,|$)\\s*(.*)$", RegexOptions.Compiled);
+
     /// <summary>
-    /// Options for <see cref="SqlClientInstrumentation"/>.
+    /// In a Data Source string like "np:\\serverName\pipe\MSSQL$instanceName\pipeName" match the
+    /// "pipe\MSSQL$instanceName" segment to extract instanceName if it is available.
+    /// </summary>
+    /// <see>
+    /// <a href="https://docs.microsoft.com/previous-versions/sql/sql-server-2016/ms189307(v=sql.130)"/>
+    /// </see>
+    private static readonly Regex NamedPipeRegex = new("pipe\\\\MSSQL\\$(.*?)\\\\", RegexOptions.Compiled);
+
+    private static readonly ConcurrentDictionary<string, SqlConnectionDetails> ConnectionDetailCache = new(StringComparer.OrdinalIgnoreCase);
+
+    private readonly bool emitOldAttributes;
+    private readonly bool emitNewAttributes;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SqlClientInstrumentationOptions"/> class.
+    /// </summary>
+    public SqlClientInstrumentationOptions()
+        : this(new ConfigurationBuilder().AddEnvironmentVariables().Build())
+    {
+    }
+
+    internal SqlClientInstrumentationOptions(IConfiguration configuration)
+    {
+        Debug.Assert(configuration != null, "configuration was null");
+
+        var httpSemanticConvention = GetSemanticConventionOptIn(configuration);
+        this.emitOldAttributes = httpSemanticConvention.HasFlag(HttpSemanticConvention.Old);
+        this.emitNewAttributes = httpSemanticConvention.HasFlag(HttpSemanticConvention.New);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether or not the <see
+    /// cref="SqlClientInstrumentation"/> should add the names of <see
+    /// cref="CommandType.StoredProcedure"/> commands as the <see
+    /// cref="SemanticConventions.AttributeDbStatement"/> tag. Default
+    /// value: <see langword="true"/>.
     /// </summary>
     /// <remarks>
-    /// For help and examples see: <a href="https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Instrumentation.SqlClient/README.md#advanced-configuration" />.
+    /// <para><b>SetDbStatementForStoredProcedure is only supported on .NET
+    /// and .NET Core runtimes.</b></para>
     /// </remarks>
-    public class SqlClientInstrumentationOptions
+    public bool SetDbStatementForStoredProcedure { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether or not the <see
+    /// cref="SqlClientInstrumentation"/> should add the text of commands as
+    /// the <see cref="SemanticConventions.AttributeDbStatement"/> tag.
+    /// Default value: <see langword="false"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>WARNING: SetDbStatementForText will capture the raw
+    /// <c>CommandText</c>. Make sure your <c>CommandText</c> property never
+    /// contains any sensitive data.</b>
+    /// </para>
+    /// <para><b>SetDbStatementForText is supported on all runtimes.</b>
+    /// <list type="bullet">
+    /// <item>On .NET and .NET Core SetDbStatementForText only applies to
+    /// <c>SqlCommand</c>s with <see cref="CommandType.Text"/>.</item>
+    /// <item>On .NET Framework SetDbStatementForText applies to all
+    /// <c>SqlCommand</c>s regardless of <see cref="CommandType"/>.
+    /// <list type="bullet">
+    /// <item>When using <c>System.Data.SqlClient</c> use
+    /// SetDbStatementForText to capture StoredProcedure command
+    /// names.</item>
+    /// <item>When using <c>Microsoft.Data.SqlClient</c> use
+    /// SetDbStatementForText to capture Text, StoredProcedure, and all
+    /// other command text.</item>
+    /// </list></item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    public bool SetDbStatementForText { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether or not the <see
+    /// cref="SqlClientInstrumentation"/> should parse the DataSource on a
+    /// SqlConnection into server name, instance name, and/or port
+    /// connection-level attribute tags. Default value: <see
+    /// langword="false"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>EnableConnectionLevelAttributes is supported on all runtimes.</b>
+    /// </para>
+    /// <para>
+    /// The default behavior is to set the SqlConnection DataSource as the <see cref="SemanticConventions.AttributePeerService"/> tag.
+    /// If enabled, SqlConnection DataSource will be parsed and the server name will be sent as the
+    /// <see cref="SemanticConventions.AttributeNetPeerName"/> or <see cref="SemanticConventions.AttributeNetPeerIp"/> tag,
+    /// the instance name will be sent as the <see cref="SemanticConventions.AttributeDbMsSqlInstanceName"/> tag,
+    /// and the port will be sent as the <see cref="SemanticConventions.AttributeNetPeerPort"/> tag if it is not 1433 (the default port).
+    /// </para>
+    /// <para>
+    /// If the environment variable OTEL_SEMCONV_STABILITY_OPT_IN is set to "http", the newer Semantic Convention v1.21.0 Attributes will be emitted.
+    /// SqlConnection DataSource will be parsed and the server name will be sent as the
+    /// <see cref="SemanticConventions.AttributeServerAddress"/> or <see cref="SemanticConventions.AttributeServerSocketAddress"/> tag,
+    /// the instance name will be sent as the <see cref="SemanticConventions.AttributeDbMsSqlInstanceName"/> tag,
+    /// and the port will be sent as the <see cref="SemanticConventions.AttributeServerPort"/> tag if it is not 1433 (the default port).
+    /// </para>
+    /// </remarks>
+    public bool EnableConnectionLevelAttributes { get; set; }
+
+    /// <summary>
+    /// Gets or sets an action to enrich an <see cref="Activity"/> with the
+    /// raw <c>SqlCommand</c> object.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>Enrich is only executed on .NET and .NET Core
+    /// runtimes.</b></para>
+    /// The parameters passed to the enrich action are:
+    /// <list type="number">
+    /// <item>The <see cref="Activity"/> being enriched.</item>
+    /// <item>The name of the event. Currently only <c>"OnCustom"</c> is
+    /// used but more events may be added in the future.</item>
+    /// <item>The raw <c>SqlCommand</c> object from which additional
+    /// information can be extracted to enrich the <see
+    /// cref="Activity"/>.</item>
+    /// </list>
+    /// </remarks>
+    public Action<Activity, string, object> Enrich { get; set; }
+
+    /// <summary>
+    /// Gets or sets a filter function that determines whether or not to
+    /// collect telemetry about a command.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>Filter is only executed on .NET and .NET Core
+    /// runtimes.</b></para>
+    /// Notes:
+    /// <list type="bullet">
+    /// <item>The first parameter passed to the filter function is the raw
+    /// <c>SqlCommand</c> object for the command being executed.</item>
+    /// <item>The return value for the filter function is interpreted as:
+    /// <list type="bullet">
+    /// <item>If filter returns <see langword="true" />, the command is
+    /// collected.</item>
+    /// <item>If filter returns <see langword="false" /> or throws an
+    /// exception the command is NOT collected.</item>
+    /// </list></item>
+    /// </list>
+    /// </remarks>
+    public Func<object, bool> Filter { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the exception will be
+    /// recorded as <see cref="ActivityEvent"/> or not. Default value: <see
+    /// langword="false"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>RecordException is only supported on .NET and .NET Core
+    /// runtimes.</b></para>
+    /// <para>For specification details see: <see
+    /// href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/exceptions.md"/>.</para>
+    /// </remarks>
+    public bool RecordException { get; set; }
+
+    internal static SqlConnectionDetails ParseDataSource(string dataSource)
     {
-        /*
-         * Match...
-         *  protocol[ ]:[ ]serverName
-         *  serverName
-         *  serverName[ ]\[ ]instanceName
-         *  serverName[ ],[ ]port
-         *  serverName[ ]\[ ]instanceName[ ],[ ]port
-         *
-         * [ ] can be any number of white-space, SQL allows it for some reason.
-         *
-         * Optional "protocol" can be "tcp", "lpc" (shared memory), or "np" (named pipes). See:
-         *  https://docs.microsoft.com/troubleshoot/sql/connect/use-server-name-parameter-connection-string, and
-         *  https://docs.microsoft.com/dotnet/api/system.data.sqlclient.sqlconnection.connectionstring?view=dotnet-plat-ext-5.0
-         *
-         * In case of named pipes the Data Source string can take form of:
-         *  np:serverName\instanceName, or
-         *  np:\\serverName\pipe\pipeName, or
-         *  np:\\serverName\pipe\MSSQL$instanceName\pipeName - in this case a separate regex (see NamedPipeRegex below)
-         *  is used to extract instanceName
-         */
-        private static readonly Regex DataSourceRegex = new("^(.*\\s*:\\s*\\\\{0,2})?(.*?)\\s*(?:[\\\\,]|$)\\s*(.*?)\\s*(?:,|$)\\s*(.*)$", RegexOptions.Compiled);
+        Match match = DataSourceRegex.Match(dataSource);
 
-        /// <summary>
-        /// In a Data Source string like "np:\\serverName\pipe\MSSQL$instanceName\pipeName" match the
-        /// "pipe\MSSQL$instanceName" segment to extract instanceName if it is available.
-        /// </summary>
-        /// <see>
-        /// <a href="https://docs.microsoft.com/previous-versions/sql/sql-server-2016/ms189307(v=sql.130)"/>
-        /// </see>
-        private static readonly Regex NamedPipeRegex = new("pipe\\\\MSSQL\\$(.*?)\\\\", RegexOptions.Compiled);
+        string serverHostName = match.Groups[2].Value;
+        string serverIpAddress = null;
 
-        private static readonly ConcurrentDictionary<string, SqlConnectionDetails> ConnectionDetailCache = new(StringComparer.OrdinalIgnoreCase);
+        string instanceName;
 
-        private readonly bool emitOldAttributes;
-        private readonly bool emitNewAttributes;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SqlClientInstrumentationOptions"/> class.
-        /// </summary>
-        public SqlClientInstrumentationOptions()
-            : this(new ConfigurationBuilder().AddEnvironmentVariables().Build())
+        var uriHostNameType = Uri.CheckHostName(serverHostName);
+        if (uriHostNameType == UriHostNameType.IPv4 || uriHostNameType == UriHostNameType.IPv6)
         {
+            serverIpAddress = serverHostName;
+            serverHostName = null;
         }
 
-        internal SqlClientInstrumentationOptions(IConfiguration configuration)
+        string maybeProtocol = match.Groups[1].Value;
+        bool isNamedPipe = maybeProtocol.Length > 0 &&
+                           maybeProtocol.StartsWith("np", StringComparison.OrdinalIgnoreCase);
+
+        if (isNamedPipe)
         {
-            Debug.Assert(configuration != null, "configuration was null");
-
-            var httpSemanticConvention = GetSemanticConventionOptIn(configuration);
-            this.emitOldAttributes = httpSemanticConvention.HasFlag(HttpSemanticConvention.Old);
-            this.emitNewAttributes = httpSemanticConvention.HasFlag(HttpSemanticConvention.New);
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether or not the <see
-        /// cref="SqlClientInstrumentation"/> should add the names of <see
-        /// cref="CommandType.StoredProcedure"/> commands as the <see
-        /// cref="SemanticConventions.AttributeDbStatement"/> tag. Default
-        /// value: <see langword="true"/>.
-        /// </summary>
-        /// <remarks>
-        /// <para><b>SetDbStatementForStoredProcedure is only supported on .NET
-        /// and .NET Core runtimes.</b></para>
-        /// </remarks>
-        public bool SetDbStatementForStoredProcedure { get; set; } = true;
-
-        /// <summary>
-        /// Gets or sets a value indicating whether or not the <see
-        /// cref="SqlClientInstrumentation"/> should add the text of commands as
-        /// the <see cref="SemanticConventions.AttributeDbStatement"/> tag.
-        /// Default value: <see langword="false"/>.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// <b>WARNING: SetDbStatementForText will capture the raw
-        /// <c>CommandText</c>. Make sure your <c>CommandText</c> property never
-        /// contains any sensitive data.</b>
-        /// </para>
-        /// <para><b>SetDbStatementForText is supported on all runtimes.</b>
-        /// <list type="bullet">
-        /// <item>On .NET and .NET Core SetDbStatementForText only applies to
-        /// <c>SqlCommand</c>s with <see cref="CommandType.Text"/>.</item>
-        /// <item>On .NET Framework SetDbStatementForText applies to all
-        /// <c>SqlCommand</c>s regardless of <see cref="CommandType"/>.
-        /// <list type="bullet">
-        /// <item>When using <c>System.Data.SqlClient</c> use
-        /// SetDbStatementForText to capture StoredProcedure command
-        /// names.</item>
-        /// <item>When using <c>Microsoft.Data.SqlClient</c> use
-        /// SetDbStatementForText to capture Text, StoredProcedure, and all
-        /// other command text.</item>
-        /// </list></item>
-        /// </list>
-        /// </para>
-        /// </remarks>
-        public bool SetDbStatementForText { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether or not the <see
-        /// cref="SqlClientInstrumentation"/> should parse the DataSource on a
-        /// SqlConnection into server name, instance name, and/or port
-        /// connection-level attribute tags. Default value: <see
-        /// langword="false"/>.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// <b>EnableConnectionLevelAttributes is supported on all runtimes.</b>
-        /// </para>
-        /// <para>
-        /// The default behavior is to set the SqlConnection DataSource as the <see cref="SemanticConventions.AttributePeerService"/> tag.
-        /// If enabled, SqlConnection DataSource will be parsed and the server name will be sent as the
-        /// <see cref="SemanticConventions.AttributeNetPeerName"/> or <see cref="SemanticConventions.AttributeNetPeerIp"/> tag,
-        /// the instance name will be sent as the <see cref="SemanticConventions.AttributeDbMsSqlInstanceName"/> tag,
-        /// and the port will be sent as the <see cref="SemanticConventions.AttributeNetPeerPort"/> tag if it is not 1433 (the default port).
-        /// </para>
-        /// <para>
-        /// If the environment variable OTEL_SEMCONV_STABILITY_OPT_IN is set to "http", the newer Semantic Convention v1.21.0 Attributes will be emitted.
-        /// SqlConnection DataSource will be parsed and the server name will be sent as the
-        /// <see cref="SemanticConventions.AttributeServerAddress"/> or <see cref="SemanticConventions.AttributeServerSocketAddress"/> tag,
-        /// the instance name will be sent as the <see cref="SemanticConventions.AttributeDbMsSqlInstanceName"/> tag,
-        /// and the port will be sent as the <see cref="SemanticConventions.AttributeServerPort"/> tag if it is not 1433 (the default port).
-        /// </para>
-        /// </remarks>
-        public bool EnableConnectionLevelAttributes { get; set; }
-
-        /// <summary>
-        /// Gets or sets an action to enrich an <see cref="Activity"/> with the
-        /// raw <c>SqlCommand</c> object.
-        /// </summary>
-        /// <remarks>
-        /// <para><b>Enrich is only executed on .NET and .NET Core
-        /// runtimes.</b></para>
-        /// The parameters passed to the enrich action are:
-        /// <list type="number">
-        /// <item>The <see cref="Activity"/> being enriched.</item>
-        /// <item>The name of the event. Currently only <c>"OnCustom"</c> is
-        /// used but more events may be added in the future.</item>
-        /// <item>The raw <c>SqlCommand</c> object from which additional
-        /// information can be extracted to enrich the <see
-        /// cref="Activity"/>.</item>
-        /// </list>
-        /// </remarks>
-        public Action<Activity, string, object> Enrich { get; set; }
-
-        /// <summary>
-        /// Gets or sets a filter function that determines whether or not to
-        /// collect telemetry about a command.
-        /// </summary>
-        /// <remarks>
-        /// <para><b>Filter is only executed on .NET and .NET Core
-        /// runtimes.</b></para>
-        /// Notes:
-        /// <list type="bullet">
-        /// <item>The first parameter passed to the filter function is the raw
-        /// <c>SqlCommand</c> object for the command being executed.</item>
-        /// <item>The return value for the filter function is interpreted as:
-        /// <list type="bullet">
-        /// <item>If filter returns <see langword="true" />, the command is
-        /// collected.</item>
-        /// <item>If filter returns <see langword="false" /> or throws an
-        /// exception the command is NOT collected.</item>
-        /// </list></item>
-        /// </list>
-        /// </remarks>
-        public Func<object, bool> Filter { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the exception will be
-        /// recorded as <see cref="ActivityEvent"/> or not. Default value: <see
-        /// langword="false"/>.
-        /// </summary>
-        /// <remarks>
-        /// <para><b>RecordException is only supported on .NET and .NET Core
-        /// runtimes.</b></para>
-        /// <para>For specification details see: <see
-        /// href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/exceptions.md"/>.</para>
-        /// </remarks>
-        public bool RecordException { get; set; }
-
-        internal static SqlConnectionDetails ParseDataSource(string dataSource)
-        {
-            Match match = DataSourceRegex.Match(dataSource);
-
-            string serverHostName = match.Groups[2].Value;
-            string serverIpAddress = null;
-
-            string instanceName;
-
-            var uriHostNameType = Uri.CheckHostName(serverHostName);
-            if (uriHostNameType == UriHostNameType.IPv4 || uriHostNameType == UriHostNameType.IPv6)
+            string pipeName = match.Groups[3].Value;
+            if (pipeName.Length > 0)
             {
-                serverIpAddress = serverHostName;
-                serverHostName = null;
-            }
-
-            string maybeProtocol = match.Groups[1].Value;
-            bool isNamedPipe = maybeProtocol.Length > 0 &&
-                               maybeProtocol.StartsWith("np", StringComparison.OrdinalIgnoreCase);
-
-            if (isNamedPipe)
-            {
-                string pipeName = match.Groups[3].Value;
-                if (pipeName.Length > 0)
+                var namedInstancePipeMatch = NamedPipeRegex.Match(pipeName);
+                if (namedInstancePipeMatch.Success)
                 {
-                    var namedInstancePipeMatch = NamedPipeRegex.Match(pipeName);
-                    if (namedInstancePipeMatch.Success)
+                    instanceName = namedInstancePipeMatch.Groups[1].Value;
+                    return new SqlConnectionDetails
                     {
-                        instanceName = namedInstancePipeMatch.Groups[1].Value;
-                        return new SqlConnectionDetails
-                        {
-                            ServerHostName = serverHostName,
-                            ServerIpAddress = serverIpAddress,
-                            InstanceName = instanceName,
-                            Port = null,
-                        };
-                    }
+                        ServerHostName = serverHostName,
+                        ServerIpAddress = serverIpAddress,
+                        InstanceName = instanceName,
+                        Port = null,
+                    };
                 }
-
-                return new SqlConnectionDetails
-                {
-                    ServerHostName = serverHostName,
-                    ServerIpAddress = serverIpAddress,
-                    InstanceName = null,
-                    Port = null,
-                };
-            }
-
-            string port;
-            if (match.Groups[4].Length > 0)
-            {
-                instanceName = match.Groups[3].Value;
-                port = match.Groups[4].Value;
-                if (port == "1433")
-                {
-                    port = null;
-                }
-            }
-            else if (int.TryParse(match.Groups[3].Value, out int parsedPort))
-            {
-                port = parsedPort == 1433 ? null : match.Groups[3].Value;
-                instanceName = null;
-            }
-            else
-            {
-                instanceName = match.Groups[3].Value;
-
-                if (string.IsNullOrEmpty(instanceName))
-                {
-                    instanceName = null;
-                }
-
-                port = null;
             }
 
             return new SqlConnectionDetails
             {
                 ServerHostName = serverHostName,
                 ServerIpAddress = serverIpAddress,
-                InstanceName = instanceName,
-                Port = port,
+                InstanceName = null,
+                Port = null,
             };
         }
 
-        internal void AddConnectionLevelDetailsToActivity(string dataSource, Activity sqlActivity)
+        string port;
+        if (match.Groups[4].Length > 0)
         {
-            if (!this.EnableConnectionLevelAttributes)
+            instanceName = match.Groups[3].Value;
+            port = match.Groups[4].Value;
+            if (port == "1433")
             {
-                sqlActivity.SetTag(SemanticConventions.AttributePeerService, dataSource);
+                port = null;
             }
-            else
+        }
+        else if (int.TryParse(match.Groups[3].Value, out int parsedPort))
+        {
+            port = parsedPort == 1433 ? null : match.Groups[3].Value;
+            instanceName = null;
+        }
+        else
+        {
+            instanceName = match.Groups[3].Value;
+
+            if (string.IsNullOrEmpty(instanceName))
             {
-                if (!ConnectionDetailCache.TryGetValue(dataSource, out SqlConnectionDetails connectionDetails))
+                instanceName = null;
+            }
+
+            port = null;
+        }
+
+        return new SqlConnectionDetails
+        {
+            ServerHostName = serverHostName,
+            ServerIpAddress = serverIpAddress,
+            InstanceName = instanceName,
+            Port = port,
+        };
+    }
+
+    internal void AddConnectionLevelDetailsToActivity(string dataSource, Activity sqlActivity)
+    {
+        if (!this.EnableConnectionLevelAttributes)
+        {
+            sqlActivity.SetTag(SemanticConventions.AttributePeerService, dataSource);
+        }
+        else
+        {
+            if (!ConnectionDetailCache.TryGetValue(dataSource, out SqlConnectionDetails connectionDetails))
+            {
+                connectionDetails = ParseDataSource(dataSource);
+                ConnectionDetailCache.TryAdd(dataSource, connectionDetails);
+            }
+
+            if (!string.IsNullOrEmpty(connectionDetails.InstanceName))
+            {
+                sqlActivity.SetTag(SemanticConventions.AttributeDbMsSqlInstanceName, connectionDetails.InstanceName);
+            }
+
+            if (this.emitOldAttributes)
+            {
+                if (!string.IsNullOrEmpty(connectionDetails.ServerHostName))
                 {
-                    connectionDetails = ParseDataSource(dataSource);
-                    ConnectionDetailCache.TryAdd(dataSource, connectionDetails);
+                    sqlActivity.SetTag(SemanticConventions.AttributeNetPeerName, connectionDetails.ServerHostName);
+                }
+                else
+                {
+                    sqlActivity.SetTag(SemanticConventions.AttributeNetPeerIp, connectionDetails.ServerIpAddress);
                 }
 
-                if (!string.IsNullOrEmpty(connectionDetails.InstanceName))
+                if (!string.IsNullOrEmpty(connectionDetails.Port))
                 {
-                    sqlActivity.SetTag(SemanticConventions.AttributeDbMsSqlInstanceName, connectionDetails.InstanceName);
+                    sqlActivity.SetTag(SemanticConventions.AttributeNetPeerPort, connectionDetails.Port);
+                }
+            }
+
+            // see the spec https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/database/database-spans.md
+            if (this.emitNewAttributes)
+            {
+                if (!string.IsNullOrEmpty(connectionDetails.ServerHostName))
+                {
+                    sqlActivity.SetTag(SemanticConventions.AttributeServerAddress, connectionDetails.ServerHostName);
+                }
+                else
+                {
+                    sqlActivity.SetTag(SemanticConventions.AttributeServerSocketAddress, connectionDetails.ServerIpAddress);
                 }
 
-                if (this.emitOldAttributes)
+                if (!string.IsNullOrEmpty(connectionDetails.Port))
                 {
-                    if (!string.IsNullOrEmpty(connectionDetails.ServerHostName))
-                    {
-                        sqlActivity.SetTag(SemanticConventions.AttributeNetPeerName, connectionDetails.ServerHostName);
-                    }
-                    else
-                    {
-                        sqlActivity.SetTag(SemanticConventions.AttributeNetPeerIp, connectionDetails.ServerIpAddress);
-                    }
-
-                    if (!string.IsNullOrEmpty(connectionDetails.Port))
-                    {
-                        sqlActivity.SetTag(SemanticConventions.AttributeNetPeerPort, connectionDetails.Port);
-                    }
-                }
-
-                // see the spec https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/database/database-spans.md
-                if (this.emitNewAttributes)
-                {
-                    if (!string.IsNullOrEmpty(connectionDetails.ServerHostName))
-                    {
-                        sqlActivity.SetTag(SemanticConventions.AttributeServerAddress, connectionDetails.ServerHostName);
-                    }
-                    else
-                    {
-                        sqlActivity.SetTag(SemanticConventions.AttributeServerSocketAddress, connectionDetails.ServerIpAddress);
-                    }
-
-                    if (!string.IsNullOrEmpty(connectionDetails.Port))
-                    {
-                        // TODO: Should we continue to emit this if the default port (1433) is being used?
-                        sqlActivity.SetTag(SemanticConventions.AttributeServerPort, connectionDetails.Port);
-                    }
+                    // TODO: Should we continue to emit this if the default port (1433) is being used?
+                    sqlActivity.SetTag(SemanticConventions.AttributeServerPort, connectionDetails.Port);
                 }
             }
         }
+    }
 
-        internal sealed class SqlConnectionDetails
-        {
-            public string ServerHostName { get; set; }
+    internal sealed class SqlConnectionDetails
+    {
+        public string ServerHostName { get; set; }
 
-            public string ServerIpAddress { get; set; }
+        public string ServerIpAddress { get; set; }
 
-            public string InstanceName { get; set; }
+        public string InstanceName { get; set; }
 
-            public string Port { get; set; }
-        }
+        public string Port { get; set; }
     }
 }

--- a/src/OpenTelemetry.Instrumentation.SqlClient/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/TracerProviderBuilderExtensions.cs
@@ -20,68 +20,67 @@ using OpenTelemetry.Instrumentation.SqlClient;
 using OpenTelemetry.Instrumentation.SqlClient.Implementation;
 using OpenTelemetry.Internal;
 
-namespace OpenTelemetry.Trace
+namespace OpenTelemetry.Trace;
+
+/// <summary>
+/// Extension methods to simplify registering of dependency instrumentation.
+/// </summary>
+public static class TracerProviderBuilderExtensions
 {
     /// <summary>
-    /// Extension methods to simplify registering of dependency instrumentation.
+    /// Enables SqlClient instrumentation.
     /// </summary>
-    public static class TracerProviderBuilderExtensions
+    /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
+    /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
+    public static TracerProviderBuilder AddSqlClientInstrumentation(this TracerProviderBuilder builder)
+        => AddSqlClientInstrumentation(builder, name: null, configureSqlClientInstrumentationOptions: null);
+
+    /// <summary>
+    /// Enables SqlClient instrumentation.
+    /// </summary>
+    /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
+    /// <param name="configureSqlClientInstrumentationOptions">Callback action for configuring <see cref="SqlClientInstrumentationOptions"/>.</param>
+    /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
+    public static TracerProviderBuilder AddSqlClientInstrumentation(
+        this TracerProviderBuilder builder,
+        Action<SqlClientInstrumentationOptions> configureSqlClientInstrumentationOptions)
+        => AddSqlClientInstrumentation(builder, name: null, configureSqlClientInstrumentationOptions);
+
+    /// <summary>
+    /// Enables SqlClient instrumentation.
+    /// </summary>
+    /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
+    /// <param name="name">Name which is used when retrieving options.</param>
+    /// <param name="configureSqlClientInstrumentationOptions">Callback action for configuring <see cref="SqlClientInstrumentationOptions"/>.</param>
+    /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
+    public static TracerProviderBuilder AddSqlClientInstrumentation(
+        this TracerProviderBuilder builder,
+        string name,
+        Action<SqlClientInstrumentationOptions> configureSqlClientInstrumentationOptions)
     {
-        /// <summary>
-        /// Enables SqlClient instrumentation.
-        /// </summary>
-        /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
-        /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
-        public static TracerProviderBuilder AddSqlClientInstrumentation(this TracerProviderBuilder builder)
-            => AddSqlClientInstrumentation(builder, name: null, configureSqlClientInstrumentationOptions: null);
+        Guard.ThrowIfNull(builder);
 
-        /// <summary>
-        /// Enables SqlClient instrumentation.
-        /// </summary>
-        /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
-        /// <param name="configureSqlClientInstrumentationOptions">Callback action for configuring <see cref="SqlClientInstrumentationOptions"/>.</param>
-        /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
-        public static TracerProviderBuilder AddSqlClientInstrumentation(
-            this TracerProviderBuilder builder,
-            Action<SqlClientInstrumentationOptions> configureSqlClientInstrumentationOptions)
-            => AddSqlClientInstrumentation(builder, name: null, configureSqlClientInstrumentationOptions);
+        name ??= Options.DefaultName;
 
-        /// <summary>
-        /// Enables SqlClient instrumentation.
-        /// </summary>
-        /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
-        /// <param name="name">Name which is used when retrieving options.</param>
-        /// <param name="configureSqlClientInstrumentationOptions">Callback action for configuring <see cref="SqlClientInstrumentationOptions"/>.</param>
-        /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
-        public static TracerProviderBuilder AddSqlClientInstrumentation(
-            this TracerProviderBuilder builder,
-            string name,
-            Action<SqlClientInstrumentationOptions> configureSqlClientInstrumentationOptions)
+        builder.ConfigureServices(services =>
         {
-            Guard.ThrowIfNull(builder);
-
-            name ??= Options.DefaultName;
-
-            builder.ConfigureServices(services =>
+            if (configureSqlClientInstrumentationOptions != null)
             {
-                if (configureSqlClientInstrumentationOptions != null)
-                {
-                    services.Configure(name, configureSqlClientInstrumentationOptions);
-                }
+                services.Configure(name, configureSqlClientInstrumentationOptions);
+            }
 
-                services.RegisterOptionsFactory(configuration => new SqlClientInstrumentationOptions(configuration));
-            });
+            services.RegisterOptionsFactory(configuration => new SqlClientInstrumentationOptions(configuration));
+        });
 
-            builder.AddInstrumentation(sp =>
-            {
-                var sqlOptions = sp.GetRequiredService<IOptionsMonitor<SqlClientInstrumentationOptions>>().Get(name);
+        builder.AddInstrumentation(sp =>
+        {
+            var sqlOptions = sp.GetRequiredService<IOptionsMonitor<SqlClientInstrumentationOptions>>().Get(name);
 
-                return new SqlClientInstrumentation(sqlOptions);
-            });
+            return new SqlClientInstrumentation(sqlOptions);
+        });
 
-            builder.AddSource(SqlActivitySourceHelper.ActivitySourceName);
+        builder.AddSource(SqlActivitySourceHelper.ActivitySourceName);
 
-            return builder;
-        }
+        return builder;
     }
 }

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/EventSourceTest.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/EventSourceTest.cs
@@ -18,14 +18,13 @@ using OpenTelemetry.Instrumentation.SqlClient.Implementation;
 using OpenTelemetry.Tests;
 using Xunit;
 
-namespace OpenTelemetry.Instrumentation.SqlClient.Tests
+namespace OpenTelemetry.Instrumentation.SqlClient.Tests;
+
+public class EventSourceTest
 {
-    public class EventSourceTest
+    [Fact]
+    public void EventSourceTest_SqlClientInstrumentationEventSource()
     {
-        [Fact]
-        public void EventSourceTest_SqlClientInstrumentationEventSource()
-        {
-            EventSourceTestHelper.MethodsAreImplementedConsistentlyWithTheirAttributes(SqlClientInstrumentationEventSource.Log);
-        }
+        EventSourceTestHelper.MethodsAreImplementedConsistentlyWithTheirAttributes(SqlClientInstrumentationEventSource.Log);
     }
 }

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientInstrumentationOptionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientInstrumentationOptionsTests.cs
@@ -20,194 +20,193 @@ using OpenTelemetry.Trace;
 using Xunit;
 using static OpenTelemetry.Internal.HttpSemanticConventionHelper;
 
-namespace OpenTelemetry.Instrumentation.SqlClient.Tests
+namespace OpenTelemetry.Instrumentation.SqlClient.Tests;
+
+public class SqlClientInstrumentationOptionsTests
 {
-    public class SqlClientInstrumentationOptionsTests
+    static SqlClientInstrumentationOptionsTests()
     {
-        static SqlClientInstrumentationOptionsTests()
+        Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+        Activity.ForceDefaultIdFormat = true;
+
+        var listener = new ActivityListener
         {
-            Activity.DefaultIdFormat = ActivityIdFormat.W3C;
-            Activity.ForceDefaultIdFormat = true;
+            ShouldListenTo = _ => true,
+            Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
+        };
 
-            var listener = new ActivityListener
-            {
-                ShouldListenTo = _ => true,
-                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
-            };
+        ActivitySource.AddActivityListener(listener);
+    }
 
-            ActivitySource.AddActivityListener(listener);
+    [Theory]
+    [InlineData("localhost", "localhost", null, null, null)]
+    [InlineData("127.0.0.1", null, "127.0.0.1", null, null)]
+    [InlineData("127.0.0.1,1433", null, "127.0.0.1", null, null)]
+    [InlineData("127.0.0.1, 1818", null, "127.0.0.1", null, "1818")]
+    [InlineData("127.0.0.1  \\  instanceName", null, "127.0.0.1", "instanceName", null)]
+    [InlineData("127.0.0.1\\instanceName, 1818", null, "127.0.0.1", "instanceName", "1818")]
+    [InlineData("tcp:127.0.0.1\\instanceName, 1818", null, "127.0.0.1", "instanceName", "1818")]
+    [InlineData("tcp:localhost", "localhost", null, null, null)]
+    [InlineData("tcp : localhost", "localhost", null, null, null)]
+    [InlineData("np : localhost", "localhost", null, null, null)]
+    [InlineData("lpc:localhost", "localhost", null, null, null)]
+    [InlineData("np:\\\\localhost\\pipe\\sql\\query", "localhost", null, null, null)]
+    [InlineData("np : \\\\localhost\\pipe\\sql\\query", "localhost", null, null, null)]
+    [InlineData("np:\\\\localhost\\pipe\\MSSQL$instanceName\\sql\\query", "localhost", null, "instanceName", null)]
+    public void ParseDataSourceTests(
+        string dataSource,
+        string expectedServerHostName,
+        string expectedServerIpAddress,
+        string expectedInstanceName,
+        string expectedPort)
+    {
+        var sqlConnectionDetails = SqlClientInstrumentationOptions.ParseDataSource(dataSource);
+
+        Assert.NotNull(sqlConnectionDetails);
+        Assert.Equal(expectedServerHostName, sqlConnectionDetails.ServerHostName);
+        Assert.Equal(expectedServerIpAddress, sqlConnectionDetails.ServerIpAddress);
+        Assert.Equal(expectedInstanceName, sqlConnectionDetails.InstanceName);
+        Assert.Equal(expectedPort, sqlConnectionDetails.Port);
+    }
+
+    [Theory]
+    [InlineData(true, "localhost", "localhost", null, null, null)]
+    [InlineData(true, "127.0.0.1,1433", null, "127.0.0.1", null, null)]
+    [InlineData(true, "127.0.0.1,1434", null, "127.0.0.1", null, "1434")]
+    [InlineData(true, "127.0.0.1\\instanceName, 1818", null, "127.0.0.1", "instanceName", "1818")]
+    [InlineData(false, "localhost", "localhost", null, null, null)]
+    public void SqlClientInstrumentationOptions_EnableConnectionLevelAttributes(
+        bool enableConnectionLevelAttributes,
+        string dataSource,
+        string expectedServerHostName,
+        string expectedServerIpAddress,
+        string expectedInstanceName,
+        string expectedPort)
+    {
+        var source = new ActivitySource("sql-client-instrumentation");
+        var activity = source.StartActivity("Test Sql Activity");
+        var options = new SqlClientInstrumentationOptions
+        {
+            EnableConnectionLevelAttributes = enableConnectionLevelAttributes,
+        };
+        options.AddConnectionLevelDetailsToActivity(dataSource, activity);
+
+        if (!enableConnectionLevelAttributes)
+        {
+            Assert.Equal(expectedServerHostName, activity.GetTagValue(SemanticConventions.AttributePeerService));
+        }
+        else
+        {
+            Assert.Equal(expectedServerHostName, activity.GetTagValue(SemanticConventions.AttributeNetPeerName));
         }
 
-        [Theory]
-        [InlineData("localhost", "localhost", null, null, null)]
-        [InlineData("127.0.0.1", null, "127.0.0.1", null, null)]
-        [InlineData("127.0.0.1,1433", null, "127.0.0.1", null, null)]
-        [InlineData("127.0.0.1, 1818", null, "127.0.0.1", null, "1818")]
-        [InlineData("127.0.0.1  \\  instanceName", null, "127.0.0.1", "instanceName", null)]
-        [InlineData("127.0.0.1\\instanceName, 1818", null, "127.0.0.1", "instanceName", "1818")]
-        [InlineData("tcp:127.0.0.1\\instanceName, 1818", null, "127.0.0.1", "instanceName", "1818")]
-        [InlineData("tcp:localhost", "localhost", null, null, null)]
-        [InlineData("tcp : localhost", "localhost", null, null, null)]
-        [InlineData("np : localhost", "localhost", null, null, null)]
-        [InlineData("lpc:localhost", "localhost", null, null, null)]
-        [InlineData("np:\\\\localhost\\pipe\\sql\\query", "localhost", null, null, null)]
-        [InlineData("np : \\\\localhost\\pipe\\sql\\query", "localhost", null, null, null)]
-        [InlineData("np:\\\\localhost\\pipe\\MSSQL$instanceName\\sql\\query", "localhost", null, "instanceName", null)]
-        public void ParseDataSourceTests(
-            string dataSource,
-            string expectedServerHostName,
-            string expectedServerIpAddress,
-            string expectedInstanceName,
-            string expectedPort)
-        {
-            var sqlConnectionDetails = SqlClientInstrumentationOptions.ParseDataSource(dataSource);
+        Assert.Equal(expectedServerIpAddress, activity.GetTagValue(SemanticConventions.AttributeNetPeerIp));
+        Assert.Equal(expectedInstanceName, activity.GetTagValue(SemanticConventions.AttributeDbMsSqlInstanceName));
+        Assert.Equal(expectedPort, activity.GetTagValue(SemanticConventions.AttributeNetPeerPort));
+    }
 
-            Assert.NotNull(sqlConnectionDetails);
-            Assert.Equal(expectedServerHostName, sqlConnectionDetails.ServerHostName);
-            Assert.Equal(expectedServerIpAddress, sqlConnectionDetails.ServerIpAddress);
-            Assert.Equal(expectedInstanceName, sqlConnectionDetails.InstanceName);
-            Assert.Equal(expectedPort, sqlConnectionDetails.Port);
+    // Tests for v1.21.0 Semantic Conventions for database client calls.
+    // see the spec https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/database/database-spans.md
+    // This test emits the new attributes.
+    // This test method can replace the other (old) test method when this library is GA.
+    [Theory]
+    [InlineData(true, "localhost", "localhost", null, null, null)]
+    [InlineData(true, "127.0.0.1,1433", null, "127.0.0.1", null, null)]
+    [InlineData(true, "127.0.0.1,1434", null, "127.0.0.1", null, "1434")]
+    [InlineData(true, "127.0.0.1\\instanceName, 1818", null, "127.0.0.1", "instanceName", "1818")]
+    [InlineData(false, "localhost", "localhost", null, null, null)]
+    public void SqlClientInstrumentationOptions_EnableConnectionLevelAttributes_New(
+        bool enableConnectionLevelAttributes,
+        string dataSource,
+        string expectedServerHostName,
+        string expectedServerIpAddress,
+        string expectedInstanceName,
+        string expectedPort)
+    {
+        var source = new ActivitySource("sql-client-instrumentation");
+        var activity = source.StartActivity("Test Sql Activity");
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string> { [SemanticConventionOptInKeyName] = "http" })
+            .Build();
+
+        var options = new SqlClientInstrumentationOptions(configuration)
+        {
+            EnableConnectionLevelAttributes = enableConnectionLevelAttributes,
+        };
+        options.AddConnectionLevelDetailsToActivity(dataSource, activity);
+
+        if (!enableConnectionLevelAttributes)
+        {
+            Assert.Equal(expectedServerHostName, activity.GetTagValue(SemanticConventions.AttributePeerService));
+        }
+        else
+        {
+            Assert.Equal(expectedServerHostName, activity.GetTagValue(SemanticConventions.AttributeServerAddress));
         }
 
-        [Theory]
-        [InlineData(true, "localhost", "localhost", null, null, null)]
-        [InlineData(true, "127.0.0.1,1433", null, "127.0.0.1", null, null)]
-        [InlineData(true, "127.0.0.1,1434", null, "127.0.0.1", null, "1434")]
-        [InlineData(true, "127.0.0.1\\instanceName, 1818", null, "127.0.0.1", "instanceName", "1818")]
-        [InlineData(false, "localhost", "localhost", null, null, null)]
-        public void SqlClientInstrumentationOptions_EnableConnectionLevelAttributes(
-            bool enableConnectionLevelAttributes,
-            string dataSource,
-            string expectedServerHostName,
-            string expectedServerIpAddress,
-            string expectedInstanceName,
-            string expectedPort)
+        Assert.Equal(expectedServerIpAddress, activity.GetTagValue(SemanticConventions.AttributeServerSocketAddress));
+        Assert.Equal(expectedInstanceName, activity.GetTagValue(SemanticConventions.AttributeDbMsSqlInstanceName));
+        Assert.Equal(expectedPort, activity.GetTagValue(SemanticConventions.AttributeServerPort));
+    }
+
+    // Tests for v1.21.0 Semantic Conventions for database client calls.
+    // see the spec https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/database/database-spans.md
+    // This test emits both the new and older attributes.
+    // This test method can be deleted when this library is GA.
+    [Theory]
+    [InlineData(true, "localhost", "localhost", null, null, null)]
+    [InlineData(true, "127.0.0.1,1433", null, "127.0.0.1", null, null)]
+    [InlineData(true, "127.0.0.1,1434", null, "127.0.0.1", null, "1434")]
+    [InlineData(true, "127.0.0.1\\instanceName, 1818", null, "127.0.0.1", "instanceName", "1818")]
+    [InlineData(false, "localhost", "localhost", null, null, null)]
+    public void SqlClientInstrumentationOptions_EnableConnectionLevelAttributes_Dupe(
+        bool enableConnectionLevelAttributes,
+        string dataSource,
+        string expectedServerHostName,
+        string expectedServerIpAddress,
+        string expectedInstanceName,
+        string expectedPort)
+    {
+        var source = new ActivitySource("sql-client-instrumentation");
+        var activity = source.StartActivity("Test Sql Activity");
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string> { [SemanticConventionOptInKeyName] = "http/dup" })
+            .Build();
+
+        var options = new SqlClientInstrumentationOptions(configuration)
         {
-            var source = new ActivitySource("sql-client-instrumentation");
-            var activity = source.StartActivity("Test Sql Activity");
-            var options = new SqlClientInstrumentationOptions
-            {
-                EnableConnectionLevelAttributes = enableConnectionLevelAttributes,
-            };
-            options.AddConnectionLevelDetailsToActivity(dataSource, activity);
+            EnableConnectionLevelAttributes = enableConnectionLevelAttributes,
+        };
+        options.AddConnectionLevelDetailsToActivity(dataSource, activity);
 
-            if (!enableConnectionLevelAttributes)
-            {
-                Assert.Equal(expectedServerHostName, activity.GetTagValue(SemanticConventions.AttributePeerService));
-            }
-            else
-            {
-                Assert.Equal(expectedServerHostName, activity.GetTagValue(SemanticConventions.AttributeNetPeerName));
-            }
-
-            Assert.Equal(expectedServerIpAddress, activity.GetTagValue(SemanticConventions.AttributeNetPeerIp));
-            Assert.Equal(expectedInstanceName, activity.GetTagValue(SemanticConventions.AttributeDbMsSqlInstanceName));
-            Assert.Equal(expectedPort, activity.GetTagValue(SemanticConventions.AttributeNetPeerPort));
+        // New
+        if (!enableConnectionLevelAttributes)
+        {
+            Assert.Equal(expectedServerHostName, activity.GetTagValue(SemanticConventions.AttributePeerService));
+        }
+        else
+        {
+            Assert.Equal(expectedServerHostName, activity.GetTagValue(SemanticConventions.AttributeServerAddress));
         }
 
-        // Tests for v1.21.0 Semantic Conventions for database client calls.
-        // see the spec https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/database/database-spans.md
-        // This test emits the new attributes.
-        // This test method can replace the other (old) test method when this library is GA.
-        [Theory]
-        [InlineData(true, "localhost", "localhost", null, null, null)]
-        [InlineData(true, "127.0.0.1,1433", null, "127.0.0.1", null, null)]
-        [InlineData(true, "127.0.0.1,1434", null, "127.0.0.1", null, "1434")]
-        [InlineData(true, "127.0.0.1\\instanceName, 1818", null, "127.0.0.1", "instanceName", "1818")]
-        [InlineData(false, "localhost", "localhost", null, null, null)]
-        public void SqlClientInstrumentationOptions_EnableConnectionLevelAttributes_New(
-            bool enableConnectionLevelAttributes,
-            string dataSource,
-            string expectedServerHostName,
-            string expectedServerIpAddress,
-            string expectedInstanceName,
-            string expectedPort)
+        Assert.Equal(expectedServerIpAddress, activity.GetTagValue(SemanticConventions.AttributeServerSocketAddress));
+        Assert.Equal(expectedInstanceName, activity.GetTagValue(SemanticConventions.AttributeDbMsSqlInstanceName));
+        Assert.Equal(expectedPort, activity.GetTagValue(SemanticConventions.AttributeServerPort));
+
+        // Old
+        if (!enableConnectionLevelAttributes)
         {
-            var source = new ActivitySource("sql-client-instrumentation");
-            var activity = source.StartActivity("Test Sql Activity");
-
-            var configuration = new ConfigurationBuilder()
-                .AddInMemoryCollection(new Dictionary<string, string> { [SemanticConventionOptInKeyName] = "http" })
-                .Build();
-
-            var options = new SqlClientInstrumentationOptions(configuration)
-            {
-                EnableConnectionLevelAttributes = enableConnectionLevelAttributes,
-            };
-            options.AddConnectionLevelDetailsToActivity(dataSource, activity);
-
-            if (!enableConnectionLevelAttributes)
-            {
-                Assert.Equal(expectedServerHostName, activity.GetTagValue(SemanticConventions.AttributePeerService));
-            }
-            else
-            {
-                Assert.Equal(expectedServerHostName, activity.GetTagValue(SemanticConventions.AttributeServerAddress));
-            }
-
-            Assert.Equal(expectedServerIpAddress, activity.GetTagValue(SemanticConventions.AttributeServerSocketAddress));
-            Assert.Equal(expectedInstanceName, activity.GetTagValue(SemanticConventions.AttributeDbMsSqlInstanceName));
-            Assert.Equal(expectedPort, activity.GetTagValue(SemanticConventions.AttributeServerPort));
+            Assert.Equal(expectedServerHostName, activity.GetTagValue(SemanticConventions.AttributePeerService));
+        }
+        else
+        {
+            Assert.Equal(expectedServerHostName, activity.GetTagValue(SemanticConventions.AttributeNetPeerName));
         }
 
-        // Tests for v1.21.0 Semantic Conventions for database client calls.
-        // see the spec https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/database/database-spans.md
-        // This test emits both the new and older attributes.
-        // This test method can be deleted when this library is GA.
-        [Theory]
-        [InlineData(true, "localhost", "localhost", null, null, null)]
-        [InlineData(true, "127.0.0.1,1433", null, "127.0.0.1", null, null)]
-        [InlineData(true, "127.0.0.1,1434", null, "127.0.0.1", null, "1434")]
-        [InlineData(true, "127.0.0.1\\instanceName, 1818", null, "127.0.0.1", "instanceName", "1818")]
-        [InlineData(false, "localhost", "localhost", null, null, null)]
-        public void SqlClientInstrumentationOptions_EnableConnectionLevelAttributes_Dupe(
-            bool enableConnectionLevelAttributes,
-            string dataSource,
-            string expectedServerHostName,
-            string expectedServerIpAddress,
-            string expectedInstanceName,
-            string expectedPort)
-        {
-            var source = new ActivitySource("sql-client-instrumentation");
-            var activity = source.StartActivity("Test Sql Activity");
-
-            var configuration = new ConfigurationBuilder()
-                .AddInMemoryCollection(new Dictionary<string, string> { [SemanticConventionOptInKeyName] = "http/dup" })
-                .Build();
-
-            var options = new SqlClientInstrumentationOptions(configuration)
-            {
-                EnableConnectionLevelAttributes = enableConnectionLevelAttributes,
-            };
-            options.AddConnectionLevelDetailsToActivity(dataSource, activity);
-
-            // New
-            if (!enableConnectionLevelAttributes)
-            {
-                Assert.Equal(expectedServerHostName, activity.GetTagValue(SemanticConventions.AttributePeerService));
-            }
-            else
-            {
-                Assert.Equal(expectedServerHostName, activity.GetTagValue(SemanticConventions.AttributeServerAddress));
-            }
-
-            Assert.Equal(expectedServerIpAddress, activity.GetTagValue(SemanticConventions.AttributeServerSocketAddress));
-            Assert.Equal(expectedInstanceName, activity.GetTagValue(SemanticConventions.AttributeDbMsSqlInstanceName));
-            Assert.Equal(expectedPort, activity.GetTagValue(SemanticConventions.AttributeServerPort));
-
-            // Old
-            if (!enableConnectionLevelAttributes)
-            {
-                Assert.Equal(expectedServerHostName, activity.GetTagValue(SemanticConventions.AttributePeerService));
-            }
-            else
-            {
-                Assert.Equal(expectedServerHostName, activity.GetTagValue(SemanticConventions.AttributeNetPeerName));
-            }
-
-            Assert.Equal(expectedServerIpAddress, activity.GetTagValue(SemanticConventions.AttributeNetPeerIp));
-            Assert.Equal(expectedInstanceName, activity.GetTagValue(SemanticConventions.AttributeDbMsSqlInstanceName));
-            Assert.Equal(expectedPort, activity.GetTagValue(SemanticConventions.AttributeNetPeerPort));
-        }
+        Assert.Equal(expectedServerIpAddress, activity.GetTagValue(SemanticConventions.AttributeNetPeerIp));
+        Assert.Equal(expectedInstanceName, activity.GetTagValue(SemanticConventions.AttributeDbMsSqlInstanceName));
+        Assert.Equal(expectedPort, activity.GetTagValue(SemanticConventions.AttributeNetPeerPort));
     }
 }

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientIntegrationTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientIntegrationTests.cs
@@ -25,107 +25,106 @@ using Testcontainers.MsSql;
 using Testcontainers.SqlEdge;
 using Xunit;
 
-namespace OpenTelemetry.Instrumentation.SqlClient.Tests
+namespace OpenTelemetry.Instrumentation.SqlClient.Tests;
+
+public sealed class SqlClientIntegrationTests : IAsyncLifetime
 {
-    public sealed class SqlClientIntegrationTests : IAsyncLifetime
+    // The Microsoft SQL Server Docker image is not compatible with ARM devices, such as Macs with Apple Silicon.
+    private readonly IContainer databaseContainer = Architecture.Arm64.Equals(RuntimeInformation.ProcessArchitecture) ? new SqlEdgeBuilder().Build() : new MsSqlBuilder().Build();
+
+    public Task InitializeAsync()
     {
-        // The Microsoft SQL Server Docker image is not compatible with ARM devices, such as Macs with Apple Silicon.
-        private readonly IContainer databaseContainer = Architecture.Arm64.Equals(RuntimeInformation.ProcessArchitecture) ? new SqlEdgeBuilder().Build() : new MsSqlBuilder().Build();
+        return this.databaseContainer.StartAsync();
+    }
 
-        public Task InitializeAsync()
-        {
-            return this.databaseContainer.StartAsync();
-        }
+    public Task DisposeAsync()
+    {
+        return this.databaseContainer.DisposeAsync().AsTask();
+    }
 
-        public Task DisposeAsync()
-        {
-            return this.databaseContainer.DisposeAsync().AsTask();
-        }
-
-        [Trait("CategoryName", "SqlIntegrationTests")]
-        [EnabledOnDockerPlatformTheory(EnabledOnDockerPlatformTheoryAttribute.DockerPlatform.Linux)]
-        [InlineData(CommandType.Text, "select 1/1", false)]
-        [InlineData(CommandType.Text, "select 1/1", false, true)]
-        [InlineData(CommandType.Text, "select 1/0", false, false, true)]
-        [InlineData(CommandType.Text, "select 1/0", false, false, true, false, false)]
-        [InlineData(CommandType.Text, "select 1/0", false, false, true, true, false)]
-        [InlineData(CommandType.StoredProcedure, "sp_who", false)]
-        [InlineData(CommandType.StoredProcedure, "sp_who", true)]
-        public void SuccessfulCommandTest(
-            CommandType commandType,
-            string commandText,
-            bool captureStoredProcedureCommandName,
-            bool captureTextCommandContent = false,
-            bool isFailure = false,
-            bool recordException = false,
-            bool shouldEnrich = true)
-        {
+    [Trait("CategoryName", "SqlIntegrationTests")]
+    [EnabledOnDockerPlatformTheory(EnabledOnDockerPlatformTheoryAttribute.DockerPlatform.Linux)]
+    [InlineData(CommandType.Text, "select 1/1", false)]
+    [InlineData(CommandType.Text, "select 1/1", false, true)]
+    [InlineData(CommandType.Text, "select 1/0", false, false, true)]
+    [InlineData(CommandType.Text, "select 1/0", false, false, true, false, false)]
+    [InlineData(CommandType.Text, "select 1/0", false, false, true, true, false)]
+    [InlineData(CommandType.StoredProcedure, "sp_who", false)]
+    [InlineData(CommandType.StoredProcedure, "sp_who", true)]
+    public void SuccessfulCommandTest(
+        CommandType commandType,
+        string commandText,
+        bool captureStoredProcedureCommandName,
+        bool captureTextCommandContent = false,
+        bool isFailure = false,
+        bool recordException = false,
+        bool shouldEnrich = true)
+    {
 #if NETFRAMEWORK
-            // Disable things not available on netfx
-            recordException = false;
-            shouldEnrich = false;
+        // Disable things not available on netfx
+        recordException = false;
+        shouldEnrich = false;
 #endif
 
-            var sampler = new TestSampler();
-            var activities = new List<Activity>();
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-                .SetSampler(sampler)
-                .AddInMemoryExporter(activities)
-                .AddSqlClientInstrumentation(options =>
-                {
+        var sampler = new TestSampler();
+        var activities = new List<Activity>();
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .SetSampler(sampler)
+            .AddInMemoryExporter(activities)
+            .AddSqlClientInstrumentation(options =>
+            {
 #if !NETFRAMEWORK
-                    options.SetDbStatementForStoredProcedure = captureStoredProcedureCommandName;
-                    options.SetDbStatementForText = captureTextCommandContent;
+                options.SetDbStatementForStoredProcedure = captureStoredProcedureCommandName;
+                options.SetDbStatementForText = captureTextCommandContent;
 #else
-                    options.SetDbStatementForText = captureStoredProcedureCommandName || captureTextCommandContent;
+                options.SetDbStatementForText = captureStoredProcedureCommandName || captureTextCommandContent;
 #endif
-                    options.RecordException = recordException;
-                    if (shouldEnrich)
-                    {
-                        options.Enrich = SqlClientTests.ActivityEnrichment;
-                    }
-                })
-                .Build();
+                options.RecordException = recordException;
+                if (shouldEnrich)
+                {
+                    options.Enrich = SqlClientTests.ActivityEnrichment;
+                }
+            })
+            .Build();
 
-            using SqlConnection sqlConnection = new SqlConnection(this.GetConnectionString());
+        using SqlConnection sqlConnection = new SqlConnection(this.GetConnectionString());
 
-            sqlConnection.Open();
+        sqlConnection.Open();
 
-            string dataSource = sqlConnection.DataSource;
+        string dataSource = sqlConnection.DataSource;
 
-            sqlConnection.ChangeDatabase("master");
+        sqlConnection.ChangeDatabase("master");
 
-            using SqlCommand sqlCommand = new SqlCommand(commandText, sqlConnection)
-            {
-                CommandType = commandType,
-            };
+        using SqlCommand sqlCommand = new SqlCommand(commandText, sqlConnection)
+        {
+            CommandType = commandType,
+        };
 
-            try
-            {
-                sqlCommand.ExecuteNonQuery();
-            }
-            catch
-            {
-            }
-
-            Assert.Single(activities);
-            var activity = activities[0];
-
-            SqlClientTests.VerifyActivityData(commandType, commandText, captureStoredProcedureCommandName, captureTextCommandContent, isFailure, recordException, shouldEnrich, dataSource, activity);
-            SqlClientTests.VerifySamplingParameters(sampler.LatestSamplingParameters);
+        try
+        {
+            sqlCommand.ExecuteNonQuery();
+        }
+        catch
+        {
         }
 
-        private string GetConnectionString()
+        Assert.Single(activities);
+        var activity = activities[0];
+
+        SqlClientTests.VerifyActivityData(commandType, commandText, captureStoredProcedureCommandName, captureTextCommandContent, isFailure, recordException, shouldEnrich, dataSource, activity);
+        SqlClientTests.VerifySamplingParameters(sampler.LatestSamplingParameters);
+    }
+
+    private string GetConnectionString()
+    {
+        switch (this.databaseContainer)
         {
-            switch (this.databaseContainer)
-            {
-                case SqlEdgeContainer container:
-                    return container.GetConnectionString();
-                case MsSqlContainer container:
-                    return container.GetConnectionString();
-                default:
-                    throw new InvalidOperationException($"Container type ${this.databaseContainer.GetType().Name} not supported.");
-            }
+            case SqlEdgeContainer container:
+                return container.GetConnectionString();
+            case MsSqlContainer container:
+                return container.GetConnectionString();
+            default:
+                throw new InvalidOperationException($"Container type ${this.databaseContainer.GetType().Name} not supported.");
         }
     }
 }

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
@@ -23,456 +23,455 @@ using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
 using Xunit;
 
-namespace OpenTelemetry.Instrumentation.SqlClient.Tests
+namespace OpenTelemetry.Instrumentation.SqlClient.Tests;
+
+public class SqlClientTests : IDisposable
 {
-    public class SqlClientTests : IDisposable
+    private const string TestConnectionString = "Data Source=(localdb)\\MSSQLLocalDB;Database=master";
+
+    private readonly FakeSqlClientDiagnosticSource fakeSqlClientDiagnosticSource;
+
+    public SqlClientTests()
     {
-        private const string TestConnectionString = "Data Source=(localdb)\\MSSQLLocalDB;Database=master";
+        this.fakeSqlClientDiagnosticSource = new FakeSqlClientDiagnosticSource();
+    }
 
-        private readonly FakeSqlClientDiagnosticSource fakeSqlClientDiagnosticSource;
+    public void Dispose()
+    {
+        this.fakeSqlClientDiagnosticSource.Dispose();
+        GC.SuppressFinalize(this);
+    }
 
-        public SqlClientTests()
+    [Fact]
+    public void SqlClient_BadArgs()
+    {
+        TracerProviderBuilder builder = null;
+        Assert.Throws<ArgumentNullException>(() => builder.AddSqlClientInstrumentation());
+    }
+
+    [Fact]
+    public void SqlClient_NamedOptions()
+    {
+        int defaultExporterOptionsConfigureOptionsInvocations = 0;
+        int namedExporterOptionsConfigureOptionsInvocations = 0;
+
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .ConfigureServices(services =>
+            {
+                services.Configure<SqlClientInstrumentationOptions>(o => defaultExporterOptionsConfigureOptionsInvocations++);
+
+                services.Configure<SqlClientInstrumentationOptions>("Instrumentation2", o => namedExporterOptionsConfigureOptionsInvocations++);
+            })
+            .AddSqlClientInstrumentation()
+            .AddSqlClientInstrumentation("Instrumentation2", configureSqlClientInstrumentationOptions: null)
+            .Build();
+
+        Assert.Equal(1, defaultExporterOptionsConfigureOptionsInvocations);
+        Assert.Equal(1, namedExporterOptionsConfigureOptionsInvocations);
+    }
+
+    // DiagnosticListener-based instrumentation is only available on .NET Core
+#if !NETFRAMEWORK
+    [Theory]
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", true, false)]
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", true, false, false)]
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.Text, "select * from sys.databases", true, false)]
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.Text, "select * from sys.databases", true, false, false)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", false, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", false, true, false)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.Text, "select * from sys.databases", false, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.Text, "select * from sys.databases", false, true, false)]
+    public void SqlClientCallsAreCollectedSuccessfully(
+        string beforeCommand,
+        string afterCommand,
+        CommandType commandType,
+        string commandText,
+        bool captureStoredProcedureCommandName,
+        bool captureTextCommandContent,
+        bool shouldEnrich = true)
+    {
+        using var sqlConnection = new SqlConnection(TestConnectionString);
+        using var sqlCommand = sqlConnection.CreateCommand();
+
+        var activities = new List<Activity>();
+        using (Sdk.CreateTracerProviderBuilder()
+                .AddSqlClientInstrumentation(
+                    (opt) =>
+                    {
+                        opt.SetDbStatementForText = captureTextCommandContent;
+                        opt.SetDbStatementForStoredProcedure = captureStoredProcedureCommandName;
+                        if (shouldEnrich)
+                        {
+                            opt.Enrich = ActivityEnrichment;
+                        }
+                    })
+                .AddInMemoryExporter(activities)
+                .Build())
         {
-            this.fakeSqlClientDiagnosticSource = new FakeSqlClientDiagnosticSource();
+            var operationId = Guid.NewGuid();
+            sqlCommand.CommandType = commandType;
+            sqlCommand.CommandText = commandText;
+
+            var beforeExecuteEventData = new
+            {
+                OperationId = operationId,
+                Command = sqlCommand,
+                Timestamp = (long?)1000000L,
+            };
+
+            this.fakeSqlClientDiagnosticSource.Write(
+                beforeCommand,
+                beforeExecuteEventData);
+
+            var afterExecuteEventData = new
+            {
+                OperationId = operationId,
+                Command = sqlCommand,
+                Timestamp = 2000000L,
+            };
+
+            this.fakeSqlClientDiagnosticSource.Write(
+                afterCommand,
+                afterExecuteEventData);
+        }
+
+        Assert.Single(activities);
+        var activity = activities[0];
+
+        VerifyActivityData(
+            sqlCommand.CommandType,
+            sqlCommand.CommandText,
+            captureStoredProcedureCommandName,
+            captureTextCommandContent,
+            false,
+            false,
+            shouldEnrich,
+            sqlConnection.DataSource,
+            activity);
+    }
+
+    [Theory]
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataWriteCommandError)]
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataWriteCommandError, false)]
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataWriteCommandError, false, true)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftWriteCommandError)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftWriteCommandError, false)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftWriteCommandError, false, true)]
+    public void SqlClientErrorsAreCollectedSuccessfully(string beforeCommand, string errorCommand, bool shouldEnrich = true, bool recordException = false)
+    {
+        using var sqlConnection = new SqlConnection(TestConnectionString);
+        using var sqlCommand = sqlConnection.CreateCommand();
+
+        var activities = new List<Activity>();
+        using (Sdk.CreateTracerProviderBuilder()
+            .AddSqlClientInstrumentation(options =>
+            {
+                options.RecordException = recordException;
+                if (shouldEnrich)
+                {
+                    options.Enrich = ActivityEnrichment;
+                }
+            })
+            .AddInMemoryExporter(activities)
+            .Build())
+        {
+            var operationId = Guid.NewGuid();
+            sqlCommand.CommandText = "SP_GetOrders";
+            sqlCommand.CommandType = CommandType.StoredProcedure;
+
+            var beforeExecuteEventData = new
+            {
+                OperationId = operationId,
+                Command = sqlCommand,
+                Timestamp = (long?)1000000L,
+            };
+
+            this.fakeSqlClientDiagnosticSource.Write(
+                beforeCommand,
+                beforeExecuteEventData);
+
+            var commandErrorEventData = new
+            {
+                OperationId = operationId,
+                Command = sqlCommand,
+                Exception = new Exception("Boom!"),
+                Timestamp = 2000000L,
+            };
+
+            this.fakeSqlClientDiagnosticSource.Write(
+                errorCommand,
+                commandErrorEventData);
+        }
+
+        Assert.Single(activities);
+        var activity = activities[0];
+
+        VerifyActivityData(
+            sqlCommand.CommandType,
+            sqlCommand.CommandText,
+            true,
+            false,
+            true,
+            recordException,
+            shouldEnrich,
+            sqlConnection.DataSource,
+            activity);
+    }
+
+    [Theory]
+    [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand)]
+    [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand)]
+    public void SqlClientCreatesActivityWithDbSystem(
+        string beforeCommand)
+    {
+        using var sqlConnection = new SqlConnection(TestConnectionString);
+        using var sqlCommand = sqlConnection.CreateCommand();
+
+        var sampler = new TestSampler
+        {
+            SamplingAction = _ => new SamplingResult(SamplingDecision.Drop),
+        };
+        using (Sdk.CreateTracerProviderBuilder()
+            .AddSqlClientInstrumentation()
+            .SetSampler(sampler)
+            .Build())
+        {
+            this.fakeSqlClientDiagnosticSource.Write(beforeCommand, new { });
+        }
+
+        VerifySamplingParameters(sampler.LatestSamplingParameters);
+    }
+
+    [Fact]
+    public void ShouldCollectTelemetryWhenFilterEvaluatesToTrue()
+    {
+        var activities = this.RunCommandWithFilter(
+            cmd =>
+            {
+                cmd.CommandText = "select 2";
+            },
+            cmd =>
+            {
+                if (cmd is SqlCommand command)
+                {
+                    return command.CommandText == "select 2";
+                }
+
+                return true;
+            });
+
+        Assert.Single(activities);
+        Assert.True(activities[0].IsAllDataRequested);
+        Assert.True(activities[0].ActivityTraceFlags.HasFlag(ActivityTraceFlags.Recorded));
+    }
+
+    [Fact]
+    public void ShouldNotCollectTelemetryWhenFilterEvaluatesToFalse()
+    {
+        var activities = this.RunCommandWithFilter(
+            cmd =>
+            {
+                cmd.CommandText = "select 1";
+            },
+            cmd =>
+            {
+                if (cmd is SqlCommand command)
+                {
+                    return command.CommandText == "select 2";
+                }
+
+                return true;
+            });
+
+        Assert.Empty(activities);
+    }
+
+    [Fact]
+    public void ShouldNotCollectTelemetryAndShouldNotPropagateExceptionWhenFilterThrowsException()
+    {
+        var activities = this.RunCommandWithFilter(
+            cmd =>
+            {
+                cmd.CommandText = "select 1";
+            },
+            cmd => throw new InvalidOperationException("foobar"));
+
+        Assert.Empty(activities);
+    }
+#endif
+
+    internal static void VerifyActivityData(
+        CommandType commandType,
+        string commandText,
+        bool captureStoredProcedureCommandName,
+        bool captureTextCommandContent,
+        bool isFailure,
+        bool recordException,
+        bool shouldEnrich,
+        string dataSource,
+        Activity activity)
+    {
+        Assert.Equal("master", activity.DisplayName);
+        Assert.Equal(ActivityKind.Client, activity.Kind);
+
+        if (!isFailure)
+        {
+            Assert.Equal(ActivityStatusCode.Unset, activity.Status);
+        }
+        else
+        {
+            var status = activity.GetStatus();
+            Assert.Equal(ActivityStatusCode.Error, activity.Status);
+            Assert.NotNull(activity.StatusDescription);
+
+            if (recordException)
+            {
+                var events = activity.Events.ToList();
+                Assert.Single(events);
+
+                Assert.Equal(SemanticConventions.AttributeExceptionEventName, events[0].Name);
+            }
+            else
+            {
+                Assert.Empty(activity.Events);
+            }
+        }
+
+        if (shouldEnrich)
+        {
+            Assert.NotEmpty(activity.Tags.Where(tag => tag.Key == "enriched"));
+            Assert.Equal("yes", activity.Tags.Where(tag => tag.Key == "enriched").FirstOrDefault().Value);
+        }
+        else
+        {
+            Assert.Empty(activity.Tags.Where(tag => tag.Key == "enriched"));
+        }
+
+        Assert.Equal(SqlActivitySourceHelper.MicrosoftSqlServerDatabaseSystemName, activity.GetTagValue(SemanticConventions.AttributeDbSystem));
+        Assert.Equal("master", activity.GetTagValue(SemanticConventions.AttributeDbName));
+
+        switch (commandType)
+        {
+            case CommandType.StoredProcedure:
+                if (captureStoredProcedureCommandName)
+                {
+                    Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbStatement));
+                }
+                else
+                {
+                    Assert.Null(activity.GetTagValue(SemanticConventions.AttributeDbStatement));
+                }
+
+                break;
+
+            case CommandType.Text:
+                if (captureTextCommandContent)
+                {
+                    Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbStatement));
+                }
+                else
+                {
+                    Assert.Null(activity.GetTagValue(SemanticConventions.AttributeDbStatement));
+                }
+
+                break;
+        }
+
+        Assert.Equal(dataSource, activity.GetTagValue(SemanticConventions.AttributePeerService));
+    }
+
+    internal static void VerifySamplingParameters(SamplingParameters samplingParameters)
+    {
+        Assert.NotNull(samplingParameters.Tags);
+        Assert.Contains(
+            samplingParameters.Tags,
+            kvp => kvp.Key == SemanticConventions.AttributeDbSystem
+                   && (string)kvp.Value == SqlActivitySourceHelper.MicrosoftSqlServerDatabaseSystemName);
+    }
+
+    internal static void ActivityEnrichment(Activity activity, string method, object obj)
+    {
+        activity.SetTag("enriched", "yes");
+
+        switch (method)
+        {
+            case "OnCustom":
+                Assert.True(obj is SqlCommand);
+                break;
+
+            default:
+                break;
+        }
+    }
+
+#if !NETFRAMEWORK
+    private Activity[] RunCommandWithFilter(
+        Action<SqlCommand> sqlCommandSetup,
+        Func<object, bool> filter)
+    {
+        using var sqlConnection = new SqlConnection(TestConnectionString);
+        using var sqlCommand = sqlConnection.CreateCommand();
+
+        var activities = new List<Activity>();
+        using (Sdk.CreateTracerProviderBuilder()
+           .AddSqlClientInstrumentation(
+               options =>
+               {
+                   options.Filter = filter;
+               })
+           .AddInMemoryExporter(activities)
+           .Build())
+        {
+            var operationId = Guid.NewGuid();
+            sqlCommandSetup(sqlCommand);
+
+            var beforeExecuteEventData = new
+            {
+                OperationId = operationId,
+                Command = sqlCommand,
+                Timestamp = (long?)1000000L,
+            };
+
+            this.fakeSqlClientDiagnosticSource.Write(
+                SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand,
+                beforeExecuteEventData);
+
+            var afterExecuteEventData = new
+            {
+                OperationId = operationId,
+                Command = sqlCommand,
+                Timestamp = 2000000L,
+            };
+
+            this.fakeSqlClientDiagnosticSource.Write(
+                SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand,
+                afterExecuteEventData);
+        }
+
+        return activities.ToArray();
+    }
+#endif
+
+    private class FakeSqlClientDiagnosticSource : IDisposable
+    {
+        private readonly DiagnosticListener listener;
+
+        public FakeSqlClientDiagnosticSource()
+        {
+            this.listener = new DiagnosticListener(SqlClientInstrumentation.SqlClientDiagnosticListenerName);
+        }
+
+        public void Write(string name, object value)
+        {
+            if (this.listener.IsEnabled(name))
+            {
+                this.listener.Write(name, value);
+            }
         }
 
         public void Dispose()
         {
-            this.fakeSqlClientDiagnosticSource.Dispose();
-            GC.SuppressFinalize(this);
-        }
-
-        [Fact]
-        public void SqlClient_BadArgs()
-        {
-            TracerProviderBuilder builder = null;
-            Assert.Throws<ArgumentNullException>(() => builder.AddSqlClientInstrumentation());
-        }
-
-        [Fact]
-        public void SqlClient_NamedOptions()
-        {
-            int defaultExporterOptionsConfigureOptionsInvocations = 0;
-            int namedExporterOptionsConfigureOptionsInvocations = 0;
-
-            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-                .ConfigureServices(services =>
-                {
-                    services.Configure<SqlClientInstrumentationOptions>(o => defaultExporterOptionsConfigureOptionsInvocations++);
-
-                    services.Configure<SqlClientInstrumentationOptions>("Instrumentation2", o => namedExporterOptionsConfigureOptionsInvocations++);
-                })
-                .AddSqlClientInstrumentation()
-                .AddSqlClientInstrumentation("Instrumentation2", configureSqlClientInstrumentationOptions: null)
-                .Build();
-
-            Assert.Equal(1, defaultExporterOptionsConfigureOptionsInvocations);
-            Assert.Equal(1, namedExporterOptionsConfigureOptionsInvocations);
-        }
-
-        // DiagnosticListener-based instrumentation is only available on .NET Core
-#if !NETFRAMEWORK
-        [Theory]
-        [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", true, false)]
-        [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", true, false, false)]
-        [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.Text, "select * from sys.databases", true, false)]
-        [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataAfterExecuteCommand, CommandType.Text, "select * from sys.databases", true, false, false)]
-        [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", false, true)]
-        [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.StoredProcedure, "SP_GetOrders", false, true, false)]
-        [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.Text, "select * from sys.databases", false, true)]
-        [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand, CommandType.Text, "select * from sys.databases", false, true, false)]
-        public void SqlClientCallsAreCollectedSuccessfully(
-            string beforeCommand,
-            string afterCommand,
-            CommandType commandType,
-            string commandText,
-            bool captureStoredProcedureCommandName,
-            bool captureTextCommandContent,
-            bool shouldEnrich = true)
-        {
-            using var sqlConnection = new SqlConnection(TestConnectionString);
-            using var sqlCommand = sqlConnection.CreateCommand();
-
-            var activities = new List<Activity>();
-            using (Sdk.CreateTracerProviderBuilder()
-                    .AddSqlClientInstrumentation(
-                        (opt) =>
-                        {
-                            opt.SetDbStatementForText = captureTextCommandContent;
-                            opt.SetDbStatementForStoredProcedure = captureStoredProcedureCommandName;
-                            if (shouldEnrich)
-                            {
-                                opt.Enrich = ActivityEnrichment;
-                            }
-                        })
-                    .AddInMemoryExporter(activities)
-                    .Build())
-            {
-                var operationId = Guid.NewGuid();
-                sqlCommand.CommandType = commandType;
-                sqlCommand.CommandText = commandText;
-
-                var beforeExecuteEventData = new
-                {
-                    OperationId = operationId,
-                    Command = sqlCommand,
-                    Timestamp = (long?)1000000L,
-                };
-
-                this.fakeSqlClientDiagnosticSource.Write(
-                    beforeCommand,
-                    beforeExecuteEventData);
-
-                var afterExecuteEventData = new
-                {
-                    OperationId = operationId,
-                    Command = sqlCommand,
-                    Timestamp = 2000000L,
-                };
-
-                this.fakeSqlClientDiagnosticSource.Write(
-                    afterCommand,
-                    afterExecuteEventData);
-            }
-
-            Assert.Single(activities);
-            var activity = activities[0];
-
-            VerifyActivityData(
-                sqlCommand.CommandType,
-                sqlCommand.CommandText,
-                captureStoredProcedureCommandName,
-                captureTextCommandContent,
-                false,
-                false,
-                shouldEnrich,
-                sqlConnection.DataSource,
-                activity);
-        }
-
-        [Theory]
-        [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataWriteCommandError)]
-        [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataWriteCommandError, false)]
-        [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand, SqlClientDiagnosticListener.SqlDataWriteCommandError, false, true)]
-        [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftWriteCommandError)]
-        [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftWriteCommandError, false)]
-        [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand, SqlClientDiagnosticListener.SqlMicrosoftWriteCommandError, false, true)]
-        public void SqlClientErrorsAreCollectedSuccessfully(string beforeCommand, string errorCommand, bool shouldEnrich = true, bool recordException = false)
-        {
-            using var sqlConnection = new SqlConnection(TestConnectionString);
-            using var sqlCommand = sqlConnection.CreateCommand();
-
-            var activities = new List<Activity>();
-            using (Sdk.CreateTracerProviderBuilder()
-                .AddSqlClientInstrumentation(options =>
-                {
-                    options.RecordException = recordException;
-                    if (shouldEnrich)
-                    {
-                        options.Enrich = ActivityEnrichment;
-                    }
-                })
-                .AddInMemoryExporter(activities)
-                .Build())
-            {
-                var operationId = Guid.NewGuid();
-                sqlCommand.CommandText = "SP_GetOrders";
-                sqlCommand.CommandType = CommandType.StoredProcedure;
-
-                var beforeExecuteEventData = new
-                {
-                    OperationId = operationId,
-                    Command = sqlCommand,
-                    Timestamp = (long?)1000000L,
-                };
-
-                this.fakeSqlClientDiagnosticSource.Write(
-                    beforeCommand,
-                    beforeExecuteEventData);
-
-                var commandErrorEventData = new
-                {
-                    OperationId = operationId,
-                    Command = sqlCommand,
-                    Exception = new Exception("Boom!"),
-                    Timestamp = 2000000L,
-                };
-
-                this.fakeSqlClientDiagnosticSource.Write(
-                    errorCommand,
-                    commandErrorEventData);
-            }
-
-            Assert.Single(activities);
-            var activity = activities[0];
-
-            VerifyActivityData(
-                sqlCommand.CommandType,
-                sqlCommand.CommandText,
-                true,
-                false,
-                true,
-                recordException,
-                shouldEnrich,
-                sqlConnection.DataSource,
-                activity);
-        }
-
-        [Theory]
-        [InlineData(SqlClientDiagnosticListener.SqlDataBeforeExecuteCommand)]
-        [InlineData(SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand)]
-        public void SqlClientCreatesActivityWithDbSystem(
-            string beforeCommand)
-        {
-            using var sqlConnection = new SqlConnection(TestConnectionString);
-            using var sqlCommand = sqlConnection.CreateCommand();
-
-            var sampler = new TestSampler
-            {
-                SamplingAction = _ => new SamplingResult(SamplingDecision.Drop),
-            };
-            using (Sdk.CreateTracerProviderBuilder()
-                .AddSqlClientInstrumentation()
-                .SetSampler(sampler)
-                .Build())
-            {
-                this.fakeSqlClientDiagnosticSource.Write(beforeCommand, new { });
-            }
-
-            VerifySamplingParameters(sampler.LatestSamplingParameters);
-        }
-
-        [Fact]
-        public void ShouldCollectTelemetryWhenFilterEvaluatesToTrue()
-        {
-            var activities = this.RunCommandWithFilter(
-                cmd =>
-                {
-                    cmd.CommandText = "select 2";
-                },
-                cmd =>
-                {
-                    if (cmd is SqlCommand command)
-                    {
-                        return command.CommandText == "select 2";
-                    }
-
-                    return true;
-                });
-
-            Assert.Single(activities);
-            Assert.True(activities[0].IsAllDataRequested);
-            Assert.True(activities[0].ActivityTraceFlags.HasFlag(ActivityTraceFlags.Recorded));
-        }
-
-        [Fact]
-        public void ShouldNotCollectTelemetryWhenFilterEvaluatesToFalse()
-        {
-            var activities = this.RunCommandWithFilter(
-                cmd =>
-                {
-                    cmd.CommandText = "select 1";
-                },
-                cmd =>
-                {
-                    if (cmd is SqlCommand command)
-                    {
-                        return command.CommandText == "select 2";
-                    }
-
-                    return true;
-                });
-
-            Assert.Empty(activities);
-        }
-
-        [Fact]
-        public void ShouldNotCollectTelemetryAndShouldNotPropagateExceptionWhenFilterThrowsException()
-        {
-            var activities = this.RunCommandWithFilter(
-                cmd =>
-                {
-                    cmd.CommandText = "select 1";
-                },
-                cmd => throw new InvalidOperationException("foobar"));
-
-            Assert.Empty(activities);
-        }
-#endif
-
-        internal static void VerifyActivityData(
-            CommandType commandType,
-            string commandText,
-            bool captureStoredProcedureCommandName,
-            bool captureTextCommandContent,
-            bool isFailure,
-            bool recordException,
-            bool shouldEnrich,
-            string dataSource,
-            Activity activity)
-        {
-            Assert.Equal("master", activity.DisplayName);
-            Assert.Equal(ActivityKind.Client, activity.Kind);
-
-            if (!isFailure)
-            {
-                Assert.Equal(ActivityStatusCode.Unset, activity.Status);
-            }
-            else
-            {
-                var status = activity.GetStatus();
-                Assert.Equal(ActivityStatusCode.Error, activity.Status);
-                Assert.NotNull(activity.StatusDescription);
-
-                if (recordException)
-                {
-                    var events = activity.Events.ToList();
-                    Assert.Single(events);
-
-                    Assert.Equal(SemanticConventions.AttributeExceptionEventName, events[0].Name);
-                }
-                else
-                {
-                    Assert.Empty(activity.Events);
-                }
-            }
-
-            if (shouldEnrich)
-            {
-                Assert.NotEmpty(activity.Tags.Where(tag => tag.Key == "enriched"));
-                Assert.Equal("yes", activity.Tags.Where(tag => tag.Key == "enriched").FirstOrDefault().Value);
-            }
-            else
-            {
-                Assert.Empty(activity.Tags.Where(tag => tag.Key == "enriched"));
-            }
-
-            Assert.Equal(SqlActivitySourceHelper.MicrosoftSqlServerDatabaseSystemName, activity.GetTagValue(SemanticConventions.AttributeDbSystem));
-            Assert.Equal("master", activity.GetTagValue(SemanticConventions.AttributeDbName));
-
-            switch (commandType)
-            {
-                case CommandType.StoredProcedure:
-                    if (captureStoredProcedureCommandName)
-                    {
-                        Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbStatement));
-                    }
-                    else
-                    {
-                        Assert.Null(activity.GetTagValue(SemanticConventions.AttributeDbStatement));
-                    }
-
-                    break;
-
-                case CommandType.Text:
-                    if (captureTextCommandContent)
-                    {
-                        Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbStatement));
-                    }
-                    else
-                    {
-                        Assert.Null(activity.GetTagValue(SemanticConventions.AttributeDbStatement));
-                    }
-
-                    break;
-            }
-
-            Assert.Equal(dataSource, activity.GetTagValue(SemanticConventions.AttributePeerService));
-        }
-
-        internal static void VerifySamplingParameters(SamplingParameters samplingParameters)
-        {
-            Assert.NotNull(samplingParameters.Tags);
-            Assert.Contains(
-                samplingParameters.Tags,
-                kvp => kvp.Key == SemanticConventions.AttributeDbSystem
-                       && (string)kvp.Value == SqlActivitySourceHelper.MicrosoftSqlServerDatabaseSystemName);
-        }
-
-        internal static void ActivityEnrichment(Activity activity, string method, object obj)
-        {
-            activity.SetTag("enriched", "yes");
-
-            switch (method)
-            {
-                case "OnCustom":
-                    Assert.True(obj is SqlCommand);
-                    break;
-
-                default:
-                    break;
-            }
-        }
-
-#if !NETFRAMEWORK
-        private Activity[] RunCommandWithFilter(
-            Action<SqlCommand> sqlCommandSetup,
-            Func<object, bool> filter)
-        {
-            using var sqlConnection = new SqlConnection(TestConnectionString);
-            using var sqlCommand = sqlConnection.CreateCommand();
-
-            var activities = new List<Activity>();
-            using (Sdk.CreateTracerProviderBuilder()
-               .AddSqlClientInstrumentation(
-                   options =>
-                   {
-                       options.Filter = filter;
-                   })
-               .AddInMemoryExporter(activities)
-               .Build())
-            {
-                var operationId = Guid.NewGuid();
-                sqlCommandSetup(sqlCommand);
-
-                var beforeExecuteEventData = new
-                {
-                    OperationId = operationId,
-                    Command = sqlCommand,
-                    Timestamp = (long?)1000000L,
-                };
-
-                this.fakeSqlClientDiagnosticSource.Write(
-                    SqlClientDiagnosticListener.SqlMicrosoftBeforeExecuteCommand,
-                    beforeExecuteEventData);
-
-                var afterExecuteEventData = new
-                {
-                    OperationId = operationId,
-                    Command = sqlCommand,
-                    Timestamp = 2000000L,
-                };
-
-                this.fakeSqlClientDiagnosticSource.Write(
-                    SqlClientDiagnosticListener.SqlMicrosoftAfterExecuteCommand,
-                    afterExecuteEventData);
-            }
-
-            return activities.ToArray();
-        }
-#endif
-
-        private class FakeSqlClientDiagnosticSource : IDisposable
-        {
-            private readonly DiagnosticListener listener;
-
-            public FakeSqlClientDiagnosticSource()
-            {
-                this.listener = new DiagnosticListener(SqlClientInstrumentation.SqlClientDiagnosticListenerName);
-            }
-
-            public void Write(string name, object value)
-            {
-                if (this.listener.IsEnabled(name))
-                {
-                    this.listener.Write(name, value);
-                }
-            }
-
-            public void Dispose()
-            {
-                this.listener.Dispose();
-            }
+            this.listener.Dispose();
         }
     }
 }

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
@@ -27,362 +27,361 @@ using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
 using Xunit;
 
-namespace OpenTelemetry.Instrumentation.SqlClient.Tests
+namespace OpenTelemetry.Instrumentation.SqlClient.Tests;
+
+public class SqlEventSourceTests
 {
-    public class SqlEventSourceTests
+    /*
+        To run the integration tests, set the OTEL_SQLCONNECTIONSTRING machine-level environment variable to a valid Sql Server connection string.
+
+        To use Docker...
+         1) Run: docker run -d --name sql2019 -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Pass@word" -p 5433:1433 mcr.microsoft.com/mssql/server:2019-latest
+         2) Set OTEL_SQLCONNECTIONSTRING as: Data Source=127.0.0.1,5433; User ID=sa; Password=Pass@word
+     */
+
+    private const string SqlConnectionStringEnvVarName = "OTEL_SQLCONNECTIONSTRING";
+    private static readonly string SqlConnectionString = SkipUnlessEnvVarFoundTheoryAttribute.GetEnvironmentVariable(SqlConnectionStringEnvVarName);
+
+    [Trait("CategoryName", "SqlIntegrationTests")]
+    [SkipUnlessEnvVarFoundTheory(SqlConnectionStringEnvVarName)]
+    [InlineData(CommandType.Text, "select 1/1", false)]
+    [InlineData(CommandType.Text, "select 1/0", false, true)]
+    [InlineData(CommandType.StoredProcedure, "sp_who", false)]
+    [InlineData(CommandType.StoredProcedure, "sp_who", true)]
+    public async Task SuccessfulCommandTest(CommandType commandType, string commandText, bool captureText, bool isFailure = false)
     {
-        /*
-            To run the integration tests, set the OTEL_SQLCONNECTIONSTRING machine-level environment variable to a valid Sql Server connection string.
-
-            To use Docker...
-             1) Run: docker run -d --name sql2019 -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Pass@word" -p 5433:1433 mcr.microsoft.com/mssql/server:2019-latest
-             2) Set OTEL_SQLCONNECTIONSTRING as: Data Source=127.0.0.1,5433; User ID=sa; Password=Pass@word
-         */
-
-        private const string SqlConnectionStringEnvVarName = "OTEL_SQLCONNECTIONSTRING";
-        private static readonly string SqlConnectionString = SkipUnlessEnvVarFoundTheoryAttribute.GetEnvironmentVariable(SqlConnectionStringEnvVarName);
-
-        [Trait("CategoryName", "SqlIntegrationTests")]
-        [SkipUnlessEnvVarFoundTheory(SqlConnectionStringEnvVarName)]
-        [InlineData(CommandType.Text, "select 1/1", false)]
-        [InlineData(CommandType.Text, "select 1/0", false, true)]
-        [InlineData(CommandType.StoredProcedure, "sp_who", false)]
-        [InlineData(CommandType.StoredProcedure, "sp_who", true)]
-        public async Task SuccessfulCommandTest(CommandType commandType, string commandText, bool captureText, bool isFailure = false)
-        {
-            var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
-                .AddProcessor(activityProcessor.Object)
-                .AddSqlClientInstrumentation(options =>
-                {
-                    options.SetDbStatementForText = captureText;
-                })
-                .Build();
-
-            using SqlConnection sqlConnection = new SqlConnection(SqlConnectionString);
-
-            await sqlConnection.OpenAsync().ConfigureAwait(false);
-
-            string dataSource = sqlConnection.DataSource;
-
-            sqlConnection.ChangeDatabase("master");
-
-            using SqlCommand sqlCommand = new SqlCommand(commandText, sqlConnection)
+        var activityProcessor = new Mock<BaseProcessor<Activity>>();
+        using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            .AddProcessor(activityProcessor.Object)
+            .AddSqlClientInstrumentation(options =>
             {
-                CommandType = commandType,
-            };
+                options.SetDbStatementForText = captureText;
+            })
+            .Build();
 
-            try
+        using SqlConnection sqlConnection = new SqlConnection(SqlConnectionString);
+
+        await sqlConnection.OpenAsync().ConfigureAwait(false);
+
+        string dataSource = sqlConnection.DataSource;
+
+        sqlConnection.ChangeDatabase("master");
+
+        using SqlCommand sqlCommand = new SqlCommand(commandText, sqlConnection)
+        {
+            CommandType = commandType,
+        };
+
+        try
+        {
+            await sqlCommand.ExecuteNonQueryAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+        }
+
+        Assert.Equal(3, activityProcessor.Invocations.Count);
+
+        var activity = (Activity)activityProcessor.Invocations[1].Arguments[0];
+
+        VerifyActivityData(commandText, captureText, isFailure, dataSource, activity);
+    }
+
+    [Theory]
+    [InlineData(typeof(FakeBehavingAdoNetSqlEventSource), CommandType.Text, "select 1/1", false)]
+    [InlineData(typeof(FakeBehavingAdoNetSqlEventSource), CommandType.Text, "select 1/0", false, true)]
+    [InlineData(typeof(FakeBehavingAdoNetSqlEventSource), CommandType.StoredProcedure, "sp_who", false)]
+    [InlineData(typeof(FakeBehavingAdoNetSqlEventSource), CommandType.StoredProcedure, "sp_who", true, false, 0, true)]
+    [InlineData(typeof(FakeBehavingMdsSqlEventSource), CommandType.Text, "select 1/1", false)]
+    [InlineData(typeof(FakeBehavingMdsSqlEventSource), CommandType.Text, "select 1/0", false, true)]
+    [InlineData(typeof(FakeBehavingMdsSqlEventSource), CommandType.StoredProcedure, "sp_who", false)]
+    [InlineData(typeof(FakeBehavingMdsSqlEventSource), CommandType.StoredProcedure, "sp_who", true, false, 0, true)]
+    public void EventSourceFakeTests(
+        Type eventSourceType,
+        CommandType commandType,
+        string commandText,
+        bool captureText,
+        bool isFailure = false,
+        int sqlExceptionNumber = 0,
+        bool enableConnectionLevelAttributes = false)
+    {
+        using IFakeBehavingSqlEventSource fakeSqlEventSource = (IFakeBehavingSqlEventSource)Activator.CreateInstance(eventSourceType);
+
+        var activityProcessor = new Mock<BaseProcessor<Activity>>();
+        using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            .AddProcessor(activityProcessor.Object)
+            .AddSqlClientInstrumentation(options =>
             {
-                await sqlCommand.ExecuteNonQueryAsync().ConfigureAwait(false);
-            }
-            catch
+                options.SetDbStatementForText = captureText;
+                options.EnableConnectionLevelAttributes = enableConnectionLevelAttributes;
+            })
+            .Build();
+
+        int objectId = Guid.NewGuid().GetHashCode();
+
+        fakeSqlEventSource.WriteBeginExecuteEvent(objectId, "127.0.0.1", "master", commandType == CommandType.StoredProcedure ? commandText : string.Empty);
+
+        // success is stored in the first bit in compositeState 0b001
+        int successFlag = !isFailure ? 1 : 0;
+
+        // isSqlException is stored in the second bit in compositeState 0b010
+        int isSqlExceptionFlag = sqlExceptionNumber > 0 ? 2 : 0;
+
+        // synchronous state is stored in the third bit in compositeState 0b100
+        int synchronousFlag = false ? 4 : 0;
+
+        int compositeState = successFlag | isSqlExceptionFlag | synchronousFlag;
+
+        fakeSqlEventSource.WriteEndExecuteEvent(objectId, compositeState, sqlExceptionNumber);
+        shutdownSignal.Dispose();
+        Assert.Equal(5, activityProcessor.Invocations.Count); // SetTracerProvider/OnStart/OnEnd/OnShutdown/Dispose called.
+
+        var activity = (Activity)activityProcessor.Invocations[2].Arguments[0];
+
+        VerifyActivityData(commandText, captureText, isFailure, "127.0.0.1", activity, enableConnectionLevelAttributes);
+    }
+
+    [Theory]
+    [InlineData(typeof(FakeMisbehavingAdoNetSqlEventSource))]
+    [InlineData(typeof(FakeMisbehavingMdsSqlEventSource))]
+    public void EventSourceFakeUnknownEventWithNullPayloadTest(Type eventSourceType)
+    {
+        using IFakeMisbehavingSqlEventSource fakeSqlEventSource = (IFakeMisbehavingSqlEventSource)Activator.CreateInstance(eventSourceType);
+
+        var activityProcessor = new Mock<BaseProcessor<Activity>>();
+        using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            .AddProcessor(activityProcessor.Object)
+            .AddSqlClientInstrumentation()
+            .Build();
+
+        fakeSqlEventSource.WriteUnknownEventWithNullPayload();
+
+        shutdownSignal.Dispose();
+
+        Assert.Equal(3, activityProcessor.Invocations.Count); // SetTracerProvider/OnShutdown/Dispose called.
+    }
+
+    [Theory]
+    [InlineData(typeof(FakeMisbehavingAdoNetSqlEventSource))]
+    [InlineData(typeof(FakeMisbehavingMdsSqlEventSource))]
+    public void EventSourceFakeInvalidPayloadTest(Type eventSourceType)
+    {
+        using IFakeMisbehavingSqlEventSource fakeSqlEventSource = (IFakeMisbehavingSqlEventSource)Activator.CreateInstance(eventSourceType);
+
+        var activityProcessor = new Mock<BaseProcessor<Activity>>();
+        using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            .AddProcessor(activityProcessor.Object)
+            .AddSqlClientInstrumentation()
+            .Build();
+
+        fakeSqlEventSource.WriteBeginExecuteEvent("arg1");
+
+        fakeSqlEventSource.WriteEndExecuteEvent("arg1", "arg2", "arg3", "arg4");
+        shutdownSignal.Dispose();
+
+        Assert.Equal(3, activityProcessor.Invocations.Count); // SetTracerProvider/OnShutdown/Dispose called.
+    }
+
+    [Theory]
+    [InlineData(typeof(FakeBehavingAdoNetSqlEventSource))]
+    [InlineData(typeof(FakeBehavingMdsSqlEventSource))]
+    public void DefaultCaptureTextFalse(Type eventSourceType)
+    {
+        using IFakeBehavingSqlEventSource fakeSqlEventSource = (IFakeBehavingSqlEventSource)Activator.CreateInstance(eventSourceType);
+
+        var activityProcessor = new Mock<BaseProcessor<Activity>>();
+        using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
+            .AddProcessor(activityProcessor.Object)
+            .AddSqlClientInstrumentation()
+            .Build();
+
+        int objectId = Guid.NewGuid().GetHashCode();
+
+        const string commandText = "TestCommandTest";
+        fakeSqlEventSource.WriteBeginExecuteEvent(objectId, "127.0.0.1", "master", commandText);
+
+        // success is stored in the first bit in compositeState 0b001
+        int successFlag = 1;
+
+        // isSqlException is stored in the second bit in compositeState 0b010
+        int isSqlExceptionFlag = 2;
+
+        // synchronous state is stored in the third bit in compositeState 0b100
+        int synchronousFlag = 4;
+
+        int compositeState = successFlag | isSqlExceptionFlag | synchronousFlag;
+
+        fakeSqlEventSource.WriteEndExecuteEvent(objectId, compositeState, 0);
+        shutdownSignal.Dispose();
+        Assert.Equal(5, activityProcessor.Invocations.Count); // SetTracerProvider/OnStart/OnEnd/OnShutdown/Dispose called.
+
+        var activity = (Activity)activityProcessor.Invocations[2].Arguments[0];
+
+        const bool captureText = false;
+        VerifyActivityData(commandText, captureText, false, "127.0.0.1", activity, false);
+    }
+
+    private static void VerifyActivityData(
+        string commandText,
+        bool captureText,
+        bool isFailure,
+        string dataSource,
+        Activity activity,
+        bool enableConnectionLevelAttributes = false)
+    {
+        Assert.Equal("master", activity.DisplayName);
+        Assert.Equal(ActivityKind.Client, activity.Kind);
+        Assert.Equal(SqlActivitySourceHelper.MicrosoftSqlServerDatabaseSystemName, activity.GetTagValue(SemanticConventions.AttributeDbSystem));
+
+        if (!enableConnectionLevelAttributes)
+        {
+            Assert.Equal(dataSource, activity.GetTagValue(SemanticConventions.AttributePeerService));
+        }
+        else
+        {
+            var connectionDetails = SqlClientInstrumentationOptions.ParseDataSource(dataSource);
+
+            if (!string.IsNullOrEmpty(connectionDetails.ServerHostName))
             {
-            }
-
-            Assert.Equal(3, activityProcessor.Invocations.Count);
-
-            var activity = (Activity)activityProcessor.Invocations[1].Arguments[0];
-
-            VerifyActivityData(commandText, captureText, isFailure, dataSource, activity);
-        }
-
-        [Theory]
-        [InlineData(typeof(FakeBehavingAdoNetSqlEventSource), CommandType.Text, "select 1/1", false)]
-        [InlineData(typeof(FakeBehavingAdoNetSqlEventSource), CommandType.Text, "select 1/0", false, true)]
-        [InlineData(typeof(FakeBehavingAdoNetSqlEventSource), CommandType.StoredProcedure, "sp_who", false)]
-        [InlineData(typeof(FakeBehavingAdoNetSqlEventSource), CommandType.StoredProcedure, "sp_who", true, false, 0, true)]
-        [InlineData(typeof(FakeBehavingMdsSqlEventSource), CommandType.Text, "select 1/1", false)]
-        [InlineData(typeof(FakeBehavingMdsSqlEventSource), CommandType.Text, "select 1/0", false, true)]
-        [InlineData(typeof(FakeBehavingMdsSqlEventSource), CommandType.StoredProcedure, "sp_who", false)]
-        [InlineData(typeof(FakeBehavingMdsSqlEventSource), CommandType.StoredProcedure, "sp_who", true, false, 0, true)]
-        public void EventSourceFakeTests(
-            Type eventSourceType,
-            CommandType commandType,
-            string commandText,
-            bool captureText,
-            bool isFailure = false,
-            int sqlExceptionNumber = 0,
-            bool enableConnectionLevelAttributes = false)
-        {
-            using IFakeBehavingSqlEventSource fakeSqlEventSource = (IFakeBehavingSqlEventSource)Activator.CreateInstance(eventSourceType);
-
-            var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
-                .AddProcessor(activityProcessor.Object)
-                .AddSqlClientInstrumentation(options =>
-                {
-                    options.SetDbStatementForText = captureText;
-                    options.EnableConnectionLevelAttributes = enableConnectionLevelAttributes;
-                })
-                .Build();
-
-            int objectId = Guid.NewGuid().GetHashCode();
-
-            fakeSqlEventSource.WriteBeginExecuteEvent(objectId, "127.0.0.1", "master", commandType == CommandType.StoredProcedure ? commandText : string.Empty);
-
-            // success is stored in the first bit in compositeState 0b001
-            int successFlag = !isFailure ? 1 : 0;
-
-            // isSqlException is stored in the second bit in compositeState 0b010
-            int isSqlExceptionFlag = sqlExceptionNumber > 0 ? 2 : 0;
-
-            // synchronous state is stored in the third bit in compositeState 0b100
-            int synchronousFlag = false ? 4 : 0;
-
-            int compositeState = successFlag | isSqlExceptionFlag | synchronousFlag;
-
-            fakeSqlEventSource.WriteEndExecuteEvent(objectId, compositeState, sqlExceptionNumber);
-            shutdownSignal.Dispose();
-            Assert.Equal(5, activityProcessor.Invocations.Count); // SetTracerProvider/OnStart/OnEnd/OnShutdown/Dispose called.
-
-            var activity = (Activity)activityProcessor.Invocations[2].Arguments[0];
-
-            VerifyActivityData(commandText, captureText, isFailure, "127.0.0.1", activity, enableConnectionLevelAttributes);
-        }
-
-        [Theory]
-        [InlineData(typeof(FakeMisbehavingAdoNetSqlEventSource))]
-        [InlineData(typeof(FakeMisbehavingMdsSqlEventSource))]
-        public void EventSourceFakeUnknownEventWithNullPayloadTest(Type eventSourceType)
-        {
-            using IFakeMisbehavingSqlEventSource fakeSqlEventSource = (IFakeMisbehavingSqlEventSource)Activator.CreateInstance(eventSourceType);
-
-            var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
-                .AddProcessor(activityProcessor.Object)
-                .AddSqlClientInstrumentation()
-                .Build();
-
-            fakeSqlEventSource.WriteUnknownEventWithNullPayload();
-
-            shutdownSignal.Dispose();
-
-            Assert.Equal(3, activityProcessor.Invocations.Count); // SetTracerProvider/OnShutdown/Dispose called.
-        }
-
-        [Theory]
-        [InlineData(typeof(FakeMisbehavingAdoNetSqlEventSource))]
-        [InlineData(typeof(FakeMisbehavingMdsSqlEventSource))]
-        public void EventSourceFakeInvalidPayloadTest(Type eventSourceType)
-        {
-            using IFakeMisbehavingSqlEventSource fakeSqlEventSource = (IFakeMisbehavingSqlEventSource)Activator.CreateInstance(eventSourceType);
-
-            var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
-                .AddProcessor(activityProcessor.Object)
-                .AddSqlClientInstrumentation()
-                .Build();
-
-            fakeSqlEventSource.WriteBeginExecuteEvent("arg1");
-
-            fakeSqlEventSource.WriteEndExecuteEvent("arg1", "arg2", "arg3", "arg4");
-            shutdownSignal.Dispose();
-
-            Assert.Equal(3, activityProcessor.Invocations.Count); // SetTracerProvider/OnShutdown/Dispose called.
-        }
-
-        [Theory]
-        [InlineData(typeof(FakeBehavingAdoNetSqlEventSource))]
-        [InlineData(typeof(FakeBehavingMdsSqlEventSource))]
-        public void DefaultCaptureTextFalse(Type eventSourceType)
-        {
-            using IFakeBehavingSqlEventSource fakeSqlEventSource = (IFakeBehavingSqlEventSource)Activator.CreateInstance(eventSourceType);
-
-            var activityProcessor = new Mock<BaseProcessor<Activity>>();
-            using var shutdownSignal = Sdk.CreateTracerProviderBuilder()
-                .AddProcessor(activityProcessor.Object)
-                .AddSqlClientInstrumentation()
-                .Build();
-
-            int objectId = Guid.NewGuid().GetHashCode();
-
-            const string commandText = "TestCommandTest";
-            fakeSqlEventSource.WriteBeginExecuteEvent(objectId, "127.0.0.1", "master", commandText);
-
-            // success is stored in the first bit in compositeState 0b001
-            int successFlag = 1;
-
-            // isSqlException is stored in the second bit in compositeState 0b010
-            int isSqlExceptionFlag = 2;
-
-            // synchronous state is stored in the third bit in compositeState 0b100
-            int synchronousFlag = 4;
-
-            int compositeState = successFlag | isSqlExceptionFlag | synchronousFlag;
-
-            fakeSqlEventSource.WriteEndExecuteEvent(objectId, compositeState, 0);
-            shutdownSignal.Dispose();
-            Assert.Equal(5, activityProcessor.Invocations.Count); // SetTracerProvider/OnStart/OnEnd/OnShutdown/Dispose called.
-
-            var activity = (Activity)activityProcessor.Invocations[2].Arguments[0];
-
-            const bool captureText = false;
-            VerifyActivityData(commandText, captureText, false, "127.0.0.1", activity, false);
-        }
-
-        private static void VerifyActivityData(
-            string commandText,
-            bool captureText,
-            bool isFailure,
-            string dataSource,
-            Activity activity,
-            bool enableConnectionLevelAttributes = false)
-        {
-            Assert.Equal("master", activity.DisplayName);
-            Assert.Equal(ActivityKind.Client, activity.Kind);
-            Assert.Equal(SqlActivitySourceHelper.MicrosoftSqlServerDatabaseSystemName, activity.GetTagValue(SemanticConventions.AttributeDbSystem));
-
-            if (!enableConnectionLevelAttributes)
-            {
-                Assert.Equal(dataSource, activity.GetTagValue(SemanticConventions.AttributePeerService));
+                Assert.Equal(connectionDetails.ServerHostName, activity.GetTagValue(SemanticConventions.AttributeNetPeerName));
             }
             else
             {
-                var connectionDetails = SqlClientInstrumentationOptions.ParseDataSource(dataSource);
-
-                if (!string.IsNullOrEmpty(connectionDetails.ServerHostName))
-                {
-                    Assert.Equal(connectionDetails.ServerHostName, activity.GetTagValue(SemanticConventions.AttributeNetPeerName));
-                }
-                else
-                {
-                    Assert.Equal(connectionDetails.ServerIpAddress, activity.GetTagValue(SemanticConventions.AttributeNetPeerIp));
-                }
-
-                if (!string.IsNullOrEmpty(connectionDetails.InstanceName))
-                {
-                    Assert.Equal(connectionDetails.InstanceName, activity.GetTagValue(SemanticConventions.AttributeDbMsSqlInstanceName));
-                }
-
-                if (!string.IsNullOrEmpty(connectionDetails.Port))
-                {
-                    Assert.Equal(connectionDetails.Port, activity.GetTagValue(SemanticConventions.AttributeNetPeerPort));
-                }
+                Assert.Equal(connectionDetails.ServerIpAddress, activity.GetTagValue(SemanticConventions.AttributeNetPeerIp));
             }
 
-            Assert.Equal("master", activity.GetTagValue(SemanticConventions.AttributeDbName));
-
-            // "db.statement_type" is never set by the SqlEventSource instrumentation
-            Assert.Null(activity.GetTagValue(SpanAttributeConstants.DatabaseStatementTypeKey));
-            if (captureText)
+            if (!string.IsNullOrEmpty(connectionDetails.InstanceName))
             {
-                Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbStatement));
-            }
-            else
-            {
-                Assert.Null(activity.GetTagValue(SemanticConventions.AttributeDbStatement));
+                Assert.Equal(connectionDetails.InstanceName, activity.GetTagValue(SemanticConventions.AttributeDbMsSqlInstanceName));
             }
 
-            if (!isFailure)
+            if (!string.IsNullOrEmpty(connectionDetails.Port))
             {
-                Assert.Equal(ActivityStatusCode.Unset, activity.Status);
-            }
-            else
-            {
-                Assert.Equal(ActivityStatusCode.Error, activity.Status);
-                Assert.NotNull(activity.StatusDescription);
+                Assert.Equal(connectionDetails.Port, activity.GetTagValue(SemanticConventions.AttributeNetPeerPort));
             }
         }
+
+        Assert.Equal("master", activity.GetTagValue(SemanticConventions.AttributeDbName));
+
+        // "db.statement_type" is never set by the SqlEventSource instrumentation
+        Assert.Null(activity.GetTagValue(SpanAttributeConstants.DatabaseStatementTypeKey));
+        if (captureText)
+        {
+            Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbStatement));
+        }
+        else
+        {
+            Assert.Null(activity.GetTagValue(SemanticConventions.AttributeDbStatement));
+        }
+
+        if (!isFailure)
+        {
+            Assert.Equal(ActivityStatusCode.Unset, activity.Status);
+        }
+        else
+        {
+            Assert.Equal(ActivityStatusCode.Error, activity.Status);
+            Assert.NotNull(activity.StatusDescription);
+        }
+    }
 
 #pragma warning disable SA1201 // Elements should appear in the correct order
 
-        // Helper interface to be able to have single test method for multiple EventSources, want to keep it close to the event sources themselves.
-        private interface IFakeBehavingSqlEventSource : IDisposable
+    // Helper interface to be able to have single test method for multiple EventSources, want to keep it close to the event sources themselves.
+    private interface IFakeBehavingSqlEventSource : IDisposable
 #pragma warning restore SA1201 // Elements should appear in the correct order
-        {
-            void WriteBeginExecuteEvent(int objectId, string dataSource, string databaseName, string commandText);
+    {
+        void WriteBeginExecuteEvent(int objectId, string dataSource, string databaseName, string commandText);
 
-            void WriteEndExecuteEvent(int objectId, int compositeState, int sqlExceptionNumber);
+        void WriteEndExecuteEvent(int objectId, int compositeState, int sqlExceptionNumber);
+    }
+
+    private interface IFakeMisbehavingSqlEventSource : IDisposable
+    {
+        void WriteBeginExecuteEvent(string arg1);
+
+        void WriteEndExecuteEvent(string arg1, string arg2, string arg3, string arg4);
+
+        void WriteUnknownEventWithNullPayload();
+    }
+
+    [EventSource(Name = SqlEventSourceListener.AdoNetEventSourceName + "-FakeFriendly")]
+    private class FakeBehavingAdoNetSqlEventSource : EventSource, IFakeBehavingSqlEventSource
+    {
+        [Event(SqlEventSourceListener.BeginExecuteEventId)]
+        public void WriteBeginExecuteEvent(int objectId, string dataSource, string databaseName, string commandText)
+        {
+            this.WriteEvent(SqlEventSourceListener.BeginExecuteEventId, objectId, dataSource, databaseName, commandText);
         }
 
-        private interface IFakeMisbehavingSqlEventSource : IDisposable
+        [Event(SqlEventSourceListener.EndExecuteEventId)]
+        public void WriteEndExecuteEvent(int objectId, int compositeState, int sqlExceptionNumber)
         {
-            void WriteBeginExecuteEvent(string arg1);
+            this.WriteEvent(SqlEventSourceListener.EndExecuteEventId, objectId, compositeState, sqlExceptionNumber);
+        }
+    }
 
-            void WriteEndExecuteEvent(string arg1, string arg2, string arg3, string arg4);
-
-            void WriteUnknownEventWithNullPayload();
+    [EventSource(Name = SqlEventSourceListener.MdsEventSourceName + "-FakeFriendly")]
+    private class FakeBehavingMdsSqlEventSource : EventSource, IFakeBehavingSqlEventSource
+    {
+        [Event(SqlEventSourceListener.BeginExecuteEventId)]
+        public void WriteBeginExecuteEvent(int objectId, string dataSource, string databaseName, string commandText)
+        {
+            this.WriteEvent(SqlEventSourceListener.BeginExecuteEventId, objectId, dataSource, databaseName, commandText);
         }
 
-        [EventSource(Name = SqlEventSourceListener.AdoNetEventSourceName + "-FakeFriendly")]
-        private class FakeBehavingAdoNetSqlEventSource : EventSource, IFakeBehavingSqlEventSource
+        [Event(SqlEventSourceListener.EndExecuteEventId)]
+        public void WriteEndExecuteEvent(int objectId, int compositeState, int sqlExceptionNumber)
         {
-            [Event(SqlEventSourceListener.BeginExecuteEventId)]
-            public void WriteBeginExecuteEvent(int objectId, string dataSource, string databaseName, string commandText)
-            {
-                this.WriteEvent(SqlEventSourceListener.BeginExecuteEventId, objectId, dataSource, databaseName, commandText);
-            }
+            this.WriteEvent(SqlEventSourceListener.EndExecuteEventId, objectId, compositeState, sqlExceptionNumber);
+        }
+    }
 
-            [Event(SqlEventSourceListener.EndExecuteEventId)]
-            public void WriteEndExecuteEvent(int objectId, int compositeState, int sqlExceptionNumber)
-            {
-                this.WriteEvent(SqlEventSourceListener.EndExecuteEventId, objectId, compositeState, sqlExceptionNumber);
-            }
+    [EventSource(Name = SqlEventSourceListener.AdoNetEventSourceName + "-FakeEvil")]
+    private class FakeMisbehavingAdoNetSqlEventSource : EventSource, IFakeMisbehavingSqlEventSource
+    {
+        [Event(SqlEventSourceListener.BeginExecuteEventId)]
+        public void WriteBeginExecuteEvent(string arg1)
+        {
+            this.WriteEvent(SqlEventSourceListener.BeginExecuteEventId, arg1);
         }
 
-        [EventSource(Name = SqlEventSourceListener.MdsEventSourceName + "-FakeFriendly")]
-        private class FakeBehavingMdsSqlEventSource : EventSource, IFakeBehavingSqlEventSource
+        [Event(SqlEventSourceListener.EndExecuteEventId)]
+        public void WriteEndExecuteEvent(string arg1, string arg2, string arg3, string arg4)
         {
-            [Event(SqlEventSourceListener.BeginExecuteEventId)]
-            public void WriteBeginExecuteEvent(int objectId, string dataSource, string databaseName, string commandText)
-            {
-                this.WriteEvent(SqlEventSourceListener.BeginExecuteEventId, objectId, dataSource, databaseName, commandText);
-            }
-
-            [Event(SqlEventSourceListener.EndExecuteEventId)]
-            public void WriteEndExecuteEvent(int objectId, int compositeState, int sqlExceptionNumber)
-            {
-                this.WriteEvent(SqlEventSourceListener.EndExecuteEventId, objectId, compositeState, sqlExceptionNumber);
-            }
+            this.WriteEvent(SqlEventSourceListener.EndExecuteEventId, arg1, arg2, arg3, arg4);
         }
 
-        [EventSource(Name = SqlEventSourceListener.AdoNetEventSourceName + "-FakeEvil")]
-        private class FakeMisbehavingAdoNetSqlEventSource : EventSource, IFakeMisbehavingSqlEventSource
+        [Event(3)]
+        public void WriteUnknownEventWithNullPayload()
         {
-            [Event(SqlEventSourceListener.BeginExecuteEventId)]
-            public void WriteBeginExecuteEvent(string arg1)
-            {
-                this.WriteEvent(SqlEventSourceListener.BeginExecuteEventId, arg1);
-            }
+            object[] args = null;
 
-            [Event(SqlEventSourceListener.EndExecuteEventId)]
-            public void WriteEndExecuteEvent(string arg1, string arg2, string arg3, string arg4)
-            {
-                this.WriteEvent(SqlEventSourceListener.EndExecuteEventId, arg1, arg2, arg3, arg4);
-            }
+            this.WriteEvent(3, args);
+        }
+    }
 
-            [Event(3)]
-            public void WriteUnknownEventWithNullPayload()
-            {
-                object[] args = null;
-
-                this.WriteEvent(3, args);
-            }
+    [EventSource(Name = SqlEventSourceListener.MdsEventSourceName + "-FakeEvil")]
+    private class FakeMisbehavingMdsSqlEventSource : EventSource, IFakeMisbehavingSqlEventSource
+    {
+        [Event(SqlEventSourceListener.BeginExecuteEventId)]
+        public void WriteBeginExecuteEvent(string arg1)
+        {
+            this.WriteEvent(SqlEventSourceListener.BeginExecuteEventId, arg1);
         }
 
-        [EventSource(Name = SqlEventSourceListener.MdsEventSourceName + "-FakeEvil")]
-        private class FakeMisbehavingMdsSqlEventSource : EventSource, IFakeMisbehavingSqlEventSource
+        [Event(SqlEventSourceListener.EndExecuteEventId)]
+        public void WriteEndExecuteEvent(string arg1, string arg2, string arg3, string arg4)
         {
-            [Event(SqlEventSourceListener.BeginExecuteEventId)]
-            public void WriteBeginExecuteEvent(string arg1)
-            {
-                this.WriteEvent(SqlEventSourceListener.BeginExecuteEventId, arg1);
-            }
+            this.WriteEvent(SqlEventSourceListener.EndExecuteEventId, arg1, arg2, arg3, arg4);
+        }
 
-            [Event(SqlEventSourceListener.EndExecuteEventId)]
-            public void WriteEndExecuteEvent(string arg1, string arg2, string arg3, string arg4)
-            {
-                this.WriteEvent(SqlEventSourceListener.EndExecuteEventId, arg1, arg2, arg3, arg4);
-            }
+        [Event(3)]
+        public void WriteUnknownEventWithNullPayload()
+        {
+            object[] args = null;
 
-            [Event(3)]
-            public void WriteUnknownEventWithNullPayload()
-            {
-                object[] args = null;
-
-                this.WriteEvent(3, args);
-            }
+            this.WriteEvent(3, args);
         }
     }
 }


### PR DESCRIPTION
…spaces

Towards #4640 

## Changes

Update projects OpenTelemetry.Instrumentation.SqlClient and OpenTelemetry.Instrumentation.SqlClient.Tests to use file scoped namespaces.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [X] Changes in public API reviewed (if applicable)
