### PR TITLE
Remove experimental feature flag from doc

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
@@ -322,13 +322,6 @@ values of the log record limits
 
 ### Otlp Log Exporter
 
-* `OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES`
-
-When set to `true`, it enables export of attributes corresponding to
-`LogRecord.Exception`. The attributes `exception.type`, `exception.message` and
-`exception.stacktrace` are defined in
-[specification](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/exceptions/exceptions-logs.md#attributes).
-
 * `OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES`
 
 When set to `true`, it enables export of `LogRecord.EventId.Id` as


### PR DESCRIPTION
Nit follow up to https://github.com/open-telemetry/opentelemetry-dotnet/pull/5258/files to cleanup the readme doc.