### PR TITLE
[ASP.NET Core] Set `http.request.method` as per spec

### DIFF
--- a/OpenTelemetry.sln
+++ b/OpenTelemetry.sln
@@ -269,6 +269,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared", "Shared", "{A49299
 		src\Shared\PeriodicExportingMetricReaderHelper.cs = src\Shared\PeriodicExportingMetricReaderHelper.cs
 		src\Shared\PooledList.cs = src\Shared\PooledList.cs
 		src\Shared\ResourceSemanticConventions.cs = src\Shared\ResourceSemanticConventions.cs
+		src\Shared\RequestMethodHelper.cs = src\Shared\RequestMethodHelper.cs
 		src\Shared\SemanticConventions.cs = src\Shared\SemanticConventions.cs
 		src\Shared\SpanAttributeConstants.cs = src\Shared\SpanAttributeConstants.cs
 		src\Shared\SpanHelper.cs = src\Shared\SpanHelper.cs

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -4,14 +4,14 @@
 
 * Updated `http.request.method` to match specification guidelines.
   * For activity, if the method does not belong to one of the [known
-    values](https://github.com/open-telemetry/semantic-conventions/blob/v1.22.0/docs/http/http-spans.md#:~:text=http.request.method%20has%20the%20following%20list%20of%20well%2Dknown%20values)then
-    the request method will be set on an additional tag
+    values](https://github.com/open-telemetry/semantic-conventions/blob/v1.22.0/docs/http/http-spans.md#:~:text=http.request.method%20has%20the%20following%20list%20of%20well%2Dknown%20values)
+    then the request method will be set on an additional tag
     `http.request.method.original` and `http.request.method` will be set to
     `_OTHER`.
   * For metrics, if the original method does not belong to one of the [known
-    values](https://github.com/open-telemetry/semantic-conventions/blob/v1.22.0/docs/http/http-spans.md#:~:text=http.request.method%20has%20the%20following%20list%20of%20well%2Dknown%20values)then
-    `http.request.method` on `http.server.request.duration` metric will be set
-    to `_OTHER`
+    values](https://github.com/open-telemetry/semantic-conventions/blob/v1.22.0/docs/http/http-spans.md#:~:text=http.request.method%20has%20the%20following%20list%20of%20well%2Dknown%20values)
+    then `http.request.method` on `http.server.request.duration` metric will be
+    set to `_OTHER`
 
   `http.request.method` is set on `http.server.request.duration` metric or
   activity when `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable is set to

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -8,10 +8,10 @@
     the request method will be set on an additional tag
     `http.request.method.original` and `http.request.method` will be set to
     `_OTHER`.
-  * For metrics, `http.request.method` on `http.server.request.duration` metric
-    will be set to `_OTHER` if the original method does not belong to one of the
-    [known
-    values](https://github.com/open-telemetry/semantic-conventions/blob/v1.22.0/docs/http/http-spans.md#:~:text=http.request.method%20has%20the%20following%20list%20of%20well%2Dknown%20values)
+  * For metrics, if the original method does not belong to one of the [known
+    values](https://github.com/open-telemetry/semantic-conventions/blob/v1.22.0/docs/http/http-spans.md#:~:text=http.request.method%20has%20the%20following%20list%20of%20well%2Dknown%20values)then
+    `http.request.method` on `http.server.request.duration` metric will be set
+    to `_OTHER`
 
   `http.request.method` is set on `http.server.request.duration` metric or
   activity when `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable is set to

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 * Updated `http.request.method` to match specification guidelines.
   * For activity, request method will be set on an additional tag
-    `http.request.method.original` will be added if the method does not belong
-    to one of the [known
+    `http.request.method.original` if the method does not belong to one of the
+    [known
     values](https://github.com/open-telemetry/semantic-conventions/blob/v1.22.0/docs/http/http-spans.md#:~:text=http.request.method%20has%20the%20following%20list%20of%20well%2Dknown%20values)
     and `http.request.method` will be set to `_OTHER`.
   * For metrics, `http.request.method` on `http.server.request.duration` metric

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -16,7 +16,7 @@
   `http.request.method` is set on `http.server.request.duration` metric or
   activity when `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable is set to
   `http` or `http/dup`.
-  (#5001)[https://github.com/open-telemetry/opentelemetry-dotnet/pull/5001]
+  ([#5001](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5001))
 
 ## 1.6.0-beta.2
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -3,11 +3,11 @@
 ## Unreleased
 
 * Updated `http.request.method` to match specification guidelines.
-  * For activity, request method will be set on an additional tag
-    `http.request.method.original` if the method does not belong to one of the
-    [known
-    values](https://github.com/open-telemetry/semantic-conventions/blob/v1.22.0/docs/http/http-spans.md#:~:text=http.request.method%20has%20the%20following%20list%20of%20well%2Dknown%20values)
-    and `http.request.method` will be set to `_OTHER`.
+  * For activity, if the method does not belong to one of the [known
+    values](https://github.com/open-telemetry/semantic-conventions/blob/v1.22.0/docs/http/http-spans.md#:~:text=http.request.method%20has%20the%20following%20list%20of%20well%2Dknown%20values)then
+    the request method will be set on an additional tag
+    `http.request.method.original` and `http.request.method` will be set to
+    `_OTHER`.
   * For metrics, `http.request.method` on `http.server.request.duration` metric
     will be set to `_OTHER` if the original method does not belong to one of the
     [known

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+* Updated `http.request.method` to match specification guidelines.
+  * For activity, request method will be set on an additional tag
+    `http.request.method.original` will be added if the method does not belong
+    to one of the [known
+    values](https://github.com/open-telemetry/semantic-conventions/blob/v1.22.0/docs/http/http-spans.md#:~:text=http.request.method%20has%20the%20following%20list%20of%20well%2Dknown%20values)
+    and `http.request.method` will be set to `_OTHER`.
+  * For metrics, `http.request.method` on `http.server.request.duration` metric
+    will be set to `_OTHER` if the original method does not belong to one of the
+    [known
+    values](https://github.com/open-telemetry/semantic-conventions/blob/v1.22.0/docs/http/http-spans.md#:~:text=http.request.method%20has%20the%20following%20list%20of%20well%2Dknown%20values)
+
+  `http.request.method` is set on `http.server.request.duration` metric or
+  activity when `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable is set to
+  `http` or `http/dup`.
+  (#5001)[https://github.com/open-telemetry/opentelemetry-dotnet/pull/5001]
+
 ## 1.6.0-beta.2
 
 Released 2023-Oct-26

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -252,7 +252,7 @@ internal class HttpInListener : ListenerHandler
                     activity.SetTag(SemanticConventions.AttributeUrlQuery, request.QueryString.Value);
                 }
 
-                if (TelemetryHelper.TryResolveHttpMethod(request.Method, out var httpMethod))
+                if (RequestMethodHelper.TryResolveHttpMethod(request.Method, out var httpMethod))
                 {
                     activity.SetTag(SemanticConventions.AttributeHttpRequestMethod, httpMethod);
                 }

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -252,7 +252,16 @@ internal class HttpInListener : ListenerHandler
                     activity.SetTag(SemanticConventions.AttributeUrlQuery, request.QueryString.Value);
                 }
 
-                activity.SetTag(SemanticConventions.AttributeHttpRequestMethod, request.Method);
+                if (TelemetryHelper.TryResolveHttpMethod(request.Method, out var httpMethod))
+                {
+                    activity.SetTag(SemanticConventions.AttributeHttpRequestMethod, httpMethod);
+                }
+                else
+                {
+                    activity.SetTag(SemanticConventions.AttributeHttpRequestMethod, httpMethod);
+                    activity.SetTag(SemanticConventions.AttributeHttpRequestMethodOriginal, request.Method);
+                }
+
                 activity.SetTag(SemanticConventions.AttributeUrlScheme, request.Scheme);
                 activity.SetTag(SemanticConventions.AttributeUrlPath, path);
                 activity.SetTag(SemanticConventions.AttributeNetworkProtocolVersion, HttpTagHelper.GetFlavorTagValueFromProtocol(request.Protocol));

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInMetricsListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInMetricsListener.cs
@@ -150,8 +150,9 @@ internal sealed class HttpInMetricsListener : ListenerHandler
         tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeNetworkProtocolName, NetworkProtocolName));
         tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeNetworkProtocolVersion, HttpTagHelper.GetFlavorTagValueFromProtocol(context.Request.Protocol)));
         tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeUrlScheme, context.Request.Scheme));
-        tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpRequestMethod, context.Request.Method));
         tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpResponseStatusCode, TelemetryHelper.GetBoxedStatusCode(context.Response.StatusCode)));
+        TelemetryHelper.TryResolveHttpMethod(context.Request.Method, out var httpMethod);
+        tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpRequestMethod, httpMethod));
 
 #if NET6_0_OR_GREATER
         var route = (context.GetEndpoint() as RouteEndpoint)?.RoutePattern.RawText;

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInMetricsListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInMetricsListener.cs
@@ -18,6 +18,8 @@
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using Microsoft.AspNetCore.Http;
+using OpenTelemetry.Internal;
+
 #if NET6_0_OR_GREATER
 using Microsoft.AspNetCore.Routing;
 #endif
@@ -151,7 +153,7 @@ internal sealed class HttpInMetricsListener : ListenerHandler
         tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeNetworkProtocolVersion, HttpTagHelper.GetFlavorTagValueFromProtocol(context.Request.Protocol)));
         tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeUrlScheme, context.Request.Scheme));
         tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpResponseStatusCode, TelemetryHelper.GetBoxedStatusCode(context.Response.StatusCode)));
-        TelemetryHelper.TryResolveHttpMethod(context.Request.Method, out var httpMethod);
+        RequestMethodHelper.TryResolveHttpMethod(context.Request.Method, out var httpMethod);
         tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpRequestMethod, httpMethod));
 
 #if NET6_0_OR_GREATER

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/TelemetryHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/TelemetryHelper.cs
@@ -17,7 +17,6 @@
 using Microsoft.AspNetCore.Http;
 #if NET8_0_OR_GREATER
 using System.Collections.Frozen;
-using System.Collections.Generic;
 #endif
 
 namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation;
@@ -38,7 +37,7 @@ internal static class TelemetryHelper
             KeyValuePair.Create(HttpMethods.Patch, HttpMethods.Patch),
             KeyValuePair.Create(HttpMethods.Post, HttpMethods.Post),
             KeyValuePair.Create(HttpMethods.Put, HttpMethods.Put),
-            KeyValuePair.Create(HttpMethods.Trace, HttpMethods.Trace)
+            KeyValuePair.Create(HttpMethods.Trace, HttpMethods.Trace),
         },
         StringComparer.OrdinalIgnoreCase);
 #else

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/TelemetryHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/TelemetryHelper.cs
@@ -14,47 +14,11 @@
 // limitations under the License.
 // </copyright>
 
-using Microsoft.AspNetCore.Http;
-#if NET8_0_OR_GREATER
-using System.Collections.Frozen;
-#endif
-
 namespace OpenTelemetry.Instrumentation.AspNetCore.Implementation;
 
 internal static class TelemetryHelper
 {
     public static readonly object[] BoxedStatusCodes;
-
-#if NET8_0_OR_GREATER
-    internal static readonly FrozenDictionary<string, string> KnownMethods = FrozenDictionary.ToFrozenDictionary(
-        new[]
-        {
-            KeyValuePair.Create(HttpMethods.Connect, HttpMethods.Connect),
-            KeyValuePair.Create(HttpMethods.Delete, HttpMethods.Delete),
-            KeyValuePair.Create(HttpMethods.Get, HttpMethods.Get),
-            KeyValuePair.Create(HttpMethods.Head, HttpMethods.Head),
-            KeyValuePair.Create(HttpMethods.Options, HttpMethods.Options),
-            KeyValuePair.Create(HttpMethods.Patch, HttpMethods.Patch),
-            KeyValuePair.Create(HttpMethods.Post, HttpMethods.Post),
-            KeyValuePair.Create(HttpMethods.Put, HttpMethods.Put),
-            KeyValuePair.Create(HttpMethods.Trace, HttpMethods.Trace),
-        },
-        StringComparer.OrdinalIgnoreCase);
-#else
-    internal static readonly Dictionary<string, string> KnownMethods = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-    {
-        { HttpMethods.Connect, HttpMethods.Connect },
-        { HttpMethods.Delete, HttpMethods.Delete },
-        { HttpMethods.Get, HttpMethods.Get },
-        { HttpMethods.Head, HttpMethods.Head },
-        { HttpMethods.Options, HttpMethods.Options },
-        { HttpMethods.Patch, HttpMethods.Patch },
-        { HttpMethods.Post, HttpMethods.Post },
-        { HttpMethods.Put, HttpMethods.Put },
-        { HttpMethods.Trace, HttpMethods.Trace },
-    };
-
-#endif
 
     static TelemetryHelper()
     {
@@ -73,20 +37,5 @@ internal static class TelemetryHelper
         }
 
         return statusCode;
-    }
-
-    public static bool TryResolveHttpMethod(string method, out string resolvedMethod)
-    {
-        if (KnownMethods.TryGetValue(method, out var result))
-        {
-            // KnownMethods ignores case. Use the value returned by the dictionary to have a consistent case.
-            resolvedMethod = result;
-            return true;
-        }
-
-        // Set to default "_OTHER" as per spec.
-        // https://github.com/open-telemetry/semantic-conventions/blob/v1.22.0/docs/http/http-spans.md#common-attributes
-        resolvedMethod = "_OTHER";
-        return false;
     }
 }

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/MeterProviderBuilderExtensions.cs
@@ -42,8 +42,9 @@ public static class MeterProviderBuilderExtensions
 #if NET8_0_OR_GREATER
         return builder.ConfigureMeters();
 #else
-        // Note: Warm-up the status code mapping.
+        // Note: Warm-up the status code and method mapping.
         _ = TelemetryHelper.BoxedStatusCodes;
+        _ = RequestMethodHelper.KnownMethods;
 
         builder.ConfigureServices(services =>
         {

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
@@ -14,6 +14,7 @@
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.GrpcNetClient\GrpcTagHelper.cs" Link="Includes\GrpcTagHelper.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.GrpcNetClient\StatusCanonicalCode.cs" Link="Includes\StatusCanonicalCode.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\RequestMethodHelper.cs" Link="Includes\RequestMethodHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\EnvironmentVariables\*.cs" Link="Includes\EnvironmentVariables\%(Filename).cs" Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1'" />
     <Compile Include="$(RepoRoot)\src\Shared\HttpSemanticConventionHelper.cs" Link="Includes\HttpSemanticConventionHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Options\*.cs" Link="Includes\Options\%(Filename).cs" />

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/TracerProviderBuilderExtensions.cs
@@ -63,8 +63,9 @@ public static class TracerProviderBuilderExtensions
     {
         Guard.ThrowIfNull(builder);
 
-        // Note: Warm-up the status code mapping.
+        // Note: Warm-up the status code and method mapping.
         _ = TelemetryHelper.BoxedStatusCodes;
+        _ = RequestMethodHelper.KnownMethods;
 
         name ??= Options.DefaultName;
 

--- a/src/Shared/RequestMethodHelper.cs
+++ b/src/Shared/RequestMethodHelper.cs
@@ -1,0 +1,78 @@
+// <copyright file="RequestMethodHelper.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+#if NET8_0_OR_GREATER
+using System.Collections.Frozen;
+#endif
+
+namespace OpenTelemetry.Internal;
+
+internal static class RequestMethodHelper
+{
+#if NET8_0_OR_GREATER
+    internal static readonly FrozenDictionary<string, string> KnownMethods;
+#else
+    internal static readonly Dictionary<string, string> KnownMethods;
+#endif
+
+    static RequestMethodHelper()
+    {
+#if NET8_0_OR_GREATER
+        KnownMethods = FrozenDictionary.ToFrozenDictionary(
+            new[]
+            {
+                KeyValuePair.Create("GET", "GET"),
+                KeyValuePair.Create("PUT", "PUT"),
+                KeyValuePair.Create("POST", "POST"),
+                KeyValuePair.Create("DELETE", "DELETE"),
+                KeyValuePair.Create("HEAD", "HEAD"),
+                KeyValuePair.Create("OPTIONS", "OPTIONS"),
+                KeyValuePair.Create("TRACE", "TRACE"),
+                KeyValuePair.Create("PATCH", "PATCH"),
+                KeyValuePair.Create("CONNECT", "CONNECT"),
+            },
+            StringComparer.OrdinalIgnoreCase);
+#else
+        KnownMethods = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            { "GET", "GET" },
+            { "PUT", "PUT" },
+            { "POST", "POST" },
+            { "DELETE", "DELETE" },
+            { "HEAD", "HEAD" },
+            { "OPTIONS", "OPTIONS" },
+            { "TRACE", "TRACE" },
+            { "PATCH", "PATCH" },
+            { "CONNECT", "CONNECT" },
+        };
+#endif
+    }
+
+    public static bool TryResolveHttpMethod(string method, out string resolvedMethod)
+    {
+        if (KnownMethods.TryGetValue(method, out var result))
+        {
+            // KnownMethods ignores case. Use the value returned by the dictionary to have a consistent case.
+            resolvedMethod = result;
+            return true;
+        }
+
+        // Set to default "_OTHER" as per spec.
+        // https://github.com/open-telemetry/semantic-conventions/blob/v1.22.0/docs/http/http-spans.md#common-attributes
+        resolvedMethod = "_OTHER";
+        return false;
+    }
+}

--- a/src/Shared/RequestMethodHelper.cs
+++ b/src/Shared/RequestMethodHelper.cs
@@ -63,10 +63,9 @@ internal static class RequestMethodHelper
 
     public static bool TryResolveHttpMethod(string method, out string resolvedMethod)
     {
-        if (KnownMethods.TryGetValue(method, out var result))
+        if (KnownMethods.TryGetValue(method, out resolvedMethod))
         {
             // KnownMethods ignores case. Use the value returned by the dictionary to have a consistent case.
-            resolvedMethod = result;
             return true;
         }
 

--- a/src/Shared/SemanticConventions.cs
+++ b/src/Shared/SemanticConventions.cs
@@ -129,4 +129,5 @@ internal static class SemanticConventions
     public const string AttributeUrlScheme = "url.scheme"; // replaces: "http.scheme" (AttributeHttpScheme)
     public const string AttributeUrlQuery = "url.query";
     public const string AttributeUserAgentOriginal = "user_agent.original"; // replaces: "http.user_agent" (AttributeHttpUserAgent)
+    public const string AttributeHttpRequestMethodOriginal = "http.request.method_original";
 }

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
@@ -27,6 +27,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Instrumentation.AspNetCore.Implementation;
+using OpenTelemetry.Internal;
 using OpenTelemetry.Tests;
 using OpenTelemetry.Trace;
 using TestApp.AspNetCore;
@@ -710,7 +711,7 @@ public sealed class BasicTests
 
         Assert.Contains(activity.TagObjects, t => t.Key == SemanticConventions.AttributeHttpRequestMethod);
 
-        if (TelemetryHelper.KnownMethods.TryGetValue(method, out var val))
+        if (RequestMethodHelper.KnownMethods.TryGetValue(method, out var val))
         {
             Assert.Equal(val, activity.GetTagValue(SemanticConventions.AttributeHttpRequestMethod) as string);
             Assert.DoesNotContain(activity.TagObjects, t => t.Key == SemanticConventions.AttributeHttpRequestMethodOriginal);

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
@@ -21,6 +21,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -31,6 +32,8 @@ using OpenTelemetry.Trace;
 using TestApp.AspNetCore;
 using TestApp.AspNetCore.Filters;
 using Xunit;
+
+using static OpenTelemetry.Internal.HttpSemanticConventionHelper;
 
 namespace OpenTelemetry.Instrumentation.AspNetCore.Tests;
 
@@ -645,6 +648,78 @@ public sealed class BasicTests
         Assert.Equal("api/Values/{id}", aspnetcoreframeworkactivity.GetTagValue(SemanticConventions.AttributeHttpRoute) as string);
         Assert.Equal("Microsoft.AspNetCore.Hosting.HttpRequestIn", aspnetcoreframeworkactivity.OperationName);
         Assert.Equal("api/Values/{id}", aspnetcoreframeworkactivity.DisplayName);
+    }
+
+    [Theory]
+    [InlineData("CONNECT")]
+    [InlineData("DELETE")]
+    [InlineData("GET")]
+    [InlineData("PUT")]
+    [InlineData("HEAD")]
+    [InlineData("OPTIONS")]
+    [InlineData("PATCH")]
+    [InlineData("Get")]
+    [InlineData("POST")]
+    [InlineData("TRACE")]
+    [InlineData("CUSTOM")]
+    public async Task HttpRequestMethodIsSetAsPerSpec(string method)
+    {
+        var exportedItems = new List<Activity>();
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string> { [SemanticConventionOptInKeyName] = "http" })
+            .Build();
+
+        void ConfigureTestServices(IServiceCollection services)
+        {
+            this.tracerProvider = Sdk.CreateTracerProviderBuilder()
+                .ConfigureServices(services => services.AddSingleton<IConfiguration>(configuration))
+                .AddAspNetCoreInstrumentation()
+                .AddInMemoryExporter(exportedItems)
+                .Build();
+        }
+
+        // Arrange
+        using var client = this.factory
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(ConfigureTestServices);
+                builder.ConfigureLogging(loggingBuilder => loggingBuilder.ClearProviders());
+            })
+            .CreateClient();
+
+        var message = new HttpRequestMessage();
+
+        message.Method = new HttpMethod(method);
+
+        try
+        {
+            using var response = await client.SendAsync(message).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+        }
+        catch
+        {
+            // ignore error.
+        }
+
+        WaitForActivityExport(exportedItems, 1);
+
+        Assert.Single(exportedItems);
+
+        var activity = exportedItems[0];
+
+        Assert.Contains(activity.TagObjects, t => t.Key == SemanticConventions.AttributeHttpRequestMethod);
+
+        if (TelemetryHelper.KnownMethods.TryGetValue(method, out var val))
+        {
+            Assert.Equal(val, activity.GetTagValue(SemanticConventions.AttributeHttpRequestMethod) as string);
+            Assert.DoesNotContain(activity.TagObjects, t => t.Key == SemanticConventions.AttributeHttpRequestMethodOriginal);
+        }
+        else
+        {
+            Assert.Equal("_OTHER", activity.GetTagValue(SemanticConventions.AttributeHttpRequestMethod) as string);
+            Assert.Equal(method, activity.GetTagValue(SemanticConventions.AttributeHttpRequestMethodOriginal) as string);
+        }
     }
 
     [Fact]

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
@@ -30,6 +30,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Instrumentation.AspNetCore.Implementation;
+using OpenTelemetry.Internal;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 using Xunit;
@@ -309,7 +310,7 @@ public class MetricTests
             attributes[tag.Key] = tag.Value;
         }
 
-        if (TelemetryHelper.KnownMethods.TryGetValue(method, out var val))
+        if (RequestMethodHelper.KnownMethods.TryGetValue(method, out var val))
         {
             Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeHttpRequestMethod && kvp.Value.ToString() == method.ToUpper());
         }

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
@@ -29,7 +29,6 @@ using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using OpenTelemetry.Instrumentation.AspNetCore.Implementation;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;


### PR DESCRIPTION
Towards #4994 
Design discussion issue #

## Changes

Fixes `http.request.method` attribute value on activity and metric as per spec. For details, see the linked issue.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
