### PR TITLE
OpenTelemetryBuilder IServiceProvider overloads

### DIFF
--- a/src/OpenTelemetry.Extensions.Hosting/.publicApi/Stable/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Extensions.Hosting/.publicApi/Stable/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+OpenTelemetry.OpenTelemetryBuilder.WithLogging(System.Action<System.IServiceProvider!, OpenTelemetry.Logs.LoggerProviderBuilder!>! configure) -> OpenTelemetry.OpenTelemetryBuilder!
+OpenTelemetry.OpenTelemetryBuilder.WithMetrics(System.Action<System.IServiceProvider!, OpenTelemetry.Metrics.MeterProviderBuilder!>! configure) -> OpenTelemetry.OpenTelemetryBuilder!
+OpenTelemetry.OpenTelemetryBuilder.WithTracing(System.Action<System.IServiceProvider!, OpenTelemetry.Trace.TracerProviderBuilder!>! configure) -> OpenTelemetry.OpenTelemetryBuilder!

--- a/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryBuilder.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryBuilder.cs
@@ -105,6 +105,25 @@ public sealed class OpenTelemetryBuilder
     }
 
     /// <summary>
+    /// Adds metric services into the builder.
+    /// </summary>
+    /// <remarks><inheritdoc cref="WithMetrics()" path="/remarks"/></remarks>
+    /// <param name="configure"><see cref="MeterProviderBuilder"/>
+    /// deferred configuration callback.</param>
+    /// <returns>The supplied <see cref="OpenTelemetryBuilder"/> for chaining
+    /// calls.</returns>
+    public OpenTelemetryBuilder WithMetrics(Action<IServiceProvider, MeterProviderBuilder> configure)
+    {
+        Guard.ThrowIfNull(configure);
+
+        this.WithMetrics();
+
+        this.Services.ConfigureOpenTelemetryMeterProvider(configure);
+
+        return this;
+    }
+
+    /// <summary>
     /// Adds tracing services into the builder.
     /// </summary>
     /// <remarks>
@@ -132,6 +151,25 @@ public sealed class OpenTelemetryBuilder
         var builder = new TracerProviderBuilderBase(this.Services);
 
         configure(builder);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds tracing services into the builder.
+    /// </summary>
+    /// <remarks><inheritdoc cref="WithTracing()" path="/remarks"/></remarks>
+    /// <param name="configure"><see cref="TracerProviderBuilder"/>
+    /// deferred configuration callback.</param>
+    /// <returns>The supplied <see cref="OpenTelemetryBuilder"/> for chaining
+    /// calls.</returns>
+    public OpenTelemetryBuilder WithTracing(Action<IServiceProvider, TracerProviderBuilder> configure)
+    {
+        Guard.ThrowIfNull(configure);
+
+        this.WithTracing();
+
+        this.Services.ConfigureOpenTelemetryTracerProvider(configure);
 
         return this;
     }
@@ -193,6 +231,38 @@ public sealed class OpenTelemetryBuilder
         var builder = new LoggerProviderBuilderBase(this.Services);
 
         configure(builder);
+
+        return this;
+    }
+
+#if EXPOSE_EXPERIMENTAL_FEATURES
+    /// <summary>
+    /// Adds logging services into the builder.
+    /// </summary>
+    /// <remarks><inheritdoc cref="WithLogging()" path="/remarks"/></remarks>
+    /// <param name="configure"><see cref="LoggerProviderBuilder"/>
+    /// deferred configuration callback.</param>
+    /// <returns>The supplied <see cref="OpenTelemetryBuilder"/> for chaining
+    /// calls.</returns>
+    public
+#else
+    /// <summary>
+    /// Adds logging services into the builder.
+    /// </summary>
+    /// <remarks><inheritdoc cref="WithLogging()" path="/remarks"/></remarks>
+    /// <param name="configure"><see cref="LoggerProviderBuilder"/>
+    /// deferred configuration callback.</param>
+    /// <returns>The supplied <see cref="OpenTelemetryBuilder"/> for chaining
+    /// calls.</returns>
+    internal
+#endif
+        OpenTelemetryBuilder WithLogging(Action<IServiceProvider, LoggerProviderBuilder> configure)
+    {
+        Guard.ThrowIfNull(configure);
+
+        this.WithLogging();
+
+        this.Services.ConfigureOpenTelemetryLoggerProvider(configure);
 
         return this;
     }

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryServicesExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryServicesExtensionsTests.cs
@@ -298,7 +298,7 @@ public class OpenTelemetryServicesExtensionsTests
     [Fact]
     public async Task AddOpenTelemetry_WithMetrics_HostConfigurationHonoredTest()
     {
-        var configureBuilderCalled = false;
+        bool configureBuilderCalled = false;
 
         var builder = new HostBuilder()
             .ConfigureAppConfiguration(builder =>

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryServicesExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryServicesExtensionsTests.cs
@@ -101,6 +101,25 @@ public class OpenTelemetryServicesExtensionsTests
     }
 
     [Fact]
+    public void AddOpenTelemetry_WithTracing_DeferredCallbackTest()
+    {
+        var services = new ServiceCollection();
+        var isHit = false;
+
+        services.AddOpenTelemetry().WithTracing((services, builder) => isHit = true);
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        Assert.NotNull(serviceProvider);
+
+        Assert.False(isHit);
+
+        _ = serviceProvider.GetRequiredService<TracerProvider>();
+
+        Assert.True(isHit);
+    }
+
+    [Fact]
     public void AddOpenTelemetry_WithTracing_DisposalTest()
     {
         var services = new ServiceCollection();
@@ -224,6 +243,25 @@ public class OpenTelemetryServicesExtensionsTests
     }
 
     [Fact]
+    public void AddOpenTelemetry_WithMetrics_DeferredCallbackTest()
+    {
+        var services = new ServiceCollection();
+        var isHit = false;
+
+        services.AddOpenTelemetry().WithMetrics((services, builder) => isHit = true);
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        Assert.NotNull(serviceProvider);
+
+        Assert.False(isHit);
+
+        _ = serviceProvider.GetRequiredService<MeterProvider>();
+
+        Assert.True(isHit);
+    }
+
+    [Fact]
     public void AddOpenTelemetry_WithMetrics_DisposalTest()
     {
         var services = new ServiceCollection();
@@ -260,7 +298,7 @@ public class OpenTelemetryServicesExtensionsTests
     [Fact]
     public async Task AddOpenTelemetry_WithMetrics_HostConfigurationHonoredTest()
     {
-        bool configureBuilderCalled = false;
+        var configureBuilderCalled = false;
 
         var builder = new HostBuilder()
             .ConfigureAppConfiguration(builder =>
@@ -344,6 +382,25 @@ public class OpenTelemetryServicesExtensionsTests
         var loggerProviders = serviceProvider.GetServices<LoggerProvider>();
 
         Assert.Single(loggerProviders);
+    }
+
+    [Fact]
+    public void AddOpenTelemetry_WithLogging_DeferredCallbackTest()
+    {
+        var services = new ServiceCollection();
+        var isHit = false;
+
+        services.AddOpenTelemetry().WithLogging((services, builder) => isHit = true);
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        Assert.NotNull(serviceProvider);
+
+        Assert.False(isHit);
+
+        _ = serviceProvider.GetRequiredService<LoggerProvider>();
+
+        Assert.True(isHit);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-dotnet/issues/5037

## Changes

Added overloads and tests for the `WithTracing` `WithMetrics` and `WithLogging` to make the `IServiceProvider` oriented functionality more discoverable & a first class citizen.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes - I can do this but don't think its necessary)
* [x] Changes in public API reviewed (if applicable)
