### PR TITLE
[sdk-logs] Improve OpenTelemetryLogger.IsEnabled

### DIFF
--- a/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLogger.cs
+++ b/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLogger.cs
@@ -44,8 +44,7 @@ internal sealed class OpenTelemetryLogger : ILogger
 
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {
-        if (!this.IsEnabled(logLevel)
-            || Sdk.SuppressInstrumentation)
+        if (!this.IsEnabled(logLevel))
         {
             return;
         }
@@ -111,7 +110,7 @@ internal sealed class OpenTelemetryLogger : ILogger
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool IsEnabled(LogLevel logLevel)
     {
-        return logLevel != LogLevel.None;
+        return logLevel != LogLevel.None && !Sdk.SuppressInstrumentation;
     }
 
     public IDisposable BeginScope<TState>(TState state)


### PR DESCRIPTION
This change should be almost transparent to the user, unless the user is relying on the side effect:

```csharp
if (logger.IsEnabled(level))
{
    // code with side effect
}
```

With this change, it will be possible to save some CPU time if it is expensive to prepare the logging arguments:

```csharp
if (logger.IsEnabled(level))
{
    var expensive = GetSomethingExpensive();
    logger.LogSomething(expensive);
}
```

The logic was originally written by me in #1329.

It was later refactored (with no change to the actual logic) https://github.com/open-telemetry/opentelemetry-dotnet/pull/1869/files#r588851416.