### PR TITLE
[repo-ci] Bump AurorNZ/paths-filter to resolve GitHub Node version warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       changes: ${{ steps.changes.outputs.changes }}
     steps:
-    - uses: AurorNZ/paths-filter@v3
+    - uses: AurorNZ/paths-filter@v4
       id: changes
       with:
         filters: |


### PR DESCRIPTION
See: https://github.com/AurorNZ/paths-filter/issues/8

## Changes

* Bump AurorNZ/paths-filter to resolve GitHub Node version warnings

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
