### PR TITLE
Use OTLP push mode in Prometheus tutorial

### DIFF
--- a/docs/metrics/getting-started-prometheus-grafana/Program.cs
+++ b/docs/metrics/getting-started-prometheus-grafana/Program.cs
@@ -29,7 +29,7 @@ public class Program
     {
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
             .AddMeter("MyCompany.MyProduct.MyLibrary")
-            .AddPrometheusHttpListener()
+            .AddOtlpExporter(options => { options.Endpoint = new Uri("http://localhost:9090/api/v1/otlp/v1/metrics"); })
             .Build();
 
         Console.WriteLine("Press any key to exit");

--- a/docs/metrics/getting-started-prometheus-grafana/Program.cs
+++ b/docs/metrics/getting-started-prometheus-grafana/Program.cs
@@ -29,10 +29,11 @@ public class Program
     {
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
             .AddMeter("MyCompany.MyProduct.MyLibrary")
+            .AddConsoleExporter()
             .AddOtlpExporter(options =>
             {
-                options.Protocol = OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf;
                 options.Endpoint = new Uri("http://localhost:9090/api/v1/otlp/v1/metrics");
+                options.Protocol = OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf;
             })
             .Build();
 

--- a/docs/metrics/getting-started-prometheus-grafana/Program.cs
+++ b/docs/metrics/getting-started-prometheus-grafana/Program.cs
@@ -29,7 +29,11 @@ public class Program
     {
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
             .AddMeter("MyCompany.MyProduct.MyLibrary")
-            .AddOtlpExporter(options => { options.Endpoint = new Uri("http://localhost:9090/api/v1/otlp/v1/metrics"); })
+            .AddOtlpExporter(options =>
+            {
+                options.Protocol = OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf;
+                options.Endpoint = new Uri("http://localhost:9090/api/v1/otlp/v1/metrics");
+            })
             .Build();
 
         Console.WriteLine("Press any key to exit");

--- a/docs/metrics/getting-started-prometheus-grafana/README.md
+++ b/docs/metrics/getting-started-prometheus-grafana/README.md
@@ -86,7 +86,7 @@ graph LR
 
 subgraph SDK
   MeterProvider
-  MetricReader1[BaseExportingMetricReader]
+  MetricReader[BaseExportingMetricReader]
   MetricReader2[BaseExportingMetricReader]
   ConsoleExporter
   OtlpExporter
@@ -98,9 +98,9 @@ end
 
 Instrument --> | Measurements | MeterProvider
 
-MeterProvider --> | Metrics | MetricReader1 --> | Push | ConsoleExporter
+MeterProvider --> | Metrics | MetricReader --> | Push | OtlpExporter
 
-MeterProvider --> | Metrics | MetricReader2 --> | Push | OtlpExporter
+MeterProvider --> | Metrics | MetricReader2 --> | Push | ConsoleExporter
 ```
 
 Also, for our learning purpose, use a while-loop to keep increasing the counter
@@ -211,8 +211,8 @@ dotnet remove package OpenTelemetry.Exporter.Console
 ```
 
 ```mermaid
-graph LR
 
+graph LR
 subgraph SDK
   MeterProvider
   MetricReader[BaseExportingMetricReader]
@@ -226,16 +226,6 @@ end
 Instrument --> | Measurements | MeterProvider
 
 MeterProvider --> | Metrics | MetricReader --> | Push | OtlpExporter
-```
-
-```mermaid
-graph TD
-
-
-OtlpExporter -->|HTTP POST http://localhost:9090/api/v1/otlp/v1/metrics| PrometheusServer
-PrometheusServer -->|http://localhost:9090/graph| PrometheusUI["Browser<br/>(Prometheus Dashboard)"]
-PrometheusServer -->|http://localhost:9090/api/| Grafana[Grafana Server]
-Grafana -->|http://localhost:3000/dashboard| GrafanaUI["Browser<br/>(Grafana Dashboard)"]
 ```
 
 ## Learn more

--- a/docs/metrics/getting-started-prometheus-grafana/README.md
+++ b/docs/metrics/getting-started-prometheus-grafana/README.md
@@ -73,7 +73,7 @@ using var meterProvider = Sdk.CreateMeterProviderBuilder()
     .Build();
 ```
 
-When we run the application, the `ConsoleExporter` was printing the metrics on
+When we ran the application, the `ConsoleExporter` was printing the metrics on
 console, and the `OtlpExporter` was attempting to send the metrics to
 `http://localhost:9090/api/v1/otlp/v1/metrics`.
 

--- a/docs/metrics/getting-started-prometheus-grafana/README.md
+++ b/docs/metrics/getting-started-prometheus-grafana/README.md
@@ -140,8 +140,8 @@ enabled:
 
 To use the graphical interface for viewing our metrics with Prometheus, navigate
 to [http://localhost:9090/graph](http://localhost:9090/graph), and type
-`MyFruitCounter` in the expression bar of the UI; finally, click the execute
-button.
+`MyFruitCounter_total` in the expression bar of the UI; finally, click the
+execute button.
 
 We should be able to see the following chart from the browser:
 
@@ -183,7 +183,7 @@ Feel free to find some handy PromQL
 [here](https://promlabs.com/promql-cheat-sheet/).
 
 In the below example, the query targets to find out what is the per-second rate
-of increase of myFruitCounter over the past 5 minutes:
+of increase of `MyFruitCounter_total` over the past 5 minutes:
 
 ![Grafana
 UI](https://user-images.githubusercontent.com/17327289/151636769-138ecb4f-b44f-477b-88eb-247fc4340252.png)

--- a/docs/metrics/getting-started-prometheus-grafana/README.md
+++ b/docs/metrics/getting-started-prometheus-grafana/README.md
@@ -120,13 +120,19 @@ and named the new file as `otel.yml` for this exercise. Then, copy and paste the
 entire content below into the `otel.yml` file we have created just now.
 
 ```yaml
-global:
-  scrape_interval: 10s
-  evaluation_interval: 10s
-scrape_configs:
-  - job_name: "otel"
-    static_configs:
-      - targets: ["localhost:9464"]
+storage:
+  tsdb:
+    out_of_order_time_window: 10m
+
+remote_write:
+  - url: http://localhost:9090/api/v1/otlp/v1/metrics
+    queue_config:
+      capacity: 1000000
+      batch_send_deadline: 10s
+      max_samples_per_send: 1000
+      max_shards: 3
+    remote_timeout: "30s"
+    follow_redirects: true
 ```
 
 ### Start Prometheus
@@ -138,7 +144,7 @@ to start the Prometheus server and verify it has been started successfully.
 Please note that we will need pass in `otel.yml` file as the argument:
 
 ```console
-./prometheus --config.file=otel.yml
+./prometheus --config.file=otel.yml --enable-feature=otlp-write-receiver
 ```
 
 ### View results in Prometheus

--- a/docs/metrics/getting-started-prometheus-grafana/getting-started-prometheus-grafana.csproj
+++ b/docs/metrics/getting-started-prometheus-grafana/getting-started-prometheus-grafana.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Prometheus.HttpListener\OpenTelemetry.Exporter.Prometheus.HttpListener.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.OpenTelemetryProtocol\OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj" />
   </ItemGroup>
 </Project>

--- a/docs/metrics/getting-started-prometheus-grafana/getting-started-prometheus-grafana.csproj
+++ b/docs/metrics/getting-started-prometheus-grafana/getting-started-prometheus-grafana.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Console\OpenTelemetry.Exporter.Console.csproj" />
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.OpenTelemetryProtocol\OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj" />
   </ItemGroup>
 </Project>

--- a/docs/trace/getting-started-jaeger/README.md
+++ b/docs/trace/getting-started-jaeger/README.md
@@ -74,7 +74,7 @@ using var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .Build();
 ```
 
-When we run the application, the `ConsoleExporter` was printing the traces on
+When we ran the application, the `ConsoleExporter` was printing the traces on
 console, and the `OtlpExporter` was attempting to send the traces to Jaeger
 Agent via the default endpoint `http://localhost:4317`.
 


### PR DESCRIPTION
Prometheus has added OTLP support https://prometheus.io/docs/prometheus/latest/feature_flags/#otlp-receiver.
Similar to #3940, this PR switches the tutorial from PrometheusExporter (PrometheusHttpListener to be precise) to OtlpExporter (which is stable).