### PR TITLE
HttpSemanticConventions - update helper class

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
@@ -17,6 +17,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\EnvironmentVariables\*.cs" Link="Includes\EnvironmentVariables\%(Filename).cs" Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'" />
     <Compile Include="$(RepoRoot)\src\Shared\HttpSemanticConventionHelper.cs" Link="Includes\HttpSemanticConventionHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Options\*.cs" Link="Includes\Options\%(Filename).cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\Shims\NullableAttributes.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(RunningDotNetPack)' == '' OR '$(RunningDotNetPack)' == 'false'">

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/OpenTelemetry.Instrumentation.GrpcNetClient.csproj
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/OpenTelemetry.Instrumentation.GrpcNetClient.csproj
@@ -16,6 +16,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\EnvironmentVariables\*.cs" Link="Includes\EnvironmentVariables\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\Shared\HttpSemanticConventionHelper.cs" Link="Includes\HttpSemanticConventionHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Options\*.cs" Link="Includes\Options\%(Filename).cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\Shims\NullableAttributes.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(RunningDotNetPack)' == '' OR '$(RunningDotNetPack)' == 'false'">

--- a/src/OpenTelemetry.Instrumentation.Http/OpenTelemetry.Instrumentation.Http.csproj
+++ b/src/OpenTelemetry.Instrumentation.Http/OpenTelemetry.Instrumentation.Http.csproj
@@ -21,6 +21,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\EnvironmentVariables\*.cs" Link="Includes\EnvironmentVariables\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\Shared\HttpSemanticConventionHelper.cs" Link="Includes\HttpSemanticConventionHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Options\*.cs" Link="Includes\Options\%(Filename).cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\Shims\NullableAttributes.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(RunningDotNetPack)' == '' OR '$(RunningDotNetPack)' == 'false'">

--- a/src/OpenTelemetry.Instrumentation.SqlClient/OpenTelemetry.Instrumentation.SqlClient.csproj
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/OpenTelemetry.Instrumentation.SqlClient.csproj
@@ -21,6 +21,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\EnvironmentVariables\*.cs" Link="Includes\EnvironmentVariables\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\Shared\HttpSemanticConventionHelper.cs" Link="Includes\HttpSemanticConventionHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Options\*.cs" Link="Includes\Options\%(Filename).cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\Shims\NullableAttributes.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(RunningDotNetPack)' == '' OR '$(RunningDotNetPack)' == 'false'">

--- a/src/OpenTelemetry/OpenTelemetry.csproj
+++ b/src/OpenTelemetry/OpenTelemetry.csproj
@@ -25,6 +25,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\MathHelper.cs" Link="Includes\MathHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Options\*.cs" Link="Includes\Options\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\Shared\ResourceSemanticConventions.cs" Link="Includes\ResourceSemanticConventions.cs" />
+    <Compile Remove="C:\REPOS\opentelemetry-dotnet-fork\src\Shared\Shims\NullableAttributes.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Shims\NullableAttributes.cs" />
   </ItemGroup>
 

--- a/src/OpenTelemetry/OpenTelemetry.csproj
+++ b/src/OpenTelemetry/OpenTelemetry.csproj
@@ -25,7 +25,6 @@
     <Compile Include="$(RepoRoot)\src\Shared\MathHelper.cs" Link="Includes\MathHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Options\*.cs" Link="Includes\Options\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\Shared\ResourceSemanticConventions.cs" Link="Includes\ResourceSemanticConventions.cs" />
-    <Compile Remove="C:\REPOS\opentelemetry-dotnet-fork\src\Shared\Shims\NullableAttributes.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Shims\NullableAttributes.cs" />
   </ItemGroup>
 

--- a/src/Shared/HttpSemanticConventionHelper.cs
+++ b/src/Shared/HttpSemanticConventionHelper.cs
@@ -60,7 +60,7 @@ internal static class HttpSemanticConventionHelper
 
         if (configuration != null && TryGetConfiguredValues(configuration, out var values))
         {
-            if (values!.Contains("http/dup"))
+            if (values.Contains("http/dup"))
             {
                 return HttpSemanticConvention.Dupe;
             }

--- a/src/Shared/HttpSemanticConventionHelper.cs
+++ b/src/Shared/HttpSemanticConventionHelper.cs
@@ -90,12 +90,8 @@ internal static class HttpSemanticConventionHelper
                 return false;
             }
 
-            var stringValues = stringValue.Split(separator: new[] { ',' }, options: StringSplitOptions.RemoveEmptyEntries)
-                .Select(value => value.Trim())
-                .Where(value => !string.IsNullOrWhiteSpace(value));
-
+            var stringValues = stringValue.Split(separator: new[] { ',', ' ' }, options: StringSplitOptions.RemoveEmptyEntries);
             values = new HashSet<string>(stringValues, StringComparer.OrdinalIgnoreCase);
-
             return true;
         }
         catch

--- a/src/Shared/HttpSemanticConventionHelper.cs
+++ b/src/Shared/HttpSemanticConventionHelper.cs
@@ -17,6 +17,7 @@
 #nullable enable
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Configuration;
 
 namespace OpenTelemetry.Internal;
@@ -57,19 +58,50 @@ internal static class HttpSemanticConventionHelper
     {
         Debug.Assert(configuration != null, "configuration was null");
 
+        if (TryGetConfiguredValues(configuration, out var values))
+        {
+            if (values!.Contains("http/dup"))
+            {
+                return HttpSemanticConvention.Dupe;
+            }
+            else if (values.Contains("http"))
+            {
+                return HttpSemanticConvention.New;
+            }
+        }
+
+        return HttpSemanticConvention.Old;
+    }
+
+    private static bool TryGetConfiguredValues(IConfiguration configuration, [NotNullWhen(true)] out HashSet<string>? values)
+    {
         try
         {
-            var envVarValue = configuration![SemanticConventionOptInKeyName];
-            return envVarValue?.ToLowerInvariant() switch
+            var stringValue = Environment.GetEnvironmentVariable(SemanticConventionOptInKeyName);
+
+            if (string.IsNullOrWhiteSpace(stringValue))
             {
-                "http" => HttpSemanticConvention.New,
-                "http/dup" => HttpSemanticConvention.Dupe,
-                _ => HttpSemanticConvention.Old,
-            };
+                stringValue = configuration![SemanticConventionOptInKeyName];
+            }
+
+            if (string.IsNullOrWhiteSpace(stringValue))
+            {
+                values = null;
+                return false;
+            }
+
+            var stringValues = stringValue.Split(separator: new[] { ',' }, options: StringSplitOptions.RemoveEmptyEntries)
+                .Select(value => value.Trim())
+                .Where(value => !string.IsNullOrWhiteSpace(value));
+
+            values = new HashSet<string>(stringValues, StringComparer.OrdinalIgnoreCase);
+
+            return true;
         }
         catch
         {
-            return HttpSemanticConvention.Old;
+            values = null;
+            return false;
         }
     }
 }

--- a/src/Shared/HttpSemanticConventionHelper.cs
+++ b/src/Shared/HttpSemanticConventionHelper.cs
@@ -77,12 +77,7 @@ internal static class HttpSemanticConventionHelper
     {
         try
         {
-            var stringValue = Environment.GetEnvironmentVariable(SemanticConventionOptInKeyName);
-
-            if (string.IsNullOrWhiteSpace(stringValue))
-            {
-                stringValue = configuration![SemanticConventionOptInKeyName];
-            }
+            var stringValue = configuration![SemanticConventionOptInKeyName];
 
             if (string.IsNullOrWhiteSpace(stringValue))
             {

--- a/src/Shared/HttpSemanticConventionHelper.cs
+++ b/src/Shared/HttpSemanticConventionHelper.cs
@@ -58,7 +58,7 @@ internal static class HttpSemanticConventionHelper
     {
         Debug.Assert(configuration != null, "configuration was null");
 
-        if (TryGetConfiguredValues(configuration, out var values))
+        if (configuration != null && TryGetConfiguredValues(configuration, out var values))
         {
             if (values!.Contains("http/dup"))
             {

--- a/test/OpenTelemetry.Tests/Shared/HttpSemanticConventionHelperTest.cs
+++ b/test/OpenTelemetry.Tests/Shared/HttpSemanticConventionHelperTest.cs
@@ -70,23 +70,6 @@ public class HttpSemanticConventionHelperTest
             Environment.SetEnvironmentVariable(SemanticConventionOptInKeyName, input);
 
             var expected = Enum.Parse(typeof(HttpSemanticConvention), expectedValue);
-            Assert.Equal(expected, GetSemanticConventionOptIn(new ConfigurationBuilder().Build()));
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable(SemanticConventionOptInKeyName, null);
-        }
-    }
-
-    [Theory]
-    [MemberData(nameof(TestCases))]
-    public void VerifyGetSemanticConventionOptIn_UsingEnvironmentVariable_ViaIConfig(string input, string expectedValue)
-    {
-        try
-        {
-            Environment.SetEnvironmentVariable(SemanticConventionOptInKeyName, input);
-
-            var expected = Enum.Parse(typeof(HttpSemanticConvention), expectedValue);
             Assert.Equal(expected, GetSemanticConventionOptIn(new ConfigurationBuilder().AddEnvironmentVariables().Build()));
         }
         finally

--- a/test/OpenTelemetry.Tests/Shared/HttpSemanticConventionHelperTest.cs
+++ b/test/OpenTelemetry.Tests/Shared/HttpSemanticConventionHelperTest.cs
@@ -22,6 +22,29 @@ namespace OpenTelemetry.Tests.Shared;
 
 public class HttpSemanticConventionHelperTest
 {
+    public static IEnumerable<object[]> TestCases => new List<object[]>
+        {
+            new object[] { null,  HttpSemanticConvention.Old },
+            new object[] { string.Empty,  HttpSemanticConvention.Old },
+            new object[] { " ",  HttpSemanticConvention.Old },
+            new object[] { "junk",  HttpSemanticConvention.Old },
+            new object[] { "none",  HttpSemanticConvention.Old },
+            new object[] { "NONE",  HttpSemanticConvention.Old },
+            new object[] { "http",  HttpSemanticConvention.New },
+            new object[] { "HTTP",  HttpSemanticConvention.New },
+            new object[] { "http/dup",  HttpSemanticConvention.Dupe },
+            new object[] { "HTTP/DUP",  HttpSemanticConvention.Dupe },
+            new object[] { "junk,,junk",  HttpSemanticConvention.Old },
+            new object[] { "junk,JUNK",  HttpSemanticConvention.Old },
+            new object[] { "junk1,junk2",  HttpSemanticConvention.Old },
+            new object[] { "junk,http",  HttpSemanticConvention.New },
+            new object[] { "junk,http , http ,junk",  HttpSemanticConvention.New },
+            new object[] { "junk,http/dup",  HttpSemanticConvention.Dupe },
+            new object[] { "junk, http/dup ",  HttpSemanticConvention.Dupe },
+            new object[] { "junk, http/dup ",  HttpSemanticConvention.Dupe },
+            new object[] { "http,http/dup",  HttpSemanticConvention.Dupe },
+        };
+
     [Fact]
     public void VerifyFlags()
     {
@@ -38,40 +61,32 @@ public class HttpSemanticConventionHelperTest
         Assert.True(testValue.HasFlag(HttpSemanticConvention.New));
     }
 
-    [Fact]
-    public void VerifyGetSemanticConventionOptIn()
-    {
-        RunTestWithEnvironmentVariable(null, HttpSemanticConvention.Old);
-        RunTestWithEnvironmentVariable(string.Empty, HttpSemanticConvention.Old);
-        RunTestWithEnvironmentVariable("junk", HttpSemanticConvention.Old);
-        RunTestWithEnvironmentVariable("none", HttpSemanticConvention.Old);
-        RunTestWithEnvironmentVariable("NONE", HttpSemanticConvention.Old);
-        RunTestWithEnvironmentVariable("http", HttpSemanticConvention.New);
-        RunTestWithEnvironmentVariable("HTTP", HttpSemanticConvention.New);
-        RunTestWithEnvironmentVariable("http/dup", HttpSemanticConvention.Dupe);
-        RunTestWithEnvironmentVariable("HTTP/DUP", HttpSemanticConvention.Dupe);
-    }
-
-    [Fact]
-    public void VerifyGetSemanticConventionOptInUsingIConfiguration()
-    {
-        RunTestWithIConfiguration(null, HttpSemanticConvention.Old);
-        RunTestWithIConfiguration(string.Empty, HttpSemanticConvention.Old);
-        RunTestWithIConfiguration("junk", HttpSemanticConvention.Old);
-        RunTestWithIConfiguration("none", HttpSemanticConvention.Old);
-        RunTestWithIConfiguration("NONE", HttpSemanticConvention.Old);
-        RunTestWithIConfiguration("http", HttpSemanticConvention.New);
-        RunTestWithIConfiguration("HTTP", HttpSemanticConvention.New);
-        RunTestWithIConfiguration("http/dup", HttpSemanticConvention.Dupe);
-        RunTestWithIConfiguration("HTTP/DUP", HttpSemanticConvention.Dupe);
-    }
-
-    private static void RunTestWithEnvironmentVariable(string value, HttpSemanticConvention expected)
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void VerifyGetSemanticConventionOptIn_UsingEnvironmentVariable(string input, string expectedValue)
     {
         try
         {
-            Environment.SetEnvironmentVariable(SemanticConventionOptInKeyName, value);
+            Environment.SetEnvironmentVariable(SemanticConventionOptInKeyName, input);
 
+            var expected = Enum.Parse(typeof(HttpSemanticConvention), expectedValue);
+            Assert.Equal(expected, GetSemanticConventionOptIn(new ConfigurationBuilder().Build()));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(SemanticConventionOptInKeyName, null);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void VerifyGetSemanticConventionOptIn_UsingEnvironmentVariable_ViaIConfig(string input, string expectedValue)
+    {
+        try
+        {
+            Environment.SetEnvironmentVariable(SemanticConventionOptInKeyName, input);
+
+            var expected = Enum.Parse(typeof(HttpSemanticConvention), expectedValue);
             Assert.Equal(expected, GetSemanticConventionOptIn(new ConfigurationBuilder().AddEnvironmentVariables().Build()));
         }
         finally
@@ -80,12 +95,15 @@ public class HttpSemanticConventionHelperTest
         }
     }
 
-    private static void RunTestWithIConfiguration(string value, HttpSemanticConvention expected)
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void VerifyGetSemanticConventionOptIn_UsingIConfiguration(string input, string expectedValue)
     {
         var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string> { [SemanticConventionOptInKeyName] = value })
+            .AddInMemoryCollection(new Dictionary<string, string> { [SemanticConventionOptInKeyName] = input })
             .Build();
 
+        var expected = Enum.Parse(typeof(HttpSemanticConvention), expectedValue);
         Assert.Equal(expected, GetSemanticConventionOptIn(configuration));
     }
 }

--- a/test/OpenTelemetry.Tests/Shared/HttpSemanticConventionHelperTest.cs
+++ b/test/OpenTelemetry.Tests/Shared/HttpSemanticConventionHelperTest.cs
@@ -41,7 +41,7 @@ public class HttpSemanticConventionHelperTest
             new object[] { "junk,http , http ,junk",  HttpSemanticConvention.New },
             new object[] { "junk,http/dup",  HttpSemanticConvention.Dupe },
             new object[] { "junk, http/dup ",  HttpSemanticConvention.Dupe },
-            new object[] { "junk, http/dup ",  HttpSemanticConvention.Dupe },
+            new object[] { "http/dup,http",  HttpSemanticConvention.Dupe },
             new object[] { "http,http/dup",  HttpSemanticConvention.Dupe },
         };
 


### PR DESCRIPTION
Towards #4484

When I started on this, I was working off the older version of the spec in the old repo.
The current version of the spec in the new repo changed the environment variable to a comma-separated list.

> SHOULD introduce an environment variable OTEL_SEMCONV_STABILITY_OPT_IN in the existing major version which is a comma-separated list of values. 
https://github.com/open-telemetry/semantic-conventions/tree/v1.21.0/docs/http

## Changes
- refactor `HttpSemanticConventionsHelper`
  - rewrite to parse a CSV
- updated several projects to include `Shared\Shims\NullableAttributes`
- refactor unit tests. 
  - replaced `InlineData` with `MemberData` so each test can use the same collection of test cases.
  - added additional csv test cases

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)

## Note about duplicate values in the Environment Variable.
Edit: 8/14: The spec has been updated to specify if both `http` and `http/dup` are specified, `http/dup` will take precedence.
https://github.com/open-telemetry/semantic-conventions/pull/249

As of today, the only valid values are `http` (emit new attributes) and `http/dup` (emit both new and old attributes).
The spec doesn't define how to handle a scenario where a user provides both values in the CSV.
I opened an issue to get clarity: https://github.com/open-telemetry/semantic-conventions/issues/240

In this scenario, Java takes a user-friendly approach of the approach of enabling both new and old attributes. I think we should do the same here.
https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/32c5d4c26708ccaa20221bb6d687f56c9efde979/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/internal/SemconvStability.java#L26-L39