### PR TITLE
Remove unnecessary package reference from SDK

### DIFF
--- a/src/OpenTelemetry/OpenTelemetry.csproj
+++ b/src/OpenTelemetry/OpenTelemetry.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" />
   </ItemGroup>
 


### PR DESCRIPTION
## Changes
- Remove unnecessary package reference to `Microsoft.Extensions.Logging` as `Microsoft.Extensions.Logging.Configuration` depends on the same
