### PR TITLE
Remove Grpc.Tools version update

### DIFF
--- a/examples/Directory.Packages.props
+++ b/examples/Directory.Packages.props
@@ -1,7 +1,6 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
   <ItemGroup>
-    <PackageVersion Update="Grpc.Tools" Version="[2.44.0,3.0)" />
     <PackageVersion Update="Microsoft.Extensions.Logging" Version="[6.0.0,)" />
     <PackageVersion Update="System.Text.Json" Version="6.0.5" />
   </ItemGroup>

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -1,7 +1,6 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
   <ItemGroup>
-    <PackageVersion Update="Grpc.Tools" Version="[2.44.0,3.0)" />
     <PackageVersion Update="Microsoft.Extensions.Logging" Version="[6.0.0,)" />
     <PackageVersion Update="System.Text.Json" Version="6.0.5" />
   </ItemGroup>


### PR DESCRIPTION
I _guess_ these are no longer needed since the default version is greater. https://github.com/open-telemetry/opentelemetry-dotnet/blob/6ef14c79d6fa2a92e9dc869a5fbf03b668d1afe7/Directory.Packages.props#L67