### PR TITLE
Fix publish package workflow

### DIFF
--- a/OpenTelemetry.proj
+++ b/OpenTelemetry.proj
@@ -7,12 +7,15 @@
     <!-- Not pack SemanticConventions project for now -->
     <SolutionProjects Remove="src\OpenTelemetry.SemanticConventions\OpenTelemetry.SemanticConventions.csproj" />
     <PackProjects Remove="src\OpenTelemetry.SemanticConventions\OpenTelemetry.SemanticConventions.csproj" />
+  </ItemGroup>
 
+  <ItemGroup Condition="'$(RunningDotNetPack)' == 'true'">
     <!-- Skip building these projects when publish packages workflow runs as these projects need to depend upon instrumentation libraries taking a project reference
     instead of  package reference on API/SDK-->
-    <SolutionProjects Remove="examples\**\*.csproj" Condition="'$(RunningDotNetPack)' == 'true'"/>
-    <SolutionProjects Remove="test\Benchmarks\Benchmarks.csproj" Condition="'$(RunningDotNetPack)' == 'true'"/>
-
+    <SolutionProjects Remove="docs\**\**\*.csproj" />
+    <SolutionProjects Remove="examples\**\*.csproj" />
+    <SolutionProjects Remove="test\Benchmarks\Benchmarks.csproj" />
+    <SolutionProjects Remove="test\OpenTelemetry.Exporter.Zipkin.Tests\OpenTelemetry.Exporter.Zipkin.Tests.csproj" />
   </ItemGroup>
 
   <Target Name="Build">


### PR DESCRIPTION
## Changes
- Skip building projects under`docs/` and `OpenTelemetry.Exporter.Zipkin.Tests` as they have a project dependency on instrumentation libraries