### PR TITLE
[prometheus-httplistener] Throw an exception if the listener cannot be started

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 * **Breaking change** Updated the `PrometheusHttpListener` to throw an exception
   if it can't be started.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#5304](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5304))
 
 ## 1.7.0-rc.1
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -2,10 +2,16 @@
 
 ## Unreleased
 
-* Export OpenMetrics format from Prometheus exporters ([#5107](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5107))
+* Export OpenMetrics format from Prometheus exporters
+  ([#5107](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5107))
+
 * For requests with OpenMetrics format, scope info is automatically added
   ([#5086](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5086)
   [#5182](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5182))
+
+* **Breaking change** Updated the `PrometheusHttpListener` to throw an exception
+  if it can't be started.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
 
 ## 1.7.0-rc.1
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
@@ -59,6 +59,8 @@ internal sealed class PrometheusHttpListener : IDisposable
                 return;
             }
 
+            this.httpListener.Start();
+
             // link the passed in token if not null
             this.tokenSource = token == default ?
                 new CancellationTokenSource() :
@@ -91,7 +93,7 @@ internal sealed class PrometheusHttpListener : IDisposable
     {
         this.Stop();
 
-        if (this.httpListener != null && this.httpListener.IsListening)
+        if (this.httpListener.IsListening)
         {
             this.httpListener.Close();
         }
@@ -111,8 +113,6 @@ internal sealed class PrometheusHttpListener : IDisposable
 
     private void WorkerProc()
     {
-        this.httpListener.Start();
-
         try
         {
             using var scope = SuppressInstrumentationScope.Begin();

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerMeterProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerMeterProviderBuilderExtensionsTests.cs
@@ -23,7 +23,7 @@ public sealed class PrometheusHttpListenerMeterProviderBuilderExtensionsTests
                 services.Configure<PrometheusHttpListenerOptions>("Exporter2", o => namedExporterOptionsConfigureOptionsInvocations++);
             })
             .AddPrometheusHttpListener()
-            .AddPrometheusHttpListener("Exporter2", o => { })
+            .AddPrometheusHttpListener("Exporter2", o => o.ScrapeEndpointPath = "/metrics2")
             .Build();
 
         Assert.Equal(1, defaultExporterOptionsConfigureOptionsInvocations);


### PR DESCRIPTION
Fixes #5283
Fixes #4913
Fixes #3292

## Changes

* Fix the `PrometheusHttpListener` so it throws from `Start` if it can't actually start.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
