### PR TITLE
[HttpClient] Fix activity displayName

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -8,6 +8,9 @@
   semantic conventions.
   ([#5068](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5068))
 
+* Update activity DisplayName as per the specification.
+  (()[])
+
 ## 1.6.0-beta.3
 
 Released 2023-Nov-17

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -9,7 +9,7 @@
   ([#5068](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5068))
 
 * Update activity DisplayName as per the specification.
-  (()[])
+  ([#5078](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5078))
 
 ## 1.6.0-beta.3
 

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -153,7 +153,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
                 return;
             }
 
-            activity.DisplayName = HttpTagHelper.GetOperationNameForHttpMethod(request.Method);
+            activity.DisplayName = RequestMethodHelper.KnownMethods.TryGetValue(request.Method.Method, out var httpMethod) ? httpMethod : "HTTP";
 
             if (!IsNet7OrGreater)
             {
@@ -162,17 +162,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
             }
 
             // see the spec https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/http/http-spans.md
-            if (RequestMethodHelper.KnownMethods.TryGetValue(request.Method.Method, out var httpMethod))
-            {
-                activity.SetTag(SemanticConventions.AttributeHttpRequestMethod, httpMethod);
-            }
-            else
-            {
-                // Set to default "_OTHER" as per spec.
-                // https://github.com/open-telemetry/semantic-conventions/blob/v1.22.0/docs/http/http-spans.md#common-attributes
-                activity.SetTag(SemanticConventions.AttributeHttpRequestMethod, "_OTHER");
-                activity.SetTag(SemanticConventions.AttributeHttpRequestMethodOriginal, request.Method.Method);
-            }
+            RequestMethodHelper.SetHttpMethodTag(activity, request.Method.Method);
 
             activity.SetTag(SemanticConventions.AttributeServerAddress, request.RequestUri.Host);
             if (!request.RequestUri.IsDefaultPort)

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -153,7 +153,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
                 return;
             }
 
-            activity.DisplayName = RequestMethodHelper.KnownMethods.TryGetValue(request.Method.Method, out var httpMethod) ? httpMethod : "HTTP";
+            RequestMethodHelper.SetHttpClientActivityDisplayName(activity, request.Method.Method);
 
             if (!IsNet7OrGreater)
             {

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
@@ -108,7 +108,7 @@ internal static class HttpWebRequestActivitySource
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void AddRequestTagsAndInstrumentRequest(HttpWebRequest request, Activity activity)
     {
-        activity.DisplayName = RequestMethodHelper.KnownMethods.TryGetValue(request.Method, out var httpMethod) ? httpMethod : "HTTP";
+        RequestMethodHelper.SetHttpClientActivityDisplayName(activity, request.Method);
 
         if (activity.IsAllDataRequested)
         {

--- a/src/Shared/RequestMethodHelper.cs
+++ b/src/Shared/RequestMethodHelper.cs
@@ -76,4 +76,10 @@ internal static class RequestMethodHelper
             activity?.SetTag(SemanticConventions.AttributeHttpRequestMethodOriginal, method);
         }
     }
+
+    public static void SetHttpClientActivityDisplayName(Activity activity, string method)
+    {
+        // https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/http/http-spans.md#name
+        activity.DisplayName = KnownMethods.TryGetValue(method, out var httpMethod) ? httpMethod : "HTTP";
+    }
 }

--- a/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.client.cs
+++ b/test/OpenTelemetry.Instrumentation.Grpc.Tests/GrpcTests.client.cs
@@ -381,7 +381,7 @@ public partial class GrpcTests
         ValidateGrpcActivity(grpcSpan);
         Assert.Equal($"greet.Greeter/SayHello", grpcSpan.DisplayName);
         Assert.Equal(0, grpcSpan.GetTagValue(SemanticConventions.AttributeRpcGrpcStatusCode));
-        Assert.Equal($"HTTP POST", httpSpan.DisplayName);
+        Assert.Equal("POST", httpSpan.DisplayName);
         Assert.Equal(grpcSpan.SpanId, httpSpan.ParentSpanId);
 
         Assert.NotEmpty(grpcSpan.Tags.Where(tag => tag.Key == "enrichedWithHttpRequestMessage"));

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.Basic.cs
@@ -414,10 +414,12 @@ public partial class HttpClientTests : IDisposable
 
         if (originalMethod.Equals(expectedMethod, StringComparison.OrdinalIgnoreCase))
         {
+            Assert.Equal(expectedMethod, activity.DisplayName);
             Assert.DoesNotContain(activity.TagObjects, t => t.Key == SemanticConventions.AttributeHttpRequestMethodOriginal);
         }
         else
         {
+            Assert.Equal("HTTP", activity.DisplayName);
             Assert.Equal(originalMethod, activity.GetTagValue(SemanticConventions.AttributeHttpRequestMethodOriginal) as string);
         }
 

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpClientTests.cs
@@ -93,7 +93,7 @@ public partial class HttpClientTests
                     ""url"": ""http://{host}:{port}/"",
                     ""responseCode"": 399,
                     ""responseExpected"": true,
-                    ""spanName"": ""HTTP GET"",
+                    ""spanName"": ""GET"",
                     ""spanStatus"": ""Unset"",
                     ""spanKind"": ""Client"",
                     ""spanAttributes"": {

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.cs
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/HttpWebRequestTests.cs
@@ -174,7 +174,7 @@ public partial class HttpWebRequestTests
                 ""method"": ""GET"",
                 ""url"": ""http://{host}:{port}/"",
                 ""responseCode"": 200,
-                ""spanName"": ""HTTP GET"",
+                ""spanName"": ""GET"",
                 ""spanStatus"": ""UNSET"",
                 ""spanKind"": ""Client"",
                 ""setHttpFlavor"": true,

--- a/test/OpenTelemetry.Instrumentation.Http.Tests/http-out-test-cases.json
+++ b/test/OpenTelemetry.Instrumentation.Http.Tests/http-out-test-cases.json
@@ -3,7 +3,7 @@
     "name": "Successful GET call to localhost",
     "method": "GET",
     "url": "http://{host}:{port}/",
-    "spanName": "HTTP GET",
+    "spanName": "GET",
     "spanStatus": "Unset",
     "responseExpected": true,
     "spanAttributes": {
@@ -20,7 +20,7 @@
     "name": "Successfully POST call to localhost",
     "method": "POST",
     "url": "http://{host}:{port}/",
-    "spanName": "HTTP POST",
+    "spanName": "POST",
     "spanStatus": "Unset",
     "responseExpected": true,
     "spanAttributes": {
@@ -38,7 +38,7 @@
     "method": "GET",
     "url": "http://{host}:{port}/path/to/resource/",
     "responseCode": 200,
-    "spanName": "HTTP GET",
+    "spanName": "GET",
     "spanStatus": "Unset",
     "responseExpected": true,
     "spanAttributes": {
@@ -56,7 +56,7 @@
     "method": "GET",
     "url": "http://{host}:{port}/path/to/resource#fragment",
     "responseCode": 200,
-    "spanName": "HTTP GET",
+    "spanName": "GET",
     "spanStatus": "Unset",
     "responseExpected": true,
     "spanAttributes": {
@@ -74,7 +74,7 @@
     "method": "GET",
     "url": "http://username:password@{host}:{port}/path/to/resource#fragment",
     "responseCode": 200,
-    "spanName": "HTTP GET",
+    "spanName": "GET",
     "spanStatus": "Unset",
     "responseExpected": true,
     "spanAttributes": {
@@ -91,7 +91,7 @@
     "name": "Call that cannot resolve DNS will be reported as error span",
     "method": "GET",
     "url": "http://sdlfaldfjalkdfjlkajdflkajlsdjf:{port}/",
-    "spanName": "HTTP GET",
+    "spanName": "GET",
     "spanStatus": "Error",
     "responseExpected": false,
     "recordException": false,
@@ -108,7 +108,7 @@
     "name": "Call that cannot resolve DNS will be reported as error span. And Records exception",
     "method": "GET",
     "url": "http://sdlfaldfjalkdfjlkajdflkajlsdjf:{port}/",
-    "spanName": "HTTP GET",
+    "spanName": "GET",
     "spanStatus": "Error",
     "responseExpected": false,
     "recordException": true,
@@ -126,7 +126,7 @@
     "method": "GET",
     "url": "http://{host}:{port}/",
     "responseCode": 200,
-    "spanName": "HTTP GET",
+    "spanName": "GET",
     "spanStatus": "Unset",
     "responseExpected": true,
     "spanAttributes": {
@@ -144,7 +144,7 @@
     "method": "GET",
     "url": "http://{host}:{port}/",
     "responseCode": 200,
-    "spanName": "HTTP GET",
+    "spanName": "GET",
     "spanStatus": "Unset",
     "responseExpected": true,
     "spanAttributes": {
@@ -162,7 +162,7 @@
     "method": "GET",
     "url": "http://{host}:{port}/",
     "responseCode": 399,
-    "spanName": "HTTP GET",
+    "spanName": "GET",
     "spanStatus": "Unset",
     "responseExpected": true,
     "spanAttributes": {
@@ -180,7 +180,7 @@
     "method": "GET",
     "url": "http://{host}:{port}/",
     "responseCode": 400,
-    "spanName": "HTTP GET",
+    "spanName": "GET",
     "spanStatus": "Error",
     "responseExpected": true,
     "spanAttributes": {
@@ -198,7 +198,7 @@
     "method": "GET",
     "url": "http://{host}:{port}/",
     "responseCode": 401,
-    "spanName": "HTTP GET",
+    "spanName": "GET",
     "spanStatus": "Error",
     "responseExpected": true,
     "spanAttributes": {
@@ -216,7 +216,7 @@
     "method": "GET",
     "url": "http://{host}:{port}/",
     "responseCode": 403,
-    "spanName": "HTTP GET",
+    "spanName": "GET",
     "spanStatus": "Error",
     "responseExpected": true,
     "spanAttributes": {
@@ -234,7 +234,7 @@
     "method": "GET",
     "url": "http://{host}:{port}/",
     "responseCode": 404,
-    "spanName": "HTTP GET",
+    "spanName": "GET",
     "spanStatus": "Error",
     "responseExpected": true,
     "spanAttributes": {
@@ -252,7 +252,7 @@
     "method": "GET",
     "url": "http://{host}:{port}/",
     "responseCode": 429,
-    "spanName": "HTTP GET",
+    "spanName": "GET",
     "spanStatus": "Error",
     "responseExpected": true,
     "spanAttributes": {
@@ -270,7 +270,7 @@
     "method": "GET",
     "url": "http://{host}:{port}/",
     "responseCode": 501,
-    "spanName": "HTTP GET",
+    "spanName": "GET",
     "spanStatus": "Error",
     "responseExpected": true,
     "spanAttributes": {
@@ -288,7 +288,7 @@
     "method": "GET",
     "url": "http://{host}:{port}/",
     "responseCode": 503,
-    "spanName": "HTTP GET",
+    "spanName": "GET",
     "spanStatus": "Error",
     "responseExpected": true,
     "spanAttributes": {
@@ -306,7 +306,7 @@
     "method": "GET",
     "url": "http://{host}:{port}/",
     "responseCode": 504,
-    "spanName": "HTTP GET",
+    "spanName": "GET",
     "spanStatus": "Error",
     "responseExpected": true,
     "spanAttributes": {
@@ -324,7 +324,7 @@
     "method": "GET",
     "url": "http://{host}:{port}/",
     "responseCode": 200,
-    "spanName": "HTTP GET",
+    "spanName": "GET",
     "spanStatus": "Unset",
     "responseExpected": true,
     "spanAttributes": {


### PR DESCRIPTION
Fixes #
Design discussion issue #

## Changes
updates http client activity display name as per specification https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#name + some minor refactor

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
