### PR TITLE
[GrpcNetClient] Clarify impact to SuppressDownstreamInstrumentation

### DIFF
--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 ## Unreleased
 
-* **Breaking Change** :
+* **Breaking Change**:
+  Please be advised that the
   [SuppressDownstreamInstrumentation](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Instrumentation.GrpcNetClient#suppressdownstreaminstrumentation)
-  option will no longer be supported when used with certain versions of
-  `OpenTelemetry.Instrumentation.Http` package. Check out this
+  option no longer works when used in conjunction with the
+  `OpenTelemetry.Instrumentation.Http` package version `1.6.0` or greater.
+  This is not a result of a change in the `OpenTelemetry.Instrumentation.GrpcNetClient`
+  package therefore this affects versions prior to this release. See this
   [issue](https://github.com/open-telemetry/opentelemetry-dotnet/issues/5092)
   for details and workaround.
-  ([#5077](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5077))
 * Removed support for the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable
   which toggled the use of the new conventions for the
   [server, client, and shared network attributes](https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/general/attributes.md#server-client-and-shared-network-attributes).

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
@@ -12,7 +12,7 @@ Released 2024-Feb-09
   option no longer works when used in conjunction with the
   `OpenTelemetry.Instrumentation.Http` package version `1.6.0` or greater.
   This is not a result of a change in the `OpenTelemetry.Instrumentation.GrpcNetClient`
-  package therefore this affects versions prior to this release. See this
+  package therefore this also affects versions prior to this release. See this
   [issue](https://github.com/open-telemetry/opentelemetry-dotnet/issues/5092)
   for details and workaround.
 * Removed support for the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/README.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/README.md
@@ -80,6 +80,11 @@ This instrumentation can be configured to change the default behavior by using
 
 ### SuppressDownstreamInstrumentation
 
+> [!CAUTION]
+> `SuppressDownstreamInstrumentation` no longer works when used in conjunction
+with the `OpenTelemetry.Instrumentation.Http` package version `1.6.0` and greater.
+This option may change or even be removed in a future release.
+
 This option prevents downstream instrumentation from being invoked.
 Grpc.Net.Client is built on top of HttpClient. When instrumentation for both
 libraries is enabled, `SuppressDownstreamInstrumentation` prevents the


### PR DESCRIPTION
We should probably decide what we're actually going to do with `SuppressDownstreamInstrumentation`, but for the purpose of getting the next release out, I just wanted to clean up our advisory.