### PR TITLE
[sdk-metrics] Refactor and improve interlocking code for doubles in MetricPoint

### DIFF
--- a/src/OpenTelemetry/Internal/InterlockedHelper.cs
+++ b/src/OpenTelemetry/Internal/InterlockedHelper.cs
@@ -1,0 +1,58 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Runtime.CompilerServices;
+
+namespace OpenTelemetry.Internal;
+
+internal static class InterlockedHelper
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Add(ref double location, double value)
+    {
+        // Note: Not calling InterlockedHelper.Read here on purpose because it
+        // is too expensive for fast/happy-path. If the first attempt fails
+        // we'll end up in an Interlocked.CompareExchange loop anyway.
+        double currentValue = Volatile.Read(ref location);
+
+        double updatedValue;
+        unchecked
+        {
+            updatedValue = currentValue + value;
+        }
+
+        var returnedValue = Interlocked.CompareExchange(ref location, updatedValue, currentValue);
+        if (returnedValue != currentValue)
+        {
+            AddRare(ref location, value, returnedValue);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static double Read(ref double location)
+        => Interlocked.CompareExchange(ref location, double.NaN, double.NaN);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void AddRare(ref double location, double value, double currentValue)
+    {
+        var sw = default(SpinWait);
+        while (true)
+        {
+            sw.SpinOnce();
+
+            double updatedValue;
+            unchecked
+            {
+                updatedValue = currentValue + value;
+            }
+
+            var returnedValue = Interlocked.CompareExchange(ref location, updatedValue, currentValue);
+            if (returnedValue == currentValue)
+            {
+                break;
+            }
+
+            currentValue = returnedValue;
+        }
+    }
+}

--- a/src/OpenTelemetry/Internal/InterlockedHelper.cs
+++ b/src/OpenTelemetry/Internal/InterlockedHelper.cs
@@ -15,13 +15,7 @@ internal static class InterlockedHelper
         // we'll end up in an Interlocked.CompareExchange loop anyway.
         double currentValue = Volatile.Read(ref location);
 
-        double updatedValue;
-        unchecked
-        {
-            updatedValue = currentValue + value;
-        }
-
-        var returnedValue = Interlocked.CompareExchange(ref location, updatedValue, currentValue);
+        var returnedValue = Interlocked.CompareExchange(ref location, currentValue + value, currentValue);
         if (returnedValue != currentValue)
         {
             AddRare(ref location, value, returnedValue);
@@ -40,13 +34,7 @@ internal static class InterlockedHelper
         {
             sw.SpinOnce();
 
-            double updatedValue;
-            unchecked
-            {
-                updatedValue = currentValue + value;
-            }
-
-            var returnedValue = Interlocked.CompareExchange(ref location, updatedValue, currentValue);
+            var returnedValue = Interlocked.CompareExchange(ref location, currentValue + value, currentValue);
             if (returnedValue == currentValue)
             {
                 break;

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -830,11 +830,6 @@ public struct MetricPoint
                     }
                     else
                     {
-                        // TODO:
-                        // Is this thread-safe way to read double?
-                        // As long as the value is not -ve infinity,
-                        // the exchange (to 0.0) will never occur,
-                        // but we get the original value atomically.
                         this.snapshotValue.AsDouble = InterlockedHelper.Read(ref this.runningValue.AsDouble);
                     }
 

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Metrics;
 
@@ -578,25 +579,7 @@ public struct MetricPoint
         {
             case AggregationType.DoubleSumIncomingDelta:
                 {
-                    double initValue, newValue;
-                    var sw = default(SpinWait);
-                    while (true)
-                    {
-                        initValue = this.runningValue.AsDouble;
-
-                        unchecked
-                        {
-                            newValue = initValue + number;
-                        }
-
-                        if (initValue == Interlocked.CompareExchange(ref this.runningValue.AsDouble, newValue, initValue))
-                        {
-                            break;
-                        }
-
-                        sw.SpinOnce();
-                    }
-
+                    InterlockedHelper.Add(ref this.runningValue.AsDouble, number);
                     break;
                 }
 
@@ -833,19 +816,14 @@ public struct MetricPoint
                 {
                     if (outputDelta)
                     {
-                        // TODO:
-                        // Is this thread-safe way to read double?
-                        // As long as the value is not -ve infinity,
-                        // the exchange (to 0.0) will never occur,
-                        // but we get the original value atomically.
-                        double initValue = Interlocked.CompareExchange(ref this.runningValue.AsDouble, 0.0, double.NegativeInfinity);
+                        double initValue = InterlockedHelper.Read(ref this.runningValue.AsDouble);
                         this.snapshotValue.AsDouble = initValue - this.deltaLastValue.AsDouble;
                         this.deltaLastValue.AsDouble = initValue;
                         this.MetricPointStatus = MetricPointStatus.NoCollectPending;
 
                         // Check again if value got updated, if yes reset status.
                         // This ensures no Updates get Lost.
-                        if (initValue != Interlocked.CompareExchange(ref this.runningValue.AsDouble, 0.0, double.NegativeInfinity))
+                        if (initValue != InterlockedHelper.Read(ref this.runningValue.AsDouble))
                         {
                             this.MetricPointStatus = MetricPointStatus.CollectPending;
                         }
@@ -857,7 +835,7 @@ public struct MetricPoint
                         // As long as the value is not -ve infinity,
                         // the exchange (to 0.0) will never occur,
                         // but we get the original value atomically.
-                        this.snapshotValue.AsDouble = Interlocked.CompareExchange(ref this.runningValue.AsDouble, 0.0, double.NegativeInfinity);
+                        this.snapshotValue.AsDouble = InterlockedHelper.Read(ref this.runningValue.AsDouble);
                     }
 
                     break;
@@ -880,17 +858,12 @@ public struct MetricPoint
 
             case AggregationType.DoubleGauge:
                 {
-                    // TODO:
-                    // Is this thread-safe way to read double?
-                    // As long as the value is not -ve infinity,
-                    // the exchange (to 0.0) will never occur,
-                    // but we get the original value atomically.
-                    this.snapshotValue.AsDouble = Interlocked.CompareExchange(ref this.runningValue.AsDouble, 0.0, double.NegativeInfinity);
+                    this.snapshotValue.AsDouble = InterlockedHelper.Read(ref this.runningValue.AsDouble);
                     this.MetricPointStatus = MetricPointStatus.NoCollectPending;
 
                     // Check again if value got updated, if yes reset status.
                     // This ensures no Updates get Lost.
-                    if (this.snapshotValue.AsDouble != Interlocked.CompareExchange(ref this.runningValue.AsDouble, 0.0, double.NegativeInfinity))
+                    if (this.snapshotValue.AsDouble != InterlockedHelper.Read(ref this.runningValue.AsDouble))
                     {
                         this.MetricPointStatus = MetricPointStatus.CollectPending;
                     }


### PR DESCRIPTION
## Changes

* Refactored the custom interlocking code for `double` values in `MetricPoint` into a helper and improved them slightly. With help from @stephentoub.
