### PR TITLE
[build] Fix ordering issues with ExposeExperimentalFeatures compiler switch

### DIFF
--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -59,6 +59,19 @@
     <Message Importance="high" Text="**AssemblyVersionDebug** TargetFramework: $(TargetFramework), MinVerVersion: $(MinVerVersion), MinVerMajor: $(MinVerMajor), MinVerMinor: $(MinVerMinor), MinVerPatch: $(MinVerPatch), MinVerPreRelease: $(MinVerPreRelease), BuildNumber: $(BuildNumber), FileVersion: $(FileVersion), ExposeExperimentalFeatures: $(ExposeExperimentalFeatures)" />
   </Target>
 
+  <Target Name="ResolveExposeExperimentalFeatures" AfterTargets="MinVer">
+    <PropertyGroup Condition="'$(ExposeExperimentalFeatures)' == 'true'">
+      <DefineConstants>$(DefineConstants);EXPOSE_EXPERIMENTAL_FEATURES</DefineConstants>
+    </PropertyGroup>
+
+    <!--PublicApi Analyzer-->
+    <ItemGroup>
+      <AdditionalFiles Include=".publicApi\Stable\$(TargetFramework)\PublicAPI.*.txt" />
+      <AdditionalFiles Include=".publicApi\Experimental\$(TargetFramework)\PublicAPI.*.txt" Condition="'$(ExposeExperimentalFeatures)' == 'true'" />
+      <AdditionalFiles Include=".publicApi\$(TargetFramework)\PublicAPI.*.txt" />
+    </ItemGroup>
+  </Target>
+
   <PropertyGroup>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/open-telemetry/opentelemetry-dotnet</RepositoryUrl>
@@ -92,9 +105,6 @@
 
   <!--PublicApi Analyzer-->
   <ItemGroup>
-    <AdditionalFiles Include=".publicApi\Stable\$(TargetFramework)\PublicAPI.*.txt" />
-    <AdditionalFiles Include=".publicApi\Experimental\$(TargetFramework)\PublicAPI.*.txt" Condition="'$(ExposeExperimentalFeatures)' == 'true'" />
-    <AdditionalFiles Include=".publicApi\$(TargetFramework)\PublicAPI.*.txt" />
     <None Include=".publicApi\**\PublicAPI.*.txt" />
   </ItemGroup>
 

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -2,10 +2,7 @@
   <Import Project=".\Common.props" />
 
   <ItemGroup>
-    <PackageReference Include="MinVer"  PrivateAssets="All" Condition="'$(IntegrationBuild)' != 'true'">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-
+    <PackageReference Include="MinVer" PrivateAssets="All" Condition="'$(IntegrationBuild)' != 'true'" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />
   </ItemGroup>
 
@@ -59,7 +56,7 @@
     <Message Importance="high" Text="**AssemblyVersionDebug** TargetFramework: $(TargetFramework), MinVerVersion: $(MinVerVersion), MinVerMajor: $(MinVerMajor), MinVerMinor: $(MinVerMinor), MinVerPatch: $(MinVerPatch), MinVerPreRelease: $(MinVerPreRelease), BuildNumber: $(BuildNumber), FileVersion: $(FileVersion), ExposeExperimentalFeatures: $(ExposeExperimentalFeatures)" />
   </Target>
 
-  <Target Name="ResolveExposeExperimentalFeatures" AfterTargets="MinVer">
+  <Target Name="ResolveExposeExperimentalFeatures" BeforeTargets="BeforeCompile" DependsOnTargets="AssemblyVersionTarget">
     <PropertyGroup Condition="'$(ExposeExperimentalFeatures)' == 'true'">
       <DefineConstants>$(DefineConstants);EXPOSE_EXPERIMENTAL_FEATURES</DefineConstants>
     </PropertyGroup>

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -8,6 +8,7 @@
 
   <PropertyGroup>
     <RunApiCompat>true</RunApiCompat>
+    <ExposeExperimentalFeatures Condition="'$(ExposeExperimentalFeatures)' == ''">true</ExposeExperimentalFeatures>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(MinVerTagPrefix)' == 'core-' AND '$(CheckAPICompatibility)' == 'true' AND '$(RunApiCompat)' == 'true'">

--- a/build/Common.props
+++ b/build/Common.props
@@ -11,7 +11,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <!--temporarily disable. See 3958-->
     <!--<AnalysisLevel>latest-All</AnalysisLevel>-->
-    <ExposeExperimentalFeatures Condition="'$(ExposeExperimentalFeatures)' == ''">true</ExposeExperimentalFeatures>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/build/Common.props
+++ b/build/Common.props
@@ -14,10 +14,6 @@
     <ExposeExperimentalFeatures Condition="'$(ExposeExperimentalFeatures)' == ''">true</ExposeExperimentalFeatures>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(ExposeExperimentalFeatures)' == 'true'">
-    <DefineConstants>$(DefineConstants);EXPOSE_EXPERIMENTAL_FEATURES</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
## Changes

* Fixes the order of things so `EXPOSE_EXPERIMENTAL_FEATURES` constant is set AFTER the version resolution logic fires