### PR TITLE
[sdk] Nullable annotations for the internal folder + some misc cleanup

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj
@@ -38,7 +38,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" RequiresExposedExperimentalFeatures="true" />
     <Compile Include="$(RepoRoot)\src\Shared\SpanAttributeConstants.cs" Link="Includes\SpanAttributeConstants.cs" RequiresExposedExperimentalFeatures="true" />
     <Compile Include="$(RepoRoot)\src\Shared\StatusHelper.cs" Link="Includes\StatusHelper.cs" RequiresExposedExperimentalFeatures="true" />
-    <Compile Include="$(RepoRoot)\src\Shared\Shims\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" RequiresExposedExperimentalFeatures="true" />
+    <Compile Include="$(RepoRoot)\src\Shared\Shims\NullableAttributes.cs" Link="Includes\Shims\NullableAttributes.cs" RequiresExposedExperimentalFeatures="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
@@ -17,7 +17,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\EnvironmentVariables\*.cs" Link="Includes\EnvironmentVariables\%(Filename).cs" Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'" />
     <Compile Include="$(RepoRoot)\src\Shared\HttpSemanticConventionHelper.cs" Link="Includes\HttpSemanticConventionHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Options\*.cs" Link="Includes\Options\%(Filename).cs" />
-    <Compile Include="$(RepoRoot)\src\Shared\Shims\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\Shims\NullableAttributes.cs" Link="Includes\Shims\NullableAttributes.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(RunningDotNetPack)' == '' OR '$(RunningDotNetPack)' == 'false'">

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/OpenTelemetry.Instrumentation.GrpcNetClient.csproj
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/OpenTelemetry.Instrumentation.GrpcNetClient.csproj
@@ -16,7 +16,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\EnvironmentVariables\*.cs" Link="Includes\EnvironmentVariables\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\Shared\HttpSemanticConventionHelper.cs" Link="Includes\HttpSemanticConventionHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Options\*.cs" Link="Includes\Options\%(Filename).cs" />
-    <Compile Include="$(RepoRoot)\src\Shared\Shims\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\Shims\NullableAttributes.cs" Link="Includes\Shims\NullableAttributes.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(RunningDotNetPack)' == '' OR '$(RunningDotNetPack)' == 'false'">

--- a/src/OpenTelemetry.Instrumentation.Http/OpenTelemetry.Instrumentation.Http.csproj
+++ b/src/OpenTelemetry.Instrumentation.Http/OpenTelemetry.Instrumentation.Http.csproj
@@ -15,7 +15,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\EnvironmentVariables\*.cs" Link="Includes\EnvironmentVariables\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\Shared\HttpSemanticConventionHelper.cs" Link="Includes\HttpSemanticConventionHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Options\*.cs" Link="Includes\Options\%(Filename).cs" />
-    <Compile Include="$(RepoRoot)\src\Shared\Shims\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\Shims\NullableAttributes.cs" Link="Includes\Shims\NullableAttributes.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(RunningDotNetPack)' == '' OR '$(RunningDotNetPack)' == 'false'">

--- a/src/OpenTelemetry.Instrumentation.SqlClient/OpenTelemetry.Instrumentation.SqlClient.csproj
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/OpenTelemetry.Instrumentation.SqlClient.csproj
@@ -15,7 +15,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\EnvironmentVariables\*.cs" Link="Includes\EnvironmentVariables\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\Shared\HttpSemanticConventionHelper.cs" Link="Includes\HttpSemanticConventionHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Options\*.cs" Link="Includes\Options\%(Filename).cs" />
-    <Compile Include="$(RepoRoot)\src\Shared\Shims\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\Shims\NullableAttributes.cs" Link="Includes\Shims\NullableAttributes.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(RunningDotNetPack)' == '' OR '$(RunningDotNetPack)' == 'false'">

--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -15,6 +15,7 @@
 // </copyright>
 
 #nullable enable
+
 using System.Diagnostics;
 #if NET6_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;

--- a/src/OpenTelemetry/Internal/SelfDiagnostics.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnostics.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 namespace OpenTelemetry.Internal;
 
 /// <summary>

--- a/src/OpenTelemetry/Internal/SelfDiagnosticsConfigParser.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnosticsConfigParser.cs
@@ -14,6 +14,9 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -43,9 +46,12 @@ internal sealed class SelfDiagnosticsConfigParser
     // This class is called in SelfDiagnosticsConfigRefresher.UpdateMemoryMappedFileFromConfiguration
     // in both main thread and the worker thread.
     // In theory the variable won't be access at the same time because worker thread first Task.Delay for a few seconds.
-    private byte[] configBuffer;
+    private byte[]? configBuffer;
 
-    public bool TryGetConfiguration(out string logDirectory, out int fileSizeInKB, out EventLevel logLevel)
+    public bool TryGetConfiguration(
+        [NotNullWhen(true)] out string? logDirectory,
+        out int fileSizeInKB,
+        out EventLevel logLevel)
     {
         logDirectory = null;
         fileSizeInKB = 0;
@@ -67,6 +73,7 @@ internal sealed class SelfDiagnosticsConfigParser
             }
 
             using FileStream file = File.Open(configFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+
             var buffer = this.configBuffer;
             if (buffer == null)
             {
@@ -76,6 +83,7 @@ internal sealed class SelfDiagnosticsConfigParser
 
             file.Read(buffer, 0, buffer.Length);
             string configJson = Encoding.UTF8.GetString(buffer);
+
             if (!TryParseLogDirectory(configJson, out logDirectory))
             {
                 return false;
@@ -101,18 +109,19 @@ internal sealed class SelfDiagnosticsConfigParser
                 return false;
             }
 
-            logLevel = (EventLevel)Enum.Parse(typeof(EventLevel), logLevelString);
-            return true;
+            return Enum.TryParse(logLevelString, out logLevel);
         }
         catch (Exception)
         {
             // do nothing on failure to open/read/parse config file
+            return false;
         }
-
-        return false;
     }
 
-    internal static bool TryParseLogDirectory(string configJson, out string logDirectory)
+    internal static bool TryParseLogDirectory(
+        string configJson,
+        [NotNullWhen(true)]
+        out string logDirectory)
     {
         var logDirectoryResult = LogDirectoryRegex.Match(configJson);
         logDirectory = logDirectoryResult.Groups["LogDirectory"].Value;
@@ -126,7 +135,10 @@ internal sealed class SelfDiagnosticsConfigParser
         return fileSizeResult.Success && int.TryParse(fileSizeResult.Groups["FileSize"].Value, out fileSizeInKB);
     }
 
-    internal static bool TryParseLogLevel(string configJson, out string logLevel)
+    internal static bool TryParseLogLevel(
+        string configJson,
+        [NotNullWhen(true)]
+        out string? logLevel)
     {
         var logLevelResult = LogLevelRegex.Match(configJson);
         logLevel = logLevelResult.Groups["LogLevel"].Value;

--- a/src/OpenTelemetry/Internal/SelfDiagnosticsEventListener.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnosticsEventListener.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System.Collections.ObjectModel;
 using System.Diagnostics.Tracing;
 using System.Text;
@@ -32,8 +34,8 @@ internal sealed class SelfDiagnosticsEventListener : EventListener
     private readonly object lockObj = new();
     private readonly EventLevel logLevel;
     private readonly SelfDiagnosticsConfigRefresher configRefresher;
-    private readonly ThreadLocal<byte[]> writeBuffer = new(() => null);
-    private readonly List<EventSource> eventSourcesBeforeConstructor = new();
+    private readonly ThreadLocal<byte[]?> writeBuffer = new(() => null);
+    private readonly List<EventSource>? eventSourcesBeforeConstructor = new();
 
     private bool disposedValue = false;
 
@@ -78,14 +80,14 @@ internal sealed class SelfDiagnosticsEventListener : EventListener
     /// <param name="buffer">The byte array to contain the resulting sequence of bytes.</param>
     /// <param name="position">The position at which to start writing the resulting sequence of bytes.</param>
     /// <returns>The position of the buffer after the last byte of the resulting sequence.</returns>
-    internal static int EncodeInBuffer(string str, bool isParameter, byte[] buffer, int position)
+    internal static int EncodeInBuffer(string? str, bool isParameter, byte[] buffer, int position)
     {
         if (string.IsNullOrEmpty(str))
         {
             return position;
         }
 
-        int charCount = str.Length;
+        int charCount = str!.Length;
         int ellipses = isParameter ? "{...}\n".Length : "...\n".Length;
 
         // Ensure there is space for "{...}\n" or "...\n".
@@ -124,7 +126,7 @@ internal sealed class SelfDiagnosticsEventListener : EventListener
         return position;
     }
 
-    internal void WriteEvent(string eventMessage, ReadOnlyCollection<object> payload)
+    internal void WriteEvent(string? eventMessage, ReadOnlyCollection<object?>? payload)
     {
         try
         {
@@ -143,10 +145,10 @@ internal sealed class SelfDiagnosticsEventListener : EventListener
                 // Not using foreach because it can cause allocations
                 for (int i = 0; i < payload.Count; ++i)
                 {
-                    object obj = payload[i];
+                    object? obj = payload[i];
                     if (obj != null)
                     {
-                        pos = EncodeInBuffer(obj.ToString(), true, buffer, pos);
+                        pos = EncodeInBuffer(obj.ToString() ?? "null", true, buffer, pos);
                     }
                     else
                     {
@@ -157,7 +159,7 @@ internal sealed class SelfDiagnosticsEventListener : EventListener
 
             buffer[pos++] = (byte)'\n';
             int byteCount = pos - 0;
-            if (this.configRefresher.TryGetLogStream(byteCount, out Stream stream, out int availableByteCount))
+            if (this.configRefresher.TryGetLogStream(byteCount, out Stream? stream, out int availableByteCount))
             {
                 if (availableByteCount >= byteCount)
                 {

--- a/src/OpenTelemetry/Internal/WildcardHelper.cs
+++ b/src/OpenTelemetry/Internal/WildcardHelper.cs
@@ -14,13 +14,19 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 
 namespace OpenTelemetry;
 
 internal static class WildcardHelper
 {
-    public static bool ContainsWildcard(string value)
+    public static bool ContainsWildcard(
+        [NotNullWhen(true)]
+        string? value)
     {
         if (value == null)
         {
@@ -30,16 +36,14 @@ internal static class WildcardHelper
         return value.Contains('*') || value.Contains('?');
     }
 
-    public static Regex GetWildcardRegex(IEnumerable<string> patterns = default)
+    public static Regex GetWildcardRegex(IEnumerable<string> patterns)
     {
-        if (patterns == null)
-        {
-            return null;
-        }
+        Debug.Assert(patterns?.Any() == true, "patterns was null or empty");
 
         var convertedPattern = string.Join(
             "|",
             from p in patterns select "(?:" + Regex.Escape(p).Replace("\\*", ".*").Replace("\\?", ".") + ')');
+
         return new Regex("^(?:" + convertedPattern + ")$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
     }
 }

--- a/src/OpenTelemetry/OpenTelemetry.csproj
+++ b/src/OpenTelemetry/OpenTelemetry.csproj
@@ -21,7 +21,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\MathHelper.cs" Link="Includes\MathHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Options\*.cs" Link="Includes\Options\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\Shared\ResourceSemanticConventions.cs" Link="Includes\ResourceSemanticConventions.cs" />
-    <Compile Include="$(RepoRoot)\src\Shared\Shims\NullableAttributes.cs" Link="Includes\NullableAttributes.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\Shims\NullableAttributes.cs" Link="Includes\Shims\NullableAttributes.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -19,6 +19,7 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Resources;
@@ -78,13 +79,11 @@ internal sealed class TracerProviderSdk : TracerProvider
 
         this.supportLegacyActivity = state.LegacyActivityOperationNames.Count > 0;
 
-        bool legacyActivityWildcardMode = false;
-        var legacyActivityWildcardModeRegex = WildcardHelper.GetWildcardRegex();
+        Regex? legacyActivityWildcardModeRegex = null;
         foreach (var legacyName in state.LegacyActivityOperationNames)
         {
             if (WildcardHelper.ContainsWildcard(legacyName))
             {
-                legacyActivityWildcardMode = true;
                 legacyActivityWildcardModeRegex = WildcardHelper.GetWildcardRegex(state.LegacyActivityOperationNames);
                 break;
             }
@@ -121,7 +120,7 @@ internal sealed class TracerProviderSdk : TracerProvider
         if (this.supportLegacyActivity)
         {
             Func<Activity, bool>? legacyActivityPredicate = null;
-            if (legacyActivityWildcardMode)
+            if (legacyActivityWildcardModeRegex != null)
             {
                 legacyActivityPredicate = activity => legacyActivityWildcardModeRegex.IsMatch(activity.OperationName);
             }


### PR DESCRIPTION
## Changes

* Added nullable annotations for things missing in the `Internal` folder of the OpenTelemetry project.
* Cleaned up `WildcardHelper` a bit.
* Added "Shims" to the include path for `NullableAttributes.cs` links.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
