### PR TITLE
added NET8 RC1 target

### DIFF
--- a/.github/workflows/ci-aot.yml
+++ b/.github/workflows/ci-aot.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false  # ensures the entire test matrix is run, even if one permutation fails
       matrix:
         os: [ ubuntu-latest ]
-        version: [ net7.0 ]
+        version: [ net8.0 ]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ You can contribute to this project from a Windows, macOS or Linux machine.
 On all platforms, the minimum requirements are:
 
 * Git client and command line tools.
-* .NET 7.0+
+* .NET 8.0
 
 ### Linux or MacOS
 

--- a/build/docker-compose.net6.0.yml
+++ b/build/docker-compose.net6.0.yml
@@ -6,4 +6,4 @@ services:
       args:
         PUBLISH_FRAMEWORK: net6.0
         TEST_SDK_VERSION: "6.0"
-        BUILD_SDK_VERSION: "7.0"
+        BUILD_SDK_VERSION: "8.0"

--- a/build/docker-compose.net7.0.yml
+++ b/build/docker-compose.net7.0.yml
@@ -6,4 +6,4 @@ services:
       args:
         PUBLISH_FRAMEWORK: net7.0
         TEST_SDK_VERSION: "7.0"
-        BUILD_SDK_VERSION: "7.0"
+        BUILD_SDK_VERSION: "8.0"

--- a/build/test-aot-compatibility.ps1
+++ b/build/test-aot-compatibility.ps1
@@ -15,7 +15,7 @@ foreach ($line in $($publishOutput -split "`r`n"))
     }
 }
 
-pushd $rootDirectory/test/OpenTelemetry.AotCompatibility.TestApp/bin/Debug/$targetNetFramework/linux-x64
+pushd $rootDirectory/test/OpenTelemetry.AotCompatibility.TestApp/bin/Release/$targetNetFramework/linux-x64
 
 Write-Host "Executing test App..."
 ./OpenTelemetry.AotCompatibility.TestApp
@@ -29,7 +29,7 @@ if ($LastExitCode -ne 0)
 popd
 
 Write-Host "Actual warning count is:", $actualWarningCount
-$expectedWarningCount = 16
+$expectedWarningCount = 0
 
 $testPassed = 0
 if ($actualWarningCount -ne $expectedWarningCount)

--- a/docs/trace/getting-started-jaeger/Program.cs
+++ b/docs/trace/getting-started-jaeger/Program.cs
@@ -15,6 +15,9 @@
 // </copyright>
 
 using System.Diagnostics;
+#if !NET6_0_OR_GREATER
+using System.Net.Http;
+#endif
 using OpenTelemetry;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -39,7 +42,7 @@ public class Program
 
         using var parent = MyActivitySource.StartActivity("JaegerDemo");
 
-        using (var client = new System.Net.Http.HttpClient())
+        using (var client = new HttpClient())
         {
             using (var slow = MyActivitySource.StartActivity("SomethingSlow"))
             {

--- a/docs/trace/getting-started-jaeger/Program.cs
+++ b/docs/trace/getting-started-jaeger/Program.cs
@@ -39,7 +39,7 @@ public class Program
 
         using var parent = MyActivitySource.StartActivity("JaegerDemo");
 
-        using (var client = new HttpClient())
+        using (var client = new System.Net.Http.HttpClient())
         {
             using (var slow = MyActivitySource.StartActivity("SomethingSlow"))
             {

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "7.0.400"
+    "version": "8.0.100-rc.1.23463.5"
   }
 }

--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/Logs/LoggerProviderServiceCollectionBuilder.cs
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/Logs/LoggerProviderServiceCollectionBuilder.cs
@@ -57,7 +57,7 @@ internal sealed class LoggerProviderServiceCollectionBuilder : LoggerProviderBui
     LoggerProviderBuilder IDeferredLoggerProviderBuilder.Configure(Action<IServiceProvider, LoggerProviderBuilder> configure)
         => this.ConfigureBuilderInternal(configure);
 
-    private LoggerProviderBuilder ConfigureBuilderInternal(Action<IServiceProvider, LoggerProviderBuilder> configure)
+    private LoggerProviderServiceCollectionBuilder ConfigureBuilderInternal(Action<IServiceProvider, LoggerProviderBuilder> configure)
     {
         var services = this.Services
             ?? throw new NotSupportedException("Builder cannot be configured during LoggerProvider construction.");
@@ -67,7 +67,7 @@ internal sealed class LoggerProviderServiceCollectionBuilder : LoggerProviderBui
         return this;
     }
 
-    private LoggerProviderBuilder ConfigureServicesInternal(Action<IServiceCollection> configure)
+    private LoggerProviderServiceCollectionBuilder ConfigureServicesInternal(Action<IServiceCollection> configure)
     {
         Guard.ThrowIfNull(configure);
 

--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/Metrics/MeterProviderServiceCollectionBuilder.cs
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/Metrics/MeterProviderServiceCollectionBuilder.cs
@@ -70,7 +70,7 @@ internal sealed class MeterProviderServiceCollectionBuilder : MeterProviderBuild
     MeterProviderBuilder IDeferredMeterProviderBuilder.Configure(Action<IServiceProvider, MeterProviderBuilder> configure)
         => this.ConfigureBuilderInternal(configure);
 
-    private MeterProviderBuilder ConfigureBuilderInternal(Action<IServiceProvider, MeterProviderBuilder> configure)
+    private MeterProviderServiceCollectionBuilder ConfigureBuilderInternal(Action<IServiceProvider, MeterProviderBuilder> configure)
     {
         var services = this.Services
             ?? throw new NotSupportedException("Builder cannot be configured during MeterProvider construction.");
@@ -80,7 +80,7 @@ internal sealed class MeterProviderServiceCollectionBuilder : MeterProviderBuild
         return this;
     }
 
-    private MeterProviderBuilder ConfigureServicesInternal(Action<IServiceCollection> configure)
+    private MeterProviderServiceCollectionBuilder ConfigureServicesInternal(Action<IServiceCollection> configure)
     {
         Guard.ThrowIfNull(configure);
 

--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/Trace/TracerProviderServiceCollectionBuilder.cs
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/Trace/TracerProviderServiceCollectionBuilder.cs
@@ -83,7 +83,7 @@ internal sealed class TracerProviderServiceCollectionBuilder : TracerProviderBui
     TracerProviderBuilder IDeferredTracerProviderBuilder.Configure(Action<IServiceProvider, TracerProviderBuilder> configure)
         => this.ConfigureBuilderInternal(configure);
 
-    private TracerProviderBuilder ConfigureBuilderInternal(Action<IServiceProvider, TracerProviderBuilder> configure)
+    private TracerProviderServiceCollectionBuilder ConfigureBuilderInternal(Action<IServiceProvider, TracerProviderBuilder> configure)
     {
         var services = this.Services
             ?? throw new NotSupportedException("Builder cannot be configured during TracerProvider construction.");
@@ -93,7 +93,7 @@ internal sealed class TracerProviderServiceCollectionBuilder : TracerProviderBui
         return this;
     }
 
-    private TracerProviderBuilder ConfigureServicesInternal(Action<IServiceCollection> configure)
+    private TracerProviderServiceCollectionBuilder ConfigureServicesInternal(Action<IServiceCollection> configure)
     {
         Guard.ThrowIfNull(configure);
 

--- a/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
+++ b/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <PublishAot Condition="!$([MSBuild]::IsOSPlatform('OSX'))">true</PublishAot>
+    <PublishAot>true</PublishAot>
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
     <SelfContained>true</SelfContained>
   </PropertyGroup>

--- a/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
+++ b/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PublishAot Condition="!$([MSBuild]::IsOSPlatform('OSX'))">true</PublishAot>
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
     <SelfContained>true</SelfContained>


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-dotnet/issues/4437

## Changes
1. Introduced [.NET8 RC1](https://github.com/dotnet/core/blob/main/release-notes/8.0/preview/8.0.0-rc.1.md?WT.mc_id=dotnet-35129-website) to [global.json](https://github.com/open-telemetry/opentelemetry-dotnet/blob/7ec26290059c3c860fc5bed6f1e0c9702b4061d5/global.json#L4C5-L4C38).
2. Retargeted AotCompatibility.TestApp to net8.0; update AOT CI accordingly - now 0 warnings! https://github.com/open-telemetry/opentelemetry-dotnet/actions/runs/6254861985/job/16983178007?pr=4868
3. Minor: fixed [CA1859](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1859) warnings in Extension files. See: https://github.com/open-telemetry/opentelemetry-dotnet/pull/4868/commits/cc7ee81a83f2c25cdf7285d04b70d319d9e288e6, and https://github.com/open-telemetry/opentelemetry-dotnet/pull/4868/commits/42f998c92a9028b3fe7dde0a56dd81230433e374

cc: @eerhardt, @vitek-karas

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
