### PR TITLE
Release instrumentation packages  1.7.1/1.7.0-beta.1

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 1.7.1
 
-Released 2024-Feb-07
+Released 2024-Feb-09
 
 * Fixed issue
   [#4466](https://github.com/open-telemetry/opentelemetry-dotnet/issues/4466)

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.7.1
+
+Released 2024-Feb-07
+
 * Fixed issue
   [#4466](https://github.com/open-telemetry/opentelemetry-dotnet/issues/4466)
   where the activity instance returned by `Activity.Current` was different than

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 1.7.0-beta.1
 
-Released 2024-Feb-07
+Released 2024-Feb-09
 
 * **Breaking Change** :
   [SuppressDownstreamInstrumentation](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Instrumentation.GrpcNetClient#suppressdownstreaminstrumentation)

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.7.0-beta.1
+
+Released 2024-Feb-07
+
 * **Breaking Change** :
   [SuppressDownstreamInstrumentation](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Instrumentation.GrpcNetClient#suppressdownstreaminstrumentation)
   option will no longer be supported when used with certain versions of

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 1.7.1
 
-Released 2024-Feb-07
+Released 2024-Feb-09
 
 * .NET Framework - fix description for `http.client.request.duration` metric.
   ([#5234](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5234))

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.7.1
+
+Released 2024-Feb-07
+
 * .NET Framework - fix description for `http.client.request.duration` metric.
   ([#5234](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5234))
 

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.7.0-beta.1
+
+Released 2024-Feb-07
+
 * Removed support for the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable
   which toggled the use of the new conventions for the
   [server, client, and shared network attributes](https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/general/attributes.md#server-client-and-shared-network-attributes).

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 1.7.0-beta.1
 
-Released 2024-Feb-07
+Released 2024-Feb-09
 
 * Removed support for the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable
   which toggled the use of the new conventions for the


### PR DESCRIPTION
## Changes

Request release for all instrumentation packages. It is especially needed for AspNetCore for AutoInstrumentation due to #5252.
Changes in other packages are also worth to release. The only package with only minor fix is HTTP.

Before merge please check if `csproj` files for SqlClient and GrpcNetClient shouldn't be updated. In these files there is no definition of `MinVerTagPrefix`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
