### PR TITLE
Moq cleanup

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -85,7 +85,6 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="[17.8.0,18.0.0)" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="[1.1.1,2.0)" />
     <PackageVersion Include="MinVer" Version="[4.3.0,5.0)" />
-    <PackageVersion Include="Moq" Version="[4.18.4,5.0)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="[1.5.1,2.0)" />
     <PackageVersion Include="RabbitMQ.Client" Version="[6.6.0,7.0)" />
     <PackageVersion Include="StyleCop.Analyzers" Version="[1.2.0-beta.507,2.0)" />

--- a/src/OpenTelemetry/AssemblyInfo.cs
+++ b/src/OpenTelemetry/AssemblyInfo.cs
@@ -23,7 +23,6 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("OpenTelemetry.Exporter.Prometheus.HttpListener.Tests" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry.Extensions.Hosting" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("OpenTelemetry.Extensions.Hosting.Tests" + AssemblyInfo.PublicKey)]
-[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2" + AssemblyInfo.MoqPublicKey)]
 [assembly: InternalsVisibleTo("Benchmarks" + AssemblyInfo.PublicKey)]
 
 #if !EXPOSE_EXPERIMENTAL_FEATURES
@@ -36,12 +35,10 @@ using System.Runtime.CompilerServices;
 file static class AssemblyInfo
 {
     public const string PublicKey = ", PublicKey=002400000480000094000000060200000024000052534131000400000100010051C1562A090FB0C9F391012A32198B5E5D9A60E9B80FA2D7B434C9E5CCB7259BD606E66F9660676AFC6692B8CDC6793D190904551D2103B7B22FA636DCBB8208839785BA402EA08FC00C8F1500CCEF28BBF599AA64FFB1E1D5DC1BF3420A3777BADFE697856E9D52070A50C3EA5821C80BEF17CA3ACFFA28F89DD413F096F898";
-    public const string MoqPublicKey = ", PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7";
 }
 #else
 file static class AssemblyInfo
 {
     public const string PublicKey = "";
-    public const string MoqPublicKey = "";
 }
 #endif


### PR DESCRIPTION
Fixes #4758
Removed the last remnants of Moq

## Changes

- Removed Moq package from Directory.Packages.props
- Removed Moq public key from AssemblyInfo.cs
