### PR TITLE
Dispose loggerFactory in benchmark

### DIFF
--- a/test/Benchmarks/Logs/LogBenchmarks.cs
+++ b/test/Benchmarks/Logs/LogBenchmarks.cs
@@ -72,6 +72,15 @@ public class LogBenchmarks
         this.loggerWithThreeProcessors = this.loggerFactoryWithThreeProcessor.CreateLogger<LogBenchmarks>();
     }
 
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        this.loggerFactoryWithNoListener.Dispose();
+        this.loggerFactoryWithOneProcessor.Dispose();
+        this.loggerFactoryWithTwoProcessor.Dispose();
+        this.loggerFactoryWithThreeProcessor.Dispose();
+    }
+
     [Benchmark]
     public void NoListenerStringInterpolation()
     {


### PR DESCRIPTION
Follow up https://github.com/open-telemetry/opentelemetry-dotnet/pull/5329#discussion_r1483511489

IDisposable won't work since it's not supported by Benchmark.NET https://github.com/dotnet/BenchmarkDotNet/issues/1409.