### PR TITLE
Mark ActivityExtensions.SetStatus obsolete After DiagnosticSource 6.0

### DIFF
--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Obsolete `ActivityExtensions.SetStatus` method. Call `Activity.SetStatus` instead.
+  ([#4864](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4864))
+
 ## 1.6.0
 
 Released 2023-Sep-05

--- a/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
@@ -32,13 +32,14 @@ public static class ActivityExtensions
 {
     /// <summary>
     /// Sets the status of activity execution.
-    /// Activity class in .NET does not support 'Status'.
-    /// This extension provides a workaround to store Status as special tags with key name of otel.status_code and otel.status_description.
-    /// Read more about SetStatus here https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status.
     /// </summary>
+    /// <remarks>
+    /// For more details see: <see href="https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Api#setting-status" />.
+    /// </remarks>
     /// <param name="activity">Activity instance.</param>
     /// <param name="status">Activity execution status.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [Obsolete("Call Activity.SetStatus instead. SetStatus will be removed in a future version.")]
     public static void SetStatus(this Activity activity, Status status)
     {
         Debug.Assert(activity != null, "Activity should not be null");


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-dotnet/issues/4755
Design discussion issue https://github.com/open-telemetry/opentelemetry-dotnet/discussions/4703

## Changes

mark `SetStatus` extensions method obsolete

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
