### PR TITLE
[repo] Add copyright header template to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,12 @@ trim_trailing_whitespace = true
 indent_size = 4
 
 ###############################
+# Copyright header            #
+###############################
+[*.cs]
+file_header_template = Copyright The OpenTelemetry Authors\nSPDX-License-Identifier: Apache-2.0
+
+###############################
 # .NET Coding Conventions     #
 ###############################
 # Directive order based on dotnet/runtime settings


### PR DESCRIPTION
## Changes

* Adds `file_header_template` in `.editorconfig` so IDEs can automatically add the copyright header when creating `.cs` files.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
