### PR TITLE
Bump codecov/codecov-action from 3.1.5 to 4.0.1

### DIFF
--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -79,4 +79,4 @@ jobs:
         env_vars: OS,TFM
         flags: ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }}
         name: Code Coverage for ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }} on [${{ matrix.os }}.${{ matrix.version }}]
-        xtra_args: --codecov-yml-path=./.github/codecov.yml
+        codecov_yml_path: .github/codecov.yml

--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -79,3 +79,4 @@ jobs:
         env_vars: OS,TFM
         flags: ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }}
         name: Code Coverage for ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }} on [${{ matrix.os }}.${{ matrix.version }}]
+        xtra_args: --codecov-yml-path=./.github/codecov.yml

--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -68,11 +68,12 @@ jobs:
       run: dotnet-coverage merge -r -f cobertura -o ./TestResults/Cobertura.xml ./TestResults/*.coverage
 
     - name: Upload code coverage ${{ inputs.code-cov-prefix }}-${{ inputs.code-cov-name }}
-      uses: codecov/codecov-action@v3.1.5
+      uses: codecov/codecov-action@v4
       continue-on-error: true # Note: Don't fail for upload failures
       env:
         OS: ${{ matrix.os }}
         TFM: ${{ matrix.version }}
+        token: ${{ secrets.CODECOV_TOKEN }}
       with:
         file: TestResults/Cobertura.xml
         env_vars: OS,TFM


### PR DESCRIPTION
Relates to #5293

There seem to be some breaking changes with [v4](https://github.com/codecov/codecov-action?tab=readme-ov-file#v4-release) that dependabot isn't privy to: https://github.com/open-telemetry/opentelemetry-dotnet/actions/runs/7730817410/job/21078288994?pr=5293#step:9:35
