### PR TITLE
Update PR template wording about changelog

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,23 @@
 Fixes #
+
 Design discussion issue #
 
 ## Changes
 
-Please provide a brief description of the changes here.
+Please provide a brief description of the changes here. If further adjustments
+are made following feedback or additional insights, please update this
+accordingly to maintain an accurate record of the change.
 
 ## Merge requirement checklist
 
-* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
+* [ ]
+  [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md)
+  guidelines followed (license requirements, nullable enabled, static analysis,
+  etc.)
 * [ ] Unit tests added/updated
-* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
+* [ ] For all non-trivial modifications, please ensure the `CHANGELOG.md` file is
+  duly updated. Each changelog entry should be self-explanatory, providing a
+  concise, yet comprehensive overview of the changes made. In instances where a
+  change is too extensive for a brief changelog description, detail the
+  modifications within the pull request description and add link to it.
 * [ ] Changes in public API reviewed (if applicable)

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -558,8 +558,11 @@ internal sealed class AggregatorStore
         {
             if (length > 1)
             {
-                // Note: We are using storage from ThreadStatic, so need to make a deep copy for Dictionary storage.
-                // Create or obtain new arrays to temporarily hold the sorted tag Keys and Values
+                // Create or obtain new arrays to temporarily hold the sorted tag Keys and Values.
+                // We could have just sorted the given tagKeysAndValues and do the lookup again,
+                // but the most likely path is that, if we did not find an entry for given order,
+                // we are unlikely to find it after sorting (unless users intentionally change tags ordering),
+                // in which cause we need to obtain a different storage anyway for sorted tags.
                 var storage = ThreadStaticStorage.GetStorage();
                 storage.CloneKeysAndValues(tagKeysAndValues, length, out var tempSortedTagKeysAndValues);
 

--- a/src/OpenTelemetry/Metrics/Tags.cs
+++ b/src/OpenTelemetry/Metrics/Tags.cs
@@ -52,6 +52,8 @@ internal readonly struct Tags : IEquatable<Tags>
 
     public readonly bool Equals(Tags other)
     {
+        // Equality check is done without sorting, so the order of tags matters.
+        // The consumer of this class AggregatorStore, is aware of this.
         var length = this.KeyValuePairs.Length;
 
         if (length != other.KeyValuePairs.Length)


### PR DESCRIPTION
A lot of times, PR desc. is not updated after PR itself is changed based on feedbacks, etc.
Changelog.md is not clear at times - we need to encourage it to be self-explanatory wherever possible, or link to PR description where the details are described.