### PR TITLE
AggregatorStore: don't double-count drops in doubles

### DIFF
--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -1033,7 +1033,6 @@ internal sealed class AggregatorStore
                         OpenTelemetrySdkEventSource.Log.MeasurementDropped(this.name, this.metricPointCapHitMessage, MetricPointCapHitFixMessage);
                     }
 
-                    Interlocked.Increment(ref this.DroppedMeasurements);
                     return;
                 }
             }
@@ -1078,7 +1077,6 @@ internal sealed class AggregatorStore
                         OpenTelemetrySdkEventSource.Log.MeasurementDropped(this.name, this.metricPointCapHitMessage, MetricPointCapHitFixMessage);
                     }
 
-                    Interlocked.Increment(ref this.DroppedMeasurements);
                     return;
                 }
             }


### PR DESCRIPTION
As funny as double counting only in doubles is, this seems like an oversight where we inadvertently call `Interlocked.Increment(ref this.DroppedMeasurements);` twice in the non-`emitOverflowAttribute` path. I noticed this digging into a related issue, so thought I'd pop up a PR while in here :)

## Changes
- Drops duplicate `DroppedMeasurements` increment in `AggregatorStore.UpdateDouble`
- Drops duplicate `DroppedMeasurements` increment in `AggregatorStore.UpdateDoubleCustomTags`

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
