### PR TITLE
[repo] Disable missing xml doc StyleCop warnings for internal members

### DIFF
--- a/build/OpenTelemetry.prod.loose.ruleset
+++ b/build/OpenTelemetry.prod.loose.ruleset
@@ -128,7 +128,6 @@
     <Rule Id="SA1518" Action="None" />
     <Rule Id="SA1519" Action="Warning" />
     <Rule Id="SA1520" Action="Warning" />
-    <Rule Id="SA1600" Action="None" />
     <Rule Id="SA1601" Action="Warning" />
     <Rule Id="SA1602" Action="Warning" />
     <Rule Id="SA1604" Action="Warning" />

--- a/build/OpenTelemetry.prod.ruleset
+++ b/build/OpenTelemetry.prod.ruleset
@@ -5,10 +5,9 @@
     <Description Resource="OpenTelemetrySDKRules_Description" />
   </Localization>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-    <Rule Id="SA1200" Action="None" />
-    <Rule Id="SA1401" Action="None" />
-    <Rule Id="SA1512" Action="None" />
-    <Rule Id="SA1518" Action="None" />
-    <Rule Id="SA1600" Action="None" />
+    <Rule Id="SA1200" Action="None" /> <!-- UsingDirectivesMustBePlacedCorrectly -->
+    <Rule Id="SA1401" Action="None" /> <!-- FieldsMustBePrivate -->
+    <Rule Id="SA1512" Action="None" /> <!-- ElementMustNotBeOnSingleLine -->
+    <Rule Id="SA1518" Action="None" /> <!-- UseLineEndingsCorrectlyAtEndOfFile -->
   </Rules>
 </RuleSet>

--- a/build/stylecop.json
+++ b/build/stylecop.json
@@ -1,9 +1,10 @@
-﻿{
+{
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
       "copyrightText": "Copyright The OpenTelemetry Authors\nSPDX-License-Identifier: Apache-2.0",
-      "xmlHeader": false
+      "xmlHeader": false,
+      "documentInternalElements": false
     },
     "orderingRules": {
       "usingDirectivesPlacement": "outsideNamespace"


### PR DESCRIPTION
See: https://github.com/open-telemetry/opentelemetry-dotnet/pull/5255#discussion_r1465719000

## Changes

* Disable warnings for missing xml docs on internal members. Reference: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/Configuration.md#documentation-requirements

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
