### PR TITLE
[Do not Merge] Benchmark metrics instrumentation for .NET8.0

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreMetrics.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-#if !NET8_0_OR_GREATER
 using System.Diagnostics.Metrics;
 using System.Reflection;
 using OpenTelemetry.Instrumentation.AspNetCore.Implementation;
@@ -60,4 +59,4 @@ internal sealed class AspNetCoreMetrics : IDisposable
         this.meter?.Dispose();
     }
 }
-#endif
+

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInMetricsListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInMetricsListener.cs
@@ -14,7 +14,6 @@
 // limitations under the License.
 // </copyright>
 
-#if !NET8_0_OR_GREATER
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using Microsoft.AspNetCore.Http;
@@ -170,4 +169,4 @@ internal sealed class HttpInMetricsListener : ListenerHandler
         this.httpServerRequestDuration.Record(Activity.Current.Duration.TotalSeconds, tags);
     }
 }
-#endif
+

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/MeterProviderBuilderExtensions.cs
@@ -14,12 +14,10 @@
 // limitations under the License.
 // </copyright>
 
-#if !NET8_0_OR_GREATER
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Instrumentation.AspNetCore;
 using OpenTelemetry.Instrumentation.AspNetCore.Implementation;
-#endif
 using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Metrics;
@@ -39,9 +37,6 @@ public static class MeterProviderBuilderExtensions
     {
         Guard.ThrowIfNull(builder);
 
-#if NET8_0_OR_GREATER
-        return builder.ConfigureMeters();
-#else
         // Note: Warm-up the status code and method mapping.
         _ = TelemetryHelper.BoxedStatusCodes;
         _ = RequestMethodHelper.KnownMethods;
@@ -64,7 +59,6 @@ public static class MeterProviderBuilderExtensions
         });
 
         return builder;
-#endif
     }
 
     internal static MeterProviderBuilder ConfigureMeters(this MeterProviderBuilder builder)


### PR DESCRIPTION
Fixes #
Design discussion issue #

## Changes
PR shows the benchmark results for metric instrumentation on .NET8.0. It compares the instrumentation done via ootb meters added in .NET8.0 versus instrumentation done via Diagnostic Src callbacks.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
