### PR TITLE
[ASP.NET Core] Remove netstandard2.1 target

### DIFF
--- a/build/Common.props
+++ b/build/Common.props
@@ -21,7 +21,7 @@
     <!-- production TFMs -->
     <TargetFrameworksForLibraries>net8.0;net6.0;netstandard2.0;$(NetFrameworkMinimumSupportedVersion)</TargetFrameworksForLibraries>
     <TargetFrameworksForLibrariesExtended>net8.0;net6.0;netstandard2.1;netstandard2.0;$(NetFrameworkMinimumSupportedVersion)</TargetFrameworksForLibrariesExtended>
-    <TargetFrameworksForAspNetCoreInstrumentation>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworksForAspNetCoreInstrumentation>
+    <TargetFrameworksForAspNetCoreInstrumentation>net8.0;net7.0;net6.0;netstandard2.0</TargetFrameworksForAspNetCoreInstrumentation>
     <TargetFrameworksForGrpcNetClientInstrumentation>net8.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworksForGrpcNetClientInstrumentation>
     <TargetFrameworksForPrometheusAspNetCore>net8.0;net6.0</TargetFrameworksForPrometheusAspNetCore>
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreInstrumentationOptions.cs
@@ -77,7 +77,7 @@ public class AspNetCoreInstrumentationOptions
     /// </remarks>
     public bool RecordException { get; set; }
 
-#if NETSTANDARD2_1 || NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
     /// <summary>
     /// Gets or sets a value indicating whether RPC attributes are added to an Activity when using Grpc.AspNetCore. Default is true.
     /// </summary>

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -9,7 +9,7 @@
   ([#5066](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5066))
 
 * Removed `netstandard2.1` target.
-  ([]())
+  ([#5094](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5094))
 
 ## 1.6.0-beta.3
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -8,6 +8,9 @@
   semantic conventions.
   ([#5066](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5066))
 
+* Removed `netstandard2.1` target.
+  ([]())
+
 ## 1.6.0-beta.3
 
 Released 2023-Nov-17

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -344,51 +344,6 @@ internal class HttpInListener : ListenerHandler
             => ExceptionPropertyFetcher.TryFetch(payload, out exc) && exc != null;
     }
 
-    private static string GetUri(HttpRequest request)
-    {
-        // this follows the suggestions from https://github.com/dotnet/aspnetcore/issues/28906
-        var scheme = request.Scheme ?? string.Empty;
-
-        // HTTP 1.0 request with NO host header would result in empty Host.
-        // Use placeholder to avoid incorrect URL like "http:///"
-        var host = request.Host.Value ?? UnknownHostName;
-        var pathBase = request.PathBase.Value ?? string.Empty;
-        var path = request.Path.Value ?? string.Empty;
-        var queryString = request.QueryString.Value ?? string.Empty;
-        var length = scheme.Length + Uri.SchemeDelimiter.Length + host.Length + pathBase.Length
-                     + path.Length + queryString.Length;
-
-#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
-        return string.Create(length, (scheme, host, pathBase, path, queryString), (span, parts) =>
-        {
-            CopyTo(ref span, parts.scheme);
-            CopyTo(ref span, Uri.SchemeDelimiter);
-            CopyTo(ref span, parts.host);
-            CopyTo(ref span, parts.pathBase);
-            CopyTo(ref span, parts.path);
-            CopyTo(ref span, parts.queryString);
-
-            static void CopyTo(ref Span<char> buffer, ReadOnlySpan<char> text)
-            {
-                if (!text.IsEmpty)
-                {
-                    text.CopyTo(buffer);
-                    buffer = buffer.Slice(text.Length);
-                }
-            }
-        });
-#else
-        return new System.Text.StringBuilder(length)
-            .Append(scheme)
-            .Append(Uri.SchemeDelimiter)
-            .Append(host)
-            .Append(pathBase)
-            .Append(path)
-            .Append(queryString)
-            .ToString();
-#endif
-    }
-
 #if !NETSTANDARD2_0
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool TryGetGrpcMethod(Activity activity, out string grpcMethod)


### PR DESCRIPTION
Fixes #
Design discussion issue #

## Changes

Removes `netstandard2.1` target.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
