### PR TITLE
[shared] PropertyFetcher perf tweak

### DIFF
--- a/src/Shared/DiagnosticSourceInstrumentation/PropertyFetcher.cs
+++ b/src/Shared/DiagnosticSourceInstrumentation/PropertyFetcher.cs
@@ -73,6 +73,9 @@ internal sealed class PropertyFetcher<T>
         return innerFetcher.TryFetch(obj, out value);
     }
 
+#if NET6_0_OR_GREATER
+    [RequiresUnreferencedCode(TrimCompatibilityMessage)]
+#endif
     private static bool TryFetchRare(object? obj, string propertyName, ref PropertyFetch? destination, out T? value)
     {
         if (obj is null)

--- a/test/OpenTelemetry.Tests/Instrumentation/PropertyFetcherTest.cs
+++ b/test/OpenTelemetry.Tests/Instrumentation/PropertyFetcherTest.cs
@@ -25,9 +25,20 @@ public class PropertyFetcherTest
     public void FetchValidProperty()
     {
         using var activity = new Activity("test");
+
         var fetch = new PropertyFetcher<string>("DisplayName");
+
+        Assert.Equal(0, fetch.NumberOfInnerFetchers);
+
         Assert.True(fetch.TryFetch(activity, out string result));
         Assert.Equal(activity.DisplayName, result);
+
+        Assert.Equal(1, fetch.NumberOfInnerFetchers);
+
+        Assert.True(fetch.TryFetch(activity, out result));
+        Assert.Equal(activity.DisplayName, result);
+
+        Assert.Equal(1, fetch.NumberOfInnerFetchers);
     }
 
     [Fact]
@@ -56,15 +67,25 @@ public class PropertyFetcherTest
     {
         var fetch = new PropertyFetcher<string>("Property");
 
+        Assert.Equal(0, fetch.NumberOfInnerFetchers);
+
         Assert.True(fetch.TryFetch(new PayloadTypeA(), out string propertyValue));
         Assert.Equal("A", propertyValue);
+
+        Assert.Equal(1, fetch.NumberOfInnerFetchers);
 
         Assert.True(fetch.TryFetch(new PayloadTypeB(), out propertyValue));
         Assert.Equal("B", propertyValue);
 
+        Assert.Equal(2, fetch.NumberOfInnerFetchers);
+
         Assert.False(fetch.TryFetch(new PayloadTypeC(), out _));
 
+        Assert.Equal(2, fetch.NumberOfInnerFetchers);
+
         Assert.False(fetch.TryFetch(null, out _));
+
+        Assert.Equal(2, fetch.NumberOfInnerFetchers);
     }
 
     [Fact]


### PR DESCRIPTION
## Changes

* Tweaks `PropertyFetcher` to have a little bit better perf

## Benchmarks

net462 build via .NET Framework 4.8.1 runtime:

|                      Method |     Mean |    Error |   StdDev | Allocated |
|---------------------------- |---------:|---------:|---------:|----------:|
|        UsingPropertyFetcher | 14.72 ns | 0.173 ns | 0.144 ns |         - |
| UsingTweakedPropertyFetcher | 11.66 ns | 0.278 ns | 0.260 ns |         - |

net6.0 build via .NET 7.0.400 sdk:

|                                     Method |      Mean |     Error |    StdDev | Allocated |
|------------------------------------------- |----------:|----------:|----------:|----------:|
|        UsingPropertyFetcher | 11.646 ns | 0.1534 ns | 0.1281 ns |         - |
|  UsingTweakedPropertyFetcher |  7.326 ns | 0.1401 ns | 0.1311 ns |         - |

<details>
<summary>Dragons</summary>

This work originally spawned out of https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1251#discussion_r1296266126 where I noticed a lower-level version of `PropertyFetcher` was _much_ faster.

There isn't a whole lot to the benchmarks, just running the same code using the existing version and the new one:

```csharp
[MemoryDiagnoser]
public class WcfReflectionBenchmarks
{
    private readonly PropertyFetcher<WebHeaderCollection> propertyFetcher = new("Headers");
    private readonly PropertyFetcherTweaks<WebHeaderCollection> propertyFetcherTweaks = new("Headers");
    private readonly HttpRequestMessageProperty request = new();

    [Benchmark]
    public WebHeaderCollection UsingPropertyFetcher()
    {
        if (!this.propertyFetcher.TryFetch(this.request, out var value))
        {
            throw new InvalidOperationException();
        }

        return value;
    }

    [Benchmark]
    public WebHeaderCollection UsingTweakedPropertyFetcher()
    {
        if (!this.propertyFetcherTweaks.TryFetch(this.request, out var value))
        {
            throw new InvalidOperationException();
        }

        return value;
    }
}
```
</details>

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [X] Unit test improvements
