### PR TITLE
[api-logs] Define OT1000 & OT1001 diagnostics and decorate APIs

### DIFF
--- a/OpenTelemetry.sln
+++ b/OpenTelemetry.sln
@@ -90,8 +90,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ISSUE_TEMPLATE", "ISSUE_TEM
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{E69578EB-B456-4062-A645-877CD964528B}"
 	ProjectSection(SolutionItems) = preProject
-		.github\workflows\ci-aot.yml = .github\workflows\ci-aot.yml
 		.github\workflows\ci-aot-md.yml = .github\workflows\ci-aot-md.yml
+		.github\workflows\ci-aot.yml = .github\workflows\ci-aot.yml
 		.github\workflows\ci-instrumentation-libraries-md.yml = .github\workflows\ci-instrumentation-libraries-md.yml
 		.github\workflows\ci-instrumentation-libraries.yml = .github\workflows\ci-instrumentation-libraries.yml
 		.github\workflows\ci-md.yml = .github\workflows\ci-md.yml
@@ -314,6 +314,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Metrics", "Metrics", "{1C45
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "getting-started-aspnetcore", "docs\logs\getting-started-aspnetcore\getting-started-aspnetcore.csproj", "{99B4D965-8782-4694-8DFA-B7A3630CEF60}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "diagnostics", "diagnostics", "{52AF6D7D-9E66-4234-9A2C-5D16C6F22B40}"
+	ProjectSection(SolutionItems) = preProject
+		docs\diagnostics\OT1000.md = docs\diagnostics\OT1000.md
+		docs\diagnostics\OT1001.md = docs\diagnostics\OT1001.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -637,6 +643,7 @@ Global
 		{A0CB9A10-F22D-4E66-A449-74B3D0361A9C} = {A49299FB-C5CD-4E0E-B7E1-B7867BBD67CC}
 		{1C459B5B-C702-46FF-BF1A-EE795E420FFA} = {A49299FB-C5CD-4E0E-B7E1-B7867BBD67CC}
 		{99B4D965-8782-4694-8DFA-B7A3630CEF60} = {3862190B-E2C5-418E-AFDC-DB281FB5C705}
+		{52AF6D7D-9E66-4234-9A2C-5D16C6F22B40} = {7C87CAF9-79D7-4C26-9FFB-F3F1FB6911F1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {55639B5C-0770-4A22-AB56-859604650521}

--- a/build/Common.props
+++ b/build/Common.props
@@ -9,6 +9,8 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Suppress warnings for repo code using experimental features -->
+    <NoWarn>$(NoWarn);OT1000;OT1001</NoWarn>
     <!--temporarily disable. See 3958-->
     <!--<AnalysisLevel>latest-All</AnalysisLevel>-->
   </PropertyGroup>

--- a/docs/diagnostics/OT1000.md
+++ b/docs/diagnostics/OT1000.md
@@ -1,0 +1,42 @@
+# OpenTelemetry .NET Diagnostic: OT1000
+
+## Overview
+
+This is an experimental feature diagnostic covering the following APIs:
+
+* `LoggerProviderBuilder`
+* `LoggerProvider`
+* `IDeferredLoggerProviderBuilder`
+
+Experimental features may be changed or removed in the future.
+
+## Details
+
+The OpenTelemetry Specification defines a `LoggerProvider` as part of its
+[API](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/bridge-api.md)
+&
+[SDK](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/sdk.md)
+components.
+
+The SDK allows calling `Shutdown` and `ForceFlush` on the `LoggerProvider` and
+also allows processors to be added dynamically to a pipeline after its creation.
+
+Today the OpenTelemetry .NET log pipeline is built on top of the
+Microsoft.Extensions.Logging `ILogger` \ `ILoggerProvider` \ `ILoggerFactory`
+APIs which do not expose such features.
+
+We also have an issue with the `ILoggingBuilder.AddOpenTelemetry` API in that it
+interacts with the `OpenTelemetryLoggerOptions` class. Options classes are NOT
+available until the `IServiceProvider` is available and services can no longer
+be registered at that point. This prevents the current logging pipeline from
+exposing the same dependency injection surface we have for traces and metrics.
+
+We are exposing these APIs to solve these issues and gather feedback about their
+usefulness.
+
+## Log Bride API
+
+The OpenTelemetry Specification defines a log bridge API which is rooted off of
+the `LoggerProvider` (`GetLogger`) and exposes a `Logger` API to submit log
+records. See [OT1001](.\OT1001.md) for details about the log bridge
+implementation status.

--- a/docs/diagnostics/OT1001.md
+++ b/docs/diagnostics/OT1001.md
@@ -1,0 +1,34 @@
+# OpenTelemetry .NET Diagnostic: OT1001
+
+## Overview
+
+This is an experimental feature diagnostic covering the following APIs:
+
+* `LoggerProvider.GetLogger`
+* `Logger`
+* `LogRecordAttributeList`
+* `LogRecordData`
+* `LogRecordSeverity`
+
+Experimental features may be changed or removed in the future.
+
+## Details
+
+The OpenTelemetry Specification defines a [Logs Bridge
+API](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/bridge-api.md).
+
+The log bridge API is used by library authors to build log appenders which route
+messages from different log frameworks into OpenTelemetry.
+
+Today the OpenTelemetry .NET log pipeline is built on top of the
+Microsoft.Extensions.Logging `ILogger` \ `ILoggerProvider` \ `ILoggerFactory`
+APIs.
+
+We are exposing these APIs gather feedback about their usefulness. An
+alternative approach may be taken which would be to append into `ILogger`
+instead of OpenTelemetry directly.
+
+## LoggerProvider API
+
+The OpenTelemetry Specification defines a `LoggerProvider` API. See
+[OT1000](.\OT1001.md) for details about the log implementation status.

--- a/docs/metrics/exemplars/docker-compose.yaml
+++ b/docs/metrics/exemplars/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
 
   # OTEL Collector to receive logs, metrics and traces from the application
   otel-collector:
-    image: otel/opentelemetry-collector:latest
+    image: otel/opentelemetry-collector:0.70.0
     command: [ "--config=/etc/otel-collector.yaml" ]
     volumes:
       - ./otel-collector.yaml:/etc/otel-collector.yaml
@@ -31,7 +31,6 @@ services:
       - --config.file=/etc/prometheus.yaml
       - --web.enable-remote-write-receiver
       - --enable-feature=exemplar-storage
-      - --log.level=debug
     volumes:
       - ./prometheus.yaml:/etc/prometheus.yaml
     ports:
@@ -39,7 +38,7 @@ services:
 
 # UI to query traces and metrics
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:9.3.2
     volumes:
       - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:
@@ -49,4 +48,3 @@ services:
       - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor
     ports:
       - "3000:3000"
-

--- a/docs/metrics/exemplars/docker-compose.yaml
+++ b/docs/metrics/exemplars/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
 
   # OTEL Collector to receive logs, metrics and traces from the application
   otel-collector:
-    image: otel/opentelemetry-collector:0.70.0
+    image: otel/opentelemetry-collector:latest
     command: [ "--config=/etc/otel-collector.yaml" ]
     volumes:
       - ./otel-collector.yaml:/etc/otel-collector.yaml
@@ -31,6 +31,7 @@ services:
       - --config.file=/etc/prometheus.yaml
       - --web.enable-remote-write-receiver
       - --enable-feature=exemplar-storage
+      - --log.level=debug
     volumes:
       - ./prometheus.yaml:/etc/prometheus.yaml
     ports:
@@ -38,7 +39,7 @@ services:
 
 # UI to query traces and metrics
   grafana:
-    image: grafana/grafana:9.3.2
+    image: grafana/grafana:latest
     volumes:
       - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
     environment:

--- a/src/OpenTelemetry.Api/Logs/IDeferredLoggerProviderBuilder.cs
+++ b/src/OpenTelemetry.Api/Logs/IDeferredLoggerProviderBuilder.cs
@@ -16,6 +16,10 @@
 
 #nullable enable
 
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
+
 namespace OpenTelemetry.Logs;
 
 #if EXPOSE_EXPERIMENTAL_FEATURES
@@ -25,6 +29,9 @@ namespace OpenTelemetry.Logs;
 /// dependency injection.
 /// </summary>
 /// <remarks><inheritdoc cref="Logger" path="/remarks"/></remarks>
+#if NET8_0_OR_GREATER
+[Experimental("OT1000", UrlFormat = "https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/diagnostics/{0}.md")]
+#endif
 public
 #else
 /// <summary>
@@ -34,7 +41,7 @@ public
 /// </summary>
 internal
 #endif
-    interface IDeferredLoggerProviderBuilder
+interface IDeferredLoggerProviderBuilder
 {
     /// <summary>
     /// Register a callback action to configure the <see

--- a/src/OpenTelemetry.Api/Logs/LogRecordAttributeList.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordAttributeList.cs
@@ -19,6 +19,9 @@
 using System.Collections;
 using System.ComponentModel;
 using System.Diagnostics;
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
 
@@ -29,6 +32,9 @@ namespace OpenTelemetry.Logs;
 /// Stores attributes to be added to a log message.
 /// </summary>
 /// <remarks><inheritdoc cref="Logger" path="/remarks"/></remarks>
+#if NET8_0_OR_GREATER
+[Experimental("OT1001", UrlFormat = "https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/diagnostics/{0}.md")]
+#endif
 public
 #else
 /// <summary>

--- a/src/OpenTelemetry.Api/Logs/LogRecordData.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordData.cs
@@ -17,6 +17,9 @@
 #nullable enable
 
 using System.Diagnostics;
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 namespace OpenTelemetry.Logs;
 
@@ -25,6 +28,9 @@ namespace OpenTelemetry.Logs;
 /// Stores details about a log message.
 /// </summary>
 /// <remarks><inheritdoc cref="Logger" path="/remarks"/></remarks>
+#if NET8_0_OR_GREATER
+[Experimental("OT1001", UrlFormat = "https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/diagnostics/{0}.md")]
+#endif
 public
 #else
 /// <summary>

--- a/src/OpenTelemetry.Api/Logs/LogRecordSeverity.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordSeverity.cs
@@ -16,6 +16,10 @@
 
 #nullable enable
 
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
+
 namespace OpenTelemetry.Logs;
 
 #if EXPOSE_EXPERIMENTAL_FEATURES
@@ -23,6 +27,9 @@ namespace OpenTelemetry.Logs;
 /// Describes the severity level of a log record.
 /// </summary>
 /// <remarks><inheritdoc cref="Logger" path="/remarks"/></remarks>
+#if NET8_0_OR_GREATER
+[Experimental("OT1001", UrlFormat = "https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/diagnostics/{0}.md")]
+#endif
 public
 #else
 /// <summary>

--- a/src/OpenTelemetry.Api/Logs/LogRecordSeverityExtensions.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordSeverityExtensions.cs
@@ -16,6 +16,10 @@
 
 #nullable enable
 
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
+
 namespace OpenTelemetry.Logs;
 
 #if EXPOSE_EXPERIMENTAL_FEATURES
@@ -23,6 +27,9 @@ namespace OpenTelemetry.Logs;
 /// Contains extension methods for the <see cref="LogRecordSeverity"/> enum.
 /// </summary>
 /// <remarks><inheritdoc cref="Logger" path="/remarks"/></remarks>
+#if NET8_0_OR_GREATER
+[Experimental("OT1001", UrlFormat = "https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/diagnostics/{0}.md")]
+#endif
 public
 #else
 /// <summary>

--- a/src/OpenTelemetry.Api/Logs/Logger.cs
+++ b/src/OpenTelemetry.Api/Logs/Logger.cs
@@ -16,6 +16,10 @@
 
 #nullable enable
 
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
+
 namespace OpenTelemetry.Logs;
 
 #if EXPOSE_EXPERIMENTAL_FEATURES
@@ -23,6 +27,9 @@ namespace OpenTelemetry.Logs;
 /// Logger is the class responsible for creating log records.
 /// </summary>
 /// <remarks><b>WARNING</b>: This is an experimental API which might change or be removed in the future. Use at your own risk.</remarks>
+#if NET8_0_OR_GREATER
+[Experimental("OT1001", UrlFormat = "https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/diagnostics/{0}.md")]
+#endif
 public
 #else
 /// <summary>
@@ -30,7 +37,7 @@ public
 /// </summary>
 internal
 #endif
-    abstract class Logger
+abstract class Logger
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="Logger"/> class.

--- a/src/OpenTelemetry.Api/Logs/LoggerProvider.cs
+++ b/src/OpenTelemetry.Api/Logs/LoggerProvider.cs
@@ -27,6 +27,9 @@ namespace OpenTelemetry.Logs;
 /// LoggerProvider is the entry point of the OpenTelemetry API. It provides access to <see cref="Logger"/>.
 /// </summary>
 /// <remarks><inheritdoc cref="Logger" path="/remarks"/></remarks>
+#if NET8_0_OR_GREATER
+[Experimental("OT1000", UrlFormat = "https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/diagnostics/{0}.md")]
+#endif
 public
 #else
 /// <summary>
@@ -49,6 +52,9 @@ internal
     /// Gets a logger.
     /// </summary>
     /// <returns><see cref="Logger"/> instance.</returns>
+#if NET8_0_OR_GREATER
+    [Experimental("OT1001", UrlFormat = "https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/diagnostics/{0}.md")]
+#endif
     public Logger GetLogger()
         => this.GetLogger(name: null, version: null);
 
@@ -57,6 +63,9 @@ internal
     /// </summary>
     /// <param name="name">Optional name identifying the instrumentation library.</param>
     /// <returns><see cref="Logger"/> instance.</returns>
+#if NET8_0_OR_GREATER
+    [Experimental("OT1001", UrlFormat = "https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/diagnostics/{0}.md")]
+#endif
     public Logger GetLogger(string? name)
         => this.GetLogger(name, version: null);
 
@@ -66,6 +75,9 @@ internal
     /// <param name="name">Optional name identifying the instrumentation library.</param>
     /// <param name="version">Optional version of the instrumentation library.</param>
     /// <returns><see cref="Logger"/> instance.</returns>
+#if NET8_0_OR_GREATER
+    [Experimental("OT1001", UrlFormat = "https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/diagnostics/{0}.md")]
+#endif
     public Logger GetLogger(string? name, string? version)
     {
         if (!this.TryCreateLogger(name, out var logger))
@@ -84,6 +96,9 @@ internal
     /// <param name="name">Optional name identifying the instrumentation library.</param>
     /// <param name="logger"><see cref="Logger"/>.</param>
     /// <returns><see langword="true"/> if the logger was created.</returns>
+#if NET8_0_OR_GREATER
+    [Experimental("OT1001", UrlFormat = "https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/diagnostics/{0}.md")]
+#endif
     protected virtual bool TryCreateLogger(
         string? name,
 #if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER

--- a/src/OpenTelemetry.Api/Logs/LoggerProviderBuilder.cs
+++ b/src/OpenTelemetry.Api/Logs/LoggerProviderBuilder.cs
@@ -16,6 +16,10 @@
 
 #nullable enable
 
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
+
 namespace OpenTelemetry.Logs;
 
 #if EXPOSE_EXPERIMENTAL_FEATURES
@@ -23,6 +27,9 @@ namespace OpenTelemetry.Logs;
 /// LoggerProviderBuilder base class.
 /// </summary>
 /// <remarks><inheritdoc cref="Logger" path="/remarks"/></remarks>
+#if NET8_0_OR_GREATER
+[Experimental("OT1000", UrlFormat = "https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/diagnostics/{0}.md")]
+#endif
 public
 #else
 /// <summary>


### PR DESCRIPTION
Relates to #4433

## Changes

* Added diagnostic definitions for `OT1000` & `OT1001`.
* Decorated experimental log APIs in OpenTelemetry.Api using the new .NET 8 [ExperimentalAttribute](https://learn.microsoft.com/dotnet/api/system.diagnostics.codeanalysis.experimentalattribute).

## Details

I decided to split things into two categories:

* OT1000: LoggerProvider & LoggerProviderBuilder
* OT1001: Log Bridge API

I did that because I think we may want to release the first category stable before the other. More details can be found in the md files I added.