### PR TITLE
Solve 404 error in unit test

### DIFF
--- a/test/TestApp.AspNetCore/Program.cs
+++ b/test/TestApp.AspNetCore/Program.cs
@@ -60,6 +60,8 @@ public class Program
 
         app.UseMiddleware<ActivityMiddleware>();
 
+        app.AddTestMiddleware();
+
         app.Run();
     }
 }

--- a/test/TestApp.AspNetCore/TestMiddleware.cs
+++ b/test/TestApp.AspNetCore/TestMiddleware.cs
@@ -1,0 +1,37 @@
+// <copyright file="TestMiddleware.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestApp.AspNetCore;
+
+public static class TestMiddleware
+{
+    private static readonly AsyncLocal<Action<IApplicationBuilder>?> Current = new();
+
+    public static IApplicationBuilder AddTestMiddleware(this IApplicationBuilder builder)
+    {
+        if (Current.Value is { } configure)
+        {
+            configure(builder);
+        }
+
+        return builder;
+    }
+
+    public static void Create(Action<IApplicationBuilder> action)
+    {
+        Current.Value = action;
+    }
+}


### PR DESCRIPTION
@vishweshbankwar noticed that a HTTP 404 error was happening in the unit test https://github.com/open-telemetry/opentelemetry-dotnet/blob/93fd7d34a718278abfa533fa3e9436eb205cab88/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs#L945
 This test was marked to be skipped for a while, maybe for this reason.

The 404 error happened because of the use of the `Configure` method of the web host builder:
https://github.com/open-telemetry/opentelemetry-dotnet/blob/93fd7d34a718278abfa533fa3e9436eb205cab88/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs#L998C1-L1005C25

Read more about the issue here:
https://github.com/dotnet/aspnetcore/issues/45372
https://github.com/dotnet/AspNetCore.Docs/issues/27844

The fix for this problem is inspired on https://github.com/dotnet/aspnetcore/issues/37680#issuecomment-1331559463
Despite the 404, the test was falsely passing, so I added another assertion to verify that the exception middleware is actually being executed.