### PR TITLE
[docs] Restore the metric overflow doc

### DIFF
--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -405,7 +405,7 @@ the first time an overflow is detected for a given metric.
 When [Delta Aggregation
 Temporality](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md#temporality)
 is used, it is possible to choose a smaller cardinality limit by allowing the
-SDK to reclaim unused metric points.
+SDK to reclaim unused combinations.
 
 > [!NOTE]
 > Reclaim unused metric points feature was introduced in OpenTelemetry .NET
@@ -425,9 +425,9 @@ cardinality limit set the SDK will only export measurements for up to `3`
 distinct key/value combinations.
 
 > [!NOTE]
-> One `MetricPoint` is reserved on every `Metric` for the special case where
-  there are no key/value pairs associated with a measurement. When choosing a
-  cardinality limit users should account for this special case.
+> Storage for one combination is reserved on every `Metric` for the special case
+  where there are no key/value pairs associated with a measurement. When
+  choosing a cardinality limit users should account for this special case.
 
 ```csharp
 Counter<long> MyFruitCounter = MyMeter.CreateCounter<long>("MyFruitCounter");

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -457,13 +457,13 @@ using var meterProvider = Sdk.CreateMeterProviderBuilder()
 //   1. No key/value pair Value=1
 //   2. (name:apple, color:red) Value=6
 //   3. (name:lemon, color:yellow) Value=7
-/*MyFruitCounter.Add(1); // Exported (No key/value pair)
+MyFruitCounter.Add(1); // Exported (No key/value pair)
 MyFruitCounter.Add(1, new("name", "apple"), new("color", "red")); // Exported
 MyFruitCounter.Add(2, new("name", "lemon"), new("color", "yellow")); // Exported
 MyFruitCounter.Add(1, new("name", "lemon"), new("color", "yellow")); // Exported
 MyFruitCounter.Add(2, new("name", "apple"), new("color", "green")); // Not exported
 MyFruitCounter.Add(5, new("name", "apple"), new("color", "red")); // Exported
-MyFruitCounter.Add(4, new("name", "lemon"), new("color", "yellow")); // Exported*/
+MyFruitCounter.Add(4, new("name", "lemon"), new("color", "yellow")); // Exported
 
 // There are four distinct key/value combinations emitted for 'AnotherFruitCounter':
 //   1. (name:kiwi)

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -462,7 +462,7 @@ MyFruitCounter.Add(1, new("name", "lemon"), new("color", "yellow")); // Exported
 MyFruitCounter.Add(2, new("name", "apple"), new("color", "green")); // Not exported
 MyFruitCounter.Add(5, new("name", "apple"), new("color", "red")); // Exported
 MyFruitCounter.Add(4, new("name", "lemon"), new("color", "yellow")); // Exported
-// Since the cardinality limit is 3, the SDK will only export measurements for the following three combinations:
+// Since the cardinality limit is 3, the SDK will only emit three combinations:
 //   1. No key/value pair Value=1
 //   2. (name:apple, color:red) Value=6
 //   3. (name:lemon, color:yellow) Value=7
@@ -479,7 +479,7 @@ AnotherFruitCounter.Add(1, new("name", "mango"), new("color", "yellow")); // Not
 AnotherFruitCounter.Add(2, new("name", "banana"), new("color", "green")); // Not exported
 AnotherFruitCounter.Add(5, new("name", "banana"), new("color", "yellow")); // Exported
 AnotherFruitCounter.Add(4, new("name", "mango"), new("color", "yellow")); // Not exported
-// Since the cardinality limit is 3, the SDK will only export measurements for the following two combinations:
+// Since the cardinality limit is 3, the SDK will only emit two combinations:
 //   1. (name:kiwi) Value=4
 //   2. (name:banana, color:yellow) Value=6
 // Note: There are only 2 exported measurements (not the 3 one might expect) because there was nothing
@@ -498,7 +498,7 @@ FlowerCounter.Add(2, new("name", "rose"), new("color", "white")); // Exported
 FlowerCounter.Add(5, new("name", "rose"), new("color", "red")); // Exported
 FlowerCounter.Add(4, new("name", "carnation"), new("color", "purple")); // Exported
 FlowerCounter.Add(4, new("name", "carnation"), new("color", "yellow")); // Exported
-// Since the cardinality limit is the default 2000 all combinations are exported:
+// Since the cardinality limit is the default 2000 all combinations are emitted:
 //   1. (name:rose, color:red) Value=6
 //   2. (name:sun_flower) Value=3
 //   3. (name:rose, color:white) Value=2

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -385,6 +385,12 @@ and the `MetricStreamConfiguration.CardinalityLimit` setting. Refer to this
 [doc](../../docs/metrics/customizing-the-sdk/README.md#changing-the-cardinality-limit-for-a-metric)
 for more information.
 
+> [!NOTE]
+> Measurements for each unique combination of attributes are stored on a
+  `MetricPoint` in the OpenTelemetry .NET SDK. When a measurement is recorded on
+  a metric for the first time the SDK will allocate enough storage for all
+  possible `MetricPoint`s for that metric based on the cardinality limit.
+
 Given a metric, once the cardinality limit is reached, any new measurement which
 cannot be independently aggregated because of the limit will be dropped or
 aggregated using the [overflow
@@ -405,7 +411,7 @@ the first time an overflow is detected for a given metric.
 When [Delta Aggregation
 Temporality](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md#temporality)
 is used, it is possible to choose a smaller cardinality limit by allowing the
-SDK to reclaim unused combinations.
+SDK to reclaim unused metric points.
 
 > [!NOTE]
 > Reclaim unused metric points feature was introduced in OpenTelemetry .NET

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -436,18 +436,9 @@ Counter<long> FlowerCounter = MyMeter.CreateCounter<long>("FlowerCounter");
 
 using var meterProvider = Sdk.CreateMeterProviderBuilder()
     .AddMeter("*")
+    .AddView(instrumentName: "MyFruitCounter", new MetricStreamConfiguration { CardinalityLimit = 3 })
+    .AddView(instrumentName: "AnotherFruitCounter", new MetricStreamConfiguration { CardinalityLimit = 3 })
     .AddConsoleExporter()
-    .AddView(i =>
-    {
-        if (i.Name == "MyFruitCounter" || i.Name == "AnotherFruitCounter")
-        {
-            // Note: Set the cardinality limit for 'MyFruitCounter' &
-            // 'AnotherFruitCounter' to 3
-            return new MetricStreamConfiguration { CardinalityLimit = 3 };
-        }
-
-        return null;
-    })
     .Build();
 
 // There are four distinct key/value combinations emitted for 'MyFruitCounter':


### PR DESCRIPTION
Following up on: https://github.com/open-telemetry/opentelemetry-dotnet/pull/5328/files#r1484926302

## Changes

* Updated and moved the cardinality overflow example we used to have in "customizing-the-sdk" into main metrics doc.