### PR TITLE
Fix publish packages workflow

### DIFF
--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -26,6 +26,9 @@ jobs:
         fetch-depth: 0 # fetching all
         ref: ${{ github.ref || 'main' }}
 
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v3
+
     - name: Install dependencies
       run: dotnet restore OpenTelemetry.proj
 


### PR DESCRIPTION
Addresses #4778 

Publish packages workflow is failing complaining about .NET 7.0.400 not installed: https://github.com/open-telemetry/opentelemetry-dotnet/actions/runs/5815436407/job/15766987166

## Changes
- Add a step to install dotnet. This would look up the `global.json` file for the right version of .NET