### PR TITLE
Http Span Status - Default to Unset if not in range defined by spec

### DIFF
--- a/src/Shared/SpanHelper.cs
+++ b/src/Shared/SpanHelper.cs
@@ -32,12 +32,13 @@ internal static class SpanHelper
     /// <returns>Resolved span <see cref="Status"/> for the Http status code.</returns>
     public static ActivityStatusCode ResolveSpanStatusForHttpStatusCode(ActivityKind kind, int httpStatusCode)
     {
-        var upperBound = kind == ActivityKind.Client ? 399 : 499;
-        if (httpStatusCode >= 100 && httpStatusCode <= upperBound)
+        var lowerBound = kind == ActivityKind.Client ? 400 : 500;
+        var upperBound = 599;
+        if (httpStatusCode >= lowerBound && httpStatusCode <= upperBound)
         {
-            return ActivityStatusCode.Unset;
+            return ActivityStatusCode.Error;
         }
 
-        return ActivityStatusCode.Error;
+        return ActivityStatusCode.Unset;
     }
 }


### PR DESCRIPTION
Fixes #
Design discussion issue #

## Changes

Updates the logic to default the status to `Unset` if the httpStatusCode does not fall under the range defined by spec

https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#status.

Previous logic could have some unwanted side effects of setting the status to error outside of defined range.

UpperBound is defined as per https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#server_error_responses

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
