### PR TITLE
[AspNetCore] [Http] remove Activity Status Description and update unit tests

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Removed the Activity Status Description that was being set during unhandled
+* Removed the Activity Status Description that was being set during
   exceptions. Activity Status will continue to be reported as `Error`.
   This is a **breaking change**. `EnrichWithException` can be leveraged
   to restore this behavior.

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 ## Unreleased
 
-* On Exception, Activity Status is set to Error. The Exception Message
-  has been removed from Activity Status Description to comply with the
-  [Http spec](https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/http/http-spans.md#status).
+* Removed the Activity Status Description that was being set during unhandled
+  exceptions. Activity Status will continue to be reported as `Error`.
   This is a **breaking change**. `EnrichWithException` can be leveraged
   to restore this behavior.
   ([#5025](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5025))

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+* On Exception, Activity Status is set to Error. The Exception Message
+  has been removed from Activity Status Description to comply with the
+  [Http spec](https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/http/http-spans.md#status).
+  This is a **breaking change**. `EnrichWithException` can be leveraged
+  to restore this behavior.
+  ([#5025](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5025))
+
 * Updated `http.request.method` to match specification guidelines.
   * For activity, if the method does not belong to one of the [known
     values](https://github.com/open-telemetry/semantic-conventions/blob/v1.22.0/docs/http/http-spans.md#:~:text=http.request.method%20has%20the%20following%20list%20of%20well%2Dknown%20values)

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -435,7 +435,7 @@ internal class HttpInListener : ListenerHandler
                 activity.RecordException(exc);
             }
 
-            activity.SetStatus(ActivityStatusCode.Error, exc.Message);
+            activity.SetStatus(ActivityStatusCode.Error);
 
             try
             {

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Removed the Activity Status Description that was being set during unhandled
+* Removed the Activity Status Description that was being set during
   exceptions. Activity Status will continue to be reported as `Error`.
   This is a **breaking change**. `EnrichWithException` can be leveraged
   to restore this behavior.

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 ## Unreleased
 
-* On Exception, Activity Status is set to Error. The Exception Message
-  has been removed from Activity Status Description to comply with the
-  [Http spec](https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/http/http-spans.md#status).
+* Removed the Activity Status Description that was being set during unhandled
+  exceptions. Activity Status will continue to be reported as `Error`.
   This is a **breaking change**. `EnrichWithException` can be leveraged
   to restore this behavior.
   ([#5025](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5025))

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+* On Exception, Activity Status is set to Error. The Exception Message
+  has been removed from Activity Status Description to comply with the
+  [Http spec](https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/http/http-spans.md#status).
+  This is a **breaking change**. `EnrichWithException` can be leveraged
+  to restore this behavior.
+  ([#5025](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5025))
+
 * Updated `http.request.method` to match specification guidelines.
   * For activity, if the method does not belong to one of the [known
     values](https://github.com/open-telemetry/semantic-conventions/blob/v1.22.0/docs/http/http-spans.md#:~:text=http.request.method%20has%20the%20following%20list%20of%20well%2Dknown%20values)

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -344,7 +344,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
 
             if (exc is HttpRequestException)
             {
-                activity.SetStatus(ActivityStatusCode.Error, exc.Message);
+                activity.SetStatus(ActivityStatusCode.Error);
             }
 
             try

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
@@ -230,57 +230,30 @@ internal static class HttpWebRequestActivitySource
         }
 
         ActivityStatusCode status;
-        string exceptionMessage = null;
 
-        if (exception is WebException wexc)
+        if (exception is WebException wexc && wexc.Response is HttpWebResponse response)
         {
-            if (wexc.Response is HttpWebResponse response)
+            statusCode = response.StatusCode;
+
+            if (tracingEmitOldAttributes)
             {
-                statusCode = response.StatusCode;
-
-                if (tracingEmitOldAttributes)
-                {
-                    activity.SetTag(SemanticConventions.AttributeHttpStatusCode, (int)statusCode);
-                }
-
-                if (tracingEmitNewAttributes)
-                {
-                    activity.SetTag(SemanticConventions.AttributeHttpResponseStatusCode, (int)statusCode);
-                }
-
-                status = SpanHelper.ResolveSpanStatusForHttpStatusCode(activity.Kind, (int)statusCode);
+                activity.SetTag(SemanticConventions.AttributeHttpStatusCode, (int)statusCode);
             }
-            else
+
+            if (tracingEmitNewAttributes)
             {
-                switch (wexc.Status)
-                {
-                    case WebExceptionStatus.Timeout:
-                    case WebExceptionStatus.RequestCanceled:
-                        status = ActivityStatusCode.Error;
-                        break;
-                    case WebExceptionStatus.SendFailure:
-                    case WebExceptionStatus.ConnectFailure:
-                    case WebExceptionStatus.SecureChannelFailure:
-                    case WebExceptionStatus.TrustFailure:
-                    case WebExceptionStatus.ServerProtocolViolation:
-                    case WebExceptionStatus.MessageLengthLimitExceeded:
-                        status = ActivityStatusCode.Error;
-                        exceptionMessage = exception.Message;
-                        break;
-                    default:
-                        status = ActivityStatusCode.Error;
-                        exceptionMessage = exception.Message;
-                        break;
-                }
+                activity.SetTag(SemanticConventions.AttributeHttpResponseStatusCode, (int)statusCode);
             }
+
+            status = SpanHelper.ResolveSpanStatusForHttpStatusCode(activity.Kind, (int)statusCode);
         }
         else
         {
             status = ActivityStatusCode.Error;
-            exceptionMessage = exception.Message;
         }
 
-        activity.SetStatus(status, exceptionMessage);
+        activity.SetStatus(status);
+
         if (TracingOptions.RecordException)
         {
             activity.RecordException(exception);

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests.cs
@@ -131,14 +131,7 @@ public class IncomingRequestsCollectionsIsAccordingToTheSpecTests
 
             // Instrumentation is not expected to set status description
             // as the reason can be inferred from SemanticConventions.AttributeHttpStatusCode
-            if (!urlPath.EndsWith("exception"))
-            {
-                Assert.True(string.IsNullOrEmpty(activity.StatusDescription));
-            }
-            else
-            {
-                Assert.Equal("exception description", activity.StatusDescription);
-            }
+            Assert.Null(activity.StatusDescription);
 
             if (recordException)
             {

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests_Dupe.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests_Dupe.cs
@@ -138,14 +138,7 @@ public class IncomingRequestsCollectionsIsAccordingToTheSpecTests_Dupe
 
             // Instrumentation is not expected to set status description
             // as the reason can be inferred from SemanticConventions.AttributeHttpStatusCode
-            if (!urlPath.EndsWith("exception"))
-            {
-                Assert.True(string.IsNullOrEmpty(activity.StatusDescription));
-            }
-            else
-            {
-                Assert.Equal("exception description", activity.StatusDescription);
-            }
+            Assert.Null(activity.StatusDescription);
 
             if (recordException)
             {

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests_New.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/IncomingRequestsCollectionsIsAccordingToTheSpecTests_New.cs
@@ -132,14 +132,7 @@ public class IncomingRequestsCollectionsIsAccordingToTheSpecTests_New
 
             // Instrumentation is not expected to set status description
             // as the reason can be inferred from SemanticConventions.AttributeHttpStatusCode
-            if (!urlPath.EndsWith("exception"))
-            {
-                Assert.True(string.IsNullOrEmpty(activity.StatusDescription));
-            }
-            else
-            {
-                Assert.Equal("exception description", activity.StatusDescription);
-            }
+            Assert.Null(activity.StatusDescription);
 
             if (recordException)
             {

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.cs
@@ -337,12 +337,7 @@ public partial class HttpClientTests
 
             // Assert.Equal(tc.SpanStatus, d[span.Status.CanonicalCode]);
             Assert.Equal(tc.SpanStatus, activity.Status.ToString());
-
-            if (tc.SpanStatusHasDescription.HasValue)
-            {
-                var desc = activity.StatusDescription;
-                Assert.Equal(tc.SpanStatusHasDescription.Value, !string.IsNullOrEmpty(desc));
-            }
+            Assert.Null(activity.StatusDescription);
 
             var normalizedAttributes = activity.TagObjects.Where(kv => !kv.Key.StartsWith("otel.")).ToDictionary(x => x.Key, x => x.Value.ToString());
 

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpTestData.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpTestData.cs
@@ -72,8 +72,6 @@ public static class HttpTestData
 
         public string SpanStatus { get; set; }
 
-        public bool? SpanStatusHasDescription { get; set; }
-
         public Dictionary<string, string> SpanAttributes { get; set; }
     }
 }

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestActivitySourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestActivitySourceTests.netfx.cs
@@ -549,7 +549,7 @@ public class HttpWebRequestActivitySourceTests : IDisposable
         Assert.Equal("Stop", exceptionEvent.Key);
 
         Assert.True(activity.Status != ActivityStatusCode.Unset);
-        Assert.NotNull(activity.StatusDescription);
+        Assert.Null(activity.StatusDescription);
     }
 
     /// <summary>
@@ -627,7 +627,7 @@ public class HttpWebRequestActivitySourceTests : IDisposable
         Assert.Equal("Stop", exceptionEvent.Key);
 
         Assert.True(exceptionEvent.Value.Status != ActivityStatusCode.Unset);
-        Assert.NotNull(exceptionEvent.Value.StatusDescription);
+        Assert.Null(exceptionEvent.Value.StatusDescription);
     }
 
     /// <summary>
@@ -669,7 +669,7 @@ public class HttpWebRequestActivitySourceTests : IDisposable
         Assert.Equal("Stop", exceptionEvent.Key);
 
         Assert.True(exceptionEvent.Value.Status != ActivityStatusCode.Unset);
-        Assert.NotNull(exceptionEvent.Value.StatusDescription);
+        Assert.Null(exceptionEvent.Value.StatusDescription);
     }
 
     [Fact]

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.cs
@@ -123,11 +123,7 @@ public partial class HttpWebRequestTests
 
                 if (tag.Key == SpanAttributeConstants.StatusDescriptionKey)
                 {
-                    if (tc.SpanStatusHasDescription.HasValue)
-                    {
-                        Assert.Equal(tc.SpanStatusHasDescription.Value, !string.IsNullOrEmpty(tagValue));
-                    }
-
+                    Assert.Null(tagValue);
                     continue;
                 }
 

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/http-out-test-cases.json
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/http-out-test-cases.json
@@ -93,7 +93,6 @@
     "url": "http://sdlfaldfjalkdfjlkajdflkajlsdjf:{port}/",
     "spanName": "HTTP GET",
     "spanStatus": "Error",
-    "spanStatusHasDescription": true,
     "responseExpected": false,
     "recordException": false,
     "spanAttributes": {
@@ -111,7 +110,6 @@
     "url": "http://sdlfaldfjalkdfjlkajdflkajlsdjf:{port}/",
     "spanName": "HTTP GET",
     "spanStatus": "Error",
-    "spanStatusHasDescription": true,
     "responseExpected": false,
     "recordException": true,
     "spanAttributes": {


### PR DESCRIPTION
Towards #4983

Previously, these libraries were setting both the Activity Status & StatusDescription via `Activity.SetStatus(ActivityStatusCode, Description)`. This PR removes the `string` description.

The Http spec states:
> Don't set the span status description if the reason can be inferred from http.response.status_code.
https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/http/http-spans.md#status


## Changes
- Instrumentation.AspNetCore
  - Remove StatusDescription
- Instrumentation.AspNetCore.Tests
  - update unit tests
- Instrumentation.Http
  - Remove StatusDescription and light refactor.
- Instrumentation.Http.Tests
  - update unit tests
  - update json tests and data model
    - remove StatusDescription from json test cases
    - remove StatusDescription fram data model

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
