### PR TITLE
[otlp] Remove Experimental Flag and emit stable Exception attributes by default

### DIFF
--- a/docs/logs/redaction/MyRedactionProcessor.cs
+++ b/docs/logs/redaction/MyRedactionProcessor.cs
@@ -31,8 +31,8 @@ internal sealed class MyRedactionProcessor : BaseProcessor<LogRecord>
             get
             {
                 var item = this.state[index];
-                var entryVal = item.Value;
-                if (entryVal != null && entryVal.ToString() != null && entryVal.ToString().Contains("<secret>"))
+                var entryVal = item.Value?.ToString();
+                if (entryVal != null && entryVal.Contains("<secret>"))
                 {
                     return new KeyValuePair<string, object>(item.Key, "newRedactedValueHere");
                 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -11,9 +11,9 @@
   `exception.type`, `exception.message`, and `exception.stacktrace` in the
   [OpenTelemetry Semantic
   Conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/exceptions/exceptions-logs.md#semantic-conventions-for-exceptions-in-logs).
-  These attributes, corresponding to `LogRecord.Exception`, are now standard and
-  will be automatically included in exports. The need for the previously
-  experimental flag is thus eliminated.
+  These attributes, corresponding to `LogRecord.Exception`, are now stable and
+  will be automatically included in exports.
+  ([#5258](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5258))
 
 ## 1.7.0
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -6,6 +6,15 @@
   `LoggerProviderBuilder.AddOtlpExporter` registration extensions.
   [#5103](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5103)
 
+* Removed the `OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES`
+  environment variable, following the stabilization of the exception attributes
+  `exception.type`, `exception.message`, and `exception.stacktrace` in the
+  [OpenTelemetry Semantic
+  Conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/exceptions/exceptions-logs.md#semantic-conventions-for-exceptions-in-logs).
+  These attributes, corresponding to `LogRecord.Exception`, are now standard and
+  will be automatically included in exports. The need for the previously
+  experimental flag is thus eliminated.
+
 ## 1.7.0
 
 Released 2023-Dec-08

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExperimentalOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExperimentalOptions.cs
@@ -14,8 +14,6 @@ internal sealed class ExperimentalOptions
 
     public const string LogRecordEventNameAttribute = "logrecord.event.name";
 
-    public const string EmitLogExceptionEnvVar = "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES";
-
     public const string EmitLogEventEnvVar = "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES";
 
     public ExperimentalOptions()
@@ -25,21 +23,11 @@ internal sealed class ExperimentalOptions
 
     public ExperimentalOptions(IConfiguration configuration)
     {
-        if (configuration.TryGetBoolValue(EmitLogExceptionEnvVar, out var emitLogExceptionAttributes))
-        {
-            this.EmitLogExceptionAttributes = emitLogExceptionAttributes;
-        }
-
         if (configuration.TryGetBoolValue(EmitLogEventEnvVar, out var emitLogEventAttributes))
         {
             this.EmitLogEventAttributes = emitLogEventAttributes;
         }
     }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether log exception attributes should be exported.
-    /// </summary>
-    public bool EmitLogExceptionAttributes { get; set; } = false;
 
     /// <summary>
     /// Gets or sets a value indicating whether log event attributes should be exported.

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpLogRecordTransformer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpLogRecordTransformer.cs
@@ -140,7 +140,7 @@ internal sealed class OtlpLogRecordTransformer
                 }
             }
 
-            if (this.experimentalOptions.EmitLogExceptionAttributes && logRecord.Exception != null)
+            if (logRecord.Exception != null)
             {
                 AddStringAttribute(otlpLogRecord, SemanticConventions.AttributeExceptionType, logRecord.Exception.GetType().Name, attributeValueLengthLimit, attributeCountLimit);
                 AddStringAttribute(otlpLogRecord, SemanticConventions.AttributeExceptionMessage, logRecord.Exception.Message, attributeValueLengthLimit, attributeCountLimit);

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
@@ -589,11 +589,8 @@ public class OtlpLogExporterTests : Http2UnencryptedSupportTests
         Assert.Equal("state", otlpLogRecord.Body.StringValue);
     }
 
-    [Theory]
-    [InlineData("true")]
-    [InlineData("false")]
-    [InlineData(null)]
-    public void CheckToOtlpLogRecordExceptionAttributes(string emitExceptionAttributes)
+    [Fact]
+    public void CheckToOtlpLogRecordExceptionAttributes()
     {
         var logRecords = new List<LogRecord>();
         using var loggerFactory = LoggerFactory.Create(builder =>
@@ -609,39 +606,22 @@ public class OtlpLogExporterTests : Http2UnencryptedSupportTests
 
         var logRecord = logRecords[0];
         var loggedException = logRecord.Exception;
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string> { [ExperimentalOptions.EmitLogExceptionEnvVar] = emitExceptionAttributes })
-            .Build();
 
-        var otlpLogRecordTransformer = new OtlpLogRecordTransformer(DefaultSdkLimitOptions, new(configuration));
+        var otlpLogRecordTransformer = new OtlpLogRecordTransformer(DefaultSdkLimitOptions, new());
 
         var otlpLogRecord = otlpLogRecordTransformer.ToOtlpLog(logRecord);
 
         Assert.NotNull(otlpLogRecord);
         var otlpLogRecordAttributes = otlpLogRecord.Attributes.ToString();
 
-        if (emitExceptionAttributes == "true")
-        {
-            Assert.Contains(SemanticConventions.AttributeExceptionType, otlpLogRecordAttributes);
-            Assert.Contains(logRecord.Exception.GetType().Name, otlpLogRecordAttributes);
+        Assert.Contains(SemanticConventions.AttributeExceptionType, otlpLogRecordAttributes);
+        Assert.Contains(logRecord.Exception.GetType().Name, otlpLogRecordAttributes);
 
-            Assert.Contains(SemanticConventions.AttributeExceptionMessage, otlpLogRecordAttributes);
-            Assert.Contains(logRecord.Exception.Message, otlpLogRecordAttributes);
+        Assert.Contains(SemanticConventions.AttributeExceptionMessage, otlpLogRecordAttributes);
+        Assert.Contains(logRecord.Exception.Message, otlpLogRecordAttributes);
 
-            Assert.Contains(SemanticConventions.AttributeExceptionStacktrace, otlpLogRecordAttributes);
-            Assert.Contains(logRecord.Exception.ToInvariantString(), otlpLogRecordAttributes);
-        }
-        else
-        {
-            Assert.DoesNotContain(SemanticConventions.AttributeExceptionType, otlpLogRecordAttributes);
-            Assert.DoesNotContain(logRecord.Exception.GetType().Name, otlpLogRecordAttributes);
-
-            Assert.DoesNotContain(SemanticConventions.AttributeExceptionMessage, otlpLogRecordAttributes);
-            Assert.DoesNotContain(logRecord.Exception.Message, otlpLogRecordAttributes);
-
-            Assert.DoesNotContain(SemanticConventions.AttributeExceptionStacktrace, otlpLogRecordAttributes);
-            Assert.DoesNotContain(logRecord.Exception.ToInvariantString(), otlpLogRecordAttributes);
-        }
+        Assert.Contains(SemanticConventions.AttributeExceptionStacktrace, otlpLogRecordAttributes);
+        Assert.Contains(logRecord.Exception.ToInvariantString(), otlpLogRecordAttributes);
     }
 
     [Fact]
@@ -1264,7 +1244,7 @@ public class OtlpLogExporterTests : Http2UnencryptedSupportTests
         var allScopeValues = otlpLogRecord.Attributes
             .Where(_ => _.Key == scopeKey1 || _.Key == scopeKey2)
             .Select(_ => _.Value.StringValue);
-        Assert.Equal(2, otlpLogRecord.Attributes.Count);
+        Assert.Equal(5, otlpLogRecord.Attributes.Count);
         Assert.Equal(2, allScopeValues.Count());
         Assert.Contains(scopeValue1, allScopeValues);
         Assert.Contains(scopeValue2, allScopeValues);


### PR DESCRIPTION
Fixes #4831
Design discussion issue #

This PR addresses the stabilization of exception attributes in the [OpenTelemetry Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/exceptions/exceptions-logs.md#semantic-conventions-for-exceptions-in-logs). With `exception.type`, `exception.message`, and `exception.stacktrace` now considered stable, the need for the `OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES` environment variable has been eliminated.

## Changes

Please provide a brief description of the changes here.

* Removed the `OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES` environment variable.
* Ensured that `exception.type`, `exception.message`, and `exception.stacktrace` are automatically included in exports

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* ~~[ ] Changes in public API reviewed (if applicable)~~
