### PR TITLE
Shim - remove reference to 1.6.0-beta.2

### DIFF
--- a/src/OpenTelemetry.Shims.OpenTracing/CHANGELOG.md
+++ b/src/OpenTelemetry.Shims.OpenTracing/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-## 1.6.0-beta.2
-
-Released 2023-Oct-26
-
 * Remove obsolete `TracerShim(Tracer, TextMapPropagator)` constructor.
   Use `TracerShim(TracerProvider)`
   or `TracerShim(TracerProvider, TextMapPropagator)` constructors.


### PR DESCRIPTION
## Changes

1.6.0-beta.2 was delisted and deprecated due to wrong reference to OTel SDK.
Removing it from the Changelog.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* ~~[ ] Changes in public API reviewed (if applicable)~~
