### PR TITLE
Fix lock for PrometheusCollectionManager

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusCollectionManager.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusCollectionManager.cs
@@ -143,7 +143,7 @@ internal sealed class PrometheusCollectionManager
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void ExitGlobalLock()
     {
-        this.globalLockState = 0;
+        Interlocked.Exchange(ref this.globalLockState, 0);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Similar to the fix made in #4031 

## Changes
- Use `Interlocked.Exchange` to set `globalLockState` to zero instead of a simple assignment
