### PR TITLE
Remove unnecessary `RequiresUnreferencedCode` attribute.

### DIFF
--- a/src/Shared/DiagnosticSourceInstrumentation/PropertyFetcher.cs
+++ b/src/Shared/DiagnosticSourceInstrumentation/PropertyFetcher.cs
@@ -117,7 +117,6 @@ internal sealed class PropertyFetcher<T>
                 // because the compiler might need to generate code specific to that type.
                 // If the type parameter is a reference type, there will be no problem; because the generated code can be shared among all reference type instantiations.
 #if NET6_0_OR_GREATER
-                [RequiresUnreferencedCode(TrimCompatibilityMessage)]
                 [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "The code guarantees that all the generic parameters are reference types.")]
 #endif
                 static PropertyFetch? DynamicInstantiationHelper(Type declaringType, PropertyInfo propertyInfo)


### PR DESCRIPTION
The entire type is marked with `RequiresUnreferencedCode` so it is implicitly inherited by all code inside that type (except for nested types).

Also - this method doesn't do anything which would make it produce trim warnings, it only produces AOT warning (which is explicitly suppressed).