### PR TITLE
[HttpClient] Add `error.type` for traces and metrics

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "8.0.0-rc.2.23480.2"
+    "version": "8.0.100-rc.2.23502.2"
   }
 }

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -18,6 +18,19 @@
   `http` or `http/dup`.
   ([#5003](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5003))
 
+* An additional attribute `error.type` will be added to activity and
+  `http.client.request.duration` metric in case of failed requests as per the
+  [specification](https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/http/http-spans.md#common-attributes).
+
+  Users moving to `net8.0` or newer frameworks from lower versions will see
+  difference in values in case of an exception. `net8.0` or newer frameworks adds
+  the ability to further drilldown the exceptions to a specific type through
+  [HttpRequestError](https://learn.microsoft.com/dotnet/api/system.net.http.httprequesterror?view=net-8.0)
+  enum. For lower versions the individual types will be rolled in to a single
+  type. This could be a **breaking change** if alerts are set based on the values.
+
+  ([#5005](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5005))
+
 ## 1.6.0-beta.2
 
 Released 2023-Oct-26

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -24,7 +24,7 @@
 
   Users moving to `net8.0` or newer frameworks from lower versions will see
   difference in values in case of an exception. `net8.0` or newer frameworks add
-  the ability to further drilldown the exceptions to a specific type through
+  the ability to further drill down the exceptions to a specific type through
   [HttpRequestError](https://learn.microsoft.com/dotnet/api/system.net.http.httprequesterror?view=net-8.0)
   enum. For lower versions, the individual types will be rolled in to a single
   type. This could be a **breaking change** if alerts are set based on the values.

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -26,7 +26,7 @@
   difference in values in case of an exception. `net8.0` or newer frameworks adds
   the ability to further drilldown the exceptions to a specific type through
   [HttpRequestError](https://learn.microsoft.com/dotnet/api/system.net.http.httprequesterror?view=net-8.0)
-  enum. For lower versions the individual types will be rolled in to a single
+  enum. For lower versions, the individual types will be rolled in to a single
   type. This could be a **breaking change** if alerts are set based on the values.
 
   The attribute will only be added when `OTEL_SEMCONV_STABILITY_OPT_IN`

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -23,7 +23,7 @@
   [specification](https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/http/http-spans.md#common-attributes).
 
   Users moving to `net8.0` or newer frameworks from lower versions will see
-  difference in values in case of an exception. `net8.0` or newer frameworks adds
+  difference in values in case of an exception. `net8.0` or newer frameworks add
   the ability to further drilldown the exceptions to a specific type through
   [HttpRequestError](https://learn.microsoft.com/dotnet/api/system.net.http.httprequesterror?view=net-8.0)
   enum. For lower versions, the individual types will be rolled in to a single

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -29,6 +29,9 @@
   enum. For lower versions the individual types will be rolled in to a single
   type. This could be a **breaking change** if alerts are set based on the values.
 
+  The attribute will only be added when `OTEL_SEMCONV_STABILITY_OPT_IN`
+  environment variable is set to `http` or `http/dup`.
+
   ([#5005](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5005))
 
 ## 1.6.0-beta.2

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -390,7 +390,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
     }
 
 #if NET8_0_OR_GREATER
-    private static object GetErrorType(Exception exc)
+    private static string GetErrorType(Exception exc)
     {
         var httpRequestException = exc as HttpRequestException;
         if (httpRequestException != null)

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -343,14 +343,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
 
             if (this.emitNewAttributes)
             {
-#if NET8_0_OR_GREATER
-                // For net8.0 and above exception type can be found using HttpRequestError.
-                // https://learn.microsoft.com/dotnet/api/system.net.http.httprequesterror?view=net-8.0
-                var errorType = GetErrorType(exc);
-#else
-                var errorType = exc.GetType().FullName;
-#endif
-                activity.SetTag(SemanticConventions.AttributeErrorType, errorType);
+                activity.SetTag(SemanticConventions.AttributeErrorType, GetErrorType(exc));
             }
 
             if (this.options.RecordException)
@@ -389,9 +382,11 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
         }
     }
 
-#if NET8_0_OR_GREATER
     private static string GetErrorType(Exception exc)
     {
+#if NET8_0_OR_GREATER
+        // For net8.0 and above exception type can be found using HttpRequestError.
+        // https://learn.microsoft.com/dotnet/api/system.net.http.httprequesterror?view=net-8.0
         var httpRequestException = exc as HttpRequestException;
         if (httpRequestException != null)
         {
@@ -417,6 +412,8 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
         {
             return exc.GetType().FullName;
         }
-    }
+#else
+        return exc.GetType().FullName;
 #endif
+    }
 }

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -387,8 +387,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
 #if NET8_0_OR_GREATER
         // For net8.0 and above exception type can be found using HttpRequestError.
         // https://learn.microsoft.com/dotnet/api/system.net.http.httprequesterror?view=net-8.0
-        var httpRequestException = exc as HttpRequestException;
-        if (httpRequestException != null)
+        if (exc is HttpRequestException httpRequestException)
         {
             return httpRequestException.HttpRequestError switch
             {
@@ -408,12 +407,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
                 _ => exc.GetType().FullName,
             };
         }
-        else
-        {
-            return exc.GetType().FullName;
-        }
-#else
-        return exc.GetType().FullName;
 #endif
+        return exc.GetType().FullName;
     }
 }

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -259,6 +259,11 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
 
             if (TryFetchResponse(payload, out HttpResponseMessage response))
             {
+                if (currentStatusCode == ActivityStatusCode.Unset)
+                {
+                    activity.SetStatus(SpanHelper.ResolveSpanStatusForHttpStatusCode(activity.Kind, (int)response.StatusCode));
+                }
+
                 if (this.emitOldAttributes)
                 {
                     activity.SetTag(SemanticConventions.AttributeHttpStatusCode, TelemetryHelper.GetBoxedStatusCode(response.StatusCode));
@@ -267,11 +272,10 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
                 if (this.emitNewAttributes)
                 {
                     activity.SetTag(SemanticConventions.AttributeHttpResponseStatusCode, TelemetryHelper.GetBoxedStatusCode(response.StatusCode));
-                }
-
-                if (currentStatusCode == ActivityStatusCode.Unset)
-                {
-                    activity.SetStatus(SpanHelper.ResolveSpanStatusForHttpStatusCode(activity.Kind, (int)response.StatusCode));
+                    if (activity.Status == ActivityStatusCode.Error)
+                    {
+                        activity.SetTag("error.type", TelemetryHelper.GetBoxedStatusCode(response.StatusCode));
+                    }
                 }
 
                 try

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -344,6 +344,8 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
             if (this.emitNewAttributes)
             {
 #if NET8_0_OR_GREATER
+                // For net8.0 and above exception type can be found using HttpRequestError.
+                // https://learn.microsoft.com/dotnet/api/system.net.http.httprequesterror?view=net-8.0
                 var errorType = GetErrorType(exc);
 #else
                 var errorType = exc.GetType().FullName;

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
@@ -141,6 +141,8 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
                 {
                     tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpResponseStatusCode, TelemetryHelper.GetBoxedStatusCode(response.StatusCode)));
 
+                    // Set error.type to status code for failed requests
+                    // https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/http/http-spans.md#common-attributes
                     if (SpanHelper.ResolveSpanStatusForHttpStatusCode(ActivityKind.Client, (int)response.StatusCode) == ActivityStatusCode.Error)
                     {
                         tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeErrorType, TelemetryHelper.GetBoxedStatusCode(response.StatusCode)));
@@ -154,6 +156,9 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
 #else
                     request.Options.TryGetValue(HttpRequestOptionsErrorKey, out var errorType);
 #endif
+
+                    // Set error.type to exception type if response was not received.
+                    // https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/http/http-spans.md#common-attributes
                     if (errorType != null)
                     {
                         tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeErrorType, errorType));

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
@@ -183,7 +183,7 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
         // The AOT-annotation DynamicallyAccessedMembers in System.Net.Http library ensures that top-level properties on the payload object are always preserved.
         // see https://github.com/dotnet/runtime/blob/f9246538e3d49b90b0e9128d7b1defef57cd6911/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L325
 #if NET6_0_OR_GREATER
-        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The eSystem.Net.Http library guarantees that top-level properties are preserved")]
+        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The System.Net.Http library guarantees that top-level properties are preserved")]
 #endif
         static bool TryFetchResponse(object payload, out HttpResponseMessage response) =>
             StopResponseFetcher.TryFetch(payload, out response) && response != null;

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
@@ -206,7 +206,7 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
         // The AOT-annotation DynamicallyAccessedMembers in System.Net.Http library ensures that top-level properties on the payload object are always preserved.
         // see https://github.com/dotnet/runtime/blob/f9246538e3d49b90b0e9128d7b1defef57cd6911/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L325
 #if NET6_0_OR_GREATER
-        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top-level properties are preserved")]
+        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The System.Net.Http library guarantees that top-level properties are preserved")]
 #endif
         static bool TryFetchException(object payload, out Exception exc)
         {
@@ -221,7 +221,7 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
         // The AOT-annotation DynamicallyAccessedMembers in System.Net.Http library ensures that top-level properties on the payload object are always preserved.
         // see https://github.com/dotnet/runtime/blob/f9246538e3d49b90b0e9128d7b1defef57cd6911/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L325
 #if NET6_0_OR_GREATER
-        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top-level properties are preserved")]
+        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The System.Net.Http library guarantees that top-level properties are preserved")]
 #endif
         static bool TryFetchRequest(object payload, out HttpRequestMessage request)
         {

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
@@ -175,7 +175,7 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
         // The AOT-annotation DynamicallyAccessedMembers in System.Net.Http library ensures that top-level properties on the payload object are always preserved.
         // see https://github.com/dotnet/runtime/blob/f9246538e3d49b90b0e9128d7b1defef57cd6911/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L325
 #if NET6_0_OR_GREATER
-        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The System.Net.Http libraryguarantees that top-level properties are preserved")]
+        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The System.Net.Http library guarantees that top-level properties are preserved")]
 #endif
         static bool TryFetchRequest(object payload, out HttpRequestMessage request) =>
             StopRequestFetcher.TryFetch(payload, out request) && request != null;

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
@@ -130,6 +130,7 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
 
                 tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeServerAddress, request.RequestUri.Host));
                 tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeUrlScheme, request.RequestUri.Scheme));
+                tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeNetworkProtocolVersion, HttpTagHelper.GetFlavorTagValueFromProtocolVersion(request.Version)));
 
                 if (!request.RequestUri.IsDefaultPort)
                 {
@@ -139,7 +140,6 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
                 if (TryFetchResponse(payload, out HttpResponseMessage response))
                 {
                     tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpResponseStatusCode, TelemetryHelper.GetBoxedStatusCode(response.StatusCode)));
-                    tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeNetworkProtocolVersion, HttpTagHelper.GetFlavorTagValueFromProtocolVersion(response.Version)));
 
                     if (SpanHelper.ResolveSpanStatusForHttpStatusCode(ActivityKind.Client, (int)response.StatusCode) == ActivityStatusCode.Error)
                     {

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
@@ -36,11 +36,13 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
     internal static readonly string MeterName = AssemblyName.Name;
     internal static readonly string MeterVersion = AssemblyName.Version.ToString();
     internal static readonly Meter Meter = new(MeterName, MeterVersion);
+    private const string OnUnhandledExceptionEvent = "System.Net.Http.Exception";
     private static readonly Histogram<double> HttpClientDuration = Meter.CreateHistogram<double>("http.client.duration", "ms", "Measures the duration of outbound HTTP requests.");
     private static readonly Histogram<double> HttpClientRequestDuration = Meter.CreateHistogram<double>("http.client.request.duration", "s", "Duration of HTTP client requests.");
 
     private static readonly PropertyFetcher<HttpRequestMessage> StopRequestFetcher = new("Request");
     private static readonly PropertyFetcher<HttpResponseMessage> StopResponseFetcher = new("Response");
+    private static readonly PropertyFetcher<Exception> StopExceptionFetcher = new("Exception");
     private readonly HttpClientMetricInstrumentationOptions options;
     private readonly bool emitOldAttributes;
     private readonly bool emitNewAttributes;
@@ -56,67 +58,93 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
 
     public override void OnEventWritten(string name, object payload)
     {
-        if (name == OnStopEvent)
+        if (name == OnUnhandledExceptionEvent)
         {
-            if (Sdk.SuppressInstrumentation)
+            if (this.emitNewAttributes)
             {
-                return;
+                this.OnExceptionEventWritten(Activity.Current, payload);
+            }
+        }
+        else if (name == OnStopEvent)
+        {
+            this.OnStopEventWritten(Activity.Current, payload);
+        }
+    }
+
+    public void OnStopEventWritten(Activity activity, object payload)
+    {
+        if (Sdk.SuppressInstrumentation)
+        {
+            return;
+        }
+
+        if (TryFetchRequest(payload, out HttpRequestMessage request))
+        {
+            // see the spec https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/trace/semantic_conventions/http.md
+            if (this.emitOldAttributes)
+            {
+                TagList tags = default;
+
+                tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpMethod, HttpTagHelper.GetNameForHttpMethod(request.Method)));
+                tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, request.RequestUri.Scheme));
+                tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpFlavor, HttpTagHelper.GetFlavorTagValueFromProtocolVersion(request.Version)));
+                tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerName, request.RequestUri.Host));
+
+                if (!request.RequestUri.IsDefaultPort)
+                {
+                    tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerPort, request.RequestUri.Port));
+                }
+
+                if (TryFetchResponse(payload, out HttpResponseMessage response))
+                {
+                    tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpStatusCode, TelemetryHelper.GetBoxedStatusCode(response.StatusCode)));
+                }
+
+                // We are relying here on HttpClient library to set duration before writing the stop event.
+                // https://github.com/dotnet/runtime/blob/90603686d314147017c8bbe1fa8965776ce607d0/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L178
+                // TODO: Follow up with .NET team if we can continue to rely on this behavior.
+                HttpClientDuration.Record(activity.Duration.TotalMilliseconds, tags);
             }
 
-            var activity = Activity.Current;
-            if (TryFetchRequest(payload, out HttpRequestMessage request))
+            // see the spec https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/http/http-spans.md
+            if (this.emitNewAttributes)
             {
-                // see the spec https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/trace/semantic_conventions/http.md
-                if (this.emitOldAttributes)
+                TagList tags = default;
+
+                tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpRequestMethod, HttpTagHelper.GetNameForHttpMethod(request.Method)));
+                tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeNetworkProtocolVersion, HttpTagHelper.GetFlavorTagValueFromProtocolVersion(request.Version)));
+                tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeServerAddress, request.RequestUri.Host));
+                tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeUrlScheme, request.RequestUri.Scheme));
+
+                if (!request.RequestUri.IsDefaultPort)
                 {
-                    TagList tags = default;
-
-                    tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpMethod, HttpTagHelper.GetNameForHttpMethod(request.Method)));
-                    tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpScheme, request.RequestUri.Scheme));
-                    tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpFlavor, HttpTagHelper.GetFlavorTagValueFromProtocolVersion(request.Version)));
-                    tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerName, request.RequestUri.Host));
-
-                    if (!request.RequestUri.IsDefaultPort)
-                    {
-                        tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeNetPeerPort, request.RequestUri.Port));
-                    }
-
-                    if (TryFetchResponse(payload, out HttpResponseMessage response))
-                    {
-                        tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpStatusCode, TelemetryHelper.GetBoxedStatusCode(response.StatusCode)));
-                    }
-
-                    // We are relying here on HttpClient library to set duration before writing the stop event.
-                    // https://github.com/dotnet/runtime/blob/90603686d314147017c8bbe1fa8965776ce607d0/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L178
-                    // TODO: Follow up with .NET team if we can continue to rely on this behavior.
-                    HttpClientDuration.Record(activity.Duration.TotalMilliseconds, tags);
+                    tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeServerPort, request.RequestUri.Port));
                 }
 
-                // see the spec https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/http/http-spans.md
-                if (this.emitNewAttributes)
+                if (TryFetchResponse(payload, out HttpResponseMessage response))
                 {
-                    TagList tags = default;
+                    tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpResponseStatusCode, TelemetryHelper.GetBoxedStatusCode(response.StatusCode)));
 
-                    tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpRequestMethod, HttpTagHelper.GetNameForHttpMethod(request.Method)));
-                    tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeNetworkProtocolVersion, HttpTagHelper.GetFlavorTagValueFromProtocolVersion(request.Version)));
-                    tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeServerAddress, request.RequestUri.Host));
-                    tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeUrlScheme, request.RequestUri.Scheme));
-
-                    if (!request.RequestUri.IsDefaultPort)
+                    var spanStatus = SpanHelper.ResolveSpanStatusForHttpStatusCode(activity.Kind, (int)response.StatusCode);
+                    if (spanStatus != ActivityStatusCode.Unset)
                     {
-                        tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeServerPort, request.RequestUri.Port));
+                        tags.Add(new KeyValuePair<string, object>("error.type", TelemetryHelper.GetBoxedStatusCode(response.StatusCode)));
                     }
-
-                    if (TryFetchResponse(payload, out HttpResponseMessage response))
-                    {
-                        tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpResponseStatusCode, TelemetryHelper.GetBoxedStatusCode(response.StatusCode)));
-                    }
-
-                    // We are relying here on HttpClient library to set duration before writing the stop event.
-                    // https://github.com/dotnet/runtime/blob/90603686d314147017c8bbe1fa8965776ce607d0/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L178
-                    // TODO: Follow up with .NET team if we can continue to rely on this behavior.
-                    HttpClientRequestDuration.Record(activity.Duration.TotalSeconds, tags);
                 }
+
+                if (response == null)
+                {
+                    var errorType = activity.GetTagValue("error.type");
+                    if (errorType != null)
+                    {
+                        tags.Add(new KeyValuePair<string, object>("error.type", errorType));
+                    }
+                }
+
+                // We are relying here on HttpClient library to set duration before writing the stop event.
+                // https://github.com/dotnet/runtime/blob/90603686d314147017c8bbe1fa8965776ce607d0/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L178
+                // TODO: Follow up with .NET team if we can continue to rely on this behavior.
+                HttpClientRequestDuration.Record(activity.Duration.TotalSeconds, tags);
             }
         }
 
@@ -135,5 +163,31 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
 #endif
         static bool TryFetchResponse(object payload, out HttpResponseMessage response) =>
             StopResponseFetcher.TryFetch(payload, out response) && response != null;
+    }
+
+    public void OnExceptionEventWritten(Activity activity, object payload)
+    {
+        if (!TryFetchException(payload, out Exception exc))
+        {
+            HttpInstrumentationEventSource.Log.NullPayload(nameof(HttpHandlerDiagnosticListener), nameof(this.OnExceptionEventWritten));
+            return;
+        }
+
+        activity.SetTag("error.type", exc.GetType().FullName);
+
+        // The AOT-annotation DynamicallyAccessedMembers in System.Net.Http library ensures that top-level properties on the payload object are always preserved.
+        // see https://github.com/dotnet/runtime/blob/f9246538e3d49b90b0e9128d7b1defef57cd6911/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L325
+#if NET6_0_OR_GREATER
+        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top-level properties are preserved")]
+#endif
+        static bool TryFetchException(object payload, out Exception exc)
+        {
+            if (!StopExceptionFetcher.TryFetch(payload, out exc) || exc == null)
+            {
+                return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
@@ -128,7 +128,6 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
                     tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpRequestMethod, "_OTHER"));
                 }
 
-                tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeNetworkProtocolVersion, HttpTagHelper.GetFlavorTagValueFromProtocolVersion(request.Version)));
                 tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeServerAddress, request.RequestUri.Host));
                 tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeUrlScheme, request.RequestUri.Scheme));
 
@@ -140,6 +139,7 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
                 if (TryFetchResponse(payload, out HttpResponseMessage response))
                 {
                     tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpResponseStatusCode, TelemetryHelper.GetBoxedStatusCode(response.StatusCode)));
+                    tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeNetworkProtocolVersion, HttpTagHelper.GetFlavorTagValueFromProtocolVersion(response.Version)));
 
                     if (SpanHelper.ResolveSpanStatusForHttpStatusCode(ActivityKind.Client, (int)response.StatusCode) == ActivityStatusCode.Error)
                     {

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerMetricsDiagnosticListener.cs
@@ -170,7 +170,7 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
         // The AOT-annotation DynamicallyAccessedMembers in System.Net.Http library ensures that top-level properties on the payload object are always preserved.
         // see https://github.com/dotnet/runtime/blob/f9246538e3d49b90b0e9128d7b1defef57cd6911/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L325
 #if NET6_0_OR_GREATER
-        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top-level properties are preserved")]
+        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The System.Net.Http libraryguarantees that top-level properties are preserved")]
 #endif
         static bool TryFetchRequest(object payload, out HttpRequestMessage request) =>
             StopRequestFetcher.TryFetch(payload, out request) && request != null;
@@ -178,7 +178,7 @@ internal sealed class HttpHandlerMetricsDiagnosticListener : ListenerHandler
         // The AOT-annotation DynamicallyAccessedMembers in System.Net.Http library ensures that top-level properties on the payload object are always preserved.
         // see https://github.com/dotnet/runtime/blob/f9246538e3d49b90b0e9128d7b1defef57cd6911/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs#L325
 #if NET6_0_OR_GREATER
-        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The event source guarantees that top-level properties are preserved")]
+        [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The eSystem.Net.Http library guarantees that top-level properties are preserved")]
 #endif
         static bool TryFetchResponse(object payload, out HttpResponseMessage response) =>
             StopResponseFetcher.TryFetch(payload, out response) && response != null;

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.cs
@@ -394,20 +394,24 @@ public partial class HttpClientTests
                 {
                     Assert.Contains(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeHttpResponseStatusCode && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeHttpStatusCode]);
 
+#if !NETFRAMEWORK
                     if (tc.ResponseCode >= 400)
                     {
                         Assert.Contains(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeErrorType && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeHttpStatusCode]);
                     }
+#endif
                 }
                 else
                 {
                     Assert.DoesNotContain(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeHttpResponseStatusCode);
+#if !NETFRAMEWORK
 #if !NET8_0_OR_GREATER
                     Assert.Contains(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeErrorType && kvp.Value.ToString() == "System.Net.Http.HttpRequestException");
 #else
                     // we are using fake address so it will be "name_resolution_error"
                     // TODO: test other error types.
                     Assert.Contains(normalizedAttributes, kvp => kvp.Key == SemanticConventions.AttributeErrorType && kvp.Value.ToString() == "name_resolution_error");
+#endif
 #endif
                 }
             }
@@ -545,7 +549,13 @@ public partial class HttpClientTests
                 }
 
 #if !NETFRAMEWORK
+#if !NET8_0_OR_GREATER
+                var numberOfTags = 6;
+#else
+                // network.protocol.version is not emitted when response if not received.
+                // https://github.com/open-telemetry/opentelemetry-dotnet/issues/4928
                 var numberOfTags = 5;
+#endif
                 if (tc.ResponseExpected)
                 {
                     var expectedStatusCode = int.Parse(normalizedAttributesTestCase[SemanticConventions.AttributeHttpStatusCode]);
@@ -563,28 +573,37 @@ public partial class HttpClientTests
                 Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeServerAddress && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeNetPeerName]);
                 Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeServerPort && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeNetPeerPort]);
                 Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeUrlScheme && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeHttpScheme]);
+#if !NET8_0_OR_GREATER
+                Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeNetworkProtocolVersion && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeHttpFlavor]);
+#endif
 
                 if (tc.ResponseExpected)
                 {
-                    Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeNetworkProtocolVersion && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeHttpFlavor]);
                     Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeHttpResponseStatusCode && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeHttpStatusCode]);
 
+#if !NETFRAMEWORK
                     if (tc.ResponseCode >= 400)
                     {
                         Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeErrorType && kvp.Value.ToString() == normalizedAttributesTestCase[SemanticConventions.AttributeHttpStatusCode]);
                     }
+#endif
                 }
                 else
                 {
-                    Assert.DoesNotContain(attributes, kvp => kvp.Key == SemanticConventions.AttributeNetworkProtocolVersion);
                     Assert.DoesNotContain(attributes, kvp => kvp.Key == SemanticConventions.AttributeHttpResponseStatusCode);
 
+#if !NETFRAMEWORK
 #if !NET8_0_OR_GREATER
                     Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeErrorType && kvp.Value.ToString() == "System.Net.Http.HttpRequestException");
 #else
                     // we are using fake address so it will be "name_resolution_error"
                     // TODO: test other error types.
                     Assert.Contains(attributes, kvp => kvp.Key == SemanticConventions.AttributeErrorType && kvp.Value.ToString() == "name_resolution_error");
+
+                    // network.protocol.version is not emitted when response if not received.
+                    // https://github.com/open-telemetry/opentelemetry-dotnet/issues/4928
+                    Assert.DoesNotContain(attributes, kvp => kvp.Key == SemanticConventions.AttributeNetworkProtocolVersion);
+#endif
 #endif
                 }
 

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/http-out-test-cases.json
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/http-out-test-cases.json
@@ -322,24 +322,6 @@
     }
   },
   {
-    "name": "Response code: 600",
-    "method": "GET",
-    "url": "http://{host}:{port}/",
-    "responseCode": 600,
-    "spanName": "HTTP GET",
-    "spanStatus": "Error",
-    "responseExpected": true,
-    "spanAttributes": {
-      "http.scheme": "http",
-      "http.method": "GET",
-      "net.peer.name": "{host}",
-      "net.peer.port": "{port}",
-      "http.flavor": "{flavor}",
-      "http.status_code": "600",
-      "http.url": "http://{host}:{port}/"
-    }
-  },
-  {
     "name": "Http version attribute populated",
     "method": "GET",
     "url": "http://{host}:{port}/",


### PR DESCRIPTION
Fixes #
Design discussion issue #

## Changes
 Adds [error.type](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#:~:text=If%20response%20status%20code%20was%20sent%20or%20received%20and%20status%20indicates%20an%20error%20according%20to%20HTTP%20span%20status%20definition%2C%20error.type%20SHOULD%20be%20set%20to%20the%20status%20code%20number%20(represented%20as%20a%20string)%2C%20an%20exception%20type%20(if%20thrown)%20or%20a%20component%2Dspecific%20error%20identifier) attribute to activity and `http.client.request.duration`  for HttpClient for `non-netframework` targets. 

1. Adds `error.type` attribute to activity for `netstandard`, `net6.0` , `net7.0` and `net8.0` targets. For `net8.0` target the value will vary due to the addition of [HttpRequestError](https://learn.microsoft.com/dotnet/api/system.net.http.httprequesterror?view=net-8.0) Enum, which allows further drilldown of `HttpRequestException` \ `HttpIOExceptiontype`. This is in sync with how the tag is emitted on `httpclient.request.duration` metric on [.NET8.0](https://github.com/dotnet/runtime/blob/69702c372a051580f76defc7ba899dde8fcd2723/src/libraries/System.Net.Http/src/System/Net/Http/Metrics/MetricsHandler.cs#L143-L173).
2. Adds `error.type` attribute to `http.client.request.duration` metric for  `netstandard`, `net6.0`  and `net7.0` targets. On `net8.0`, metric will be emitted via added meter `System.Net.Http` within instrumentation library.

TODO: Cover `HttpWebRequest`.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
