### PR TITLE
Update main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ libraries](https://github.com/open-telemetry/opentelemetry-specification/blob/ma
 * [ASP.NET Core](./src/OpenTelemetry.Instrumentation.AspNetCore/README.md)
 * gRPC client:
   [Grpc.Net.Client](./src/OpenTelemetry.Instrumentation.GrpcNetClient/README.md)
-* Http clients: [System.Net.Http.HttpClient and
+* HTTP clients: [System.Net.Http.HttpClient and
   System.Net.HttpWebRequest](./src/OpenTelemetry.Instrumentation.Http/README.md)
 * SQL clients: [Microsoft.Data.SqlClient and
   System.Data.SqlClient](./src/OpenTelemetry.Instrumentation.SqlClient/README.md)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ libraries](https://github.com/open-telemetry/opentelemetry-specification/blob/ma
   [Grpc.Net.Client](./src/OpenTelemetry.Instrumentation.GrpcNetClient/README.md)
 * Http clients: [System.Net.Http.HttpClient and
   System.Net.HttpWebRequest](./src/OpenTelemetry.Instrumentation.Http/README.md)
-* Sql clients: [Microsoft.Data.SqlClient and
+* SQL clients: [Microsoft.Data.SqlClient and
   System.Data.SqlClient](./src/OpenTelemetry.Instrumentation.SqlClient/README.md)
 
 Here are the [exporter

--- a/README.md
+++ b/README.md
@@ -51,9 +51,12 @@ Here are the [instrumentation
 libraries](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/glossary.md#instrumentation-library):
 
 * [ASP.NET Core](./src/OpenTelemetry.Instrumentation.AspNetCore/README.md)
-* [Grpc.Net.Client](./src/OpenTelemetry.Instrumentation.GrpcNetClient/README.md)
-* [HttpClient and HttpWebRequest](./src/OpenTelemetry.Instrumentation.Http/README.md)
-* [SQL client](./src/OpenTelemetry.Instrumentation.SqlClient/README.md)
+* gRPC client:
+  [Grpc.Net.Client](./src/OpenTelemetry.Instrumentation.GrpcNetClient/README.md)
+* Http clients: [System.Net.Http.HttpClient and
+  System.Net.HttpWebRequest](./src/OpenTelemetry.Instrumentation.Http/README.md)
+* Sql clients: [Microsoft.Data.SqlClient and
+  System.Data.SqlClient](./src/OpenTelemetry.Instrumentation.SqlClient/README.md)
 
 Here are the [exporter
 libraries](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/glossary.md#exporter-library):


### PR DESCRIPTION
Follow up to #5180 

## Changes
- Addressing https://github.com/open-telemetry/opentelemetry-dotnet/pull/5180#discussion_r1427333942 to have consistency in the listing of instrumentation libraries' details
