### PR TITLE
Use 7.0.306 .NET SDK images

### DIFF
--- a/build/docker-compose.net6.0.yml
+++ b/build/docker-compose.net6.0.yml
@@ -6,4 +6,4 @@ services:
       args:
         PUBLISH_FRAMEWORK: net6.0
         TEST_SDK_VERSION: "6.0"
-        BUILD_SDK_VERSION: "7.0"
+        BUILD_SDK_VERSION: "7.0.306"

--- a/build/docker-compose.net7.0.yml
+++ b/build/docker-compose.net7.0.yml
@@ -6,4 +6,4 @@ services:
       args:
         PUBLISH_FRAMEWORK: net7.0
         TEST_SDK_VERSION: "7.0"
-        BUILD_SDK_VERSION: "7.0"
+        BUILD_SDK_VERSION: "7.0.306"


### PR DESCRIPTION
New 7.0.400 SDK was released today. Seems the new docker images are causing our integration tests to fail to build.

Probably related to this issue @utpilla found https://github.com/dotnet/aspnetcore/issues/47932

Hard coding to use 7.0.306 images for now makes the build pass.