### PR TITLE
Scope info should only be exported for Prometheus if OpenMetrics is requested

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Export OpenMetrics format from Prometheus exporters ([#5107](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5107))
-* For requests with OpenMetrics format, scope info is automatically added 
+* For requests with OpenMetrics format, scope info is automatically added
   ([#5086](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5086)
   [#5182](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5182))
 

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Export OpenMetrics format from Prometheus exporters ([#5107](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5107))
-* For requests with OpenMetrics format, scope info is automatically added ([#5086](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5086))
+* For requests with OpenMetrics format, scope info is automatically added ([#5086](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5086) [#5182](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5182))
 
 ## 1.7.0-rc.1
 

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Export OpenMetrics format from Prometheus exporters ([#5107](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5107))
-* For requests with OpenMetrics format, scope info is automatically added ([#5086](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5086) [#5182](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5182))
+* Requests with OpenMetrics format automatically add scope info ([#5086](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5086) [#5182](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5182))
 
 ## 1.7.0-rc.1
 

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## Unreleased
 
 * Export OpenMetrics format from Prometheus exporters ([#5107](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5107))
-* Requests with OpenMetrics format automatically add scope info ([#5086](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5086) [#5182](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5182))
+* For requests with OpenMetrics format, scope info is automatically added 
+  ([#5086](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5086)
+  [#5182](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5182))
 
 ## 1.7.0-rc.1
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Export OpenMetrics format from Prometheus exporters ([#5107](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5107))
-* For requests with OpenMetrics format, scope info is automatically added 
+* For requests with OpenMetrics format, scope info is automatically added
   ([#5086](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5086)
   [#5182](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5182))
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Export OpenMetrics format from Prometheus exporters ([#5107](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5107))
-* For requests with OpenMetrics format, scope info is automatically added ([#5086](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5086))
+* For requests with OpenMetrics format, scope info is automatically added ([#5086](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5086) [#5182](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5182))
 
 ## 1.7.0-rc.1
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Export OpenMetrics format from Prometheus exporters ([#5107](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5107))
-* For requests with OpenMetrics format, scope info is automatically added ([#5086](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5086) [#5182](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5182))
+* Requests with OpenMetrics format automatically add scope info ([#5086](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5086) [#5182](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5182))
 
 ## 1.7.0-rc.1
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## Unreleased
 
 * Export OpenMetrics format from Prometheus exporters ([#5107](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5107))
-* Requests with OpenMetrics format automatically add scope info ([#5086](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5086) [#5182](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5182))
+* For requests with OpenMetrics format, scope info is automatically added 
+  ([#5086](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5086)
+  [#5182](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5182))
 
 ## 1.7.0-rc.1
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusCollectionManager.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusCollectionManager.cs
@@ -172,31 +172,34 @@ internal sealed class PrometheusCollectionManager
 
         try
         {
-            this.scopes.Clear();
-
-            foreach (var metric in metrics)
+            if (this.exporter.OpenMetricsRequested)
             {
-                if (PrometheusSerializer.CanWriteMetric(metric))
-                {
-                    if (this.scopes.Add(metric.MeterName))
-                    {
-                        try
-                        {
-                            cursor = PrometheusSerializer.WriteScopeInfo(this.buffer, cursor, metric.MeterName);
+                this.scopes.Clear();
 
-                            break;
-                        }
-                        catch (IndexOutOfRangeException)
+                foreach (var metric in metrics)
+                {
+                    if (PrometheusSerializer.CanWriteMetric(metric))
+                    {
+                        if (this.scopes.Add(metric.MeterName))
                         {
-                            if (!this.IncreaseBufferSize())
+                            try
                             {
-                                // there are two cases we might run into the following condition:
-                                // 1. we have many metrics to be exported - in this case we probably want
-                                //    to put some upper limit and allow the user to configure it.
-                                // 2. we got an IndexOutOfRangeException which was triggered by some other
-                                //    code instead of the buffer[cursor++] - in this case we should give up
-                                //    at certain point rather than allocating like crazy.
-                                throw;
+                                cursor = PrometheusSerializer.WriteScopeInfo(this.buffer, cursor, metric.MeterName);
+
+                                break;
+                            }
+                            catch (IndexOutOfRangeException)
+                            {
+                                if (!this.IncreaseBufferSize())
+                                {
+                                    // there are two cases we might run into the following condition:
+                                    // 1. we have many metrics to be exported - in this case we probably want
+                                    //    to put some upper limit and allow the user to configure it.
+                                    // 2. we got an IndexOutOfRangeException which was triggered by some other
+                                    //    code instead of the buffer[cursor++] - in this case we should give up
+                                    //    at certain point rather than allocating like crazy.
+                                    throw;
+                                }
                             }
                         }
                     }

--- a/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMiddlewareTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMiddlewareTests.cs
@@ -328,10 +328,7 @@ public sealed class PrometheusExporterMiddlewareTests
                   + "# TYPE counter_double_total counter\n"
                   + $"counter_double_total{{otel_scope_name='{MeterName}',otel_scope_version='{MeterVersion}',key1='value1',key2='value2'}} 101.17 (\\d+\\.\\d{{3}})\n"
                   + "# EOF\n"
-                : "# TYPE otel_scope_info info\n"
-                  + "# HELP otel_scope_info Scope metadata\n"
-                  + $"otel_scope_info{{otel_scope_name='{MeterName}'}} 1\n"
-                  + "# TYPE counter_double_total counter\n"
+                : "# TYPE counter_double_total counter\n"
                   + $"counter_double_total{{otel_scope_name='{MeterName}',otel_scope_version='{MeterVersion}',key1='value1',key2='value2'}} 101.17 (\\d+)\n"
                   + "# EOF\n";
 

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
@@ -176,10 +176,7 @@ public class PrometheusHttpListenerTests
                   + "# TYPE counter_double_total counter\n"
                   + $"counter_double_total{{otel_scope_name='{MeterName}',otel_scope_version='{MeterVersion}',key1='value1',key2='value2'}} 101.17 (\\d+\\.\\d{{3}})\n"
                   + "# EOF\n"
-                : "# TYPE otel_scope_info info\n"
-                  + "# HELP otel_scope_info Scope metadata\n"
-                  + $"otel_scope_info{{otel_scope_name='{MeterName}'}} 1\n"
-                  + "# TYPE counter_double_total counter\n"
+                : "# TYPE counter_double_total counter\n"
                   + $"counter_double_total{{otel_scope_name='{MeterName}',otel_scope_version='{MeterVersion}',key1='value1',key2='value2'}} 101.17 (\\d+)\n"
                   + "# EOF\n";
 


### PR DESCRIPTION
Fixes #3972

## Changes

`otel_scope_info` was mistakenly being exported for non-OpenMetrics scrapes. This fix corrects this so that it will only be exposed for OpenMetrics.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
