### PR TITLE
OpenTelemetry.Exporter.Console: Print exception attributes according to SemConv

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
@@ -94,7 +94,8 @@ public class ConsoleLogRecordExporter : ConsoleExporter<LogRecord>
                         // See https://github.com/open-telemetry/opentelemetry-dotnet/pull/3182
                         // for explanation.
                         var valueToTransform = logRecord.Attributes[i].Key.Equals("{OriginalFormat}")
-                            ? new KeyValuePair<string, object>("OriginalFormat (a.k.a Body)",
+                            ? new KeyValuePair<string, object>(
+                                "OriginalFormat (a.k.a Body)",
                                 logRecord.Attributes[i].Value)
                             : logRecord.Attributes[i];
 
@@ -166,6 +167,17 @@ public class ConsoleLogRecordExporter : ConsoleExporter<LogRecord>
         return ExportResult.Success;
     }
 
+    protected override void Dispose(bool disposing)
+    {
+        if (!this.disposed)
+        {
+            this.disposed = true;
+            this.disposedStackTrace = Environment.StackTrace;
+        }
+
+        base.Dispose(disposing);
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void PrintAttribute(string key, string value)
     {
@@ -176,16 +188,5 @@ public class ConsoleLogRecordExporter : ConsoleExporter<LogRecord>
         {
             this.WriteLine($"{string.Empty,-4}{result}");
         }
-    }
-
-    protected override void Dispose(bool disposing)
-    {
-        if (!this.disposed)
-        {
-            this.disposed = true;
-            this.disposedStackTrace = Environment.StackTrace;
-        }
-
-        base.Dispose(disposing);
     }
 }

--- a/src/OpenTelemetry.Exporter.Console/OpenTelemetry.Exporter.Console.csproj
+++ b/src/OpenTelemetry.Exporter.Console/OpenTelemetry.Exporter.Console.csproj
@@ -35,6 +35,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\DiagnosticDefinitions.cs" Link="Includes\DiagnosticDefinitions.cs" RequiresExposedExperimentalFeatures="true" />
     <Compile Include="$(RepoRoot)\src\Shared\ExceptionExtensions.cs" Link="Includes\ExceptionExtensions.cs" RequiresExposedExperimentalFeatures="true" />
     <Compile Include="$(RepoRoot)\src\Shared\SpanAttributeConstants.cs" Link="Includes\SpanAttributeConstants.cs" RequiresExposedExperimentalFeatures="true" />
+    <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" RequiresExposedExperimentalFeatures="true" />
   </ItemGroup>
 
 </Project>

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -21,6 +21,14 @@ Released 2024-Feb-09
   (see: [dotnet/aspnetcore#52652](https://github.com/dotnet/aspnetcore/pull/52652)).
   ([#5135](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5135))
 
+* Fixes scenario when the `net6.0` target of this library is loaded into a
+  .NET 7+ process and the instrumentation does not behave as expected. This
+  is an unusual scenario that does not affect users consuming this package
+  normally. This fix is primarily to support the
+  [opentelemetry-dotnet-instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5252)
+  project.
+  ([#5252](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5252))
+
 ## 1.7.0
 
 Released 2023-Dec-13

--- a/test/OpenTelemetry.Exporter.Console.Tests/ConsoleLogRecordExporterTest.cs
+++ b/test/OpenTelemetry.Exporter.Console.Tests/ConsoleLogRecordExporterTest.cs
@@ -1,0 +1,57 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.Extensions.Logging;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using Xunit;
+
+namespace OpenTelemetry.Exporter.Console.Tests;
+
+public class ConsoleLogRecordExporterTest
+{
+    [Fact]
+    public void VerifyExceptionAttributesAreWritten()
+    {
+        using var writer = new StringWriter();
+        System.Console.SetOut(writer);
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource("*")
+            .ConfigureResource(resource =>
+                resource.AddService(
+                    serviceName: "Test_VerifyExceptionAttributesAreWritten",
+                    serviceVersion: "1.0.0"))
+            .AddConsoleExporter()
+            .Build();
+
+        using ILoggerFactory factory = LoggerFactory
+            .Create(builder => builder.AddOpenTelemetry(n =>
+            {
+                n.AddConsoleExporter();
+            }));
+
+        ILogger logger = factory.CreateLogger("Program");
+        try
+        {
+            int num1 = 5, num2 = 0, division_res = 0;
+            division_res = num1 / num2;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "You divided by 0");
+        }
+
+        writer.Flush();
+        var consoleLog = writer.ToString();
+
+        Assert.Contains("exception.type", consoleLog);
+        Assert.Contains("DivideByZeroException", consoleLog);
+
+        Assert.Contains("exception.message", consoleLog);
+        Assert.Contains("Attempted to divide by zero.", consoleLog);
+
+        Assert.Contains("exception.stacktrace", consoleLog);
+        Assert.Contains("System.DivideByZeroException: Attempted to divide by zero.", consoleLog);
+    }
+}

--- a/test/OpenTelemetry.Exporter.Console.Tests/ConsoleLogRecordExporterTest.cs
+++ b/test/OpenTelemetry.Exporter.Console.Tests/ConsoleLogRecordExporterTest.cs
@@ -12,6 +12,7 @@ public class ConsoleLogRecordExporterTest
     [Fact]
     public void VerifyExceptionAttributesAreWritten()
     {
+        var originalConsoleOut = System.Console.Out;
         using var writer = new StringWriter();
         System.Console.SetOut(writer);
 
@@ -26,6 +27,7 @@ public class ConsoleLogRecordExporterTest
 
         writer.Flush();
         var consoleLog = writer.ToString();
+        System.Console.SetOut(originalConsoleOut);
 
         Assert.Contains("exception.type", consoleLog);
         Assert.Contains("Exception", consoleLog);


### PR DESCRIPTION
Follow up from https://github.com/open-telemetry/opentelemetry-dotnet/issues/5342#issuecomment-1937110524 - and https://github.com/open-telemetry/semantic-conventions/issues/689

## Changes

`ConsoleLogRecordExporter` prints exception attributes according to the [SemConv spec](https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions-logs/). With this PR, `ConsoleLogRecordExporter` behaves similarly to [`OtlpLogRecordTransformer`](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpLogRecordTransformer.cs#L144-L149) from `OpenTelemetry.Exporter.OpenTelemetryProtocol`.


## Open questions

- [ ] I'm not familiar with previous design choices, but I really wonder why this is not done directly in [/src/OpenTelemetry/Logs](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry/Logs)? E.g. in [LogRecord.cs ](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry/Logs/LogRecord.cs). With that, all exporters would benefit from this and the responsibility of filling the attributes according to the spec would not be the responsibility of the exporter.

Since I'm fairly new to the code-base I wanted to ask this before I do any such changes - let me know if you think it'd make sense to explore this and I'm happy to update the PR - or open a follow up.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
