### PR TITLE
Fix TFM bugs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -77,7 +77,6 @@
     <PackageVersion Include="RabbitMQ.Client" Version="[6.5.0,7.0)" />
     <PackageVersion Include="StyleCop.Analyzers" Version="[1.2.0-beta.507,2.0)" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="[6.4.0]" />
-    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="Testcontainers.MsSql" Version="3.3.0" />
     <PackageVersion Include="Testcontainers.SqlEdge" Version="3.3.0" />
     <PackageVersion Include="xunit" Version="[2.5.0,3.0)" />

--- a/build/Common.props
+++ b/build/Common.props
@@ -26,7 +26,7 @@
     <TargetFrameworksForAspNetCoreTests>net8.0;net7.0;net6.0</TargetFrameworksForAspNetCoreTests>
     <TargetFrameworksForAotCompatibilityTests>net8.0</TargetFrameworksForAotCompatibilityTests>
     <TargetFrameworksForDocs>net7.0;net6.0</TargetFrameworksForDocs>
-    <TargetFrameworksForDocs Condition="$(OS) == 'Windows_NT' And '$(UsingMicrosoftNETSdkWeb)' == 'False'">
+    <TargetFrameworksForDocs Condition="$(OS) == 'Windows_NT' And '$(UsingMicrosoftNETSdkWeb)' != 'True'">
       $(TargetFrameworksForDocs);net481;net48;net472;net471;net47;net462
     </TargetFrameworksForDocs>
     <TargetFrameworksForTests>net8.0;net7.0;net6.0</TargetFrameworksForTests>

--- a/docs/trace/getting-started-jaeger/Program.cs
+++ b/docs/trace/getting-started-jaeger/Program.cs
@@ -15,7 +15,7 @@
 // </copyright>
 
 using System.Diagnostics;
-#if !NET6_0_OR_GREATER
+#if NETFRAMEWORK
 using System.Net.Http;
 #endif
 using OpenTelemetry;

--- a/docs/trace/getting-started-jaeger/getting-started-jaeger.csproj
+++ b/docs/trace/getting-started-jaeger/getting-started-jaeger.csproj
@@ -6,6 +6,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="System.Net.Http" Condition="$(TargetFramework.StartsWith('net4'))" />
+    <Reference Include="System.Net.Http" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
   </ItemGroup>
 </Project>

--- a/docs/trace/getting-started-jaeger/getting-started-jaeger.csproj
+++ b/docs/trace/getting-started-jaeger/getting-started-jaeger.csproj
@@ -4,6 +4,7 @@
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.OpenTelemetryProtocol\OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj" />
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.Http\OpenTelemetry.Instrumentation.Http.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <Reference Include="System.Net.Http" Condition="$(TargetFramework.StartsWith('net4'))" />
   </ItemGroup>

--- a/docs/trace/getting-started-jaeger/getting-started-jaeger.csproj
+++ b/docs/trace/getting-started-jaeger/getting-started-jaeger.csproj
@@ -5,6 +5,6 @@
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.Http\OpenTelemetry.Instrumentation.Http.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Net.Http" Condition="$(TargetFramework) == 'net472' or $(TargetFramework) == 'net48'"/>
+    <Reference Include="System.Net.Http" Condition="$(TargetFramework.StartsWith('net4'))" />
   </ItemGroup>
 </Project>

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/OpenTelemetry.Instrumentation.Http.Tests.csproj
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/OpenTelemetry.Instrumentation.Http.Tests.csproj
@@ -15,7 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Net.Http" Condition="'$(TargetFramework)' == 'net462'" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="System.Text.Json" />
@@ -23,6 +22,10 @@
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Net.Http" Condition="'$(TargetFramework)' == 'net462'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix two issues:
1. the TFM comparsion logic should use `!= true` instead of `== false` since in certain environments the property doesn't exist.
2. the `System.Net.Http` reference should be coming from framework instead of package, @cijothomas explained to me that https://www.nuget.org/packages/System.Net.Http/ nuget should not be used at all because it's abandoned since year 2018.