### PR TITLE
Link to .NET 9 log filter plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ repo.
 
 If you are new here, please read the getting started docs:
 
-* Logs: [ASP.NET Core](./docs/logs/getting-started-aspnetcore/README.md) | [Console](./docs/logs/getting-started-console/README.md)
+* [Logs](./docs/logs/README.md): [ASP.NET
+  Core](./docs/logs/getting-started-aspnetcore/README.md) |
+  [Console](./docs/logs/getting-started-console/README.md)
 * Metrics: [ASP.NET Core](./docs/metrics/getting-started-aspnetcore/README.md) |
   [Console](./docs/metrics/getting-started-console/README.md)
 * Traces: [ASP.NET Core](./docs/trace/getting-started-aspnetcore/README.md) |

--- a/docs/logs/README.md
+++ b/docs/logs/README.md
@@ -156,7 +156,8 @@ to learn more.
 
 ## Log Correlation
 
-In OpenTelemetry, logs are automatically correlated to traces. Check the [Log
+In OpenTelemetry, logs are automatically correlated to
+[traces](../trace/README.md). Check the [Log
 Correlation](./correlation/README.md) tutorial to learn more.
 
 ## Log Enrichment
@@ -165,8 +166,15 @@ TBD
 
 ## Log Filtering
 
-Check the [Customizing OpenTelemetry .NET SDK for
-Logs](./customizing-the-sdk/README.md#log-filtering) document to learn more.
+The [Customizing OpenTelemetry .NET SDK for
+Logs](./customizing-the-sdk/README.md#log-filtering) document has provided
+instructions for basic filtering based on logger category name and severity
+level.
+
+For more advanced filtering and sampling, the .NET team has a plan to cover it
+in .NET 9 timeframe, please use this [runtime
+issue](https://github.com/dotnet/runtime/issues/82465) to track the progress or
+provide feedback and suggestions.
 
 ## Log Redaction
 


### PR DESCRIPTION
1. Updated the links.
2. For log filtering, mentioned the .NET 9 filtering/sampling issue.