### PR TITLE
Minor perf optimization

### DIFF
--- a/src/OpenTelemetry/Internal/SelfDiagnosticsConfigRefresher.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnosticsConfigRefresher.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;
 using System.IO.MemoryMappedFiles;
-using System.Text;
 
 namespace OpenTelemetry.Internal;
 
@@ -18,7 +17,7 @@ namespace OpenTelemetry.Internal;
 /// </summary>
 internal class SelfDiagnosticsConfigRefresher : IDisposable
 {
-    public static readonly byte[] MessageOnNewFile = Encoding.UTF8.GetBytes("If you are seeing this message, it means that the OpenTelemetry SDK has successfully created the log file used to write self-diagnostic logs. This file will be appended with logs as they appear. If you do not see any logs following this line, it means no logs of the configured LogLevel is occurring. You may change the LogLevel to show lower log levels, so that logs of lower severities will be shown.\n");
+    public static readonly byte[] MessageOnNewFile = "If you are seeing this message, it means that the OpenTelemetry SDK has successfully created the log file used to write self-diagnostic logs. This file will be appended with logs as they appear. If you do not see any logs following this line, it means no logs of the configured LogLevel is occurring. You may change the LogLevel to show lower log levels, so that logs of lower severities will be shown.\n"u8.ToArray();
 
     private const int ConfigurationUpdatePeriodMilliSeconds = 10000;
 


### PR DESCRIPTION
## Changes
- Use utf-8 string literal to avoid allocating the string with utf-16 encoding: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/reference-types#utf-8-string-literals
