### PR TITLE
[sdk-metrics] Support exemplars when using exponential histograms

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -51,8 +51,9 @@
   ([#5386](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5386))
 
 * **Experimental (pre-release builds only):** Added support for exemplars when
-  using Base2 Exponential Bucket Histogram Aggregation via the View API.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  using Base2 Exponential Bucket Histogram Aggregation configured via the View
+  API.
+  ([#5396](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5396))
 
 ## 1.7.0
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -50,6 +50,10 @@
   metrics exporters which support exemplars.
   ([#5386](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5386))
 
+* **Experimental (pre-release builds only):** Added support for exemplars when
+  using Base2 Exponential Bucket Histogram Aggregation via the View API.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.7.0
 
 Released 2023-Dec-08

--- a/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
@@ -23,17 +23,24 @@ public class MetricExemplarTests : MetricTestsBase
         var exportedItems = new List<Metric>();
 
         using var meter = new Meter($"{Utils.GetCurrentMethodName()}");
-        var counter = meter.CreateCounter<double>("testCounter");
+        var counterDouble = meter.CreateCounter<double>("testCounterDouble");
+        var counterLong = meter.CreateCounter<long>("testCounterLong");
 
         using var container = this.BuildMeterProvider(out var meterProvider, builder => builder
             .AddMeter(meter.Name)
             .SetExemplarFilter(new AlwaysOnExemplarFilter())
-            .AddView(
-                "testCounter",
-                new MetricStreamConfiguration
+            .AddView(i =>
+            {
+                if (i.Name.StartsWith("testCounter"))
                 {
-                    ExemplarReservoirFactory = () => new SimpleFixedSizeExemplarReservoir(3),
-                })
+                    return new MetricStreamConfiguration
+                    {
+                        ExemplarReservoirFactory = () => new SimpleFixedSizeExemplarReservoir(3),
+                    };
+                }
+
+                return null;
+            })
             .AddInMemoryExporter(exportedItems, metricReaderOptions =>
             {
                 metricReaderOptions.TemporalityPreference = temporality;
@@ -42,17 +49,14 @@ public class MetricExemplarTests : MetricTestsBase
         var measurementValues = GenerateRandomValues(2, false, null);
         foreach (var value in measurementValues)
         {
-            counter.Add(value.Value);
+            counterDouble.Add(value.Value);
+            counterLong.Add((long)value.Value);
         }
 
         meterProvider.ForceFlush(MaxTimeToAllowForFlush);
-        var metricPoint = GetFirstMetricPoint(exportedItems);
-        Assert.NotNull(metricPoint);
-        Assert.True(metricPoint.Value.StartTime >= testStartTime);
-        Assert.True(metricPoint.Value.EndTime != default);
 
-        var exemplars = GetExemplars(metricPoint.Value);
-        ValidateExemplars(exemplars, metricPoint.Value.StartTime, metricPoint.Value.EndTime, measurementValues);
+        ValidateFirstPhase("testCounterDouble", testStartTime, exportedItems, measurementValues, e => e.DoubleValue);
+        ValidateFirstPhase("testCounterLong", testStartTime, exportedItems, measurementValues, e => e.LongValue);
 
         exportedItems.Clear();
 
@@ -64,55 +68,206 @@ public class MetricExemplarTests : MetricTestsBase
         foreach (var value in secondMeasurementValues)
         {
             using var act = new Activity("test").Start();
-            counter.Add(value.Value);
+            counterDouble.Add(value.Value);
+            counterLong.Add((long)value.Value);
         }
 
         meterProvider.ForceFlush(MaxTimeToAllowForFlush);
-        metricPoint = GetFirstMetricPoint(exportedItems);
-        Assert.NotNull(metricPoint);
-        Assert.True(metricPoint.Value.StartTime >= testStartTime);
-        Assert.True(metricPoint.Value.EndTime != default);
 
-        exemplars = GetExemplars(metricPoint.Value);
+        ValidateSecondPhase("testCounterDouble", temporality, testStartTime, exportedItems, measurementValues, secondMeasurementValues, e => e.DoubleValue);
+        ValidateSecondPhase("testCounterLong", temporality, testStartTime, exportedItems, measurementValues, secondMeasurementValues, e => e.LongValue);
 
-        if (temporality == MetricReaderTemporalityPreference.Cumulative)
+        void ValidateFirstPhase(
+            string instrumentName,
+            DateTime testStartTime,
+            List<Metric> exportedItems,
+            (double Value, bool ExpectTraceId)[] measurementValues,
+            Func<Exemplar, double> getExemplarValueFunc)
         {
-            // Current design:
-            //  First collect we saw Exemplar A & B
-            //  Second collect we saw Exemplar C but B remained in the reservoir
-            Assert.Equal(2, exemplars.Count);
-            secondMeasurementValues = secondMeasurementValues.Concat(measurementValues.Skip(1).Take(1)).ToArray();
-        }
-        else
-        {
-            Assert.Single(exemplars);
+            var metricPoint = GetFirstMetricPoint(exportedItems.Where(m => m.Name == instrumentName));
+
+            Assert.NotNull(metricPoint);
+            Assert.True(metricPoint.Value.StartTime >= testStartTime);
+            Assert.True(metricPoint.Value.EndTime != default);
+
+            var exemplars = GetExemplars(metricPoint.Value);
+
+            ValidateExemplars(exemplars, metricPoint.Value.StartTime, metricPoint.Value.EndTime, measurementValues, getExemplarValueFunc);
         }
 
-        ValidateExemplars(exemplars, metricPoint.Value.StartTime, metricPoint.Value.EndTime, secondMeasurementValues);
+        void ValidateSecondPhase(
+            string instrumentName,
+            MetricReaderTemporalityPreference temporality,
+            DateTime testStartTime,
+            List<Metric> exportedItems,
+            (double Value, bool ExpectTraceId)[] firstMeasurementValues,
+            (double Value, bool ExpectTraceId)[] secondMeasurementValues,
+            Func<Exemplar, double> getExemplarValueFunc)
+        {
+            var metricPoint = GetFirstMetricPoint(exportedItems.Where(m => m.Name == instrumentName));
+
+            Assert.NotNull(metricPoint);
+            Assert.True(metricPoint.Value.StartTime >= testStartTime);
+            Assert.True(metricPoint.Value.EndTime != default);
+
+            var exemplars = GetExemplars(metricPoint.Value);
+
+            if (temporality == MetricReaderTemporalityPreference.Cumulative)
+            {
+                // Current design:
+                //  First collect we saw Exemplar A & B
+                //  Second collect we saw Exemplar C but B remained in the reservoir
+                Assert.Equal(2, exemplars.Count);
+                secondMeasurementValues = secondMeasurementValues.Concat(firstMeasurementValues.Skip(1).Take(1)).ToArray();
+            }
+            else
+            {
+                Assert.Single(exemplars);
+            }
+
+            ValidateExemplars(exemplars, metricPoint.Value.StartTime, metricPoint.Value.EndTime, secondMeasurementValues, getExemplarValueFunc);
+        }
     }
 
     [Theory]
     [InlineData(MetricReaderTemporalityPreference.Cumulative)]
     [InlineData(MetricReaderTemporalityPreference.Delta)]
-    public void TestExemplarsHistogram(MetricReaderTemporalityPreference temporality)
+    public void TestExemplarsObservable(MetricReaderTemporalityPreference temporality)
+    {
+        DateTime testStartTime = DateTime.UtcNow;
+        var exportedItems = new List<Metric>();
+
+        (double Value, bool ExpectTraceId)[] measurementValues = new (double Value, bool ExpectTraceId)[]
+        {
+            (18D, false),
+            (19D, false),
+        };
+
+        int measurementIndex = 0;
+
+        using var meter = new Meter($"{Utils.GetCurrentMethodName()}");
+        var gaugeDouble = meter.CreateObservableGauge("testGaugeDouble", () => measurementValues[measurementIndex].Value);
+        var gaugeLong = meter.CreateObservableGauge("testGaugeLong", () => (long)measurementValues[measurementIndex].Value);
+        var counterDouble = meter.CreateObservableCounter("counterDouble", () => measurementValues[measurementIndex].Value);
+        var counterLong = meter.CreateObservableCounter("counterLong", () => (long)measurementValues[measurementIndex].Value);
+
+        using var container = this.BuildMeterProvider(out var meterProvider, builder => builder
+            .AddMeter(meter.Name)
+            .SetExemplarFilter(new AlwaysOnExemplarFilter())
+            .AddView(i =>
+            {
+                if (i.Name.StartsWith("testGauge"))
+                {
+                    return new MetricStreamConfiguration
+                    {
+                        ExemplarReservoirFactory = () => new SimpleFixedSizeExemplarReservoir(3),
+                    };
+                }
+
+                return null;
+            })
+            .AddInMemoryExporter(exportedItems, metricReaderOptions =>
+            {
+                metricReaderOptions.TemporalityPreference = temporality;
+            }));
+
+        meterProvider.ForceFlush(MaxTimeToAllowForFlush);
+
+        ValidateFirstPhase("testGaugeDouble", testStartTime, exportedItems, measurementValues, e => e.DoubleValue);
+        ValidateFirstPhase("testGaugeLong", testStartTime, exportedItems, measurementValues, e => e.LongValue);
+        ValidateFirstPhase("counterDouble", testStartTime, exportedItems, measurementValues, e => e.DoubleValue);
+        ValidateFirstPhase("counterLong", testStartTime, exportedItems, measurementValues, e => e.LongValue);
+
+        exportedItems.Clear();
+
+        measurementIndex++;
+
+#if NETFRAMEWORK
+        Thread.Sleep(10); // Compensates for low resolution timing in netfx.
+#endif
+
+        meterProvider.ForceFlush(MaxTimeToAllowForFlush);
+
+        ValidateSecondPhase("testGaugeDouble", testStartTime, exportedItems, measurementValues, e => e.DoubleValue);
+        ValidateSecondPhase("testGaugeLong", testStartTime, exportedItems, measurementValues, e => e.LongValue);
+
+        void ValidateFirstPhase(
+            string instrumentName,
+            DateTime testStartTime,
+            List<Metric> exportedItems,
+            (double Value, bool ExpectTraceId)[] measurementValues,
+            Func<Exemplar, double> getExemplarValueFunc)
+        {
+            var metricPoint = GetFirstMetricPoint(exportedItems.Where(m => m.Name == instrumentName));
+            Assert.NotNull(metricPoint);
+            Assert.True(metricPoint.Value.StartTime >= testStartTime);
+            Assert.True(metricPoint.Value.EndTime != default);
+
+            var exemplars = GetExemplars(metricPoint.Value);
+            ValidateExemplars(exemplars, metricPoint.Value.StartTime, metricPoint.Value.EndTime, measurementValues.Take(1), getExemplarValueFunc);
+        }
+
+        static void ValidateSecondPhase(
+            string instrumentName,
+            DateTime testStartTime,
+            List<Metric> exportedItems,
+            (double Value, bool ExpectTraceId)[] measurementValues,
+            Func<Exemplar, double> getExemplarValueFunc)
+        {
+            var metricPoint = GetFirstMetricPoint(exportedItems.Where(m => m.Name == instrumentName));
+
+            Assert.NotNull(metricPoint);
+            Assert.True(metricPoint.Value.StartTime >= testStartTime);
+            Assert.True(metricPoint.Value.EndTime != default);
+
+            var exemplars = GetExemplars(metricPoint.Value);
+
+            // Note: Gauges are only observed when collection happens. For
+            // Cumulative & Delta the behavior will be the same. We will record the
+            // single measurement each time as the only exemplar.
+
+            Assert.Single(exemplars);
+            ValidateExemplars(exemplars, metricPoint.Value.StartTime, metricPoint.Value.EndTime, measurementValues.Skip(1), getExemplarValueFunc);
+        }
+    }
+
+    [Theory]
+    [InlineData(MetricReaderTemporalityPreference.Cumulative)]
+    [InlineData(MetricReaderTemporalityPreference.Delta)]
+    public void TestExemplarsHistogramWithBuckets(MetricReaderTemporalityPreference temporality)
     {
         DateTime testStartTime = DateTime.UtcNow;
         var exportedItems = new List<Metric>();
 
         using var meter = new Meter($"{Utils.GetCurrentMethodName()}");
-        var histogram = meter.CreateHistogram<double>("testHistogram");
+        var histogramWithBucketsAndMinMaxDouble = meter.CreateHistogram<double>("histogramWithBucketsAndMinMaxDouble");
+        var histogramWithBucketsDouble = meter.CreateHistogram<double>("histogramWithBucketsDouble");
+        var histogramWithBucketsAndMinMaxLong = meter.CreateHistogram<long>("histogramWithBucketsAndMinMaxLong");
+        var histogramWithBucketsLong = meter.CreateHistogram<long>("histogramWithBucketsLong");
 
         var buckets = new double[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
 
         using var container = this.BuildMeterProvider(out var meterProvider, builder => builder
             .AddMeter(meter.Name)
             .SetExemplarFilter(new AlwaysOnExemplarFilter())
-            .AddView(
-                "testHistogram",
-                new ExplicitBucketHistogramConfiguration
+            .AddView(i =>
+            {
+                if (i.Name.StartsWith("histogramWithBucketsAndMinMax"))
                 {
-                    Boundaries = buckets,
-                })
+                    return new ExplicitBucketHistogramConfiguration
+                    {
+                        Boundaries = buckets,
+                    };
+                }
+                else
+                {
+                    return new ExplicitBucketHistogramConfiguration
+                    {
+                        Boundaries = buckets,
+                        RecordMinMax = false,
+                    };
+                }
+            })
             .AddInMemoryExporter(exportedItems, metricReaderOptions =>
             {
                 metricReaderOptions.TemporalityPreference = temporality;
@@ -125,17 +280,18 @@ public class MetricExemplarTests : MetricTestsBase
             .ToArray();
         foreach (var value in measurementValues)
         {
-            histogram.Record(value.Value);
+            histogramWithBucketsAndMinMaxDouble.Record(value.Value);
+            histogramWithBucketsDouble.Record(value.Value);
+            histogramWithBucketsAndMinMaxLong.Record((long)value.Value);
+            histogramWithBucketsLong.Record((long)value.Value);
         }
 
         meterProvider.ForceFlush(MaxTimeToAllowForFlush);
-        var metricPoint = GetFirstMetricPoint(exportedItems);
-        Assert.NotNull(metricPoint);
-        Assert.True(metricPoint.Value.StartTime >= testStartTime);
-        Assert.True(metricPoint.Value.EndTime != default);
 
-        var exemplars = GetExemplars(metricPoint.Value);
-        ValidateExemplars(exemplars, metricPoint.Value.StartTime, metricPoint.Value.EndTime, measurementValues);
+        ValidateFirstPhase("histogramWithBucketsAndMinMaxDouble", testStartTime, exportedItems, measurementValues);
+        ValidateFirstPhase("histogramWithBucketsDouble", testStartTime, exportedItems, measurementValues);
+        ValidateFirstPhase("histogramWithBucketsAndMinMaxLong", testStartTime, exportedItems, measurementValues);
+        ValidateFirstPhase("histogramWithBucketsLong", testStartTime, exportedItems, measurementValues);
 
         exportedItems.Clear();
 
@@ -147,28 +303,314 @@ public class MetricExemplarTests : MetricTestsBase
         foreach (var value in secondMeasurementValues)
         {
             using var act = new Activity("test").Start();
-            histogram.Record(value.Value);
+            histogramWithBucketsAndMinMaxDouble.Record(value.Value);
+            histogramWithBucketsDouble.Record(value.Value);
+            histogramWithBucketsAndMinMaxLong.Record((long)value.Value);
+            histogramWithBucketsLong.Record((long)value.Value);
         }
 
         meterProvider.ForceFlush(MaxTimeToAllowForFlush);
-        metricPoint = GetFirstMetricPoint(exportedItems);
-        Assert.NotNull(metricPoint);
-        Assert.True(metricPoint.Value.StartTime >= testStartTime);
-        Assert.True(metricPoint.Value.EndTime != default);
 
-        exemplars = GetExemplars(metricPoint.Value);
+        ValidateScondPhase("histogramWithBucketsAndMinMaxDouble", temporality, testStartTime, exportedItems, measurementValues, secondMeasurementValues);
+        ValidateScondPhase("histogramWithBucketsDouble", temporality, testStartTime, exportedItems, measurementValues, secondMeasurementValues);
+        ValidateScondPhase("histogramWithBucketsAndMinMaxLong", temporality, testStartTime, exportedItems, measurementValues, secondMeasurementValues);
+        ValidateScondPhase("histogramWithBucketsLong", temporality, testStartTime, exportedItems, measurementValues, secondMeasurementValues);
 
-        if (temporality == MetricReaderTemporalityPreference.Cumulative)
+        static void ValidateFirstPhase(
+            string instrumentName,
+            DateTime testStartTime,
+            List<Metric> exportedItems,
+            (double Value, bool ExpectTraceId)[] measurementValues)
         {
-            Assert.Equal(11, exemplars.Count);
-            secondMeasurementValues = secondMeasurementValues.Concat(measurementValues.Skip(1)).ToArray();
-        }
-        else
-        {
-            Assert.Single(exemplars);
+            var metricPoint = GetFirstMetricPoint(exportedItems.Where(n => n.Name == instrumentName));
+
+            Assert.NotNull(metricPoint);
+            Assert.True(metricPoint.Value.StartTime >= testStartTime);
+            Assert.True(metricPoint.Value.EndTime != default);
+
+            var exemplars = GetExemplars(metricPoint.Value);
+
+            ValidateExemplars(exemplars, metricPoint.Value.StartTime, metricPoint.Value.EndTime, measurementValues, e => e.DoubleValue);
         }
 
-        ValidateExemplars(exemplars, metricPoint.Value.StartTime, metricPoint.Value.EndTime, secondMeasurementValues);
+        static void ValidateScondPhase(
+            string instrumentName,
+            MetricReaderTemporalityPreference temporality,
+            DateTime testStartTime,
+            List<Metric> exportedItems,
+            (double Value, bool ExpectTraceId)[] firstMeasurementValues,
+            (double Value, bool ExpectTraceId)[] secondMeasurementValues)
+        {
+            var metricPoint = GetFirstMetricPoint(exportedItems.Where(n => n.Name == instrumentName));
+
+            Assert.NotNull(metricPoint);
+            Assert.True(metricPoint.Value.StartTime >= testStartTime);
+            Assert.True(metricPoint.Value.EndTime != default);
+
+            var exemplars = GetExemplars(metricPoint.Value);
+
+            if (temporality == MetricReaderTemporalityPreference.Cumulative)
+            {
+                Assert.Equal(11, exemplars.Count);
+                secondMeasurementValues = secondMeasurementValues.Concat(firstMeasurementValues.Skip(1)).ToArray();
+            }
+            else
+            {
+                Assert.Single(exemplars);
+            }
+
+            ValidateExemplars(exemplars, metricPoint.Value.StartTime, metricPoint.Value.EndTime, secondMeasurementValues, e => e.DoubleValue);
+        }
+    }
+
+    [Theory]
+    [InlineData(MetricReaderTemporalityPreference.Cumulative)]
+    [InlineData(MetricReaderTemporalityPreference.Delta)]
+    public void TestExemplarsHistogramWithoutBuckets(MetricReaderTemporalityPreference temporality)
+    {
+        DateTime testStartTime = DateTime.UtcNow;
+        var exportedItems = new List<Metric>();
+
+        using var meter = new Meter($"{Utils.GetCurrentMethodName()}");
+        var histogramWithoutBucketsAndMinMaxDouble = meter.CreateHistogram<double>("histogramWithoutBucketsAndMinMaxDouble");
+        var histogramWithoutBucketsDouble = meter.CreateHistogram<double>("histogramWithoutBucketsDouble");
+        var histogramWithoutBucketsAndMinMaxLong = meter.CreateHistogram<long>("histogramWithoutBucketsAndMinMaxLong");
+        var histogramWithoutBucketsLong = meter.CreateHistogram<long>("histogramWithoutBucketsLong");
+
+        using var container = this.BuildMeterProvider(out var meterProvider, builder => builder
+            .AddMeter(meter.Name)
+            .SetExemplarFilter(new AlwaysOnExemplarFilter())
+            .AddView(i =>
+            {
+                if (i.Name.StartsWith("histogramWithoutBucketsAndMinMax"))
+                {
+                    return new ExplicitBucketHistogramConfiguration
+                    {
+                        Boundaries = Array.Empty<double>(),
+                        ExemplarReservoirFactory = () => new SimpleFixedSizeExemplarReservoir(3),
+                    };
+                }
+                else
+                {
+                    return new ExplicitBucketHistogramConfiguration
+                    {
+                        Boundaries = Array.Empty<double>(),
+                        RecordMinMax = false,
+                        ExemplarReservoirFactory = () => new SimpleFixedSizeExemplarReservoir(3),
+                    };
+                }
+            })
+            .AddInMemoryExporter(exportedItems, metricReaderOptions =>
+            {
+                metricReaderOptions.TemporalityPreference = temporality;
+            }));
+
+        var measurementValues = GenerateRandomValues(2, false, null);
+        foreach (var value in measurementValues)
+        {
+            histogramWithoutBucketsAndMinMaxDouble.Record(value.Value);
+            histogramWithoutBucketsDouble.Record(value.Value);
+            histogramWithoutBucketsAndMinMaxLong.Record((long)value.Value);
+            histogramWithoutBucketsLong.Record((long)value.Value);
+        }
+
+        meterProvider.ForceFlush(MaxTimeToAllowForFlush);
+
+        ValidateFirstPhase("histogramWithoutBucketsAndMinMaxDouble", testStartTime, exportedItems, measurementValues);
+        ValidateFirstPhase("histogramWithoutBucketsDouble", testStartTime, exportedItems, measurementValues);
+        ValidateFirstPhase("histogramWithoutBucketsAndMinMaxLong", testStartTime, exportedItems, measurementValues);
+        ValidateFirstPhase("histogramWithoutBucketsLong", testStartTime, exportedItems, measurementValues);
+
+        exportedItems.Clear();
+
+#if NETFRAMEWORK
+        Thread.Sleep(10); // Compensates for low resolution timing in netfx.
+#endif
+
+        var secondMeasurementValues = GenerateRandomValues(1, true, measurementValues);
+        foreach (var value in secondMeasurementValues)
+        {
+            using var act = new Activity("test").Start();
+            histogramWithoutBucketsAndMinMaxDouble.Record(value.Value);
+            histogramWithoutBucketsDouble.Record(value.Value);
+            histogramWithoutBucketsAndMinMaxLong.Record((long)value.Value);
+            histogramWithoutBucketsLong.Record((long)value.Value);
+        }
+
+        meterProvider.ForceFlush(MaxTimeToAllowForFlush);
+
+        ValidateSecondPhase("histogramWithoutBucketsAndMinMaxDouble", temporality, testStartTime, exportedItems, measurementValues, secondMeasurementValues);
+        ValidateSecondPhase("histogramWithoutBucketsDouble", temporality, testStartTime, exportedItems, measurementValues, secondMeasurementValues);
+        ValidateSecondPhase("histogramWithoutBucketsAndMinMaxLong", temporality, testStartTime, exportedItems, measurementValues, secondMeasurementValues);
+        ValidateSecondPhase("histogramWithoutBucketsLong", temporality, testStartTime, exportedItems, measurementValues, secondMeasurementValues);
+
+        static void ValidateFirstPhase(
+            string instrumentName,
+            DateTime testStartTime,
+            List<Metric> exportedItems,
+            (double Value, bool ExpectTraceId)[] measurementValues)
+        {
+            var metricPoint = GetFirstMetricPoint(exportedItems.Where(n => n.Name == instrumentName));
+
+            Assert.NotNull(metricPoint);
+            Assert.True(metricPoint.Value.StartTime >= testStartTime);
+            Assert.True(metricPoint.Value.EndTime != default);
+
+            var exemplars = GetExemplars(metricPoint.Value);
+
+            ValidateExemplars(exemplars, metricPoint.Value.StartTime, metricPoint.Value.EndTime, measurementValues, e => e.DoubleValue);
+        }
+
+        static void ValidateSecondPhase(
+            string instrumentName,
+            MetricReaderTemporalityPreference temporality,
+            DateTime testStartTime,
+            List<Metric> exportedItems,
+            (double Value, bool ExpectTraceId)[] firstMeasurementValues,
+            (double Value, bool ExpectTraceId)[] secondMeasurementValues)
+        {
+            var metricPoint = GetFirstMetricPoint(exportedItems.Where(m => m.Name == instrumentName));
+
+            Assert.NotNull(metricPoint);
+            Assert.True(metricPoint.Value.StartTime >= testStartTime);
+            Assert.True(metricPoint.Value.EndTime != default);
+
+            var exemplars = GetExemplars(metricPoint.Value);
+
+            if (temporality == MetricReaderTemporalityPreference.Cumulative)
+            {
+                Assert.Equal(2, exemplars.Count);
+                secondMeasurementValues = secondMeasurementValues.Concat(firstMeasurementValues.Skip(1)).ToArray();
+            }
+            else
+            {
+                Assert.Single(exemplars);
+            }
+
+            ValidateExemplars(exemplars, metricPoint.Value.StartTime, metricPoint.Value.EndTime, secondMeasurementValues, e => e.DoubleValue);
+        }
+    }
+
+    [Theory]
+    [InlineData(MetricReaderTemporalityPreference.Cumulative)]
+    [InlineData(MetricReaderTemporalityPreference.Delta)]
+    public void TestExemplarsExponentialHistogram(MetricReaderTemporalityPreference temporality)
+    {
+        DateTime testStartTime = DateTime.UtcNow;
+        var exportedItems = new List<Metric>();
+
+        using var meter = new Meter($"{Utils.GetCurrentMethodName()}");
+        var exponentialHistogramWithMinMaxDouble = meter.CreateHistogram<double>("exponentialHistogramWithMinMaxDouble");
+        var exponentialHistogramDouble = meter.CreateHistogram<double>("exponentialHistogramDouble");
+        var exponentialHistogramWithMinMaxLong = meter.CreateHistogram<long>("exponentialHistogramWithMinMaxLong");
+        var exponentialHistogramLong = meter.CreateHistogram<long>("exponentialHistogramLong");
+
+        using var container = this.BuildMeterProvider(out var meterProvider, builder => builder
+            .AddMeter(meter.Name)
+            .SetExemplarFilter(new AlwaysOnExemplarFilter())
+            .AddView(i =>
+            {
+                if (i.Name.StartsWith("exponentialHistogramWithMinMax"))
+                {
+                    return new Base2ExponentialBucketHistogramConfiguration();
+                }
+                else
+                {
+                    return new Base2ExponentialBucketHistogramConfiguration()
+                    {
+                        RecordMinMax = false,
+                    };
+                }
+            })
+            .AddInMemoryExporter(exportedItems, metricReaderOptions =>
+            {
+                metricReaderOptions.TemporalityPreference = temporality;
+            }));
+
+        var measurementValues = GenerateRandomValues(20, false, null);
+        foreach (var value in measurementValues)
+        {
+            exponentialHistogramWithMinMaxDouble.Record(value.Value);
+            exponentialHistogramDouble.Record(value.Value);
+            exponentialHistogramWithMinMaxLong.Record((long)value.Value);
+            exponentialHistogramLong.Record((long)value.Value);
+        }
+
+        meterProvider.ForceFlush(MaxTimeToAllowForFlush);
+
+        ValidateFirstPhase("exponentialHistogramWithMinMaxDouble", testStartTime, exportedItems, measurementValues);
+        ValidateFirstPhase("exponentialHistogramDouble", testStartTime, exportedItems, measurementValues);
+        ValidateFirstPhase("exponentialHistogramWithMinMaxLong", testStartTime, exportedItems, measurementValues);
+        ValidateFirstPhase("exponentialHistogramLong", testStartTime, exportedItems, measurementValues);
+
+        exportedItems.Clear();
+
+#if NETFRAMEWORK
+        Thread.Sleep(10); // Compensates for low resolution timing in netfx.
+#endif
+
+        var secondMeasurementValues = GenerateRandomValues(1, true, measurementValues);
+        foreach (var value in secondMeasurementValues)
+        {
+            using var act = new Activity("test").Start();
+            exponentialHistogramWithMinMaxDouble.Record(value.Value);
+            exponentialHistogramDouble.Record(value.Value);
+            exponentialHistogramWithMinMaxLong.Record((long)value.Value);
+            exponentialHistogramLong.Record((long)value.Value);
+        }
+
+        meterProvider.ForceFlush(MaxTimeToAllowForFlush);
+
+        ValidateSecondPhase("exponentialHistogramWithMinMaxDouble", temporality, testStartTime, exportedItems, measurementValues, secondMeasurementValues);
+        ValidateSecondPhase("exponentialHistogramDouble", temporality, testStartTime, exportedItems, measurementValues, secondMeasurementValues);
+        ValidateSecondPhase("exponentialHistogramWithMinMaxLong", temporality, testStartTime, exportedItems, measurementValues, secondMeasurementValues);
+        ValidateSecondPhase("exponentialHistogramLong", temporality, testStartTime, exportedItems, measurementValues, secondMeasurementValues);
+
+        static void ValidateFirstPhase(
+            string instrumentName,
+            DateTime testStartTime,
+            List<Metric> exportedItems,
+            (double Value, bool ExpectTraceId)[] measurementValues)
+        {
+            var metricPoint = GetFirstMetricPoint(exportedItems.Where(m => m.Name == instrumentName));
+
+            Assert.NotNull(metricPoint);
+            Assert.True(metricPoint.Value.StartTime >= testStartTime);
+            Assert.True(metricPoint.Value.EndTime != default);
+
+            var exemplars = GetExemplars(metricPoint.Value);
+
+            ValidateExemplars(exemplars, metricPoint.Value.StartTime, metricPoint.Value.EndTime, measurementValues, e => e.DoubleValue);
+        }
+
+        static void ValidateSecondPhase(
+            string instrumentName,
+            MetricReaderTemporalityPreference temporality,
+            DateTime testStartTime,
+            List<Metric> exportedItems,
+            (double Value, bool ExpectTraceId)[] firstMeasurementValues,
+            (double Value, bool ExpectTraceId)[] secondMeasurementValues)
+        {
+            var metricPoint = GetFirstMetricPoint(exportedItems.Where(m => m.Name == instrumentName));
+
+            Assert.NotNull(metricPoint);
+            Assert.True(metricPoint.Value.StartTime >= testStartTime);
+            Assert.True(metricPoint.Value.EndTime != default);
+
+            var exemplars = GetExemplars(metricPoint.Value);
+
+            if (temporality == MetricReaderTemporalityPreference.Cumulative)
+            {
+                Assert.Equal(20, exemplars.Count);
+                secondMeasurementValues = secondMeasurementValues.Concat(firstMeasurementValues.Skip(1).Take(19)).ToArray();
+            }
+            else
+            {
+                Assert.Single(exemplars);
+            }
+
+            ValidateExemplars(exemplars, metricPoint.Value.StartTime, metricPoint.Value.EndTime, secondMeasurementValues, e => e.DoubleValue);
+        }
     }
 
     [Fact]
@@ -226,9 +668,9 @@ public class MetricExemplarTests : MetricTestsBase
         var values = new (double, bool)[count];
         for (int i = 0; i < count; i++)
         {
-            var nextValue = random.NextDouble();
-            if (values.Any(m => m.Item1 == nextValue)
-                || previousValues?.Any(m => m.Value == nextValue) == true)
+            var nextValue = random.NextDouble() * 100_000;
+            if (values.Any(m => m.Item1 == nextValue || m.Item1 == (long)nextValue)
+                || previousValues?.Any(m => m.Value == nextValue || m.Value == (long)nextValue) == true)
             {
                 i--;
                 continue;
@@ -244,7 +686,8 @@ public class MetricExemplarTests : MetricTestsBase
         IReadOnlyList<Exemplar> exemplars,
         DateTimeOffset startTime,
         DateTimeOffset endTime,
-        (double Value, bool ExpectTraceId)[] measurementValues)
+        IEnumerable<(double Value, bool ExpectTraceId)> measurementValues,
+        Func<Exemplar, double> getExemplarValueFunc)
     {
         int count = 0;
 
@@ -253,7 +696,8 @@ public class MetricExemplarTests : MetricTestsBase
             Assert.True(exemplar.Timestamp >= startTime && exemplar.Timestamp <= endTime, $"{startTime} < {exemplar.Timestamp} < {endTime}");
             Assert.Equal(0, exemplar.FilteredTags.MaximumCount);
 
-            var measurement = measurementValues.FirstOrDefault(v => v.Value == exemplar.DoubleValue);
+            var measurement = measurementValues.FirstOrDefault(v => v.Value == getExemplarValueFunc(exemplar)
+                || (long)v.Value == getExemplarValueFunc(exemplar));
             Assert.NotEqual(default, measurement);
             if (measurement.ExpectTraceId)
             {
@@ -269,6 +713,6 @@ public class MetricExemplarTests : MetricTestsBase
             count++;
         }
 
-        Assert.Equal(measurementValues.Length, count);
+        Assert.Equal(measurementValues.Count(), count);
     }
 }

--- a/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
@@ -154,18 +154,6 @@ public class MetricExemplarTests : MetricTestsBase
         using var container = this.BuildMeterProvider(out var meterProvider, builder => builder
             .AddMeter(meter.Name)
             .SetExemplarFilter(new AlwaysOnExemplarFilter())
-            .AddView(i =>
-            {
-                if (i.Name.StartsWith("testGauge"))
-                {
-                    return new MetricStreamConfiguration
-                    {
-                        ExemplarReservoirFactory = () => new SimpleFixedSizeExemplarReservoir(3),
-                    };
-                }
-
-                return null;
-            })
             .AddInMemoryExporter(exportedItems, metricReaderOptions =>
             {
                 metricReaderOptions.TemporalityPreference = temporality;

--- a/test/OpenTelemetry.Tests/Metrics/MetricTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricTestsBase.cs
@@ -159,7 +159,7 @@ public class MetricTestsBase
         return count;
     }
 
-    public static MetricPoint? GetFirstMetricPoint(List<Metric> metrics)
+    public static MetricPoint? GetFirstMetricPoint(IEnumerable<Metric> metrics)
     {
         foreach (var metric in metrics)
         {


### PR DESCRIPTION
## Changes

* Adds support for exemplars when using exponential histograms.
* Improves test coverage for the permutations of the `MetricPoint.UpdateWithExemplar` methods (`double` & `long`):
   
   ![image](https://github.com/open-telemetry/opentelemetry-dotnet/assets/28367120/aa6b0d8d-e1f6-4c94-9861-17414710538d)

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
