### PR TITLE
[sdk] Allow `/` in metric instrument names

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## Unreleased
 
-* Allowed metric instrument names to contain `/` characters. ([#4882](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4882))
-
 * Update `AggregatorStore` to reclaim unused MetricPoints for Delta aggregation
   temporality.
   ([#4486](https://github.com/open-telemetry/opentelemetry-dotnet/issues/4486))
+
+* Allowed metric instrument names to contain `/` characters. ([#4882](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4882))
 
 ## 1.6.0
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Allowed metric instrument names to contain `/` characters. ([#4887](https://github.com/open-telemetry/opentelemetry-dotnet/issues/4877))
+
 ## 1.6.0
 
 Released 2023-Sep-05

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Allowed metric instrument names to contain `/` characters. ([#4887](https://github.com/open-telemetry/opentelemetry-dotnet/issues/4877))
+* Allowed metric instrument names to contain `/` characters. ([#4882](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4882))
 
 ## 1.6.0
 

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderSdk.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderSdk.cs
@@ -46,7 +46,7 @@ internal sealed class MeterProviderBuilderSdk : MeterProviderBuilder, IMeterProv
     // Customers: This is not guaranteed to work forever. We may change this
     // mechanism in the future do this at your own risk.
     public static Regex InstrumentNameRegex { get; set; } = new(
-        @"^[a-z][a-z0-9-._]{0,254}$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        @"^[a-z][a-z0-9-._/]{0,254}$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     public List<InstrumentationRegistration> Instrumentation { get; } = new();
 

--- a/test/OpenTelemetry.Tests/Metrics/MetricTestData.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricTestData.cs
@@ -39,6 +39,7 @@ public class MetricTestData
                 new object[] { "my_metric2" },
                 new object[] { new string('m', 255) },
                 new object[] { "CaSe-InSeNsItIvE" },
+                new object[] { "my_metric/environment/database" },
        };
 
     public static IEnumerable<object[]> InvalidHistogramBoundaries


### PR DESCRIPTION
Fixes #4877
Design discussion issue #

## Changes
Updates the regex in `MeterProviderBuilderSdk.cs` to allow metric instrument names to contain `/` characters. This is in response to the issue raised in [#4887](https://github.com/open-telemetry/opentelemetry-dotnet/issues/4877). Now, metric names like `my_metric/environment/database` can be used. Corresponding changes are also made to the tests and CHANGELOG.md.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
