### PR TITLE
making OtlpLogExporter public

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/Experimental/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/Experimental/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+OpenTelemetry.Exporter.OtlpLogExporter.OtlpLogExporter(OpenTelemetry.Exporter.OtlpExporterOptions options) -> void

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/Stable/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/Stable/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+OpenTelemetry.Exporter.OtlpLogExporter
+override OpenTelemetry.Exporter.OtlpLogExporter.Export(in OpenTelemetry.Batch<OpenTelemetry.Logs.LogRecord> logRecordBatch) -> OpenTelemetry.ExportResult

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporter.cs
@@ -28,7 +28,7 @@ namespace OpenTelemetry.Exporter;
 /// Exporter consuming <see cref="LogRecord"/> and exporting the data using
 /// the OpenTelemetry protocol (OTLP).
 /// </summary>
-internal sealed class OtlpLogExporter : BaseExporter<LogRecord>
+public sealed class OtlpLogExporter : BaseExporter<LogRecord>
 {
     private readonly IExportClient<OtlpCollector.ExportLogsServiceRequest> exportClient;
     private readonly OtlpLogRecordTransformer otlpLogRecordTransformer;


### PR DESCRIPTION
Fixes #
Fixes https://github.com/open-telemetry/opentelemetry-dotnet/issues/4971

## Changes

The only change is making OtlpLogExporter public.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
