### PR TITLE
Minor clean up for console logging doc

### DIFF
--- a/docs/logs/getting-started-console/README.md
+++ b/docs/logs/getting-started-console/README.md
@@ -17,7 +17,7 @@ You should see the following output:
 Hello World!
 ```
 
-Install the latest version of
+Install the
 [OpenTelemetry.Exporter.Console](../../../src/OpenTelemetry.Exporter.Console/README.md)
 package:
 

--- a/docs/logs/getting-started-console/README.md
+++ b/docs/logs/getting-started-console/README.md
@@ -18,13 +18,10 @@ Hello World!
 ```
 
 Install the latest version of
-[Microsoft.Extensions.Logging](https://www.nuget.org/packages/Microsoft.Extensions.Logging/)
-package and
 [OpenTelemetry.Exporter.Console](../../../src/OpenTelemetry.Exporter.Console/README.md)
 package:
 
 ```sh
-dotnet add package Microsoft.Extensions.Logging
 dotnet add package OpenTelemetry.Exporter.Console
 ```
 


### PR DESCRIPTION
Remove the part which is no longer needed due to #4933.
Maybe wait till 1.7.0 stable release?