### PR TITLE
[sdk] Hardcode known histograms using seconds

### DIFF
--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -202,7 +202,7 @@ internal sealed class AggregatorStore
         {
             switch (metricStreamIdentity.MeterName)
             {
-                // .NET 8 meter
+                // AspNetCore .NET 8 meter
                 case "Microsoft.AspNetCore.RateLimiting":
                 {
                     switch (metricStreamIdentity.InstrumentName)
@@ -229,7 +229,7 @@ internal sealed class AggregatorStore
                     break;
                 }
 
-                // AspNetCore instrumentation
+                // AspNetCore .NET 8 meter
                 case "Microsoft.AspNetCore.Hosting":
                 {
                     switch (metricStreamIdentity.InstrumentName)
@@ -241,7 +241,7 @@ internal sealed class AggregatorStore
                     break;
                 }
 
-                // AspNetCore instrumentation
+                // AspNetCore .NET 8 meter
                 case "Microsoft.AspNetCore.Server.Kestrel":
                 {
                     switch (metricStreamIdentity.InstrumentName)
@@ -254,7 +254,7 @@ internal sealed class AggregatorStore
                     break;
                 }
 
-                // AspNetCore instrumentation
+                // AspNetCore .NET 8 meter
                 case "Microsoft.AspNetCore.Http.Connections":
                 {
                     switch (metricStreamIdentity.InstrumentName)
@@ -272,6 +272,30 @@ internal sealed class AggregatorStore
                     switch (metricStreamIdentity.InstrumentName)
                     {
                         case "dns.lookups.duration":
+                            return Metric.DefaultHistogramBoundsSeconds;
+                    }
+
+                    break;
+                }
+
+                // OTel AspNetCore Instrumentation
+                case "OpenTelemetry.Instrumentation.AspNetCore":
+                {
+                    switch (metricStreamIdentity.InstrumentName)
+                    {
+                        case "http.server.duration":
+                            return Metric.DefaultHistogramBoundsSeconds;
+                    }
+
+                    break;
+                }
+
+                // OTel Http Instrumentation
+                case "OpenTelemetry.Instrumentation.Http":
+                {
+                    switch (metricStreamIdentity.InstrumentName)
+                    {
+                        case "http.client.duration":
                             return Metric.DefaultHistogramBoundsSeconds;
                     }
 

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -24,20 +24,20 @@ internal sealed class AggregatorStore
 {
     private static readonly string MetricPointCapHitFixMessage = "Consider opting in for the experimental SDK feature to emit all the throttled metrics under the overflow attribute by setting env variable OTEL_DOTNET_EXPERIMENTAL_METRICS_EMIT_OVERFLOW_ATTRIBUTE = true. You could also modify instrumentation to reduce the number of unique key/value pair combinations. Or use Views to drop unwanted tags. Or use MeterProviderBuilder.SetMaxMetricPointsPerMetricStream to set higher limit.";
     private static readonly Comparison<KeyValuePair<string, object>> DimensionComparisonDelegate = (x, y) => x.Key.CompareTo(y.Key);
-    private static readonly Dictionary<(string, string), double[]> DefaultHistogramBoundMappings = new()
+    private static readonly IReadOnlyDictionary<(string, string), double[]> DefaultHistogramBoundMappings = new Dictionary<(string, string), double[]>()
     {
-        { ("Microsoft.AspNetCore.RateLimiting", "aspnetcore.rate_limiting.request_lease.duration"), Metric.DefaultHistogramBoundsSeconds },
+        { ("Microsoft.AspNetCore.Hosting", "http.server.request.duration"), Metric.DefaultHistogramBoundsSeconds },
+        { ("Microsoft.AspNetCore.Http.Connections", "signalr.server.connection.duration"), Metric.DefaultHistogramBoundsSeconds },
         { ("Microsoft.AspNetCore.RateLimiting", "aspnetcore.rate_limiting.request.time_in_queue"), Metric.DefaultHistogramBoundsSeconds },
+        { ("Microsoft.AspNetCore.RateLimiting", "aspnetcore.rate_limiting.request_lease.duration"), Metric.DefaultHistogramBoundsSeconds },
+        { ("Microsoft.AspNetCore.Server.Kestrel", "kestrel.connection.duration"), Metric.DefaultHistogramBoundsSeconds },
+        { ("Microsoft.AspNetCore.Server.Kestrel", "kestrel.tls_handshake.duration"), Metric.DefaultHistogramBoundsSeconds },
+        { ("OpenTelemetry.Instrumentation.AspNetCore", "http.server.duration"), Metric.DefaultHistogramBoundsSeconds },
+        { ("OpenTelemetry.Instrumentation.Http", "http.client.duration"), Metric.DefaultHistogramBoundsSeconds },
         { ("System.Net.Http", "http.client.connection.duration"), Metric.DefaultHistogramBoundsSeconds },
         { ("System.Net.Http", "http.client.request.duration"), Metric.DefaultHistogramBoundsSeconds },
         { ("System.Net.Http", "http.client.request.time_in_queue"), Metric.DefaultHistogramBoundsSeconds },
-        { ("Microsoft.AspNetCore.Hosting", "http.server.request.duration"), Metric.DefaultHistogramBoundsSeconds },
-        { ("Microsoft.AspNetCore.Server.Kestrel", "kestrel.connection.duration"), Metric.DefaultHistogramBoundsSeconds },
-        { ("Microsoft.AspNetCore.Server.Kestrel", "kestrel.tls_handshake.duration"), Metric.DefaultHistogramBoundsSeconds },
-        { ("Microsoft.AspNetCore.Http.Connections", "signalr.server.connection.duration"), Metric.DefaultHistogramBoundsSeconds },
         { ("System.Net.NameResolution", "dns.lookups.duration"), Metric.DefaultHistogramBoundsSeconds },
-        { ("OpenTelemetry.Instrumentation.AspNetCore", "http.server.duration"), Metric.DefaultHistogramBoundsSeconds },
-        { ("OpenTelemetry.Instrumentation.Http", "http.client.duration"), Metric.DefaultHistogramBoundsSeconds },
     };
 
     private readonly object lockZeroTags = new();

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -24,21 +24,6 @@ internal sealed class AggregatorStore
 {
     private static readonly string MetricPointCapHitFixMessage = "Consider opting in for the experimental SDK feature to emit all the throttled metrics under the overflow attribute by setting env variable OTEL_DOTNET_EXPERIMENTAL_METRICS_EMIT_OVERFLOW_ATTRIBUTE = true. You could also modify instrumentation to reduce the number of unique key/value pair combinations. Or use Views to drop unwanted tags. Or use MeterProviderBuilder.SetMaxMetricPointsPerMetricStream to set higher limit.";
     private static readonly Comparison<KeyValuePair<string, object>> DimensionComparisonDelegate = (x, y) => x.Key.CompareTo(y.Key);
-    private static readonly IReadOnlyDictionary<(string, string), double[]> DefaultHistogramBoundMappings = new Dictionary<(string, string), double[]>()
-    {
-        { ("Microsoft.AspNetCore.Hosting", "http.server.request.duration"), Metric.DefaultHistogramBoundsSeconds },
-        { ("Microsoft.AspNetCore.Http.Connections", "signalr.server.connection.duration"), Metric.DefaultHistogramBoundsSeconds },
-        { ("Microsoft.AspNetCore.RateLimiting", "aspnetcore.rate_limiting.request.time_in_queue"), Metric.DefaultHistogramBoundsSeconds },
-        { ("Microsoft.AspNetCore.RateLimiting", "aspnetcore.rate_limiting.request_lease.duration"), Metric.DefaultHistogramBoundsSeconds },
-        { ("Microsoft.AspNetCore.Server.Kestrel", "kestrel.connection.duration"), Metric.DefaultHistogramBoundsSeconds },
-        { ("Microsoft.AspNetCore.Server.Kestrel", "kestrel.tls_handshake.duration"), Metric.DefaultHistogramBoundsSeconds },
-        { ("OpenTelemetry.Instrumentation.AspNetCore", "http.server.duration"), Metric.DefaultHistogramBoundsSeconds },
-        { ("OpenTelemetry.Instrumentation.Http", "http.client.duration"), Metric.DefaultHistogramBoundsSeconds },
-        { ("System.Net.Http", "http.client.connection.duration"), Metric.DefaultHistogramBoundsSeconds },
-        { ("System.Net.Http", "http.client.request.duration"), Metric.DefaultHistogramBoundsSeconds },
-        { ("System.Net.Http", "http.client.request.time_in_queue"), Metric.DefaultHistogramBoundsSeconds },
-        { ("System.Net.NameResolution", "dns.lookups.duration"), Metric.DefaultHistogramBoundsSeconds },
-    };
 
     private readonly object lockZeroTags = new();
     private readonly object lockOverflowTag = new();
@@ -215,10 +200,10 @@ internal sealed class AggregatorStore
 
     private static double[] FindDefaultHistogramBounds(in MetricStreamIdentity metricStreamIdentity)
     {
-        if (metricStreamIdentity.Unit == "s" && DefaultHistogramBoundMappings
-            .TryGetValue((metricStreamIdentity.MeterName, metricStreamIdentity.InstrumentName), out double[] histogramBounds))
+        if (metricStreamIdentity.Unit == "s" && Metric.DefaultHistogramBoundMappings
+            .Contains((metricStreamIdentity.MeterName, metricStreamIdentity.InstrumentName)))
         {
-            return histogramBounds;
+            return Metric.DefaultHistogramBoundsSeconds;
         }
 
         return Metric.DefaultHistogramBounds;

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -28,6 +28,7 @@ public sealed class Metric
     internal const int DefaultExponentialHistogramMaxScale = 20;
 
     internal static readonly double[] DefaultHistogramBounds = new double[] { 0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000 };
+    internal static readonly double[] DefaultHistogramBoundsSeconds = new double[] { 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10 };
 
     private readonly AggregatorStore aggStore;
 

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -38,7 +38,7 @@ public sealed class Metric
         ("Microsoft.AspNetCore.Server.Kestrel", "kestrel.connection.duration"),
         ("Microsoft.AspNetCore.Server.Kestrel", "kestrel.tls_handshake.duration"),
         ("OpenTelemetry.Instrumentation.AspNetCore", "http.server.duration"),
-        ("OpenTelemetry.Instrumentation.Http", "http.client.duration"),
+        ("OpenTelemetry.Instrumentation.Http", "http.client.request.duration"),
         ("System.Net.Http", "http.client.connection.duration"),
         ("System.Net.Http", "http.client.request.duration"),
         ("System.Net.Http", "http.client.request.time_in_queue"),

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -29,6 +29,21 @@ public sealed class Metric
 
     internal static readonly double[] DefaultHistogramBounds = new double[] { 0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000 };
     internal static readonly double[] DefaultHistogramBoundsSeconds = new double[] { 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10 };
+    internal static readonly HashSet<(string, string)> DefaultHistogramBoundMappings = new()
+    {
+        ("Microsoft.AspNetCore.Hosting", "http.server.request.duration"),
+        ("Microsoft.AspNetCore.Http.Connections", "signalr.server.connection.duration"),
+        ("Microsoft.AspNetCore.RateLimiting", "aspnetcore.rate_limiting.request.time_in_queue"),
+        ("Microsoft.AspNetCore.RateLimiting", "aspnetcore.rate_limiting.request_lease.duration"),
+        ("Microsoft.AspNetCore.Server.Kestrel", "kestrel.connection.duration"),
+        ("Microsoft.AspNetCore.Server.Kestrel", "kestrel.tls_handshake.duration"),
+        ("OpenTelemetry.Instrumentation.AspNetCore", "http.server.duration"),
+        ("OpenTelemetry.Instrumentation.Http", "http.client.duration"),
+        ("System.Net.Http", "http.client.connection.duration"),
+        ("System.Net.Http", "http.client.request.duration"),
+        ("System.Net.Http", "http.client.request.time_in_queue"),
+        ("System.Net.NameResolution", "dns.lookups.duration"),
+    };
 
     private readonly AggregatorStore aggStore;
 

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -37,7 +37,7 @@ public sealed class Metric
         ("Microsoft.AspNetCore.RateLimiting", "aspnetcore.rate_limiting.request_lease.duration"),
         ("Microsoft.AspNetCore.Server.Kestrel", "kestrel.connection.duration"),
         ("Microsoft.AspNetCore.Server.Kestrel", "kestrel.tls_handshake.duration"),
-        ("OpenTelemetry.Instrumentation.AspNetCore", "http.server.duration"),
+        ("OpenTelemetry.Instrumentation.AspNetCore", "http.server.request.duration"),
         ("OpenTelemetry.Instrumentation.Http", "http.client.request.duration"),
         ("System.Net.Http", "http.client.connection.duration"),
         ("System.Net.Http", "http.client.request.duration"),

--- a/test/OpenTelemetry.Tests/Metrics/AggregatorTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/AggregatorTestsBase.cs
@@ -239,18 +239,18 @@ public abstract class AggregatorTestsBase
     }
 
     [Theory]
+    [InlineData("Microsoft.AspNetCore.Hosting", "http.server.request.duration")]
+    [InlineData("Microsoft.AspNetCore.Http.Connections", "signalr.server.connection.duration")]
     [InlineData("Microsoft.AspNetCore.RateLimiting", "aspnetcore.rate_limiting.request_lease.duration")]
     [InlineData("Microsoft.AspNetCore.RateLimiting", "aspnetcore.rate_limiting.request.time_in_queue")]
+    [InlineData("Microsoft.AspNetCore.Server.Kestrel", "kestrel.connection.duration")]
+    [InlineData("Microsoft.AspNetCore.Server.Kestrel", "kestrel.tls_handshake.duration")]
+    [InlineData("OpenTelemetry.Instrumentation.AspNetCore", "http.server.duration")]
+    [InlineData("OpenTelemetry.Instrumentation.Http", "http.client.duration")]
     [InlineData("System.Net.Http", "http.client.connection.duration")]
     [InlineData("System.Net.Http", "http.client.request.duration")]
     [InlineData("System.Net.Http", "http.client.request.time_in_queue")]
-    [InlineData("Microsoft.AspNetCore.Hosting", "http.server.request.duration")]
-    [InlineData("Microsoft.AspNetCore.Server.Kestrel", "kestrel.connection.duration")]
-    [InlineData("Microsoft.AspNetCore.Server.Kestrel", "kestrel.tls_handshake.duration")]
-    [InlineData("Microsoft.AspNetCore.Http.Connections", "signalr.server.connection.duration")]
     [InlineData("System.Net.NameResolution", "dns.lookups.duration")]
-    [InlineData("OpenTelemetry.Instrumentation.AspNetCore", "http.server.duration")]
-    [InlineData("OpenTelemetry.Instrumentation.Http", "http.client.duration")]
     public void HistogramBucketsDefaultUpdatesForSecondsTest(string meterName, string instrumentName)
     {
         RunTest(meterName, instrumentName, unit: "s");

--- a/test/OpenTelemetry.Tests/Metrics/AggregatorTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/AggregatorTestsBase.cs
@@ -251,6 +251,7 @@ public abstract class AggregatorTestsBase
     [InlineData("System.Net.Http", "http.client.request.duration")]
     [InlineData("System.Net.Http", "http.client.request.time_in_queue")]
     [InlineData("System.Net.NameResolution", "dns.lookups.duration")]
+    [InlineData("General.App", "simple.alternative.counter")]
     public void HistogramBucketsDefaultUpdatesForSecondsTest(string meterName, string instrumentName)
     {
         RunTest(meterName, instrumentName, unit: "s");
@@ -275,7 +276,8 @@ public abstract class AggregatorTestsBase
 
             Assert.NotNull(aggregatorStore.HistogramBounds);
             Assert.Equal(
-                unit == "s" ? Metric.DefaultHistogramBoundsSeconds : Metric.DefaultHistogramBounds,
+                unit == "s" && Metric.DefaultHistogramBoundMappings.Contains((meterName, instrumentName)) ?
+                    Metric.DefaultHistogramBoundsSeconds : Metric.DefaultHistogramBounds,
                 aggregatorStore.HistogramBounds);
         }
     }

--- a/test/OpenTelemetry.Tests/Metrics/AggregatorTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/AggregatorTestsBase.cs
@@ -238,6 +238,48 @@ public abstract class AggregatorTestsBase
         Assert.Equal(200, argsToThread.SumOfDelta + lastDelta);
     }
 
+    [Theory]
+    [InlineData("Microsoft.AspNetCore.RateLimiting", "aspnetcore.rate_limiting.request_lease.duration")]
+    [InlineData("Microsoft.AspNetCore.RateLimiting", "aspnetcore.rate_limiting.request.time_in_queue")]
+    [InlineData("System.Net.Http", "http.client.connection.duration")]
+    [InlineData("System.Net.Http", "http.client.request.duration")]
+    [InlineData("System.Net.Http", "http.client.request.time_in_queue")]
+    [InlineData("Microsoft.AspNetCore.Hosting", "http.server.request.duration")]
+    [InlineData("Microsoft.AspNetCore.Server.Kestrel", "kestrel.connection.duration")]
+    [InlineData("Microsoft.AspNetCore.Server.Kestrel", "kestrel.tls_handshake.duration")]
+    [InlineData("Microsoft.AspNetCore.Http.Connections", "signalr.server.connection.duration")]
+    [InlineData("System.Net.NameResolution", "dns.lookups.duration")]
+    [InlineData("OpenTelemetry.Instrumentation.AspNetCore", "http.server.duration")]
+    [InlineData("OpenTelemetry.Instrumentation.Http", "http.client.duration")]
+    public void HistogramBucketsDefaultUpdatesForSecondsTest(string meterName, string instrumentName)
+    {
+        RunTest(meterName, instrumentName, unit: "s");
+        RunTest(meterName, instrumentName, unit: "ms");
+        RunTest(meterName, instrumentName, unit: "By");
+        RunTest(meterName, instrumentName, unit: null);
+
+        void RunTest(string meterName, string instrumentName, string unit)
+        {
+            using var meter = new Meter(meterName);
+
+            var instrument = meter.CreateHistogram<double>(instrumentName, unit);
+
+            var metricStreamIdentity = new MetricStreamIdentity(instrument, metricStreamConfiguration: null);
+
+            AggregatorStore aggregatorStore = new(
+                metricStreamIdentity,
+                AggregationType.Histogram,
+                AggregationTemporality.Cumulative,
+                maxMetricPoints: 1024,
+                this.emitOverflowAttribute);
+
+            Assert.NotNull(aggregatorStore.HistogramBounds);
+            Assert.Equal(
+                unit == "s" ? Metric.DefaultHistogramBoundsSeconds : Metric.DefaultHistogramBounds,
+                aggregatorStore.HistogramBounds);
+        }
+    }
+
     internal static void AssertExponentialBucketsAreCorrect(Base2ExponentialBucketHistogram expectedHistogram, ExponentialHistogramData data)
     {
         Assert.Equal(expectedHistogram.Scale, data.Scale);


### PR DESCRIPTION
Closes #4797 
Design discussion issue #4797

## Changes

* Change histogram default boundaries when `MetricStreamIdentity.Unit` is set to "s"
* New default buckets are set to `{ 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10 }`
* Created a set of well-known Meters/Instruments for the default
* Added unit-test for the new defaults

## Acknowledgement

The PR is created with the assistance from @CodeBlanch

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `[CHANGELOG.md](http://changelog.md/)` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)