### PR TITLE
OTLP Exporter: Conditionally compile experimental log features

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ extension scenarios:
 * Building a custom sampler for
   [traces](./docs/trace/extending-the-sdk/README.md#sampler).
 
+## Experimental Features
+
+Various experimental features are available by the components of OpenTelemetry
+.NET.
+
+Experimental features are enabled in a variety of different ways. Some features
+are only available in pre-release builds while others may be available in
+stable builds gated by a feature flag. Feature flags are implemented using
+environment variables (e.g., `OTEL_DOTNET_EXPERIMENTAL_SOME_FEATURE`).
+
+The README of a each component will contain information for any available
+experimental features and how to use them.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ are only available in pre-release builds while others may be available in
 stable builds gated by a feature flag. Feature flags are implemented using
 environment variables (e.g., `OTEL_DOTNET_EXPERIMENTAL_SOME_FEATURE`).
 
+Experimental features are subject to breaking changes. Typically, they are
+works-in-progress that we intend to eventually provide in a stable release.
+However, this is not guaranteed and they may be removed entirely.
+
 The README of a each component will contain information for any available
 experimental features and how to use them.
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -12,6 +12,11 @@ exporter.
   [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.23.0/specification/metrics/sdk_exporters/otlp.md#additional-configuration).
   ([#4667](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4667))
 
+* **[Experimental feature](./README.md#experimental-features)**
+  Exporting the following fields from `LogRecord` is now considered
+  an experimental feature: `CategoryName`, `EventId`, and `Exception`.
+  Refer to the documentation for more details.
+
 ## 1.6.0-alpha.1
 
 Released 2023-Jul-12
@@ -34,20 +39,18 @@ Released 2023-Jul-12
   for more details.
   ([#4647](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4647))
 
-* **Experimental (pre-release builds only):**
+* **[Experimental feature](./README.md#experimental-features)**
+  Add back support for Exemplars which is now treated as an experimental
+  feature available only in pre-release builds. See
+  [exemplars](../../docs/metrics/customizing-the-sdk/README.md#exemplars) for
+  instructions to enable exemplars.
+  ([#4553](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4553))
 
-  * Note: See
-    [#4735](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4735)
-    for the introduction of experimental api support.
-
-  * Add back support for Exemplars. See
-    [exemplars](../../docs/metrics/customizing-the-sdk/README.md#exemplars) for
-    instructions to enable exemplars.
-    ([#4553](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4553))
-
-  * Updated to support `Severity` and `SeverityText` when exporting
-    `LogRecord`s.
-    ([#4568](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4568))
+* **[Experimental feature](./README.md#experimental-features)**
+  The `Severity` and `SeverityText` fields on `LogRecord` are only available in
+  pre-release builds of the SDK. Pre-release builds of the OTLP exporter will
+  export these fields.
+  ([#4568](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4568))
 
 ## 1.5.1
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
@@ -79,7 +79,7 @@ internal static class LogRecordExtensions
 
             var attributeValueLengthLimit = sdkLimitOptions.AttributeValueLengthLimit;
             var attributeCountLimit = sdkLimitOptions.AttributeCountLimit ?? int.MaxValue;
-
+#if EXPOSE_EXPERIMENTAL_FEATURES
             // First add the generic attributes like Category, EventId and Exception,
             // so they are less likely being dropped because of AttributeCountLimit.
 
@@ -109,7 +109,7 @@ internal static class LogRecordExtensions
                 otlpLogRecord.AddStringAttribute(SemanticConventions.AttributeExceptionMessage, logRecord.Exception.Message, attributeValueLengthLimit, attributeCountLimit);
                 otlpLogRecord.AddStringAttribute(SemanticConventions.AttributeExceptionStacktrace, logRecord.Exception.ToInvariantString(), attributeValueLengthLimit, attributeCountLimit);
             }
-
+#endif
             bool bodyPopulatedFromFormattedMessage = false;
             if (logRecord.FormattedMessage != null)
             {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/LogRecordExtensions.cs
@@ -16,9 +16,13 @@
 
 using System.Runtime.CompilerServices;
 using Google.Protobuf;
+#if EXPOSE_EXPERIMENTAL_FEATURES
 using OpenTelemetry.Internal;
+#endif
 using OpenTelemetry.Logs;
+#if EXPOSE_EXPERIMENTAL_FEATURES
 using OpenTelemetry.Trace;
+#endif
 using OtlpCollector = OpenTelemetry.Proto.Collector.Logs.V1;
 using OtlpCommon = OpenTelemetry.Proto.Common.V1;
 using OtlpLogs = OpenTelemetry.Proto.Logs.V1;

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
@@ -233,6 +233,31 @@ services.AddHttpClient(
 Note: The single instance returned by `HttpClientFactory` is reused by all
 export requests.
 
+## Experimental features
+
+The OTLP exporter contains the following
+[experimental features](../../README.md#experimental-features):
+
+* The
+  [exemplar specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#exemplar)
+  is not yet stable. Pre-release builds of the OpenTelemetry .NET SDK and the
+  OTLP exporter support sampling and exporting exemplars.
+* Support for exporting the following fields on `LogRecord`: `CategoryName`,
+  `EventId`, and `Exception`. These fields are unique to OpenTelemetry .NET's
+  data model (i.e., they are not reflected in the
+  [standard data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#log-and-event-record-definition)).
+  Therefore, the conventions
+  for exporting these fields is not yet stable. In pre-release builds, these
+  fields are exported as attributes mapped as follows:
+  * `CategoryName` maps to `dotnet.ilogger.category_name`.
+  * `EventId` maps to two attributes `Id` and `Name` representing
+    `Event.Id` and `EventId.Name`, respectively.
+  * `Exception` maps to the attributes defined by the experimental
+    [exception semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/exceptions/exceptions-logs.md#attributes).
+* In pre-release builds of the OpenTelemetry .NET SDK `LogRecord` contains new
+  fields: `Severity` and `SeverityText`, and they will be exported by the OTLP
+  exporter.
+
 ## Troubleshooting
 
 This component uses an

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
@@ -697,7 +697,7 @@ public class OtlpLogExporterTests : Http2UnencryptedSupportTests
         // Assert.
         var logRecord = logRecords.Single();
         var otlpLogRecord = logRecord.ToOtlpLog(DefaultSdkLimitOptions);
-        Assert.Equal(1, otlpLogRecord.Attributes.Count);
+        Assert.Single(otlpLogRecord.Attributes);
         var actualScope = TryGetAttribute(otlpLogRecord, scopeKey);
         Assert.NotNull(actualScope);
         Assert.Equal(scopeKey, actualScope.Key);
@@ -736,7 +736,7 @@ public class OtlpLogExporterTests : Http2UnencryptedSupportTests
         // Assert.
         var logRecord = logRecords.Single();
         var otlpLogRecord = logRecord.ToOtlpLog(DefaultSdkLimitOptions);
-        Assert.Equal(1, otlpLogRecord.Attributes.Count);
+        Assert.Single(otlpLogRecord.Attributes);
         var actualScope = TryGetAttribute(otlpLogRecord, scopeKey);
         Assert.NotNull(actualScope);
         Assert.Equal(scopeKey, actualScope.Key);
@@ -787,7 +787,7 @@ public class OtlpLogExporterTests : Http2UnencryptedSupportTests
         // Assert.
         var logRecord = logRecords.Single();
         var otlpLogRecord = logRecord.ToOtlpLog(DefaultSdkLimitOptions);
-        Assert.Equal(1, otlpLogRecord.Attributes.Count);
+        Assert.Single(otlpLogRecord.Attributes);
         var actualScope = TryGetAttribute(otlpLogRecord, scopeKey);
         Assert.NotNull(actualScope);
         Assert.Equal(scopeKey, actualScope.Key);
@@ -826,7 +826,7 @@ public class OtlpLogExporterTests : Http2UnencryptedSupportTests
         // Assert.
         var logRecord = logRecords.Single();
         var otlpLogRecord = logRecord.ToOtlpLog(DefaultSdkLimitOptions);
-        Assert.Equal(1, otlpLogRecord.Attributes.Count);
+        Assert.Single(otlpLogRecord.Attributes);
         var actualScope = TryGetAttribute(otlpLogRecord, scopeKey);
         Assert.NotNull(actualScope);
         Assert.Equal(scopeKey, actualScope.Key);
@@ -865,7 +865,7 @@ public class OtlpLogExporterTests : Http2UnencryptedSupportTests
         // Assert.
         var logRecord = logRecords.Single();
         var otlpLogRecord = logRecord.ToOtlpLog(DefaultSdkLimitOptions);
-        Assert.Equal(1, otlpLogRecord.Attributes.Count);
+        Assert.Single(otlpLogRecord.Attributes);
         var actualScope = TryGetAttribute(otlpLogRecord, scopeKey);
         Assert.NotNull(actualScope);
         Assert.Equal(scopeKey, actualScope.Key);
@@ -965,7 +965,7 @@ public class OtlpLogExporterTests : Http2UnencryptedSupportTests
         // Assert.
         var logRecord = logRecords.Single();
         var otlpLogRecord = logRecord.ToOtlpLog(DefaultSdkLimitOptions);
-        Assert.Equal(1, otlpLogRecord.Attributes.Count);
+        Assert.Single(otlpLogRecord.Attributes);
         var actualScope = TryGetAttribute(otlpLogRecord, scopeKey);
         Assert.NotNull(actualScope);
         Assert.Equal(scopeKey, actualScope.Key);
@@ -1004,7 +1004,7 @@ public class OtlpLogExporterTests : Http2UnencryptedSupportTests
         // Assert.
         var logRecord = logRecords.Single();
         var otlpLogRecord = logRecord.ToOtlpLog(DefaultSdkLimitOptions);
-        Assert.Equal(1, otlpLogRecord.Attributes.Count);
+        Assert.Single(otlpLogRecord.Attributes);
         var actualScope = TryGetAttribute(otlpLogRecord, scopeKey);
         Assert.NotNull(actualScope);
         Assert.Equal(scopeKey, actualScope.Key);

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
@@ -23,7 +23,9 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
+#if EXPOSE_EXPERIMENTAL_FEATURES
 using OpenTelemetry.Internal;
+#endif
 using OpenTelemetry.Logs;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;


### PR DESCRIPTION
I want to prioritize shipping a stable OTLP log exporter. While there are important conversations to be had to fully resolve this conversation https://github.com/open-telemetry/opentelemetry-dotnet/pull/4754#discussion_r1287525697, it should not block a stable exporter release.

For our upcoming stable release, this PR will exclude the following fields on `LogRecord` from being exported by the OTLP exporter:

* `EventId`
* `CategoryName`
* `Exception`

The first two fields are not part of the OpenTelemetry log data model, so exporting them requires us to carefully consider the conventions we use to map them.

There are [experimental conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/exceptions/exceptions-logs.md) defined for `Exception`, however my preference would be to exclude all three of these fields for now and later expose them all via feature flag.

