### PR TITLE
Remove zero bucket for the histogram buckets for ASP.NET Core and HttpClient metrics

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -22,7 +22,7 @@
   * `signalr.server.connection.duration`
   * `kestrel.connection.duration`
   * `http.client.connection.duration`
-  
+
   These histogram metrics which have their `Unit` as `s` (second) will have
   their default histogram buckets as `[ 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2,
   5, 10, 30, 60, 120, 300 ]`.

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -21,9 +21,11 @@
   metrics from ASP.NET Core and HttpClient runtime:
   * `signalr.server.connection.duration`
   * `kestrel.connection.duration`
-  * `http.client.connection.duration` These histogram metrics which have their
-  `Unit` as `s` (second) will have their default histogram buckets as `[ 0.01,
-  0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300 ]`.
+  * `http.client.connection.duration`
+  
+  These histogram metrics which have their `Unit` as `s` (second) will have
+  their default histogram buckets as `[ 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2,
+  5, 10, 30, 60, 120, 300 ]`.
   ([#5008](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5008))
 
 * Remove the bucket with value `0` for histogram buckets for metrics from

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -26,6 +26,10 @@
   0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300 ]`.
   ([#5008](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5008))
 
+* Remove the bucket with value `0` for histogram buckets for metrics from
+  ASP.NET Core and HttpClient.
+  ([#5021](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5021))
+
 ## 1.7.0-alpha.1
 
 Released 2023-Oct-16

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -27,8 +27,9 @@
   their default histogram buckets as `[ 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2,
   5, 10, 30, 60, 120, 300 ]`.
   ([#5008](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5008))
+  ([#5021](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5021))
 
-* Remove the bucket with value `0` for histogram buckets for metrics from
+* Remove the bucket with value `0` for histogram buckets for all metrics from
   ASP.NET Core and HttpClient.
   ([#5021](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5021))
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -17,8 +17,13 @@
   ([#5004](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5004))
   ([#5016](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5016))
 
-* Update `AggregatorStore` to provide known connection metrics with larger
-  histogram buckets.
+* Update Metrics SDK to override the default histogram buckets for the following
+  metrics from ASP.NET Core and HttpClient runtime:
+  * `signalr.server.connection.duration`
+  * `kestrel.connection.duration`
+  * `http.client.connection.duration` These histogram metrics which have their
+  `Unit` as `s` (second) will have their default histogram buckets as `[ 0.01,
+  0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300 ]`.
   ([#5008](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5008))
 
 ## 1.7.0-alpha.1

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -30,7 +30,7 @@ public sealed class Metric
     internal static readonly double[] DefaultHistogramBounds = new double[] { 0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000 };
 
     // Short default histogram bounds. Based on the recommended semantic convention values for http.server.request.duration.
-    internal static readonly double[] DefaultHistogramBoundsShortSeconds = new double[] { 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10 };
+    internal static readonly double[] DefaultHistogramBoundsShortSeconds = new double[] { 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10 };
     internal static readonly HashSet<(string, string)> DefaultHistogramBoundShortMappings = new()
     {
         ("Microsoft.AspNetCore.Hosting", "http.server.request.duration"),
@@ -45,7 +45,7 @@ public sealed class Metric
     };
 
     // Long default histogram bounds. Not based on a standard. May change in the future.
-    internal static readonly double[] DefaultHistogramBoundsLongSeconds = new double[] { 0, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300 };
+    internal static readonly double[] DefaultHistogramBoundsLongSeconds = new double[] { 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300 };
     internal static readonly HashSet<(string, string)> DefaultHistogramBoundLongMappings = new()
     {
         ("Microsoft.AspNetCore.Http.Connections", "signalr.server.connection.duration"),

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
@@ -557,9 +557,15 @@ public class MetricTests
             histogramBounds.Add(t.ExplicitBound);
         }
 
-        Assert.Equal(
-            expected: new List<double> { 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, double.PositiveInfinity },
-            actual: histogramBounds);
+        // TODO: Remove the check for the older bounds once 1.7.0 is released. This is a temporary fix for instrumentation libraries CI workflow.
+
+        var expectedHistogramBoundsOld = new List<double> { 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, double.PositiveInfinity };
+        var expectedHistogramBoundsNew = new List<double> { 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, double.PositiveInfinity };
+
+        var histogramBoundsMatchCorrectly = Enumerable.SequenceEqual(expectedHistogramBoundsOld, histogramBounds) ||
+            Enumerable.SequenceEqual(expectedHistogramBoundsNew, histogramBounds);
+
+        Assert.True(histogramBoundsMatchCorrectly);
 
         return attributes;
     }

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/MetricTests.cs
@@ -558,7 +558,7 @@ public class MetricTests
         }
 
         Assert.Equal(
-            expected: new List<double> { 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, double.PositiveInfinity },
+            expected: new List<double> { 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, double.PositiveInfinity },
             actual: histogramBounds);
 
         return attributes;

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.cs
@@ -546,7 +546,7 @@ public partial class HttpClientTests
                 }
 
                 Assert.Equal(
-                    expected: new List<double> { 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, double.PositiveInfinity },
+                    expected: new List<double> { 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, double.PositiveInfinity },
                     actual: histogramBounds);
             }
         }

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.cs
@@ -545,9 +545,15 @@ public partial class HttpClientTests
                     histogramBounds.Add(t.ExplicitBound);
                 }
 
-                Assert.Equal(
-                    expected: new List<double> { 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, double.PositiveInfinity },
-                    actual: histogramBounds);
+                // TODO: Remove the check for the older bounds once 1.7.0 is released. This is a temporary fix for instrumentation libraries CI workflow.
+
+                var expectedHistogramBoundsOld = new List<double> { 0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, double.PositiveInfinity };
+                var expectedHistogramBoundsNew = new List<double> { 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, double.PositiveInfinity };
+
+                var histogramBoundsMatchCorrectly = Enumerable.SequenceEqual(expectedHistogramBoundsOld, histogramBounds) ||
+                    Enumerable.SequenceEqual(expectedHistogramBoundsNew, histogramBounds);
+
+                Assert.True(histogramBoundsMatchCorrectly);
             }
         }
     }


### PR DESCRIPTION
Fixes #4908 

## Changes
- Remove zero bucket for the histogram buckets for ASP.NET Core and HttpClient metrics

Please provide a brief description of the changes here.

## Merge requirement checklist

* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
