### PR TITLE
[HttpClient & ASP.NET Core] Document request durations

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/README.md
@@ -136,6 +136,23 @@ newer versions.
     recommended buckets by default for `http.server.request.duration`. This
     applies to all targeted frameworks.
 
+## Activity and http.server.request.duration details
+
+`Activity.Duration` and `http.client.request.duration` values represents the
+time used to handle an inbound HTTP request as measured at the hosting layer of
+ASP.NET Core. The time measurement starts once the underlying web host has:
+
+* Sufficiently parsed the HTTP request headers on the inbound network stream to
+  identify the new request.
+* Initialized the context data structures such as the
+  [HttpContext](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.http.httpcontext).
+
+The time ends when:
+
+* The ASP.NET Core handler pipeline is finished executing.
+* All response data has been sent.
+* The context data structures for the request are being disposed.
+
 ## Advanced configuration
 
 This instrumentation can be configured to change the default behavior by using

--- a/src/OpenTelemetry.Instrumentation.Http/README.md
+++ b/src/OpenTelemetry.Instrumentation.Http/README.md
@@ -145,6 +145,13 @@ newer versions.
     recommended buckets by default for `http.client.request.duration`. This
     applies to all targeted frameworks.
 
+## Activity and http.client.request.duration when using HttpClient
+
+`Activity.Duration` and `http.client.request.duration` values represents the
+time the underlying client handler takes to complete the request. Completing the
+request includes the time up to reading response headers from the network
+stream. It doesn't include the time spent reading the response body.
+
 ## Advanced configuration
 
 This instrumentation can be configured to change the default behavior by using


### PR DESCRIPTION
Fixes #
Design discussion issue #

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
