### PR TITLE
[OpenTracing.Shim] TracerShim constructor

### DIFF
--- a/examples/Console/TestOpenTracingShim.cs
+++ b/examples/Console/TestOpenTracingShim.cs
@@ -27,18 +27,18 @@ internal class TestOpenTracingShim
 {
     internal static object Run(OpenTracingShimOptions options)
     {
-        // Enable OpenTelemetry for the source "MyCompany.MyProduct.MyWebServer"
+        // Enable OpenTelemetry for the source "opentracing-shim"
         // and use Console exporter.
         using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-                .AddSource("MyCompany.MyProduct.MyWebServer")
+                .AddSource("opentracing-shim")
                 .ConfigureResource(r => r.AddService("MyServiceName"))
                 .AddConsoleExporter()
                 .Build();
 
         // Instantiate the OpenTracing shim. The underlying OpenTelemetry tracer will create
-        // spans using the "MyCompany.MyProduct.MyWebServer" source.
+        // spans using the "opentracing-shim" source.
         var openTracingTracerShim = new TracerShim(
-            TracerProvider.Default.GetTracer("MyCompany.MyProduct.MyWebServer"),
+            TracerProvider.Default,
             Propagators.DefaultTextMapPropagator);
 
         // The OpenTracing Tracer shim instance must be registered prior to any calls

--- a/src/OpenTelemetry.Shims.OpenTracing/.publicApi/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Shims.OpenTracing/.publicApi/net462/PublicAPI.Unshipped.txt
@@ -5,3 +5,5 @@ OpenTelemetry.Shims.OpenTracing.TracerShim.Extract<TCarrier>(OpenTracing.Propaga
 OpenTelemetry.Shims.OpenTracing.TracerShim.Inject<TCarrier>(OpenTracing.ISpanContext spanContext, OpenTracing.Propagation.IFormat<TCarrier> format, TCarrier carrier) -> void
 OpenTelemetry.Shims.OpenTracing.TracerShim.ScopeManager.get -> OpenTracing.IScopeManager
 OpenTelemetry.Shims.OpenTracing.TracerShim.TracerShim(OpenTelemetry.Trace.Tracer tracer, OpenTelemetry.Context.Propagation.TextMapPropagator textFormat) -> void
+OpenTelemetry.Shims.OpenTracing.TracerShim.TracerShim(OpenTelemetry.Trace.TracerProvider tracerProvider) -> void
+OpenTelemetry.Shims.OpenTracing.TracerShim.TracerShim(OpenTelemetry.Trace.TracerProvider tracerProvider, OpenTelemetry.Context.Propagation.TextMapPropagator textFormat) -> void

--- a/src/OpenTelemetry.Shims.OpenTracing/.publicApi/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Shims.OpenTracing/.publicApi/net6.0/PublicAPI.Unshipped.txt
@@ -5,3 +5,5 @@ OpenTelemetry.Shims.OpenTracing.TracerShim.Extract<TCarrier>(OpenTracing.Propaga
 OpenTelemetry.Shims.OpenTracing.TracerShim.Inject<TCarrier>(OpenTracing.ISpanContext spanContext, OpenTracing.Propagation.IFormat<TCarrier> format, TCarrier carrier) -> void
 OpenTelemetry.Shims.OpenTracing.TracerShim.ScopeManager.get -> OpenTracing.IScopeManager
 OpenTelemetry.Shims.OpenTracing.TracerShim.TracerShim(OpenTelemetry.Trace.Tracer tracer, OpenTelemetry.Context.Propagation.TextMapPropagator textFormat) -> void
+OpenTelemetry.Shims.OpenTracing.TracerShim.TracerShim(OpenTelemetry.Trace.TracerProvider tracerProvider) -> void
+OpenTelemetry.Shims.OpenTracing.TracerShim.TracerShim(OpenTelemetry.Trace.TracerProvider tracerProvider, OpenTelemetry.Context.Propagation.TextMapPropagator textFormat) -> void

--- a/src/OpenTelemetry.Shims.OpenTracing/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Shims.OpenTracing/.publicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -5,3 +5,5 @@ OpenTelemetry.Shims.OpenTracing.TracerShim.Extract<TCarrier>(OpenTracing.Propaga
 OpenTelemetry.Shims.OpenTracing.TracerShim.Inject<TCarrier>(OpenTracing.ISpanContext spanContext, OpenTracing.Propagation.IFormat<TCarrier> format, TCarrier carrier) -> void
 OpenTelemetry.Shims.OpenTracing.TracerShim.ScopeManager.get -> OpenTracing.IScopeManager
 OpenTelemetry.Shims.OpenTracing.TracerShim.TracerShim(OpenTelemetry.Trace.Tracer tracer, OpenTelemetry.Context.Propagation.TextMapPropagator textFormat) -> void
+OpenTelemetry.Shims.OpenTracing.TracerShim.TracerShim(OpenTelemetry.Trace.TracerProvider tracerProvider) -> void
+OpenTelemetry.Shims.OpenTracing.TracerShim.TracerShim(OpenTelemetry.Trace.TracerProvider tracerProvider, OpenTelemetry.Context.Propagation.TextMapPropagator textFormat) -> void

--- a/src/OpenTelemetry.Shims.OpenTracing/CHANGELOG.md
+++ b/src/OpenTelemetry.Shims.OpenTracing/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Fix: Do not raise `ArgumentException` if `Activity` behind the shim span
   has an invalid context.
   ([#2787](https://github.com/open-telemetry/opentelemetry-dotnet/issues/2787))
+* Obsolete `TracerShim(Tracer, TextMapPropagator)` constructor.
+  Provide `TracerShim(TracerProvider)`
+  and `TracerShim(TracerProvider, TextMapPropagator)` constructors.
+  ([#4812](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4812))
 
 ## 1.5.0-beta.1
 

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/IntegrationTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/IntegrationTests.cs
@@ -26,7 +26,6 @@ public class IntegrationTests
 {
     private const string ChildActivitySource = "ChildActivitySource";
     private const string ParentActivitySource = "ParentActivitySource";
-    private const string ShimTracerName = "OpenTracing.Shim";
 
     [Theory]
     [InlineData(SamplingDecision.Drop, SamplingDecision.Drop, SamplingDecision.Drop)]
@@ -63,14 +62,14 @@ public class IntegrationTests
                 b => b.AddSource(ParentActivitySource))
             .When(
                 shimSamplingDecision == SamplingDecision.RecordAndSample,
-                b => b.AddSource(ShimTracerName))
+                b => b.AddSource("opentracing-shim"))
             .When(
                 childActivitySamplingDecision == SamplingDecision.RecordAndSample,
                 b => b.AddSource(ChildActivitySource))
             .Build();
 
         ITracer otTracer = new TracerShim(
-            tracerProvider.GetTracer(ShimTracerName),
+            tracerProvider,
             Propagators.DefaultTextMapPropagator);
 
         // Real usage requires a call OpenTracing.Util.GlobalTracer.Register(otTracer),

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/TracerShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/TracerShimTests.cs
@@ -27,27 +27,20 @@ namespace OpenTelemetry.Shims.OpenTracing.Tests;
 
 public class TracerShimTests
 {
-    private const string TracerName = "defaultactivitysource";
-
     [Fact]
     public void CtorArgumentValidation()
     {
-        // null tracer and text format
-        Assert.Throws<ArgumentNullException>(() => new TracerShim(null, null));
+        // null tracer provider and text format
+        Assert.Throws<ArgumentNullException>(() => new TracerShim((TracerProvider)null, null));
 
-        // null tracer
-        Assert.Throws<ArgumentNullException>(() => new TracerShim(null, new TraceContextPropagator()));
-
-        // null context format
-        var tracerMock = new Mock<Tracer>();
-        Assert.Throws<ArgumentNullException>(() => new TracerShim(TracerProvider.Default.GetTracer("test"), null));
+        // null tracer provider
+        Assert.Throws<ArgumentNullException>(() => new TracerShim((TracerProvider)null, new TraceContextPropagator()));
     }
 
     [Fact]
     public void ScopeManager_NotNull()
     {
-        var tracer = TracerProvider.Default.GetTracer(TracerName);
-        var shim = new TracerShim(tracer, new TraceContextPropagator());
+        var shim = new TracerShim(TracerProvider.Default, new TraceContextPropagator());
 
         // Internals of the ScopeManagerShim tested elsewhere
         Assert.NotNull(shim.ScopeManager as ScopeManagerShim);
@@ -56,8 +49,7 @@ public class TracerShimTests
     [Fact]
     public void BuildSpan_NotNull()
     {
-        var tracer = TracerProvider.Default.GetTracer(TracerName);
-        var shim = new TracerShim(tracer, new TraceContextPropagator());
+        var shim = new TracerShim(TracerProvider.Default, new TraceContextPropagator());
 
         // Internals of the SpanBuilderShim tested elsewhere
         Assert.NotNull(shim.BuildSpan("foo") as SpanBuilderShim);
@@ -66,8 +58,7 @@ public class TracerShimTests
     [Fact]
     public void Inject_ArgumentValidation()
     {
-        var tracer = TracerProvider.Default.GetTracer(TracerName);
-        var shim = new TracerShim(tracer, new TraceContextPropagator());
+        var shim = new TracerShim(TracerProvider.Default, new TraceContextPropagator());
 
         var spanContextShim = new SpanContextShim(new SpanContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.None));
         var mockFormat = new Mock<IFormat<ITextMap>>();
@@ -82,8 +73,7 @@ public class TracerShimTests
     [Fact]
     public void Inject_UnknownFormatIgnored()
     {
-        var tracer = TracerProvider.Default.GetTracer(TracerName);
-        var shim = new TracerShim(tracer, new TraceContextPropagator());
+        var shim = new TracerShim(TracerProvider.Default, new TraceContextPropagator());
 
         var spanContextShim = new SpanContextShim(new SpanContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded));
 
@@ -98,8 +88,7 @@ public class TracerShimTests
     [Fact]
     public void Extract_ArgumentValidation()
     {
-        var tracer = TracerProvider.Default.GetTracer(TracerName);
-        var shim = new TracerShim(tracer, new TraceContextPropagator());
+        var shim = new TracerShim(TracerProvider.Default, new TraceContextPropagator());
 
         Assert.Throws<ArgumentNullException>(() => shim.Extract(null, new Mock<ITextMap>().Object));
         Assert.Throws<ArgumentNullException>(() => shim.Extract(new Mock<IFormat<ITextMap>>().Object, null));
@@ -108,8 +97,7 @@ public class TracerShimTests
     [Fact]
     public void Extract_UnknownFormatIgnored()
     {
-        var tracer = TracerProvider.Default.GetTracer(TracerName);
-        var shim = new TracerShim(tracer, new TraceContextPropagator());
+        var shim = new TracerShim(TracerProvider.Default, new TraceContextPropagator());
 
         var spanContextShim = new SpanContextShim(new SpanContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.None));
 
@@ -124,8 +112,7 @@ public class TracerShimTests
     [Fact]
     public void Extract_InvalidTraceParent()
     {
-        var tracer = TracerProvider.Default.GetTracer(TracerName);
-        var shim = new TracerShim(tracer, new TraceContextPropagator());
+        var shim = new TracerShim(TracerProvider.Default, new TraceContextPropagator());
 
         var mockCarrier = new Mock<ITextMap>();
 
@@ -154,8 +141,7 @@ public class TracerShimTests
 
         var format = new TraceContextPropagator();
 
-        var tracer = TracerProvider.Default.GetTracer(TracerName);
-        var shim = new TracerShim(tracer, format);
+        var shim = new TracerShim(TracerProvider.Default, format);
 
         // first inject
         shim.Inject(spanContextShim, BuiltinFormats.TextMap, carrier);


### PR DESCRIPTION
Fixes #4727

## Changes

TracerShim constructor met https://github.com/open-telemetry/opentelemetry-specification/blob/90eec0ffd8e52dddbd308e346cd5098f611164dd/specification/compatibility/opentracing.md
Old constructor marked as obsolete. It can be removed now/after this release.
2 new constructors to met criteria. If there is no propagator, the default one is used.
Unit tests covers only non-obsolete constructor.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
