### PR TITLE
Update default value for simple exemplar reservoir size

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Increased the character limit of the Meter instrument name from 63 to 255.
   ([#4774](https://github.com/open-telemetry/opentelemetry-dotnet/issues/4774))
 
+* Update default size for `SimpleExemplarReservoir` to `1`.
+  ([#4803](https://github.com/open-telemetry/opentelemetry-dotnet/issues/4803))
+
 ## 1.6.0-rc.1
 
 Released 2023-Aug-21

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -26,8 +26,7 @@ namespace OpenTelemetry.Metrics;
 /// </summary>
 public struct MetricPoint
 {
-    // TODO: Ask spec to define a default value for this.
-    private const int DefaultSimpleReservoirPoolSize = 10;
+    private const int DefaultSimpleReservoirPoolSize = 1;
 
     private readonly AggregatorStore aggregatorStore;
 


### PR DESCRIPTION
Spec has provided a default value for `SimpleExemplarReservoir` size: https://github.com/open-telemetry/opentelemetry-specification/pull/3670

## Changes
- Update the default size for `SimpleExemplarReservoir` to `1`.

## Merge requirement checklist

* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
