### PR TITLE
Doc fix for RecordException

### DIFF
--- a/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
@@ -57,20 +57,26 @@ public static class ActivityExtensions
     }
 
     /// <summary>
-    /// Adds an activity event containing information from the specified exception.
+    /// Adds an <see cref="ActivityEvent"/>  containing information from the specified exception.
     /// </summary>
     /// <param name="activity">Activity instance.</param>
     /// <param name="ex">Exception to be recorded.</param>
+    /// <remarks> The exception is recorded as per https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/exceptions.md.
+    /// "exception.stacktrace" is represented using the value of https://learn.microsoft.com/dotnet/api/system.exception.tostring.
+    /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void RecordException(this Activity activity, Exception? ex)
         => RecordException(activity, ex, default);
 
     /// <summary>
-    /// Adds an activity event containing information from the specified exception and additional tags.
+    /// Adds an <see cref="ActivityEvent"/> containing information from the specified exception and additional tags.
     /// </summary>
     /// <param name="activity">Activity instance.</param>
     /// <param name="ex">Exception to be recorded.</param>
     /// <param name="tags">Additional tags to record on the event.</param>
+    /// <remarks> The exception is recorded as per https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/exceptions.md.
+    /// "exception.stacktrace" is represented using the value of https://learn.microsoft.com/dotnet/api/system.exception.tostring.
+    /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void RecordException(this Activity activity, Exception? ex, in TagList tags)
     {


### PR DESCRIPTION
Fixes #1569 

Given we were using `ToString()` from the 1st stable release, documenting that `ex.ToString()` is the chosen representation of stacktrace. #1569 has question about using `ToString()` vs `StackTrace`, but given this is already part of stable release, we need to keep this behavior.

It is okay to provide an option to customize this, if there is demand, or change the chosen representation in v2.0. This PR is just documenting the existing behavior.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
