### PR TITLE
Bump OTLP proto files to 1.1.0

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/logs/v1/logs.proto
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/logs/v1/logs.proto
@@ -55,6 +55,9 @@ message ResourceLogs {
   // A list of ScopeLogs that originate from a resource.
   repeated ScopeLogs scope_logs = 2;
 
+  // The Schema URL, if known. This is the identifier of the Schema that the resource data
+  // is recorded in. To learn more about Schema URL see
+  // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
   // This schema_url applies to the data in the "resource" field. It does not apply
   // to the data in the "scope_logs" field which have their own schema_url field.
   string schema_url = 3;
@@ -70,6 +73,9 @@ message ScopeLogs {
   // A list of log records.
   repeated LogRecord log_records = 2;
 
+  // The Schema URL, if known. This is the identifier of the Schema that the log data
+  // is recorded in. To learn more about Schema URL see
+  // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
   // This schema_url applies to all logs in the "logs" field.
   string schema_url = 3;
 }
@@ -104,9 +110,11 @@ enum SeverityNumber {
   SEVERITY_NUMBER_FATAL4 = 24;
 }
 
-// LogRecordFlags is defined as a protobuf 'uint32' type and is to be used as
-// bit-fields. Each non-zero value defined in this enum is a bit-mask.
-// To extract the bit-field, for example, use an expression like:
+// LogRecordFlags represents constants used to interpret the
+// LogRecord.flags field, which is protobuf 'fixed32' type and is to
+// be used as bit-fields. Each non-zero value defined in this enum is
+// a bit-mask.  To extract the bit-field, for example, use an
+// expression like:
 //
 //   (logRecord.flags & LOG_RECORD_FLAGS_TRACE_FLAGS_MASK)
 //

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/metrics/v1/metrics.proto
@@ -55,6 +55,9 @@ message ResourceMetrics {
   // A list of metrics that originate from a resource.
   repeated ScopeMetrics scope_metrics = 2;
 
+  // The Schema URL, if known. This is the identifier of the Schema that the resource data
+  // is recorded in. To learn more about Schema URL see
+  // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
   // This schema_url applies to the data in the "resource" field. It does not apply
   // to the data in the "scope_metrics" field which have their own schema_url field.
   string schema_url = 3;
@@ -70,6 +73,9 @@ message ScopeMetrics {
   // A list of metrics that originate from an instrumentation library.
   repeated Metric metrics = 2;
 
+  // The Schema URL, if known. This is the identifier of the Schema that the metric data
+  // is recorded in. To learn more about Schema URL see
+  // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
   // This schema_url applies to all metrics in the "metrics" field.
   string schema_url = 3;
 }
@@ -162,7 +168,7 @@ message ScopeMetrics {
 message Metric {
   reserved 4, 6, 8;
 
-  // name of the metric, including its DNS name prefix. It must be unique.
+  // name of the metric.
   string name = 1;
 
   // description of the metric, which can be used in documentation.

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/trace/v1/trace.proto
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/trace/v1/trace.proto
@@ -55,6 +55,9 @@ message ResourceSpans {
   // A list of ScopeSpans that originate from a resource.
   repeated ScopeSpans scope_spans = 2;
 
+  // The Schema URL, if known. This is the identifier of the Schema that the resource data
+  // is recorded in. To learn more about Schema URL see
+  // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
   // This schema_url applies to the data in the "resource" field. It does not apply
   // to the data in the "scope_spans" field which have their own schema_url field.
   string schema_url = 3;
@@ -70,6 +73,9 @@ message ScopeSpans {
   // A list of Spans that originate from an instrumentation scope.
   repeated Span spans = 2;
 
+  // The Schema URL, if known. This is the identifier of the Schema that the span data
+  // is recorded in. To learn more about Schema URL see
+  // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
   // This schema_url applies to all spans and span events in the "spans" field.
   string schema_url = 3;
 }
@@ -102,6 +108,22 @@ message Span {
   // The `span_id` of this span's parent span. If this is a root span, then this
   // field must be empty. The ID is an 8-byte array.
   bytes parent_span_id = 4;
+
+  // Flags, a bit field. 8 least significant bits are the trace
+  // flags as defined in W3C Trace Context specification. Readers
+  // MUST not assume that 24 most significant bits will be zero.
+  // To read the 8-bit W3C trace flag, use `flags & SPAN_FLAGS_TRACE_FLAGS_MASK`.
+  //
+  // When creating span messages, if the message is logically forwarded from another source
+  // with an equivalent flags fields (i.e., usually another OTLP span message), the field SHOULD
+  // be copied as-is. If creating from a source that does not have an equivalent flags field
+  // (such as a runtime representation of an OpenTelemetry span), the high 24 bits MUST
+  // be set to zero.
+  //
+  // [Optional].
+  //
+  // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
+  fixed32 flags = 16;
 
   // A description of the span's operation.
   //
@@ -236,6 +258,16 @@ message Span {
     // dropped_attributes_count is the number of dropped attributes. If the value is 0,
     // then no attributes were dropped.
     uint32 dropped_attributes_count = 5;
+
+    // Flags, a bit field. 8 least significant bits are the trace
+    // flags as defined in W3C Trace Context specification. Readers
+    // MUST not assume that 24 most significant bits will be zero.
+    // When creating new spans, the most-significant 24-bits MUST be
+    // zero.  To read the 8-bit W3C trace flag (use flags &
+    // SPAN_FLAGS_TRACE_FLAGS_MASK).  [Optional].
+    //
+    // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
+    fixed32 flags = 6;
   }
 
   // links is a collection of Links, which are references from this span to a span
@@ -273,4 +305,29 @@ message Status {
 
   // The status code.
   StatusCode code = 3;
+}
+
+// SpanFlags represents constants used to interpret the
+// Span.flags field, which is protobuf 'fixed32' type and is to
+// be used as bit-fields. Each non-zero value defined in this enum is
+// a bit-mask.  To extract the bit-field, for example, use an
+// expression like:
+//
+//   (span.flags & SPAN_FLAGS_TRACE_FLAGS_MASK)
+//
+// See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
+//
+// Note that Span flags were introduced in version 1.1 of the
+// OpenTelemetry protocol.  Older Span producers do not set this
+// field, consequently consumers should not rely on the absence of a
+// particular flag bit to indicate the presence of a particular feature.
+enum SpanFlags {
+  // The zero value for the enum. Should not be used for comparisons.
+  // Instead use bitwise "and" with the appropriate mask as shown above.
+  SPAN_FLAGS_DO_NOT_USE = 0;
+
+  // Bits 0-7 are used for trace flags.
+  SPAN_FLAGS_TRACE_FLAGS_MASK = 0x000000FF;
+
+  // Bits 8-31 are reserved for future use.
 }


### PR DESCRIPTION
## Changes

Bump OTLP proto files to [1.1.0](https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v1.1.0).

## Important changes

Add `flags` field to `Span` and `Span/Link` for W3C-specified Trace Context flags in https://github.com/open-telemetry/opentelemetry-proto/pull/503

I think that support for this is good candidate for separate issue.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
