### PR TITLE
OpenTracing shim should use core MinVerTagPrefix

### DIFF
--- a/src/OpenTelemetry.Shims.OpenTracing/OpenTelemetry.Shims.OpenTracing.csproj
+++ b/src/OpenTelemetry.Shims.OpenTracing/OpenTelemetry.Shims.OpenTracing.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>$(TargetFrameworksForLibraries)</TargetFrameworks>
     <Description>OpenTracing shim for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);distributed-tracing;OpenTracing</PackageTags>
+    <MinVerTagPrefix>core-</MinVerTagPrefix>
     <IsPackable>true</IsPackable>
     <!--
     TODO: Disable this exception, and actually do document all public API.


### PR DESCRIPTION
The OpenTracing shim is similar to the prometheus exporter in that it is a core component (i.e., it is declared in the OpenTelemetry specification https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/compatibility/opentracing.md), but it is not yet ready for a stable release.