### PR TITLE
[Exemplars] Add isSampled check for Histograms

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -68,7 +68,7 @@
   -->
   <!-- 'net7.0' is the default `TargetFramework`. Use `VersionOverride` in the project to override the package versions from a different `TargetFramework` -->
   <ItemGroup>
-    <PackageVersion Include="BenchmarkDotNet" Version="[0.13.6,0.14)" />
+    <PackageVersion Include="BenchmarkDotNet" Version="[0.13.10,0.14)" />
     <PackageVersion Include="CommandLineParser" Version="[2.9.1,3.0)" />
     <PackageVersion Include="Grpc.AspNetCore" Version="[2.55.0,3.0)" />
     <PackageVersion Include="Grpc.AspNetCore.Server" Version="[2.55.0, 3.0)" />

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -535,25 +535,25 @@ public struct MetricPoint
 
             case AggregationType.Histogram:
                 {
-                    this.UpdateHistogram((double)number, tags, true);
+                    this.UpdateHistogram((double)number, tags, reportExemplar: true, isSampled);
                     break;
                 }
 
             case AggregationType.HistogramWithMinMax:
                 {
-                    this.UpdateHistogramWithMinMax((double)number, tags, true);
+                    this.UpdateHistogramWithMinMax((double)number, tags, reportExemplar: true, isSampled);
                     break;
                 }
 
             case AggregationType.HistogramWithBuckets:
                 {
-                    this.UpdateHistogramWithBuckets((double)number, tags, true);
+                    this.UpdateHistogramWithBuckets((double)number, tags, reportExemplar: true, isSampled);
                     break;
                 }
 
             case AggregationType.HistogramWithMinMaxBuckets:
                 {
-                    this.UpdateHistogramWithBucketsAndMinMax((double)number, tags, true);
+                    this.UpdateHistogramWithBucketsAndMinMax((double)number, tags, reportExemplar: true, isSampled);
                     break;
                 }
 
@@ -762,25 +762,25 @@ public struct MetricPoint
 
             case AggregationType.Histogram:
                 {
-                    this.UpdateHistogram(number, tags, true);
+                    this.UpdateHistogram(number, tags, reportExemplar: true, isSampled);
                     break;
                 }
 
             case AggregationType.HistogramWithMinMax:
                 {
-                    this.UpdateHistogramWithMinMax(number, tags, true);
+                    this.UpdateHistogramWithMinMax(number, tags, reportExemplar: true, isSampled);
                     break;
                 }
 
             case AggregationType.HistogramWithBuckets:
                 {
-                    this.UpdateHistogramWithBuckets(number, tags, true);
+                    this.UpdateHistogramWithBuckets(number, tags, reportExemplar: true, isSampled);
                     break;
                 }
 
             case AggregationType.HistogramWithMinMaxBuckets:
                 {
-                    this.UpdateHistogramWithBucketsAndMinMax(number, tags, true);
+                    this.UpdateHistogramWithBucketsAndMinMax(number, tags, reportExemplar: true, isSampled);
                     break;
                 }
 
@@ -1384,7 +1384,7 @@ public struct MetricPoint
         Interlocked.Exchange(ref isCriticalSectionOccupied, 0);
     }
 
-    private void UpdateHistogram(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool reportExemplar = false)
+    private void UpdateHistogram(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool reportExemplar = false, bool isSampled = false)
     {
         Debug.Assert(this.mpComponents?.HistogramBuckets != null, "HistogramBuckets was null");
 
@@ -1398,7 +1398,7 @@ public struct MetricPoint
             histogramBuckets.RunningSum += number;
         }
 
-        if (reportExemplar)
+        if (reportExemplar && isSampled)
         {
             Debug.Assert(this.mpComponents.ExemplarReservoir != null, "ExemplarReservoir was null");
 
@@ -1410,7 +1410,7 @@ public struct MetricPoint
         ReleaseLock(ref histogramBuckets.IsCriticalSectionOccupied);
     }
 
-    private void UpdateHistogramWithMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool reportExemplar = false)
+    private void UpdateHistogramWithMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool reportExemplar = false, bool isSampled = false)
     {
         Debug.Assert(this.mpComponents?.HistogramBuckets != null, "HistogramBuckets was null");
 
@@ -1426,7 +1426,7 @@ public struct MetricPoint
             histogramBuckets.RunningMax = Math.Max(histogramBuckets.RunningMax, number);
         }
 
-        if (reportExemplar)
+        if (reportExemplar && isSampled)
         {
             Debug.Assert(this.mpComponents.ExemplarReservoir != null, "ExemplarReservoir was null");
 
@@ -1438,7 +1438,7 @@ public struct MetricPoint
         ReleaseLock(ref histogramBuckets.IsCriticalSectionOccupied);
     }
 
-    private void UpdateHistogramWithBuckets(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool reportExemplar = false)
+    private void UpdateHistogramWithBuckets(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool reportExemplar = false, bool isSampled = false)
     {
         Debug.Assert(this.mpComponents?.HistogramBuckets != null, "HistogramBuckets was null");
 
@@ -1456,7 +1456,7 @@ public struct MetricPoint
             histogramBuckets.RunningSum += number;
             histogramBuckets.RunningBucketCounts![i]++;
 
-            if (reportExemplar)
+            if (reportExemplar && isSampled)
             {
                 Debug.Assert(this.mpComponents.ExemplarReservoir != null, "ExemplarReservoir was null");
 
@@ -1469,7 +1469,7 @@ public struct MetricPoint
         ReleaseLock(ref histogramBuckets.IsCriticalSectionOccupied);
     }
 
-    private void UpdateHistogramWithBucketsAndMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool reportExemplar = false)
+    private void UpdateHistogramWithBucketsAndMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool reportExemplar = false, bool isSampled = false)
     {
         Debug.Assert(this.mpComponents?.HistogramBuckets != null, "histogramBuckets was null");
 
@@ -1487,7 +1487,7 @@ public struct MetricPoint
             histogramBuckets.RunningSum += number;
             histogramBuckets.RunningBucketCounts![i]++;
 
-            if (reportExemplar)
+            if (reportExemplar && isSampled)
             {
                 Debug.Assert(this.mpComponents.ExemplarReservoir != null, "ExemplarReservoir was null");
 

--- a/test/Benchmarks/Metrics/ExemplarBenchmarks.cs
+++ b/test/Benchmarks/Metrics/ExemplarBenchmarks.cs
@@ -22,21 +22,21 @@ using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
 
 /*
-BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.23424.1000)
+BenchmarkDotNet v0.13.10, Windows 11 (10.0.23424.1000)
 Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
-.NET SDK=7.0.203
-  [Host]     : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
-  DefaultJob : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
+.NET SDK 8.0.100-rc.2.23502.2
+  [Host]     : .NET 7.0.13 (7.0.1323.51816), X64 RyuJIT AVX2
+  DefaultJob : .NET 7.0.13 (7.0.1323.51816), X64 RyuJIT AVX2
 
 
-|                    Method | ExemplarFilter |     Mean |   Error |  StdDev | Allocated |
-|-------------------------- |--------------- |---------:|--------:|--------:|----------:|
-|   HistogramNoTagReduction |      AlwaysOff | 315.5 ns | 5.93 ns | 5.55 ns |         - |
-| HistogramWithTagReduction |      AlwaysOff | 296.4 ns | 0.95 ns | 0.89 ns |         - |
-|   HistogramNoTagReduction |       AlwaysOn | 366.5 ns | 6.96 ns | 7.74 ns |         - |
-| HistogramWithTagReduction |       AlwaysOn | 397.1 ns | 4.09 ns | 3.82 ns |         - |
-|   HistogramNoTagReduction |  HighValueOnly | 364.8 ns | 2.73 ns | 2.28 ns |         - |
-| HistogramWithTagReduction |  HighValueOnly | 391.9 ns | 4.38 ns | 4.10 ns |         - |
+| Method                    | ExemplarFilter | Mean     | Error   | StdDev  |
+|-------------------------- |--------------- |---------:|--------:|--------:|
+| HistogramNoTagReduction   | AlwaysOff      | 316.7 ns | 1.01 ns | 0.89 ns |
+| HistogramWithTagReduction | AlwaysOff      | 298.9 ns | 2.44 ns | 2.16 ns |
+| HistogramNoTagReduction   | AlwaysOn       | 359.6 ns | 1.26 ns | 1.11 ns |
+| HistogramWithTagReduction | AlwaysOn       | 400.1 ns | 4.16 ns | 3.90 ns |
+| HistogramNoTagReduction   | HighValueOnly  | 325.3 ns | 3.33 ns | 2.78 ns |
+| HistogramWithTagReduction | HighValueOnly  | 320.7 ns | 4.91 ns | 4.60 ns |
 */
 
 namespace Benchmarks.Metrics;


### PR DESCRIPTION
## Changes
- Add `isSampled` check for Histogram updates so that we call ExemplarReservoir only when the ExemplarFilter samples the measurement
- Update Benchmark.NET package version

## Merge requirement checklist

* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
