### PR TITLE
add an option for enumerable with a string value on the LogRecordScope enumerator

### DIFF
--- a/src/OpenTelemetry/Logs/LogRecordScope.cs
+++ b/src/OpenTelemetry/Logs/LogRecordScope.cs
@@ -64,6 +64,10 @@ public readonly struct LogRecordScope
             {
                 this.scope = new List<KeyValuePair<string, object?>>(scopeEnumerable);
             }
+            else if (scope is IEnumerable<KeyValuePair<string, string?>> scopeEnumerableString)
+            {
+                this.scope = scopeEnumerableString.Select(kvp => new KeyValuePair<string, object?>(kvp.Key, kvp.Value)).ToList();
+            }
             else
             {
                 this.scope = new List<KeyValuePair<string, object?>>


### PR DESCRIPTION
Fixes #
https://github.com/dotnet/runtime/issues/90071
Design discussion issue #

## Changes
the enumerator should be able to get a IEnumerable<KeyValuePair<string, string?>>  and enumerate it correctly instead of creating a KeyValuePair with an empty string as  akey 
Please provide a brief description of the changes here.
added another else if to the enumerator to create the required read only list for baggage
## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated ---- 
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
