### PR TITLE
Rename SqlClientInstrumentationOptions to SqlClientTraceInstrumentationOptions

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/.publicApi/PublicAPI.Unshipped.txt
@@ -1,18 +1,18 @@
-OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions
-OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.EnableConnectionLevelAttributes.get -> bool
-OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.EnableConnectionLevelAttributes.set -> void
-OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.Enrich.get -> System.Action<System.Diagnostics.Activity, string, object>
-OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.Enrich.set -> void
-OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.Filter.get -> System.Func<object, bool>
-OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.Filter.set -> void
-OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.RecordException.get -> bool
-OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.RecordException.set -> void
-OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.SetDbStatementForStoredProcedure.get -> bool
-OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.SetDbStatementForStoredProcedure.set -> void
-OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.SetDbStatementForText.get -> bool
-OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.SetDbStatementForText.set -> void
-OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions.SqlClientInstrumentationOptions() -> void
+OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions
+OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.EnableConnectionLevelAttributes.get -> bool
+OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.EnableConnectionLevelAttributes.set -> void
+OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.Enrich.get -> System.Action<System.Diagnostics.Activity, string, object>
+OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.Enrich.set -> void
+OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.Filter.get -> System.Func<object, bool>
+OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.Filter.set -> void
+OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.RecordException.get -> bool
+OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.RecordException.set -> void
+OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.SetDbStatementForStoredProcedure.get -> bool
+OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.SetDbStatementForStoredProcedure.set -> void
+OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.SetDbStatementForText.get -> bool
+OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.SetDbStatementForText.set -> void
+OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions.SqlClientTraceInstrumentationOptions() -> void
 OpenTelemetry.Trace.TracerProviderBuilderExtensions
 static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddSqlClientInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder builder) -> OpenTelemetry.Trace.TracerProviderBuilder
-static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddSqlClientInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder builder, string name, System.Action<OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions> configureSqlClientInstrumentationOptions) -> OpenTelemetry.Trace.TracerProviderBuilder
-static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddSqlClientInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Instrumentation.SqlClient.SqlClientInstrumentationOptions> configureSqlClientInstrumentationOptions) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddSqlClientInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder builder, string name, System.Action<OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions> configureSqlClientTraceInstrumentationOptions) -> OpenTelemetry.Trace.TracerProviderBuilder
+static OpenTelemetry.Trace.TracerProviderBuilderExtensions.AddSqlClientInstrumentation(this OpenTelemetry.Trace.TracerProviderBuilder builder, System.Action<OpenTelemetry.Instrumentation.SqlClient.SqlClientTraceInstrumentationOptions> configureSqlClientTraceInstrumentationOptions) -> OpenTelemetry.Trace.TracerProviderBuilder

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -8,6 +8,9 @@
   Now that this suite of attributes are stable, this instrumentation will only
   emit the new attributes.
   ([#5270](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5270))
+* **Breaking Change**: Renamed `SqlClientInstrumentationOptions` to
+  `SqlClientTraceInstrumentationOptions`.
+  ([#5285](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5285))
 
 ## 1.6.0-beta.3
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
@@ -32,12 +32,12 @@ internal sealed class SqlClientDiagnosticListener : ListenerHandler
     private readonly PropertyFetcher<CommandType> commandTypeFetcher = new("CommandType");
     private readonly PropertyFetcher<object> commandTextFetcher = new("CommandText");
     private readonly PropertyFetcher<Exception> exceptionFetcher = new("Exception");
-    private readonly SqlClientInstrumentationOptions options;
+    private readonly SqlClientTraceInstrumentationOptions options;
 
-    public SqlClientDiagnosticListener(string sourceName, SqlClientInstrumentationOptions options)
+    public SqlClientDiagnosticListener(string sourceName, SqlClientTraceInstrumentationOptions options)
         : base(sourceName)
     {
-        this.options = options ?? new SqlClientInstrumentationOptions();
+        this.options = options ?? new SqlClientTraceInstrumentationOptions();
     }
 
     public override bool SupportsNullActivity => true;

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlEventSourceListener.netfx.cs
@@ -29,13 +29,13 @@ internal sealed class SqlEventSourceListener : EventListener
     internal const int BeginExecuteEventId = 1;
     internal const int EndExecuteEventId = 2;
 
-    private readonly SqlClientInstrumentationOptions options;
+    private readonly SqlClientTraceInstrumentationOptions options;
     private EventSource adoNetEventSource;
     private EventSource mdsEventSource;
 
-    public SqlEventSourceListener(SqlClientInstrumentationOptions options = null)
+    public SqlEventSourceListener(SqlClientTraceInstrumentationOptions options = null)
     {
-        this.options = options ?? new SqlClientInstrumentationOptions();
+        this.options = options ?? new SqlClientTraceInstrumentationOptions();
     }
 
     public override void Dispose()

--- a/src/OpenTelemetry.Instrumentation.SqlClient/README.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/README.md
@@ -75,12 +75,12 @@ For an ASP.NET application, adding instrumentation is typically done in the
 ## Advanced configuration
 
 This instrumentation can be configured to change the default behavior by using
-`SqlClientInstrumentationOptions`.
+`SqlClientTraceInstrumentationOptions`.
 
 ### Capturing database statements
 
-The `SqlClientInstrumentationOptions` class exposes two properties that can be
-used to configure how the
+The `SqlClientTraceInstrumentationOptions` class exposes two properties that can
+be used to configure how the
 [`db.statement`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md#call-level-attributes)
 attribute is captured upon execution of a query but the behavior depends on the
 runtime used.

--- a/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentation.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientInstrumentation.cs
@@ -44,7 +44,7 @@ internal sealed class SqlClientInstrumentation : IDisposable
     [RequiresUnreferencedCode(SqlClientTrimmingUnsupportedMessage)]
 #endif
     public SqlClientInstrumentation(
-        SqlClientInstrumentationOptions options = null)
+        SqlClientTraceInstrumentationOptions options = null)
     {
 #if NETFRAMEWORK
         this.sqlEventSourceListener = new SqlEventSourceListener(options);

--- a/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientTraceInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/SqlClientTraceInstrumentationOptions.cs
@@ -15,7 +15,7 @@ namespace OpenTelemetry.Instrumentation.SqlClient;
 /// <remarks>
 /// For help and examples see: <a href="https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Instrumentation.SqlClient/README.md#advanced-configuration" />.
 /// </remarks>
-public class SqlClientInstrumentationOptions
+public class SqlClientTraceInstrumentationOptions
 {
     /*
      * Match...

--- a/src/OpenTelemetry.Instrumentation.SqlClient/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/TracerProviderBuilderExtensions.cs
@@ -26,28 +26,28 @@ public static class TracerProviderBuilderExtensions
     [RequiresUnreferencedCode(SqlClientInstrumentation.SqlClientTrimmingUnsupportedMessage)]
 #endif
     public static TracerProviderBuilder AddSqlClientInstrumentation(this TracerProviderBuilder builder)
-        => AddSqlClientInstrumentation(builder, name: null, configureSqlClientInstrumentationOptions: null);
+        => AddSqlClientInstrumentation(builder, name: null, configureSqlClientTraceInstrumentationOptions: null);
 
     /// <summary>
     /// Enables SqlClient instrumentation.
     /// </summary>
     /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
-    /// <param name="configureSqlClientInstrumentationOptions">Callback action for configuring <see cref="SqlClientInstrumentationOptions"/>.</param>
+    /// <param name="configureSqlClientTraceInstrumentationOptions">Callback action for configuring <see cref="SqlClientTraceInstrumentationOptions"/>.</param>
     /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
 #if NET6_0_OR_GREATER
     [RequiresUnreferencedCode(SqlClientInstrumentation.SqlClientTrimmingUnsupportedMessage)]
 #endif
     public static TracerProviderBuilder AddSqlClientInstrumentation(
         this TracerProviderBuilder builder,
-        Action<SqlClientInstrumentationOptions> configureSqlClientInstrumentationOptions)
-        => AddSqlClientInstrumentation(builder, name: null, configureSqlClientInstrumentationOptions);
+        Action<SqlClientTraceInstrumentationOptions> configureSqlClientTraceInstrumentationOptions)
+        => AddSqlClientInstrumentation(builder, name: null, configureSqlClientTraceInstrumentationOptions);
 
     /// <summary>
     /// Enables SqlClient instrumentation.
     /// </summary>
     /// <param name="builder"><see cref="TracerProviderBuilder"/> being configured.</param>
     /// <param name="name">Name which is used when retrieving options.</param>
-    /// <param name="configureSqlClientInstrumentationOptions">Callback action for configuring <see cref="SqlClientInstrumentationOptions"/>.</param>
+    /// <param name="configureSqlClientTraceInstrumentationOptions">Callback action for configuring <see cref="SqlClientTraceInstrumentationOptions"/>.</param>
     /// <returns>The instance of <see cref="TracerProviderBuilder"/> to chain the calls.</returns>
 #if NET6_0_OR_GREATER
     [RequiresUnreferencedCode(SqlClientInstrumentation.SqlClientTrimmingUnsupportedMessage)]
@@ -56,20 +56,20 @@ public static class TracerProviderBuilderExtensions
     public static TracerProviderBuilder AddSqlClientInstrumentation(
         this TracerProviderBuilder builder,
         string name,
-        Action<SqlClientInstrumentationOptions> configureSqlClientInstrumentationOptions)
+        Action<SqlClientTraceInstrumentationOptions> configureSqlClientTraceInstrumentationOptions)
     {
         Guard.ThrowIfNull(builder);
 
         name ??= Options.DefaultName;
 
-        if (configureSqlClientInstrumentationOptions != null)
+        if (configureSqlClientTraceInstrumentationOptions != null)
         {
-            builder.ConfigureServices(services => services.Configure(name, configureSqlClientInstrumentationOptions));
+            builder.ConfigureServices(services => services.Configure(name, configureSqlClientTraceInstrumentationOptions));
         }
 
         builder.AddInstrumentation(sp =>
         {
-            var sqlOptions = sp.GetRequiredService<IOptionsMonitor<SqlClientInstrumentationOptions>>().Get(name);
+            var sqlOptions = sp.GetRequiredService<IOptionsMonitor<SqlClientTraceInstrumentationOptions>>().Get(name);
 
             return new SqlClientInstrumentation(sqlOptions);
         });

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTests.cs
@@ -47,12 +47,12 @@ public class SqlClientTests : IDisposable
         using var tracerProvider = Sdk.CreateTracerProviderBuilder()
             .ConfigureServices(services =>
             {
-                services.Configure<SqlClientInstrumentationOptions>(o => defaultExporterOptionsConfigureOptionsInvocations++);
+                services.Configure<SqlClientTraceInstrumentationOptions>(o => defaultExporterOptionsConfigureOptionsInvocations++);
 
-                services.Configure<SqlClientInstrumentationOptions>("Instrumentation2", o => namedExporterOptionsConfigureOptionsInvocations++);
+                services.Configure<SqlClientTraceInstrumentationOptions>("Instrumentation2", o => namedExporterOptionsConfigureOptionsInvocations++);
             })
             .AddSqlClientInstrumentation()
-            .AddSqlClientInstrumentation("Instrumentation2", configureSqlClientInstrumentationOptions: null)
+            .AddSqlClientInstrumentation("Instrumentation2", configureSqlClientTraceInstrumentationOptions: null)
             .Build();
 
         Assert.Equal(1, defaultExporterOptionsConfigureOptionsInvocations);

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTraceInstrumentationOptionsTests.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlClientTraceInstrumentationOptionsTests.cs
@@ -7,9 +7,9 @@ using Xunit;
 
 namespace OpenTelemetry.Instrumentation.SqlClient.Tests;
 
-public class SqlClientInstrumentationOptionsTests
+public class SqlClientTraceInstrumentationOptionsTests
 {
-    static SqlClientInstrumentationOptionsTests()
+    static SqlClientTraceInstrumentationOptionsTests()
     {
         Activity.DefaultIdFormat = ActivityIdFormat.W3C;
         Activity.ForceDefaultIdFormat = true;
@@ -45,7 +45,7 @@ public class SqlClientInstrumentationOptionsTests
         string expectedInstanceName,
         string expectedPort)
     {
-        var sqlConnectionDetails = SqlClientInstrumentationOptions.ParseDataSource(dataSource);
+        var sqlConnectionDetails = SqlClientTraceInstrumentationOptions.ParseDataSource(dataSource);
 
         Assert.NotNull(sqlConnectionDetails);
         Assert.Equal(expectedServerHostName, sqlConnectionDetails.ServerHostName);
@@ -60,7 +60,7 @@ public class SqlClientInstrumentationOptionsTests
     [InlineData(true, "127.0.0.1,1434", null, "127.0.0.1", null, "1434")]
     [InlineData(true, "127.0.0.1\\instanceName, 1818", null, "127.0.0.1", "instanceName", "1818")]
     [InlineData(false, "localhost", "localhost", null, null, null)]
-    public void SqlClientInstrumentationOptions_EnableConnectionLevelAttributes(
+    public void SqlClientTraceInstrumentationOptions_EnableConnectionLevelAttributes(
         bool enableConnectionLevelAttributes,
         string dataSource,
         string expectedServerHostName,
@@ -70,7 +70,7 @@ public class SqlClientInstrumentationOptionsTests
     {
         var source = new ActivitySource("sql-client-instrumentation");
         var activity = source.StartActivity("Test Sql Activity");
-        var options = new SqlClientInstrumentationOptions()
+        var options = new SqlClientTraceInstrumentationOptions()
         {
             EnableConnectionLevelAttributes = enableConnectionLevelAttributes,
         };

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
@@ -222,7 +222,7 @@ public class SqlEventSourceTests
         }
         else
         {
-            var connectionDetails = SqlClientInstrumentationOptions.ParseDataSource(dataSource);
+            var connectionDetails = SqlClientTraceInstrumentationOptions.ParseDataSource(dataSource);
 
             if (!string.IsNullOrEmpty(connectionDetails.ServerHostName))
             {


### PR DESCRIPTION
Fixes #
Design discussion issue #
Propagate changes from #5109

## Changes

Rename `SqlClientInstrumentationOptions` to `SqlClientTraceInstrumentationOptions`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
