### PR TITLE
Fixed Missing Endpoint

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Http;
 #if !NETSTANDARD
+using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Routing;
 #endif
 using OpenTelemetry.Context.Propagation;
@@ -236,7 +237,8 @@ internal class HttpInListener : ListenerHandler
             var response = context.Response;
 
 #if !NETSTANDARD
-            var routePattern = (context.GetEndpoint() as RouteEndpoint)?.RoutePattern.RawText;
+            var routePattern = (context.Features.Get<IExceptionHandlerPathFeature>()?.Endpoint as RouteEndpoint ??
+                    context.GetEndpoint() as RouteEndpoint)?.RoutePattern.RawText;
             if (!string.IsNullOrEmpty(routePattern))
             {
                 activity.DisplayName = GetDisplayName(context.Request.Method, routePattern);

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInMetricsListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInMetricsListener.cs
@@ -9,6 +9,7 @@ using OpenTelemetry.Internal;
 
 #if NET6_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Routing;
 #endif
 using OpenTelemetry.Trace;
@@ -88,7 +89,9 @@ internal sealed class HttpInMetricsListener : ListenerHandler
         tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpRequestMethod, httpMethod));
 
 #if NET6_0_OR_GREATER
-        var route = (context.GetEndpoint() as RouteEndpoint)?.RoutePattern.RawText;
+        // Check the exception handler feature first in case the endpoint was overwritten
+        var route = (context.Features.Get<IExceptionHandlerPathFeature>()?.Endpoint as RouteEndpoint ??
+                     context.GetEndpoint() as RouteEndpoint)?.RoutePattern.RawText;
         if (!string.IsNullOrEmpty(route))
         {
             tags.Add(new KeyValuePair<string, object>(SemanticConventions.AttributeHttpRoute, route));

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/README.net6.0.md
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/README.net6.0.md
@@ -592,6 +592,8 @@
 }
 ```
 
+## ExceptionMiddleware: Exception Handled by Exception Handler Middleware
+
 ```json
 {
   "IdealHttpRoute": "/Exception",

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/README.net6.0.md
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/README.net6.0.md
@@ -22,6 +22,7 @@
 | :green_heart: | RazorPages | [Static content](#razorpages-static-content) |
 | :green_heart: | MinimalApi | [Action without parameter](#minimalapi-action-without-parameter) |
 | :green_heart: | MinimalApi | [Action with parameter](#minimalapi-action-with-parameter) |
+| :green_heart: | ExceptionMiddleware | [Exception Handled by Exception Handler Middleware](#exceptionmiddleware-exception-handled-by-exception-handler-middleware) |
 
 ## ConventionalRouting: Root path
 
@@ -586,6 +587,23 @@
     "HttpContext.GetRouteData()": {
       "id": "123"
     },
+    "ActionDescriptor": null
+  }
+}
+```
+
+```json
+{
+  "IdealHttpRoute": "/Exception",
+  "ActivityDisplayName": "GET /Exception",
+  "ActivityHttpRoute": "/Exception",
+  "MetricHttpRoute": "/Exception",
+  "RouteInfo": {
+    "HttpMethod": "GET",
+    "Path": "/Exception",
+    "RoutePattern.RawText": null,
+    "IRouteDiagnosticsMetadata.Route": null,
+    "HttpContext.GetRouteData()": {},
     "ActionDescriptor": null
   }
 }

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/README.net7.0.md
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/README.net7.0.md
@@ -24,6 +24,7 @@
 | :green_heart: | MinimalApi | [Action with parameter](#minimalapi-action-with-parameter) |
 | :green_heart: | MinimalApi | [Action without parameter (MapGroup)](#minimalapi-action-without-parameter-mapgroup) |
 | :green_heart: | MinimalApi | [Action with parameter (MapGroup)](#minimalapi-action-with-parameter-mapgroup) |
+| :green_heart: | ExceptionMiddleware | [Exception Handled by Exception Handler Middleware](#exceptionmiddleware-exception-handled-by-exception-handler-middleware) |
 
 ## ConventionalRouting: Root path
 
@@ -628,6 +629,25 @@
     "HttpContext.GetRouteData()": {
       "id": "123"
     },
+    "ActionDescriptor": null
+  }
+}
+```
+
+## ExceptionMiddleware: Exception Handled by Exception Handler Middleware
+
+```json
+{
+  "IdealHttpRoute": "/Exception",
+  "ActivityDisplayName": "GET /Exception",
+  "ActivityHttpRoute": "/Exception",
+  "MetricHttpRoute": "/Exception",
+  "RouteInfo": {
+    "HttpMethod": "GET",
+    "Path": "/Exception",
+    "RoutePattern.RawText": null,
+    "IRouteDiagnosticsMetadata.Route": null,
+    "HttpContext.GetRouteData()": {},
     "ActionDescriptor": null
   }
 }

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTestCases.json
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTestCases.json
@@ -201,7 +201,6 @@
   },
   {
     "name": "Exception Handled by Exception Handler Middleware",
-    "minimumDotnetVersion": 7,
     "testApplicationScenario": "ExceptionMiddleware",
     "httpMethod": "GET",
     "path": "/Exception",

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTestCases.json
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTestCases.json
@@ -198,5 +198,15 @@
     "expectedStatusCode": 200,
     "currentHttpRoute": null,
     "expectedHttpRoute": "/MinimalApiUsingMapGroup/{id}"
+  },
+  {
+    "name": "Exception Handled by Exception Handler Middleware",
+    "minimumDotnetVersion": 7,
+    "testApplicationScenario": "ExceptionMiddleware",
+    "httpMethod": "GET",
+    "path": "/Exception",
+    "expectedStatusCode": 500,
+    "currentHttpRoute": null,
+    "expectedHttpRoute": "/Exception"
   }
 ]

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/TestApplicationFactory.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/TestApplicationFactory.cs
@@ -184,7 +184,16 @@ internal class TestApplicationFactory
         app.Urls.Clear();
         app.Urls.Add("http://[::1]:0");
 
+// TODO: Remove this condition once ASP.NET Core 8.0.2.
+// Currently, .NET 8 has a different behavior than .NET 6 and 7.
+// This is because ASP.NET Core 8+ has native metric instrumentation.
+// When ASP.NET Core 8.0.2 is released then its behavior will align with .NET 6/7.
+// See: https://github.com/dotnet/aspnetcore/issues/52648#issuecomment-1853432776
+#if !NET8_0_OR_GREATER
         app.MapGet("/Exception", (ctx) => throw new ApplicationException());
+#else
+        app.MapGet("/Exception", () => Results.Content(content: "Error", contentType: null, contentEncoding: null, statusCode: 500));
+#endif
 
         return app;
     }

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/TestApplicationFactory.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/TestApplicationFactory.cs
@@ -33,6 +33,11 @@ public enum TestApplicationScenario
     /// An Razor Pages application.
     /// </summary>
     RazorPages,
+
+    /// <summary>
+    /// Application with Exception Handling Middleware.
+    /// </summary>
+    ExceptionMiddleware,
 }
 
 internal class TestApplicationFactory
@@ -53,6 +58,8 @@ internal class TestApplicationFactory
                 return CreateMinimalApiApplication();
             case TestApplicationScenario.RazorPages:
                 return CreateRazorPagesApplication();
+            case TestApplicationScenario.ExceptionMiddleware:
+                return CreateExceptionHandlerApplication();
             default:
                 throw new ArgumentException($"Invalid {nameof(TestApplicationScenario)}");
         }
@@ -151,6 +158,28 @@ internal class TestApplicationFactory
         app.UseStaticFiles();
         app.UseRouting();
         app.MapRazorPages();
+
+        return app;
+    }
+
+    private static WebApplication CreateExceptionHandlerApplication()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+
+#if NET7_0_OR_GREATER
+        builder.Services.AddProblemDetails();
+#endif
+
+        var app = builder.Build();
+
+#if NET7_0_OR_GREATER
+        app.UseExceptionHandler();
+#endif
+        app.Urls.Clear();
+        app.Urls.Add("http://[::1]:0");
+
+        app.MapGet("/Exception", (ctx) => throw new ApplicationException());
 
         return app;
     }

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/TestApplicationFactory.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/TestApplicationFactory.cs
@@ -170,7 +170,6 @@ internal class TestApplicationFactory
 
         var app = builder.Build();
 
-#if NET6_0_OR_GREATER
         app.UseExceptionHandler(exceptionHandlerApp =>
         {
             exceptionHandlerApp.Run(async context =>
@@ -180,7 +179,7 @@ internal class TestApplicationFactory
                 await context.Response.WriteAsync(exceptionHandlerPathFeature?.Error.Message ?? "An exception was thrown.");
             });
         });
-#endif
+
         app.Urls.Clear();
         app.Urls.Add("http://[::1]:0");
 

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/TestApplicationFactory.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/TestApplicationFactory.cs
@@ -183,11 +183,11 @@ internal class TestApplicationFactory
         app.Urls.Clear();
         app.Urls.Add("http://[::1]:0");
 
-// TODO: Remove this condition once ASP.NET Core 8.0.2.
-// Currently, .NET 8 has a different behavior than .NET 6 and 7.
-// This is because ASP.NET Core 8+ has native metric instrumentation.
-// When ASP.NET Core 8.0.2 is released then its behavior will align with .NET 6/7.
-// See: https://github.com/dotnet/aspnetcore/issues/52648#issuecomment-1853432776
+        // TODO: Remove this condition once ASP.NET Core 8.0.2.
+        // Currently, .NET 8 has a different behavior than .NET 6 and 7.
+        // This is because ASP.NET Core 8+ has native metric instrumentation.
+        // When ASP.NET Core 8.0.2 is released then its behavior will align with .NET 6/7.
+        // See: https://github.com/dotnet/aspnetcore/issues/52648#issuecomment-1853432776
 #if !NET8_0_OR_GREATER
         app.MapGet("/Exception", (ctx) => throw new ApplicationException());
 #else

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/TestApplicationFactory.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/TestApplicationFactory.cs
@@ -167,13 +167,13 @@ internal class TestApplicationFactory
         var builder = WebApplication.CreateBuilder();
         builder.Logging.ClearProviders();
 
-#if NET7_0_OR_GREATER
+#if NET6_0_OR_GREATER
         builder.Services.AddProblemDetails();
 #endif
 
         var app = builder.Build();
 
-#if NET7_0_OR_GREATER
+#if NET6_0_OR_GREATER
         app.UseExceptionHandler();
 #endif
         app.Urls.Clear();


### PR DESCRIPTION
When an exception if processed by the ExceptionHandler middleware the original endpoint is deleted

Fixes #5134

## Changes

Source endpoint from exception handler feature 

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
