### PR TITLE
Minor docs tweak

### DIFF
--- a/docs/logs/correlation/Program.cs
+++ b/docs/logs/correlation/Program.cs
@@ -38,8 +38,7 @@ public class Program
         {
             activity?.SetTag("foo", 1);
 
-            // emit logs within the context
-            // of activity
+            // Emit logs within the context of activity
             logger.LogInformation("Hello from {name} {price}.", "tomato", 2.99);
         }
     }

--- a/docs/logs/getting-started-aspnetcore/README.md
+++ b/docs/logs/getting-started-aspnetcore/README.md
@@ -139,8 +139,7 @@ to work with it.
 
 ## Learn more
 
-* [Compile-time logging source
-  generation](https://docs.microsoft.com/dotnet/core/extensions/logger-message-generator)
+* [Logging in C# and .NET](https://learn.microsoft.com/dotnet/core/extensions/logging)
 * [Logging with Complex Objects](../complex-objects/README.md)
 * [Customizing the OpenTelemetry .NET SDK](../customizing-the-sdk/README.md)
 * [Extending the OpenTelemetry .NET SDK](../extending-the-sdk/README.md)

--- a/docs/logs/getting-started-console/README.md
+++ b/docs/logs/getting-started-console/README.md
@@ -113,8 +113,7 @@ learn more.
 
 ## Learn more
 
-* [Compile-time logging source
-  generation](https://docs.microsoft.com/dotnet/core/extensions/logger-message-generator)
+* [Logging in C# and .NET](https://learn.microsoft.com/dotnet/core/extensions/logging)
 * [Logging with Complex Objects](../complex-objects/README.md)
 * [Customizing the OpenTelemetry .NET SDK](../customizing-the-sdk/README.md)
 * [Extending the OpenTelemetry .NET SDK](../extending-the-sdk/README.md)


### PR DESCRIPTION
1. Updated the links to point to .NET official docs which were updated last Dec. with better clarity.
2. Editorial change to a code comment.