### PR TITLE
[sdk-metrics] Improve exemplar tests

### DIFF
--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -17,6 +17,7 @@ internal sealed class AggregatorStore
     internal readonly int CardinalityLimit;
     internal readonly bool EmitOverflowAttribute;
     internal readonly ConcurrentDictionary<Tags, LookupData>? TagsToMetricPointIndexDictionaryDelta;
+    internal readonly Func<ExemplarReservoir?>? ExemplarReservoirFactory;
     internal long DroppedMeasurements = 0;
 
     private static readonly string MetricPointCapHitFixMessage = "Consider opting in for the experimental SDK feature to emit all the throttled metrics under the overflow attribute by setting env variable OTEL_DOTNET_EXPERIMENTAL_METRICS_EMIT_OVERFLOW_ATTRIBUTE = true. You could also modify instrumentation to reduce the number of unique key/value pair combinations. Or use Views to drop unwanted tags. Or use MeterProviderBuilder.SetMaxMetricPointsPerMetricStream to set higher limit.";
@@ -59,7 +60,8 @@ internal sealed class AggregatorStore
         int cardinalityLimit,
         bool emitOverflowAttribute,
         bool shouldReclaimUnusedMetricPoints,
-        ExemplarFilter? exemplarFilter = null)
+        ExemplarFilter? exemplarFilter = null,
+        Func<ExemplarReservoir?>? exemplarReservoirFactory = null)
     {
         this.name = metricStreamIdentity.InstrumentName;
         this.CardinalityLimit = cardinalityLimit;
@@ -74,6 +76,7 @@ internal sealed class AggregatorStore
         this.exponentialHistogramMaxScale = metricStreamIdentity.ExponentialHistogramMaxScale;
         this.StartTimeExclusive = DateTimeOffset.UtcNow;
         this.exemplarFilter = exemplarFilter ?? DefaultExemplarFilter;
+        this.ExemplarReservoirFactory = exemplarReservoirFactory;
         if (metricStreamIdentity.TagKeys == null)
         {
             this.updateLongCallback = this.UpdateLong;

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -49,7 +49,8 @@ public sealed class Metric
         int cardinalityLimit,
         bool emitOverflowAttribute,
         bool shouldReclaimUnusedMetricPoints,
-        ExemplarFilter? exemplarFilter = null)
+        ExemplarFilter? exemplarFilter = null,
+        Func<ExemplarReservoir?>? exemplarReservoirFactory = null)
     {
         this.InstrumentIdentity = instrumentIdentity;
 
@@ -155,7 +156,15 @@ public sealed class Metric
             throw new NotSupportedException($"Unsupported Instrument Type: {instrumentIdentity.InstrumentType.FullName}");
         }
 
-        this.AggregatorStore = new AggregatorStore(instrumentIdentity, aggType, temporality, cardinalityLimit, emitOverflowAttribute, shouldReclaimUnusedMetricPoints, exemplarFilter);
+        this.AggregatorStore = new AggregatorStore(
+            instrumentIdentity,
+            aggType,
+            temporality,
+            cardinalityLimit,
+            emitOverflowAttribute,
+            shouldReclaimUnusedMetricPoints,
+            exemplarFilter,
+            exemplarReservoirFactory);
         this.Temporality = temporality;
     }
 

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -72,7 +72,7 @@ public struct MetricPoint
         }
         catch
         {
-            // todo: Log that the factory on view threw an exception
+            // TODO : Log that the factory on view threw an exception, once view exposes that capability
             reservoir = null;
         }
 
@@ -81,9 +81,9 @@ public struct MetricPoint
         {
             this.mpComponents = new MetricPointOptionalComponents();
             this.mpComponents.HistogramBuckets = new HistogramBuckets(histogramExplicitBounds);
-            if (isExemplarEnabled)
+            if (isExemplarEnabled && reservoir == null)
             {
-                reservoir ??= new AlignedHistogramBucketExemplarReservoir(histogramExplicitBounds!.Length);
+                reservoir = new AlignedHistogramBucketExemplarReservoir(histogramExplicitBounds!.Length);
             }
         }
         else if (this.aggType == AggregationType.Histogram ||

--- a/src/OpenTelemetry/Metrics/MetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/MetricReaderExt.cs
@@ -147,14 +147,14 @@ public abstract partial class MetricReader
                 {
                     bool shouldReclaimUnusedMetricPoints = this.parentProvider is MeterProviderSdk meterProviderSdk && meterProviderSdk.ShouldReclaimUnusedMetricPoints;
 
-                    var cardinalityLimit = this.cardinalityLimit;
-
-                    if (metricStreamConfig != null && metricStreamConfig.CardinalityLimit != null)
-                    {
-                        cardinalityLimit = metricStreamConfig.CardinalityLimit.Value;
-                    }
-
-                    Metric metric = new(metricStreamIdentity, this.GetAggregationTemporality(metricStreamIdentity.InstrumentType), cardinalityLimit, this.emitOverflowAttribute, shouldReclaimUnusedMetricPoints, this.exemplarFilter);
+                    Metric metric = new(
+                        metricStreamIdentity,
+                        this.GetAggregationTemporality(metricStreamIdentity.InstrumentType),
+                        metricStreamConfig?.CardinalityLimit ?? this.cardinalityLimit,
+                        this.emitOverflowAttribute,
+                        shouldReclaimUnusedMetricPoints,
+                        this.exemplarFilter,
+                        metricStreamConfig?.ExemplarReservoirFactory);
 
                     this.instrumentIdentityToMetric[metricStreamIdentity] = metric;
                     this.metrics![index] = metric;

--- a/src/OpenTelemetry/Metrics/MetricStreamConfiguration.cs
+++ b/src/OpenTelemetry/Metrics/MetricStreamConfiguration.cs
@@ -133,6 +133,10 @@ public class MetricStreamConfiguration
         }
     }
 
+    // TODO: Expose this to be complaint with the spec:
+    // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#stream-configuration
+    internal Func<ExemplarReservoir?>? ExemplarReservoirFactory { get; set; }
+
     internal string[]? CopiedTagKeys { get; private set; }
 
     internal int? ViewId { get; set; }

--- a/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
@@ -1,23 +1,18 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable enable
+
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using OpenTelemetry.Tests;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace OpenTelemetry.Metrics.Tests;
 
 public class MetricExemplarTests : MetricTestsBase
 {
     private const int MaxTimeToAllowForFlush = 10000;
-    private readonly ITestOutputHelper output;
-
-    public MetricExemplarTests(ITestOutputHelper output)
-    {
-        this.output = output;
-    }
 
     [Theory]
     [InlineData(MetricReaderTemporalityPreference.Cumulative)]
@@ -33,15 +28,21 @@ public class MetricExemplarTests : MetricTestsBase
         using var container = this.BuildMeterProvider(out var meterProvider, builder => builder
             .AddMeter(meter.Name)
             .SetExemplarFilter(new AlwaysOnExemplarFilter())
+            .AddView(
+                "testCounter",
+                new MetricStreamConfiguration
+                {
+                    ExemplarReservoirFactory = () => new SimpleFixedSizeExemplarReservoir(3),
+                })
             .AddInMemoryExporter(exportedItems, metricReaderOptions =>
             {
                 metricReaderOptions.TemporalityPreference = temporality;
             }));
 
-        var measurementValues = GenerateRandomValues(10);
+        var measurementValues = GenerateRandomValues(2, false, null);
         foreach (var value in measurementValues)
         {
-            counter.Add(value);
+            counter.Add(value.Value);
         }
 
         meterProvider.ForceFlush(MaxTimeToAllowForFlush);
@@ -49,14 +50,9 @@ public class MetricExemplarTests : MetricTestsBase
         Assert.NotNull(metricPoint);
         Assert.True(metricPoint.Value.StartTime >= testStartTime);
         Assert.True(metricPoint.Value.EndTime != default);
-        var exemplars = GetExemplars(metricPoint.Value);
 
-        // TODO: Modify the test to better test cumulative.
-        // In cumulative, where SimpleFixedSizeExemplarReservoir's size is
-        // more than the count of new measurements, it is possible
-        // that the exemplar value is for a measurement that was recorded in the prior
-        // cycle. The current ValidateExemplars() does not handle this case.
-        ValidateExemplars(exemplars, metricPoint.Value.StartTime, metricPoint.Value.EndTime, measurementValues, false);
+        var exemplars = GetExemplars(metricPoint.Value);
+        ValidateExemplars(exemplars, metricPoint.Value.StartTime, metricPoint.Value.EndTime, measurementValues);
 
         exportedItems.Clear();
 
@@ -64,12 +60,11 @@ public class MetricExemplarTests : MetricTestsBase
         Thread.Sleep(10); // Compensates for low resolution timing in netfx.
 #endif
 
-        measurementValues = GenerateRandomValues(10);
-        foreach (var value in measurementValues)
+        var secondMeasurementValues = GenerateRandomValues(1, true, measurementValues);
+        foreach (var value in secondMeasurementValues)
         {
-            var act = new Activity("test").Start();
-            counter.Add(value);
-            act.Stop();
+            using var act = new Activity("test").Start();
+            counter.Add(value.Value);
         }
 
         meterProvider.ForceFlush(MaxTimeToAllowForFlush);
@@ -77,12 +72,29 @@ public class MetricExemplarTests : MetricTestsBase
         Assert.NotNull(metricPoint);
         Assert.True(metricPoint.Value.StartTime >= testStartTime);
         Assert.True(metricPoint.Value.EndTime != default);
+
         exemplars = GetExemplars(metricPoint.Value);
-        ValidateExemplars(exemplars, metricPoint.Value.StartTime, metricPoint.Value.EndTime, measurementValues, true);
+
+        if (temporality == MetricReaderTemporalityPreference.Cumulative)
+        {
+            // Current design:
+            //  First collect we saw Exemplar A & B
+            //  Second collect we saw Exemplar C but B remained in the reservoir
+            Assert.Equal(2, exemplars.Count);
+            secondMeasurementValues = secondMeasurementValues.Concat(measurementValues.Skip(1).Take(1)).ToArray();
+        }
+        else
+        {
+            Assert.Single(exemplars);
+        }
+
+        ValidateExemplars(exemplars, metricPoint.Value.StartTime, metricPoint.Value.EndTime, secondMeasurementValues);
     }
 
-    [Fact]
-    public void TestExemplarsHistogram()
+    [Theory]
+    [InlineData(MetricReaderTemporalityPreference.Cumulative)]
+    [InlineData(MetricReaderTemporalityPreference.Delta)]
+    public void TestExemplarsHistogram(MetricReaderTemporalityPreference temporality)
     {
         DateTime testStartTime = DateTime.UtcNow;
         var exportedItems = new List<Metric>();
@@ -90,18 +102,30 @@ public class MetricExemplarTests : MetricTestsBase
         using var meter = new Meter($"{Utils.GetCurrentMethodName()}");
         var histogram = meter.CreateHistogram<double>("testHistogram");
 
+        var buckets = new double[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+
         using var container = this.BuildMeterProvider(out var meterProvider, builder => builder
             .AddMeter(meter.Name)
             .SetExemplarFilter(new AlwaysOnExemplarFilter())
+            .AddView(
+                "testHistogram",
+                new ExplicitBucketHistogramConfiguration
+                {
+                    Boundaries = buckets,
+                })
             .AddInMemoryExporter(exportedItems, metricReaderOptions =>
             {
-                metricReaderOptions.TemporalityPreference = MetricReaderTemporalityPreference.Delta;
+                metricReaderOptions.TemporalityPreference = temporality;
             }));
 
-        var measurementValues = GenerateRandomValues(10);
+        var measurementValues = buckets
+            /* 2000 is here to test overflow measurement */
+            .Concat(new double[] { 2000 })
+            .Select(b => (Value: b, ExpectTraceId: false))
+            .ToArray();
         foreach (var value in measurementValues)
         {
-            histogram.Record(value);
+            histogram.Record(value.Value);
         }
 
         meterProvider.ForceFlush(MaxTimeToAllowForFlush);
@@ -109,8 +133,9 @@ public class MetricExemplarTests : MetricTestsBase
         Assert.NotNull(metricPoint);
         Assert.True(metricPoint.Value.StartTime >= testStartTime);
         Assert.True(metricPoint.Value.EndTime != default);
+
         var exemplars = GetExemplars(metricPoint.Value);
-        ValidateExemplars(exemplars, metricPoint.Value.StartTime, metricPoint.Value.EndTime, measurementValues, false);
+        ValidateExemplars(exemplars, metricPoint.Value.StartTime, metricPoint.Value.EndTime, measurementValues);
 
         exportedItems.Clear();
 
@@ -118,11 +143,11 @@ public class MetricExemplarTests : MetricTestsBase
         Thread.Sleep(10); // Compensates for low resolution timing in netfx.
 #endif
 
-        measurementValues = GenerateRandomValues(10);
-        foreach (var value in measurementValues)
+        var secondMeasurementValues = buckets.Take(1).Select(b => (Value: b, ExpectTraceId: true)).ToArray();
+        foreach (var value in secondMeasurementValues)
         {
             using var act = new Activity("test").Start();
-            histogram.Record(value);
+            histogram.Record(value.Value);
         }
 
         meterProvider.ForceFlush(MaxTimeToAllowForFlush);
@@ -130,8 +155,20 @@ public class MetricExemplarTests : MetricTestsBase
         Assert.NotNull(metricPoint);
         Assert.True(metricPoint.Value.StartTime >= testStartTime);
         Assert.True(metricPoint.Value.EndTime != default);
+
         exemplars = GetExemplars(metricPoint.Value);
-        ValidateExemplars(exemplars, metricPoint.Value.StartTime, metricPoint.Value.EndTime, measurementValues, true);
+
+        if (temporality == MetricReaderTemporalityPreference.Cumulative)
+        {
+            Assert.Equal(11, exemplars.Count);
+            secondMeasurementValues = secondMeasurementValues.Concat(measurementValues.Skip(1)).ToArray();
+        }
+        else
+        {
+            Assert.Single(exemplars);
+        }
+
+        ValidateExemplars(exemplars, metricPoint.Value.StartTime, metricPoint.Value.EndTime, secondMeasurementValues);
     }
 
     [Fact]
@@ -152,10 +189,14 @@ public class MetricExemplarTests : MetricTestsBase
                 metricReaderOptions.TemporalityPreference = MetricReaderTemporalityPreference.Delta;
             }));
 
-        var measurementValues = GenerateRandomValues(10);
+        var measurementValues = GenerateRandomValues(10, false, null);
         foreach (var value in measurementValues)
         {
-            histogram.Record(value, new("key1", "value1"), new("key2", "value1"), new("key3", "value1"));
+            histogram.Record(
+                value.Value,
+                new("key1", "value1"),
+                new("key2", "value1"),
+                new("key3", "value1"));
         }
 
         meterProvider.ForceFlush(MaxTimeToAllowForFlush);
@@ -176,27 +217,45 @@ public class MetricExemplarTests : MetricTestsBase
         }
     }
 
-    private static double[] GenerateRandomValues(int count)
+    private static (double Value, bool ExpectTraceId)[] GenerateRandomValues(
+        int count,
+        bool expectTraceId,
+        (double Value, bool ExpectTraceId)[]? previousValues)
     {
         var random = new Random();
-        var values = new double[count];
+        var values = new (double, bool)[count];
         for (int i = 0; i < count; i++)
         {
-            values[i] = random.NextDouble();
+            var nextValue = random.NextDouble();
+            if (values.Any(m => m.Item1 == nextValue)
+                || previousValues?.Any(m => m.Value == nextValue) == true)
+            {
+                i--;
+                continue;
+            }
+
+            values[i] = (nextValue, expectTraceId);
         }
 
         return values;
     }
 
-    private static void ValidateExemplars(IReadOnlyList<Exemplar> exemplars, DateTimeOffset startTime, DateTimeOffset endTime, double[] measurementValues, bool traceContextExists)
+    private static void ValidateExemplars(
+        IReadOnlyList<Exemplar> exemplars,
+        DateTimeOffset startTime,
+        DateTimeOffset endTime,
+        (double Value, bool ExpectTraceId)[] measurementValues)
     {
-        Assert.NotNull(exemplars);
+        int count = 0;
+
         foreach (var exemplar in exemplars)
         {
             Assert.True(exemplar.Timestamp >= startTime && exemplar.Timestamp <= endTime, $"{startTime} < {exemplar.Timestamp} < {endTime}");
-            Assert.Contains(exemplar.DoubleValue, measurementValues);
             Assert.Equal(0, exemplar.FilteredTags.MaximumCount);
-            if (traceContextExists)
+
+            var measurement = measurementValues.FirstOrDefault(v => v.Value == exemplar.DoubleValue);
+            Assert.NotEqual(default, measurement);
+            if (measurement.ExpectTraceId)
             {
                 Assert.NotEqual(default, exemplar.TraceId);
                 Assert.NotEqual(default, exemplar.SpanId);
@@ -206,6 +265,10 @@ public class MetricExemplarTests : MetricTestsBase
                 Assert.Equal(default, exemplar.TraceId);
                 Assert.Equal(default, exemplar.SpanId);
             }
+
+            count++;
         }
+
+        Assert.Equal(measurementValues.Length, count);
     }
 }


### PR DESCRIPTION
[Originally part of #5364]

## Changes

* Adds internal `ExemplarReservoir` factory on view API.
* Use the view API to test delta/cumulative temporality behaviors in exemplar tests.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
