### PR TITLE
Remove threshold for MetricPoint reclaim

### DIFF
--- a/test/OpenTelemetry.Tests/Metrics/MeterProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MeterProviderSdkTest.cs
@@ -96,13 +96,9 @@ public class MeterProviderSdkTest
             Assert.Single(exportedItems);
         }
 
-#if DEBUG
-        // Note: This is inside a debug block because when running in CI the
-        // event source sees events from other tests running in parallel.
-        var metricInstrumentIgnoredEvents = inMemoryEventListener.Events.Where((e) => e.EventId == 33);
+        var metricInstrumentIgnoredEvents = inMemoryEventListener.Events.Where((e) => e.EventId == 33 && e.Payload[1] as string == meterName);
 
         Assert.Single(metricInstrumentIgnoredEvents);
-#endif
 
         void RunTest()
         {

--- a/test/OpenTelemetry.Tests/Metrics/MetricOverflowAttributeTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricOverflowAttributeTestsBase.cs
@@ -27,8 +27,6 @@ namespace OpenTelemetry.Metrics.Tests;
 
 public abstract class MetricOverflowAttributeTestsBase
 {
-    public const string ReclaimUnusedMetricPointsConfigKey = "OTEL_DOTNET_EXPERIMENTAL_METRICS_RECLAIM_UNUSED_METRIC_POINTS";
-
     private readonly bool shouldReclaimUnusedMetricPoints;
     private readonly Dictionary<string, string> configurationData = new()
     {
@@ -43,7 +41,7 @@ public abstract class MetricOverflowAttributeTestsBase
 
         if (shouldReclaimUnusedMetricPoints)
         {
-            this.configurationData[ReclaimUnusedMetricPointsConfigKey] = "true";
+            this.configurationData[MetricTestsBase.ReclaimUnusedMetricPointsConfigKey] = "true";
         }
 
         this.configuration = new ConfigurationBuilder()


### PR DESCRIPTION
Towards #2360 

If a user opts-in for Metric Point reclaim feature, then the SDK would now just start the reclaiming behavior instead of waiting for the usage to reach a threshold. This is done to clean-up metrics faster. The threshold was originally introduced to avoid the perf impact for users who wouldn't require the reclaim feature. Now that MetricPoint reclaim is not enabled by default and is only enabled for users who opt-in for it, we could get rid of the threshold check.

## Changes
- Remove threshold for MetricPoint reclaim
- Update MetricPoint reclaim tests to also run with the metric overflow attribute set to `true`

## Merge requirement checklist

* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
