### PR TITLE
[sdk-metrics] Obsolete SetMaxMetricPointsPerMetricStream + standarize on "Cardinality Limit" name

### DIFF
--- a/docs/diagnostics/experimental-apis/OTEL1003.md
+++ b/docs/diagnostics/experimental-apis/OTEL1003.md
@@ -25,7 +25,7 @@ From the specification:
 We are exposing these APIs experimentally until the specification declares them
 stable.
 
-### Setting the default cardinality limit for the MeterProvider:
+### Setting the default cardinality limit for the MeterProvider
 
 There is nothing in the OpenTelemetry Specification currently for defining the
 default cardinality limit for a MeterProvider.
@@ -36,7 +36,7 @@ using var meterProvider = Sdk.CreateMeterProviderBuilder()
     .Build();
 ```
 
-### Setting cardinality limit for a specific Metric via the View API:
+### Setting cardinality limit for a specific Metric via the View API
 
 The OpenTelemetry Specification defines the [cardinality
 limit](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#cardinality-limits)

--- a/docs/diagnostics/experimental-apis/OTEL1003.md
+++ b/docs/diagnostics/experimental-apis/OTEL1003.md
@@ -4,7 +4,6 @@
 
 This is an Experimental API diagnostic covering the following API:
 
-* `MeterProviderBuilderExtensions.SetCardinalityLimit`
 * `MetricStreamConfiguration.CardinalityLimit.get`
 * `MetricStreamConfiguration.CardinalityLimit.set`
 
@@ -24,17 +23,6 @@ From the specification:
 
 We are exposing these APIs experimentally until the specification declares them
 stable.
-
-### Setting the default cardinality limit for the MeterProvider
-
-There is nothing in the OpenTelemetry Specification currently for defining the
-default cardinality limit for a MeterProvider.
-
-```csharp
-using var meterProvider = Sdk.CreateMeterProviderBuilder()
-    .SetCardinalityLimit(5000)
-    .Build();
-```
 
 ### Setting cardinality limit for a specific Metric via the View API
 

--- a/docs/diagnostics/experimental-apis/OTEL1003.md
+++ b/docs/diagnostics/experimental-apis/OTEL1003.md
@@ -15,14 +15,14 @@ From the specification:
 
 > The cardinality limit for an aggregation is defined in one of three ways:
 >
-> 1. A [view](#view) with criteria matching the instrument an aggregation is
->    created for has an `aggregation_cardinality_limit` value defined for the
->    stream, that value SHOULD be used.
+> 1. A view with criteria matching the instrument an aggregation is created for
+>    has an `aggregation_cardinality_limit` value defined for the stream, that
+>    value SHOULD be used.
 > 2. If there is no matching view, but the `MetricReader` defines a default
 >    cardinality limit value based on the instrument an aggregation is created
 >    for, that value SHOULD be used.
-> 3. If none of the previous values are defined, the default value of 2000 SHOULD
->    be used.
+> 3. If none of the previous values are defined, the default value of 2000
+>    SHOULD be used.
 
 We are exposing these APIs experimentally until the specification declares them
 stable.

--- a/docs/diagnostics/experimental-apis/OTEL1003.md
+++ b/docs/diagnostics/experimental-apis/OTEL1003.md
@@ -14,7 +14,7 @@ Experimental APIs may be changed or removed in the future.
 From the specification:
 
 > The cardinality limit for an aggregation is defined in one of three ways:
-> 
+>
 > 1. A [view](#view) with criteria matching the instrument an aggregation is
 >    created for has an `aggregation_cardinality_limit` value defined for the
 >    stream, that value SHOULD be used.

--- a/docs/diagnostics/experimental-apis/OTEL1003.md
+++ b/docs/diagnostics/experimental-apis/OTEL1003.md
@@ -4,6 +4,7 @@
 
 This is an Experimental API diagnostic covering the following API:
 
+* `MeterProviderBuilderExtensions.SetCardinalityLimit`
 * `MetricStreamConfiguration.CardinalityLimit.get`
 * `MetricStreamConfiguration.CardinalityLimit.set`
 
@@ -11,14 +12,10 @@ Experimental APIs may be changed or removed in the future.
 
 ## Details
 
-The OpenTelemetry Specification defines the
-[cardinality limit](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#cardinality-limits)
-of a metric can be set by the matching view.
-
 From the specification:
 
-> The cardinality limit for an aggregation is defined in one of three ways:
-> A view with criteria matching the instrument an aggregation is created for has
+> The cardinality limit for an aggregation is defined in one of three ways: A
+> view with criteria matching the instrument an aggregation is created for has
 > an aggregation_cardinality_limit value defined for the stream, that value
 > SHOULD be used. If there is no matching view, but the MetricReader defines a
 > default cardinality limit value based on the instrument an aggregation is
@@ -27,3 +24,28 @@ From the specification:
 
 We are exposing these APIs experimentally until the specification declares them
 stable.
+
+### Setting the default cardinality limit for the MeterProvider:
+
+There is nothing in the OpenTelemetry Specification currently for defining the
+default cardinality limit for a MeterProvider.
+
+```csharp
+using var meterProvider = Sdk.CreateMeterProviderBuilder()
+    .SetCardinalityLimit(5000)
+    .Build();
+```
+
+### Setting cardinality limit for a specific Metric via the View API:
+
+The OpenTelemetry Specification defines the [cardinality
+limit](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#cardinality-limits)
+of a metric can be set by the matching view.
+
+```csharp
+using var meterProvider = Sdk.CreateMeterProviderBuilder()
+    .AddView(
+        instrumentName: "MyFruitCounter",
+        new MetricStreamConfiguration { CardinalityLimit = 10 })
+    .Build();
+```

--- a/docs/diagnostics/experimental-apis/OTEL1003.md
+++ b/docs/diagnostics/experimental-apis/OTEL1003.md
@@ -43,4 +43,5 @@ using var meterProvider = Sdk.CreateMeterProviderBuilder()
 
 ### Setting cardinality limit for a specific MetricReader
 
-This is NOT currently supported by OpenTelemetry .NET.
+[This is not currently supported by OpenTelemetry
+.NET.](https://github.com/open-telemetry/opentelemetry-dotnet/issues/5331)

--- a/docs/diagnostics/experimental-apis/OTEL1003.md
+++ b/docs/diagnostics/experimental-apis/OTEL1003.md
@@ -13,13 +13,16 @@ Experimental APIs may be changed or removed in the future.
 
 From the specification:
 
-> The cardinality limit for an aggregation is defined in one of three ways: A
-> view with criteria matching the instrument an aggregation is created for has
-> an aggregation_cardinality_limit value defined for the stream, that value
-> SHOULD be used. If there is no matching view, but the MetricReader defines a
-> default cardinality limit value based on the instrument an aggregation is
-> created for, that value SHOULD be used. If none of the previous values are
-> defined, the default value of 2000 SHOULD be used.
+> The cardinality limit for an aggregation is defined in one of three ways:
+> 
+> 1. A [view](#view) with criteria matching the instrument an aggregation is
+>    created for has an `aggregation_cardinality_limit` value defined for the
+>    stream, that value SHOULD be used.
+> 2. If there is no matching view, but the `MetricReader` defines a default
+>    cardinality limit value based on the instrument an aggregation is created
+>    for, that value SHOULD be used.
+> 3. If none of the previous values are defined, the default value of 2000 SHOULD
+>    be used.
 
 We are exposing these APIs experimentally until the specification declares them
 stable.
@@ -37,3 +40,7 @@ using var meterProvider = Sdk.CreateMeterProviderBuilder()
         new MetricStreamConfiguration { CardinalityLimit = 10 })
     .Build();
 ```
+
+### Setting cardinality limit for a specific MetricReader
+
+This is NOT currently supported by OpenTelemetry .NET.

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -386,12 +386,12 @@ and the `MetricStreamConfiguration.CardinalityLimit` setting. Refer to this
 for more information.
 
 Given a metric, once the cardinality limit is reached, any new measurement which
-cannot be independently aggregated because of the limit will be dropped (a
-warning is written to the [self-diagnostic
-log](../../src/OpenTelemetry/README.md#self-diagnostics)) or aggregated using
-the [overflow
+cannot be independently aggregated because of the limit will be dropped or
+aggregated using the [overflow
 attribute](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#overflow-attribute)
-(if enabled).
+(if enabled). When NOT using the overflow attribute feature a warning is written
+to the [self-diagnostic log](../../src/OpenTelemetry/README.md#self-diagnostics)
+the first time an overflow is detected for a given metric.
 
 > [!NOTE]
 > Overflow attribute was introduced in OpenTelemetry .NET

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -356,11 +356,10 @@ predictable and reliable behavior when excessive cardinality happens, whether it
 was due to a malicious attack or developer making mistakes while writing code.
 
 OpenTelemetry has a default cardinality limit of `2000` per metric. This limit
-can be configured at `MeterProvider` level using the
-`SetMaxMetricPointsPerMetricStream` method, or at individual
-[view](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view)
-level using `MetricStreamConfiguration.CardinalityLimit`. Refer to this
-[doc](../../docs/metrics/customizing-the-sdk/README.md#changing-maximum-metricpoints-per-metricstream)
+can be configured for individual metrics by using
+[views](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view)
+and the `MetricStreamConfiguration.CardinalityLimit` setting. Refer to this
+[doc](../../docs/metrics/customizing-the-sdk/README.md#changing-the-cardinality-limit-for-a-metric)
 for more information.
 
 Given a metric, once the cardinality limit is reached, any new measurement which

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -363,9 +363,12 @@ and the `MetricStreamConfiguration.CardinalityLimit` setting. Refer to this
 for more information.
 
 Given a metric, once the cardinality limit is reached, any new measurement which
-cannot be independently aggregated because of the limit will be aggregated using
+cannot be independently aggregated because of the limit will be dropped (a
+warning is written to the [self-diagnostic
+log](../../src/OpenTelemetry/README.md#self-diagnostics)) or aggregated using
 the [overflow
-attribute](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#overflow-attribute).
+attribute](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#overflow-attribute)
+(if enabled).
 
 > [!NOTE]
 > Overflow attribute was introduced in OpenTelemetry .NET

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -356,8 +356,8 @@ predictable and reliable behavior when excessive cardinality happens, whether it
 was due to a malicious attack or developer making mistakes while writing code.
 
 OpenTelemetry has a default cardinality limit of `2000` per metric. This limit
-can be configured for individual metrics by using
-[views](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view)
+can be configured at the individual metric level using the [View
+API](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view)
 and the `MetricStreamConfiguration.CardinalityLimit` setting. Refer to this
 [doc](../../docs/metrics/customizing-the-sdk/README.md#changing-the-cardinality-limit-for-a-metric)
 for more information.

--- a/docs/metrics/customizing-the-sdk/README.md
+++ b/docs/metrics/customizing-the-sdk/README.md
@@ -369,14 +369,6 @@ AnotherFruitCounter.Add(1, new("name", "apple"), new("color", "red"));
 
 ### Changing the cardinality limit for a Metric
 
-A Metric contains many Metric points which are the storage buckets for
-aggregation of measurements for the unique combinations of key/values recorded
-by an instrument. To protect the SDK from unbounded memory usage, there is a
-default limit of 2000 metric points per metric which will be maintained by the
-SDK. Once the limit is hit, any new key/value combination for a metric will be
-ignored. The SDK chooses the key/value combinations in the order in which they
-are emitted.
-
 To set the [cardinality limit](../README.md#cardinality-limits) for an
 individual metric, use `MetricStreamConfiguration.CardinalityLimit` setting on
 the View API:
@@ -384,7 +376,10 @@ the View API:
 ```csharp
 var meterProvider = Sdk.CreateMeterProviderBuilder()
     .AddMeter("MyCompany.MyProduct.MyLibrary")
-    .AddView(instrumentName: "MyFruitCounter", new MetricStreamConfiguration { CardinalityLimit = 10 })
+    // Set a custom CardinalityLimit (10) for "MyFruitCounter"
+    .AddView(
+        instrumentName: "MyFruitCounter",
+        new MetricStreamConfiguration { CardinalityLimit = 10 })
     .AddConsoleExporter()
     .Build();
 ```

--- a/docs/metrics/customizing-the-sdk/README.md
+++ b/docs/metrics/customizing-the-sdk/README.md
@@ -369,12 +369,13 @@ AnotherFruitCounter.Add(1, new("name", "apple"), new("color", "red"));
 
 ### Changing the cardinality limit for a Metric
 
-A Metric contains many Metric points which are the number of unique combinations
-of key/values recorded by an instrument. To protect the SDK from unbounded
-memory usage, there is a default limit of 2000 metric points per metric which
-will be maintained by the SDK. Once the limit is hit, any new key/value
-combination for a metric will be ignored. The SDK chooses the key/value
-combinations in the order in which they are emitted.
+A Metric contains many Metric points which are the storage buckets for
+aggregation of measurements for the unique combinations of key/values recorded
+by an instrument. To protect the SDK from unbounded memory usage, there is a
+default limit of 2000 metric points per metric which will be maintained by the
+SDK. Once the limit is hit, any new key/value combination for a metric will be
+ignored. The SDK chooses the key/value combinations in the order in which they
+are emitted.
 
 To set the [cardinality limit](../README.md#cardinality-limits) for an
 individual metric, use `MetricStreamConfiguration.CardinalityLimit` setting on

--- a/docs/metrics/customizing-the-sdk/README.md
+++ b/docs/metrics/customizing-the-sdk/README.md
@@ -373,6 +373,11 @@ To set the [cardinality limit](../README.md#cardinality-limits) for an
 individual metric, use `MetricStreamConfiguration.CardinalityLimit` setting on
 the View API:
 
+> [!NOTE]
+> `MetricStreamConfiguration.CardinalityLimit` is an experimental API only
+  available in pre-release builds. For details see:
+  [OTEL1003](../../diagnostics/experimental-apis/OTEL1003.md).
+
 ```csharp
 var meterProvider = Sdk.CreateMeterProviderBuilder()
     .AddMeter("MyCompany.MyProduct.MyLibrary")

--- a/docs/metrics/customizing-the-sdk/README.md
+++ b/docs/metrics/customizing-the-sdk/README.md
@@ -372,7 +372,7 @@ AnotherFruitCounter.Add(1, new("name", "apple"), new("color", "red"));
 A Metric contains many Metric points which are the number of unique combinations
 of key/values recorded by an instrument. To protect the SDK from unbounded
 memory usage, there is a default limit of 2000 metric points per metric which
-will be maintained at any given time. Once the limit is hit, any new key/value
+will be maintained by the SDK. Once the limit is hit, any new key/value
 combination for a metric will be ignored. The SDK chooses the key/value
 combinations in the order in which they are emitted.
 

--- a/src/OpenTelemetry/.publicApi/Experimental/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/Experimental/PublicAPI.Unshipped.txt
@@ -31,6 +31,7 @@ static OpenTelemetry.Logs.LoggerProviderBuilderExtensions.SetResourceBuilder(thi
 static OpenTelemetry.Logs.LoggerProviderExtensions.AddProcessor(this OpenTelemetry.Logs.LoggerProvider! provider, OpenTelemetry.BaseProcessor<OpenTelemetry.Logs.LogRecord!>! processor) -> OpenTelemetry.Logs.LoggerProvider!
 static OpenTelemetry.Logs.LoggerProviderExtensions.ForceFlush(this OpenTelemetry.Logs.LoggerProvider! provider, int timeoutMilliseconds = -1) -> bool
 static OpenTelemetry.Logs.LoggerProviderExtensions.Shutdown(this OpenTelemetry.Logs.LoggerProvider! provider, int timeoutMilliseconds = -1) -> bool
+static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetCardinalityLimit(this OpenTelemetry.Metrics.MeterProviderBuilder! meterProviderBuilder, int cardinalityLimit) -> OpenTelemetry.Metrics.MeterProviderBuilder!
 static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetExemplarFilter(this OpenTelemetry.Metrics.MeterProviderBuilder! meterProviderBuilder, OpenTelemetry.Metrics.ExemplarFilter! exemplarFilter) -> OpenTelemetry.Metrics.MeterProviderBuilder!
 static OpenTelemetry.OpenTelemetryBuilderSdkExtensions.WithLogging(this OpenTelemetry.IOpenTelemetryBuilder! builder) -> OpenTelemetry.IOpenTelemetryBuilder!
 static OpenTelemetry.OpenTelemetryBuilderSdkExtensions.WithLogging(this OpenTelemetry.IOpenTelemetryBuilder! builder, System.Action<OpenTelemetry.Logs.LoggerProviderBuilder!>! configure) -> OpenTelemetry.IOpenTelemetryBuilder!

--- a/src/OpenTelemetry/.publicApi/Experimental/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/Experimental/PublicAPI.Unshipped.txt
@@ -31,7 +31,6 @@ static OpenTelemetry.Logs.LoggerProviderBuilderExtensions.SetResourceBuilder(thi
 static OpenTelemetry.Logs.LoggerProviderExtensions.AddProcessor(this OpenTelemetry.Logs.LoggerProvider! provider, OpenTelemetry.BaseProcessor<OpenTelemetry.Logs.LogRecord!>! processor) -> OpenTelemetry.Logs.LoggerProvider!
 static OpenTelemetry.Logs.LoggerProviderExtensions.ForceFlush(this OpenTelemetry.Logs.LoggerProvider! provider, int timeoutMilliseconds = -1) -> bool
 static OpenTelemetry.Logs.LoggerProviderExtensions.Shutdown(this OpenTelemetry.Logs.LoggerProvider! provider, int timeoutMilliseconds = -1) -> bool
-static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetCardinalityLimit(this OpenTelemetry.Metrics.MeterProviderBuilder! meterProviderBuilder, int cardinalityLimit) -> OpenTelemetry.Metrics.MeterProviderBuilder!
 static OpenTelemetry.Metrics.MeterProviderBuilderExtensions.SetExemplarFilter(this OpenTelemetry.Metrics.MeterProviderBuilder! meterProviderBuilder, OpenTelemetry.Metrics.ExemplarFilter! exemplarFilter) -> OpenTelemetry.Metrics.MeterProviderBuilder!
 static OpenTelemetry.OpenTelemetryBuilderSdkExtensions.WithLogging(this OpenTelemetry.IOpenTelemetryBuilder! builder) -> OpenTelemetry.IOpenTelemetryBuilder!
 static OpenTelemetry.OpenTelemetryBuilderSdkExtensions.WithLogging(this OpenTelemetry.IOpenTelemetryBuilder! builder, System.Action<OpenTelemetry.Logs.LoggerProviderBuilder!>! configure) -> OpenTelemetry.IOpenTelemetryBuilder!

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -39,9 +39,8 @@
   ([#5265](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5265))
 
 * **Experimental (pre-release builds only):** Obsoleted
-  `MeterProviderBuilderExtensions.SetMaxMetricPointsPerMetricStream` and added
-  `MeterProviderBuilderExtensions.SetCardinalityLimit`. The new method does the
-  same thing but has a more spec-compliant name.
+  `MeterProviderBuilderExtensions.SetMaxMetricPointsPerMetricStream` in favor of
+  the new View-based `CardinalityLimit` API.
   ([#5328](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5328))
 
 ## 1.7.0

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -21,9 +21,10 @@
 
 * **Experimental (pre-release builds only):** Added support for setting
   `CardinalityLimit` (the maximum number of data points allowed for a metric)
-  when configuring a view and obsoleted
-  `MeterProviderBuilderExtensions.SetMaxMetricPointsPerMetricStream`. The
-  default cardinality limit for metrics remains at `2000`.
+  when configuring a view (applies to individual metrics) and obsoleted
+  `MeterProviderBuilderExtensions.SetMaxMetricPointsPerMetricStream` (previously
+  applied to all metrics). The default cardinality limit for metrics remains at
+  `2000`.
   ([#5312](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5312),
   [#5328](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5328))
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -42,7 +42,7 @@
   `MeterProviderBuilderExtensions.SetMaxMetricPointsPerMetricStream` and added
   `MeterProviderBuilderExtensions.SetCardinalityLimit`. The new method does the
   same thing but has a more spec-compliant name.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#5328](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5328))
 
 ## 1.7.0
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -21,8 +21,11 @@
 
 * **Experimental (pre-release builds only):** Added support for setting
   `CardinalityLimit` (the maximum number of data points allowed for a metric)
-  when configuring a view.
-  ([#5312](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5312))
+  when configuring a view and obsoleted
+  `MeterProviderBuilderExtensions.SetMaxMetricPointsPerMetricStream`. The
+  default cardinality limit for metrics remains at `2000`.
+  ([#5312](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5312),
+  [#5328](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5328))
 
 * Updated `LogRecord` to keep `CategoryName` and `Logger` in sync when using the
   experimental Log Bridge API.
@@ -37,11 +40,6 @@
   `IOpenTelemetryBuilder.WithMetrics` extension method can configure
   [IMetricsListener](https://learn.microsoft.com/dotNet/api/microsoft.extensions.diagnostics.metrics.imetricslistener).
   ([#5265](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5265))
-
-* **Experimental (pre-release builds only):** Obsoleted
-  `MeterProviderBuilderExtensions.SetMaxMetricPointsPerMetricStream` in favor of
-  the new View-based `CardinalityLimit` API.
-  ([#5328](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5328))
 
 ## 1.7.0
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -38,6 +38,12 @@
   [IMetricsListener](https://learn.microsoft.com/dotNet/api/microsoft.extensions.diagnostics.metrics.imetricslistener).
   ([#5265](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5265))
 
+* **Experimental (pre-release builds only):** Obsoleted
+  `MeterProviderBuilderExtensions.SetMaxMetricPointsPerMetricStream` and added
+  `MeterProviderBuilderExtensions.SetCardinalityLimit`. The new method does the
+  same thing but has a more spec-compliant name.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.7.0
 
 Released 2023-Dec-08

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -14,6 +14,7 @@ internal sealed class AggregatorStore
     internal readonly bool OutputDelta;
     internal readonly bool OutputDeltaWithUnusedMetricPointReclaimEnabled;
     internal readonly int CardinalityLimit;
+    internal readonly bool EmitOverflowAttribute;
     internal long DroppedMeasurements = 0;
 
     private static readonly string MetricPointCapHitFixMessage = "Consider opting in for the experimental SDK feature to emit all the throttled metrics under the overflow attribute by setting env variable OTEL_DOTNET_EXPERIMENTAL_METRICS_EMIT_OVERFLOW_ATTRIBUTE = true. You could also modify instrumentation to reduce the number of unique key/value pair combinations. Or use Views to drop unwanted tags. Or use MeterProviderBuilder.SetMaxMetricPointsPerMetricStream to set higher limit.";
@@ -43,7 +44,6 @@ internal sealed class AggregatorStore
     private readonly int exponentialHistogramMaxScale;
     private readonly UpdateLongDelegate updateLongCallback;
     private readonly UpdateDoubleDelegate updateDoubleCallback;
-    private readonly bool emitOverflowAttribute;
     private readonly ExemplarFilter exemplarFilter;
     private readonly Func<KeyValuePair<string, object?>[], int, int> lookupAggregatorStore;
 
@@ -89,7 +89,7 @@ internal sealed class AggregatorStore
             this.tagsKeysInterestingCount = hs.Count;
         }
 
-        this.emitOverflowAttribute = emitOverflowAttribute;
+        this.EmitOverflowAttribute = emitOverflowAttribute;
 
         var reservedMetricPointsCount = 1;
 
@@ -227,7 +227,7 @@ internal sealed class AggregatorStore
 
         int startIndexForReclaimableMetricPoints = 1;
 
-        if (this.emitOverflowAttribute)
+        if (this.EmitOverflowAttribute)
         {
             startIndexForReclaimableMetricPoints = 2; // Index 0 and 1 are reserved for no tags and overflow
 
@@ -929,7 +929,7 @@ internal sealed class AggregatorStore
             {
                 Interlocked.Increment(ref this.DroppedMeasurements);
 
-                if (this.emitOverflowAttribute)
+                if (this.EmitOverflowAttribute)
                 {
                     this.InitializeOverflowTagPointIfNotInitialized();
                     this.metricPoints[1].Update(value);
@@ -973,7 +973,7 @@ internal sealed class AggregatorStore
             {
                 Interlocked.Increment(ref this.DroppedMeasurements);
 
-                if (this.emitOverflowAttribute)
+                if (this.EmitOverflowAttribute)
                 {
                     this.InitializeOverflowTagPointIfNotInitialized();
                     this.metricPoints[1].Update(value);
@@ -1017,7 +1017,7 @@ internal sealed class AggregatorStore
             {
                 Interlocked.Increment(ref this.DroppedMeasurements);
 
-                if (this.emitOverflowAttribute)
+                if (this.EmitOverflowAttribute)
                 {
                     this.InitializeOverflowTagPointIfNotInitialized();
                     this.metricPoints[1].Update(value);
@@ -1061,7 +1061,7 @@ internal sealed class AggregatorStore
             {
                 Interlocked.Increment(ref this.DroppedMeasurements);
 
-                if (this.emitOverflowAttribute)
+                if (this.EmitOverflowAttribute)
                 {
                     this.InitializeOverflowTagPointIfNotInitialized();
                     this.metricPoints[1].Update(value);

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderExtensions.cs
@@ -218,7 +218,7 @@ public static class MeterProviderBuilderExtensions
         {
             if (builder is MeterProviderBuilderSdk meterProviderBuilderSdk)
             {
-                meterProviderBuilderSdk.SetMaxMetricStreams(maxMetricStreams);
+                meterProviderBuilderSdk.SetMetricLimit(maxMetricStreams);
             }
         });
 

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderExtensions.cs
@@ -1,10 +1,12 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#if EXPOSE_EXPERIMENTAL_FEATURES
+using System.ComponentModel;
 #if NET6_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 #endif
-using System.ComponentModel;
+#endif
 using System.Diagnostics.Metrics;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderExtensions.cs
@@ -4,6 +4,7 @@
 #if NET6_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 #endif
+using System.ComponentModel;
 using System.Diagnostics.Metrics;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.DependencyInjection;
@@ -230,14 +231,14 @@ public static class MeterProviderBuilderExtensions
     /// This limits the number of unique combinations of key/value pairs used
     /// for reporting measurements.
     /// </summary>
-    /// <remarks>
-    /// If a particular key/value pair combination is used at least once,
-    /// it will contribute to the limit for the life of the process.
-    /// This may change in the future. See: https://github.com/open-telemetry/opentelemetry-dotnet/issues/2360.
-    /// </remarks>
+    /// <inheritdoc cref="SetCardinalityLimit(MeterProviderBuilder, int)"/>
     /// <param name="meterProviderBuilder"><see cref="MeterProviderBuilder"/>.</param>
     /// <param name="maxMetricPointsPerMetricStream">Maximum number of metric points allowed per metric stream.</param>
     /// <returns>The supplied <see cref="MeterProviderBuilder"/> for chaining.</returns>
+#if EXPOSE_EXPERIMENTAL_FEATURES
+    [Obsolete("Call SetCardinalityLimit instead this method will be removed in a future version.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+#endif
     public static MeterProviderBuilder SetMaxMetricPointsPerMetricStream(this MeterProviderBuilder meterProviderBuilder, int maxMetricPointsPerMetricStream)
     {
         Guard.ThrowIfOutOfRange(maxMetricPointsPerMetricStream, min: 1);
@@ -247,6 +248,40 @@ public static class MeterProviderBuilderExtensions
             if (builder is MeterProviderBuilderSdk meterProviderBuilderSdk)
             {
                 meterProviderBuilderSdk.SetMaxMetricPointsPerMetricStream(maxMetricPointsPerMetricStream);
+            }
+        });
+
+        return meterProviderBuilder;
+    }
+
+#if EXPOSE_EXPERIMENTAL_FEATURES
+    /// <summary>
+    /// Sets a positive integer value defining the maximum number of
+    /// data points allowed for metrics managed by the MeterProvider.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>WARNING</b>: This is an experimental API which might change or
+    /// be removed in the future. Use at your own risk.</para>
+    /// </remarks>
+    /// <param name="meterProviderBuilder"><see cref="MeterProviderBuilder"/>.</param>
+    /// <param name="cardinalityLimit">Cardinality limit.</param>
+    /// <returns>The supplied <see cref="MeterProviderBuilder"/> for chaining.</returns>
+#if NET8_0_OR_GREATER
+    [Experimental(DiagnosticDefinitions.CardinalityLimitExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
+#endif
+    public
+#else
+    internal
+#endif
+        static MeterProviderBuilder SetCardinalityLimit(this MeterProviderBuilder meterProviderBuilder, int cardinalityLimit)
+    {
+        Guard.ThrowIfOutOfRange(cardinalityLimit, min: 1, max: int.MaxValue);
+
+        meterProviderBuilder.ConfigureBuilder((sp, builder) =>
+        {
+            if (builder is MeterProviderBuilderSdk meterProviderBuilderSdk)
+            {
+                meterProviderBuilderSdk.SetCardinalityLimit(cardinalityLimit);
             }
         });
 

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderExtensions.cs
@@ -238,7 +238,7 @@ public static class MeterProviderBuilderExtensions
     /// <param name="maxMetricPointsPerMetricStream">Maximum number of metric points allowed per metric stream.</param>
     /// <returns>The supplied <see cref="MeterProviderBuilder"/> for chaining.</returns>
 #if EXPOSE_EXPERIMENTAL_FEATURES
-    [Obsolete("Call SetCardinalityLimit instead this method will be removed in a future version.")]
+    [Obsolete("Call SetCardinalityLimit instead. This method will be removed in a future version.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
 #endif
     public static MeterProviderBuilder SetMaxMetricPointsPerMetricStream(this MeterProviderBuilder meterProviderBuilder, int maxMetricPointsPerMetricStream)

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderExtensions.cs
@@ -3,9 +3,9 @@
 
 #if EXPOSE_EXPERIMENTAL_FEATURES
 using System.ComponentModel;
+#endif
 #if NET6_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
-#endif
 #endif
 using System.Diagnostics.Metrics;
 using System.Text.RegularExpressions;
@@ -256,40 +256,6 @@ public static class MeterProviderBuilderExtensions
         return meterProviderBuilder;
     }
 
-#if EXPOSE_EXPERIMENTAL_FEATURES
-    /// <summary>
-    /// Sets a positive integer value defining the maximum number of
-    /// data points allowed for metrics managed by the MeterProvider.
-    /// </summary>
-    /// <remarks>
-    /// <para><b>WARNING</b>: This is an experimental API which might change or
-    /// be removed in the future. Use at your own risk.</para>
-    /// </remarks>
-    /// <param name="meterProviderBuilder"><see cref="MeterProviderBuilder"/>.</param>
-    /// <param name="cardinalityLimit">Cardinality limit.</param>
-    /// <returns>The supplied <see cref="MeterProviderBuilder"/> for chaining.</returns>
-#if NET8_0_OR_GREATER
-    [Experimental(DiagnosticDefinitions.CardinalityLimitExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
-#endif
-    public
-#else
-    internal
-#endif
-        static MeterProviderBuilder SetCardinalityLimit(this MeterProviderBuilder meterProviderBuilder, int cardinalityLimit)
-    {
-        Guard.ThrowIfOutOfRange(cardinalityLimit, min: 1, max: int.MaxValue);
-
-        meterProviderBuilder.ConfigureBuilder((sp, builder) =>
-        {
-            if (builder is MeterProviderBuilderSdk meterProviderBuilderSdk)
-            {
-                meterProviderBuilderSdk.SetCardinalityLimit(cardinalityLimit);
-            }
-        });
-
-        return meterProviderBuilder;
-    }
-
     /// <summary>
     /// Sets the <see cref="ResourceBuilder"/> from which the Resource associated with
     /// this provider is built from. Overwrites currently set ResourceBuilder.
@@ -349,6 +315,40 @@ public static class MeterProviderBuilderExtensions
         }
 
         throw new NotSupportedException($"Build is not supported on '{meterProviderBuilder?.GetType().FullName ?? "null"}' instances.");
+    }
+
+#if EXPOSE_EXPERIMENTAL_FEATURES
+    /// <summary>
+    /// Sets a positive integer value defining the maximum number of
+    /// data points allowed for metrics managed by the MeterProvider.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>WARNING</b>: This is an experimental API which might change or
+    /// be removed in the future. Use at your own risk.</para>
+    /// </remarks>
+    /// <param name="meterProviderBuilder"><see cref="MeterProviderBuilder"/>.</param>
+    /// <param name="cardinalityLimit">Cardinality limit.</param>
+    /// <returns>The supplied <see cref="MeterProviderBuilder"/> for chaining.</returns>
+#if NET8_0_OR_GREATER
+    [Experimental(DiagnosticDefinitions.CardinalityLimitExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
+#endif
+    public
+#else
+    internal
+#endif
+        static MeterProviderBuilder SetCardinalityLimit(this MeterProviderBuilder meterProviderBuilder, int cardinalityLimit)
+    {
+        Guard.ThrowIfOutOfRange(cardinalityLimit, min: 1, max: int.MaxValue);
+
+        meterProviderBuilder.ConfigureBuilder((sp, builder) =>
+        {
+            if (builder is MeterProviderBuilderSdk meterProviderBuilderSdk)
+            {
+                meterProviderBuilderSdk.SetCardinalityLimit(cardinalityLimit);
+            }
+        });
+
+        return meterProviderBuilder;
     }
 
 #if EXPOSE_EXPERIMENTAL_FEATURES

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderExtensions.cs
@@ -1,9 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#if EXPOSE_EXPERIMENTAL_FEATURES
-using System.ComponentModel;
-#endif
 #if NET6_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 #endif
@@ -233,13 +230,16 @@ public static class MeterProviderBuilderExtensions
     /// This limits the number of unique combinations of key/value pairs used
     /// for reporting measurements.
     /// </summary>
-    /// <inheritdoc cref="SetCardinalityLimit(MeterProviderBuilder, int)"/>
+    /// <remarks>
+    /// If a particular key/value pair combination is used at least once,
+    /// it will contribute to the limit for the life of the process.
+    /// This may change in the future. See: https://github.com/open-telemetry/opentelemetry-dotnet/issues/2360.
+    /// </remarks>
     /// <param name="meterProviderBuilder"><see cref="MeterProviderBuilder"/>.</param>
     /// <param name="maxMetricPointsPerMetricStream">Maximum number of metric points allowed per metric stream.</param>
     /// <returns>The supplied <see cref="MeterProviderBuilder"/> for chaining.</returns>
 #if EXPOSE_EXPERIMENTAL_FEATURES
-    [Obsolete("Call SetCardinalityLimit instead. This method will be removed in a future version.")]
-    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Use MetricStreamConfiguration.CardinalityLimit via the AddView API instead. This method will be removed in a future version.")]
 #endif
     public static MeterProviderBuilder SetMaxMetricPointsPerMetricStream(this MeterProviderBuilder meterProviderBuilder, int maxMetricPointsPerMetricStream)
     {
@@ -249,7 +249,7 @@ public static class MeterProviderBuilderExtensions
         {
             if (builder is MeterProviderBuilderSdk meterProviderBuilderSdk)
             {
-                meterProviderBuilderSdk.SetMaxMetricPointsPerMetricStream(maxMetricPointsPerMetricStream);
+                meterProviderBuilderSdk.SetDefaultCardinalityLimit(maxMetricPointsPerMetricStream);
             }
         });
 
@@ -315,40 +315,6 @@ public static class MeterProviderBuilderExtensions
         }
 
         throw new NotSupportedException($"Build is not supported on '{meterProviderBuilder?.GetType().FullName ?? "null"}' instances.");
-    }
-
-#if EXPOSE_EXPERIMENTAL_FEATURES
-    /// <summary>
-    /// Sets a positive integer value defining the maximum number of
-    /// data points allowed for metrics managed by the MeterProvider.
-    /// </summary>
-    /// <remarks>
-    /// <para><b>WARNING</b>: This is an experimental API which might change or
-    /// be removed in the future. Use at your own risk.</para>
-    /// </remarks>
-    /// <param name="meterProviderBuilder"><see cref="MeterProviderBuilder"/>.</param>
-    /// <param name="cardinalityLimit">Cardinality limit.</param>
-    /// <returns>The supplied <see cref="MeterProviderBuilder"/> for chaining.</returns>
-#if NET8_0_OR_GREATER
-    [Experimental(DiagnosticDefinitions.CardinalityLimitExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
-#endif
-    public
-#else
-    internal
-#endif
-        static MeterProviderBuilder SetCardinalityLimit(this MeterProviderBuilder meterProviderBuilder, int cardinalityLimit)
-    {
-        Guard.ThrowIfOutOfRange(cardinalityLimit, min: 1, max: int.MaxValue);
-
-        meterProviderBuilder.ConfigureBuilder((sp, builder) =>
-        {
-            if (builder is MeterProviderBuilderSdk meterProviderBuilderSdk)
-            {
-                meterProviderBuilderSdk.SetCardinalityLimit(cardinalityLimit);
-            }
-        });
-
-        return meterProviderBuilder;
     }
 
 #if EXPOSE_EXPERIMENTAL_FEATURES

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderSdk.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderSdk.cs
@@ -15,7 +15,7 @@ namespace OpenTelemetry.Metrics;
 /// </summary>
 internal sealed class MeterProviderBuilderSdk : MeterProviderBuilder, IMeterProviderBuilder
 {
-    public const int DefaultMaxMetricStreams = 1000;
+    public const int DefaultMetricLimit = 1000;
     public const int DefaultCardinalityLimit = 2000;
     private const string DefaultInstrumentationVersion = "1.0.0.0";
 
@@ -49,7 +49,7 @@ internal sealed class MeterProviderBuilderSdk : MeterProviderBuilder, IMeterProv
 
     public List<Func<Instrument, MetricStreamConfiguration?>> ViewConfigs { get; } = new();
 
-    public int MaxMetricStreams { get; private set; } = DefaultMaxMetricStreams;
+    public int MetricLimit { get; private set; } = DefaultMetricLimit;
 
     public int CardinalityLimit { get; private set; } = DefaultCardinalityLimit;
 
@@ -186,9 +186,9 @@ internal sealed class MeterProviderBuilderSdk : MeterProviderBuilder, IMeterProv
         return this;
     }
 
-    public MeterProviderBuilder SetMaxMetricStreams(int maxMetricStreams)
+    public MeterProviderBuilder SetMetricLimit(int metricLimit)
     {
-        this.MaxMetricStreams = maxMetricStreams;
+        this.MetricLimit = metricLimit;
 
         return this;
     }

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderSdk.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderSdk.cs
@@ -16,7 +16,7 @@ namespace OpenTelemetry.Metrics;
 internal sealed class MeterProviderBuilderSdk : MeterProviderBuilder, IMeterProviderBuilder
 {
     public const int MaxMetricsDefault = 1000;
-    public const int MaxMetricPointsPerMetricDefault = 2000;
+    public const int CardinalityLimitDefault = 2000;
     private const string DefaultInstrumentationVersion = "1.0.0.0";
 
     private readonly IServiceProvider serviceProvider;
@@ -51,7 +51,7 @@ internal sealed class MeterProviderBuilderSdk : MeterProviderBuilder, IMeterProv
 
     public int MaxMetricStreams { get; private set; } = MaxMetricsDefault;
 
-    public int MaxMetricPointsPerMetricStream { get; private set; } = MaxMetricPointsPerMetricDefault;
+    public int CardinalityLimit { get; private set; } = CardinalityLimitDefault;
 
     /// <summary>
     /// Returns whether the given instrument name is valid according to the specification.
@@ -193,9 +193,9 @@ internal sealed class MeterProviderBuilderSdk : MeterProviderBuilder, IMeterProv
         return this;
     }
 
-    public MeterProviderBuilder SetMaxMetricPointsPerMetricStream(int maxMetricPointsPerMetricStream)
+    public MeterProviderBuilder SetCardinalityLimit(int cardinalityLimit)
     {
-        this.MaxMetricPointsPerMetricStream = maxMetricPointsPerMetricStream;
+        this.CardinalityLimit = cardinalityLimit;
 
         return this;
     }

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderSdk.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderSdk.cs
@@ -15,8 +15,8 @@ namespace OpenTelemetry.Metrics;
 /// </summary>
 internal sealed class MeterProviderBuilderSdk : MeterProviderBuilder, IMeterProviderBuilder
 {
-    public const int MaxMetricsDefault = 1000;
-    public const int CardinalityLimitDefault = 2000;
+    public const int DefaultMaxMetricStreams = 1000;
+    public const int DefaultCardinalityLimit = 2000;
     private const string DefaultInstrumentationVersion = "1.0.0.0";
 
     private readonly IServiceProvider serviceProvider;
@@ -49,9 +49,9 @@ internal sealed class MeterProviderBuilderSdk : MeterProviderBuilder, IMeterProv
 
     public List<Func<Instrument, MetricStreamConfiguration?>> ViewConfigs { get; } = new();
 
-    public int MaxMetricStreams { get; private set; } = MaxMetricsDefault;
+    public int MaxMetricStreams { get; private set; } = DefaultMaxMetricStreams;
 
-    public int CardinalityLimit { get; private set; } = CardinalityLimitDefault;
+    public int CardinalityLimit { get; private set; } = DefaultCardinalityLimit;
 
     /// <summary>
     /// Returns whether the given instrument name is valid according to the specification.
@@ -193,7 +193,7 @@ internal sealed class MeterProviderBuilderSdk : MeterProviderBuilder, IMeterProv
         return this;
     }
 
-    public MeterProviderBuilder SetCardinalityLimit(int cardinalityLimit)
+    public MeterProviderBuilder SetDefaultCardinalityLimit(int cardinalityLimit)
     {
         this.CardinalityLimit = cardinalityLimit;
 

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -78,7 +78,7 @@ internal sealed class MeterProviderSdk : MeterProvider
             reader.SetParentProvider(this);
 
             reader.ApplyParentProviderSettings(
-                state.MaxMetricStreams,
+                state.MetricLimit,
                 state.CardinalityLimit,
                 state.ExemplarFilter,
                 isEmitOverflowAttributeKeySet);

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -76,9 +76,12 @@ internal sealed class MeterProviderSdk : MeterProvider
             Guard.ThrowIfNull(reader);
 
             reader.SetParentProvider(this);
-            reader.SetMaxMetricStreams(state.MaxMetricStreams);
-            reader.SetMaxMetricPointsPerMetricStream(state.MaxMetricPointsPerMetricStream, isEmitOverflowAttributeKeySet);
-            reader.SetExemplarFilter(state.ExemplarFilter);
+
+            reader.ApplyParentProviderSettings(
+                state.MaxMetricStreams,
+                state.CardinalityLimit,
+                state.ExemplarFilter,
+                isEmitOverflowAttributeKeySet);
 
             if (this.reader == null)
             {

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -46,7 +46,7 @@ public sealed class Metric
     internal Metric(
         MetricStreamIdentity instrumentIdentity,
         AggregationTemporality temporality,
-        int maxMetricPointsPerMetricStream,
+        int cardinalityLimit,
         bool emitOverflowAttribute,
         bool shouldReclaimUnusedMetricPoints,
         ExemplarFilter? exemplarFilter = null)
@@ -155,7 +155,7 @@ public sealed class Metric
             throw new NotSupportedException($"Unsupported Instrument Type: {instrumentIdentity.InstrumentType.FullName}");
         }
 
-        this.aggStore = new AggregatorStore(instrumentIdentity, aggType, temporality, maxMetricPointsPerMetricStream, emitOverflowAttribute, shouldReclaimUnusedMetricPoints, exemplarFilter);
+        this.aggStore = new AggregatorStore(instrumentIdentity, aggType, temporality, cardinalityLimit, emitOverflowAttribute, shouldReclaimUnusedMetricPoints, exemplarFilter);
         this.Temporality = temporality;
     }
 

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -41,7 +41,7 @@ public sealed class Metric
         ("System.Net.Http", "http.client.connection.duration"),
     };
 
-    private readonly AggregatorStore aggStore;
+    internal readonly AggregatorStore AggregatorStore;
 
     internal Metric(
         MetricStreamIdentity instrumentIdentity,
@@ -155,7 +155,7 @@ public sealed class Metric
             throw new NotSupportedException($"Unsupported Instrument Type: {instrumentIdentity.InstrumentType.FullName}");
         }
 
-        this.aggStore = new AggregatorStore(instrumentIdentity, aggType, temporality, cardinalityLimit, emitOverflowAttribute, shouldReclaimUnusedMetricPoints, exemplarFilter);
+        this.AggregatorStore = new AggregatorStore(instrumentIdentity, aggType, temporality, cardinalityLimit, emitOverflowAttribute, shouldReclaimUnusedMetricPoints, exemplarFilter);
         this.Temporality = temporality;
     }
 
@@ -211,14 +211,14 @@ public sealed class Metric
     /// </summary>
     /// <returns><see cref="MetricPointsAccessor"/>.</returns>
     public MetricPointsAccessor GetMetricPoints()
-        => this.aggStore.GetMetricPoints();
+        => this.AggregatorStore.GetMetricPoints();
 
     internal void UpdateLong(long value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
-        => this.aggStore.Update(value, tags);
+        => this.AggregatorStore.Update(value, tags);
 
     internal void UpdateDouble(double value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
-        => this.aggStore.Update(value, tags);
+        => this.AggregatorStore.Update(value, tags);
 
     internal int Snapshot()
-        => this.aggStore.Snapshot();
+        => this.AggregatorStore.Snapshot();
 }

--- a/src/OpenTelemetry/Metrics/MetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/MetricReaderExt.cs
@@ -137,12 +137,14 @@ public abstract partial class MetricReader
                 {
                     bool shouldReclaimUnusedMetricPoints = this.parentProvider is MeterProviderSdk meterProviderSdk && meterProviderSdk.ShouldReclaimUnusedMetricPoints;
 
+                    var cardinalityLimit = this.cardinalityLimit;
+
                     if (metricStreamConfig != null && metricStreamConfig.CardinalityLimit != null)
                     {
-                        this.cardinalityLimit = metricStreamConfig.CardinalityLimit.Value;
+                        cardinalityLimit = metricStreamConfig.CardinalityLimit.Value;
                     }
 
-                    Metric metric = new(metricStreamIdentity, this.GetAggregationTemporality(metricStreamIdentity.InstrumentType), this.cardinalityLimit, this.emitOverflowAttribute, shouldReclaimUnusedMetricPoints, this.exemplarFilter);
+                    Metric metric = new(metricStreamIdentity, this.GetAggregationTemporality(metricStreamIdentity.InstrumentType), cardinalityLimit, this.emitOverflowAttribute, shouldReclaimUnusedMetricPoints, this.exemplarFilter);
 
                     this.instrumentIdentityToMetric[metricStreamIdentity] = metric;
                     this.metrics![index] = metric;

--- a/src/OpenTelemetry/Metrics/MetricStreamConfiguration.cs
+++ b/src/OpenTelemetry/Metrics/MetricStreamConfiguration.cs
@@ -111,7 +111,7 @@ public class MetricStreamConfiguration
     /// limits</see>.</para>
     /// Note: If not set, the MeterProvider cardinality limit value will be
     /// used, which defaults to 2000. Call <see
-    /// cref="MeterProviderBuilderExtensions.SetMaxMetricPointsPerMetricStream"/>
+    /// cref="MeterProviderBuilderExtensions.SetCardinalityLimit"/>
     /// to configure the MeterProvider default.
     /// </remarks>
 #if NET8_0_OR_GREATER

--- a/src/OpenTelemetry/Metrics/MetricStreamConfiguration.cs
+++ b/src/OpenTelemetry/Metrics/MetricStreamConfiguration.cs
@@ -109,10 +109,8 @@ public class MetricStreamConfiguration
     /// <para>Spec reference: <see
     /// href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#cardinality-limits">Cardinality
     /// limits</see>.</para>
-    /// Note: If not set, the MeterProvider cardinality limit value will be
-    /// used, which defaults to 2000. Call <see
-    /// cref="MeterProviderBuilderExtensions.SetCardinalityLimit"/>
-    /// to configure the MeterProvider default.
+    /// Note: If not set the default MeterProvider cardinality limit of 2000
+    /// will apply.
     /// </remarks>
 #if NET8_0_OR_GREATER
     [Experimental(DiagnosticDefinitions.CardinalityLimitExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]

--- a/test/OpenTelemetry.Tests/Metrics/AggregatorTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/AggregatorTestsBase.cs
@@ -255,7 +255,7 @@ public abstract class AggregatorTestsBase
             metricStreamIdentity,
             AggregationType.Histogram,
             AggregationTemporality.Cumulative,
-            maxMetricPoints: 1024,
+            cardinalityLimit: 1024,
             this.emitOverflowAttribute,
             this.shouldReclaimUnusedMetricPoints);
 
@@ -332,7 +332,7 @@ public abstract class AggregatorTestsBase
             metricStreamIdentity,
             aggregationType,
             aggregationTemporality,
-            maxMetricPoints: 1024,
+            cardinalityLimit: 1024,
             this.emitOverflowAttribute,
             this.shouldReclaimUnusedMetricPoints,
             exemplarsEnabled ? new AlwaysOnExemplarFilter() : null);
@@ -442,7 +442,7 @@ public abstract class AggregatorTestsBase
             metricStreamIdentity,
             AggregationType.Base2ExponentialHistogram,
             AggregationTemporality.Cumulative,
-            maxMetricPoints: 1024,
+            cardinalityLimit: 1024,
             this.emitOverflowAttribute,
             this.shouldReclaimUnusedMetricPoints);
 

--- a/test/OpenTelemetry.Tests/Metrics/MetricApiTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricApiTestsBase.cs
@@ -1423,26 +1423,26 @@ public abstract class MetricApiTestsBase : MetricTestsBase
         // for no tag point!
         // This may be changed later.
         counterLong.Add(10);
-        for (int i = 0; i < MeterProviderBuilderSdk.MaxMetricPointsPerMetricDefault + 1; i++)
+        for (int i = 0; i < MeterProviderBuilderSdk.CardinalityLimitDefault + 1; i++)
         {
             counterLong.Add(10, new KeyValuePair<string, object>("key", "value" + i));
         }
 
         meterProvider.ForceFlush(MaxTimeToAllowForFlush);
-        Assert.Equal(MeterProviderBuilderSdk.MaxMetricPointsPerMetricDefault, MetricPointCount());
+        Assert.Equal(MeterProviderBuilderSdk.CardinalityLimitDefault, MetricPointCount());
 
         exportedItems.Clear();
         counterLong.Add(10);
-        for (int i = 0; i < MeterProviderBuilderSdk.MaxMetricPointsPerMetricDefault + 1; i++)
+        for (int i = 0; i < MeterProviderBuilderSdk.CardinalityLimitDefault + 1; i++)
         {
             counterLong.Add(10, new KeyValuePair<string, object>("key", "value" + i));
         }
 
         meterProvider.ForceFlush(MaxTimeToAllowForFlush);
-        Assert.Equal(MeterProviderBuilderSdk.MaxMetricPointsPerMetricDefault, MetricPointCount());
+        Assert.Equal(MeterProviderBuilderSdk.CardinalityLimitDefault, MetricPointCount());
 
         counterLong.Add(10);
-        for (int i = 0; i < MeterProviderBuilderSdk.MaxMetricPointsPerMetricDefault + 1; i++)
+        for (int i = 0; i < MeterProviderBuilderSdk.CardinalityLimitDefault + 1; i++)
         {
             counterLong.Add(10, new KeyValuePair<string, object>("key", "value" + i));
         }
@@ -1453,7 +1453,7 @@ public abstract class MetricApiTestsBase : MetricTestsBase
         counterLong.Add(10, new KeyValuePair<string, object>("key", "valueC"));
         exportedItems.Clear();
         meterProvider.ForceFlush(MaxTimeToAllowForFlush);
-        Assert.Equal(MeterProviderBuilderSdk.MaxMetricPointsPerMetricDefault, MetricPointCount());
+        Assert.Equal(MeterProviderBuilderSdk.CardinalityLimitDefault, MetricPointCount());
     }
 
     [Fact]

--- a/test/OpenTelemetry.Tests/Metrics/MetricApiTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricApiTestsBase.cs
@@ -1423,26 +1423,26 @@ public abstract class MetricApiTestsBase : MetricTestsBase
         // for no tag point!
         // This may be changed later.
         counterLong.Add(10);
-        for (int i = 0; i < MeterProviderBuilderSdk.CardinalityLimitDefault + 1; i++)
+        for (int i = 0; i < MeterProviderBuilderSdk.DefaultCardinalityLimit + 1; i++)
         {
             counterLong.Add(10, new KeyValuePair<string, object>("key", "value" + i));
         }
 
         meterProvider.ForceFlush(MaxTimeToAllowForFlush);
-        Assert.Equal(MeterProviderBuilderSdk.CardinalityLimitDefault, MetricPointCount());
+        Assert.Equal(MeterProviderBuilderSdk.DefaultCardinalityLimit, MetricPointCount());
 
         exportedItems.Clear();
         counterLong.Add(10);
-        for (int i = 0; i < MeterProviderBuilderSdk.CardinalityLimitDefault + 1; i++)
+        for (int i = 0; i < MeterProviderBuilderSdk.DefaultCardinalityLimit + 1; i++)
         {
             counterLong.Add(10, new KeyValuePair<string, object>("key", "value" + i));
         }
 
         meterProvider.ForceFlush(MaxTimeToAllowForFlush);
-        Assert.Equal(MeterProviderBuilderSdk.CardinalityLimitDefault, MetricPointCount());
+        Assert.Equal(MeterProviderBuilderSdk.DefaultCardinalityLimit, MetricPointCount());
 
         counterLong.Add(10);
-        for (int i = 0; i < MeterProviderBuilderSdk.CardinalityLimitDefault + 1; i++)
+        for (int i = 0; i < MeterProviderBuilderSdk.DefaultCardinalityLimit + 1; i++)
         {
             counterLong.Add(10, new KeyValuePair<string, object>("key", "value" + i));
         }
@@ -1453,7 +1453,7 @@ public abstract class MetricApiTestsBase : MetricTestsBase
         counterLong.Add(10, new KeyValuePair<string, object>("key", "valueC"));
         exportedItems.Clear();
         meterProvider.ForceFlush(MaxTimeToAllowForFlush);
-        Assert.Equal(MeterProviderBuilderSdk.CardinalityLimitDefault, MetricPointCount());
+        Assert.Equal(MeterProviderBuilderSdk.DefaultCardinalityLimit, MetricPointCount());
     }
 
     [Fact]

--- a/test/OpenTelemetry.Tests/Metrics/MetricOverflowAttributeTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricOverflowAttributeTestsBase.cs
@@ -174,7 +174,7 @@ public abstract class MetricOverflowAttributeTestsBase
         counter.Add(10); // Record measurement for zero tags
 
         // Max number for MetricPoints available for use when emitted with tags
-        int maxMetricPointsForUse = MeterProviderBuilderSdk.MaxMetricPointsPerMetricDefault - 2;
+        int maxMetricPointsForUse = MeterProviderBuilderSdk.CardinalityLimitDefault - 2;
 
         for (int i = 0; i < maxMetricPointsForUse; i++)
         {
@@ -325,7 +325,7 @@ public abstract class MetricOverflowAttributeTestsBase
         histogram.Record(10); // Record measurement for zero tags
 
         // Max number for MetricPoints available for use when emitted with tags
-        int maxMetricPointsForUse = MeterProviderBuilderSdk.MaxMetricPointsPerMetricDefault - 2;
+        int maxMetricPointsForUse = MeterProviderBuilderSdk.CardinalityLimitDefault - 2;
 
         for (int i = 0; i < maxMetricPointsForUse; i++)
         {

--- a/test/OpenTelemetry.Tests/Metrics/MetricOverflowAttributeTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricOverflowAttributeTestsBase.cs
@@ -174,7 +174,7 @@ public abstract class MetricOverflowAttributeTestsBase
         counter.Add(10); // Record measurement for zero tags
 
         // Max number for MetricPoints available for use when emitted with tags
-        int maxMetricPointsForUse = MeterProviderBuilderSdk.CardinalityLimitDefault - 2;
+        int maxMetricPointsForUse = MeterProviderBuilderSdk.DefaultCardinalityLimit - 2;
 
         for (int i = 0; i < maxMetricPointsForUse; i++)
         {
@@ -325,7 +325,7 @@ public abstract class MetricOverflowAttributeTestsBase
         histogram.Record(10); // Record measurement for zero tags
 
         // Max number for MetricPoints available for use when emitted with tags
-        int maxMetricPointsForUse = MeterProviderBuilderSdk.CardinalityLimitDefault - 2;
+        int maxMetricPointsForUse = MeterProviderBuilderSdk.DefaultCardinalityLimit - 2;
 
         for (int i = 0; i < maxMetricPointsForUse; i++)
         {

--- a/test/OpenTelemetry.Tests/Metrics/MetricOverflowAttributeTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricOverflowAttributeTestsBase.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics.Metrics;
-using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Tests;
@@ -66,12 +65,7 @@ public abstract class MetricOverflowAttributeTestsBase
         meterProvider.ForceFlush();
 
         Assert.Single(exportedItems);
-        var metric = exportedItems[0];
-
-        var aggregatorStore = typeof(Metric).GetField("aggStore", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(metric) as AggregatorStore;
-        var emitOverflowAttribute = (bool)typeof(AggregatorStore).GetField("emitOverflowAttribute", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(aggregatorStore);
-
-        Assert.Equal(isEmitOverflowAttributeKeySet, emitOverflowAttribute);
+        Assert.Equal(isEmitOverflowAttributeKeySet, exportedItems[0].AggregatorStore.EmitOverflowAttribute);
     }
 
     [Theory]
@@ -106,12 +100,7 @@ public abstract class MetricOverflowAttributeTestsBase
         meterProvider.ForceFlush();
 
         Assert.Single(exportedItems);
-        var metric = exportedItems[0];
-
-        var aggregatorStore = typeof(Metric).GetField("aggStore", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(metric) as AggregatorStore;
-        var emitOverflowAttribute = (bool)typeof(AggregatorStore).GetField("emitOverflowAttribute", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(aggregatorStore);
-
-        Assert.Equal(isEmitOverflowAttributeKeySet, emitOverflowAttribute);
+        Assert.Equal(isEmitOverflowAttributeKeySet, exportedItems[0].AggregatorStore.EmitOverflowAttribute);
     }
 
     [Theory]
@@ -140,12 +129,7 @@ public abstract class MetricOverflowAttributeTestsBase
         meterProvider.ForceFlush();
 
         Assert.Single(exportedItems);
-        var metric = exportedItems[0];
-
-        var aggregatorStore = typeof(Metric).GetField("aggStore", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(metric) as AggregatorStore;
-        var emitOverflowAttribute = (bool)typeof(AggregatorStore).GetField("emitOverflowAttribute", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(aggregatorStore);
-
-        Assert.Equal(isEmitOverflowAttributeKeySet, emitOverflowAttribute);
+        Assert.Equal(isEmitOverflowAttributeKeySet, exportedItems[0].AggregatorStore.EmitOverflowAttribute);
     }
 
     [Theory]

--- a/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTestsBase.cs
@@ -316,7 +316,7 @@ public abstract class MetricPointReclaimTestsBase
                 }
 
                 // This is to ensure that the lookup dictionary does not have unbounded growth
-                Assert.True(metricPointLookupDictionary.Count <= (MeterProviderBuilderSdk.MaxMetricPointsPerMetricDefault * 2));
+                Assert.True(metricPointLookupDictionary.Count <= (MeterProviderBuilderSdk.CardinalityLimitDefault * 2));
 
                 foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                 {

--- a/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTestsBase.cs
@@ -286,16 +286,11 @@ public abstract class MetricPointReclaimTestsBase
 
         private readonly bool assertNoDroppedMeasurements;
 
-        private readonly FieldInfo aggStoreFieldInfo;
-
         private readonly FieldInfo metricPointLookupDictionaryFieldInfo;
 
         public CustomExporter(bool assertNoDroppedMeasurements)
         {
             this.assertNoDroppedMeasurements = assertNoDroppedMeasurements;
-
-            var metricFields = typeof(Metric).GetFields(BindingFlags.NonPublic | BindingFlags.Instance);
-            this.aggStoreFieldInfo = metricFields!.FirstOrDefault(field => field.Name == "aggStore");
 
             var aggregatorStoreFields = typeof(AggregatorStore).GetFields(BindingFlags.NonPublic | BindingFlags.Instance);
             this.metricPointLookupDictionaryFieldInfo = aggregatorStoreFields!.FirstOrDefault(field => field.Name == "tagsToMetricPointIndexDictionaryDelta");
@@ -305,7 +300,7 @@ public abstract class MetricPointReclaimTestsBase
         {
             foreach (var metric in batch)
             {
-                var aggStore = this.aggStoreFieldInfo.GetValue(metric) as AggregatorStore;
+                var aggStore = metric.AggregatorStore;
                 var metricPointLookupDictionary = this.metricPointLookupDictionaryFieldInfo.GetValue(aggStore) as ConcurrentDictionary<Tags, LookupData>;
 
                 var droppedMeasurements = aggStore.DroppedMeasurements;

--- a/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTestsBase.cs
@@ -316,7 +316,7 @@ public abstract class MetricPointReclaimTestsBase
                 }
 
                 // This is to ensure that the lookup dictionary does not have unbounded growth
-                Assert.True(metricPointLookupDictionary.Count <= (MeterProviderBuilderSdk.CardinalityLimitDefault * 2));
+                Assert.True(metricPointLookupDictionary.Count <= (MeterProviderBuilderSdk.DefaultCardinalityLimit * 2));
 
                 foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                 {

--- a/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
@@ -928,7 +928,7 @@ public class MetricViewTests : MetricTestsBase
 
         using var container = this.BuildMeterProvider(out var meterProvider, builder => builder
             .AddMeter(meter.Name)
-            .SetMaxMetricPointsPerMetricStream(3)
+            .SetCardinalityLimit(3)
             .AddView((instrument) =>
             {
                 return new MetricStreamConfiguration() { Name = "MetricStreamA", CardinalityLimit = 10000 };

--- a/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
@@ -928,7 +928,7 @@ public class MetricViewTests : MetricTestsBase
 
         using var container = this.BuildMeterProvider(out var meterProvider, builder => builder
             .AddMeter(meter.Name)
-            .SetCardinalityLimit(3)
+            .SetMaxMetricPointsPerMetricStream(3)
             .AddView((instrument) =>
             {
                 return new MetricStreamConfiguration() { Name = "MetricStreamA", CardinalityLimit = 10000 };


### PR DESCRIPTION
Follow-up to #5312

## Changes

* Fixed a bug introduced by #5312 where a view specifying `CardinalityLimit` actually changes the value stored on the `MetricReader` which will then apply to any metrics recorded after the one which had the view apply: https://github.com/open-telemetry/opentelemetry-dotnet/pull/5328/commits/f1b62b0763253ae978b6e57ce999044d509810f4
* Obsolete `MeterProviderBuilderExtensions.SetMaxMetricPointsPerMetricStream` in favor of the View API added in #5312.
* Renames internal values to standardize on the "cardinality limit" name.
* Doc updates to no longer mention the global method.
* A bit of refactoring to how the settings get passed from `MeterProvider` to `MetricReader`.
* A bit of refactoring to remove the reflection in the new tests.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
