### PR TITLE
Update Metrics Benchmarks

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ net6.0, net7.0 ]
+        version: [ net6.0, net7.0, net8.0 ]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ net6.0, net7.0, net8.0 ]
+        version: [ net6.0, net7.0 ]
     steps:
       - uses: actions/checkout@v4
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -92,8 +92,8 @@
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="[6.5.0,)" />
     <PackageVersion Include="Testcontainers.MsSql" Version="3.6.0" />
     <PackageVersion Include="Testcontainers.SqlEdge" Version="3.6.0" />
-    <PackageVersion Include="xunit" Version="[2.6.1,3.0)" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="[2.5.3,3.0)" />
+    <PackageVersion Include="xunit" Version="[2.6.2,3.0)" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="[2.5.4,3.0)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/test/Benchmarks/Metrics/Base2ExponentialHistogramBenchmarks.cs
+++ b/test/Benchmarks/Metrics/Base2ExponentialHistogramBenchmarks.cs
@@ -22,20 +22,20 @@ using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
 
 /*
-BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.23424.1000)
+BenchmarkDotNet v0.13.10, Windows 11 (10.0.23424.1000)
 Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
-.NET SDK=7.0.203
-  [Host]     : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
-  DefaultJob : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
+.NET SDK 8.0.100
+  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+  DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
 
 
-|                      Method |      Mean |    Error |   StdDev | Allocated |
+| Method                      | Mean      | Error    | StdDev   | Allocated |
 |---------------------------- |----------:|---------:|---------:|----------:|
-|            HistogramHotPath |  54.78 ns | 0.907 ns | 0.848 ns |         - |
-|  HistogramWith1LabelHotPath | 115.37 ns | 0.388 ns | 0.363 ns |         - |
-| HistogramWith3LabelsHotPath | 228.03 ns | 3.767 ns | 3.146 ns |         - |
-| HistogramWith5LabelsHotPath | 316.60 ns | 5.980 ns | 9.311 ns |         - |
-| HistogramWith7LabelsHotPath | 366.86 ns | 2.694 ns | 3.596 ns |         - |
+| HistogramHotPath            |  42.27 ns | 0.298 ns | 0.279 ns |         - |
+| HistogramWith1LabelHotPath  |  88.90 ns | 1.103 ns | 1.032 ns |         - |
+| HistogramWith3LabelsHotPath | 166.95 ns | 1.759 ns | 1.559 ns |         - |
+| HistogramWith5LabelsHotPath | 248.19 ns | 2.523 ns | 2.237 ns |         - |
+| HistogramWith7LabelsHotPath | 310.95 ns | 5.627 ns | 4.988 ns |         - |
 */
 
 namespace Benchmarks.Metrics;

--- a/test/Benchmarks/Metrics/Base2ExponentialHistogramMapToIndexBenchmarks.cs
+++ b/test/Benchmarks/Metrics/Base2ExponentialHistogramMapToIndexBenchmarks.cs
@@ -18,18 +18,18 @@ using BenchmarkDotNet.Attributes;
 using OpenTelemetry.Metrics;
 
 /*
-BenchmarkDotNet=v0.13.5, OS=macOS Ventura 13.4 (22F66) [Darwin 22.5.0]
-Apple M1 Max, 1 CPU, 10 logical and 10 physical cores
-.NET SDK=7.0.101
-  [Host]     : .NET 7.0.1 (7.0.122.56804), Arm64 RyuJIT AdvSIMD
-  DefaultJob : .NET 7.0.1 (7.0.122.56804), Arm64 RyuJIT AdvSIMD
+BenchmarkDotNet v0.13.10, Windows 11 (10.0.23424.1000)
+Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
+.NET SDK 8.0.100
+  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+  DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
 
 
-|     Method | Scale |     Mean |    Error |   StdDev | Allocated |
-|----------- |------ |---------:|---------:|---------:|----------:|
-| MapToIndex |   -11 | 11.60 ns | 0.057 ns | 0.053 ns |         - |
-| MapToIndex |     3 | 14.63 ns | 0.135 ns | 0.126 ns |         - |
-| MapToIndex |    20 | 14.40 ns | 0.026 ns | 0.024 ns |         - |
+| Method     | Scale | Mean      | Error     | StdDev    | Allocated |
+|----------- |------ |----------:|----------:|----------:|----------:|
+| MapToIndex | -11   |  4.003 ns | 0.0288 ns | 0.0240 ns |         - |
+| MapToIndex | 3     | 11.081 ns | 0.1222 ns | 0.1143 ns |         - |
+| MapToIndex | 20    | 11.077 ns | 0.1103 ns | 0.1032 ns |         - |
 */
 
 namespace Benchmarks.Metrics;

--- a/test/Benchmarks/Metrics/Base2ExponentialHistogramScaleBenchmarks.cs
+++ b/test/Benchmarks/Metrics/Base2ExponentialHistogramScaleBenchmarks.cs
@@ -21,18 +21,18 @@ using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
 
 /*
-BenchmarkDotNet=v0.13.5, OS=macOS Ventura 13.4 (22F66) [Darwin 22.5.0]
-Apple M1 Max, 1 CPU, 10 logical and 10 physical cores
-.NET SDK=7.0.101
-  [Host]     : .NET 7.0.1 (7.0.122.56804), Arm64 RyuJIT AdvSIMD
-  DefaultJob : .NET 7.0.1 (7.0.122.56804), Arm64 RyuJIT AdvSIMD
+BenchmarkDotNet v0.13.10, Windows 11 (10.0.23424.1000)
+Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
+.NET SDK 8.0.100
+  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+  DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
 
 
-|           Method | Scale |     Mean |    Error |   StdDev | Allocated |
+| Method           | Scale | Mean     | Error    | StdDev   | Allocated |
 |----------------- |------ |---------:|---------:|---------:|----------:|
-| HistogramHotPath |   -11 | 29.79 ns | 0.054 ns | 0.042 ns |         - |
-| HistogramHotPath |     3 | 32.10 ns | 0.086 ns | 0.080 ns |         - |
-| HistogramHotPath |    20 | 32.08 ns | 0.076 ns | 0.063 ns |         - |
+| HistogramHotPath | -11   | 32.44 ns | 0.196 ns | 0.174 ns |         - |
+| HistogramHotPath | 3     | 42.33 ns | 0.158 ns | 0.124 ns |         - |
+| HistogramHotPath | 20    | 40.57 ns | 0.363 ns | 0.322 ns |         - |
 */
 
 namespace Benchmarks.Metrics;

--- a/test/Benchmarks/Metrics/ExemplarBenchmarks.cs
+++ b/test/Benchmarks/Metrics/ExemplarBenchmarks.cs
@@ -24,19 +24,19 @@ using OpenTelemetry.Tests;
 /*
 BenchmarkDotNet v0.13.10, Windows 11 (10.0.23424.1000)
 Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
-.NET SDK 8.0.100-rc.2.23502.2
-  [Host]     : .NET 7.0.13 (7.0.1323.51816), X64 RyuJIT AVX2
-  DefaultJob : .NET 7.0.13 (7.0.1323.51816), X64 RyuJIT AVX2
+.NET SDK 8.0.100
+  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+  DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
 
 
-| Method                    | ExemplarFilter | Mean     | Error   | StdDev  |
-|-------------------------- |--------------- |---------:|--------:|--------:|
-| HistogramNoTagReduction   | AlwaysOff      | 316.7 ns | 1.01 ns | 0.89 ns |
-| HistogramWithTagReduction | AlwaysOff      | 298.9 ns | 2.44 ns | 2.16 ns |
-| HistogramNoTagReduction   | AlwaysOn       | 359.6 ns | 1.26 ns | 1.11 ns |
-| HistogramWithTagReduction | AlwaysOn       | 400.1 ns | 4.16 ns | 3.90 ns |
-| HistogramNoTagReduction   | HighValueOnly  | 325.3 ns | 3.33 ns | 2.78 ns |
-| HistogramWithTagReduction | HighValueOnly  | 320.7 ns | 4.91 ns | 4.60 ns |
+| Method                    | ExemplarFilter | Mean     | Error   | StdDev  | Allocated |
+|-------------------------- |--------------- |---------:|--------:|--------:|----------:|
+| HistogramNoTagReduction   | AlwaysOff      | 274.2 ns | 2.94 ns | 2.60 ns |         - |
+| HistogramWithTagReduction | AlwaysOff      | 241.6 ns | 1.78 ns | 1.58 ns |         - |
+| HistogramNoTagReduction   | AlwaysOn       | 300.9 ns | 3.10 ns | 2.90 ns |         - |
+| HistogramWithTagReduction | AlwaysOn       | 312.9 ns | 4.81 ns | 4.50 ns |         - |
+| HistogramNoTagReduction   | HighValueOnly  | 262.8 ns | 2.24 ns | 1.99 ns |         - |
+| HistogramWithTagReduction | HighValueOnly  | 258.3 ns | 5.12 ns | 5.03 ns |         - |
 */
 
 namespace Benchmarks.Metrics;

--- a/test/Benchmarks/Metrics/HistogramBenchmarks.cs
+++ b/test/Benchmarks/Metrics/HistogramBenchmarks.cs
@@ -22,35 +22,35 @@ using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
 
 /*
-BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.23424.1000)
+BenchmarkDotNet v0.13.10, Windows 11 (10.0.23424.1000)
 Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
-.NET SDK=7.0.203
-  [Host]     : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
-  DefaultJob : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
+.NET SDK 8.0.100
+  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+  DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
 
 
-|                      Method | BoundCount |      Mean |     Error |    StdDev |    Median | Allocated |
+| Method                      | BoundCount | Mean      | Error     | StdDev    | Median    | Allocated |
 |---------------------------- |----------- |----------:|----------:|----------:|----------:|----------:|
-|            HistogramHotPath |         10 |  50.11 ns |  0.219 ns |  0.204 ns |  50.06 ns |         - |
-|  HistogramWith1LabelHotPath |         10 | 108.52 ns |  0.559 ns |  0.523 ns | 108.44 ns |         - |
-| HistogramWith3LabelsHotPath |         10 | 212.31 ns |  1.873 ns |  1.661 ns | 212.32 ns |         - |
-| HistogramWith5LabelsHotPath |         10 | 299.97 ns |  5.162 ns |  5.737 ns | 298.60 ns |         - |
-| HistogramWith7LabelsHotPath |         10 | 349.53 ns |  2.115 ns |  1.875 ns | 349.62 ns |         - |
-|            HistogramHotPath |         49 |  61.34 ns |  0.171 ns |  0.160 ns |  61.35 ns |         - |
-|  HistogramWith1LabelHotPath |         49 | 118.64 ns |  1.539 ns |  1.285 ns | 118.09 ns |         - |
-| HistogramWith3LabelsHotPath |         49 | 226.70 ns |  1.653 ns |  1.465 ns | 226.62 ns |         - |
-| HistogramWith5LabelsHotPath |         49 | 314.40 ns |  5.185 ns |  4.850 ns | 313.96 ns |         - |
-| HistogramWith7LabelsHotPath |         49 | 375.37 ns |  5.796 ns |  5.138 ns | 373.76 ns |         - |
-|            HistogramHotPath |         50 |  60.08 ns |  0.062 ns |  0.049 ns |  60.08 ns |         - |
-|  HistogramWith1LabelHotPath |         50 | 118.16 ns |  0.640 ns |  0.568 ns | 118.03 ns |         - |
-| HistogramWith3LabelsHotPath |         50 | 258.96 ns |  3.710 ns |  3.098 ns | 259.70 ns |         - |
-| HistogramWith5LabelsHotPath |         50 | 353.81 ns |  5.646 ns |  5.281 ns | 351.81 ns |         - |
-| HistogramWith7LabelsHotPath |         50 | 406.75 ns |  6.491 ns |  6.072 ns | 406.01 ns |         - |
-|            HistogramHotPath |       1000 |  86.82 ns |  0.543 ns |  0.481 ns |  86.68 ns |         - |
-|  HistogramWith1LabelHotPath |       1000 | 147.04 ns |  0.535 ns |  0.447 ns | 146.88 ns |         - |
-| HistogramWith3LabelsHotPath |       1000 | 619.11 ns | 10.943 ns | 14.608 ns | 617.10 ns |         - |
-| HistogramWith5LabelsHotPath |       1000 | 759.64 ns | 22.509 ns | 63.855 ns | 737.58 ns |         - |
-| HistogramWith7LabelsHotPath |       1000 | 760.85 ns |  6.220 ns |  5.514 ns | 761.68 ns |         - |
+| HistogramHotPath            | 10         |  38.36 ns |  0.401 ns |  0.375 ns |  38.28 ns |         - |
+| HistogramWith1LabelHotPath  | 10         |  78.66 ns |  0.258 ns |  0.241 ns |  78.67 ns |         - |
+| HistogramWith3LabelsHotPath | 10         | 162.22 ns |  0.946 ns |  0.839 ns | 162.03 ns |         - |
+| HistogramWith5LabelsHotPath | 10         | 230.90 ns |  1.262 ns |  1.181 ns | 231.12 ns |         - |
+| HistogramWith7LabelsHotPath | 10         | 288.06 ns |  1.362 ns |  1.208 ns | 288.01 ns |         - |
+| HistogramHotPath            | 49         |  48.23 ns |  0.137 ns |  0.128 ns |  48.22 ns |         - |
+| HistogramWith1LabelHotPath  | 49         |  90.52 ns |  0.404 ns |  0.358 ns |  90.47 ns |         - |
+| HistogramWith3LabelsHotPath | 49         | 170.17 ns |  0.801 ns |  0.710 ns | 170.07 ns |         - |
+| HistogramWith5LabelsHotPath | 49         | 244.93 ns |  3.935 ns |  3.681 ns | 244.85 ns |         - |
+| HistogramWith7LabelsHotPath | 49         | 308.28 ns |  5.927 ns |  5.544 ns | 306.44 ns |         - |
+| HistogramHotPath            | 50         |  49.22 ns |  0.280 ns |  0.249 ns |  49.25 ns |         - |
+| HistogramWith1LabelHotPath  | 50         |  91.70 ns |  0.589 ns |  0.492 ns |  91.68 ns |         - |
+| HistogramWith3LabelsHotPath | 50         | 213.74 ns |  4.258 ns |  5.537 ns | 212.26 ns |         - |
+| HistogramWith5LabelsHotPath | 50         | 299.59 ns |  5.940 ns | 13.408 ns | 296.23 ns |         - |
+| HistogramWith7LabelsHotPath | 50         | 342.75 ns |  5.066 ns |  4.491 ns | 341.84 ns |         - |
+| HistogramHotPath            | 1000       |  72.04 ns |  0.723 ns |  0.603 ns |  71.94 ns |         - |
+| HistogramWith1LabelHotPath  | 1000       | 118.73 ns |  2.130 ns |  1.992 ns | 117.98 ns |         - |
+| HistogramWith3LabelsHotPath | 1000       | 545.71 ns | 10.644 ns | 12.258 ns | 543.55 ns |         - |
+| HistogramWith5LabelsHotPath | 1000       | 661.81 ns | 14.837 ns | 42.091 ns | 651.99 ns |         - |
+| HistogramWith7LabelsHotPath | 1000       | 709.50 ns | 14.123 ns | 39.368 ns | 698.27 ns |         - |
 */
 
 namespace Benchmarks.Metrics;

--- a/test/Benchmarks/Metrics/MetricCollectBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricCollectBenchmarks.cs
@@ -21,17 +21,17 @@ using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
 
 /*
-BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.23424.1000)
+BenchmarkDotNet v0.13.10, Windows 11 (10.0.23424.1000)
 Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
-.NET SDK=7.0.203
-  [Host]     : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
-  DefaultJob : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
+.NET SDK 8.0.100
+  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+  DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
 
 
-|  Method | UseWithRef |     Mean |    Error |   StdDev | Allocated |
+| Method  | UseWithRef | Mean     | Error    | StdDev   | Allocated |
 |-------- |----------- |---------:|---------:|---------:|----------:|
-| Collect |      False | 18.45 us | 0.161 us | 0.151 us |      96 B |
-| Collect |       True | 17.71 us | 0.347 us | 0.644 us |      96 B |
+| Collect | False      | 21.03 us | 0.148 us | 0.361 us |      96 B |
+| Collect | True       | 20.37 us | 0.399 us | 0.559 us |      96 B |
 */
 
 namespace Benchmarks.Metrics;

--- a/test/Benchmarks/Metrics/MetricsBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricsBenchmarks.cs
@@ -22,27 +22,27 @@ using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
 
 /*
-BenchmarkDotNet v0.13.6, Windows 11 (10.0.23424.1000)
+BenchmarkDotNet v0.13.10, Windows 11 (10.0.23424.1000)
 Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
-.NET SDK 7.0.400
-  [Host]     : .NET 7.0.10 (7.0.1023.36312), X64 RyuJIT AVX2
-  DefaultJob : .NET 7.0.10 (7.0.1023.36312), X64 RyuJIT AVX2
+.NET SDK 8.0.100
+  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+  DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
 
 
-|                    Method | AggregationTemporality |      Mean |    Error |   StdDev | Allocated |
+| Method                    | AggregationTemporality | Mean      | Error    | StdDev   | Allocated |
 |-------------------------- |----------------------- |----------:|---------:|---------:|----------:|
-|            CounterHotPath |             Cumulative |  21.61 ns | 0.084 ns | 0.078 ns |         - |
-| CounterWith1LabelsHotPath |             Cumulative |  69.08 ns | 0.261 ns | 0.244 ns |         - |
-| CounterWith3LabelsHotPath |             Cumulative | 149.77 ns | 0.549 ns | 0.486 ns |         - |
-| CounterWith5LabelsHotPath |             Cumulative | 236.47 ns | 1.684 ns | 1.493 ns |         - |
-| CounterWith6LabelsHotPath |             Cumulative | 276.48 ns | 1.442 ns | 1.349 ns |         - |
-| CounterWith7LabelsHotPath |             Cumulative | 294.09 ns | 2.354 ns | 2.202 ns |         - |
-|            CounterHotPath |                  Delta |  27.32 ns | 0.380 ns | 0.355 ns |         - |
-| CounterWith1LabelsHotPath |                  Delta |  80.83 ns | 0.219 ns | 0.183 ns |         - |
-| CounterWith3LabelsHotPath |                  Delta | 162.48 ns | 1.053 ns | 0.985 ns |         - |
-| CounterWith5LabelsHotPath |                  Delta | 255.48 ns | 1.807 ns | 1.602 ns |         - |
-| CounterWith6LabelsHotPath |                  Delta | 281.75 ns | 2.761 ns | 2.583 ns |         - |
-| CounterWith7LabelsHotPath |                  Delta | 310.29 ns | 1.817 ns | 1.611 ns |         - |
+| CounterHotPath            | Cumulative             |  15.37 ns | 0.072 ns | 0.064 ns |         - |
+| CounterWith1LabelsHotPath | Cumulative             |  60.67 ns | 0.764 ns | 0.677 ns |         - |
+| CounterWith3LabelsHotPath | Cumulative             | 112.98 ns | 0.843 ns | 0.704 ns |         - |
+| CounterWith5LabelsHotPath | Cumulative             | 196.83 ns | 1.632 ns | 1.447 ns |         - |
+| CounterWith6LabelsHotPath | Cumulative             | 225.96 ns | 2.676 ns | 2.503 ns |         - |
+| CounterWith7LabelsHotPath | Cumulative             | 249.96 ns | 3.459 ns | 3.066 ns |         - |
+| CounterHotPath            | Delta                  |  19.83 ns | 0.158 ns | 0.148 ns |         - |
+| CounterWith1LabelsHotPath | Delta                  |  59.88 ns | 0.251 ns | 0.235 ns |         - |
+| CounterWith3LabelsHotPath | Delta                  | 124.24 ns | 1.490 ns | 1.394 ns |         - |
+| CounterWith5LabelsHotPath | Delta                  | 203.75 ns | 3.755 ns | 5.504 ns |         - |
+| CounterWith6LabelsHotPath | Delta                  | 226.50 ns | 2.036 ns | 1.805 ns |         - |
+| CounterWith7LabelsHotPath | Delta                  | 253.83 ns | 1.247 ns | 0.973 ns |         - |
 */
 
 namespace Benchmarks.Metrics;

--- a/test/Benchmarks/Metrics/MetricsViewBenchmarks.cs
+++ b/test/Benchmarks/Metrics/MetricsViewBenchmarks.cs
@@ -22,20 +22,20 @@ using OpenTelemetry.Metrics;
 using OpenTelemetry.Tests;
 
 /*
-BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.23424.1000)
+BenchmarkDotNet v0.13.10, Windows 11 (10.0.23424.1000)
 Intel Core i7-9700 CPU 3.00GHz, 1 CPU, 8 logical and 8 physical cores
-.NET SDK=7.0.203
-  [Host]     : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
-  DefaultJob : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
+.NET SDK 8.0.100
+  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+  DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
 
 
-|         Method |   ViewConfig |     Mean |   Error |  StdDev | Allocated |
-|--------------- |------------- |---------:|--------:|--------:|----------:|
-| CounterHotPath |       NoView | 254.6 ns | 1.62 ns | 1.27 ns |         - |
-| CounterHotPath |       ViewNA | 257.9 ns | 3.00 ns | 2.80 ns |         - |
-| CounterHotPath |  ViewApplied | 282.7 ns | 5.60 ns | 6.45 ns |         - |
-| CounterHotPath | ViewToRename | 256.8 ns | 0.83 ns | 0.70 ns |         - |
-| CounterHotPath |  ViewZeroTag | 112.1 ns | 1.87 ns | 1.75 ns |         - |
+| Method         | ViewConfig   | Mean      | Error    | StdDev   | Allocated |
+|--------------- |------------- |----------:|---------:|---------:|----------:|
+| CounterHotPath | NoView       | 217.94 ns | 3.950 ns | 3.502 ns |         - |
+| CounterHotPath | ViewNA       | 206.09 ns | 1.634 ns | 1.364 ns |         - |
+| CounterHotPath | ViewApplied  | 210.63 ns | 4.116 ns | 5.904 ns |         - |
+| CounterHotPath | ViewToRename | 207.05 ns | 1.592 ns | 1.329 ns |         - |
+| CounterHotPath | ViewZeroTag  |  68.67 ns | 0.613 ns | 0.573 ns |         - |
 */
 
 namespace Benchmarks.Metrics;


### PR DESCRIPTION
## Changes
- Update Metrics benchmarks (.NET 8 has improved perf for `ConcurrentDictionary` https://github.com/dotnet/runtime/pull/81557)
- Update the version of xUnit packages
- Update integration workflow to also run the test on .NET 8
