### PR TITLE
[repo] Bump sqlclient package version to avoid security warning

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -76,7 +76,7 @@
     <PackageVersion Include="Grpc.AspNetCore.Server" Version="[2.59.0, 3.0)" />
     <PackageVersion Include="Grpc.Tools" Version="[2.59.0,3.0)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="[3.11.0-beta1.23525.2]" />
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.2" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.3" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="[8.0.0,)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[8.0.0,)" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="[8.0.0,)" />


### PR DESCRIPTION
Only used in tests, but gives warning with every build, so this fixes that.
https://github.com/advisories/GHSA-98g6-xh36-x2p7