### PR TITLE
[aspnetcore-route-docs] Fix markdown to make markdownlint v15 happy

### DIFF
--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/README.net6.0.md
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/README.net6.0.md
@@ -8,9 +8,9 @@
 | :green_heart: | ConventionalRouting | [Not Found (404)](#conventionalrouting-not-found-404) |
 | :green_heart: | ConventionalRouting | [Route template with parameter constraint](#conventionalrouting-route-template-with-parameter-constraint) |
 | :green_heart: | ConventionalRouting | [Path that does not match parameter constraint](#conventionalrouting-path-that-does-not-match-parameter-constraint) |
-| :broken_heart: | ConventionalRouting | [Area using area:exists, default controller/action](#conventionalrouting-area-using-areaexists-default-controlleraction) |
-| :broken_heart: | ConventionalRouting | [Area using area:exists, non-default action](#conventionalrouting-area-using-areaexists-non-default-action) |
-| :broken_heart: | ConventionalRouting | [Area w/o area:exists, default controller/action](#conventionalrouting-area-wo-areaexists-default-controlleraction) |
+| :broken_heart: | ConventionalRouting | [Area using `area:exists`, default controller/action](#conventionalrouting-area-using-areaexists-default-controlleraction) |
+| :broken_heart: | ConventionalRouting | [Area using `area:exists`, non-default action](#conventionalrouting-area-using-areaexists-non-default-action) |
+| :broken_heart: | ConventionalRouting | [Area w/o `area:exists`, default controller/action](#conventionalrouting-area-wo-areaexists-default-controlleraction) |
 | :green_heart: | AttributeRouting | [Default action](#attributerouting-default-action) |
 | :green_heart: | AttributeRouting | [Action without parameter](#attributerouting-action-without-parameter) |
 | :green_heart: | AttributeRouting | [Action with parameter](#attributerouting-action-with-parameter) |
@@ -194,7 +194,7 @@
 }
 ```
 
-## ConventionalRouting: Area using area:exists, default controller/action
+## ConventionalRouting: Area using `area:exists`, default controller/action
 
 ```json
 {
@@ -225,7 +225,7 @@
 }
 ```
 
-## ConventionalRouting: Area using area:exists, non-default action
+## ConventionalRouting: Area using `area:exists`, non-default action
 
 ```json
 {
@@ -256,7 +256,7 @@
 }
 ```
 
-## ConventionalRouting: Area w/o area:exists, default controller/action
+## ConventionalRouting: Area w/o `area:exists`, default controller/action
 
 ```json
 {

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/README.net7.0.md
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/README.net7.0.md
@@ -8,9 +8,9 @@
 | :green_heart: | ConventionalRouting | [Not Found (404)](#conventionalrouting-not-found-404) |
 | :green_heart: | ConventionalRouting | [Route template with parameter constraint](#conventionalrouting-route-template-with-parameter-constraint) |
 | :green_heart: | ConventionalRouting | [Path that does not match parameter constraint](#conventionalrouting-path-that-does-not-match-parameter-constraint) |
-| :broken_heart: | ConventionalRouting | [Area using area:exists, default controller/action](#conventionalrouting-area-using-areaexists-default-controlleraction) |
-| :broken_heart: | ConventionalRouting | [Area using area:exists, non-default action](#conventionalrouting-area-using-areaexists-non-default-action) |
-| :broken_heart: | ConventionalRouting | [Area w/o area:exists, default controller/action](#conventionalrouting-area-wo-areaexists-default-controlleraction) |
+| :broken_heart: | ConventionalRouting | [Area using `area:exists`, default controller/action](#conventionalrouting-area-using-areaexists-default-controlleraction) |
+| :broken_heart: | ConventionalRouting | [Area using `area:exists`, non-default action](#conventionalrouting-area-using-areaexists-non-default-action) |
+| :broken_heart: | ConventionalRouting | [Area w/o `area:exists`, default controller/action](#conventionalrouting-area-wo-areaexists-default-controlleraction) |
 | :green_heart: | AttributeRouting | [Default action](#attributerouting-default-action) |
 | :green_heart: | AttributeRouting | [Action without parameter](#attributerouting-action-without-parameter) |
 | :green_heart: | AttributeRouting | [Action with parameter](#attributerouting-action-with-parameter) |
@@ -196,7 +196,7 @@
 }
 ```
 
-## ConventionalRouting: Area using area:exists, default controller/action
+## ConventionalRouting: Area using `area:exists`, default controller/action
 
 ```json
 {
@@ -227,7 +227,7 @@
 }
 ```
 
-## ConventionalRouting: Area using area:exists, non-default action
+## ConventionalRouting: Area using `area:exists`, non-default action
 
 ```json
 {
@@ -258,7 +258,7 @@
 }
 ```
 
-## ConventionalRouting: Area w/o area:exists, default controller/action
+## ConventionalRouting: Area w/o `area:exists`, default controller/action
 
 ```json
 {

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/README.net8.0.md
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/README.net8.0.md
@@ -8,9 +8,9 @@
 | :green_heart: | ConventionalRouting | [Not Found (404)](#conventionalrouting-not-found-404) |
 | :green_heart: | ConventionalRouting | [Route template with parameter constraint](#conventionalrouting-route-template-with-parameter-constraint) |
 | :green_heart: | ConventionalRouting | [Path that does not match parameter constraint](#conventionalrouting-path-that-does-not-match-parameter-constraint) |
-| :broken_heart: | ConventionalRouting | [Area using area:exists, default controller/action](#conventionalrouting-area-using-areaexists-default-controlleraction) |
-| :broken_heart: | ConventionalRouting | [Area using area:exists, non-default action](#conventionalrouting-area-using-areaexists-non-default-action) |
-| :broken_heart: | ConventionalRouting | [Area w/o area:exists, default controller/action](#conventionalrouting-area-wo-areaexists-default-controlleraction) |
+| :broken_heart: | ConventionalRouting | [Area using `area:exists`, default controller/action](#conventionalrouting-area-using-areaexists-default-controlleraction) |
+| :broken_heart: | ConventionalRouting | [Area using `area:exists`, non-default action](#conventionalrouting-area-using-areaexists-non-default-action) |
+| :broken_heart: | ConventionalRouting | [Area w/o `area:exists`, default controller/action](#conventionalrouting-area-wo-areaexists-default-controlleraction) |
 | :green_heart: | AttributeRouting | [Default action](#attributerouting-default-action) |
 | :green_heart: | AttributeRouting | [Action without parameter](#attributerouting-action-without-parameter) |
 | :green_heart: | AttributeRouting | [Action with parameter](#attributerouting-action-with-parameter) |
@@ -24,6 +24,7 @@
 | :green_heart: | MinimalApi | [Action with parameter](#minimalapi-action-with-parameter) |
 | :green_heart: | MinimalApi | [Action without parameter (MapGroup)](#minimalapi-action-without-parameter-mapgroup) |
 | :green_heart: | MinimalApi | [Action with parameter (MapGroup)](#minimalapi-action-with-parameter-mapgroup) |
+| :green_heart: | ExceptionMiddleware | [Exception Handled by Exception Handler Middleware](#exceptionmiddleware-exception-handled-by-exception-handler-middleware) |
 
 ## ConventionalRouting: Root path
 
@@ -195,7 +196,7 @@
 }
 ```
 
-## ConventionalRouting: Area using area:exists, default controller/action
+## ConventionalRouting: Area using `area:exists`, default controller/action
 
 ```json
 {
@@ -226,7 +227,7 @@
 }
 ```
 
-## ConventionalRouting: Area using area:exists, non-default action
+## ConventionalRouting: Area using `area:exists`, non-default action
 
 ```json
 {
@@ -257,7 +258,7 @@
 }
 ```
 
-## ConventionalRouting: Area w/o area:exists, default controller/action
+## ConventionalRouting: Area w/o `area:exists`, default controller/action
 
 ```json
 {
@@ -628,6 +629,25 @@
     "HttpContext.GetRouteData()": {
       "id": "123"
     },
+    "ActionDescriptor": null
+  }
+}
+```
+
+## ExceptionMiddleware: Exception Handled by Exception Handler Middleware
+
+```json
+{
+  "IdealHttpRoute": "/Exception",
+  "ActivityDisplayName": "GET /Exception",
+  "ActivityHttpRoute": "/Exception",
+  "MetricHttpRoute": "/Exception",
+  "RouteInfo": {
+    "HttpMethod": "GET",
+    "Path": "/Exception",
+    "RoutePattern.RawText": "/Exception",
+    "IRouteDiagnosticsMetadata.Route": "/Exception",
+    "HttpContext.GetRouteData()": {},
     "ActionDescriptor": null
   }
 }

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTestCases.json
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTestCases.json
@@ -54,7 +54,7 @@
     "expectedHttpRoute": ""
   },
   {
-    "name": "Area using area:exists, default controller/action",
+    "name": "Area using `area:exists`, default controller/action",
     "testApplicationScenario": "ConventionalRouting",
     "httpMethod": "GET",
     "path": "/MyArea",
@@ -63,7 +63,7 @@
     "expectedHttpRoute": "{area:exists}/ControllerForMyArea/Default/{id?}"
   },
   {
-    "name": "Area using area:exists, non-default action",
+    "name": "Area using `area:exists`, non-default action",
     "testApplicationScenario": "ConventionalRouting",
     "httpMethod": "GET",
     "path": "/MyArea/ControllerForMyArea/NonDefault",
@@ -72,7 +72,7 @@
     "expectedHttpRoute": "{area:exists}/ControllerForMyArea/NonDefault/{id?}"
   },
   {
-    "name": "Area w/o area:exists, default controller/action",
+    "name": "Area w/o `area:exists`, default controller/action",
     "testApplicationScenario": "ConventionalRouting",
     "httpMethod": "GET",
     "path": "/SomePrefix",

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTestFixture.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTestFixture.cs
@@ -71,7 +71,7 @@ public class RoutingTestFixture : IDisposable
         {
             var result = this.testResults[i];
             var emoji = result.TestCase.CurrentHttpRoute == null ? ":green_heart:" : ":broken_heart:";
-            sb.AppendLine($"| {emoji} | {result.TestCase.TestApplicationScenario} | [{result.TestCase.Name}]({MakeAnchorTag(result.TestCase.TestApplicationScenario, result.TestCase.Name)}) |");
+            sb.AppendLine($"| {emoji} | {result.TestCase.TestApplicationScenario} | [{result.TestCase.Name}]({GenerateLinkFragment(result.TestCase.TestApplicationScenario, result.TestCase.Name)}) |");
         }
 
         for (var i = 0; i < this.testResults.Count; ++i)
@@ -88,10 +88,12 @@ public class RoutingTestFixture : IDisposable
         var readmeFileName = $"README.net{Environment.Version.Major}.0.md";
         File.WriteAllText(Path.Combine("..", "..", "..", "RouteTests", readmeFileName), sb.ToString());
 
-        static string MakeAnchorTag(TestApplicationScenario scenario, string name)
+        // Generates a link fragment that should comply with markdownlint rule MD051
+        // https://github.com/DavidAnson/markdownlint/blob/main/doc/md051.md
+        static string GenerateLinkFragment(TestApplicationScenario scenario, string name)
         {
             var chars = name.ToCharArray()
-                .Where(c => !char.IsPunctuation(c) || c == '-')
+                .Where(c => (!char.IsPunctuation(c) && c != '`') || c == '-')
                 .Select(c => c switch
                 {
                     '-' => '-',


### PR DESCRIPTION
Our `markdownlint` CI fails when bumping `markdownlint` to version 15 (see #5290).

I did not have the time to determine the true root cause of this problem. Part of me thinks there may be a bug in `markdownlint` because the links in these readmes were perfectly functional.

It appears that `markdownlint` does not like link fragments that link to headers containing multiple `:` characters. To work around this I have place backticks around `area:exists`.