### PR TITLE
Add `url.scheme` to `http.client.request.duration` metric

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -64,8 +64,8 @@
   ([#4931](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4931))
 
   * Added `url.scheme` attribute to `http.client.request.duration` metric. The
-  metric will be emitted when `OTEL_SEMCONV_STABILITY_OPT_IN` is set to `http`
-  or `http/dup`.
+  metric will be emitted when `OTEL_SEMCONV_STABILITY_OPT_IN` environment
+  variable is set to `http` or `http/dup`.
   ([#4989](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4989))
 
 ## 1.5.1-beta.1

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -66,7 +66,7 @@
   * Added `url.scheme` attribute to `http.client.request.duration` metric. The
   metric will be emitted when `OTEL_SEMCONV_STABILITY_OPT_IN` is set to `http`
   or `http/dup`.
-  ([]())
+  ([#4989](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4989))
 
 ## 1.5.1-beta.1
 

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -63,6 +63,11 @@
 
   ([#4931](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4931))
 
+  * Added `url.scheme` attribute to `http.client.request.duration` metric. The
+  metric will be emitted when `OTEL_SEMCONV_STABILITY_OPT_IN` is set to `http`
+  or `http/dup`.
+  ([]())
+
 ## 1.5.1-beta.1
 
 Released 2023-Jul-20

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
@@ -100,6 +100,7 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
                     tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpRequestMethod, HttpTagHelper.GetNameForHttpMethod(request.Method)));
                     tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeNetworkProtocolVersion, HttpTagHelper.GetFlavorTagValueFromProtocolVersion(request.Version)));
                     tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeServerAddress, request.RequestUri.Host));
+                    tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeUrlScheme, request.RequestUri.Scheme));
 
                     if (!request.RequestUri.IsDefaultPort)
                     {

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
@@ -497,6 +497,7 @@ internal static class HttpWebRequestActivitySource
 
                 tags.Add(SemanticConventions.AttributeHttpRequestMethod, request.Method);
                 tags.Add(SemanticConventions.AttributeServerAddress, request.RequestUri.Host);
+                tags.Add(SemanticConventions.AttributeUrlScheme, request.RequestUri.Scheme);
                 tags.Add(SemanticConventions.AttributeNetworkProtocolVersion, HttpTagHelper.GetFlavorTagValueFromProtocolVersion(request.ProtocolVersion));
                 if (!request.RequestUri.IsDefaultPort)
                 {

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.cs
@@ -519,7 +519,7 @@ public partial class HttpClientTests
                     attributes[tag.Key] = tag.Value;
                 }
 
-                var expectedAttributeCount = 4 + (tc.ResponseExpected ? 1 : 0);
+                var expectedAttributeCount = 5 + (tc.ResponseExpected ? 1 : 0);
 
                 Assert.Equal(expectedAttributeCount, attributes.Count);
 
@@ -527,6 +527,7 @@ public partial class HttpClientTests
                 Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeServerAddress && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeNetPeerName]);
                 Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeServerPort && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeNetPeerPort]);
                 Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeNetworkProtocolVersion && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeHttpFlavor]);
+                Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeUrlScheme && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeHttpScheme]);
                 if (tc.ResponseExpected)
                 {
                     Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeHttpResponseStatusCode && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeHttpStatusCode]);


### PR DESCRIPTION
Fixes #
Design discussion issue #

## Changes
Adding `url.scheme` to `http.client.request.duration` that was added recently. The attribute is `required`.
Spec link: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-metrics.md#metric-httpclientrequestduration


Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
