### PR TITLE
Update DiagnosticsSource package version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <OTelLatestStableVer>1.6.0</OTelLatestStableVer>
+    <DiagnosticsSourceVer>8.0.0-rc.1.23419.4</DiagnosticsSourceVer>
+    <MicrosoftExtensionsVer>$(DiagnosticsSourceVer)</MicrosoftExtensionsVer>
   </PropertyGroup>
 
   <!--
@@ -29,7 +31,7 @@
         3) Since version 3.1.0, the .NET runtime team is holding a high bar for backward compatibility on
           Microsoft.Extensions.Logging even during major version bumps, so compatibility is not a concern here.
     -->
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0-rc.1.23419.4" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsVer)" />
 
     <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="[3.1.0,)" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="[3.1.0,)" />
@@ -49,7 +51,7 @@
         3) The .NET runtime team provides extra backward compatibility guarantee to System.Diagnostics.DiagnosticSource
           even during major version bumps, so compatibility is not a concern here.
     -->
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="$(DiagnosticsSourceVer)" />
 
     <!-- A conservative version of System.Text.Encodings.Web must be used here since there is no backward compatibility guarantee during major version bumps. -->
     <PackageVersion Include="System.Text.Encodings.Web" Version="4.7.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <OTelLatestStableVer>1.6.0</OTelLatestStableVer>
-    <DiagnosticsSourceVer>8.0.0-rc.2.23479.6</DiagnosticsSourceVer>
-    <MicrosoftExtensionsVer>$(DiagnosticsSourceVer)</MicrosoftExtensionsVer>
   </PropertyGroup>
 
   <!--
@@ -31,7 +29,7 @@
         3) Since version 3.1.0, the .NET runtime team is holding a high bar for backward compatibility on
           Microsoft.Extensions.Logging even during major version bumps, so compatibility is not a concern here.
     -->
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsVer)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0-rc.2.23479.6" />
 
     <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="[3.1.0,)" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="[3.1.0,)" />
@@ -51,7 +49,7 @@
         3) The .NET runtime team provides extra backward compatibility guarantee to System.Diagnostics.DiagnosticSource
           even during major version bumps, so compatibility is not a concern here.
     -->
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="$(DiagnosticsSourceVer)" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.0-rc.2.23479.6" />
 
     <!-- A conservative version of System.Text.Encodings.Web must be used here since there is no backward compatibility guarantee during major version bumps. -->
     <PackageVersion Include="System.Text.Encodings.Web" Version="4.7.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <OTelLatestStableVer>1.6.0</OTelLatestStableVer>
-    <DiagnosticsSourceVer>8.0.0-rc.1.23419.4</DiagnosticsSourceVer>
+    <DiagnosticsSourceVer>8.0.0-rc.2.23479.6</DiagnosticsSourceVer>
     <MicrosoftExtensionsVer>$(DiagnosticsSourceVer)</MicrosoftExtensionsVer>
   </PropertyGroup>
 

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Updated `System.Diagnostics.DiagnosticSource` package version to
+  `8.0.0-rc.1.23419.4`.
+  ([#4959](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4959))
+
 ## 1.7.0-alpha.1
 
 Released 2023-Oct-16

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Updated `System.Diagnostics.DiagnosticSource` package version to
-  `8.0.0-rc.1.23419.4`.
+  `8.0.0-rc.2.23479.6`.
   ([#4959](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4959))
 
 ## 1.7.0-alpha.1

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Updated `Microsoft.Extensions.Logging` package version to
+  `8.0.0-rc.2.23479.6`.
+  ([#4959](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4959))
+
 ## 1.7.0-alpha.1
 
 Released 2023-Oct-16


### PR DESCRIPTION
## Changes
- Update DiagnosticsSource package version for `OpenTelemetry.Api` to `8.0.0-rc.2.23479.6`
- Updated `Microsoft.Extensions.Logging` package version for `OpenTelemetry` to `8.0.0-rc.2.23479.6`

## Merge requirement checklist

* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
