### PR TITLE
Fix SimpleExemplarReservoir for cumulative

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -15,6 +15,9 @@
   state compared to the current activity. For details see:
   [#5136](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5136)
 
+* Fixed an issue where `SimpleExemplarReservoir` was not resetting internal
+  state for cumulative temporality.
+
 ## 1.7.0
 
 Released 2023-Dec-08

--- a/src/OpenTelemetry/Metrics/Exemplar/SimpleExemplarReservoir.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/SimpleExemplarReservoir.cs
@@ -57,8 +57,12 @@ internal sealed class SimpleExemplarReservoir : ExemplarReservoir
             if (reset)
             {
                 this.runningExemplars[i].Timestamp = default;
-                this.measurementsSeen = 0;
             }
+
+            // Reset internal state irrespective of temporality.
+            // This ensures incoming measurements have fair chance
+            // of making it to the reservoir.
+            this.measurementsSeen = 0;
         }
 
         return this.tempExemplars;

--- a/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
@@ -19,8 +19,10 @@ public class MetricExemplarTests : MetricTestsBase
         this.output = output;
     }
 
-    [Fact]
-    public void TestExemplarsCounter()
+    [Theory]
+    [InlineData(MetricReaderTemporalityPreference.Cumulative)]
+    [InlineData(MetricReaderTemporalityPreference.Delta)]
+    public void TestExemplarsCounter(MetricReaderTemporalityPreference temporality)
     {
         DateTime testStartTime = DateTime.UtcNow;
         var exportedItems = new List<Metric>();
@@ -33,7 +35,7 @@ public class MetricExemplarTests : MetricTestsBase
             .SetExemplarFilter(new AlwaysOnExemplarFilter())
             .AddInMemoryExporter(exportedItems, metricReaderOptions =>
             {
-                metricReaderOptions.TemporalityPreference = MetricReaderTemporalityPreference.Delta;
+                metricReaderOptions.TemporalityPreference = temporality;
             }));
 
         var measurementValues = GenerateRandomValues(10);


### PR DESCRIPTION
Fixes `SimplerExemplarReservoir` for cumulative temporality to reset internal state during collect. Before this change, newer measurements had no fair chance to make it to the reservoir. This PR resets the "number_of_measurements_seen" with every collect, so new measurements had fair chance to make it to reservoir, subject to the reservoir sampling algorithm.

Spec ref: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#simplefixedsizeexemplarreservoir

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
