### PR TITLE
HTTP Instrumentation - fix description for http.client.request.duration

### DIFF
--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * .NET Framework - fix description for `http.client.request.duration` metric.
-  ([#1538](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1538))
+  ([#5234](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5234))
 
 ## 1.7.0
 

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* .NET Framework - fix description for `http.client.request.duration` metric.
+  ([#1538](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1538))
+
 ## 1.7.0
 
 Released 2023-Dec-13

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
@@ -35,7 +35,7 @@ internal static class HttpWebRequestActivitySource
     private static readonly string Version = AssemblyName.Version.ToString();
     private static readonly ActivitySource WebRequestActivitySource = new(ActivitySourceName, Version);
     private static readonly Meter WebRequestMeter = new(MeterName, Version);
-    private static readonly Histogram<double> HttpClientRequestDuration = WebRequestMeter.CreateHistogram<double>("http.client.request.duration", "s", "Measures the duration of outbound HTTP requests.");
+    private static readonly Histogram<double> HttpClientRequestDuration = WebRequestMeter.CreateHistogram<double>("http.client.request.duration", "s", "Duration of HTTP client requests.");
 
     private static HttpClientTraceInstrumentationOptions tracingOptions;
 


### PR DESCRIPTION
Fixes N/A
Design discussion issue # See similar PR https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1538

## Changes

HTTP Instrumentation - fix description for http.client.request.duration

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* ~~[ ] Changes in public API reviewed (if applicable)~~
