### PR TITLE
GrpcChannel support custom HttpClient.

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * GrpcExporter support custom HttpClient.
-  ([#4813](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4813))
+  ([#4813](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4814))
 
 ## 1.6.0-rc.1
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* GrpcExporter support custom HttpClient.
+  ([#4813](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4813))
+
 ## 1.6.0-rc.1
 
 Released 2023-Aug-21

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -168,8 +168,9 @@ public class OtlpExporterOptions
     /// <remarks>
     /// Notes:
     /// <list type="bullet">
-    /// <item>This is only invoked for the <see
-    /// cref="OtlpExportProtocol.HttpProtobuf"/> protocol.</item>
+    /// <item>This is invoked for the <see
+    /// cref="OtlpExportProtocol.HttpProtobuf"/> protocol or &lt;see
+    /// cref="OtlpExportProtocol.Grpc"/>(only netstandard2.1+ and net6.0+) protocol.</item>
     /// <item>The default behavior when using the <see
     /// cref="OtlpTraceExporterHelperExtensions.AddOtlpExporter(TracerProviderBuilder,
     /// Action{OtlpExporterOptions})"/> extension is if an <a

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
@@ -43,7 +43,9 @@ internal static class OtlpExporterOptionsExtensions
         }
 
 #if NETSTANDARD2_1 || NET6_0_OR_GREATER
-        return GrpcChannel.ForAddress(options.Endpoint);
+        var httpClient = options.HttpClientFactory == null || options.HttpClientFactory == options.DefaultHttpClientFactory ? null : options.HttpClientFactory();
+
+        return GrpcChannel.ForAddress(options.Endpoint, new GrpcChannelOptions { HttpClient = httpClient });
 #else
         ChannelCredentials channelCredentials;
         if (options.Endpoint.Scheme == Uri.UriSchemeHttps)

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/ExportClient/OtlpGrpcTraceExportClientTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/ExportClient/OtlpGrpcTraceExportClientTests.cs
@@ -1,0 +1,76 @@
+// <copyright file="OtlpGrpcTraceExportClientTests.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET6_0_OR_GREATER
+using System.Reflection;
+using Grpc.Net.Client;
+using Moq;
+#endif
+using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
+using Xunit;
+
+namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests;
+
+public class OtlpGrpcTraceExportClientTests
+{
+    [Fact]
+    public void NewOtlpGrpcTraceExportClient_OtlpExporterOptions_ExporterHasCorrectProperties()
+    {
+        var header1 = new
+        {
+            Name = "hdr1", Value = "val1"
+        };
+        var header2 = new
+        {
+            Name = "hdr2", Value = "val2"
+        };
+
+        var options = new OtlpExporterOptions
+        {
+            Headers = $"{header1.Name}={header1.Value}, {header2.Name} = {header2.Value}",
+        };
+
+        var client = new OtlpGrpcTraceExportClient(options);
+
+        Assert.NotNull(client.Channel);
+
+        Assert.Equal(2 + OtlpExporterOptions.StandardHeaders.Length, client.Headers.Count);
+        Assert.Contains(client.Headers, kvp => kvp.Key == header1.Name && kvp.Value == header1.Value);
+        Assert.Contains(client.Headers, kvp => kvp.Key == header2.Name && kvp.Value == header2.Value);
+
+        for (int i = 0; i < OtlpExporterOptions.StandardHeaders.Length; i++)
+        {
+            Assert.Contains(client.Headers, entry => entry.Key.Equals(OtlpExporterOptions.StandardHeaders[i].Key, StringComparison.OrdinalIgnoreCase) && entry.Value == OtlpExporterOptions.StandardHeaders[i].Value);
+        }
+    }
+
+#if NET6_0_OR_GREATER
+    [Fact]
+    public void NewOtlpGrpcTraceExportClient_UseCustomHttpClient()
+    {
+        var httpClient = new Mock<HttpClient>();
+
+        var options = new OtlpExporterOptions
+        {
+            HttpClientFactory = () => httpClient.Object
+        };
+
+        var client = new OtlpGrpcTraceExportClient(options);
+
+        Assert.Equal(httpClient.Object, typeof(GrpcChannel).GetProperty("HttpInvoker", BindingFlags.Instance|BindingFlags.NonPublic)?.GetValue(client.Channel));
+    }
+#endif
+}


### PR DESCRIPTION
Design discussion issue #4813

Set `PooledConnectionLifetime` to avoid not following dns changes.

``` C#
new HttpClient(new SocketsHttpHandler
{
    PooledConnectionLifetime = TimeSpan.FromMinutes(2)
})
```

## Changes

Use the existing `OtlpExporterOptions.HttpClientFactory` property (Maybe is a break changes if `OtlpExporterOptions.Protocol` is `OtlpExportProtocol.Grpc` and `OtlpExporterOptions.HttpClientFactory` has set).

If use `OtlpExporterOptions.HttpClientFactory` will lose [client load balancer](https://github.com/grpc/grpc-dotnet/blob/master/src/Grpc.Net.Client/GrpcChannel.cs#L513) feature, Add `OtlpExporterOptions.HttpHandlerFactory` can fix it..

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
