### PR TITLE
Fixed resource readme to reflect actual default

### DIFF
--- a/docs/logs/customizing-the-sdk/README.md
+++ b/docs/logs/customizing-the-sdk/README.md
@@ -56,8 +56,11 @@ For more information on Processors, please review [Extending the SDK](../extendi
 
 [Resource](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md)
 is the immutable representation of the entity producing the telemetry.
-If no `Resource` is explicitly configured, the default is to use a resource
-indicating this [Telemetry
+If no `Resource` is explicitly configured, the
+[default](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md#semantic-attributes-with-sdk-provided-default-value)
+is to use a resource indicating this
+[Service](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md#service)
+and [Telemetry
 SDK](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md#telemetry-sdk).
 The `SetResourceBuilder` method on `OpenTelemetryLoggerOptions` can be used to
 set a single `ResourceBuilder`. If `SetResourceBuilder` is called multiple

--- a/docs/metrics/customizing-the-sdk/README.md
+++ b/docs/metrics/customizing-the-sdk/README.md
@@ -574,7 +574,9 @@ is the immutable representation of the entity producing the telemetry. If no
 `Resource` is explicitly configured, the
 [default](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md#semantic-attributes-with-sdk-provided-default-value)
 is to use a resource indicating this
-[Service](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md#service).
+[Service](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md#service)
+and [Telemetry
+SDK](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md#telemetry-sdk).
 The `ConfigureResource` method on `MeterProviderBuilder` can be used to set a
 configure the resource on the provider. When the provider is built, it
 automatically builds the final `Resource` from the configured `ResourceBuilder`.

--- a/docs/trace/customizing-the-sdk/README.md
+++ b/docs/trace/customizing-the-sdk/README.md
@@ -289,8 +289,10 @@ writing custom exporters.
 is the immutable representation of the entity producing the telemetry. If no
 `Resource` is explicitly configured, the
 [default](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md#semantic-attributes-with-sdk-provided-default-value)
-resource is used to indicate the
-[Service](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md#service).
+is to use a resource indicating this
+[Service](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md#service)
+and [Telemetry
+SDK](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md#telemetry-sdk).
 The `ConfigureResource` method on `TracerProviderBuilder` can be used to
 configure the resource on the provider. `ConfigureResource` accepts an `Action`
 to configure the `ResourceBuilder`. Multiple calls to `ConfigureResource` can be


### PR DESCRIPTION
1. Fix doc to indicate TelemetrySdk is also part of default. (Original PR where this was added: https://github.com/open-telemetry/opentelemetry-dotnet/pull/4369)
2. Consistent wording across logs,metrics and traces. In future, "Resource" is a good candidate to move to a single place, and have it referred from all 3. This PR is not doing that refactoring.