### PR TITLE
[repo] Bump StyleCop.Analyzers to latest NuGet

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -87,7 +87,7 @@
     <PackageVersion Include="MinVer" Version="[4.3.0,5.0)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="[1.5.1,2.0)" />
     <PackageVersion Include="RabbitMQ.Client" Version="[6.6.0,7.0)" />
-    <PackageVersion Include="StyleCop.Analyzers" Version="[1.2.0-beta.507,2.0)" />
+    <PackageVersion Include="StyleCop.Analyzers" Version="[1.2.0-beta.556,2.0)" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="[6.5.0,)" />
     <PackageVersion Include="Testcontainers.MsSql" Version="3.6.0" />
     <PackageVersion Include="Testcontainers.SqlEdge" Version="3.6.0" />


### PR DESCRIPTION
## Changes

* Bump `StyleCop.Analyzers` to `1.2.0-beta.556`. Seems to resolve some warnings being generated for C#12 syntax (ex https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3745)

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
