### PR TITLE
Remove ILogger scope from the ASP.NET Core logging getting started doc

### DIFF
--- a/docs/logs/getting-started-aspnetcore/Program.cs
+++ b/docs/logs/getting-started-aspnetcore/Program.cs
@@ -15,8 +15,6 @@ builder.Logging.ClearProviders();
 
 builder.Logging.AddOpenTelemetry(logging =>
 {
-    logging.IncludeScopes = true;
-
     var resourceBuilder = ResourceBuilder
         .CreateDefault()
         .AddService(builder.Environment.ApplicationName);

--- a/docs/logs/getting-started-aspnetcore/README.md
+++ b/docs/logs/getting-started-aspnetcore/README.md
@@ -83,12 +83,9 @@ pipeline. OpenTelemetry SDK is then configured with a
 export the logs to the console for demonstration purpose (note: ConsoleExporter
 is not intended for production usage, other exporters such as [OTLP
 Exporter](../../../src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md)
-should be used instead). In addition, `OpenTelemetryLoggerOptions.IncludeScopes`
-is enabled so the logs will include the [log
-scopes](https://learn.microsoft.com/dotnet/core/extensions/logging#log-scopes).
-From the console output we can see the log scopes that are coming from the
-ASP.NET Core framework, and we can see logs from both our logger and the ASP.NET
-Core framework loggers, as indicated by the `LogRecord.CategoryName`.
+should be used instead). From the console output we can see logs from both our
+logger and the ASP.NET Core framework loggers, as indicated by the
+`LogRecord.CategoryName`.
 
 The example has demonstrated the best practice from ASP.NET Core by injecting
 generic `ILogger<T>`:


### PR DESCRIPTION
ILogger scope has introduced some confusion to folks who just want to get started.
This PR makes the getting-started doc simpler and cleaner.