### PR TITLE
Update test package for AspNetCore instrumentation tests

### DIFF
--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/OpenTelemetry.Instrumentation.AspNetCore.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/OpenTelemetry.Instrumentation.AspNetCore.Tests.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="6.0.21" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #4763

## Changes
- Update the package version of `Microsoft.AspNetCore.Mvc.Testing` to `6.0.21` which has the runtime [fix](https://github.com/dotnet/runtime/pull/61621) to increase the timeout for building `IHost`
