### PR TITLE
[Instrumentation.SqlClient] Stop emitting db.statement_type attribute

### DIFF
--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -11,6 +11,8 @@
 * **Breaking Change**: Renamed `SqlClientInstrumentationOptions` to
   `SqlClientTraceInstrumentationOptions`.
   ([#5285](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5285))
+* Stop emitting `db.statement_type` attribute.
+  ([#5301](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5301))
 
 ## 1.6.0-beta.3
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -11,7 +11,7 @@
 * **Breaking Change**: Renamed `SqlClientInstrumentationOptions` to
   `SqlClientTraceInstrumentationOptions`.
   ([#5285](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5285))
-* Stop emitting `db.statement_type` attribute.
+* **Breaking Change**: Stop emitting `db.statement_type` attribute.
   ([#5301](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5301))
 
 ## 1.6.0-beta.3

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlClientDiagnosticListener.cs
@@ -108,7 +108,6 @@ internal sealed class SqlClientDiagnosticListener : ListenerHandler
                             switch (commandType)
                             {
                                 case CommandType.StoredProcedure:
-                                    activity.SetTag(SpanAttributeConstants.DatabaseStatementTypeKey, nameof(CommandType.StoredProcedure));
                                     if (this.options.SetDbStatementForStoredProcedure)
                                     {
                                         activity.SetTag(SemanticConventions.AttributeDbStatement, (string)commandText);
@@ -117,7 +116,6 @@ internal sealed class SqlClientDiagnosticListener : ListenerHandler
                                     break;
 
                                 case CommandType.Text:
-                                    activity.SetTag(SpanAttributeConstants.DatabaseStatementTypeKey, nameof(CommandType.Text));
                                     if (this.options.SetDbStatementForText)
                                     {
                                         activity.SetTag(SemanticConventions.AttributeDbStatement, (string)commandText);
@@ -126,7 +124,6 @@ internal sealed class SqlClientDiagnosticListener : ListenerHandler
                                     break;
 
                                 case CommandType.TableDirect:
-                                    activity.SetTag(SpanAttributeConstants.DatabaseStatementTypeKey, nameof(CommandType.TableDirect));
                                     break;
                             }
                         }

--- a/src/Shared/SpanAttributeConstants.cs
+++ b/src/Shared/SpanAttributeConstants.cs
@@ -12,5 +12,4 @@ internal static class SpanAttributeConstants
 {
     public const string StatusCodeKey = "otel.status_code";
     public const string StatusDescriptionKey = "otel.status_description";
-    public const string DatabaseStatementTypeKey = "db.statement_type";
 }

--- a/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
+++ b/test/OpenTelemetry.Instrumentation.SqlClient.Tests/SqlEventSourceTests.netfx.cs
@@ -246,8 +246,6 @@ public class SqlEventSourceTests
 
         Assert.Equal("master", activity.GetTagValue(SemanticConventions.AttributeDbName));
 
-        // "db.statement_type" is never set by the SqlEventSource instrumentation
-        Assert.Null(activity.GetTagValue(SpanAttributeConstants.DatabaseStatementTypeKey));
         if (captureText)
         {
             Assert.Equal(commandText, activity.GetTagValue(SemanticConventions.AttributeDbStatement));


### PR DESCRIPTION
Fixes #
Design discussion issue #

## Changes

[Instrumentation.SqlClient] Stop emitting `db.statement_type` attribute.
It was introduced in https://github.com/open-telemetry/opentelemetry-dotnet/pull/761/files#r450626620. It is not part of semantic convention. I didn't find any other occurrence for this except https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1559

As a separate work, we should consider adding `db.operation`/sanitizing `db.statement`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* ~~[ ] Changes in public API reviewed (if applicable)~~ N/A
