### PR TITLE
[dev.documentation] for up to 3 tags, its faster to directly pass the…

### DIFF
--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -31,7 +31,7 @@ MyFruitCounter.Add(7, new("color", "red"), new("name", "apple"), new("taste", "s
   performance. Using
   [`TagList`](https://learn.microsoft.com/dotnet/api/system.diagnostics.taglist?view=net-7.0#remarks)
   avoids allocating any memory for up to eight tags, thereby, reducing the
-  pressure on GC to free up memory.
+  pressure on GC to free up memory. DO NOT use `TagList` when emitting less than three tags as that would lead to poorer performance than individually emitting the tags.
 - Do not use TagList for `<3 tags`, as that will have poorer performance than directly passing.
 
 ```csharp

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -32,6 +32,7 @@ MyFruitCounter.Add(7, new("color", "red"), new("name", "apple"), new("taste", "s
   [`TagList`](https://learn.microsoft.com/dotnet/api/system.diagnostics.taglist?view=net-7.0#remarks)
   avoids allocating any memory for up to eight tags, thereby, reducing the
   pressure on GC to free up memory.
+- Do not use TagList for `<3 tags`, as that will have poorer performance than directly passing.
 
 ```csharp
 var tags = new TagList

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -27,12 +27,15 @@ MyFruitCounter.Add(5, new("name", "apple"), new("color", "red"), new("taste", "s
 MyFruitCounter.Add(7, new("color", "red"), new("name", "apple"), new("taste", "sweet")); // <--- DON'T DO THIS
 ```
 
-- When emitting metrics with more than three tags, use `TagList` for better
-  performance. Using
+For the best performance, it is highly recommended to pass in tags in certain
+ways so allocations are only happening on the stack rather than the heap,
+which eliminates pressure on the GC (garbage collector):
+
+- When reporting measurements with 3 tags or less,
+  emit the tags individually.
+- When reporting measurements with more than 3 tags, use
   [`TagList`](https://learn.microsoft.com/dotnet/api/system.diagnostics.taglist?view=net-7.0#remarks)
-  avoids allocating any memory for up to eight tags, thereby, reducing the
-  pressure on GC to free up memory. DO NOT use `TagList` when emitting less than three tags as that would lead to poorer performance than individually emitting the tags.
-- Do not use TagList for `<3 tags`, as that will have poorer performance than directly passing.
+  for better performance.
 
 ```csharp
 var tags = new TagList


### PR DESCRIPTION
…m without TagList.

Fixes: https://github.com/open-telemetry/opentelemetry-dotnet/issues/4810

## Changes

for up to 3 tags, its faster to directly pass them without TagList.
https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/metrics (The doc probably need to call this out explicitly)

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
