### PR TITLE
Remove Jaeger Exporter - part 1: remove references in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ libraries](https://github.com/open-telemetry/opentelemetry-specification/blob/ma
 
 * [Console](./src/OpenTelemetry.Exporter.Console/README.md)
 * [In-memory](./src/OpenTelemetry.Exporter.InMemory/README.md)
-* [Jaeger](./src/OpenTelemetry.Exporter.Jaeger/README.md)
 * [OTLP](./src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md)
   (OpenTelemetry Protocol)
 * [Prometheus AspNetCore](./src/OpenTelemetry.Exporter.Prometheus.AspNetCore/README.md)

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -28,7 +28,7 @@ versions [1.1.0, 2.0.0).
 
 Core components refer to the set of components which are required as per the
 spec. This includes API, SDK, and exporters which are required by the
-specification. These exporters are OTLP, Jaeger, Zipkin, Console and InMemory.
+specification. These exporters are OTLP, Zipkin, Console and InMemory.
 
 The core components are always versioned and released together. For example, if
 Zipkin exporter has a bug fix and is released as 1.0.1, then all other core

--- a/docs/trace/customizing-the-sdk/README.md
+++ b/docs/trace/customizing-the-sdk/README.md
@@ -268,8 +268,8 @@ var tracerProvider = Sdk.CreateTracerProviderBuilder()
 
 It is also common for exporters to provide their own extensions to simplify
 registration. The snippet below shows how to add the
-[OtlpExporter](../../../src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md) to the
-provider before it is built.
+[OtlpExporter](../../../src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md)
+to the provider before it is built.
 
  ```csharp
 using OpenTelemetry;

--- a/docs/trace/customizing-the-sdk/README.md
+++ b/docs/trace/customizing-the-sdk/README.md
@@ -268,7 +268,7 @@ var tracerProvider = Sdk.CreateTracerProviderBuilder()
 
 It is also common for exporters to provide their own extensions to simplify
 registration. The snippet below shows how to add the
-[ZipkinExporter](../../../src/OpenTelemetry.Exporter.Zipkin/README.md) to the
+[OtlpExporter](../../../src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md) to the
 provider before it is built.
 
  ```csharp
@@ -276,7 +276,7 @@ using OpenTelemetry;
 using OpenTelemetry.Trace;
 
 var tracerProvider = Sdk.CreateTracerProviderBuilder()
-    .AddZipkinExporter()
+    .AddOtlpExporter()
     .Build();
 ```
 
@@ -620,7 +620,7 @@ components.
 Options classes can always be configured through code but users typically want to
 control key settings through configuration.
 
-The following example shows how to configure `ZipkinExporterOptions` by binding
+The following example shows how to configure `OtlpExporterOptions` by binding
 to an `IConfiguration` section.
 
 Json config file (usually appsettings.json):
@@ -628,8 +628,8 @@ Json config file (usually appsettings.json):
 ```json
 {
   "OpenTelemetry": {
-    "Zipkin": {
-      "Endpoint": "http://localhost:9411/api/v2/spans"
+    "Otlp": {
+      "Endpoint": "http://localhost:4317"
     }
   }
 }
@@ -640,11 +640,11 @@ Code:
 ```csharp
 var appBuilder = WebApplication.CreateBuilder(args);
 
-appBuilder.Services.Configure<ZipkinExporterOptions>(
-    appBuilder.Configuration.GetSection("OpenTelemetry:Zipkin"));
+appBuilder.Services.Configure<OtlpExporterOptions>(
+    appBuilder.Configuration.GetSection("OpenTelemetry:Otlp"));
 
 appBuilder.Services.AddOpenTelemetry()
-    .WithTracing(builder => builder.AddZipkinExporter());
+    .WithTracing(builder => builder.AddOtlpExporter());
 ```
 
 The OpenTelemetry .NET SDK supports running multiple `TracerProvider`s inside
@@ -654,7 +654,7 @@ users to target configuration at specific components a "name" parameter is
 typically supported on configuration extensions to control the options instance
 used for the component being registered.
 
-The below example shows how to configure two `ZipkinExporter` instances inside a
+The below example shows how to configure two `OtlpExporter` instances inside a
 single `TracerProvider` sending to different ports.
 
 Json config file (usually appsettings.json):
@@ -662,11 +662,11 @@ Json config file (usually appsettings.json):
 ```json
 {
   "OpenTelemetry": {
-    "ZipkinPrimary": {
-      "Endpoint": "http://localhost:9411/api/v2/spans"
+    "OtlpPrimary": {
+      "Endpoint": "http://localhost:4317"
     },
-    "ZipkinSecondary": {
-      "Endpoint": "http://localhost:9421/api/v2/spans"
+    "OtlpSecondary": {
+      "Endpoint": "http://localhost:4327"
     },
   }
 }
@@ -677,16 +677,16 @@ Code:
 ```csharp
 var appBuilder = WebApplication.CreateBuilder(args);
 
-appBuilder.Services.Configure<ZipkinExporterOptions>(
-    "ZipkinPrimary",
-    appBuilder.Configuration.GetSection("OpenTelemetry:ZipkinPrimary"));
+appBuilder.Services.Configure<OtlpExporterOptions>(
+    "OtlpPrimary",
+    appBuilder.Configuration.GetSection("OpenTelemetry:OtlpPrimary"));
 
-appBuilder.Services.Configure<ZipkinExporterOptions>(
-    "ZipkinSecondary",
-    appBuilder.Configuration.GetSection("OpenTelemetry:ZipkinSecondary"));
+appBuilder.Services.Configure<OtlpExporterOptions>(
+    "OtlpSecondary",
+    appBuilder.Configuration.GetSection("OpenTelemetry:OtlpSecondary"));
 
 appBuilder.Services.AddOpenTelemetry()
     .WithTracing(builder => builder
-        .AddZipkinExporter(name: "ZipkinPrimary", configure: null)
-        .AddZipkinExporter(name: "ZipkinSecondary", configure: null));
+        .AddOtlpExporter(name: "OtlpPrimary", configure: null)
+        .AddOtlpExporter(name: "OtlpSecondary", configure: null));
 ```

--- a/docs/trace/customizing-the-sdk/README.md
+++ b/docs/trace/customizing-the-sdk/README.md
@@ -268,7 +268,7 @@ var tracerProvider = Sdk.CreateTracerProviderBuilder()
 
 It is also common for exporters to provide their own extensions to simplify
 registration. The snippet below shows how to add the
-[JaegerExporter](../../../src/OpenTelemetry.Exporter.Jaeger/README.md) to the
+[ZipkinExporter](../../../src/OpenTelemetry.Exporter.Zipkin/README.md) to the
 provider before it is built.
 
  ```csharp
@@ -276,7 +276,7 @@ using OpenTelemetry;
 using OpenTelemetry.Trace;
 
 var tracerProvider = Sdk.CreateTracerProviderBuilder()
-    .AddJaegerExporter()
+    .AddZipkinExporter()
     .Build();
 ```
 
@@ -620,7 +620,7 @@ components.
 Options classes can always be configured through code but users typically want to
 control key settings through configuration.
 
-The following example shows how to configure `JaegerExporterOptions` by binding
+The following example shows how to configure `ZipkinExporterOptions` by binding
 to an `IConfiguration` section.
 
 Json config file (usually appsettings.json):
@@ -628,13 +628,8 @@ Json config file (usually appsettings.json):
 ```json
 {
   "OpenTelemetry": {
-    "Jaeger": {
-      "Protocol": "UdpCompactThrift"
-      "AgentHost": "localhost",
-      "AgentPort": 6831,
-      "BatchExportProcessorOptions": {
-        "ScheduledDelayMilliseconds": 5000
-      }
+    "Zipkin": {
+      "Endpoint": "http://localhost:9411/api/v2/spans"
     }
   }
 }
@@ -645,11 +640,11 @@ Code:
 ```csharp
 var appBuilder = WebApplication.CreateBuilder(args);
 
-appBuilder.Services.Configure<JaegerExporterOptions>(
-    appBuilder.Configuration.GetSection("OpenTelemetry:Jaeger"));
+appBuilder.Services.Configure<ZipkinExporterOptions>(
+    appBuilder.Configuration.GetSection("OpenTelemetry:Zipkin"));
 
 appBuilder.Services.AddOpenTelemetry()
-    .WithTracing(builder => builder.AddJaegerExporter());
+    .WithTracing(builder => builder.AddZipkinExporter());
 ```
 
 The OpenTelemetry .NET SDK supports running multiple `TracerProvider`s inside
@@ -659,7 +654,7 @@ users to target configuration at specific components a "name" parameter is
 typically supported on configuration extensions to control the options instance
 used for the component being registered.
 
-The below example shows how to configure two `JaegerExporter` instances inside a
+The below example shows how to configure two `ZipkinExporter` instances inside a
 single `TracerProvider` sending to different ports.
 
 Json config file (usually appsettings.json):
@@ -667,12 +662,12 @@ Json config file (usually appsettings.json):
 ```json
 {
   "OpenTelemetry": {
-    "JaegerPrimary": {
-      "AgentPort": 1818
+    "ZipkinPrimary": {
+      "Endpoint": "http://localhost:9411/api/v2/spans"
     },
-    "JaegerSecondary": {
-      "AgentPort": 8818
-    }
+    "ZipkinSecondary": {
+      "Endpoint": "http://localhost:9421/api/v2/spans"
+    },
   }
 }
 ```
@@ -682,16 +677,16 @@ Code:
 ```csharp
 var appBuilder = WebApplication.CreateBuilder(args);
 
-appBuilder.Services.Configure<JaegerExporterOptions>(
-    "JaegerPrimary",
-    appBuilder.Configuration.GetSection("OpenTelemetry:JaegerPrimary"));
+appBuilder.Services.Configure<ZipkinExporterOptions>(
+    "ZipkinPrimary",
+    appBuilder.Configuration.GetSection("OpenTelemetry:ZipkinPrimary"));
 
-appBuilder.Services.Configure<JaegerExporterOptions>(
-    "JaegerSecondary",
-    appBuilder.Configuration.GetSection("OpenTelemetry:JaegerSecondary"));
+appBuilder.Services.Configure<ZipkinExporterOptions>(
+    "ZipkinSecondary",
+    appBuilder.Configuration.GetSection("OpenTelemetry:ZipkinSecondary"));
 
 appBuilder.Services.AddOpenTelemetry()
     .WithTracing(builder => builder
-        .AddJaegerExporter(name: "JaegerPrimary", configure: null)
-        .AddJaegerExporter(name: "JaegerSecondary", configure: null));
+        .AddZipkinExporter(name: "ZipkinPrimary", configure: null)
+        .AddZipkinExporter(name: "ZipkinSecondary", configure: null));
 ```

--- a/docs/trace/extending-the-sdk/README.md
+++ b/docs/trace/extending-the-sdk/README.md
@@ -16,7 +16,6 @@ OpenTelemetry .NET SDK has provided the following built-in trace exporters:
 
 * [Console](../../../src/OpenTelemetry.Exporter.Console/README.md)
 * [InMemory](../../../src/OpenTelemetry.Exporter.InMemory/README.md)
-* [Jaeger](../../../src/OpenTelemetry.Exporter.Jaeger/README.md)
 * [OpenTelemetryProtocol](../../../src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md)
 * [Zipkin](../../../src/OpenTelemetry.Exporter.Zipkin/README.md)
 

--- a/docs/trace/getting-started-jaeger/README.md
+++ b/docs/trace/getting-started-jaeger/README.md
@@ -142,7 +142,7 @@ Jaeger -->|http://localhost:16686/| JaegerUI["Browser<br/>(Jaeger UI)"]
 
 ## Final cleanup
 
-In the end, remove the Console Exporter so we only have Jaeger Exporter in the
+In the end, remove the Console Exporter so we only have OTLP Exporter in the
 final application:
 
 ```csharp

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -12,6 +12,8 @@
   `OTEL_DOTNET_EXPERIMENTAL_METRICS_EMIT_OVERFLOW_ATTRIBUTE` to `true` before
   setting up the `MeterProvider`.
   ([#4737](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4737))
+* Remove Jaeger Exporter from the core SDK. Jaeger supports OTLP protocol natively.
+  ([#4777](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4777))
 
 ## 1.6.0-alpha.1
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -12,8 +12,6 @@
   `OTEL_DOTNET_EXPERIMENTAL_METRICS_EMIT_OVERFLOW_ATTRIBUTE` to `true` before
   setting up the `MeterProvider`.
   ([#4737](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4737))
-* Remove Jaeger Exporter from the core SDK. Jaeger supports OTLP protocol natively.
-  ([#4777](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4777))
 
 ## 1.6.0-alpha.1
 


### PR DESCRIPTION
Fixes #4638
Design discussion issue #

## Changes

Please provide a brief description of the changes here.

Remove Jaeger Exporter references in all docs.

Following PRs are to come which will remove Jaeger Exporter in examples, tests, and implementation.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated: N/A
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable): N/A
