### PR TITLE
[AOT] suppressed trimming warnings in HTTP Instrumentation package

### DIFF
--- a/build/test-aot-compatibility.ps1
+++ b/build/test-aot-compatibility.ps1
@@ -29,7 +29,7 @@ if ($LastExitCode -ne 0)
 popd
 
 Write-Host "Actual warning count is:", $actualWarningCount
-$expectedWarningCount = 20
+$expectedWarningCount = 19
 
 $testPassed = 0
 if ($actualWarningCount -ne $expectedWarningCount)

--- a/build/test-aot-compatibility.ps1
+++ b/build/test-aot-compatibility.ps1
@@ -29,7 +29,7 @@ if ($LastExitCode -ne 0)
 popd
 
 Write-Host "Actual warning count is:", $actualWarningCount
-$expectedWarningCount = 26
+$expectedWarningCount = 20
 
 $testPassed = 0
 if ($actualWarningCount -ne $expectedWarningCount)

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -306,7 +306,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
     // in Systm.Net.Http library ensures that top-level properties on the payload object are always preserved.
     // see https://github.com/dotnet/runtime/blob/f9246538e3d49b90b0e9128d7b1defef57cd6911/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L325
 #if NET6_0_OR_GREATER
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top level properties are preserved")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top-level properties are preserved")]
 #endif
     private bool TryFetchException(object payload, out Exception exc)
     {
@@ -322,7 +322,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
     // in Systm.Net.Http library ensures that top-level properties on the payload object are always preserved.
     // see https://github.com/dotnet/runtime/blob/f9246538e3d49b90b0e9128d7b1defef57cd6911/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L325
 #if NET6_0_OR_GREATER
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top level properties are preserved")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top-level properties are preserved")]
 #endif
     private bool TryFetchRequest(object payload, out HttpRequestMessage request)
     {
@@ -338,7 +338,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
     // in Systm.Net.Http library ensures that top-level properties on the payload object are always preserved.
     // see https://github.com/dotnet/runtime/blob/f9246538e3d49b90b0e9128d7b1defef57cd6911/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L325
 #if NET6_0_OR_GREATER
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top level properties are preserved")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top-level properties are preserved")]
 #endif
     private bool TryFetchResponse(object payload, out HttpResponseMessage response)
     {
@@ -350,6 +350,12 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
         return true;
     }
 
+    // The AOT-annotation DynamicallyAccessedMembers(https://learn.microsoft.com/dotnet/api/system.diagnostics.codeanalysis.dynamicallyaccessedmembersattribute?view=net-7.0)
+    // in Systm.Net.Http library ensures that top-level properties on the payload object are always preserved.
+    // see https://github.com/dotnet/runtime/blob/f9246538e3d49b90b0e9128d7b1defef57cd6911/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L325
+#if NET6_0_OR_GREATER
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top-level properties are preserved")]
+#endif
     private TaskStatus GetRequestStatus(object payload)
     {
         //// https://github.com/dotnet/runtime/blob/master/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -220,7 +220,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
     {
         if (activity.IsAllDataRequested)
         {
-            var requestTaskStatus = this.GetRequestStatusOnStopActivity(payload);
+            var requestTaskStatus = this.GetRequestStatus(payload);
 
             ActivityStatusCode currentStatusCode = activity.Status;
             if (requestTaskStatus != TaskStatus.RanToCompletion)
@@ -242,7 +242,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
                 }
             }
 
-            if (this.stopResponseFetcher.TryFetch(payload, out HttpResponseMessage response) && response != null)
+            if (!this.TryFetchResponse(payload, out HttpResponseMessage response))
             {
                 if (this.emitOldAttributes)
                 {
@@ -340,7 +340,17 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
 #if NET6_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top level properties are preserved")]
 #endif
-    private TaskStatus GetRequestStatusOnStopActivity(object payload)
+    private bool TryFetchResponse(object payload, out HttpResponseMessage response)
+    {
+        if (!this.stopResponseFetcher.TryFetch(payload, out response) || response == null)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private TaskStatus GetRequestStatus(object payload)
     {
         //// https://github.com/dotnet/runtime/blob/master/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
         //// requestTaskStatus is not null

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -302,7 +302,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
         }
     }
 
-    // The AOT-annotation DynamicallyAccessedMembers in Systm.Net.Http library ensures that top-level properties on the payload object are always preserved.
+    // The AOT-annotation DynamicallyAccessedMembers in System.Net.Http library ensures that top-level properties on the payload object are always preserved.
     // see https://github.com/dotnet/runtime/blob/f9246538e3d49b90b0e9128d7b1defef57cd6911/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L325
 #if NET6_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top-level properties are preserved")]
@@ -317,7 +317,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
         return true;
     }
 
-    // The AOT-annotation DynamicallyAccessedMembers in Systm.Net.Http library ensures that top-level properties on the payload object are always preserved.
+    // The AOT-annotation DynamicallyAccessedMembers in System.Net.Http library ensures that top-level properties on the payload object are always preserved.
     // see https://github.com/dotnet/runtime/blob/f9246538e3d49b90b0e9128d7b1defef57cd6911/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L325
 #if NET6_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top-level properties are preserved")]
@@ -332,7 +332,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
         return true;
     }
 
-    // The AOT-annotation DynamicallyAccessedMembers in Systm.Net.Http library ensures that top-level properties on the payload object are always preserved.
+    // The AOT-annotation DynamicallyAccessedMembers in System.Net.Http library ensures that top-level properties on the payload object are always preserved.
     // see https://github.com/dotnet/runtime/blob/f9246538e3d49b90b0e9128d7b1defef57cd6911/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L325
 #if NET6_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top-level properties are preserved")]
@@ -347,7 +347,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
         return false;
     }
 
-    // The AOT-annotation DynamicallyAccessedMembers in Systm.Net.Http library ensures that top-level properties on the payload object are always preserved.
+    // The AOT-annotation DynamicallyAccessedMembers in System.Net.Http library ensures that top-level properties on the payload object are always preserved.
     // see https://github.com/dotnet/runtime/blob/f9246538e3d49b90b0e9128d7b1defef57cd6911/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L325
 #if NET6_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top-level properties are preserved")]

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -242,7 +242,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
                 }
             }
 
-            if (!this.TryFetchResponse(payload, out HttpResponseMessage response))
+            if (this.TryFetchResponse(payload, out HttpResponseMessage response))
             {
                 if (this.emitOldAttributes)
                 {
@@ -342,12 +342,12 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
 #endif
     private bool TryFetchResponse(object payload, out HttpResponseMessage response)
     {
-        if (!this.stopResponseFetcher.TryFetch(payload, out response) || response == null)
+        if (this.stopResponseFetcher.TryFetch(payload, out response) && response != null)
         {
-            return false;
+            return true;
         }
 
-        return true;
+        return false;
     }
 
     // The AOT-annotation DynamicallyAccessedMembers(https://learn.microsoft.com/dotnet/api/system.diagnostics.codeanalysis.dynamicallyaccessedmembersattribute?view=net-7.0)

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
@@ -76,7 +76,7 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
                         tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerPort, request.RequestUri.Port));
                     }
 
-                    if (StopResponseFetcher.TryFetch(payload, out HttpResponseMessage response) && response != null)
+                    if (TryFetchResponse(payload, out HttpResponseMessage response))
                     {
                         tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpStatusCode, TelemetryHelper.GetBoxedStatusCode(response.StatusCode)));
                     }
@@ -108,7 +108,7 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
         }
     }
 
-    // The AOT-annotation DynamicallyAccessedMembers in Systm.Net.Http library ensures that top-level properties on the payload object are always preserved.
+    // The AOT-annotation DynamicallyAccessedMembers in System.Net.Http library ensures that top-level properties on the payload object are always preserved.
     // see https://github.com/dotnet/runtime/blob/f9246538e3d49b90b0e9128d7b1defef57cd6911/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L325
 #if NET6_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top-level properties are preserved")]
@@ -116,7 +116,7 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
     private static bool TryFetchResponse(object payload, out HttpResponseMessage response) =>
         StopResponseFetcher.TryFetch(payload, out response) && response != null;
 
-    // The AOT-annotation DynamicallyAccessedMembers in Systm.Net.Http library ensures that top-level properties on the payload object are always preserved.
+    // The AOT-annotation DynamicallyAccessedMembers in System.Net.Http library ensures that top-level properties on the payload object are always preserved.
     // see https://github.com/dotnet/runtime/blob/f9246538e3d49b90b0e9128d7b1defef57cd6911/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L325
 #if NET6_0_OR_GREATER
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top-level properties are preserved")]

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
@@ -118,10 +118,10 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
     {
         if (this.stopResponseFetcher.TryFetch(payload, out response) && response != null)
         {
-            return false;
+            return true;
         }
 
-        return true;
+        return false;
     }
 
     // The AOT-annotation DynamicallyAccessedMembers(https://learn.microsoft.com/dotnet/api/system.diagnostics.codeanalysis.dynamicallyaccessedmembersattribute?view=net-7.0)
@@ -134,9 +134,9 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
     {
         if (this.stopRequestFetcher.TryFetch(payload, out request) && request != null)
         {
-            return false;
+            return true;
         }
 
-        return true;
+        return false;
     }
 }

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
@@ -31,8 +31,8 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
 {
     internal const string OnStopEvent = "System.Net.Http.HttpRequestOut.Stop";
 
-    private static readonly PropertyFetcher<HttpResponseMessage> StopResponseFetcher = new("Response");
     private static readonly PropertyFetcher<HttpRequestMessage> StopRequestFetcher = new("Request");
+    private static readonly PropertyFetcher<HttpResponseMessage> StopResponseFetcher = new("Response");
     private readonly Histogram<double> httpClientDuration;
     private readonly HttpClientMetricInstrumentationOptions options;
     private readonly bool emitOldAttributes;

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
@@ -112,7 +112,7 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
     // in Systm.Net.Http library ensures that top-level properties on the payload object are always preserved.
     // see https://github.com/dotnet/runtime/blob/f9246538e3d49b90b0e9128d7b1defef57cd6911/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L325
 #if NET6_0_OR_GREATER
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top level properties are preserved")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top-level properties are preserved")]
 #endif
     private bool TryFetchResponse(object payload, out HttpResponseMessage response)
     {
@@ -128,7 +128,7 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
     // in Systm.Net.Http library ensures that top-level properties on the payload object are always preserved.
     // see https://github.com/dotnet/runtime/blob/f9246538e3d49b90b0e9128d7b1defef57cd6911/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L325
 #if NET6_0_OR_GREATER
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top level properties are preserved")]
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top-level properties are preserved")]
 #endif
     private bool TryFetchRequest(object payload, out HttpRequestMessage request)
     {

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
@@ -106,21 +106,21 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
                 this.httpClientDuration.Record(activity.Duration.TotalMilliseconds, tags);
             }
         }
+
+        // The AOT-annotation DynamicallyAccessedMembers in System.Net.Http library ensures that top-level properties on the payload object are always preserved.
+        // see https://github.com/dotnet/runtime/blob/f9246538e3d49b90b0e9128d7b1defef57cd6911/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L325
+#if NET6_0_OR_GREATER
+        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top-level properties are preserved")]
+#endif
+        static bool TryFetchRequest(object payload, out HttpRequestMessage request) =>
+            StopRequestFetcher.TryFetch(payload, out request) && request != null;
+
+        // The AOT-annotation DynamicallyAccessedMembers in System.Net.Http library ensures that top-level properties on the payload object are always preserved.
+        // see https://github.com/dotnet/runtime/blob/f9246538e3d49b90b0e9128d7b1defef57cd6911/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L325
+#if NET6_0_OR_GREATER
+        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top-level properties are preserved")]
+#endif
+        static bool TryFetchResponse(object payload, out HttpResponseMessage response) =>
+            StopResponseFetcher.TryFetch(payload, out response) && response != null;
     }
-
-    // The AOT-annotation DynamicallyAccessedMembers in System.Net.Http library ensures that top-level properties on the payload object are always preserved.
-    // see https://github.com/dotnet/runtime/blob/f9246538e3d49b90b0e9128d7b1defef57cd6911/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L325
-#if NET6_0_OR_GREATER
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top-level properties are preserved")]
-#endif
-    private static bool TryFetchResponse(object payload, out HttpResponseMessage response) =>
-        StopResponseFetcher.TryFetch(payload, out response) && response != null;
-
-    // The AOT-annotation DynamicallyAccessedMembers in System.Net.Http library ensures that top-level properties on the payload object are always preserved.
-    // see https://github.com/dotnet/runtime/blob/f9246538e3d49b90b0e9128d7b1defef57cd6911/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L325
-#if NET6_0_OR_GREATER
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top-level properties are preserved")]
-#endif
-    private static bool TryFetchRequest(object payload, out HttpRequestMessage request) =>
-        StopRequestFetcher.TryFetch(payload, out request) && request != null;
 }

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
@@ -15,6 +15,9 @@
 // </copyright>
 
 using System.Diagnostics;
+#if NET6_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Diagnostics.Metrics;
 #if NETFRAMEWORK
 using System.Net.Http;
@@ -56,7 +59,7 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
             }
 
             var activity = Activity.Current;
-            if (this.stopRequestFetcher.TryFetch(payload, out HttpRequestMessage request) && request != null)
+            if (this.TryFetchRequest(payload, out HttpRequestMessage request))
             {
                 TagList tags = default;
 
@@ -91,7 +94,7 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
                         tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeServerPort, request.RequestUri.Port));
                     }
 
-                    if (this.stopResponseFetcher.TryFetch(payload, out HttpResponseMessage response) && response != null)
+                    if (this.TryFetchResponse(payload, out HttpResponseMessage response))
                     {
                         tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpResponseStatusCode, TelemetryHelper.GetBoxedStatusCode(response.StatusCode)));
                     }
@@ -103,5 +106,37 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
                 this.httpClientDuration.Record(activity.Duration.TotalMilliseconds, tags);
             }
         }
+    }
+
+    // The AOT-annotation DynamicallyAccessedMembers(https://learn.microsoft.com/dotnet/api/system.diagnostics.codeanalysis.dynamicallyaccessedmembersattribute?view=net-7.0)
+    // in Systm.Net.Http library ensures that top-level properties on the payload object are always preserved.
+    // see https://github.com/dotnet/runtime/blob/f9246538e3d49b90b0e9128d7b1defef57cd6911/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L325
+#if NET6_0_OR_GREATER
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top level properties are preserved")]
+#endif
+    private bool TryFetchResponse(object payload, out HttpResponseMessage response)
+    {
+        if (this.stopResponseFetcher.TryFetch(payload, out response) && response != null)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    // The AOT-annotation DynamicallyAccessedMembers(https://learn.microsoft.com/dotnet/api/system.diagnostics.codeanalysis.dynamicallyaccessedmembersattribute?view=net-7.0)
+    // in Systm.Net.Http library ensures that top-level properties on the payload object are always preserved.
+    // see https://github.com/dotnet/runtime/blob/f9246538e3d49b90b0e9128d7b1defef57cd6911/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L325
+#if NET6_0_OR_GREATER
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top level properties are preserved")]
+#endif
+    private bool TryFetchRequest(object payload, out HttpRequestMessage request)
+    {
+        if (this.stopRequestFetcher.TryFetch(payload, out request) && request != null)
+        {
+            return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-dotnet/issues/3429

cc: @eerhardt, @vitek-karas 

## Changes

Suppressed trimming warnings IL2026 in HTTP Instrumentation package because the AOT-annotation DynamicallyAccessedMembers
https://learn.microsoft.com/dotnet/api/system.diagnostics.codeanalysis.dynamicallyaccessedmembersattribute?view=net-7.0
in Systm.Net.Http library ensures that top-level properties on the payload object are always preserved.
See https://github.com/dotnet/runtime/blob/f9246538e3d49b90b0e9128d7b1defef57cd6911/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L325

In .NET runtime repo, there is an API proposal to make payload types in System.Net.Http.DiagnosticsHandler public: https://github.com/dotnet/runtime/issues/82910. 
Once .NET runtime makes the above change, OTel should update the HTTP instrumentation implementation to access the public payload types directly.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
