### PR TITLE
Fix histogram for dns.lookup.duration

### DIFF
--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -41,7 +41,7 @@ public sealed class Metric
         ("OpenTelemetry.Instrumentation.Http", "http.client.request.duration"),
         ("System.Net.Http", "http.client.request.duration"),
         ("System.Net.Http", "http.client.request.time_in_queue"),
-        ("System.Net.NameResolution", "dns.lookups.duration"),
+        ("System.Net.NameResolution", "dns.lookup.duration"),
     };
 
     // Long default histogram bounds. Not based on a standard. May change in the future.

--- a/test/OpenTelemetry.Tests/Metrics/AggregatorTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/AggregatorTestsBase.cs
@@ -253,7 +253,7 @@ public abstract class AggregatorTestsBase
     [InlineData("System.Net.Http", "http.client.connection.duration", "s", KnownHistogramBuckets.DefaultLongSeconds)]
     [InlineData("System.Net.Http", "http.client.request.duration", "s", KnownHistogramBuckets.DefaultShortSeconds)]
     [InlineData("System.Net.Http", "http.client.request.time_in_queue", "s", KnownHistogramBuckets.DefaultShortSeconds)]
-    [InlineData("System.Net.NameResolution", "dns.lookups.duration", "s", KnownHistogramBuckets.DefaultShortSeconds)]
+    [InlineData("System.Net.NameResolution", "dns.lookup.duration", "s", KnownHistogramBuckets.DefaultShortSeconds)]
     [InlineData("General.App", "simple.alternative.counter", "s", KnownHistogramBuckets.Default)]
     public void HistogramBucketsDefaultUpdatesForSecondsTest(string meterName, string instrumentName, string unit, KnownHistogramBuckets expectedHistogramBuckets)
     {


### PR DESCRIPTION
Related to https://github.com/dotnet/runtime/issues/92917.

I do not think that it is worth to keep support for .net8-rc/unstable. It should be fine to support only GA version.

## Changes

Update metric name for `DefaultHistogramBoundShortMappings`. I do not think that it needs Changelog entry.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~