### PR TITLE
Add metric bucket override for OpenTelemetry.Instrumentation.AspNet

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -44,6 +44,15 @@
   before setting up the `MeterProvider`.
   ([#5052](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5052))
 
+* Update Metrics SDK to override the default histogram buckets for ASP.NET
+  (.NET Framework) and the specific instrument:
+  * `http.request.server.duration`
+
+  Histogram metrics which have their `Unit` as `s` (second) will have their
+  default histogram buckets as `[ 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25,
+  0.5, 0.75, 1, 2.5, 5, 7.5, 10 ]`.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.7.0-alpha.1
 
 Released 2023-Oct-16

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -45,12 +45,12 @@
   ([#5052](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5052))
 
 * Update Metrics SDK to override the default histogram buckets for ASP.NET
-  (.NET Framework) and the specific instrument:
-  * `http.request.server.duration`
+  (.NET Framework).
 
-  Histogram metrics which have their `Unit` as `s` (second) will have their
-  default histogram buckets as `[ 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25,
-  0.5, 0.75, 1, 2.5, 5, 7.5, 10 ]`.
+  Histogram metrics for the meter name `OpenTelemetry.Instrumentation.AspNet`
+  and instrument name `http.request.server.duration` which have their `Unit`
+  as `s` (second) will have their default histogram buckets as `[ 0.005, 0.01,
+  0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10 ]`.
   ([#5063](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5063))
 
 ## 1.7.0-alpha.1

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -51,7 +51,7 @@
   Histogram metrics which have their `Unit` as `s` (second) will have their
   default histogram buckets as `[ 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25,
   0.5, 0.75, 1, 2.5, 5, 7.5, 10 ]`.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#5063](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5063))
 
 ## 1.7.0-alpha.1
 

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -37,6 +37,7 @@ public sealed class Metric
         ("Microsoft.AspNetCore.RateLimiting", "aspnetcore.rate_limiting.request.time_in_queue"),
         ("Microsoft.AspNetCore.RateLimiting", "aspnetcore.rate_limiting.request_lease.duration"),
         ("Microsoft.AspNetCore.Server.Kestrel", "kestrel.tls_handshake.duration"),
+        ("OpenTelemetry.Instrumentation.AspNet", "http.server.request.duration"),
         ("OpenTelemetry.Instrumentation.AspNetCore", "http.server.request.duration"),
         ("OpenTelemetry.Instrumentation.Http", "http.client.request.duration"),
         ("System.Net.Http", "http.client.request.duration"),

--- a/test/OpenTelemetry.Tests/Metrics/AggregatorTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/AggregatorTestsBase.cs
@@ -247,6 +247,8 @@ public abstract class AggregatorTestsBase
     [InlineData("Microsoft.AspNetCore.RateLimiting", "aspnetcore.rate_limiting.request.time_in_queue", "s", KnownHistogramBuckets.DefaultShortSeconds)]
     [InlineData("Microsoft.AspNetCore.Server.Kestrel", "kestrel.connection.duration", "s", KnownHistogramBuckets.DefaultLongSeconds)]
     [InlineData("Microsoft.AspNetCore.Server.Kestrel", "kestrel.tls_handshake.duration", "s", KnownHistogramBuckets.DefaultShortSeconds)]
+    [InlineData("OpenTelemetry.Instrumentation.AspNet", "http.server.duration", "ms", KnownHistogramBuckets.Default)]
+    [InlineData("OpenTelemetry.Instrumentation.AspNet", "http.server.request.duration", "s", KnownHistogramBuckets.DefaultShortSeconds)]
     [InlineData("OpenTelemetry.Instrumentation.AspNetCore", "http.server.duration", "ms", KnownHistogramBuckets.Default)]
     [InlineData("OpenTelemetry.Instrumentation.Http", "http.client.duration", "ms", KnownHistogramBuckets.Default)]
     [InlineData("System.Net.Http", "http.client.connection.duration", "s", KnownHistogramBuckets.DefaultLongSeconds)]


### PR DESCRIPTION
This came up in a [PR](<https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1429>) from the opentelemetry-dotnet-contrib project.

Without this change any user of `OpenTelemetry.Instrumentation.AspNet` would have to explicitly add a view.

## Changes

Updates `DefaultHistogramBoundShortMappings` to include an override for `OpenTelemetry.Instrumentation.AspNet` (`http.request.server.duration`).

Created this PR since @cijothomas suggested this [here](<https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1429#discussion_r1397902272>).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
