### PR TITLE
[sdk] Rename SimpleExemplarReservoir to SimpleFixedSizeExemplarReservoir

### DIFF
--- a/docs/metrics/customizing-the-sdk/README.md
+++ b/docs/metrics/customizing-the-sdk/README.md
@@ -471,9 +471,9 @@ Histograms with buckets, and it stores at most one exemplar per histogram
 bucket. The exemplar stored is the last measurement recorded - i.e. any new
 measurement overwrites the previous one in that bucket.
 
-* `SimpleExemplarReservoir` is the default reservoir used for all metrics except
-Histograms with buckets. It has a fixed reservoir pool, and implements the
-equivalent of [naive
+* `SimpleFixedSizeExemplarReservoir` is the default reservoir used for all
+metrics except Histograms with buckets. It has a fixed reservoir pool, and
+implements the equivalent of [naive
 reservoir](https://en.wikipedia.org/wiki/Reservoir_sampling). The reservoir pool
 size (currently defaulting to 1) determines the maximum number of exemplars
 stored.

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -45,6 +45,7 @@
 * Renamed `SimpleExemplarReservoir` to `SimpleFixedSizeExemplarReservoir` for
   alignment with the name used in the [OpenTelemetry
   Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#simplefixedsizeexemplarreservoir).
+  ([#5359](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5359))
 
 ## 1.7.0
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -42,11 +42,6 @@
   [IMetricsListener](https://learn.microsoft.com/dotNet/api/microsoft.extensions.diagnostics.metrics.imetricslistener).
   ([#5265](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5265))
 
-* Renamed `SimpleExemplarReservoir` to `SimpleFixedSizeExemplarReservoir` for
-  alignment with the name used in the [OpenTelemetry
-  Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#simplefixedsizeexemplarreservoir).
-  ([#5359](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5359))
-
 ## 1.7.0
 
 Released 2023-Dec-08

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -42,6 +42,10 @@
   [IMetricsListener](https://learn.microsoft.com/dotNet/api/microsoft.extensions.diagnostics.metrics.imetricslistener).
   ([#5265](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5265))
 
+* Renamed `SimpleExemplarReservoir` to `SimpleFixedSizeExemplarReservoir` for
+  alignment with the name used in the [OpenTelemetry
+  Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#simplefixedsizeexemplarreservoir).
+
 ## 1.7.0
 
 Released 2023-Dec-08

--- a/src/OpenTelemetry/Metrics/Exemplar/SimpleFixedSizeExemplarReservoir.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/SimpleFixedSizeExemplarReservoir.cs
@@ -6,9 +6,9 @@ using System.Diagnostics;
 namespace OpenTelemetry.Metrics;
 
 /// <summary>
-/// The SimpleExemplarReservoir implementation.
+/// The SimpleFixedSizeExemplarReservoir implementation.
 /// </summary>
-internal sealed class SimpleExemplarReservoir : ExemplarReservoir
+internal sealed class SimpleFixedSizeExemplarReservoir : ExemplarReservoir
 {
     private readonly int poolSize;
     private readonly Random random;
@@ -17,7 +17,7 @@ internal sealed class SimpleExemplarReservoir : ExemplarReservoir
 
     private long measurementsSeen;
 
-    public SimpleExemplarReservoir(int poolSize)
+    public SimpleFixedSizeExemplarReservoir(int poolSize)
     {
         this.poolSize = poolSize;
         this.runningExemplars = new Exemplar[poolSize];

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -91,7 +91,7 @@ public struct MetricPoint
 
         if (aggregatorStore!.IsExemplarEnabled() && reservoir == null)
         {
-            reservoir = new SimpleExemplarReservoir(DefaultSimpleReservoirPoolSize);
+            reservoir = new SimpleFixedSizeExemplarReservoir(DefaultSimpleReservoirPoolSize);
         }
 
         if (reservoir != null)

--- a/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
@@ -52,7 +52,7 @@ public class MetricExemplarTests : MetricTestsBase
         var exemplars = GetExemplars(metricPoint.Value);
 
         // TODO: Modify the test to better test cumulative.
-        // In cumulative where SimpleFixedSizeExemplarReservoir's size is
+        // In cumulative, where SimpleFixedSizeExemplarReservoir's size is
         // more than the count of new measurements, it is possible
         // that the exemplar value is for a measurement that was recorded in the prior
         // cycle. The current ValidateExemplars() does not handle this case.

--- a/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
@@ -52,7 +52,7 @@ public class MetricExemplarTests : MetricTestsBase
         var exemplars = GetExemplars(metricPoint.Value);
 
         // TODO: Modify the test to better test cumulative.
-        // In cumulative where SimpleExemplarReservoir's size is
+        // In cumulative where SimpleFixedSizeExemplarReservoir's size is
         // more than the count of new measurements, it is possible
         // that the exemplar value is for a measurement that was recorded in the prior
         // cycle. The current ValidateExemplars() does not handle this case.


### PR DESCRIPTION
Fixes #5336
Design discussion issue #

## Changes

Please provide a brief description of the changes here.

This PR renames the `SimpleExemplarReservoir` class to `SimpleFixedSizeExemplarReservoir` to align with the terminology used in the OpenTelemetry Specification. This change ensures consistency and clarity in the SDK's naming convention.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
