### PR TITLE
[Do not merge] ASP.NET Core tracing perf summary

### DIFF
--- a/PerfTestAspNetCore/ActivityExtensions.cs
+++ b/PerfTestAspNetCore/ActivityExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace PerfTestAspNetCore
+{
+    public static class ActivityExtensions
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static object? GetTagValue(this Activity activity, string tagName)
+        {
+            Debug.Assert(activity != null, "Activity should not be null");
+
+            foreach (ref readonly var tag in activity.EnumerateTagObjects())
+            {
+                if (tag.Key == tagName)
+                {
+                    return tag.Value;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/PerfTestAspNetCore/Controllers/WeatherForecastController.cs
+++ b/PerfTestAspNetCore/Controllers/WeatherForecastController.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace PerfTestAspNetCore.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class WeatherForecastController : ControllerBase
+    {
+        private static readonly string[] Summaries = new[]
+        {
+        "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+    };
+
+        private readonly ILogger<WeatherForecastController> _logger;
+
+        public WeatherForecastController(ILogger<WeatherForecastController> logger)
+        {
+            _logger = logger;
+        }
+
+        [HttpGet(Name = "GetWeatherForecast")]
+        public IEnumerable<WeatherForecast> Get()
+        {
+            return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+            {
+                Date = DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+            })
+            .ToArray();
+        }
+    }
+}

--- a/PerfTestAspNetCore/DiagnosticSourceListener.cs
+++ b/PerfTestAspNetCore/DiagnosticSourceListener.cs
@@ -1,0 +1,18 @@
+﻿namespace PerfTestAspNetCore;
+
+public class DiagnosticSourceListener : IObserver<KeyValuePair<string, object?>>
+{
+    public void OnCompleted()
+    {
+    }
+
+    public void OnError(Exception error)
+    {
+    }
+
+    public void OnNext(KeyValuePair<string, object?> value)
+    {
+        // do nothing
+        // Measure how much perf is impacted by simply subscribing to diagnostic source.
+    }
+}

--- a/PerfTestAspNetCore/DiagnosticSourceObserver.cs
+++ b/PerfTestAspNetCore/DiagnosticSourceObserver.cs
@@ -1,0 +1,36 @@
+﻿using System.Diagnostics;
+
+namespace PerfTestAspNetCore
+{
+    internal sealed class DiagnosticSourceSubscriber : IObserver<DiagnosticListener>
+    {
+        private static readonly HashSet<string> DiagnosticSourceEvents = new()
+        {
+            "Microsoft.AspNetCore.Hosting.HttpRequestIn",
+            "Microsoft.AspNetCore.Hosting.HttpRequestIn.Start",
+            "Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop",
+            "Microsoft.AspNetCore.Mvc.BeforeAction",
+            "Microsoft.AspNetCore.Diagnostics.UnhandledException",
+            "Microsoft.AspNetCore.Hosting.UnhandledException",
+        };
+
+        private readonly Func<string, object?, object?, bool> isEnabled = (eventName, _, _)
+            => DiagnosticSourceEvents.Contains(eventName);
+
+        public void OnCompleted()
+        {
+        }
+
+        public void OnError(Exception error)
+        {
+        }
+
+        public void OnNext(DiagnosticListener value)
+        {
+            if (value.Name == "Microsoft.AspNetCore")
+            {
+                _ = value.Subscribe(new DiagnosticSourceListener(), isEnabled);
+            }
+        }
+    }
+}

--- a/PerfTestAspNetCore/HttpTagHelper.cs
+++ b/PerfTestAspNetCore/HttpTagHelper.cs
@@ -1,0 +1,36 @@
+﻿using System.Diagnostics;
+
+namespace PerfTestAspNetCore
+{
+    public class HttpTagHelper
+    {
+        public static string GetFlavorTagValueFromProtocol(string protocol)
+        {
+            switch (protocol)
+            {
+                case "HTTP/2":
+                    return "2.0";
+
+                case "HTTP/3":
+                    return "3.0";
+
+                case "HTTP/1.1":
+                    return "1.1";
+
+                default:
+                    return protocol;
+            }
+        }
+
+        public static ActivityStatusCode ResolveSpanStatusForHttpStatusCode(ActivityKind kind, int httpStatusCode)
+        {
+            var upperBound = kind == ActivityKind.Client ? 399 : 499;
+            if (httpStatusCode >= 100 && httpStatusCode <= upperBound)
+            {
+                return ActivityStatusCode.Unset;
+            }
+
+            return ActivityStatusCode.Error;
+        }
+    }
+}

--- a/PerfTestAspNetCore/InstrumentationOptions.cs
+++ b/PerfTestAspNetCore/InstrumentationOptions.cs
@@ -1,0 +1,11 @@
+﻿namespace PerfTestAspNetCore
+{
+    public class InstrumentationOptions
+    {
+        public bool EnableDiagnosticSource { get; set; }
+
+        public bool EnableOTel { get; set; }
+
+        public bool EnableMiddleware { get; set; }
+    }
+}

--- a/PerfTestAspNetCore/PerfTestAspNetCore.csproj
+++ b/PerfTestAspNetCore/PerfTestAspNetCore.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.9" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.5.1-beta.1" />
+	<PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  </ItemGroup>
+
+</Project>

--- a/PerfTestAspNetCore/Program.cs
+++ b/PerfTestAspNetCore/Program.cs
@@ -1,0 +1,83 @@
+using OpenTelemetry;
+using OpenTelemetry.Context.Propagation;
+using OpenTelemetry.Trace;
+using PerfTestAspNetCore;
+using System.Diagnostics;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+var instrumentationOptions = new InstrumentationOptions();
+
+builder.Configuration.GetSection("InstrumentationOptions").Bind(instrumentationOptions);
+
+builder.Services.AddControllers();
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+Console.WriteLine("DiagnosticSourceListener-WithoutActivityEnrichment-Enabled: " + instrumentationOptions.EnableDiagnosticSource);
+Console.WriteLine("OTelInstrumentation-Enabled: " + instrumentationOptions.EnableOTel);
+Console.WriteLine("Telemetry-Middleware-Enabled: " + instrumentationOptions.EnableMiddleware);
+
+if (instrumentationOptions.EnableDiagnosticSource)
+{
+    ActivitySource.AddActivityListener(new ActivityListener
+    {
+        ShouldListenTo = source => source.Name == "Microsoft.AspNetCore",
+        Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded,
+        ActivityStarted = activity => { },
+        ActivityStopped = activity => { },
+    });
+
+    DiagnosticListener.AllListeners.Subscribe(new DiagnosticSourceSubscriber());
+}
+
+if (instrumentationOptions.EnableOTel)
+{
+    Environment.SetEnvironmentVariable("OTEL_SEMCONV_STABILITY_OPT_IN", "http");
+    // Set default propagator so that overhead is not caused by context extraction.
+    // Set EnableGrpcAspNetCoreSupport = false, avoid additional work to find grpc tags.
+    Sdk.SetDefaultTextMapPropagator(new TraceContextPropagator());
+    Sdk.CreateTracerProviderBuilder()
+        .SetSampler(new AlwaysOnSampler())
+        .AddAspNetCoreInstrumentation(o => o.EnableGrpcAspNetCoreSupport = false)
+        .Build();
+}
+
+if (instrumentationOptions.EnableMiddleware)
+{
+    builder.Services.AddSingleton<TelemetryMiddleware>();
+
+    ActivitySource.AddActivityListener(new ActivityListener
+    {
+        ShouldListenTo = source => source.Name == "Microsoft.AspNetCore",
+        Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded,
+        ActivityStarted = activity => { },
+        ActivityStopped = activity => { },
+    });
+}
+
+builder.Logging.ClearProviders();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+if (instrumentationOptions.EnableMiddleware)
+{
+    app.UseMiddleware<TelemetryMiddleware>();
+}
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/PerfTestAspNetCore/SemanticConventions.cs
+++ b/PerfTestAspNetCore/SemanticConventions.cs
@@ -1,0 +1,114 @@
+﻿#nullable enable
+namespace PerfTestAspNetCore;
+
+/// <summary>
+/// Constants for semantic attribute names outlined by the OpenTelemetry specifications.
+/// <see href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/README.md"/> and
+/// <see href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/README.md"/>.
+/// </summary>
+internal static class SemanticConventions
+{
+    // The set of constants matches the specification as of this commit.
+    // https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions
+    // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/exceptions.md
+    public const string AttributeNetTransport = "net.transport";
+    public const string AttributeNetPeerIp = "net.peer.ip";
+    public const string AttributeNetPeerPort = "net.peer.port";
+    public const string AttributeNetPeerName = "net.peer.name";
+    public const string AttributeNetHostIp = "net.host.ip";
+    public const string AttributeNetHostPort = "net.host.port";
+    public const string AttributeNetHostName = "net.host.name";
+
+    public const string AttributeEnduserId = "enduser.id";
+    public const string AttributeEnduserRole = "enduser.role";
+    public const string AttributeEnduserScope = "enduser.scope";
+
+    public const string AttributePeerService = "peer.service";
+
+    public const string AttributeHttpMethod = "http.method";
+    public const string AttributeHttpUrl = "http.url";
+    public const string AttributeHttpTarget = "http.target";
+    public const string AttributeHttpHost = "http.host";
+    public const string AttributeHttpScheme = "http.scheme";
+    public const string AttributeHttpStatusCode = "http.status_code";
+    public const string AttributeHttpStatusText = "http.status_text";
+    public const string AttributeHttpFlavor = "http.flavor";
+    public const string AttributeHttpServerName = "http.server_name";
+    public const string AttributeHttpRoute = "http.route";
+    public const string AttributeHttpClientIP = "http.client_ip";
+    public const string AttributeHttpUserAgent = "http.user_agent";
+    public const string AttributeHttpRequestContentLength = "http.request_content_length";
+    public const string AttributeHttpRequestContentLengthUncompressed = "http.request_content_length_uncompressed";
+    public const string AttributeHttpResponseContentLength = "http.response_content_length";
+    public const string AttributeHttpResponseContentLengthUncompressed = "http.response_content_length_uncompressed";
+
+    public const string AttributeDbSystem = "db.system";
+    public const string AttributeDbConnectionString = "db.connection_string";
+    public const string AttributeDbUser = "db.user";
+    public const string AttributeDbMsSqlInstanceName = "db.mssql.instance_name";
+    public const string AttributeDbJdbcDriverClassName = "db.jdbc.driver_classname";
+    public const string AttributeDbName = "db.name";
+    public const string AttributeDbStatement = "db.statement";
+    public const string AttributeDbOperation = "db.operation";
+    public const string AttributeDbInstance = "db.instance";
+    public const string AttributeDbUrl = "db.url";
+    public const string AttributeDbCassandraKeyspace = "db.cassandra.keyspace";
+    public const string AttributeDbHBaseNamespace = "db.hbase.namespace";
+    public const string AttributeDbRedisDatabaseIndex = "db.redis.database_index";
+    public const string AttributeDbMongoDbCollection = "db.mongodb.collection";
+
+    public const string AttributeRpcSystem = "rpc.system";
+    public const string AttributeRpcService = "rpc.service";
+    public const string AttributeRpcMethod = "rpc.method";
+    public const string AttributeRpcGrpcStatusCode = "rpc.grpc.status_code";
+
+    public const string AttributeMessageType = "message.type";
+    public const string AttributeMessageId = "message.id";
+    public const string AttributeMessageCompressedSize = "message.compressed_size";
+    public const string AttributeMessageUncompressedSize = "message.uncompressed_size";
+
+    public const string AttributeFaasTrigger = "faas.trigger";
+    public const string AttributeFaasExecution = "faas.execution";
+    public const string AttributeFaasDocumentCollection = "faas.document.collection";
+    public const string AttributeFaasDocumentOperation = "faas.document.operation";
+    public const string AttributeFaasDocumentTime = "faas.document.time";
+    public const string AttributeFaasDocumentName = "faas.document.name";
+    public const string AttributeFaasTime = "faas.time";
+    public const string AttributeFaasCron = "faas.cron";
+
+    public const string AttributeMessagingSystem = "messaging.system";
+    public const string AttributeMessagingDestination = "messaging.destination";
+    public const string AttributeMessagingDestinationKind = "messaging.destination_kind";
+    public const string AttributeMessagingTempDestination = "messaging.temp_destination";
+    public const string AttributeMessagingProtocol = "messaging.protocol";
+    public const string AttributeMessagingProtocolVersion = "messaging.protocol_version";
+    public const string AttributeMessagingUrl = "messaging.url";
+    public const string AttributeMessagingMessageId = "messaging.message_id";
+    public const string AttributeMessagingConversationId = "messaging.conversation_id";
+    public const string AttributeMessagingPayloadSize = "messaging.message_payload_size_bytes";
+    public const string AttributeMessagingPayloadCompressedSize = "messaging.message_payload_compressed_size_bytes";
+    public const string AttributeMessagingOperation = "messaging.operation";
+
+    public const string AttributeExceptionEventName = "exception";
+    public const string AttributeExceptionType = "exception.type";
+    public const string AttributeExceptionMessage = "exception.message";
+    public const string AttributeExceptionStacktrace = "exception.stacktrace";
+
+    // v1.21.0
+    // https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/http/http-spans.md
+    // https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/database/database-spans.md
+    // https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/rpc/rpc-spans.md
+    public const string AttributeClientAddress = "client.address";
+    public const string AttributeClientPort = "client.port";
+    public const string AttributeHttpRequestMethod = "http.request.method"; // replaces: "http.method" (AttributeHttpMethod)
+    public const string AttributeHttpResponseStatusCode = "http.response.status_code"; // replaces: "http.status_code" (AttributeHttpStatusCode)
+    public const string AttributeNetworkProtocolVersion = "network.protocol.version"; // replaces: "http.flavor" (AttributeHttpFlavor)
+    public const string AttributeServerAddress = "server.address"; // replaces: "net.host.name" (AttributeNetHostName) and "net.peer.name" (AttributeNetPeerName)
+    public const string AttributeServerPort = "server.port"; // replaces: "net.host.port" (AttributeNetHostPort) and "net.peer.port" (AttributeNetPeerPort)
+    public const string AttributeServerSocketAddress = "server.socket.address"; // replaces: "net.peer.ip" (AttributeNetPeerIp)
+    public const string AttributeUrlFull = "url.full"; // replaces: "http.url" (AttributeHttpUrl)
+    public const string AttributeUrlPath = "url.path"; // replaces: "http.target" (AttributeHttpTarget)
+    public const string AttributeUrlScheme = "url.scheme"; // replaces: "http.scheme" (AttributeHttpScheme)
+    public const string AttributeUrlQuery = "url.query";
+    public const string AttributeUserAgentOriginal = "user_agent.original"; // replaces: "http.user_agent" (AttributeHttpUserAgent)
+}

--- a/PerfTestAspNetCore/TelemetryMiddleware.cs
+++ b/PerfTestAspNetCore/TelemetryMiddleware.cs
@@ -1,0 +1,77 @@
+﻿using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace PerfTestAspNetCore;
+
+public class TelemetryMiddleware : IMiddleware
+{
+    public TelemetryMiddleware()
+    {
+    }
+
+    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        try
+        {
+            var activity = Activity.Current;
+
+            await next(context).ConfigureAwait(false);
+            OnRequestEnd(context, context.Response.StatusCode, null);
+        }
+        catch (Exception ex)
+        {
+            int resultCode = context.Response.StatusCode < StatusCodes.Status400BadRequest ? StatusCodes.Status500InternalServerError : context.Response.StatusCode;
+            OnRequestEnd(context, resultCode, ex.GetType());
+
+            throw;
+        }
+    }
+
+    private void OnRequestEnd(HttpContext httpContext, int resultCode, Type? exceptionType)
+    {
+        var activity = Activity.Current;
+        var endpoint = httpContext.GetEndpoint() as RouteEndpoint;
+
+        var request = httpContext.Request;
+        var path = (request.PathBase.HasValue || request.Path.HasValue) ? (request.PathBase + request.Path).ToString() : "/";
+        if (request.Host.HasValue)
+        {
+            activity?.SetTag(SemanticConventions.AttributeServerAddress, request.Host.Host);
+
+            if (request.Host.Port is not null && request.Host.Port != 80 && request.Host.Port != 443)
+            {
+                activity?.SetTag(SemanticConventions.AttributeServerPort, request.Host.Port);
+            }
+        }
+
+        if (request.QueryString.HasValue)
+        {
+            activity?.SetTag(SemanticConventions.AttributeUrlQuery, request.QueryString.Value);
+        }
+
+        activity?.SetTag(SemanticConventions.AttributeHttpRequestMethod, request.Method);
+        activity?.SetTag(SemanticConventions.AttributeUrlScheme, request.Scheme);
+        activity?.SetTag(SemanticConventions.AttributeUrlPath, path);
+        activity?.SetTag(SemanticConventions.AttributeNetworkProtocolVersion, HttpTagHelper.GetFlavorTagValueFromProtocol(request.Protocol));
+
+        if (request.Headers.TryGetValue("User-Agent", out var values))
+        {
+            var userAgent = values.Count > 0 ? values[0] : null;
+            if (!string.IsNullOrEmpty(userAgent))
+            {
+                activity?.SetTag(SemanticConventions.AttributeUserAgentOriginal, userAgent);
+            }
+        }
+
+        activity?.SetTag(SemanticConventions.AttributeHttpRoute, endpoint?.RoutePattern.RawText);
+        activity?.SetTag(SemanticConventions.AttributeHttpResponseStatusCode, resultCode);
+        activity?.SetStatus(HttpTagHelper.ResolveSpanStatusForHttpStatusCode(activity.Kind, httpContext.Response.StatusCode));
+
+        // This is additional work that instrumentation library is doing
+        // This is needed in cases when the propagator used by user is not default
+        // and instrumentation library creates a new activity (different one from framework)
+        // Adding it here in order to do 1:1 comparison
+        // This has potential of improvement.
+        var tagValue = activity?.GetTagValue("IsCreatedByInstrumentation");
+    }
+}

--- a/PerfTestAspNetCore/WeatherForecast.cs
+++ b/PerfTestAspNetCore/WeatherForecast.cs
@@ -1,0 +1,13 @@
+namespace PerfTestAspNetCore
+{
+    public class WeatherForecast
+    {
+        public DateOnly Date { get; set; }
+
+        public int TemperatureC { get; set; }
+
+        public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+
+        public string? Summary { get; set; }
+    }
+}

--- a/PerfTestAspNetCore/appsettings.Development.json
+++ b/PerfTestAspNetCore/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/PerfTestAspNetCore/appsettings.json
+++ b/PerfTestAspNetCore/appsettings.json
@@ -1,0 +1,14 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "InstrumentationOptions": {
+    "EnableDiagnosticSource": false,
+    "EnableOTel": false,
+    "EnableMiddleware": false
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
Towards #4214

## Changes
This PR is summarizing the issue raised in #4214. The numbers shared in the original issue does not show 1:1 comparison of instrumentation done via middleware versus diagnostic source callbacks. The test app shown in this PR attempts to do 1:1 comparison to find the root cause of overhead.

The tests are divided into 4 categories and performed using https://github.com/codesenberg/bombardier:

`bombardier-windows-amd64.exe -c 1 -n 1000000 http://localhost:5152/weatherforecast`


**No instrumentation**

```
Statistics        Avg      Stdev        Max
  Reqs/sec      5603.76     314.83    6520.68
  Latency      175.29us   102.62us    99.70ms
  HTTP codes:
    1xx - 0, 2xx - 1000000, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     3.33MB/s
```

**Instrumentation done via middleware**
```
Reqs/sec      5324.58     298.88    6118.92
  Latency      183.84us   115.64us   113.10ms
  HTTP codes:
    1xx - 0, 2xx - 1000000, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     3.17MB/s
```

**Enabling Diagnostic Source callbacks without activity enrichment (This is to show the overhead caused by just subscribing to events)**
```
Reqs/sec      5334.77     270.81    6340.36
  Latency      183.59us   100.17us    97.32ms
  HTTP codes:
    1xx - 0, 2xx - 1000000, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     3.17MB/s
```

**Instrumentation done via instrumentation library**
```
Statistics        Avg      Stdev        Max
  Reqs/sec      5093.24     254.27    6031.88
  Latency      194.53us   100.95us    97.94ms
  HTTP codes:
    1xx - 0, 2xx - 1000000, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     3.03MB/s
```

In **summary**:
Instrumentation via middleware causes **~5%** overhead
Instrumentation via instrumentation library causes **~10%** overhead with ~**5%** caused by DiagnosticSource events subscription.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
