### PR TITLE
[sdk-logs] Keep LogRecord.State & LogRecord.Attributes in sync if either is updated by a log processor

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* `LogRecord.Attributes` and `LogRecord.StateValues` will now automatically
+  update if `LogRecord.State` is set inside a processor.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.7.0
 
 Released 2023-Dec-08

--- a/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLogger.cs
+++ b/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLogger.cs
@@ -79,7 +79,7 @@ internal sealed class OpenTelemetryLogger : ILogger
 
             LogRecordData.SetActivityContext(ref data, activity);
 
-            var attributes = record.Attributes =
+            var attributes = record.AttributeData =
                 ProcessState(record, ref iloggerData, in state, this.options.IncludeAttributes, this.options.ParseStateValues);
 
             if (!TryGetOriginalFormatFromAttributes(attributes, out var originalFormat))
@@ -133,7 +133,7 @@ internal sealed class OpenTelemetryLogger : ILogger
         }
     }
 
-    private static IReadOnlyList<KeyValuePair<string, object?>>? ProcessState<TState>(
+    internal static IReadOnlyList<KeyValuePair<string, object?>>? ProcessState<TState>(
         LogRecord logRecord,
         ref LogRecord.LogRecordILoggerData iLoggerData,
         in TState state,

--- a/src/OpenTelemetry/Logs/LoggerSdk.cs
+++ b/src/OpenTelemetry/Logs/LoggerSdk.cs
@@ -38,7 +38,7 @@ internal sealed class LoggerSdk : Logger
 
             logRecord.Logger = this;
 
-            logRecord.Attributes = attributes.Export(ref logRecord.AttributeStorage);
+            logRecord.AttributeData = attributes.Export(ref logRecord.AttributeStorage);
 
             processor.OnEnd(logRecord);
 

--- a/test/OpenTelemetry.Tests/Logs/LogRecordStateProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/LogRecordStateProcessorTests.cs
@@ -1,0 +1,266 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#nullable enable
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace OpenTelemetry.Logs.Tests;
+
+public class LogRecordStateProcessorTests
+{
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    public void LogProcessorSetStateTest(bool includeAttributes, bool parseStateValues)
+    {
+        List<LogRecord> exportedItems = new();
+
+        using (var loggerFactory = CreateLoggerFactory(includeAttributes, parseStateValues, exportedItems, OnEnd))
+        {
+            var logger = loggerFactory.CreateLogger("TestLogger");
+
+            logger.LogInformation("Hello world {data}", 1234);
+        }
+
+        Assert.Single(exportedItems);
+
+        AssertStateAndAttributes(
+            exportedItems[0],
+            attributesExpectedCount: !includeAttributes ? 0 : parseStateValues ? 1 : 3,
+            stateExpectedCount: !includeAttributes || parseStateValues ? 1 : 3,
+            out var state,
+            out var attributes);
+
+        void OnEnd(LogRecord logRecord)
+        {
+            AssertStateAndAttributes(
+                logRecord,
+                attributesExpectedCount: includeAttributes ? 2 : 0,
+                stateExpectedCount: !includeAttributes || parseStateValues ? 0 : 2,
+                out var state,
+                out var attributes);
+
+            logRecord.State = new List<KeyValuePair<string, object?>>(state)
+            {
+                new("enrichedData", "OTel"),
+            };
+        }
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    public void LogProcessorSetStateToUnsupportedTypeTest(bool includeAttributes, bool parseStateValues)
+    {
+        List<LogRecord> exportedItems = new();
+
+        using (var loggerFactory = CreateLoggerFactory(includeAttributes, parseStateValues, exportedItems, OnEnd))
+        {
+            var logger = loggerFactory.CreateLogger("TestLogger");
+
+            logger.LogInformation("Hello world {data}", 1234);
+        }
+
+        Assert.Single(exportedItems);
+
+        AssertStateAndAttributes(
+            exportedItems[0],
+            attributesExpectedCount: 0,
+            stateExpectedCount: 0,
+            out var state,
+            out var attributes);
+
+        Assert.True(exportedItems[0].State is CustomState);
+
+        void OnEnd(LogRecord logRecord)
+        {
+            AssertStateAndAttributes(
+                logRecord,
+                attributesExpectedCount: includeAttributes ? 2 : 0,
+                stateExpectedCount: !includeAttributes || parseStateValues ? 0 : 2,
+                out var state,
+                out var attributes);
+
+            logRecord.State = new CustomState("OTel");
+        }
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    public void LogProcessorSetAttributesTest(bool includeAttributes, bool parseStateValues)
+    {
+        List<LogRecord> exportedItems = new();
+
+        using (var loggerFactory = CreateLoggerFactory(includeAttributes, parseStateValues, exportedItems, OnEnd))
+        {
+            var logger = loggerFactory.CreateLogger("TestLogger");
+
+            logger.LogInformation("Hello world {data}", 1234);
+        }
+
+        Assert.Single(exportedItems);
+
+        AssertStateAndAttributes(
+            exportedItems[0],
+            attributesExpectedCount: !includeAttributes ? 1 : 3,
+            stateExpectedCount: !includeAttributes || parseStateValues ? 0 : 3,
+            out var state,
+            out var attributes);
+
+        void OnEnd(LogRecord logRecord)
+        {
+            AssertStateAndAttributes(
+                logRecord,
+                attributesExpectedCount: includeAttributes ? 2 : 0,
+                stateExpectedCount: !includeAttributes || parseStateValues ? 0 : 2,
+                out var state,
+                out var attributes);
+
+            logRecord.Attributes = new List<KeyValuePair<string, object?>>(attributes)
+            {
+                new("enrichedData", "OTel"),
+            };
+        }
+    }
+
+    [Theory]
+    [InlineData(true, false, 0)]
+    [InlineData(false, true, 0)]
+    [InlineData(true, true, 0)]
+    [InlineData(false, false, 0)]
+    [InlineData(true, false, 1)]
+    [InlineData(false, true, 1)]
+    [InlineData(true, true, 1)]
+    [InlineData(false, false, 1)]
+    public void LogProcessorSetAttributesAndStateMixedTest(bool includeAttributes, bool parseStateValues, int order)
+    {
+        List<LogRecord> exportedItems = new();
+
+        using (var loggerFactory = CreateLoggerFactory(includeAttributes, parseStateValues, exportedItems, OnEnd))
+        {
+            var logger = loggerFactory.CreateLogger("TestLogger");
+
+            logger.LogInformation("Hello world {data}", 1234);
+        }
+
+        Assert.Single(exportedItems);
+
+        AssertStateAndAttributes(
+            exportedItems[0],
+            attributesExpectedCount: !includeAttributes ? 1 : 3,
+            stateExpectedCount: !includeAttributes ? 1 : 3,
+            out var state,
+            out var attributes);
+
+        void OnEnd(LogRecord logRecord)
+        {
+            AssertStateAndAttributes(
+                logRecord,
+                attributesExpectedCount: includeAttributes ? 2 : 0,
+                stateExpectedCount: !includeAttributes || parseStateValues ? 0 : 2,
+                out var state,
+                out var attributes);
+
+            if (order == 0)
+            {
+                logRecord.State = logRecord.Attributes = new List<KeyValuePair<string, object?>>(attributes)
+                {
+                    new("enrichedData", "OTel"),
+                };
+            }
+            else
+            {
+                var newState = new List<KeyValuePair<string, object?>>(attributes)
+                {
+                    new("enrichedData", "OTel"),
+                };
+
+                logRecord.State = newState;
+                logRecord.Attributes = newState;
+            }
+        }
+    }
+
+    private static ILoggerFactory CreateLoggerFactory(
+        bool includeAttributes,
+        bool parseStateValues,
+        List<LogRecord> exportedItems,
+        Action<LogRecord> onEndAction)
+    {
+        return LoggerFactory.Create(logging => logging
+            .AddOpenTelemetry(options =>
+            {
+                options.IncludeAttributes = includeAttributes;
+                options.ParseStateValues = parseStateValues;
+
+                options
+                    .AddProcessor(new LogRecordStateProcessor(onEndAction))
+                    .AddInMemoryExporter(exportedItems);
+            }));
+    }
+
+    private static void AssertStateAndAttributes(
+        LogRecord logRecord,
+        int attributesExpectedCount,
+        int stateExpectedCount,
+        [NotNull] out IReadOnlyList<KeyValuePair<string, object?>>? state,
+        [NotNull] out IReadOnlyList<KeyValuePair<string, object?>>? attributes)
+    {
+        state = logRecord.State as IReadOnlyList<KeyValuePair<string, object?>>;
+        attributes = logRecord.Attributes;
+
+        if (stateExpectedCount > 0)
+        {
+            Assert.NotNull(state);
+            Assert.Equal(stateExpectedCount, state.Count);
+        }
+        else
+        {
+            Assert.Null(state);
+            state = Array.Empty<KeyValuePair<string, object?>>();
+        }
+
+        if (attributesExpectedCount > 0)
+        {
+            Assert.NotNull(attributes);
+            Assert.Equal(attributesExpectedCount, attributes.Count);
+        }
+        else
+        {
+            Assert.Null(attributes);
+            attributes = Array.Empty<KeyValuePair<string, object?>>();
+        }
+    }
+
+    private sealed class LogRecordStateProcessor : BaseProcessor<LogRecord>
+    {
+        private readonly Action<LogRecord> onEndAction;
+
+        public LogRecordStateProcessor(Action<LogRecord> onEndAction)
+        {
+            this.onEndAction = onEndAction;
+        }
+
+        public override void OnEnd(LogRecord data)
+        {
+            this.onEndAction(data);
+
+            base.OnEnd(data);
+        }
+    }
+
+    private sealed class CustomState(string enrichedData)
+    {
+        public string EnrichedData { get; } = enrichedData;
+    }
+}


### PR DESCRIPTION
Relates to #4609

## Changes

* Updates the `LogRecord` class so that if `Attributes` \ `StateValues` or `State` is set directly they will be kept in sync.

## Details

We're still discovering some code out in the wild that isn't handling `State` \ `Attributes` \ `StateValues` very well. Example:

```csharp
        public override void OnEnd(LogRecord data)
        {
            if (this.IsLogToBeProcessed(data))
            {
                if (data.State is IReadOnlyList<KeyValuePair<string, object>> listOfKvp)
                {
                    data.State = this.AddFields(data, listOfKvp);
                }
            }
        }
```

That code is flawed in that it ignores `Attributes` \ `StateValues` (which may be set instead of `State`) BUT, if users have `ParseStateValues=false` AND they are using an exporter which is preferring `State` over `Attributes` \ `StateValues`, it will work fine.

The problem is since 1.5.0+ things have changed:

* `Attributes` & `StateValues` will be set from the initial state. 
* A lot of exporters were updated to prefer `Attributes` \ `StateValues` over `State`.

The result of those changes is the code above sets a new `State` but `Attributes` \ `StateValues` remains set to what was parsed/resolved from the initial `State` value. The initial data is exported and these enrichment processors become broken.

To smooth this out what this PR does is keep everything in sync automatically.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
