### PR TITLE
Minor perf improvement for AspNetCore instrumentation

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -39,7 +39,17 @@ internal class HttpInListener : ListenerHandler
     private const string DiagnosticSourceName = "Microsoft.AspNetCore";
     private const string UnknownHostName = "UNKNOWN-HOST";
 
-    private static readonly Func<HttpRequest, string, IEnumerable<string>> HttpRequestHeaderValuesGetter = (request, name) => request.Headers[name];
+    private static readonly Func<HttpRequest, string, IEnumerable<string>> HttpRequestHeaderValuesGetter = (request, name) =>
+    {
+        if (request.Headers.TryGetValue(name, out var value))
+        {
+            // This causes allocation as the `StringValues` struct has to be casted to an `IEnumerable<string>` object.
+            return value;
+        }
+
+        return Enumerable.Empty<string>();
+    };
+
     private static readonly PropertyFetcher<Exception> ExceptionPropertyFetcher = new("Exception");
 
 #if !NET6_0_OR_GREATER


### PR DESCRIPTION
## Changes
- Updated the request headers getter to return `Enumerable.Empty<string>()` when a given header is not present. Before this PR, the getter would have returned `StringValues.Empty` struct which would incur an allocation when being casted to `IEnumerable<string>` for the propagators.
- This saves about 48 B in scenarios where we don't have any trace context and baggage related headers in the request
