### PR TITLE
[otlp] Update changelog to indicate Breaking change

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 Released 2023-Aug-21
 
-* Excluded attributes corresponding to `LogRecord.EventId`,
+* **Breaking**: Excluded attributes corresponding to `LogRecord.EventId`,
 `LogRecord.CategoryName` and `LogRecord.Exception` from the exported data. This
 is done as the semantic conventions for these attributes are not yet stable.
 ([#4781](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4781))

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 Released 2023-Aug-21
 
-* **Breaking**: Excluded attributes corresponding to `LogRecord.EventId`,
+* **Breaking change**: Excluded attributes corresponding to `LogRecord.EventId`,
 `LogRecord.CategoryName` and `LogRecord.Exception` from the exported data. This
 is done as the semantic conventions for these attributes are not yet stable.
 ([#4781](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4781))


### PR DESCRIPTION
Fixes #
Design discussion issue #

## Changes
Update changelog to indicate Breaking change for `LogRecord.EventId`, `LogRecord.CategoryName` and `LogRecord.Exception` attributes
Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
