### PR TITLE
Increase the character limit of the Meter instrument name

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Increased the character limit of the Meter instrument name from 63 to 255.
+  ([#4774](https://github.com/open-telemetry/opentelemetry-dotnet/issues/4774))
+
 ## 1.6.0-rc.1
 
 Released 2023-Aug-21

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderSdk.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderSdk.cs
@@ -48,7 +48,7 @@ internal sealed class MeterProviderBuilderSdk : MeterProviderBuilder, IMeterProv
     // Customers: This is not guaranteed to work forever. We may change this
     // mechanism in the future do this at your own risk.
     public static Regex InstrumentNameRegex { get; set; } = new(
-        @"^[a-z][a-z0-9-._]{0,62}$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        @"^[a-z][a-z0-9-._]{0,254}$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     public List<InstrumentationRegistration> Instrumentation { get; } = new();
 

--- a/test/OpenTelemetry.Tests/Metrics/MetricTestData.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricTestData.cs
@@ -25,7 +25,7 @@ public class MetricTestData
                 new object[] { "-first-char-not-alphabetic" },
                 new object[] { "1first-char-not-alphabetic" },
                 new object[] { "invalid+separator" },
-                new object[] { new string('m', 64) },
+                new object[] { new string('m', 256) },
                 new object[] { "a\xb5" }, // `\xb5` is the Micro character
        };
 
@@ -37,7 +37,7 @@ public class MetricTestData
                 new object[] { "my-2-instrument" },
                 new object[] { "my.metric" },
                 new object[] { "my_metric2" },
-                new object[] { new string('m', 63) },
+                new object[] { new string('m', 255) },
                 new object[] { "CaSe-InSeNsItIvE" },
        };
 


### PR DESCRIPTION
Design discussion issue #4774

## Changes

Changed the limit of the instrument name regex from 63 to 244 as specified [here](https://github.com/open-telemetry/opentelemetry-specification/blob/d2f4c8e54c3c44ccc2449336443df33d7f818035/specification/metrics/api.md?plain=1#L209) in the Open Telemetry metrics API specification.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
