### PR TITLE
commit

### DIFF
--- a/src/OpenTelemetry.Api/.publicApi/Stable/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/Stable/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+OpenTelemetry.Logs.LogRecordData.CategoryName.get -> string!
+OpenTelemetry.Logs.LogRecordData.CategoryName.set -> void

--- a/src/OpenTelemetry.Api/Logs/LogRecordData.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordData.cs
@@ -125,6 +125,11 @@ internal
     /// </summary>
     public string? Body { get; set; } = null;
 
+    /// <summary>
+    /// Gets or sets the log category name.
+    /// </summary>
+    public string CategoryName { get; set; } = string.Empty;
+
     internal static void SetActivityContext(ref LogRecordData data, Activity? activity)
     {
         if (activity != null)

--- a/src/OpenTelemetry/Logs/LogRecord.cs
+++ b/src/OpenTelemetry/Logs/LogRecord.cs
@@ -142,7 +142,7 @@ public sealed class LogRecord
     /// </remarks>
     public string? CategoryName
     {
-        get => this.ILoggerData.CategoryName;
+        get => this.ILoggerData.CategoryName ?? this.Data.CategoryName;
         set => this.ILoggerData.CategoryName = value;
     }
 


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-dotnet/issues/5274

## Changes

This would add a new property to the LogRecordData struct with a default value, which would allow us to set LogRecord.CategoryName when using the logging bridge API

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
