### PR TITLE
OpenTelemetrySdkEventSource updates for activity tracking

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Modified OpenTelemetrySdkEventSource with the following changes to support activity tracking:
+  * ActivityStarted and ActivityStopped events have been renamed to ActivityStart and ActivityStop respectively. This is to comply with the naming convention for activity tracking.
+  * ActivityStart and ActivityStop use the Start and Stop operation codes (EventOpCode) respectively.
+
 * Fixed an issue where `LogRecord.Attributes` (or `LogRecord.StateValues` alias)
   could become out of sync with `LogRecord.State` if either is set directly via
   the public setters. This was done to further mitigate issues introduced in

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-* Modified OpenTelemetrySdkEventSource with the following changes to support activity tracking:
-  * ActivityStarted and ActivityStopped events have been renamed to ActivityStart and ActivityStop respectively. This is to comply with the naming convention for activity tracking.
-  * ActivityStart and ActivityStop use the Start and Stop operation codes (EventOpCode) respectively.
+* Added ActivityTracking to OpenTelemetrySdkEventSource.
+  * Added Activities keyword.
+  * Added ActivityStart and ActivityStop events at Informational level using Activites keyword.
 
 * Fixed an issue where `LogRecord.Attributes` (or `LogRecord.StateValues` alias)
   could become out of sync with `LogRecord.State` if either is set directly via

--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -69,7 +69,7 @@ internal sealed class OpenTelemetrySdkEventSource : EventSource
             // https://github.com/dotnet/runtime/issues/61857
             var activityId = string.Concat("00-", activity.TraceId.ToHexString(), "-", activity.SpanId.ToHexString());
             activityId = string.Concat(activityId, activity.ActivityTraceFlags.HasFlag(ActivityTraceFlags.Recorded) ? "-01" : "-00");
-            this.ActivityStarted(activity.DisplayName, activityId);
+            this.ActivityStart(activity.DisplayName, activityId);
         }
     }
 
@@ -78,7 +78,7 @@ internal sealed class OpenTelemetrySdkEventSource : EventSource
     {
         if (this.IsEnabled(EventLevel.Verbose, EventKeywords.All))
         {
-            this.ActivityStopped(activity.DisplayName, activity.Id);
+            this.ActivityStop(activity.DisplayName, activity.Id);
         }
     }
 
@@ -175,14 +175,14 @@ internal sealed class OpenTelemetrySdkEventSource : EventSource
         this.WriteEvent(16, exception);
     }
 
-    [Event(24, Message = "Activity started. Name = '{0}', Id = '{1}'.", Level = EventLevel.Verbose)]
-    public void ActivityStarted(string name, string id)
+    [Event(24, Message = "Activity started. Name = '{0}', Id = '{1}'.", Level = EventLevel.Verbose, Opcode = EventOpcode.Start)]
+    public void ActivityStart(string name, string id)
     {
         this.WriteEvent(24, name, id);
     }
 
-    [Event(25, Message = "Activity stopped. Name = '{0}', Id = '{1}'.", Level = EventLevel.Verbose)]
-    public void ActivityStopped(string name, string? id)
+    [Event(25, Message = "Activity stopped. Name = '{0}', Id = '{1}'.", Level = EventLevel.Verbose, Opcode = EventOpcode.Stop)]
+    public void ActivityStop(string name, string? id)
     {
         this.WriteEvent(25, name, id);
     }

--- a/test/Benchmarks/EventSourceBenchmarks.cs
+++ b/test/Benchmarks/EventSourceBenchmarks.cs
@@ -17,7 +17,7 @@ public class EventSourceBenchmarks
         activity.Start();
         activity.Stop();
 
-        OpenTelemetrySdkEventSource.Log.ActivityStarted(activity.OperationName, activity.Id);
+        OpenTelemetrySdkEventSource.Log.ActivityStart(activity.OperationName, activity.Id);
     }
 
     [Benchmark]

--- a/test/Benchmarks/EventSourceBenchmarks.cs
+++ b/test/Benchmarks/EventSourceBenchmarks.cs
@@ -17,7 +17,7 @@ public class EventSourceBenchmarks
         activity.Start();
         activity.Stop();
 
-        OpenTelemetrySdkEventSource.Log.ActivityStart(activity.OperationName, activity.Id);
+        OpenTelemetrySdkEventSource.Log.ActivityStarted(activity.OperationName, activity.Id);
     }
 
     [Benchmark]

--- a/test/OpenTelemetry.Tests/EventSourceTest.cs
+++ b/test/OpenTelemetry.Tests/EventSourceTest.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace OpenTelemetry.Tests;
 
+[Collection("Uses-OpenTelemetrySdkEventSource")] // Prevent parallel execution with other tests that exercise the SdkEventSource
 public class EventSourceTest
 {
     [Fact]

--- a/test/OpenTelemetry.Tests/Internal/SdkEventSourceTest.cs
+++ b/test/OpenTelemetry.Tests/Internal/SdkEventSourceTest.cs
@@ -4,11 +4,10 @@
 
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
-using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
 using Xunit;
 
-namespace OpenTelemetry.Tests.Internal;
+namespace OpenTelemetry.Internal.Tests;
 
 [Collection("Uses-OpenTelemetrySdkEventSource")] // Prevent parallel execution with other tests that exercise the SdkEventSource
 public class SdkEventSourceTest : IDisposable
@@ -22,7 +21,7 @@ public class SdkEventSourceTest : IDisposable
     }
 
     [Fact]
-    public void ActivityStartUsesOpCodeStart()
+    public void ActivityTrackingWorks()
     {
         using TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
             .AddSource("TestSource")
@@ -48,8 +47,8 @@ public class SdkEventSourceTest : IDisposable
             EventWrittenEventArgs startEvent = this.listener.Events[i * 2];
             EventWrittenEventArgs stopEvent = this.listener.Events[(i * 2) + 1];
 
-            Assert.Equal(nameof(OpenTelemetrySdkEventSource.ActivityStart), startEvent.EventName);
-            Assert.Equal(nameof(OpenTelemetrySdkEventSource.ActivityStop), stopEvent.EventName);
+            Assert.Equal("ActivityStart", startEvent.EventName);
+            Assert.Equal("ActivityStop", stopEvent.EventName);
 
             // Start and Stop should be matched on ActivityId.
             Assert.Equal(startEvent.ActivityId, stopEvent.ActivityId);
@@ -86,7 +85,7 @@ public class SdkEventSourceTest : IDisposable
             if (eventSource.Name == SdkEventSourceName)
             {
                 this.eventSourcesEnabled.Add(eventSource);
-                this.EnableEvents(eventSource, EventLevel.Verbose, EventKeywords.All);
+                this.EnableEvents(eventSource, EventLevel.Informational, OpenTelemetrySdkEventSource.Keywords.Activities);
             }
             else if (eventSource.Name == "System.Threading.Tasks.TplEventSource")
             {

--- a/test/OpenTelemetry.Tests/Internal/SdkEventSourceTest.cs
+++ b/test/OpenTelemetry.Tests/Internal/SdkEventSourceTest.cs
@@ -1,0 +1,121 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+#nullable enable
+
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using OpenTelemetry.Internal;
+using OpenTelemetry.Trace;
+using Xunit;
+
+namespace OpenTelemetry.Tests.Internal;
+
+[Collection("Uses-OpenTelemetrySdkEventSource")] // Prevent parallel execution with other tests that exercise the SdkEventSource
+public class SdkEventSourceTest : IDisposable
+{
+    private readonly SdkEventListener listener = new();
+
+    public void Dispose()
+    {
+        this.listener.Dispose();
+    }
+
+    [Fact]
+    public void ActivityStartUsesOpCodeStart()
+    {
+        using (TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddSource("TestSource")
+            .Build())
+        {
+            // Clear any events that were emitted during Build.
+            this.listener.Events.Clear();
+
+            const int numActivities = 4;
+
+            using ActivitySource activitySource = new("TestSource");
+            for (int i = 0; i < numActivities; i++)
+            {
+                using Activity? activity = activitySource.StartActivity($"Test Activity {i}");
+            }
+
+            // There should be 2 events for each activity: ActivityStart and ActivityStop.
+            Assert.Equal(numActivities * 2, this.listener.Events.Count);
+
+            HashSet<Guid> activityIds = [];
+            for (int i = 0; i < numActivities; i++)
+            {
+                EventWrittenEventArgs startEvent = this.listener.Events[i * 2];
+                EventWrittenEventArgs stopEvent = this.listener.Events[(i * 2) + 1];
+
+                Assert.Equal(nameof(OpenTelemetrySdkEventSource.ActivityStart), startEvent.EventName);
+                Assert.Equal(nameof(OpenTelemetrySdkEventSource.ActivityStop), stopEvent.EventName);
+
+                // Start and Stop should be matched on ActivityId.
+                Assert.Equal(startEvent.ActivityId, stopEvent.ActivityId);
+
+                // ActivityIds should be unique.
+                Assert.True(activityIds.Add(startEvent.ActivityId));
+            }
+        }
+    }
+
+    private sealed class SdkEventListener : EventListener
+    {
+        private static readonly string SdkEventSourceName = EventSource.GetName(typeof(OpenTelemetrySdkEventSource));
+        private readonly HashSet<EventSource> eventSourcesEnabled = [];
+
+        public List<EventWrittenEventArgs> Events { get; } = [];
+
+        public override void Dispose()
+        {
+            try
+            {
+                foreach (EventSource eventSource in this.eventSourcesEnabled)
+                {
+                    this.DisableEvents(eventSource);
+                }
+            }
+            finally
+            {
+                base.Dispose();
+            }
+        }
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            if (eventSource.Name == SdkEventSourceName)
+            {
+                this.eventSourcesEnabled.Add(eventSource);
+                this.EnableEvents(eventSource, EventLevel.Verbose, EventKeywords.All);
+            }
+            else if (eventSource.Name == "System.Threading.Tasks.TplEventSource")
+            {
+                // In addition to the OpenTelemetrySdkEventSource we need
+                // the TPL EventSource to enable activity tracking. When
+                // enabled and an EventSource writes events with
+                // EventOpCode.Start/Stop, then the ActivityTracker will
+                // generate new path-like ActivityIDs.
+                // Also note that activity tracking requires that the
+                // Start/Stop events are a matched pair, named like
+                // "xyzStart" and "xyzStop". ActivityTracker matches the
+                // stop event with the start event by recognizing those
+                // exact suffixes.
+                this.eventSourcesEnabled.Add(eventSource);
+                const EventKeywords taskFlowActivityIds = (EventKeywords)0x80;
+                this.EnableEvents(eventSource, EventLevel.Informational, taskFlowActivityIds);
+            }
+
+            base.OnEventSourceCreated(eventSource);
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            if (eventData.EventSource.Name == SdkEventSourceName)
+            {
+                this.Events.Add(eventData);
+            }
+
+            base.OnEventWritten(eventData);
+        }
+    }
+}

--- a/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsEventListenerTest.cs
+++ b/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsEventListenerTest.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace OpenTelemetry.Internal.Tests;
 
+[Collection("Uses-OpenTelemetrySdkEventSource")] // Prevent parallel execution with other tests that exercise the SdkEventSource
 public class SelfDiagnosticsEventListenerTest
 {
     private const string LOGFILEPATH = "Diagnostics.log";
@@ -32,7 +33,7 @@ public class SelfDiagnosticsEventListenerTest
         _ = new SelfDiagnosticsEventListener(EventLevel.Error, configRefresher);
 
         // Emitting a Verbose event. Or any EventSource event with lower severity than Error.
-        OpenTelemetrySdkEventSource.Log.ActivityStarted("Activity started", "1");
+        OpenTelemetrySdkEventSource.Log.ActivityStart("Activity started", "1");
         Assert.False(configRefresher.TryGetLogStreamCalled);
     }
 
@@ -115,7 +116,7 @@ public class SelfDiagnosticsEventListenerTest
         _ = new SelfDiagnosticsEventListener(EventLevel.Error, configRefresher);
 
         // Act: emit an event with severity lower than configured
-        OpenTelemetrySdkEventSource.Log.ActivityStarted("ActivityStart", "123");
+        OpenTelemetrySdkEventSource.Log.ActivityStart("ActivityStart", "123");
 
         // Assert
         Assert.False(configRefresher.TryGetLogStreamCalled);

--- a/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsEventListenerTest.cs
+++ b/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsEventListenerTest.cs
@@ -33,7 +33,7 @@ public class SelfDiagnosticsEventListenerTest
         _ = new SelfDiagnosticsEventListener(EventLevel.Error, configRefresher);
 
         // Emitting a Verbose event. Or any EventSource event with lower severity than Error.
-        OpenTelemetrySdkEventSource.Log.ActivityStart("Activity started", "1");
+        OpenTelemetrySdkEventSource.Log.ActivityStarted("Activity started", "1");
         Assert.False(configRefresher.TryGetLogStreamCalled);
     }
 
@@ -116,7 +116,7 @@ public class SelfDiagnosticsEventListenerTest
         _ = new SelfDiagnosticsEventListener(EventLevel.Error, configRefresher);
 
         // Act: emit an event with severity lower than configured
-        OpenTelemetrySdkEventSource.Log.ActivityStart("ActivityStart", "123");
+        OpenTelemetrySdkEventSource.Log.ActivityStarted("ActivityStart", "123");
 
         // Assert
         Assert.False(configRefresher.TryGetLogStreamCalled);


### PR DESCRIPTION
## Changes

This change addresses issues with the OpenTelemetrySdkEventSource discovered during testing of profiler support for .NET applications. For example, we use dotnet-trace to profile an OpenTelemetry application. To enable activity tracking, we enable the OpenTelemetrySdkEventSource like this:

```
dotnet-trace collect -p <pid> --profile cpu-sampling --providers OpenTelemetry-Sdk
```

In the resulting trace, however, we observe the following problem:
- ActivityIds are not set on the ActivityStarted/Stopped events from the OpenTelemetry-Sdk provider.

This is because of two problems:
1. The ActivityStarted/Stopped events are not emitted with the Start/Stop OpCodes.
2. Even when the OpCodes are added the ActivityTracker doesn't pair up the two events because they are using the wrong suffixes. The ActivityTracker specifically checks for the suffixes "Start" and "Stop". See item 4 here: https://learn.microsoft.com/dotnet/core/diagnostics/eventsource-instrumentation#best-practices and the code [here](https://source.dot.net/#System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/ActivityTracker.cs,cc4a994235d93cb4).

To address these two issues: 
1. Added new Activities keyword.
2. Added new ActivityStart and ActivityStop events using the Activities keyword and Informational level.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
