### PR TITLE
Update aspnetcore docs to remove prerelease

### DIFF
--- a/docs/metrics/getting-started-aspnetcore/README.md
+++ b/docs/metrics/getting-started-aspnetcore/README.md
@@ -20,14 +20,8 @@ packages:
 ```sh
 dotnet add package OpenTelemetry.Exporter.Console
 dotnet add package OpenTelemetry.Extensions.Hosting
-dotnet add package OpenTelemetry.Instrumentation.AspNetCore --prerelease
+dotnet add package OpenTelemetry.Instrumentation.AspNetCore
 ```
-
-> **Note** This quickstart guide uses prerelease packages. For a quickstart
-> which only relies on stable packages see: [Getting Started - Console
-> Application](../getting-started-console/README.md). For more information about
-> when instrumentation will be marked as stable see: [Instrumentation-1.0.0
-> milestone](https://github.com/open-telemetry/opentelemetry-dotnet/milestone/23).
 
 Update the `Program.cs` file with the code from [Program.cs](./Program.cs).
 

--- a/docs/trace/getting-started-aspnetcore/README.md
+++ b/docs/trace/getting-started-aspnetcore/README.md
@@ -20,14 +20,8 @@ packages:
 ```sh
 dotnet add package OpenTelemetry.Exporter.Console
 dotnet add package OpenTelemetry.Extensions.Hosting
-dotnet add package OpenTelemetry.Instrumentation.AspNetCore --prerelease
+dotnet add package OpenTelemetry.Instrumentation.AspNetCore
 ```
-
-> **Note** This quickstart guide uses prerelease packages. For a quickstart
-> which only relies on stable packages see: [Getting Started - Console
-> Application](../getting-started-console/README.md). For more information about
-> when instrumentation will be marked as stable see: [Instrumentation-1.0.0
-> milestone](https://github.com/open-telemetry/opentelemetry-dotnet/milestone/23).
 
 Update the `Program.cs` file with the code from [Program.cs](./Program.cs).
 


### PR DESCRIPTION
## Changes

This PR updates the ASP.NET Core docs to remove the `--prerelease` option from the `dotnet add package` command. It also removed the redundant note about the use of prerelease packages. The `OpenTelemetry.Instrumentation.AspNetCore` package is now stable.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
