### PR TITLE
Add MinVerTagPrefix for SQL and gRPC instrumentation

### DIFF
--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/OpenTelemetry.Instrumentation.GrpcNetClient.csproj
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/OpenTelemetry.Instrumentation.GrpcNetClient.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(TargetFrameworksForGrpcNetClientInstrumentation)</TargetFrameworks>
     <Description>gRPC for .NET client instrumentation for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);distributed-tracing</PackageTags>
+    <MinVerTagPrefix>Instrumentation.Grpc-</MinVerTagPrefix>
     <IncludeDiagnosticSourceInstrumentationHelpers>true</IncludeDiagnosticSourceInstrumentationHelpers>
 
     <!-- this is temporary. will remove in future PR. -->

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/OpenTelemetry.Instrumentation.GrpcNetClient.csproj
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/OpenTelemetry.Instrumentation.GrpcNetClient.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(TargetFrameworksForGrpcNetClientInstrumentation)</TargetFrameworks>
     <Description>gRPC for .NET client instrumentation for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);distributed-tracing</PackageTags>
-    <MinVerTagPrefix>Instrumentation.Grpc-</MinVerTagPrefix>
+    <MinVerTagPrefix>Instrumentation.GrpcNetClient-</MinVerTagPrefix>
     <IncludeDiagnosticSourceInstrumentationHelpers>true</IncludeDiagnosticSourceInstrumentationHelpers>
 
     <!-- this is temporary. will remove in future PR. -->

--- a/src/OpenTelemetry.Instrumentation.SqlClient/OpenTelemetry.Instrumentation.SqlClient.csproj
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/OpenTelemetry.Instrumentation.SqlClient.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(TargetFrameworksForLibraries)</TargetFrameworks>
     <Description>SqlClient instrumentation for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);distributed-tracing</PackageTags>
+    <MinVerTagPrefix>Instrumentation.SqlClient-</MinVerTagPrefix>
     <IncludeDiagnosticSourceInstrumentationHelpers>true</IncludeDiagnosticSourceInstrumentationHelpers>
 
     <!-- this is temporary. will remove in future PR. -->


### PR DESCRIPTION
In prep for release #5322.

SQL and gRPC instrumentation has not yet received a release that aligns major/minor version with the 1.7 API/SDK release.