### PR TITLE
[ci] Add push trigger and workflow_dispatch trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,13 @@
 name: Build
 
 on:
+  workflow_dispatch:
+  # The push trigger would run the CI workflow when any changes get merged to main branch.
+  # The build badge on the main README uses the CI results on the main branch to report the build status.
+  push:
+    branches: [ 'main*' ]
+    paths-ignore:
+    - '**.md'
   pull_request:
     branches: [ 'main*' ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ on:
   # The build badge on the main README uses the CI results on the main branch to report the build status.
   push:
     branches: [ 'main*' ]
-    paths-ignore:
-    - '**.md'
   pull_request:
     branches: [ 'main*' ]
 


### PR DESCRIPTION
![image](https://github.com/open-telemetry/opentelemetry-dotnet/assets/66651184/7ee299d4-984c-447b-a64c-40296d2ac3e6)

## Changes
- Added `push trigger` so that the build badge shows the right status. Currently, it still points to some old CI workflow run on main branch
- Added a `workflow_dispatch` trigger so that we can manually trigger builds when required