### PR TITLE
[sdk] Add missing XML comments and nullable decorations for public APIs

### DIFF
--- a/src/OpenTelemetry.Api/OpenTelemetry.Api.csproj
+++ b/src/OpenTelemetry.Api/OpenTelemetry.Api.csproj
@@ -3,8 +3,6 @@
     <TargetFrameworks>$(DefaultTargetFrameworks)</TargetFrameworks>
     <Description>OpenTelemetry .NET API</Description>
     <RootNamespace>OpenTelemetry</RootNamespace>
-
-    <NoWarn>$(NoWarn),CS0618</NoWarn>
     <MinVerTagPrefix>core-</MinVerTagPrefix>
 
     <!-- this is temporary. will remove in future PR. -->

--- a/src/OpenTelemetry/.publicApi/Experimental/net462/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/Experimental/net462/PublicAPI.Unshipped.txt
@@ -31,12 +31,12 @@ static OpenTelemetry.Logs.LoggerProviderExtensions.ForceFlush(this OpenTelemetry
 static OpenTelemetry.Logs.LoggerProviderExtensions.Shutdown(this OpenTelemetry.Logs.LoggerProvider! provider, int timeoutMilliseconds = -1) -> bool
 static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetExemplarFilter(this OpenTelemetry.Metrics.MeterProviderBuilder! meterProviderBuilder, OpenTelemetry.Metrics.ExemplarFilter! exemplarFilter) -> OpenTelemetry.Metrics.MeterProviderBuilder!
 static OpenTelemetry.Sdk.CreateLoggerProviderBuilder() -> OpenTelemetry.Logs.LoggerProviderBuilder!
-~abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~OpenTelemetry.Metrics.Exemplar.FilteredTags.get -> System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string, object>>
-~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~override OpenTelemetry.Metrics.TraceBasedExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~override OpenTelemetry.Metrics.TraceBasedExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
+abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+OpenTelemetry.Metrics.Exemplar.FilteredTags.get -> System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string!, object?>>?
+override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+override OpenTelemetry.Metrics.TraceBasedExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+override OpenTelemetry.Metrics.TraceBasedExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool

--- a/src/OpenTelemetry/.publicApi/Experimental/net6.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/Experimental/net6.0/PublicAPI.Unshipped.txt
@@ -31,12 +31,12 @@ static OpenTelemetry.Logs.LoggerProviderExtensions.ForceFlush(this OpenTelemetry
 static OpenTelemetry.Logs.LoggerProviderExtensions.Shutdown(this OpenTelemetry.Logs.LoggerProvider! provider, int timeoutMilliseconds = -1) -> bool
 static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetExemplarFilter(this OpenTelemetry.Metrics.MeterProviderBuilder! meterProviderBuilder, OpenTelemetry.Metrics.ExemplarFilter! exemplarFilter) -> OpenTelemetry.Metrics.MeterProviderBuilder!
 static OpenTelemetry.Sdk.CreateLoggerProviderBuilder() -> OpenTelemetry.Logs.LoggerProviderBuilder!
-~abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~OpenTelemetry.Metrics.Exemplar.FilteredTags.get -> System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string, object>>
-~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~override OpenTelemetry.Metrics.TraceBasedExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~override OpenTelemetry.Metrics.TraceBasedExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
+abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+OpenTelemetry.Metrics.Exemplar.FilteredTags.get -> System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string!, object?>>?
+override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+override OpenTelemetry.Metrics.TraceBasedExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+override OpenTelemetry.Metrics.TraceBasedExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool

--- a/src/OpenTelemetry/.publicApi/Experimental/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/Experimental/netstandard2.0/PublicAPI.Unshipped.txt
@@ -31,12 +31,12 @@ static OpenTelemetry.Logs.LoggerProviderExtensions.ForceFlush(this OpenTelemetry
 static OpenTelemetry.Logs.LoggerProviderExtensions.Shutdown(this OpenTelemetry.Logs.LoggerProvider! provider, int timeoutMilliseconds = -1) -> bool
 static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetExemplarFilter(this OpenTelemetry.Metrics.MeterProviderBuilder! meterProviderBuilder, OpenTelemetry.Metrics.ExemplarFilter! exemplarFilter) -> OpenTelemetry.Metrics.MeterProviderBuilder!
 static OpenTelemetry.Sdk.CreateLoggerProviderBuilder() -> OpenTelemetry.Logs.LoggerProviderBuilder!
-~abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~OpenTelemetry.Metrics.Exemplar.FilteredTags.get -> System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string, object>>
-~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~override OpenTelemetry.Metrics.TraceBasedExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~override OpenTelemetry.Metrics.TraceBasedExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
+abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+OpenTelemetry.Metrics.Exemplar.FilteredTags.get -> System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string!, object?>>?
+override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+override OpenTelemetry.Metrics.TraceBasedExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+override OpenTelemetry.Metrics.TraceBasedExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool

--- a/src/OpenTelemetry/.publicApi/Experimental/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/Experimental/netstandard2.1/PublicAPI.Unshipped.txt
@@ -31,12 +31,12 @@ static OpenTelemetry.Logs.LoggerProviderExtensions.ForceFlush(this OpenTelemetry
 static OpenTelemetry.Logs.LoggerProviderExtensions.Shutdown(this OpenTelemetry.Logs.LoggerProvider! provider, int timeoutMilliseconds = -1) -> bool
 static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetExemplarFilter(this OpenTelemetry.Metrics.MeterProviderBuilder! meterProviderBuilder, OpenTelemetry.Metrics.ExemplarFilter! exemplarFilter) -> OpenTelemetry.Metrics.MeterProviderBuilder!
 static OpenTelemetry.Sdk.CreateLoggerProviderBuilder() -> OpenTelemetry.Logs.LoggerProviderBuilder!
-~abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~OpenTelemetry.Metrics.Exemplar.FilteredTags.get -> System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string, object>>
-~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~override OpenTelemetry.Metrics.TraceBasedExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
-~override OpenTelemetry.Metrics.TraceBasedExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string, object>> tags) -> bool
+abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+abstract OpenTelemetry.Metrics.ExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+OpenTelemetry.Metrics.Exemplar.FilteredTags.get -> System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string!, object?>>?
+override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+override OpenTelemetry.Metrics.AlwaysOffExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+override OpenTelemetry.Metrics.AlwaysOnExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+override OpenTelemetry.Metrics.TraceBasedExemplarFilter.ShouldSample(double value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool
+override OpenTelemetry.Metrics.TraceBasedExemplarFilter.ShouldSample(long value, System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>> tags) -> bool

--- a/src/OpenTelemetry/.publicApi/Stable/net462/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry/.publicApi/Stable/net462/PublicAPI.Shipped.txt
@@ -1,28 +1,28 @@
 #nullable enable
 ~OpenTelemetry.Batch<T>.GetEnumerator() -> OpenTelemetry.Batch<T>.Enumerator
-~OpenTelemetry.Metrics.BaseExportingMetricReader.BaseExportingMetricReader(OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric> exporter) -> void
-~OpenTelemetry.Metrics.ExplicitBucketHistogramConfiguration.Boundaries.get -> double[]
-~OpenTelemetry.Metrics.ExplicitBucketHistogramConfiguration.Boundaries.set -> void
-~OpenTelemetry.Metrics.IPullMetricExporter.Collect.get -> System.Func<int, bool>
-~OpenTelemetry.Metrics.IPullMetricExporter.Collect.set -> void
-~OpenTelemetry.Metrics.Metric.Description.get -> string
-~OpenTelemetry.Metrics.Metric.MeterName.get -> string
-~OpenTelemetry.Metrics.Metric.MeterVersion.get -> string
-~OpenTelemetry.Metrics.Metric.Name.get -> string
-~OpenTelemetry.Metrics.Metric.Unit.get -> string
-~OpenTelemetry.Metrics.MetricStreamConfiguration.Description.get -> string
-~OpenTelemetry.Metrics.MetricStreamConfiguration.Description.set -> void
-~OpenTelemetry.Metrics.MetricStreamConfiguration.Name.get -> string
-~OpenTelemetry.Metrics.MetricStreamConfiguration.Name.set -> void
-~OpenTelemetry.Metrics.MetricStreamConfiguration.TagKeys.get -> string[]
-~OpenTelemetry.Metrics.MetricStreamConfiguration.TagKeys.set -> void
-~OpenTelemetry.Metrics.PeriodicExportingMetricReader.PeriodicExportingMetricReader(OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric> exporter, int exportIntervalMilliseconds = 60000, int exportTimeoutMilliseconds = 30000) -> void
+OpenTelemetry.Metrics.BaseExportingMetricReader.BaseExportingMetricReader(OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric!>! exporter) -> void
+OpenTelemetry.Metrics.ExplicitBucketHistogramConfiguration.Boundaries.get -> double[]?
+OpenTelemetry.Metrics.ExplicitBucketHistogramConfiguration.Boundaries.set -> void
+OpenTelemetry.Metrics.IPullMetricExporter.Collect.get -> System.Func<int, bool>?
+OpenTelemetry.Metrics.IPullMetricExporter.Collect.set -> void
+OpenTelemetry.Metrics.Metric.Description.get -> string!
+OpenTelemetry.Metrics.Metric.MeterName.get -> string!
+OpenTelemetry.Metrics.Metric.MeterVersion.get -> string!
+OpenTelemetry.Metrics.Metric.Name.get -> string!
+OpenTelemetry.Metrics.Metric.Unit.get -> string!
+OpenTelemetry.Metrics.MetricStreamConfiguration.Description.get -> string?
+OpenTelemetry.Metrics.MetricStreamConfiguration.Description.set -> void
+OpenTelemetry.Metrics.MetricStreamConfiguration.Name.get -> string?
+OpenTelemetry.Metrics.MetricStreamConfiguration.Name.set -> void
+OpenTelemetry.Metrics.MetricStreamConfiguration.TagKeys.get -> string![]?
+OpenTelemetry.Metrics.MetricStreamConfiguration.TagKeys.set -> void
+OpenTelemetry.Metrics.PeriodicExportingMetricReader.PeriodicExportingMetricReader(OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric!>! exporter, int exportIntervalMilliseconds = 60000, int exportTimeoutMilliseconds = 30000) -> void
 ~override OpenTelemetry.Metrics.MeterProviderBuilderBase.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation>! instrumentationFactory) -> OpenTelemetry.Metrics.MeterProviderBuilder!
 ~override OpenTelemetry.Trace.TracerProviderBuilderBase.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation>! instrumentationFactory) -> OpenTelemetry.Trace.TracerProviderBuilder!
-~readonly OpenTelemetry.Metrics.BaseExportingMetricReader.exporter -> OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric>
-~static OpenTelemetry.Metrics.MeterProviderExtensions.ForceFlush(this OpenTelemetry.Metrics.MeterProvider provider, int timeoutMilliseconds = -1) -> bool
-~static OpenTelemetry.Metrics.MeterProviderExtensions.Shutdown(this OpenTelemetry.Metrics.MeterProvider provider, int timeoutMilliseconds = -1) -> bool
-~static OpenTelemetry.Metrics.MetricStreamConfiguration.Drop.get -> OpenTelemetry.Metrics.MetricStreamConfiguration
+readonly OpenTelemetry.Metrics.BaseExportingMetricReader.exporter -> OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric!>!
+static OpenTelemetry.Metrics.MeterProviderExtensions.ForceFlush(this OpenTelemetry.Metrics.MeterProvider! provider, int timeoutMilliseconds = -1) -> bool
+static OpenTelemetry.Metrics.MeterProviderExtensions.Shutdown(this OpenTelemetry.Metrics.MeterProvider! provider, int timeoutMilliseconds = -1) -> bool
+static OpenTelemetry.Metrics.MetricStreamConfiguration.Drop.get -> OpenTelemetry.Metrics.MetricStreamConfiguration!
 abstract OpenTelemetry.BaseExporter<T>.Export(in OpenTelemetry.Batch<T!> batch) -> OpenTelemetry.ExportResult
 abstract OpenTelemetry.BaseExportProcessor<T>.OnExport(T! data) -> void
 abstract OpenTelemetry.Trace.Sampler.ShouldSample(in OpenTelemetry.Trace.SamplingParameters samplingParameters) -> OpenTelemetry.Trace.SamplingResult
@@ -253,7 +253,7 @@ OpenTelemetry.ProviderExtensions
 OpenTelemetry.ReadOnlyTagCollection
 OpenTelemetry.ReadOnlyTagCollection.Count.get -> int
 OpenTelemetry.ReadOnlyTagCollection.Enumerator
-OpenTelemetry.ReadOnlyTagCollection.Enumerator.Current.get -> System.Collections.Generic.KeyValuePair<string!, object!>
+OpenTelemetry.ReadOnlyTagCollection.Enumerator.Current.get -> System.Collections.Generic.KeyValuePair<string!, object?>
 OpenTelemetry.ReadOnlyTagCollection.Enumerator.Enumerator() -> void
 OpenTelemetry.ReadOnlyTagCollection.Enumerator.MoveNext() -> bool
 OpenTelemetry.ReadOnlyTagCollection.GetEnumerator() -> OpenTelemetry.ReadOnlyTagCollection.Enumerator

--- a/src/OpenTelemetry/.publicApi/Stable/net6.0/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry/.publicApi/Stable/net6.0/PublicAPI.Shipped.txt
@@ -1,28 +1,28 @@
 #nullable enable
 ~OpenTelemetry.Batch<T>.GetEnumerator() -> OpenTelemetry.Batch<T>.Enumerator
-~OpenTelemetry.Metrics.BaseExportingMetricReader.BaseExportingMetricReader(OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric> exporter) -> void
-~OpenTelemetry.Metrics.ExplicitBucketHistogramConfiguration.Boundaries.get -> double[]
-~OpenTelemetry.Metrics.ExplicitBucketHistogramConfiguration.Boundaries.set -> void
-~OpenTelemetry.Metrics.IPullMetricExporter.Collect.get -> System.Func<int, bool>
-~OpenTelemetry.Metrics.IPullMetricExporter.Collect.set -> void
-~OpenTelemetry.Metrics.Metric.Description.get -> string
-~OpenTelemetry.Metrics.Metric.MeterName.get -> string
-~OpenTelemetry.Metrics.Metric.MeterVersion.get -> string
-~OpenTelemetry.Metrics.Metric.Name.get -> string
-~OpenTelemetry.Metrics.Metric.Unit.get -> string
-~OpenTelemetry.Metrics.MetricStreamConfiguration.Description.get -> string
-~OpenTelemetry.Metrics.MetricStreamConfiguration.Description.set -> void
-~OpenTelemetry.Metrics.MetricStreamConfiguration.Name.get -> string
-~OpenTelemetry.Metrics.MetricStreamConfiguration.Name.set -> void
-~OpenTelemetry.Metrics.MetricStreamConfiguration.TagKeys.get -> string[]
-~OpenTelemetry.Metrics.MetricStreamConfiguration.TagKeys.set -> void
-~OpenTelemetry.Metrics.PeriodicExportingMetricReader.PeriodicExportingMetricReader(OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric> exporter, int exportIntervalMilliseconds = 60000, int exportTimeoutMilliseconds = 30000) -> void
+OpenTelemetry.Metrics.BaseExportingMetricReader.BaseExportingMetricReader(OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric!>! exporter) -> void
+OpenTelemetry.Metrics.ExplicitBucketHistogramConfiguration.Boundaries.get -> double[]?
+OpenTelemetry.Metrics.ExplicitBucketHistogramConfiguration.Boundaries.set -> void
+OpenTelemetry.Metrics.IPullMetricExporter.Collect.get -> System.Func<int, bool>?
+OpenTelemetry.Metrics.IPullMetricExporter.Collect.set -> void
+OpenTelemetry.Metrics.Metric.Description.get -> string!
+OpenTelemetry.Metrics.Metric.MeterName.get -> string!
+OpenTelemetry.Metrics.Metric.MeterVersion.get -> string!
+OpenTelemetry.Metrics.Metric.Name.get -> string!
+OpenTelemetry.Metrics.Metric.Unit.get -> string!
+OpenTelemetry.Metrics.MetricStreamConfiguration.Description.get -> string?
+OpenTelemetry.Metrics.MetricStreamConfiguration.Description.set -> void
+OpenTelemetry.Metrics.MetricStreamConfiguration.Name.get -> string?
+OpenTelemetry.Metrics.MetricStreamConfiguration.Name.set -> void
+OpenTelemetry.Metrics.MetricStreamConfiguration.TagKeys.get -> string![]?
+OpenTelemetry.Metrics.MetricStreamConfiguration.TagKeys.set -> void
+OpenTelemetry.Metrics.PeriodicExportingMetricReader.PeriodicExportingMetricReader(OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric!>! exporter, int exportIntervalMilliseconds = 60000, int exportTimeoutMilliseconds = 30000) -> void
 ~override OpenTelemetry.Metrics.MeterProviderBuilderBase.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation>! instrumentationFactory) -> OpenTelemetry.Metrics.MeterProviderBuilder!
 ~override OpenTelemetry.Trace.TracerProviderBuilderBase.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation>! instrumentationFactory) -> OpenTelemetry.Trace.TracerProviderBuilder!
-~readonly OpenTelemetry.Metrics.BaseExportingMetricReader.exporter -> OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric>
-~static OpenTelemetry.Metrics.MeterProviderExtensions.ForceFlush(this OpenTelemetry.Metrics.MeterProvider provider, int timeoutMilliseconds = -1) -> bool
-~static OpenTelemetry.Metrics.MeterProviderExtensions.Shutdown(this OpenTelemetry.Metrics.MeterProvider provider, int timeoutMilliseconds = -1) -> bool
-~static OpenTelemetry.Metrics.MetricStreamConfiguration.Drop.get -> OpenTelemetry.Metrics.MetricStreamConfiguration
+readonly OpenTelemetry.Metrics.BaseExportingMetricReader.exporter -> OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric!>!
+static OpenTelemetry.Metrics.MeterProviderExtensions.ForceFlush(this OpenTelemetry.Metrics.MeterProvider! provider, int timeoutMilliseconds = -1) -> bool
+static OpenTelemetry.Metrics.MeterProviderExtensions.Shutdown(this OpenTelemetry.Metrics.MeterProvider! provider, int timeoutMilliseconds = -1) -> bool
+static OpenTelemetry.Metrics.MetricStreamConfiguration.Drop.get -> OpenTelemetry.Metrics.MetricStreamConfiguration!
 abstract OpenTelemetry.BaseExporter<T>.Export(in OpenTelemetry.Batch<T!> batch) -> OpenTelemetry.ExportResult
 abstract OpenTelemetry.BaseExportProcessor<T>.OnExport(T! data) -> void
 abstract OpenTelemetry.Trace.Sampler.ShouldSample(in OpenTelemetry.Trace.SamplingParameters samplingParameters) -> OpenTelemetry.Trace.SamplingResult
@@ -253,7 +253,7 @@ OpenTelemetry.ProviderExtensions
 OpenTelemetry.ReadOnlyTagCollection
 OpenTelemetry.ReadOnlyTagCollection.Count.get -> int
 OpenTelemetry.ReadOnlyTagCollection.Enumerator
-OpenTelemetry.ReadOnlyTagCollection.Enumerator.Current.get -> System.Collections.Generic.KeyValuePair<string!, object!>
+OpenTelemetry.ReadOnlyTagCollection.Enumerator.Current.get -> System.Collections.Generic.KeyValuePair<string!, object?>
 OpenTelemetry.ReadOnlyTagCollection.Enumerator.Enumerator() -> void
 OpenTelemetry.ReadOnlyTagCollection.Enumerator.MoveNext() -> bool
 OpenTelemetry.ReadOnlyTagCollection.GetEnumerator() -> OpenTelemetry.ReadOnlyTagCollection.Enumerator

--- a/src/OpenTelemetry/.publicApi/Stable/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry/.publicApi/Stable/netstandard2.0/PublicAPI.Shipped.txt
@@ -1,28 +1,28 @@
 #nullable enable
 ~OpenTelemetry.Batch<T>.GetEnumerator() -> OpenTelemetry.Batch<T>.Enumerator
-~OpenTelemetry.Metrics.BaseExportingMetricReader.BaseExportingMetricReader(OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric> exporter) -> void
-~OpenTelemetry.Metrics.ExplicitBucketHistogramConfiguration.Boundaries.get -> double[]
-~OpenTelemetry.Metrics.ExplicitBucketHistogramConfiguration.Boundaries.set -> void
-~OpenTelemetry.Metrics.IPullMetricExporter.Collect.get -> System.Func<int, bool>
-~OpenTelemetry.Metrics.IPullMetricExporter.Collect.set -> void
-~OpenTelemetry.Metrics.Metric.Description.get -> string
-~OpenTelemetry.Metrics.Metric.MeterName.get -> string
-~OpenTelemetry.Metrics.Metric.MeterVersion.get -> string
-~OpenTelemetry.Metrics.Metric.Name.get -> string
-~OpenTelemetry.Metrics.Metric.Unit.get -> string
-~OpenTelemetry.Metrics.MetricStreamConfiguration.Description.get -> string
-~OpenTelemetry.Metrics.MetricStreamConfiguration.Description.set -> void
-~OpenTelemetry.Metrics.MetricStreamConfiguration.Name.get -> string
-~OpenTelemetry.Metrics.MetricStreamConfiguration.Name.set -> void
-~OpenTelemetry.Metrics.MetricStreamConfiguration.TagKeys.get -> string[]
-~OpenTelemetry.Metrics.MetricStreamConfiguration.TagKeys.set -> void
-~OpenTelemetry.Metrics.PeriodicExportingMetricReader.PeriodicExportingMetricReader(OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric> exporter, int exportIntervalMilliseconds = 60000, int exportTimeoutMilliseconds = 30000) -> void
+OpenTelemetry.Metrics.BaseExportingMetricReader.BaseExportingMetricReader(OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric!>! exporter) -> void
+OpenTelemetry.Metrics.ExplicitBucketHistogramConfiguration.Boundaries.get -> double[]?
+OpenTelemetry.Metrics.ExplicitBucketHistogramConfiguration.Boundaries.set -> void
+OpenTelemetry.Metrics.IPullMetricExporter.Collect.get -> System.Func<int, bool>?
+OpenTelemetry.Metrics.IPullMetricExporter.Collect.set -> void
+OpenTelemetry.Metrics.Metric.Description.get -> string!
+OpenTelemetry.Metrics.Metric.MeterName.get -> string!
+OpenTelemetry.Metrics.Metric.MeterVersion.get -> string!
+OpenTelemetry.Metrics.Metric.Name.get -> string!
+OpenTelemetry.Metrics.Metric.Unit.get -> string!
+OpenTelemetry.Metrics.MetricStreamConfiguration.Description.get -> string?
+OpenTelemetry.Metrics.MetricStreamConfiguration.Description.set -> void
+OpenTelemetry.Metrics.MetricStreamConfiguration.Name.get -> string?
+OpenTelemetry.Metrics.MetricStreamConfiguration.Name.set -> void
+OpenTelemetry.Metrics.MetricStreamConfiguration.TagKeys.get -> string![]?
+OpenTelemetry.Metrics.MetricStreamConfiguration.TagKeys.set -> void
+OpenTelemetry.Metrics.PeriodicExportingMetricReader.PeriodicExportingMetricReader(OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric!>! exporter, int exportIntervalMilliseconds = 60000, int exportTimeoutMilliseconds = 30000) -> void
 ~override OpenTelemetry.Metrics.MeterProviderBuilderBase.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation>! instrumentationFactory) -> OpenTelemetry.Metrics.MeterProviderBuilder!
 ~override OpenTelemetry.Trace.TracerProviderBuilderBase.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation>! instrumentationFactory) -> OpenTelemetry.Trace.TracerProviderBuilder!
-~readonly OpenTelemetry.Metrics.BaseExportingMetricReader.exporter -> OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric>
-~static OpenTelemetry.Metrics.MeterProviderExtensions.ForceFlush(this OpenTelemetry.Metrics.MeterProvider provider, int timeoutMilliseconds = -1) -> bool
-~static OpenTelemetry.Metrics.MeterProviderExtensions.Shutdown(this OpenTelemetry.Metrics.MeterProvider provider, int timeoutMilliseconds = -1) -> bool
-~static OpenTelemetry.Metrics.MetricStreamConfiguration.Drop.get -> OpenTelemetry.Metrics.MetricStreamConfiguration
+readonly OpenTelemetry.Metrics.BaseExportingMetricReader.exporter -> OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric!>!
+static OpenTelemetry.Metrics.MeterProviderExtensions.ForceFlush(this OpenTelemetry.Metrics.MeterProvider! provider, int timeoutMilliseconds = -1) -> bool
+static OpenTelemetry.Metrics.MeterProviderExtensions.Shutdown(this OpenTelemetry.Metrics.MeterProvider! provider, int timeoutMilliseconds = -1) -> bool
+static OpenTelemetry.Metrics.MetricStreamConfiguration.Drop.get -> OpenTelemetry.Metrics.MetricStreamConfiguration!
 abstract OpenTelemetry.BaseExporter<T>.Export(in OpenTelemetry.Batch<T!> batch) -> OpenTelemetry.ExportResult
 abstract OpenTelemetry.BaseExportProcessor<T>.OnExport(T! data) -> void
 abstract OpenTelemetry.Trace.Sampler.ShouldSample(in OpenTelemetry.Trace.SamplingParameters samplingParameters) -> OpenTelemetry.Trace.SamplingResult
@@ -253,7 +253,7 @@ OpenTelemetry.ProviderExtensions
 OpenTelemetry.ReadOnlyTagCollection
 OpenTelemetry.ReadOnlyTagCollection.Count.get -> int
 OpenTelemetry.ReadOnlyTagCollection.Enumerator
-OpenTelemetry.ReadOnlyTagCollection.Enumerator.Current.get -> System.Collections.Generic.KeyValuePair<string!, object!>
+OpenTelemetry.ReadOnlyTagCollection.Enumerator.Current.get -> System.Collections.Generic.KeyValuePair<string!, object?>
 OpenTelemetry.ReadOnlyTagCollection.Enumerator.Enumerator() -> void
 OpenTelemetry.ReadOnlyTagCollection.Enumerator.MoveNext() -> bool
 OpenTelemetry.ReadOnlyTagCollection.GetEnumerator() -> OpenTelemetry.ReadOnlyTagCollection.Enumerator

--- a/src/OpenTelemetry/.publicApi/Stable/netstandard2.1/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry/.publicApi/Stable/netstandard2.1/PublicAPI.Shipped.txt
@@ -1,28 +1,28 @@
 #nullable enable
 ~OpenTelemetry.Batch<T>.GetEnumerator() -> OpenTelemetry.Batch<T>.Enumerator
-~OpenTelemetry.Metrics.BaseExportingMetricReader.BaseExportingMetricReader(OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric> exporter) -> void
-~OpenTelemetry.Metrics.ExplicitBucketHistogramConfiguration.Boundaries.get -> double[]
-~OpenTelemetry.Metrics.ExplicitBucketHistogramConfiguration.Boundaries.set -> void
-~OpenTelemetry.Metrics.IPullMetricExporter.Collect.get -> System.Func<int, bool>
-~OpenTelemetry.Metrics.IPullMetricExporter.Collect.set -> void
-~OpenTelemetry.Metrics.Metric.Description.get -> string
-~OpenTelemetry.Metrics.Metric.MeterName.get -> string
-~OpenTelemetry.Metrics.Metric.MeterVersion.get -> string
-~OpenTelemetry.Metrics.Metric.Name.get -> string
-~OpenTelemetry.Metrics.Metric.Unit.get -> string
-~OpenTelemetry.Metrics.MetricStreamConfiguration.Description.get -> string
-~OpenTelemetry.Metrics.MetricStreamConfiguration.Description.set -> void
-~OpenTelemetry.Metrics.MetricStreamConfiguration.Name.get -> string
-~OpenTelemetry.Metrics.MetricStreamConfiguration.Name.set -> void
-~OpenTelemetry.Metrics.MetricStreamConfiguration.TagKeys.get -> string[]
-~OpenTelemetry.Metrics.MetricStreamConfiguration.TagKeys.set -> void
-~OpenTelemetry.Metrics.PeriodicExportingMetricReader.PeriodicExportingMetricReader(OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric> exporter, int exportIntervalMilliseconds = 60000, int exportTimeoutMilliseconds = 30000) -> void
+OpenTelemetry.Metrics.BaseExportingMetricReader.BaseExportingMetricReader(OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric!>! exporter) -> void
+OpenTelemetry.Metrics.ExplicitBucketHistogramConfiguration.Boundaries.get -> double[]?
+OpenTelemetry.Metrics.ExplicitBucketHistogramConfiguration.Boundaries.set -> void
+OpenTelemetry.Metrics.IPullMetricExporter.Collect.get -> System.Func<int, bool>?
+OpenTelemetry.Metrics.IPullMetricExporter.Collect.set -> void
+OpenTelemetry.Metrics.Metric.Description.get -> string!
+OpenTelemetry.Metrics.Metric.MeterName.get -> string!
+OpenTelemetry.Metrics.Metric.MeterVersion.get -> string!
+OpenTelemetry.Metrics.Metric.Name.get -> string!
+OpenTelemetry.Metrics.Metric.Unit.get -> string!
+OpenTelemetry.Metrics.MetricStreamConfiguration.Description.get -> string?
+OpenTelemetry.Metrics.MetricStreamConfiguration.Description.set -> void
+OpenTelemetry.Metrics.MetricStreamConfiguration.Name.get -> string?
+OpenTelemetry.Metrics.MetricStreamConfiguration.Name.set -> void
+OpenTelemetry.Metrics.MetricStreamConfiguration.TagKeys.get -> string![]?
+OpenTelemetry.Metrics.MetricStreamConfiguration.TagKeys.set -> void
+OpenTelemetry.Metrics.PeriodicExportingMetricReader.PeriodicExportingMetricReader(OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric!>! exporter, int exportIntervalMilliseconds = 60000, int exportTimeoutMilliseconds = 30000) -> void
 ~override OpenTelemetry.Metrics.MeterProviderBuilderBase.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation>! instrumentationFactory) -> OpenTelemetry.Metrics.MeterProviderBuilder!
 ~override OpenTelemetry.Trace.TracerProviderBuilderBase.AddInstrumentation<TInstrumentation>(System.Func<TInstrumentation>! instrumentationFactory) -> OpenTelemetry.Trace.TracerProviderBuilder!
-~readonly OpenTelemetry.Metrics.BaseExportingMetricReader.exporter -> OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric>
-~static OpenTelemetry.Metrics.MeterProviderExtensions.ForceFlush(this OpenTelemetry.Metrics.MeterProvider provider, int timeoutMilliseconds = -1) -> bool
-~static OpenTelemetry.Metrics.MeterProviderExtensions.Shutdown(this OpenTelemetry.Metrics.MeterProvider provider, int timeoutMilliseconds = -1) -> bool
-~static OpenTelemetry.Metrics.MetricStreamConfiguration.Drop.get -> OpenTelemetry.Metrics.MetricStreamConfiguration
+readonly OpenTelemetry.Metrics.BaseExportingMetricReader.exporter -> OpenTelemetry.BaseExporter<OpenTelemetry.Metrics.Metric!>!
+static OpenTelemetry.Metrics.MeterProviderExtensions.ForceFlush(this OpenTelemetry.Metrics.MeterProvider! provider, int timeoutMilliseconds = -1) -> bool
+static OpenTelemetry.Metrics.MeterProviderExtensions.Shutdown(this OpenTelemetry.Metrics.MeterProvider! provider, int timeoutMilliseconds = -1) -> bool
+static OpenTelemetry.Metrics.MetricStreamConfiguration.Drop.get -> OpenTelemetry.Metrics.MetricStreamConfiguration!
 abstract OpenTelemetry.BaseExporter<T>.Export(in OpenTelemetry.Batch<T!> batch) -> OpenTelemetry.ExportResult
 abstract OpenTelemetry.BaseExportProcessor<T>.OnExport(T! data) -> void
 abstract OpenTelemetry.Trace.Sampler.ShouldSample(in OpenTelemetry.Trace.SamplingParameters samplingParameters) -> OpenTelemetry.Trace.SamplingResult
@@ -253,7 +253,7 @@ OpenTelemetry.ProviderExtensions
 OpenTelemetry.ReadOnlyTagCollection
 OpenTelemetry.ReadOnlyTagCollection.Count.get -> int
 OpenTelemetry.ReadOnlyTagCollection.Enumerator
-OpenTelemetry.ReadOnlyTagCollection.Enumerator.Current.get -> System.Collections.Generic.KeyValuePair<string!, object!>
+OpenTelemetry.ReadOnlyTagCollection.Enumerator.Current.get -> System.Collections.Generic.KeyValuePair<string!, object?>
 OpenTelemetry.ReadOnlyTagCollection.Enumerator.Enumerator() -> void
 OpenTelemetry.ReadOnlyTagCollection.Enumerator.MoveNext() -> bool
 OpenTelemetry.ReadOnlyTagCollection.GetEnumerator() -> OpenTelemetry.ReadOnlyTagCollection.Enumerator

--- a/src/OpenTelemetry/BaseExportProcessor.cs
+++ b/src/OpenTelemetry/BaseExportProcessor.cs
@@ -47,7 +47,11 @@ public enum ExportProcessorType
 public abstract class BaseExportProcessor<T> : BaseProcessor<T>
     where T : class
 {
+    /// <summary>
+    /// Gets the exporter used by the processor.
+    /// </summary>
     protected readonly BaseExporter<T> exporter;
+
     private readonly string friendlyTypeName;
     private bool disposed;
 
@@ -74,6 +78,7 @@ public abstract class BaseExportProcessor<T> : BaseProcessor<T>
     {
     }
 
+    /// <inheritdoc />
     public override void OnEnd(T data)
     {
         this.OnExport(data);
@@ -86,6 +91,17 @@ public abstract class BaseExportProcessor<T> : BaseProcessor<T>
         this.exporter.ParentProvider = parentProvider;
     }
 
+    /// <summary>
+    /// Called synchronously when a telemetry object is exported.
+    /// </summary>
+    /// <param name="data">
+    /// The exported telemetry object.
+    /// </param>
+    /// <remarks>
+    /// This function is called synchronously on the thread which ended
+    /// the telemetry object. This function should be thread-safe, and
+    /// should not block indefinitely or throw exceptions.
+    /// </remarks>
     protected abstract void OnExport(T data);
 
     /// <inheritdoc />

--- a/src/OpenTelemetry/BatchExportProcessorOptions.cs
+++ b/src/OpenTelemetry/BatchExportProcessorOptions.cs
@@ -18,6 +18,10 @@
 
 namespace OpenTelemetry;
 
+/// <summary>
+/// Contains batch export processor options.
+/// </summary>
+/// <typeparam name="T">The type of telemetry object to be exported.</typeparam>
 public class BatchExportProcessorOptions<T>
     where T : class
 {

--- a/src/OpenTelemetry/CompositeProcessor.cs
+++ b/src/OpenTelemetry/CompositeProcessor.cs
@@ -21,12 +21,20 @@ using OpenTelemetry.Internal;
 
 namespace OpenTelemetry;
 
+/// <summary>
+/// Represents a chain of <see cref="BaseProcessor{T}"/>s.
+/// </summary>
+/// <typeparam name="T">The type of object to be processed.</typeparam>
 public class CompositeProcessor<T> : BaseProcessor<T>
 {
     internal readonly DoublyLinkedListNode Head;
     private DoublyLinkedListNode tail;
     private bool disposed;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CompositeProcessor{T}"/> class.
+    /// </summary>
+    /// <param name="processors">Processors to add to the composite processor chain.</param>
     public CompositeProcessor(IEnumerable<BaseProcessor<T>> processors)
     {
         Guard.ThrowIfNull(processors);
@@ -46,6 +54,11 @@ public class CompositeProcessor<T> : BaseProcessor<T>
         }
     }
 
+    /// <summary>
+    /// Adds a processor to the composite processor chain.
+    /// </summary>
+    /// <param name="processor"><see cref="BaseProcessor{T}"/>.</param>
+    /// <returns>The current instance to support call chaining.</returns>
     public CompositeProcessor<T> AddProcessor(BaseProcessor<T> processor)
     {
         Guard.ThrowIfNull(processor);

--- a/src/OpenTelemetry/Metrics/AggregationTemporality.cs
+++ b/src/OpenTelemetry/Metrics/AggregationTemporality.cs
@@ -14,8 +14,14 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 namespace OpenTelemetry.Metrics;
 
+/// <summary>
+/// Enumeration used to define the aggregation temporality for a <see
+/// cref="Metric"/>.
+/// </summary>
 public enum AggregationTemporality : byte
 {
     /// <summary>

--- a/src/OpenTelemetry/Metrics/BaseExportingMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/BaseExportingMetricReader.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System.Diagnostics;
 using OpenTelemetry.Internal;
 
@@ -25,7 +27,11 @@ namespace OpenTelemetry.Metrics;
 /// </summary>
 public class BaseExportingMetricReader : MetricReader
 {
+    /// <summary>
+    /// Gets the exporter used by the metric reader.
+    /// </summary>
     protected readonly BaseExporter<Metric> exporter;
+
     private readonly ExportModes supportedExportModes = ExportModes.Push | ExportModes.Pull;
     private readonly string exportCalledMessage;
     private readonly string exportSucceededMessage;
@@ -75,6 +81,9 @@ public class BaseExportingMetricReader : MetricReader
 
     internal BaseExporter<Metric> Exporter => this.exporter;
 
+    /// <summary>
+    /// Gets the supported <see cref="ExportModes"/>.
+    /// </summary>
     protected ExportModes SupportedExportModes => this.supportedExportModes;
 
     internal override void SetParentProvider(BaseProvider parentProvider)

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderBase.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderBase.cs
@@ -30,6 +30,9 @@ public class MeterProviderBuilderBase : MeterProviderBuilder, IMeterProviderBuil
     private readonly bool allowBuild;
     private readonly MeterProviderServiceCollectionBuilder innerBuilder;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MeterProviderBuilderBase"/> class.
+    /// </summary>
     public MeterProviderBuilderBase()
     {
         var services = new ServiceCollection();

--- a/src/OpenTelemetry/Metrics/Exemplar/AlignedHistogramBucketExemplarReservoir.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/AlignedHistogramBucketExemplarReservoir.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System.Diagnostics;
 
 namespace OpenTelemetry.Metrics;
@@ -23,23 +25,21 @@ namespace OpenTelemetry.Metrics;
 /// </summary>
 internal sealed class AlignedHistogramBucketExemplarReservoir : ExemplarReservoir
 {
-    private readonly int length;
     private readonly Exemplar[] runningExemplars;
     private readonly Exemplar[] tempExemplars;
 
     public AlignedHistogramBucketExemplarReservoir(int length)
     {
-        this.length = length;
         this.runningExemplars = new Exemplar[length + 1];
         this.tempExemplars = new Exemplar[length + 1];
     }
 
-    public override void Offer(long value, ReadOnlySpan<KeyValuePair<string, object>> tags, int index = default)
+    public override void Offer(long value, ReadOnlySpan<KeyValuePair<string, object?>> tags, int index = default)
     {
         this.OfferAtBoundary(value, tags, index);
     }
 
-    public override void Offer(double value, ReadOnlySpan<KeyValuePair<string, object>> tags, int index = default)
+    public override void Offer(double value, ReadOnlySpan<KeyValuePair<string, object?>> tags, int index = default)
     {
         this.OfferAtBoundary(value, tags, index);
     }
@@ -59,7 +59,7 @@ internal sealed class AlignedHistogramBucketExemplarReservoir : ExemplarReservoi
                 // TODO: The cost is paid irrespective of whether the
                 // Exporter supports Exemplar or not. One idea is to
                 // defer this until first exporter attempts read.
-                this.tempExemplars[i].FilteredTags = this.runningExemplars[i].FilteredTags.Except(actualTags.KeyAndValues.ToList()).ToList();
+                this.tempExemplars[i].FilteredTags = this.runningExemplars[i].FilteredTags!.Except(actualTags.KeyAndValues.ToList()).ToList();
             }
 
             if (reset)
@@ -71,7 +71,7 @@ internal sealed class AlignedHistogramBucketExemplarReservoir : ExemplarReservoi
         return this.tempExemplars;
     }
 
-    private void OfferAtBoundary(double value, ReadOnlySpan<KeyValuePair<string, object>> tags, int index)
+    private void OfferAtBoundary(double value, ReadOnlySpan<KeyValuePair<string, object?>> tags, int index)
     {
         ref var exemplar = ref this.runningExemplars[index];
         exemplar.Timestamp = DateTimeOffset.UtcNow;
@@ -91,7 +91,7 @@ internal sealed class AlignedHistogramBucketExemplarReservoir : ExemplarReservoi
 
         if (exemplar.FilteredTags == null)
         {
-            exemplar.FilteredTags = new List<KeyValuePair<string, object>>(tags.Length);
+            exemplar.FilteredTags = new List<KeyValuePair<string, object?>>(tags.Length);
         }
         else
         {

--- a/src/OpenTelemetry/Metrics/Exemplar/AlwaysOffExemplarFilter.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/AlwaysOffExemplarFilter.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 namespace OpenTelemetry.Metrics;
 
 #if EXPOSE_EXPERIMENTAL_FEATURES
@@ -32,12 +34,14 @@ internal
 #endif
     sealed class AlwaysOffExemplarFilter : ExemplarFilter
 {
-    public override bool ShouldSample(long value, ReadOnlySpan<KeyValuePair<string, object>> tags)
+    /// <inheritdoc/>
+    public override bool ShouldSample(long value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
     {
         return false;
     }
 
-    public override bool ShouldSample(double value, ReadOnlySpan<KeyValuePair<string, object>> tags)
+    /// <inheritdoc/>
+    public override bool ShouldSample(double value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
     {
         return false;
     }

--- a/src/OpenTelemetry/Metrics/Exemplar/AlwaysOnExemplarFilter.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/AlwaysOnExemplarFilter.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 namespace OpenTelemetry.Metrics;
 
 #if EXPOSE_EXPERIMENTAL_FEATURES
@@ -30,12 +32,14 @@ internal
 #endif
     sealed class AlwaysOnExemplarFilter : ExemplarFilter
 {
-    public override bool ShouldSample(long value, ReadOnlySpan<KeyValuePair<string, object>> tags)
+    /// <inheritdoc/>
+    public override bool ShouldSample(long value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
     {
         return true;
     }
 
-    public override bool ShouldSample(double value, ReadOnlySpan<KeyValuePair<string, object>> tags)
+    /// <inheritdoc/>
+    public override bool ShouldSample(double value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
     {
         return true;
     }

--- a/src/OpenTelemetry/Metrics/Exemplar/Exemplar.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/Exemplar.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System.Diagnostics;
 
 namespace OpenTelemetry.Metrics;
@@ -59,6 +61,6 @@ internal
     /// <summary>
     /// Gets the FilteredTags (i.e any tags that were dropped during aggregation).
     /// </summary>
-    public List<KeyValuePair<string, object>> FilteredTags { get; internal set; }
+    public List<KeyValuePair<string, object?>>? FilteredTags { get; internal set; }
 }
 

--- a/src/OpenTelemetry/Metrics/Exemplar/ExemplarFilter.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/ExemplarFilter.cs
@@ -13,6 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
+#nullable enable
+
 namespace OpenTelemetry.Metrics;
 
 #if EXPOSE_EXPERIMENTAL_FEATURES
@@ -45,7 +48,7 @@ internal
     /// <c>false</c> to indicate this measurement is not eligible to become Exemplar
     /// and will not be given to the ExemplarReservoir.
     /// </returns>
-    public abstract bool ShouldSample(long value, ReadOnlySpan<KeyValuePair<string, object>> tags);
+    public abstract bool ShouldSample(long value, ReadOnlySpan<KeyValuePair<string, object?>> tags);
 
     /// <summary>
     /// Determines if a given measurement is eligible for being
@@ -63,5 +66,5 @@ internal
     /// <c>false</c> to indicate this measurement is not eligible to become Exemplar
     /// and will not be given to the ExemplarReservoir.
     /// </returns>
-    public abstract bool ShouldSample(double value, ReadOnlySpan<KeyValuePair<string, object>> tags);
+    public abstract bool ShouldSample(double value, ReadOnlySpan<KeyValuePair<string, object?>> tags);
 }

--- a/src/OpenTelemetry/Metrics/Exemplar/ExemplarReservoir.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/ExemplarReservoir.cs
@@ -13,6 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
+#nullable enable
+
 namespace OpenTelemetry.Metrics;
 
 /// <summary>
@@ -27,7 +30,7 @@ internal abstract class ExemplarReservoir
     /// <param name="tags">The complete set of tags provided with the measurement.</param>
     /// <param name="index">The histogram bucket index where this measurement is going to be stored.
     /// This is optional and is only relevant for Histogram with buckets.</param>
-    public abstract void Offer(long value, ReadOnlySpan<KeyValuePair<string, object>> tags, int index = default);
+    public abstract void Offer(long value, ReadOnlySpan<KeyValuePair<string, object?>> tags, int index = default);
 
     /// <summary>
     /// Offers measurement to the reservoir.
@@ -36,7 +39,7 @@ internal abstract class ExemplarReservoir
     /// <param name="tags">The complete set of tags provided with the measurement.</param>
     /// <param name="index">The histogram bucket index where this measurement is going to be stored.
     /// This is optional and is only relevant for Histogram with buckets.</param>
-    public abstract void Offer(double value, ReadOnlySpan<KeyValuePair<string, object>> tags, int index = default);
+    public abstract void Offer(double value, ReadOnlySpan<KeyValuePair<string, object?>> tags, int index = default);
 
     /// <summary>
     /// Collects all the exemplars accumulated by the Reservoir.

--- a/src/OpenTelemetry/Metrics/Exemplar/SimpleExemplarReservoir.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/SimpleExemplarReservoir.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System.Diagnostics;
 
 namespace OpenTelemetry.Metrics;
@@ -39,12 +41,12 @@ internal sealed class SimpleExemplarReservoir : ExemplarReservoir
         this.random = new Random();
     }
 
-    public override void Offer(long value, ReadOnlySpan<KeyValuePair<string, object>> tags, int index = default)
+    public override void Offer(long value, ReadOnlySpan<KeyValuePair<string, object?>> tags, int index = default)
     {
         this.Offer(value, tags);
     }
 
-    public override void Offer(double value, ReadOnlySpan<KeyValuePair<string, object>> tags, int index = default)
+    public override void Offer(double value, ReadOnlySpan<KeyValuePair<string, object?>> tags, int index = default)
     {
         this.Offer(value, tags);
     }
@@ -64,7 +66,7 @@ internal sealed class SimpleExemplarReservoir : ExemplarReservoir
                 // TODO: The cost is paid irrespective of whether the
                 // Exporter supports Exemplar or not. One idea is to
                 // defer this until first exporter attempts read.
-                this.tempExemplars[i].FilteredTags = this.runningExemplars[i].FilteredTags.Except(actualTags.KeyAndValues.ToList()).ToList();
+                this.tempExemplars[i].FilteredTags = this.runningExemplars[i].FilteredTags!.Except(actualTags.KeyAndValues.ToList()).ToList();
             }
 
             if (reset)
@@ -77,7 +79,7 @@ internal sealed class SimpleExemplarReservoir : ExemplarReservoir
         return this.tempExemplars;
     }
 
-    private void Offer(double value, ReadOnlySpan<KeyValuePair<string, object>> tags)
+    private void Offer(double value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
     {
         if (this.measurementsSeen < this.poolSize)
         {
@@ -112,7 +114,7 @@ internal sealed class SimpleExemplarReservoir : ExemplarReservoir
         this.measurementsSeen++;
     }
 
-    private void StoreTags(ref Exemplar exemplar, ReadOnlySpan<KeyValuePair<string, object>> tags)
+    private void StoreTags(ref Exemplar exemplar, ReadOnlySpan<KeyValuePair<string, object?>> tags)
     {
         if (tags == default)
         {
@@ -126,7 +128,7 @@ internal sealed class SimpleExemplarReservoir : ExemplarReservoir
 
         if (exemplar.FilteredTags == null)
         {
-            exemplar.FilteredTags = new List<KeyValuePair<string, object>>(tags.Length);
+            exemplar.FilteredTags = new List<KeyValuePair<string, object?>>(tags.Length);
         }
         else
         {

--- a/src/OpenTelemetry/Metrics/Exemplar/TraceBasedExemplarFilter.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/TraceBasedExemplarFilter.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System.Diagnostics;
 
 namespace OpenTelemetry.Metrics;
@@ -34,12 +36,14 @@ internal
 #endif
     sealed class TraceBasedExemplarFilter : ExemplarFilter
 {
-    public override bool ShouldSample(long value, ReadOnlySpan<KeyValuePair<string, object>> tags)
+    /// <inheritdoc/>
+    public override bool ShouldSample(long value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
     {
         return Activity.Current?.Recorded ?? false;
     }
 
-    public override bool ShouldSample(double value, ReadOnlySpan<KeyValuePair<string, object>> tags)
+    /// <inheritdoc/>
+    public override bool ShouldSample(double value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
     {
         return Activity.Current?.Recorded ?? false;
     }

--- a/src/OpenTelemetry/Metrics/ExplicitBucketHistogramConfiguration.cs
+++ b/src/OpenTelemetry/Metrics/ExplicitBucketHistogramConfiguration.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 namespace OpenTelemetry.Metrics;
 
 /// <summary>
@@ -36,7 +38,7 @@ public class ExplicitBucketHistogramConfiguration : HistogramConfiguration
     /// </list>
     /// Note: A copy is made of the provided array.
     /// </remarks>
-    public double[] Boundaries
+    public double[]? Boundaries
     {
         get
         {
@@ -70,7 +72,7 @@ public class ExplicitBucketHistogramConfiguration : HistogramConfiguration
         }
     }
 
-    internal double[] CopiedBoundaries { get; private set; }
+    internal double[]? CopiedBoundaries { get; private set; }
 
     private static bool IsSortedAndDistinct(double[] values)
     {

--- a/src/OpenTelemetry/Metrics/ExponentialHistogramBuckets.cs
+++ b/src/OpenTelemetry/Metrics/ExponentialHistogramBuckets.cs
@@ -18,6 +18,10 @@
 
 namespace OpenTelemetry.Metrics;
 
+/// <summary>
+/// Contains the buckets of an exponential histogram.
+/// </summary>
+// Note: Does not implement IEnumerable<> to prevent accidental boxing.
 public sealed class ExponentialHistogramBuckets
 {
     private long[] buckets = Array.Empty<long>();
@@ -27,8 +31,15 @@ public sealed class ExponentialHistogramBuckets
     {
     }
 
+    /// <summary>
+    /// Gets the exponential histogram offset.
+    /// </summary>
     public int Offset { get; private set; }
 
+    /// <summary>
+    /// Returns an enumerator that iterates through the <see cref="ExponentialHistogramBuckets"/>.
+    /// </summary>
+    /// <returns><see cref="Enumerator"/>.</returns>
     public Enumerator GetEnumerator() => new(this.buckets, this.size);
 
     internal void SnapshotBuckets(CircularBufferBuckets buckets)
@@ -45,10 +56,12 @@ public sealed class ExponentialHistogramBuckets
 
     internal ExponentialHistogramBuckets Copy()
     {
-        var copy = new ExponentialHistogramBuckets();
-        copy.size = this.size;
-        copy.Offset = this.Offset;
-        copy.buckets = new long[this.buckets.Length];
+        var copy = new ExponentialHistogramBuckets
+        {
+            size = this.size,
+            Offset = this.Offset,
+            buckets = new long[this.buckets.Length],
+        };
         Array.Copy(this.buckets, copy.buckets, this.buckets.Length);
         return copy;
     }

--- a/src/OpenTelemetry/Metrics/ExponentialHistogramData.cs
+++ b/src/OpenTelemetry/Metrics/ExponentialHistogramData.cs
@@ -18,6 +18,9 @@
 
 namespace OpenTelemetry.Metrics;
 
+/// <summary>
+/// Contains the data for an exponential histogram.
+/// </summary>
 public sealed class ExponentialHistogramData
 {
     internal ExponentialHistogramData()
@@ -26,21 +29,35 @@ public sealed class ExponentialHistogramData
         this.NegativeBuckets = new();
     }
 
+    /// <summary>
+    /// Gets the exponential histogram scale.
+    /// </summary>
     public int Scale { get; internal set; }
 
+    /// <summary>
+    /// Gets the exponential histogram zero count.
+    /// </summary>
     public long ZeroCount { get; internal set; }
 
+    /// <summary>
+    /// Gets the exponential histogram positive buckets.
+    /// </summary>
     public ExponentialHistogramBuckets PositiveBuckets { get; private set; }
 
+    /// <summary>
+    /// Gets the exponential histogram negative buckets.
+    /// </summary>
     internal ExponentialHistogramBuckets NegativeBuckets { get; private set; }
 
     internal ExponentialHistogramData Copy()
     {
-        var copy = new ExponentialHistogramData();
-        copy.Scale = this.Scale;
-        copy.ZeroCount = this.ZeroCount;
-        copy.PositiveBuckets = this.PositiveBuckets.Copy();
-        copy.NegativeBuckets = this.NegativeBuckets.Copy();
+        var copy = new ExponentialHistogramData
+        {
+            Scale = this.Scale,
+            ZeroCount = this.ZeroCount,
+            PositiveBuckets = this.PositiveBuckets.Copy(),
+            NegativeBuckets = this.NegativeBuckets.Copy(),
+        };
         return copy;
     }
 }

--- a/src/OpenTelemetry/Metrics/ExportModes.cs
+++ b/src/OpenTelemetry/Metrics/ExportModes.cs
@@ -14,8 +14,13 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 namespace OpenTelemetry.Metrics;
 
+/// <summary>
+/// Describes the mode of a metric exporter.
+/// </summary>
 [Flags]
 public enum ExportModes : byte
 {

--- a/src/OpenTelemetry/Metrics/ExportModesAttribute.cs
+++ b/src/OpenTelemetry/Metrics/ExportModesAttribute.cs
@@ -14,17 +14,29 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 namespace OpenTelemetry.Metrics;
 
+/// <summary>
+/// An attribute for declaring the supported <see cref="ExportModes"/> of a metric exporter.
+/// </summary>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
 public sealed class ExportModesAttribute : Attribute
 {
     private readonly ExportModes supportedExportModes;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExportModesAttribute"/> class.
+    /// </summary>
+    /// <param name="supported"><see cref="ExportModes"/>.</param>
     public ExportModesAttribute(ExportModes supported)
     {
         this.supportedExportModes = supported;
     }
 
+    /// <summary>
+    /// Gets the supported <see cref="ExportModes"/>.
+    /// </summary>
     public ExportModes Supported => this.supportedExportModes;
 }

--- a/src/OpenTelemetry/Metrics/HistogramBuckets.cs
+++ b/src/OpenTelemetry/Metrics/HistogramBuckets.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
@@ -27,9 +29,9 @@ public class HistogramBuckets
 {
     internal const int DefaultBoundaryCountForBinarySearch = 50;
 
-    internal readonly double[] ExplicitBounds;
+    internal readonly double[]? ExplicitBounds;
 
-    internal readonly long[] RunningBucketCounts;
+    internal readonly long[]? RunningBucketCounts;
     internal readonly long[] SnapshotBucketCounts;
 
     internal double RunningSum;
@@ -43,20 +45,20 @@ public class HistogramBuckets
 
     internal int IsCriticalSectionOccupied = 0;
 
-    private readonly BucketLookupNode bucketLookupTreeRoot;
+    private readonly BucketLookupNode? bucketLookupTreeRoot;
 
     private readonly Func<double, int> findHistogramBucketIndex;
 
-    internal HistogramBuckets(double[] explicitBounds)
+    internal HistogramBuckets(double[]? explicitBounds)
     {
         this.ExplicitBounds = explicitBounds;
         this.findHistogramBucketIndex = this.FindBucketIndexLinear;
         if (explicitBounds != null && explicitBounds.Length >= DefaultBoundaryCountForBinarySearch)
         {
-            this.bucketLookupTreeRoot = ConstructBalancedBST(explicitBounds, 0, explicitBounds.Length);
+            this.bucketLookupTreeRoot = ConstructBalancedBST(explicitBounds, 0, explicitBounds.Length)!;
             this.findHistogramBucketIndex = this.FindBucketIndexBinary;
 
-            static BucketLookupNode ConstructBalancedBST(double[] values, int min, int max)
+            static BucketLookupNode? ConstructBalancedBST(double[] values, int min, int max)
             {
                 if (min == max)
                 {
@@ -79,6 +81,10 @@ public class HistogramBuckets
         this.SnapshotBucketCounts = explicitBounds != null ? new long[explicitBounds.Length + 1] : new long[0];
     }
 
+    /// <summary>
+    /// Returns an enumerator that iterates through the <see cref="HistogramBuckets"/>.
+    /// </summary>
+    /// <returns><see cref="Enumerator"/>.</returns>
     public Enumerator GetEnumerator() => new(this);
 
     internal HistogramBuckets Copy()
@@ -102,13 +108,13 @@ public class HistogramBuckets
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal int FindBucketIndexBinary(double value)
     {
-        BucketLookupNode current = this.bucketLookupTreeRoot;
+        BucketLookupNode? current = this.bucketLookupTreeRoot;
 
         Debug.Assert(current != null, "Bucket root was null.");
 
         do
         {
-            if (value <= current.LowerBoundExclusive)
+            if (value <= current!.LowerBoundExclusive)
             {
                 current = current.Left;
             }
@@ -123,14 +129,18 @@ public class HistogramBuckets
         }
         while (current != null);
 
-        return this.ExplicitBounds.Length;
+        Debug.Assert(this.ExplicitBounds != null, "ExplicitBounds was null.");
+
+        return this.ExplicitBounds!.Length;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal int FindBucketIndexLinear(double value)
     {
+        Debug.Assert(this.ExplicitBounds != null, "ExplicitBounds was null.");
+
         int i;
-        for (i = 0; i < this.ExplicitBounds.Length; i++)
+        for (i = 0; i < this.ExplicitBounds!.Length; i++)
         {
             // Upper bound is inclusive
             if (value <= this.ExplicitBounds[i])
@@ -178,7 +188,7 @@ public class HistogramBuckets
             if (this.index < this.numberOfBuckets)
             {
                 double explicitBound = this.index < this.numberOfBuckets - 1
-                    ? this.histogramMeasurements.ExplicitBounds[this.index]
+                    ? this.histogramMeasurements.ExplicitBounds![this.index]
                     : double.PositiveInfinity;
                 long bucketCount = this.histogramMeasurements.SnapshotBucketCounts[this.index];
                 this.Current = new HistogramBucket(explicitBound, bucketCount);
@@ -198,8 +208,8 @@ public class HistogramBuckets
 
         public int Index { get; set; }
 
-        public BucketLookupNode Left { get; set; }
+        public BucketLookupNode? Left { get; set; }
 
-        public BucketLookupNode Right { get; set; }
+        public BucketLookupNode? Right { get; set; }
     }
 }

--- a/src/OpenTelemetry/Metrics/HistogramConfiguration.cs
+++ b/src/OpenTelemetry/Metrics/HistogramConfiguration.cs
@@ -14,8 +14,13 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 namespace OpenTelemetry.Metrics;
 
+/// <summary>
+/// Stores configuration for a histogram MetricStream.
+/// </summary>
 public class HistogramConfiguration : MetricStreamConfiguration
 {
     /// <summary>

--- a/src/OpenTelemetry/Metrics/IPullMetricExporter.cs
+++ b/src/OpenTelemetry/Metrics/IPullMetricExporter.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 namespace OpenTelemetry.Metrics;
 
 /// <summary>
@@ -21,5 +23,8 @@ namespace OpenTelemetry.Metrics;
 /// </summary>
 public interface IPullMetricExporter
 {
-    Func<int, bool> Collect { get; set; }
+    /// <summary>
+    /// Gets or sets the Collect delegate.
+    /// </summary>
+    Func<int, bool>? Collect { get; set; }
 }

--- a/src/OpenTelemetry/Metrics/MeterProviderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderExtensions.cs
@@ -14,10 +14,16 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
+using System.Diagnostics.CodeAnalysis;
 using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Metrics;
 
+/// <summary>
+/// Contains extension methods for the <see cref="MeterProvider"/> class.
+/// </summary>
 public static class MeterProviderExtensions
 {
     /// <summary>
@@ -111,7 +117,10 @@ public static class MeterProviderExtensions
     /// <param name="provider">The MeterProvider from which Exporter should be found.</param>
     /// <param name="exporter">The exporter instance.</param>
     /// <returns>true if the exporter of specified Type is found; otherwise false.</returns>
-    internal static bool TryFindExporter<T>(this MeterProvider provider, out T exporter)
+    internal static bool TryFindExporter<T>(
+        this MeterProvider provider,
+        [NotNullWhen(true)]
+        out T? exporter)
         where T : BaseExporter<Metric>
     {
         if (provider is MeterProviderSdk meterProviderSdk)
@@ -122,7 +131,7 @@ public static class MeterProviderExtensions
         exporter = null;
         return false;
 
-        static bool TryFindExporter(MetricReader reader, out T exporter)
+        static bool TryFindExporter(MetricReader? reader, out T? exporter)
         {
             if (reader is BaseExportingMetricReader exportingMetricReader)
             {

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -14,12 +14,14 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System.Diagnostics.Metrics;
 
 namespace OpenTelemetry.Metrics;
 
 /// <summary>
-/// Represents a Metric stream which can contain multiple MetricPoints.
+/// Represents a metric stream which can contain multiple metric points.
 /// </summary>
 public sealed class Metric
 {
@@ -52,7 +54,7 @@ public sealed class Metric
         AggregationTemporality temporality,
         int maxMetricPointsPerMetricStream,
         bool emitOverflowAttribute,
-        ExemplarFilter exemplarFilter = null)
+        ExemplarFilter? exemplarFilter = null)
     {
         this.InstrumentIdentity = instrumentIdentity;
 
@@ -163,41 +165,61 @@ public sealed class Metric
         this.InstrumentDisposed = false;
     }
 
+    /// <summary>
+    /// Gets the <see cref="Metrics.MetricType"/> for the metric stream.
+    /// </summary>
     public MetricType MetricType { get; private set; }
 
+    /// <summary>
+    /// Gets the <see cref="AggregationTemporality"/> for the metric stream.
+    /// </summary>
     public AggregationTemporality Temporality { get; private set; }
 
+    /// <summary>
+    /// Gets the name for the metric stream.
+    /// </summary>
     public string Name => this.InstrumentIdentity.InstrumentName;
 
+    /// <summary>
+    /// Gets the description for the metric stream.
+    /// </summary>
     public string Description => this.InstrumentIdentity.Description;
 
+    /// <summary>
+    /// Gets the unit for the metric stream.
+    /// </summary>
     public string Unit => this.InstrumentIdentity.Unit;
 
+    /// <summary>
+    /// Gets the meter name for the metric stream.
+    /// </summary>
     public string MeterName => this.InstrumentIdentity.MeterName;
 
+    /// <summary>
+    /// Gets the meter version for the metric stream.
+    /// </summary>
     public string MeterVersion => this.InstrumentIdentity.MeterVersion;
 
+    /// <summary>
+    /// Gets the <see cref="MetricStreamIdentity"/> for the metric stream.
+    /// </summary>
     internal MetricStreamIdentity InstrumentIdentity { get; private set; }
 
     internal bool InstrumentDisposed { get; set; }
 
+    /// <summary>
+    /// Get the metric points for the metric stream.
+    /// </summary>
+    /// <returns><see cref="MetricPointsAccessor"/>.</returns>
     public MetricPointsAccessor GetMetricPoints()
-    {
-        return this.aggStore.GetMetricPoints();
-    }
+        => this.aggStore.GetMetricPoints();
 
-    internal void UpdateLong(long value, ReadOnlySpan<KeyValuePair<string, object>> tags)
-    {
-        this.aggStore.Update(value, tags);
-    }
+    internal void UpdateLong(long value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
+        => this.aggStore.Update(value, tags);
 
-    internal void UpdateDouble(double value, ReadOnlySpan<KeyValuePair<string, object>> tags)
-    {
-        this.aggStore.Update(value, tags);
-    }
+    internal void UpdateDouble(double value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
+        => this.aggStore.Update(value, tags);
 
     internal int Snapshot()
-    {
-        return this.aggStore.Snapshot();
-    }
+        => this.aggStore.Snapshot();
 }

--- a/src/OpenTelemetry/Metrics/MetricReader.cs
+++ b/src/OpenTelemetry/Metrics/MetricReader.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using OpenTelemetry.Internal;
@@ -27,10 +29,10 @@ public abstract partial class MetricReader : IDisposable
 {
     private const MetricReaderTemporalityPreference MetricReaderTemporalityPreferenceUnspecified = (MetricReaderTemporalityPreference)0;
 
-    private static Func<Type, AggregationTemporality> cumulativeTemporalityPreferenceFunc =
+    private static readonly Func<Type, AggregationTemporality> CumulativeTemporalityPreferenceFunc =
         (instrumentType) => AggregationTemporality.Cumulative;
 
-    private static Func<Type, AggregationTemporality> monotonicDeltaTemporalityPreferenceFunc = (instrumentType) =>
+    private static readonly Func<Type, AggregationTemporality> MonotonicDeltaTemporalityPreferenceFunc = (instrumentType) =>
     {
         return instrumentType.GetGenericTypeDefinition() switch
         {
@@ -53,11 +55,14 @@ public abstract partial class MetricReader : IDisposable
     private readonly object onCollectLock = new();
     private readonly TaskCompletionSource<bool> shutdownTcs = new();
     private MetricReaderTemporalityPreference temporalityPreference = MetricReaderTemporalityPreferenceUnspecified;
-    private Func<Type, AggregationTemporality> temporalityFunc = cumulativeTemporalityPreferenceFunc;
+    private Func<Type, AggregationTemporality> temporalityFunc = CumulativeTemporalityPreferenceFunc;
     private int shutdownCount;
-    private TaskCompletionSource<bool> collectionTcs;
-    private BaseProvider parentProvider;
+    private TaskCompletionSource<bool>? collectionTcs;
+    private BaseProvider? parentProvider;
 
+    /// <summary>
+    /// Gets or sets the metric reader temporality preference.
+    /// </summary>
     public MetricReaderTemporalityPreference TemporalityPreference
     {
         get
@@ -78,16 +83,11 @@ public abstract partial class MetricReader : IDisposable
             }
 
             this.temporalityPreference = value;
-            switch (value)
+            this.temporalityFunc = value switch
             {
-                case MetricReaderTemporalityPreference.Delta:
-                    this.temporalityFunc = monotonicDeltaTemporalityPreferenceFunc;
-                    break;
-                case MetricReaderTemporalityPreference.Cumulative:
-                default:
-                    this.temporalityFunc = cumulativeTemporalityPreferenceFunc;
-                    break;
-            }
+                MetricReaderTemporalityPreference.Delta => MonotonicDeltaTemporalityPreferenceFunc,
+                _ => CumulativeTemporalityPreferenceFunc,
+            };
         }
     }
 

--- a/src/OpenTelemetry/Metrics/MetricStreamConfiguration.cs
+++ b/src/OpenTelemetry/Metrics/MetricStreamConfiguration.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 namespace OpenTelemetry.Metrics;
 
 /// <summary>
@@ -21,7 +23,7 @@ namespace OpenTelemetry.Metrics;
 /// </summary>
 public class MetricStreamConfiguration
 {
-    private string name;
+    private string? name;
 
     /// <summary>
     /// Gets the drop configuration.
@@ -38,7 +40,7 @@ public class MetricStreamConfiguration
     /// <remarks>
     /// Note: If not provided the instrument name will be used.
     /// </remarks>
-    public string Name
+    public string? Name
     {
         get => this.name;
         set
@@ -58,7 +60,7 @@ public class MetricStreamConfiguration
     /// <remarks>
     /// Note: If not provided the instrument description will be used.
     /// </remarks>
-    public string Description { get; set; }
+    public string? Description { get; set; }
 
     /// <summary>
     /// Gets or sets the optional tag keys to include in the metric stream.
@@ -75,7 +77,7 @@ public class MetricStreamConfiguration
     /// <item>A copy is made of the provided array.</item>
     /// </list>
     /// </remarks>
-    public string[] TagKeys
+    public string[]? TagKeys
     {
         get
         {
@@ -104,7 +106,7 @@ public class MetricStreamConfiguration
         }
     }
 
-    internal string[] CopiedTagKeys { get; private set; }
+    internal string[]? CopiedTagKeys { get; private set; }
 
     internal int? ViewId { get; set; }
 

--- a/src/OpenTelemetry/Metrics/MetricStreamIdentity.cs
+++ b/src/OpenTelemetry/Metrics/MetricStreamIdentity.cs
@@ -14,16 +14,18 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System.Diagnostics.Metrics;
 
 namespace OpenTelemetry.Metrics;
 
 internal readonly struct MetricStreamIdentity : IEquatable<MetricStreamIdentity>
 {
-    private static readonly StringArrayEqualityComparer StringArrayComparer = new StringArrayEqualityComparer();
+    private static readonly StringArrayEqualityComparer StringArrayComparer = new();
     private readonly int hashCode;
 
-    public MetricStreamIdentity(Instrument instrument, MetricStreamConfiguration metricStreamConfiguration)
+    public MetricStreamIdentity(Instrument instrument, MetricStreamConfiguration? metricStreamConfiguration)
     {
         this.MeterName = instrument.Meter.Name;
         this.MeterVersion = instrument.Meter.Version ?? string.Empty;
@@ -72,8 +74,8 @@ internal readonly struct MetricStreamIdentity : IEquatable<MetricStreamIdentity>
             hash = (hash * 31) + this.HistogramRecordMinMax.GetHashCode();
             hash = (hash * 31) + this.ExponentialHistogramMaxSize.GetHashCode();
             hash = (hash * 31) + this.ExponentialHistogramMaxScale.GetHashCode();
-            hash = (hash * 31) + (this.Unit?.GetHashCode() ?? 0);
-            hash = (hash * 31) + (this.Description?.GetHashCode() ?? 0);
+            hash = (hash * 31) + this.Unit.GetHashCode();
+            hash = (hash * 31) + this.Description.GetHashCode();
             hash = (hash * 31) + (this.ViewId ?? 0);
             hash = (hash * 31) + (this.TagKeys != null ? StringArrayComparer.GetHashCode(this.TagKeys) : 0);
             if (this.HistogramBucketBounds != null)
@@ -106,9 +108,9 @@ internal readonly struct MetricStreamIdentity : IEquatable<MetricStreamIdentity>
 
     public string MetricStreamName { get; }
 
-    public string[] TagKeys { get; }
+    public string[]? TagKeys { get; }
 
-    public double[] HistogramBucketBounds { get; }
+    public double[]? HistogramBucketBounds { get; }
 
     public int ExponentialHistogramMaxSize { get; }
 
@@ -120,7 +122,7 @@ internal readonly struct MetricStreamIdentity : IEquatable<MetricStreamIdentity>
 
     public static bool operator !=(MetricStreamIdentity metricIdentity1, MetricStreamIdentity metricIdentity2) => !metricIdentity1.Equals(metricIdentity2);
 
-    public readonly override bool Equals(object obj)
+    public override readonly bool Equals(object? obj)
     {
         return obj is MetricStreamIdentity other && this.Equals(other);
     }
@@ -141,9 +143,9 @@ internal readonly struct MetricStreamIdentity : IEquatable<MetricStreamIdentity>
             && HistogramBoundsEqual(this.HistogramBucketBounds, other.HistogramBucketBounds);
     }
 
-    public readonly override int GetHashCode() => this.hashCode;
+    public override readonly int GetHashCode() => this.hashCode;
 
-    private static bool HistogramBoundsEqual(double[] bounds1, double[] bounds2)
+    private static bool HistogramBoundsEqual(double[]? bounds1, double[]? bounds2)
     {
         if (ReferenceEquals(bounds1, bounds2))
         {

--- a/src/OpenTelemetry/Metrics/MetricType.cs
+++ b/src/OpenTelemetry/Metrics/MetricType.cs
@@ -14,8 +14,13 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 namespace OpenTelemetry.Metrics;
 
+/// <summary>
+/// Enumeration used to define the type of a <see cref="Metric"/>.
+/// </summary>
 [Flags]
 public enum MetricType : byte
 {

--- a/src/OpenTelemetry/Metrics/MetricTypeExtensions.cs
+++ b/src/OpenTelemetry/Metrics/MetricTypeExtensions.cs
@@ -14,10 +14,15 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System.Runtime.CompilerServices;
 
 namespace OpenTelemetry.Metrics;
 
+/// <summary>
+/// Contains extension methods for performing common operations against the <see cref="MetricType"/> class.
+/// </summary>
 public static class MetricTypeExtensions
 {
 #pragma warning disable SA1310 // field should not contain an underscore
@@ -45,6 +50,12 @@ public static class MetricTypeExtensions
 
 #pragma warning restore SA1310 // field should not contain an underscore
 
+    /// <summary>
+    /// Determines if the supplied <see cref="MetricType"/> is a sum definition.
+    /// </summary>
+    /// <param name="self"><see cref="MetricType"/>.</param>
+    /// <returns><see langword="true"/> if the supplied <see cref="MetricType"/>
+    /// is a sum definition.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsSum(this MetricType self)
     {
@@ -52,24 +63,48 @@ public static class MetricTypeExtensions
         return type == METRIC_TYPE_MONOTONIC_SUM || type == METRIC_TYPE_NON_MONOTONIC_SUM;
     }
 
+    /// <summary>
+    /// Determines if the supplied <see cref="MetricType"/> is a gauge definition.
+    /// </summary>
+    /// <param name="self"><see cref="MetricType"/>.</param>
+    /// <returns><see langword="true"/> if the supplied <see cref="MetricType"/>
+    /// is a gauge definition.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsGauge(this MetricType self)
     {
         return (self & METRIC_TYPE_MASK) == METRIC_TYPE_GAUGE;
     }
 
+    /// <summary>
+    /// Determines if the supplied <see cref="MetricType"/> is a histogram definition.
+    /// </summary>
+    /// <param name="self"><see cref="MetricType"/>.</param>
+    /// <returns><see langword="true"/> if the supplied <see cref="MetricType"/>
+    /// is a histogram definition.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsHistogram(this MetricType self)
     {
         return self.HasFlag(METRIC_TYPE_HISTOGRAM);
     }
 
+    /// <summary>
+    /// Determines if the supplied <see cref="MetricType"/> is a double definition.
+    /// </summary>
+    /// <param name="self"><see cref="MetricType"/>.</param>
+    /// <returns><see langword="true"/> if the supplied <see cref="MetricType"/>
+    /// is a double definition.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsDouble(this MetricType self)
     {
         return (self & POINT_KIND_MASK) == POINT_KIND_R8;
     }
 
+    /// <summary>
+    /// Determines if the supplied <see cref="MetricType"/> is a long definition.
+    /// </summary>
+    /// <param name="self"><see cref="MetricType"/>.</param>
+    /// <returns><see langword="true"/> if the supplied <see cref="MetricType"/>
+    /// is a long definition.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsLong(this MetricType self)
     {

--- a/src/OpenTelemetry/Metrics/PeriodicExportingMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/PeriodicExportingMetricReader.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System.Diagnostics;
 using OpenTelemetry.Internal;
 

--- a/src/OpenTelemetry/Metrics/PeriodicExportingMetricReaderOptions.cs
+++ b/src/OpenTelemetry/Metrics/PeriodicExportingMetricReaderOptions.cs
@@ -14,11 +14,20 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using Microsoft.Extensions.Configuration;
 using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Metrics;
 
+/// <summary>
+/// Contains periodic metric reader options.
+/// </summary>
+/// <remarks>
+/// Note: OTEL_METRIC_EXPORT_INTERVAL and OTEL_METRIC_EXPORT_TIMEOUT environment
+/// variables are parsed during object construction.
+/// </remarks>
 public class PeriodicExportingMetricReaderOptions
 {
     internal const string OTelMetricExportIntervalEnvVarKey = "OTEL_METRIC_EXPORT_INTERVAL";

--- a/src/OpenTelemetry/OpenTelemetry.csproj
+++ b/src/OpenTelemetry/OpenTelemetry.csproj
@@ -2,10 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(DefaultTargetFrameworks);netstandard2.1</TargetFrameworks>
     <Description>OpenTelemetry .NET SDK</Description>
-    <!--
-    TODO: Disable this exception, and actually do document all public API.
-    -->
-    <NoWarn>$(NoWarn),1591,CS0618</NoWarn>
     <MinVerTagPrefix>core-</MinVerTagPrefix>
 
     <!-- this is temporary. will remove in future PR. -->

--- a/src/OpenTelemetry/ReadOnlyTagCollection.cs
+++ b/src/OpenTelemetry/ReadOnlyTagCollection.cs
@@ -25,11 +25,11 @@ namespace OpenTelemetry;
 // prevent accidental boxing.
 public readonly struct ReadOnlyTagCollection
 {
-    internal readonly KeyValuePair<string, object>[] KeyAndValues;
+    internal readonly KeyValuePair<string, object?>[] KeyAndValues;
 
-    internal ReadOnlyTagCollection(KeyValuePair<string, object>[]? keyAndValues)
+    internal ReadOnlyTagCollection(KeyValuePair<string, object?>[]? keyAndValues)
     {
-        this.KeyAndValues = keyAndValues ?? Array.Empty<KeyValuePair<string, object>>();
+        this.KeyAndValues = keyAndValues ?? Array.Empty<KeyValuePair<string, object?>>();
     }
 
     /// <summary>
@@ -62,7 +62,7 @@ public readonly struct ReadOnlyTagCollection
         /// <summary>
         /// Gets the tag at the current position of the enumerator.
         /// </summary>
-        public KeyValuePair<string, object> Current { get; private set; }
+        public KeyValuePair<string, object?> Current { get; private set; }
 
         /// <summary>
         /// Advances the enumerator to the next element of the <see

--- a/src/OpenTelemetry/SuppressInstrumentationScope.cs
+++ b/src/OpenTelemetry/SuppressInstrumentationScope.cs
@@ -21,6 +21,9 @@ using OpenTelemetry.Context;
 
 namespace OpenTelemetry;
 
+/// <summary>
+/// Contains methods managing instrumentation of internal operations.
+/// </summary>
 public sealed class SuppressInstrumentationScope : IDisposable
 {
     // An integer value which controls whether instrumentation should be suppressed (disabled).

--- a/src/OpenTelemetry/Trace/BatchActivityExportProcessor.cs
+++ b/src/OpenTelemetry/Trace/BatchActivityExportProcessor.cs
@@ -20,8 +20,19 @@ using System.Diagnostics;
 
 namespace OpenTelemetry;
 
+/// <summary>
+/// Implements processor that batches <see cref="Activity"/> objects before calling exporter.
+/// </summary>
 public class BatchActivityExportProcessor : BatchExportProcessor<Activity>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BatchActivityExportProcessor"/> class.
+    /// </summary>
+    /// <param name="exporter"><inheritdoc cref="BatchExportProcessor{T}.BatchExportProcessor" path="/param[@name='exporter']"/></param>
+    /// <param name="maxQueueSize"><inheritdoc cref="BatchExportProcessor{T}.BatchExportProcessor" path="/param[@name='maxQueueSize']"/></param>
+    /// <param name="scheduledDelayMilliseconds"><inheritdoc cref="BatchExportProcessor{T}.BatchExportProcessor" path="/param[@name='scheduledDelayMilliseconds']"/></param>
+    /// <param name="exporterTimeoutMilliseconds"><inheritdoc cref="BatchExportProcessor{T}.BatchExportProcessor" path="/param[@name='exporterTimeoutMilliseconds']"/></param>
+    /// <param name="maxExportBatchSize"><inheritdoc cref="BatchExportProcessor{T}.BatchExportProcessor" path="/param[@name='maxExportBatchSize']"/></param>
     public BatchActivityExportProcessor(
         BaseExporter<Activity> exporter,
         int maxQueueSize = DefaultMaxQueueSize,

--- a/src/OpenTelemetry/Trace/Sampler.cs
+++ b/src/OpenTelemetry/Trace/Sampler.cs
@@ -25,6 +25,9 @@ namespace OpenTelemetry.Trace;
 /// </summary>
 public abstract class Sampler
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Sampler"/> class.
+    /// </summary>
     protected Sampler()
     {
         this.Description = this.GetType().Name;

--- a/src/OpenTelemetry/Trace/SimpleActivityExportProcessor.cs
+++ b/src/OpenTelemetry/Trace/SimpleActivityExportProcessor.cs
@@ -20,8 +20,15 @@ using System.Diagnostics;
 
 namespace OpenTelemetry;
 
+/// <summary>
+/// Implements processor that exports <see cref="Activity"/> objects at each OnEnd call.
+/// </summary>
 public class SimpleActivityExportProcessor : SimpleExportProcessor<Activity>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SimpleActivityExportProcessor"/> class.
+    /// </summary>
+    /// <param name="exporter"><inheritdoc cref="SimpleExportProcessor{T}.SimpleExportProcessor" path="/param[@name='exporter']"/>.</param>
     public SimpleActivityExportProcessor(BaseExporter<Activity> exporter)
         : base(exporter)
     {


### PR DESCRIPTION
## Changes

* Removed `<NoWarn>$(NoWarn),CS0618</NoWarn>` from OpenTelemetry.Api csproj. That didn't seem to introduce any new warnings.
* Removed `<NoWarn>$(NoWarn),1591,CS0618</NoWarn>` from OpenTelemetry csproj. This generated warnings for anything in public API missing XML docs. Added those docs.
* Added nullable annotations for everything remaining in the OpenTelemetry public API. Mostly metric files/artifacts. There is still some internal stuff missing annotations before we can turn it on for the whole SDK project, follow-up effort for that.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
