### PR TITLE
[metrics] Fix perf regression introduced by metric point reclaim feature

### DIFF
--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -50,7 +50,7 @@ public struct MetricPoint
     {
         Debug.Assert(aggregatorStore != null, "AggregatorStore was null.");
         Debug.Assert(histogramExplicitBounds != null, "Histogram explicit Bounds was null.");
-        Debug.Assert(!aggregatorStore.OutputDeltaWithUnusedMetricPointReclaimEnabled || lookupData != null, "LookupData was null.");
+        Debug.Assert(!aggregatorStore!.OutputDeltaWithUnusedMetricPointReclaimEnabled || lookupData != null, "LookupData was null.");
 
         this.aggType = aggType;
         this.Tags = new ReadOnlyTagCollection(tagKeysAndValues);

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -50,11 +50,7 @@ public struct MetricPoint
     {
         Debug.Assert(aggregatorStore != null, "AggregatorStore was null.");
         Debug.Assert(histogramExplicitBounds != null, "Histogram explicit Bounds was null.");
-
-        if (aggregatorStore!.OutputDelta && aggregatorStore.ShouldReclaimUnusedMetricPoints)
-        {
-            Debug.Assert(lookupData != null, "LookupData was null.");
-        }
+        Debug.Assert(!aggregatorStore.OutputDeltaWithUnusedMetricPointReclaimEnabled || lookupData != null, "LookupData was null.");
 
         this.aggType = aggType;
         this.Tags = new ReadOnlyTagCollection(tagKeysAndValues);
@@ -445,7 +441,7 @@ public struct MetricPoint
         // by ignoring Zero points
         this.MetricPointStatus = MetricPointStatus.CollectPending;
 
-        if (this.aggregatorStore.OutputDelta)
+        if (this.aggregatorStore.OutputDeltaWithUnusedMetricPointReclaimEnabled)
         {
             Interlocked.Decrement(ref this.ReferenceCount);
         }
@@ -570,7 +566,7 @@ public struct MetricPoint
         // by ignoring Zero points
         this.MetricPointStatus = MetricPointStatus.CollectPending;
 
-        if (this.aggregatorStore.OutputDelta)
+        if (this.aggregatorStore.OutputDeltaWithUnusedMetricPointReclaimEnabled)
         {
             Interlocked.Decrement(ref this.ReferenceCount);
         }
@@ -666,7 +662,7 @@ public struct MetricPoint
         // by ignoring Zero points
         this.MetricPointStatus = MetricPointStatus.CollectPending;
 
-        if (this.aggregatorStore.OutputDelta)
+        if (this.aggregatorStore.OutputDeltaWithUnusedMetricPointReclaimEnabled)
         {
             Interlocked.Decrement(ref this.ReferenceCount);
         }
@@ -797,7 +793,7 @@ public struct MetricPoint
         // by ignoring Zero points
         this.MetricPointStatus = MetricPointStatus.CollectPending;
 
-        if (this.aggregatorStore.OutputDelta)
+        if (this.aggregatorStore.OutputDeltaWithUnusedMetricPointReclaimEnabled)
         {
             Interlocked.Decrement(ref this.ReferenceCount);
         }


### PR DESCRIPTION
[Noticed this while working on #5131]

## Changes

* Fixes a perf regression introduced by metric point reclaim for delta temporality even when disabled.

## Benchmarks

Before:
| Method         | AggregationTemporality | Mean     | Error    | StdDev   |
|--------------- |----------------------- |---------:|---------:|---------:|
| CounterHotPath | Cumulative             | 10.07 ns | 0.058 ns | 0.054 ns |
| CounterHotPath | Delta                  | 13.60 ns | 0.179 ns | 0.159 ns |

After:
| Method         | AggregationTemporality | Mean     | Error    | StdDev   |
|--------------- |----------------------- |---------:|---------:|---------:|
| CounterHotPath | Cumulative             | 10.93 ns | 0.185 ns | 0.155 ns |
| CounterHotPath | Delta                  | **10.17 ns** | 0.117 ns | 0.103 ns |

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
