### PR TITLE
[Instrumentation.AspNetCore] Use static Meter and Histogram

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreMetrics.cs
@@ -15,8 +15,6 @@
 // </copyright>
 
 #if !NET8_0_OR_GREATER
-using System.Diagnostics.Metrics;
-using System.Reflection;
 using OpenTelemetry.Instrumentation.AspNetCore.Implementation;
 
 namespace OpenTelemetry.Instrumentation.AspNetCore;
@@ -26,12 +24,6 @@ namespace OpenTelemetry.Instrumentation.AspNetCore;
 /// </summary>
 internal sealed class AspNetCoreMetrics : IDisposable
 {
-    internal static readonly AssemblyName AssemblyName = typeof(HttpInListener).Assembly.GetName();
-    internal static readonly string InstrumentationName = AssemblyName.Name;
-    internal static readonly string InstrumentationVersion = AssemblyName.Version.ToString();
-
-    private static readonly Meter InstrumentationMeter = new(InstrumentationName, InstrumentationVersion);
-
     private static readonly HashSet<string> DiagnosticSourceEvents = new()
     {
         "Microsoft.AspNetCore.Hosting.HttpRequestIn",
@@ -48,7 +40,7 @@ internal sealed class AspNetCoreMetrics : IDisposable
 
     internal AspNetCoreMetrics()
     {
-        var metricsListener = new HttpInMetricsListener("Microsoft.AspNetCore", InstrumentationMeter);
+        var metricsListener = new HttpInMetricsListener("Microsoft.AspNetCore");
         this.diagnosticSourceSubscriber = new DiagnosticSourceSubscriber(metricsListener, this.isEnabled, AspNetCoreInstrumentationEventSource.Log.UnknownErrorProcessingEvent);
         this.diagnosticSourceSubscriber.Subscribe();
     }

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreMetrics.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreMetrics.cs
@@ -30,6 +30,8 @@ internal sealed class AspNetCoreMetrics : IDisposable
     internal static readonly string InstrumentationName = AssemblyName.Name;
     internal static readonly string InstrumentationVersion = AssemblyName.Version.ToString();
 
+    private static readonly Meter InstrumentationMeter = new(InstrumentationName, InstrumentationVersion);
+
     private static readonly HashSet<string> DiagnosticSourceEvents = new()
     {
         "Microsoft.AspNetCore.Hosting.HttpRequestIn",
@@ -43,12 +45,10 @@ internal sealed class AspNetCoreMetrics : IDisposable
         => DiagnosticSourceEvents.Contains(eventName);
 
     private readonly DiagnosticSourceSubscriber diagnosticSourceSubscriber;
-    private readonly Meter meter;
 
     internal AspNetCoreMetrics()
     {
-        this.meter = new Meter(InstrumentationName, InstrumentationVersion);
-        var metricsListener = new HttpInMetricsListener("Microsoft.AspNetCore", this.meter);
+        var metricsListener = new HttpInMetricsListener("Microsoft.AspNetCore", InstrumentationMeter);
         this.diagnosticSourceSubscriber = new DiagnosticSourceSubscriber(metricsListener, this.isEnabled, AspNetCoreInstrumentationEventSource.Log.UnknownErrorProcessingEvent);
         this.diagnosticSourceSubscriber.Subscribe();
     }
@@ -57,7 +57,6 @@ internal sealed class AspNetCoreMetrics : IDisposable
     public void Dispose()
     {
         this.diagnosticSourceSubscriber?.Dispose();
-        this.meter?.Dispose();
     }
 }
 #endif

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/MeterProviderBuilderExtensions.cs
@@ -44,7 +44,7 @@ public static class MeterProviderBuilderExtensions
         _ = TelemetryHelper.BoxedStatusCodes;
         _ = RequestMethodHelper.KnownMethods;
 
-        builder.AddMeter(AspNetCoreMetrics.InstrumentationName);
+        builder.AddMeter(HttpInMetricsListener.InstrumentationName);
 
         builder.AddInstrumentation(new AspNetCoreMetrics());
 


### PR DESCRIPTION
Towards #4376 

## Changes
- Use static Meter and Histogram
- This should allow for multiple SDK registrations with instrumentation so that they can be disposed without affect each other.(This is also consistent with how we have defined ActivitySource and Meter for Http instrumentation)
