### PR TITLE
[sdk] Nullable annotations for the metrics folder

### DIFF
--- a/src/OpenTelemetry/Metrics/AggregationType.cs
+++ b/src/OpenTelemetry/Metrics/AggregationType.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 namespace OpenTelemetry.Metrics;
 
 internal enum AggregationType

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -14,7 +14,10 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using OpenTelemetry.Internal;
 
@@ -23,11 +26,12 @@ namespace OpenTelemetry.Metrics;
 internal sealed class AggregatorStore
 {
     private static readonly string MetricPointCapHitFixMessage = "Consider opting in for the experimental SDK feature to emit all the throttled metrics under the overflow attribute by setting env variable OTEL_DOTNET_EXPERIMENTAL_METRICS_EMIT_OVERFLOW_ATTRIBUTE = true. You could also modify instrumentation to reduce the number of unique key/value pair combinations. Or use Views to drop unwanted tags. Or use MeterProviderBuilder.SetMaxMetricPointsPerMetricStream to set higher limit.";
-    private static readonly Comparison<KeyValuePair<string, object>> DimensionComparisonDelegate = (x, y) => x.Key.CompareTo(y.Key);
+    private static readonly Comparison<KeyValuePair<string, object?>> DimensionComparisonDelegate = (x, y) => x.Key.CompareTo(y.Key);
+    private static readonly ExemplarFilter DefaultExemplarFilter = new AlwaysOffExemplarFilter();
 
     private readonly object lockZeroTags = new();
     private readonly object lockOverflowTag = new();
-    private readonly HashSet<string> tagKeysInteresting;
+    private readonly HashSet<string>? tagKeysInteresting;
     private readonly int tagsKeysInterestingCount;
 
     private readonly ConcurrentDictionary<Tags, int> tagsToMetricPointIndexDictionary =
@@ -60,7 +64,7 @@ internal sealed class AggregatorStore
         AggregationTemporality temporality,
         int maxMetricPoints,
         bool emitOverflowAttribute,
-        ExemplarFilter exemplarFilter = null)
+        ExemplarFilter? exemplarFilter = null)
     {
         this.name = metricStreamIdentity.InstrumentName;
         this.maxMetricPoints = maxMetricPoints;
@@ -73,7 +77,7 @@ internal sealed class AggregatorStore
         this.exponentialHistogramMaxSize = metricStreamIdentity.ExponentialHistogramMaxSize;
         this.exponentialHistogramMaxScale = metricStreamIdentity.ExponentialHistogramMaxScale;
         this.StartTimeExclusive = DateTimeOffset.UtcNow;
-        this.exemplarFilter = exemplarFilter ?? new AlwaysOffExemplarFilter();
+        this.exemplarFilter = exemplarFilter ?? DefaultExemplarFilter;
         if (metricStreamIdentity.TagKeys == null)
         {
             this.updateLongCallback = this.UpdateLong;
@@ -98,9 +102,9 @@ internal sealed class AggregatorStore
         }
     }
 
-    private delegate void UpdateLongDelegate(long value, ReadOnlySpan<KeyValuePair<string, object>> tags);
+    private delegate void UpdateLongDelegate(long value, ReadOnlySpan<KeyValuePair<string, object?>> tags);
 
-    private delegate void UpdateDoubleDelegate(double value, ReadOnlySpan<KeyValuePair<string, object>> tags);
+    private delegate void UpdateDoubleDelegate(double value, ReadOnlySpan<KeyValuePair<string, object?>> tags);
 
     internal DateTimeOffset StartTimeExclusive { get; private set; }
 
@@ -115,12 +119,12 @@ internal sealed class AggregatorStore
         return this.exemplarFilter is not AlwaysOffExemplarFilter;
     }
 
-    internal void Update(long value, ReadOnlySpan<KeyValuePair<string, object>> tags)
+    internal void Update(long value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
     {
         this.updateLongCallback(value, tags);
     }
 
-    internal void Update(double value, ReadOnlySpan<KeyValuePair<string, object>> tags)
+    internal void Update(double value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
     {
         this.updateDoubleCallback(value, tags);
     }
@@ -234,7 +238,7 @@ internal sealed class AggregatorStore
             {
                 if (!this.overflowTagMetricPointInitialized)
                 {
-                    this.metricPoints[1] = new MetricPoint(this, this.aggType, new KeyValuePair<string, object>[] { new("otel.metric.overflow", true) }, this.histogramBounds, this.exponentialHistogramMaxSize, this.exponentialHistogramMaxScale);
+                    this.metricPoints[1] = new MetricPoint(this, this.aggType, new KeyValuePair<string, object?>[] { new("otel.metric.overflow", true) }, this.histogramBounds, this.exponentialHistogramMaxSize, this.exponentialHistogramMaxScale);
                     this.overflowTagMetricPointInitialized = true;
                 }
             }
@@ -242,7 +246,7 @@ internal sealed class AggregatorStore
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private int LookupAggregatorStore(KeyValuePair<string, object>[] tagKeysAndValues, int length)
+    private int LookupAggregatorStore(KeyValuePair<string, object?>[] tagKeysAndValues, int length)
     {
         var givenTags = new Tags(tagKeysAndValues);
 
@@ -275,10 +279,10 @@ internal sealed class AggregatorStore
                     // so we need to make a deep copy for Dictionary storage.
                     if (length <= ThreadStaticStorage.MaxTagCacheSize)
                     {
-                        var givenTagKeysAndValues = new KeyValuePair<string, object>[length];
+                        var givenTagKeysAndValues = new KeyValuePair<string, object?>[length];
                         tagKeysAndValues.CopyTo(givenTagKeysAndValues.AsSpan());
 
-                        var sortedTagKeysAndValues = new KeyValuePair<string, object>[length];
+                        var sortedTagKeysAndValues = new KeyValuePair<string, object?>[length];
                         tempSortedTagKeysAndValues.CopyTo(sortedTagKeysAndValues.AsSpan());
 
                         givenTags = new Tags(givenTagKeysAndValues);
@@ -328,7 +332,7 @@ internal sealed class AggregatorStore
                 }
 
                 // Note: We are using storage from ThreadStatic, so need to make a deep copy for Dictionary storage.
-                var givenTagKeysAndValues = new KeyValuePair<string, object>[length];
+                var givenTagKeysAndValues = new KeyValuePair<string, object?>[length];
 
                 tagKeysAndValues.CopyTo(givenTagKeysAndValues.AsSpan());
 
@@ -366,7 +370,7 @@ internal sealed class AggregatorStore
         return aggregatorIndex;
     }
 
-    private void UpdateLong(long value, ReadOnlySpan<KeyValuePair<string, object>> tags)
+    private void UpdateLong(long value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
     {
         try
         {
@@ -407,7 +411,7 @@ internal sealed class AggregatorStore
         }
     }
 
-    private void UpdateLongCustomTags(long value, ReadOnlySpan<KeyValuePair<string, object>> tags)
+    private void UpdateLongCustomTags(long value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
     {
         try
         {
@@ -448,7 +452,7 @@ internal sealed class AggregatorStore
         }
     }
 
-    private void UpdateDouble(double value, ReadOnlySpan<KeyValuePair<string, object>> tags)
+    private void UpdateDouble(double value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
     {
         try
         {
@@ -489,7 +493,7 @@ internal sealed class AggregatorStore
         }
     }
 
-    private void UpdateDoubleCustomTags(double value, ReadOnlySpan<KeyValuePair<string, object>> tags)
+    private void UpdateDoubleCustomTags(double value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
     {
         try
         {
@@ -530,7 +534,7 @@ internal sealed class AggregatorStore
         }
     }
 
-    private int FindMetricAggregatorsDefault(ReadOnlySpan<KeyValuePair<string, object>> tags)
+    private int FindMetricAggregatorsDefault(ReadOnlySpan<KeyValuePair<string, object?>> tags)
     {
         int tagLength = tags.Length;
         if (tagLength == 0)
@@ -546,7 +550,7 @@ internal sealed class AggregatorStore
         return this.LookupAggregatorStore(tagKeysAndValues, tagLength);
     }
 
-    private int FindMetricAggregatorsCustomTag(ReadOnlySpan<KeyValuePair<string, object>> tags)
+    private int FindMetricAggregatorsCustomTag(ReadOnlySpan<KeyValuePair<string, object?>> tags)
     {
         int tagLength = tags.Length;
         if (tagLength == 0 || this.tagsKeysInterestingCount == 0)
@@ -555,12 +559,11 @@ internal sealed class AggregatorStore
             return 0;
         }
 
-        // TODO: Get only interesting tags
-        // from the incoming tags
-
         var storage = ThreadStaticStorage.GetStorage();
 
-        storage.SplitToKeysAndValues(tags, tagLength, this.tagKeysInteresting, out var tagKeysAndValues, out var actualLength);
+        Debug.Assert(this.tagKeysInteresting != null, "this.tagKeysInteresting was null");
+
+        storage.SplitToKeysAndValues(tags, tagLength, this.tagKeysInteresting!, out var tagKeysAndValues, out var actualLength);
 
         // Actual number of tags depend on how many
         // of the incoming tags has user opted to
@@ -571,6 +574,8 @@ internal sealed class AggregatorStore
             return 0;
         }
 
-        return this.LookupAggregatorStore(tagKeysAndValues, actualLength);
+        Debug.Assert(tagKeysAndValues != null, "tagKeysAndValues was null");
+
+        return this.LookupAggregatorStore(tagKeysAndValues!, actualLength);
     }
 }

--- a/src/OpenTelemetry/Metrics/Base2ExponentialBucketHistogram.LowerBoundary.cs
+++ b/src/OpenTelemetry/Metrics/Base2ExponentialBucketHistogram.LowerBoundary.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 namespace OpenTelemetry.Metrics;
 
 /// <content>

--- a/src/OpenTelemetry/Metrics/Base2ExponentialBucketHistogram.cs
+++ b/src/OpenTelemetry/Metrics/Base2ExponentialBucketHistogram.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System.Diagnostics;
 using OpenTelemetry.Internal;
 
@@ -38,7 +40,7 @@ internal sealed partial class Base2ExponentialBucketHistogram
 
     internal int IsCriticalSectionOccupied = 0;
 
-    internal ExponentialHistogramData SnapshotExponentialHistogramData = new ExponentialHistogramData();
+    internal ExponentialHistogramData SnapshotExponentialHistogramData = new();
 
     private int scale;
     private double scalingFactor; // 2 ^ scale / log(2)
@@ -237,11 +239,13 @@ internal sealed partial class Base2ExponentialBucketHistogram
     internal Base2ExponentialBucketHistogram Copy()
     {
         Debug.Assert(this.PositiveBuckets.Capacity == this.NegativeBuckets.Capacity, "Capacity of positive and negative buckets are not equal.");
-        var copy = new Base2ExponentialBucketHistogram(this.PositiveBuckets.Capacity, this.SnapshotExponentialHistogramData.Scale);
-        copy.SnapshotSum = this.SnapshotSum;
-        copy.SnapshotMin = this.SnapshotMin;
-        copy.SnapshotMax = this.SnapshotMax;
-        copy.SnapshotExponentialHistogramData = this.SnapshotExponentialHistogramData.Copy();
-        return copy;
+
+        return new Base2ExponentialBucketHistogram(this.PositiveBuckets.Capacity, this.SnapshotExponentialHistogramData.Scale)
+        {
+            SnapshotSum = this.SnapshotSum,
+            SnapshotMin = this.SnapshotMin,
+            SnapshotMax = this.SnapshotMax,
+            SnapshotExponentialHistogramData = this.SnapshotExponentialHistogramData.Copy(),
+        };
     }
 }

--- a/src/OpenTelemetry/Metrics/Base2ExponentialBucketHistogramConfiguration.cs
+++ b/src/OpenTelemetry/Metrics/Base2ExponentialBucketHistogramConfiguration.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 namespace OpenTelemetry.Metrics;
 
 /// <summary>

--- a/src/OpenTelemetry/Metrics/CircularBufferBuckets.cs
+++ b/src/OpenTelemetry/Metrics/CircularBufferBuckets.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using OpenTelemetry.Internal;
@@ -25,7 +27,7 @@ namespace OpenTelemetry.Metrics;
 /// </summary>
 internal sealed class CircularBufferBuckets
 {
-    private long[] trait;
+    private long[]? trait;
     private int begin = 0;
     private int end = -1;
 
@@ -62,7 +64,12 @@ internal sealed class CircularBufferBuckets
     /// </remarks>
     public long this[int index]
     {
-        get => this.trait[this.ModuloIndex(index)];
+        get
+        {
+            Debug.Assert(this.trait != null, "trait was null");
+
+            return this.trait![this.ModuloIndex(index)];
+        }
     }
 
     /// <summary>

--- a/src/OpenTelemetry/Metrics/CompositeMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/CompositeMetricReader.cs
@@ -14,7 +14,10 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Metrics;
@@ -153,7 +156,7 @@ internal sealed partial class CompositeMetricReader : MetricReader
 
     public struct Enumerator
     {
-        private DoublyLinkedListNode node;
+        private DoublyLinkedListNode? node;
 
         internal Enumerator(DoublyLinkedListNode node)
         {
@@ -161,6 +164,7 @@ internal sealed partial class CompositeMetricReader : MetricReader
             this.Current = null;
         }
 
+        [AllowNull]
         public MetricReader Current { get; private set; }
 
         public bool MoveNext()
@@ -185,8 +189,8 @@ internal sealed partial class CompositeMetricReader : MetricReader
             this.Value = value;
         }
 
-        public DoublyLinkedListNode Previous { get; set; }
+        public DoublyLinkedListNode? Previous { get; set; }
 
-        public DoublyLinkedListNode Next { get; set; }
+        public DoublyLinkedListNode? Next { get; set; }
     }
 }

--- a/src/OpenTelemetry/Metrics/CompositeMetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/CompositeMetricReaderExt.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 
@@ -30,13 +32,16 @@ internal sealed partial class CompositeMetricReader
         for (var cur = this.Head; cur != null; cur = cur.Next)
         {
             var metric = cur.Value.AddMetricWithNoViews(instrument);
-            metrics.Add(metric);
+            if (metric != null)
+            {
+                metrics.Add(metric);
+            }
         }
 
         return metrics;
     }
 
-    internal void RecordSingleStreamLongMeasurements(List<Metric> metrics, long value, ReadOnlySpan<KeyValuePair<string, object>> tags)
+    internal void RecordSingleStreamLongMeasurements(List<Metric> metrics, long value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
     {
         Debug.Assert(metrics.Count == this.count, "The count of metrics to be updated for a CompositeReader must match the number of individual readers.");
 
@@ -52,7 +57,7 @@ internal sealed partial class CompositeMetricReader
         }
     }
 
-    internal void RecordSingleStreamDoubleMeasurements(List<Metric> metrics, double value, ReadOnlySpan<KeyValuePair<string, object>> tags)
+    internal void RecordSingleStreamDoubleMeasurements(List<Metric> metrics, double value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
     {
         Debug.Assert(metrics.Count == this.count, "The count of metrics to be updated for a CompositeReader must match the number of individual readers.");
 
@@ -68,7 +73,7 @@ internal sealed partial class CompositeMetricReader
         }
     }
 
-    internal List<List<Metric>> AddMetricsSuperListWithViews(Instrument instrument, List<MetricStreamConfiguration> metricStreamConfigs)
+    internal List<List<Metric>> AddMetricsSuperListWithViews(Instrument instrument, List<MetricStreamConfiguration?> metricStreamConfigs)
     {
         var metricsSuperList = new List<List<Metric>>(this.count);
         for (var cur = this.Head; cur != null; cur = cur.Next)
@@ -80,7 +85,7 @@ internal sealed partial class CompositeMetricReader
         return metricsSuperList;
     }
 
-    internal void RecordLongMeasurements(List<List<Metric>> metricsSuperList, long value, ReadOnlySpan<KeyValuePair<string, object>> tags)
+    internal void RecordLongMeasurements(List<List<Metric>> metricsSuperList, long value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
     {
         Debug.Assert(metricsSuperList.Count == this.count, "The count of metrics to be updated for a CompositeReader must match the number of individual readers.");
 
@@ -96,7 +101,7 @@ internal sealed partial class CompositeMetricReader
         }
     }
 
-    internal void RecordDoubleMeasurements(List<List<Metric>> metricsSuperList, double value, ReadOnlySpan<KeyValuePair<string, object>> tags)
+    internal void RecordDoubleMeasurements(List<List<Metric>> metricsSuperList, double value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
     {
         Debug.Assert(metricsSuperList.Count == this.count, "The count of metrics to be updated for a CompositeReader must match the number of individual readers.");
 

--- a/src/OpenTelemetry/Metrics/CompositeMetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/CompositeMetricReaderExt.cs
@@ -26,47 +26,46 @@ namespace OpenTelemetry.Metrics;
 /// </summary>
 internal sealed partial class CompositeMetricReader
 {
-    internal List<Metric> AddMetricsWithNoViews(Instrument instrument)
+    internal List<Metric?> AddMetricsWithNoViews(Instrument instrument)
     {
-        var metrics = new List<Metric>(this.count);
+        var metrics = new List<Metric?>(this.count);
+
         for (var cur = this.Head; cur != null; cur = cur.Next)
         {
-            var metric = cur.Value.AddMetricWithNoViews(instrument);
-            if (metric != null)
-            {
-                metrics.Add(metric);
-            }
+            metrics.Add(cur.Value.AddMetricWithNoViews(instrument));
         }
 
         return metrics;
     }
 
-    internal void RecordSingleStreamLongMeasurements(List<Metric> metrics, long value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
+    internal void RecordSingleStreamLongMeasurements(List<Metric?> metrics, long value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
     {
         Debug.Assert(metrics.Count == this.count, "The count of metrics to be updated for a CompositeReader must match the number of individual readers.");
 
         int index = 0;
         for (var cur = this.Head; cur != null; cur = cur.Next)
         {
-            if (metrics[index] != null)
+            var metric = metrics[index];
+            if (metric != null)
             {
-                cur.Value.RecordSingleStreamLongMeasurement(metrics[index], value, tags);
+                cur.Value.RecordSingleStreamLongMeasurement(metric, value, tags);
             }
 
             index++;
         }
     }
 
-    internal void RecordSingleStreamDoubleMeasurements(List<Metric> metrics, double value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
+    internal void RecordSingleStreamDoubleMeasurements(List<Metric?> metrics, double value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
     {
         Debug.Assert(metrics.Count == this.count, "The count of metrics to be updated for a CompositeReader must match the number of individual readers.");
 
         int index = 0;
         for (var cur = this.Head; cur != null; cur = cur.Next)
         {
-            if (metrics[index] != null)
+            var metric = metrics[index];
+            if (metric != null)
             {
-                cur.Value.RecordSingleStreamDoubleMeasurement(metrics[index], value, tags);
+                cur.Value.RecordSingleStreamDoubleMeasurement(metric, value, tags);
             }
 
             index++;
@@ -117,16 +116,17 @@ internal sealed partial class CompositeMetricReader
         }
     }
 
-    internal void CompleteSingleStreamMeasurements(List<Metric> metrics)
+    internal void CompleteSingleStreamMeasurements(List<Metric?> metrics)
     {
         Debug.Assert(metrics.Count == this.count, "The count of metrics to be updated for a CompositeReader must match the number of individual readers.");
 
         int index = 0;
         for (var cur = this.Head; cur != null; cur = cur.Next)
         {
-            if (metrics[index] != null)
+            var metric = metrics[index];
+            if (metric != null)
             {
-                cur.Value.CompleteSingleStreamMeasurement(metrics[index]);
+                cur.Value.CompleteSingleStreamMeasurement(metric);
             }
 
             index++;

--- a/src/OpenTelemetry/Metrics/HistogramBucket.cs
+++ b/src/OpenTelemetry/Metrics/HistogramBucket.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 namespace OpenTelemetry.Metrics;
 
 /// <summary>

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -389,7 +389,7 @@ internal sealed class MeterProviderSdk : MeterProvider
         }
         else
         {
-            if (state is not List<Metric> metrics)
+            if (state is not List<Metric?> metrics)
             {
                 // TODO: log
                 return;
@@ -493,7 +493,7 @@ internal sealed class MeterProviderSdk : MeterProvider
         }
         else
         {
-            if (state is not List<Metric> metrics)
+            if (state is not List<Metric?> metrics)
             {
                 OpenTelemetrySdkEventSource.Log.MeasurementDropped(instrument!.Name, "SDK internal error occurred.", "Contact SDK owners.");
                 return;
@@ -519,7 +519,7 @@ internal sealed class MeterProviderSdk : MeterProvider
         }
         else
         {
-            if (state is not List<Metric> metrics)
+            if (state is not List<Metric?> metrics)
             {
                 OpenTelemetrySdkEventSource.Log.MeasurementDropped(instrument!.Name, "SDK internal error occurred.", "Contact SDK owners.");
                 return;

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -45,7 +45,7 @@ public struct MetricPoint
     internal MetricPoint(
         AggregatorStore aggregatorStore,
         AggregationType aggType,
-        KeyValuePair<string, object?>[] tagKeysAndValues,
+        KeyValuePair<string, object?>[]? tagKeysAndValues,
         double[] histogramExplicitBounds,
         int exponentialHistogramMaxSize,
         int exponentialHistogramMaxScale)
@@ -252,9 +252,14 @@ public struct MetricPoint
             this.ThrowNotSupportedMetricTypeException(nameof(this.GetHistogramSum));
         }
 
+        Debug.Assert(
+            this.mpComponents?.HistogramBuckets != null
+            || this.mpComponents?.Base2ExponentialBucketHistogram != null,
+            "HistogramBuckets and Base2ExponentialBucketHistogram were both null");
+
         return this.mpComponents!.HistogramBuckets != null
             ? this.mpComponents.HistogramBuckets.SnapshotSum
-            : this.mpComponents.Base2ExponentialBucketHistogram.SnapshotSum;
+            : this.mpComponents.Base2ExponentialBucketHistogram!.SnapshotSum;
     }
 
     /// <summary>
@@ -275,7 +280,9 @@ public struct MetricPoint
             this.ThrowNotSupportedMetricTypeException(nameof(this.GetHistogramBuckets));
         }
 
-        return this.mpComponents!.HistogramBuckets;
+        Debug.Assert(this.mpComponents?.HistogramBuckets != null, "HistogramBuckets was null");
+
+        return this.mpComponents!.HistogramBuckets!;
     }
 
     /// <summary>
@@ -294,7 +301,9 @@ public struct MetricPoint
             this.ThrowNotSupportedMetricTypeException(nameof(this.GetExponentialHistogramData));
         }
 
-        return this.mpComponents!.Base2ExponentialBucketHistogram.GetExponentialHistogramData();
+        Debug.Assert(this.mpComponents?.Base2ExponentialBucketHistogram != null, "Base2ExponentialBucketHistogram was null");
+
+        return this.mpComponents!.Base2ExponentialBucketHistogram!.GetExponentialHistogramData();
     }
 
     /// <summary>
@@ -447,9 +456,11 @@ public struct MetricPoint
 
                     if (isSampled)
                     {
+                        Debug.Assert(this.mpComponents.ExemplarReservoir != null, "ExemplarReservoir was null");
+
                         // TODO: Need to ensure that the lock is always released.
                         // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
-                        this.mpComponents.ExemplarReservoir.Offer(number, tags);
+                        this.mpComponents.ExemplarReservoir!.Offer(number, tags);
                     }
 
                     ReleaseLock(ref this.mpComponents!.IsCriticalSectionOccupied);
@@ -463,9 +474,11 @@ public struct MetricPoint
 
                     this.runningValue.AsLong = number;
 
+                    Debug.Assert(this.mpComponents.ExemplarReservoir != null, "ExemplarReservoir was null");
+
                     // TODO: Need to ensure that the lock is always released.
                     // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
-                    this.mpComponents.ExemplarReservoir.Offer(number, tags);
+                    this.mpComponents.ExemplarReservoir!.Offer(number, tags);
 
                     ReleaseLock(ref this.mpComponents!.IsCriticalSectionOccupied);
 
@@ -478,9 +491,11 @@ public struct MetricPoint
 
                     this.runningValue.AsLong = number;
 
+                    Debug.Assert(this.mpComponents.ExemplarReservoir != null, "ExemplarReservoir was null");
+
                     // TODO: Need to ensure that the lock is always released.
                     // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
-                    this.mpComponents.ExemplarReservoir.Offer(number, tags);
+                    this.mpComponents.ExemplarReservoir!.Offer(number, tags);
 
                     ReleaseLock(ref this.mpComponents!.IsCriticalSectionOccupied);
 
@@ -644,9 +659,11 @@ public struct MetricPoint
 
                     if (isSampled)
                     {
+                        Debug.Assert(this.mpComponents.ExemplarReservoir != null, "ExemplarReservoir was null");
+
                         // TODO: Need to ensure that the lock is always released.
                         // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
-                        this.mpComponents.ExemplarReservoir.Offer(number, tags);
+                        this.mpComponents.ExemplarReservoir!.Offer(number, tags);
                     }
 
                     ReleaseLock(ref this.mpComponents!.IsCriticalSectionOccupied);
@@ -663,9 +680,11 @@ public struct MetricPoint
                         this.runningValue.AsDouble = number;
                     }
 
+                    Debug.Assert(this.mpComponents.ExemplarReservoir != null, "ExemplarReservoir was null");
+
                     // TODO: Need to ensure that the lock is always released.
                     // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
-                    this.mpComponents.ExemplarReservoir.Offer(number, tags);
+                    this.mpComponents.ExemplarReservoir!.Offer(number, tags);
 
                     ReleaseLock(ref this.mpComponents!.IsCriticalSectionOccupied);
 
@@ -681,9 +700,11 @@ public struct MetricPoint
                         this.runningValue.AsDouble = number;
                     }
 
+                    Debug.Assert(this.mpComponents.ExemplarReservoir != null, "ExemplarReservoir was null");
+
                     // TODO: Need to ensure that the lock is always released.
                     // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
-                    this.mpComponents.ExemplarReservoir.Offer(number, tags);
+                    this.mpComponents.ExemplarReservoir!.Offer(number, tags);
 
                     ReleaseLock(ref this.mpComponents!.IsCriticalSectionOccupied);
 
@@ -844,7 +865,9 @@ public struct MetricPoint
                 {
                     var histogramBuckets = this.mpComponents!.HistogramBuckets;
 
-                    AcquireLock(ref histogramBuckets.IsCriticalSectionOccupied);
+                    Debug.Assert(this.mpComponents.HistogramBuckets != null, "HistogramBuckets was null");
+
+                    AcquireLock(ref histogramBuckets!.IsCriticalSectionOccupied);
 
                     this.snapshotValue.AsLong = this.runningValue.AsLong;
                     histogramBuckets.SnapshotSum = histogramBuckets.RunningSum;
@@ -879,7 +902,9 @@ public struct MetricPoint
                 {
                     var histogramBuckets = this.mpComponents!.HistogramBuckets;
 
-                    AcquireLock(ref histogramBuckets.IsCriticalSectionOccupied);
+                    Debug.Assert(this.mpComponents.HistogramBuckets != null, "HistogramBuckets was null");
+
+                    AcquireLock(ref histogramBuckets!.IsCriticalSectionOccupied);
                     this.snapshotValue.AsLong = this.runningValue.AsLong;
                     histogramBuckets.SnapshotSum = histogramBuckets.RunningSum;
 
@@ -900,7 +925,9 @@ public struct MetricPoint
                 {
                     var histogramBuckets = this.mpComponents!.HistogramBuckets;
 
-                    AcquireLock(ref histogramBuckets.IsCriticalSectionOccupied);
+                    Debug.Assert(this.mpComponents.HistogramBuckets != null, "HistogramBuckets was null");
+
+                    AcquireLock(ref histogramBuckets!.IsCriticalSectionOccupied);
 
                     this.snapshotValue.AsLong = this.runningValue.AsLong;
                     histogramBuckets.SnapshotSum = histogramBuckets.RunningSum;
@@ -938,7 +965,9 @@ public struct MetricPoint
                 {
                     var histogramBuckets = this.mpComponents!.HistogramBuckets;
 
-                    AcquireLock(ref histogramBuckets.IsCriticalSectionOccupied);
+                    Debug.Assert(this.mpComponents.HistogramBuckets != null, "HistogramBuckets was null");
+
+                    AcquireLock(ref histogramBuckets!.IsCriticalSectionOccupied);
 
                     this.snapshotValue.AsLong = this.runningValue.AsLong;
                     histogramBuckets.SnapshotSum = histogramBuckets.RunningSum;
@@ -964,7 +993,9 @@ public struct MetricPoint
                 {
                     var histogram = this.mpComponents!.Base2ExponentialBucketHistogram;
 
-                    AcquireLock(ref histogram.IsCriticalSectionOccupied);
+                    Debug.Assert(this.mpComponents.Base2ExponentialBucketHistogram != null, "Base2ExponentialBucketHistogram was null");
+
+                    AcquireLock(ref histogram!.IsCriticalSectionOccupied);
 
                     this.snapshotValue.AsLong = this.runningValue.AsLong;
                     histogram.SnapshotSum = histogram.RunningSum;
@@ -988,7 +1019,9 @@ public struct MetricPoint
                 {
                     var histogram = this.mpComponents!.Base2ExponentialBucketHistogram;
 
-                    AcquireLock(ref histogram.IsCriticalSectionOccupied);
+                    Debug.Assert(this.mpComponents.Base2ExponentialBucketHistogram != null, "Base2ExponentialBucketHistogram was null");
+
+                    AcquireLock(ref histogram!.IsCriticalSectionOccupied);
 
                     this.snapshotValue.AsLong = this.runningValue.AsLong;
                     histogram.SnapshotSum = histogram.RunningSum;
@@ -1096,7 +1129,9 @@ public struct MetricPoint
                 {
                     var histogramBuckets = this.mpComponents!.HistogramBuckets;
 
-                    AcquireLock(ref histogramBuckets.IsCriticalSectionOccupied);
+                    Debug.Assert(this.mpComponents.HistogramBuckets != null, "HistogramBuckets was null");
+
+                    AcquireLock(ref histogramBuckets!.IsCriticalSectionOccupied);
 
                     this.snapshotValue.AsLong = this.runningValue.AsLong;
                     histogramBuckets.SnapshotSum = histogramBuckets.RunningSum;
@@ -1131,7 +1166,9 @@ public struct MetricPoint
                 {
                     var histogramBuckets = this.mpComponents!.HistogramBuckets;
 
-                    AcquireLock(ref histogramBuckets.IsCriticalSectionOccupied);
+                    Debug.Assert(this.mpComponents.HistogramBuckets != null, "HistogramBuckets was null");
+
+                    AcquireLock(ref histogramBuckets!.IsCriticalSectionOccupied);
 
                     this.snapshotValue.AsLong = this.runningValue.AsLong;
                     histogramBuckets.SnapshotSum = histogramBuckets.RunningSum;
@@ -1154,7 +1191,9 @@ public struct MetricPoint
                 {
                     var histogramBuckets = this.mpComponents!.HistogramBuckets;
 
-                    AcquireLock(ref histogramBuckets.IsCriticalSectionOccupied);
+                    Debug.Assert(this.mpComponents.HistogramBuckets != null, "HistogramBuckets was null");
+
+                    AcquireLock(ref histogramBuckets!.IsCriticalSectionOccupied);
 
                     this.snapshotValue.AsLong = this.runningValue.AsLong;
                     histogramBuckets.SnapshotSum = histogramBuckets.RunningSum;
@@ -1192,7 +1231,9 @@ public struct MetricPoint
                 {
                     var histogramBuckets = this.mpComponents!.HistogramBuckets;
 
-                    AcquireLock(ref histogramBuckets.IsCriticalSectionOccupied);
+                    Debug.Assert(this.mpComponents.HistogramBuckets != null, "HistogramBuckets was null");
+
+                    AcquireLock(ref histogramBuckets!.IsCriticalSectionOccupied);
 
                     this.snapshotValue.AsLong = this.runningValue.AsLong;
                     histogramBuckets.SnapshotSum = histogramBuckets.RunningSum;
@@ -1219,7 +1260,9 @@ public struct MetricPoint
                 {
                     var histogram = this.mpComponents!.Base2ExponentialBucketHistogram;
 
-                    AcquireLock(ref histogram.IsCriticalSectionOccupied);
+                    Debug.Assert(this.mpComponents.Base2ExponentialBucketHistogram != null, "Base2ExponentialBucketHistogram was null");
+
+                    AcquireLock(ref histogram!.IsCriticalSectionOccupied);
 
                     this.snapshotValue.AsLong = this.runningValue.AsLong;
                     histogram.SnapshotSum = histogram.RunningSum;
@@ -1243,7 +1286,9 @@ public struct MetricPoint
                 {
                     var histogram = this.mpComponents!.Base2ExponentialBucketHistogram;
 
-                    AcquireLock(ref histogram.IsCriticalSectionOccupied);
+                    Debug.Assert(this.mpComponents.Base2ExponentialBucketHistogram != null, "Base2ExponentialBucketHistogram was null");
+
+                    AcquireLock(ref histogram!.IsCriticalSectionOccupied);
 
                     this.snapshotValue.AsLong = this.runningValue.AsLong;
                     histogram.SnapshotSum = histogram.RunningSum;
@@ -1287,7 +1332,9 @@ public struct MetricPoint
     {
         var histogramBuckets = this.mpComponents!.HistogramBuckets;
 
-        AcquireLock(ref histogramBuckets.IsCriticalSectionOccupied);
+        Debug.Assert(this.mpComponents.HistogramBuckets != null, "HistogramBuckets was null");
+
+        AcquireLock(ref histogramBuckets!.IsCriticalSectionOccupied);
 
         unchecked
         {
@@ -1297,9 +1344,11 @@ public struct MetricPoint
 
         if (reportExemplar)
         {
+            Debug.Assert(this.mpComponents.ExemplarReservoir != null, "ExemplarReservoir was null");
+
             // TODO: Need to ensure that the lock is always released.
             // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
-            this.mpComponents.ExemplarReservoir.Offer(number, tags);
+            this.mpComponents.ExemplarReservoir!.Offer(number, tags);
         }
 
         ReleaseLock(ref histogramBuckets.IsCriticalSectionOccupied);
@@ -1309,7 +1358,9 @@ public struct MetricPoint
     {
         var histogramBuckets = this.mpComponents!.HistogramBuckets;
 
-        AcquireLock(ref histogramBuckets.IsCriticalSectionOccupied);
+        Debug.Assert(this.mpComponents.HistogramBuckets != null, "HistogramBuckets was null");
+
+        AcquireLock(ref histogramBuckets!.IsCriticalSectionOccupied);
 
         unchecked
         {
@@ -1321,9 +1372,11 @@ public struct MetricPoint
 
         if (reportExemplar)
         {
+            Debug.Assert(this.mpComponents.ExemplarReservoir != null, "ExemplarReservoir was null");
+
             // TODO: Need to ensure that the lock is always released.
             // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
-            this.mpComponents.ExemplarReservoir.Offer(number, tags);
+            this.mpComponents.ExemplarReservoir!.Offer(number, tags);
         }
 
         ReleaseLock(ref histogramBuckets.IsCriticalSectionOccupied);
@@ -1332,7 +1385,10 @@ public struct MetricPoint
     private void UpdateHistogramWithBuckets(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool reportExemplar = false)
     {
         var histogramBuckets = this.mpComponents!.HistogramBuckets;
-        int i = histogramBuckets.FindBucketIndex(number);
+
+        Debug.Assert(this.mpComponents.HistogramBuckets != null, "HistogramBuckets was null");
+
+        int i = histogramBuckets!.FindBucketIndex(number);
 
         Debug.Assert(histogramBuckets.RunningBucketCounts != null, "histogramBuckets.RunningBucketCounts was null");
 
@@ -1343,11 +1399,14 @@ public struct MetricPoint
             this.runningValue.AsLong++;
             histogramBuckets.RunningSum += number;
             histogramBuckets.RunningBucketCounts![i]++;
+
             if (reportExemplar)
             {
+                Debug.Assert(this.mpComponents.ExemplarReservoir != null, "ExemplarReservoir was null");
+
                 // TODO: Need to ensure that the lock is always released.
                 // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
-                this.mpComponents.ExemplarReservoir.Offer(number, tags, i);
+                this.mpComponents.ExemplarReservoir!.Offer(number, tags, i);
             }
         }
 
@@ -1357,7 +1416,10 @@ public struct MetricPoint
     private void UpdateHistogramWithBucketsAndMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool reportExemplar = false)
     {
         var histogramBuckets = this.mpComponents!.HistogramBuckets;
-        int i = histogramBuckets.FindBucketIndex(number);
+
+        Debug.Assert(histogramBuckets != null, "histogramBuckets was null");
+
+        int i = histogramBuckets!.FindBucketIndex(number);
 
         AcquireLock(ref histogramBuckets.IsCriticalSectionOccupied);
 
@@ -1368,11 +1430,14 @@ public struct MetricPoint
             this.runningValue.AsLong++;
             histogramBuckets.RunningSum += number;
             histogramBuckets.RunningBucketCounts![i]++;
+
             if (reportExemplar)
             {
+                Debug.Assert(this.mpComponents.ExemplarReservoir != null, "ExemplarReservoir was null");
+
                 // TODO: Need to ensure that the lock is always released.
                 // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
-                this.mpComponents.ExemplarReservoir.Offer(number, tags, i);
+                this.mpComponents.ExemplarReservoir!.Offer(number, tags, i);
             }
 
             histogramBuckets.RunningMin = Math.Min(histogramBuckets.RunningMin, number);
@@ -1393,7 +1458,9 @@ public struct MetricPoint
 
         var histogram = this.mpComponents!.Base2ExponentialBucketHistogram;
 
-        AcquireLock(ref histogram.IsCriticalSectionOccupied);
+        Debug.Assert(histogram != null, "histogram was null");
+
+        AcquireLock(ref histogram!.IsCriticalSectionOccupied);
 
         unchecked
         {
@@ -1416,7 +1483,9 @@ public struct MetricPoint
 
         var histogram = this.mpComponents!.Base2ExponentialBucketHistogram;
 
-        AcquireLock(ref histogram.IsCriticalSectionOccupied);
+        Debug.Assert(histogram != null, "histogram was null");
+
+        AcquireLock(ref histogram!.IsCriticalSectionOccupied);
 
         unchecked
         {

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -315,22 +315,22 @@ public struct MetricPoint
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public readonly bool TryGetHistogramMinMaxValues(out double min, out double max)
     {
-        if (this.aggType == AggregationType.HistogramWithMinMax ||
-                        this.aggType == AggregationType.HistogramWithMinMaxBuckets)
+        if (this.aggType == AggregationType.HistogramWithMinMax
+            || this.aggType == AggregationType.HistogramWithMinMaxBuckets)
         {
-            Debug.Assert(this.mpComponents!.HistogramBuckets != null, "histogramBuckets was null");
+            Debug.Assert(this.mpComponents?.HistogramBuckets != null, "HistogramBuckets was null");
 
             min = this.mpComponents!.HistogramBuckets!.SnapshotMin;
-            max = this.mpComponents!.HistogramBuckets!.SnapshotMax;
+            max = this.mpComponents.HistogramBuckets.SnapshotMax;
             return true;
         }
 
         if (this.aggType == AggregationType.Base2ExponentialHistogramWithMinMax)
         {
-            Debug.Assert(this.mpComponents!.Base2ExponentialBucketHistogram != null, "base2ExponentialBucketHistogram was null");
+            Debug.Assert(this.mpComponents?.Base2ExponentialBucketHistogram != null, "Base2ExponentialBucketHistogram was null");
 
             min = this.mpComponents!.Base2ExponentialBucketHistogram!.SnapshotMin;
-            max = this.mpComponents!.Base2ExponentialBucketHistogram!.SnapshotMax;
+            max = this.mpComponents.Base2ExponentialBucketHistogram.SnapshotMax;
             return true;
         }
 
@@ -443,6 +443,8 @@ public struct MetricPoint
 
     internal void UpdateWithExemplar(long number, ReadOnlySpan<KeyValuePair<string, object?>> tags, bool isSampled)
     {
+        Debug.Assert(this.mpComponents != null, "this.mpComponents was null");
+
         switch (this.aggType)
         {
             case AggregationType.LongSumIncomingDelta:
@@ -646,6 +648,8 @@ public struct MetricPoint
 
     internal void UpdateWithExemplar(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags, bool isSampled)
     {
+        Debug.Assert(this.mpComponents != null, "this.mpComponents was null");
+
         switch (this.aggType)
         {
             case AggregationType.DoubleSumIncomingDelta:
@@ -863,9 +867,9 @@ public struct MetricPoint
 
             case AggregationType.HistogramWithBuckets:
                 {
-                    var histogramBuckets = this.mpComponents!.HistogramBuckets;
+                    Debug.Assert(this.mpComponents?.HistogramBuckets != null, "HistogramBuckets was null");
 
-                    Debug.Assert(this.mpComponents.HistogramBuckets != null, "HistogramBuckets was null");
+                    var histogramBuckets = this.mpComponents!.HistogramBuckets;
 
                     AcquireLock(ref histogramBuckets!.IsCriticalSectionOccupied);
 
@@ -900,9 +904,9 @@ public struct MetricPoint
 
             case AggregationType.Histogram:
                 {
-                    var histogramBuckets = this.mpComponents!.HistogramBuckets;
+                    Debug.Assert(this.mpComponents?.HistogramBuckets != null, "HistogramBuckets was null");
 
-                    Debug.Assert(this.mpComponents.HistogramBuckets != null, "HistogramBuckets was null");
+                    var histogramBuckets = this.mpComponents!.HistogramBuckets;
 
                     AcquireLock(ref histogramBuckets!.IsCriticalSectionOccupied);
                     this.snapshotValue.AsLong = this.runningValue.AsLong;
@@ -923,9 +927,9 @@ public struct MetricPoint
 
             case AggregationType.HistogramWithMinMaxBuckets:
                 {
-                    var histogramBuckets = this.mpComponents!.HistogramBuckets;
+                    Debug.Assert(this.mpComponents?.HistogramBuckets != null, "HistogramBuckets was null");
 
-                    Debug.Assert(this.mpComponents.HistogramBuckets != null, "HistogramBuckets was null");
+                    var histogramBuckets = this.mpComponents!.HistogramBuckets;
 
                     AcquireLock(ref histogramBuckets!.IsCriticalSectionOccupied);
 
@@ -963,9 +967,9 @@ public struct MetricPoint
 
             case AggregationType.HistogramWithMinMax:
                 {
-                    var histogramBuckets = this.mpComponents!.HistogramBuckets;
+                    Debug.Assert(this.mpComponents?.HistogramBuckets != null, "HistogramBuckets was null");
 
-                    Debug.Assert(this.mpComponents.HistogramBuckets != null, "HistogramBuckets was null");
+                    var histogramBuckets = this.mpComponents!.HistogramBuckets;
 
                     AcquireLock(ref histogramBuckets!.IsCriticalSectionOccupied);
 
@@ -991,9 +995,9 @@ public struct MetricPoint
 
             case AggregationType.Base2ExponentialHistogram:
                 {
-                    var histogram = this.mpComponents!.Base2ExponentialBucketHistogram;
+                    Debug.Assert(this.mpComponents?.Base2ExponentialBucketHistogram != null, "Base2ExponentialBucketHistogram was null");
 
-                    Debug.Assert(this.mpComponents.Base2ExponentialBucketHistogram != null, "Base2ExponentialBucketHistogram was null");
+                    var histogram = this.mpComponents!.Base2ExponentialBucketHistogram;
 
                     AcquireLock(ref histogram!.IsCriticalSectionOccupied);
 
@@ -1017,9 +1021,9 @@ public struct MetricPoint
 
             case AggregationType.Base2ExponentialHistogramWithMinMax:
                 {
-                    var histogram = this.mpComponents!.Base2ExponentialBucketHistogram;
+                    Debug.Assert(this.mpComponents?.Base2ExponentialBucketHistogram != null, "Base2ExponentialBucketHistogram was null");
 
-                    Debug.Assert(this.mpComponents.Base2ExponentialBucketHistogram != null, "Base2ExponentialBucketHistogram was null");
+                    var histogram = this.mpComponents!.Base2ExponentialBucketHistogram;
 
                     AcquireLock(ref histogram!.IsCriticalSectionOccupied);
 
@@ -1049,6 +1053,8 @@ public struct MetricPoint
 
     internal void TakeSnapshotWithExemplar(bool outputDelta)
     {
+        Debug.Assert(this.mpComponents != null, "this.mpComponents was null");
+
         switch (this.aggType)
         {
             case AggregationType.LongSumIncomingDelta:
@@ -1129,7 +1135,7 @@ public struct MetricPoint
                 {
                     var histogramBuckets = this.mpComponents!.HistogramBuckets;
 
-                    Debug.Assert(this.mpComponents.HistogramBuckets != null, "HistogramBuckets was null");
+                    Debug.Assert(histogramBuckets != null, "histogramBuckets was null");
 
                     AcquireLock(ref histogramBuckets!.IsCriticalSectionOccupied);
 
@@ -1166,7 +1172,7 @@ public struct MetricPoint
                 {
                     var histogramBuckets = this.mpComponents!.HistogramBuckets;
 
-                    Debug.Assert(this.mpComponents.HistogramBuckets != null, "HistogramBuckets was null");
+                    Debug.Assert(histogramBuckets != null, "histogramBuckets was null");
 
                     AcquireLock(ref histogramBuckets!.IsCriticalSectionOccupied);
 
@@ -1191,7 +1197,7 @@ public struct MetricPoint
                 {
                     var histogramBuckets = this.mpComponents!.HistogramBuckets;
 
-                    Debug.Assert(this.mpComponents.HistogramBuckets != null, "HistogramBuckets was null");
+                    Debug.Assert(histogramBuckets != null, "histogramBuckets was null");
 
                     AcquireLock(ref histogramBuckets!.IsCriticalSectionOccupied);
 
@@ -1231,7 +1237,7 @@ public struct MetricPoint
                 {
                     var histogramBuckets = this.mpComponents!.HistogramBuckets;
 
-                    Debug.Assert(this.mpComponents.HistogramBuckets != null, "HistogramBuckets was null");
+                    Debug.Assert(histogramBuckets != null, "histogramBuckets was null");
 
                     AcquireLock(ref histogramBuckets!.IsCriticalSectionOccupied);
 
@@ -1260,7 +1266,7 @@ public struct MetricPoint
                 {
                     var histogram = this.mpComponents!.Base2ExponentialBucketHistogram;
 
-                    Debug.Assert(this.mpComponents.Base2ExponentialBucketHistogram != null, "Base2ExponentialBucketHistogram was null");
+                    Debug.Assert(histogram != null, "histogram was null");
 
                     AcquireLock(ref histogram!.IsCriticalSectionOccupied);
 
@@ -1286,7 +1292,7 @@ public struct MetricPoint
                 {
                     var histogram = this.mpComponents!.Base2ExponentialBucketHistogram;
 
-                    Debug.Assert(this.mpComponents.Base2ExponentialBucketHistogram != null, "Base2ExponentialBucketHistogram was null");
+                    Debug.Assert(histogram != null, "histogram was null");
 
                     AcquireLock(ref histogram!.IsCriticalSectionOccupied);
 
@@ -1330,9 +1336,9 @@ public struct MetricPoint
 
     private void UpdateHistogram(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool reportExemplar = false)
     {
-        var histogramBuckets = this.mpComponents!.HistogramBuckets;
+        Debug.Assert(this.mpComponents?.HistogramBuckets != null, "HistogramBuckets was null");
 
-        Debug.Assert(this.mpComponents.HistogramBuckets != null, "HistogramBuckets was null");
+        var histogramBuckets = this.mpComponents!.HistogramBuckets;
 
         AcquireLock(ref histogramBuckets!.IsCriticalSectionOccupied);
 
@@ -1356,9 +1362,9 @@ public struct MetricPoint
 
     private void UpdateHistogramWithMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool reportExemplar = false)
     {
-        var histogramBuckets = this.mpComponents!.HistogramBuckets;
+        Debug.Assert(this.mpComponents?.HistogramBuckets != null, "HistogramBuckets was null");
 
-        Debug.Assert(this.mpComponents.HistogramBuckets != null, "HistogramBuckets was null");
+        var histogramBuckets = this.mpComponents!.HistogramBuckets;
 
         AcquireLock(ref histogramBuckets!.IsCriticalSectionOccupied);
 
@@ -1384,9 +1390,9 @@ public struct MetricPoint
 
     private void UpdateHistogramWithBuckets(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool reportExemplar = false)
     {
-        var histogramBuckets = this.mpComponents!.HistogramBuckets;
+        Debug.Assert(this.mpComponents?.HistogramBuckets != null, "HistogramBuckets was null");
 
-        Debug.Assert(this.mpComponents.HistogramBuckets != null, "HistogramBuckets was null");
+        var histogramBuckets = this.mpComponents!.HistogramBuckets;
 
         int i = histogramBuckets!.FindBucketIndex(number);
 
@@ -1415,9 +1421,9 @@ public struct MetricPoint
 
     private void UpdateHistogramWithBucketsAndMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool reportExemplar = false)
     {
-        var histogramBuckets = this.mpComponents!.HistogramBuckets;
+        Debug.Assert(this.mpComponents?.HistogramBuckets != null, "histogramBuckets was null");
 
-        Debug.Assert(histogramBuckets != null, "histogramBuckets was null");
+        var histogramBuckets = this.mpComponents!.HistogramBuckets;
 
         int i = histogramBuckets!.FindBucketIndex(number);
 
@@ -1456,9 +1462,9 @@ public struct MetricPoint
             return;
         }
 
-        var histogram = this.mpComponents!.Base2ExponentialBucketHistogram;
+        Debug.Assert(this.mpComponents?.Base2ExponentialBucketHistogram != null, "Base2ExponentialBucketHistogram was null");
 
-        Debug.Assert(histogram != null, "histogram was null");
+        var histogram = this.mpComponents!.Base2ExponentialBucketHistogram;
 
         AcquireLock(ref histogram!.IsCriticalSectionOccupied);
 
@@ -1481,9 +1487,9 @@ public struct MetricPoint
             return;
         }
 
-        var histogram = this.mpComponents!.Base2ExponentialBucketHistogram;
+        Debug.Assert(this.mpComponents?.Base2ExponentialBucketHistogram != null, "Base2ExponentialBucketHistogram was null");
 
-        Debug.Assert(histogram != null, "histogram was null");
+        var histogram = this.mpComponents!.Base2ExponentialBucketHistogram;
 
         AcquireLock(ref histogram!.IsCriticalSectionOccupied);
 

--- a/src/OpenTelemetry/Metrics/MetricPointOptionalComponents.cs
+++ b/src/OpenTelemetry/Metrics/MetricPointOptionalComponents.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 namespace OpenTelemetry.Metrics;
 
 /// <summary>
@@ -25,23 +27,27 @@ namespace OpenTelemetry.Metrics;
 /// </summary>
 internal sealed class MetricPointOptionalComponents
 {
-    public HistogramBuckets HistogramBuckets;
+    public HistogramBuckets? HistogramBuckets;
 
-    public Base2ExponentialBucketHistogram Base2ExponentialBucketHistogram;
+    public Base2ExponentialBucketHistogram? Base2ExponentialBucketHistogram;
 
-    public ExemplarReservoir ExemplarReservoir;
+    public ExemplarReservoir? ExemplarReservoir;
 
-    public Exemplar[] Exemplars;
+    public Exemplar[]? Exemplars;
 
     public int IsCriticalSectionOccupied = 0;
 
     internal MetricPointOptionalComponents Copy()
     {
-        MetricPointOptionalComponents copy = new MetricPointOptionalComponents();
-        copy.HistogramBuckets = this.HistogramBuckets?.Copy();
-        copy.Base2ExponentialBucketHistogram = this.Base2ExponentialBucketHistogram?.Copy();
+        MetricPointOptionalComponents copy = new MetricPointOptionalComponents
+        {
+            HistogramBuckets = this.HistogramBuckets?.Copy(),
+            Base2ExponentialBucketHistogram = this.Base2ExponentialBucketHistogram?.Copy(),
+        };
+
         if (this.Exemplars != null)
         {
+            copy.Exemplars = new Exemplar[this.Exemplars.Length];
             Array.Copy(this.Exemplars, copy.Exemplars, this.Exemplars.Length);
         }
 

--- a/src/OpenTelemetry/Metrics/MetricPointStatus.cs
+++ b/src/OpenTelemetry/Metrics/MetricPointStatus.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 namespace OpenTelemetry.Metrics;
 
 internal enum MetricPointStatus

--- a/src/OpenTelemetry/Metrics/MetricPointValueStorage.cs
+++ b/src/OpenTelemetry/Metrics/MetricPointValueStorage.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using System.Runtime.InteropServices;
 
 namespace OpenTelemetry.Metrics;

--- a/src/OpenTelemetry/Metrics/MetricPointsAccessor.cs
+++ b/src/OpenTelemetry/Metrics/MetricPointsAccessor.cs
@@ -14,7 +14,9 @@
 // limitations under the License.
 // </copyright>
 
-using OpenTelemetry.Internal;
+#nullable enable
+
+using System.Diagnostics;
 
 namespace OpenTelemetry.Metrics;
 
@@ -30,10 +32,11 @@ public readonly struct MetricPointsAccessor
 
     internal MetricPointsAccessor(MetricPoint[] metricsPoints, int[] metricPointsToProcess, long targetCount)
     {
-        Guard.ThrowIfNull(metricsPoints);
+        Debug.Assert(metricsPoints != null, "metricPoints was null");
+        Debug.Assert(metricPointsToProcess != null, "metricPointsToProcess was null");
 
-        this.metricsPoints = metricsPoints;
-        this.metricPointsToProcess = metricPointsToProcess;
+        this.metricsPoints = metricsPoints!;
+        this.metricPointsToProcess = metricPointsToProcess!;
         this.targetCount = targetCount;
     }
 
@@ -65,7 +68,7 @@ public readonly struct MetricPointsAccessor
         /// <summary>
         /// Gets the <see cref="MetricPoint"/> at the current position of the enumerator.
         /// </summary>
-        public ref readonly MetricPoint Current
+        public readonly ref readonly MetricPoint Current
             => ref this.metricsPoints[this.metricPointsToProcess[this.index]];
 
         /// <summary>

--- a/src/OpenTelemetry/Metrics/MetricReaderTemporalityPreference.cs
+++ b/src/OpenTelemetry/Metrics/MetricReaderTemporalityPreference.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 namespace OpenTelemetry.Metrics;
 
 /// <summary>

--- a/src/OpenTelemetry/Metrics/MetricStreamIdentity.cs
+++ b/src/OpenTelemetry/Metrics/MetricStreamIdentity.cs
@@ -51,7 +51,14 @@ internal readonly struct MetricStreamIdentity : IEquatable<MetricStreamIdentity>
         hashCode.Add(this.Unit);
         hashCode.Add(this.Description);
         hashCode.Add(this.ViewId);
-        hashCode.Add(this.TagKeys, StringArrayComparer);
+
+        // Note: The this.TagKeys! here is strange but it is fine for the value
+        // to be null. HashCode.Add is coded to handle the value being null. We
+        // are essentially suppressing a false positive due to an issue/quirk
+        // with the annotations. See:
+        // https://github.com/dotnet/runtime/pull/91905.
+        hashCode.Add(this.TagKeys!, StringArrayComparer);
+
         hashCode.Add(this.ExponentialHistogramMaxSize);
         hashCode.Add(this.ExponentialHistogramMaxScale);
         if (this.HistogramBucketBounds != null)

--- a/src/OpenTelemetry/Metrics/PullMetricScope.cs
+++ b/src/OpenTelemetry/Metrics/PullMetricScope.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 using OpenTelemetry.Context;
 
 namespace OpenTelemetry.Metrics;

--- a/src/OpenTelemetry/Metrics/StringArrayEqualityComparer.cs
+++ b/src/OpenTelemetry/Metrics/StringArrayEqualityComparer.cs
@@ -14,11 +14,15 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
+using System.Diagnostics;
+
 namespace OpenTelemetry.Metrics;
 
 internal sealed class StringArrayEqualityComparer : IEqualityComparer<string[]>
 {
-    public bool Equals(string[] strings1, string[] strings2)
+    public bool Equals(string[]? strings1, string[]? strings2)
     {
         if (ReferenceEquals(strings1, strings2))
         {
@@ -50,8 +54,11 @@ internal sealed class StringArrayEqualityComparer : IEqualityComparer<string[]>
 
     public int GetHashCode(string[] strings)
     {
+        Debug.Assert(strings != null, "strings was null");
+
 #if NET6_0_OR_GREATER
         HashCode hashCode = default;
+
         for (int i = 0; i < strings.Length; i++)
         {
             hashCode.Add(strings[i]);
@@ -61,7 +68,7 @@ internal sealed class StringArrayEqualityComparer : IEqualityComparer<string[]>
 #else
         var hash = 17;
 
-        for (int i = 0; i < strings.Length; i++)
+        for (int i = 0; i < strings!.Length; i++)
         {
             unchecked
             {

--- a/src/OpenTelemetry/Metrics/Tags.cs
+++ b/src/OpenTelemetry/Metrics/Tags.cs
@@ -14,13 +14,15 @@
 // limitations under the License.
 // </copyright>
 
+#nullable enable
+
 namespace OpenTelemetry.Metrics;
 
 internal readonly struct Tags : IEquatable<Tags>
 {
     private readonly int hashCode;
 
-    public Tags(KeyValuePair<string, object>[] keyValuePairs)
+    public Tags(KeyValuePair<string, object?>[] keyValuePairs)
     {
         this.KeyValuePairs = keyValuePairs;
 
@@ -50,13 +52,13 @@ internal readonly struct Tags : IEquatable<Tags>
         this.hashCode = hash;
     }
 
-    public readonly KeyValuePair<string, object>[] KeyValuePairs { get; }
+    public readonly KeyValuePair<string, object?>[] KeyValuePairs { get; }
 
     public static bool operator ==(Tags tag1, Tags tag2) => tag1.Equals(tag2);
 
     public static bool operator !=(Tags tag1, Tags tag2) => !tag1.Equals(tag2);
 
-    public override readonly bool Equals(object obj)
+    public override readonly bool Equals(object? obj)
     {
         return obj is Tags other && this.Equals(other);
     }

--- a/src/OpenTelemetry/OpenTelemetry.csproj
+++ b/src/OpenTelemetry/OpenTelemetry.csproj
@@ -3,9 +3,6 @@
     <TargetFrameworks>$(DefaultTargetFrameworks);netstandard2.1</TargetFrameworks>
     <Description>OpenTelemetry .NET SDK</Description>
     <MinVerTagPrefix>core-</MinVerTagPrefix>
-
-    <!-- this is temporary. will remove in future PR. -->
-    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changes

* Added nullable annotations for things missing in the Metrics folder of the OpenTelemetry project.
* Enable nullable reference types globally for the OpenTelemetry project.

Note: I'll do a follow-up to remove `#nullable enable` from all the files.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
