### PR TITLE
[sdk-metrics] Refactor exemplar offer duplicated code into helper methods inside MetricPoint

### DIFF
--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -994,7 +994,7 @@ internal sealed class AggregatorStore
             // TODO: can special case built-in filters to be bit faster.
             if (this.IsExemplarEnabled() && this.exemplarFilter.ShouldSample(value, tags))
             {
-                this.metricPoints[index].UpdateWithExemplar(value, tags: tags);
+                this.metricPoints[index].UpdateWithExemplar(value, tags);
             }
             else
             {
@@ -1080,7 +1080,7 @@ internal sealed class AggregatorStore
             // TODO: can special case built-in filters to be bit faster.
             if (this.IsExemplarEnabled() && this.exemplarFilter.ShouldSample(value, tags))
             {
-                this.metricPoints[index].UpdateWithExemplar(value, tags: tags);
+                this.metricPoints[index].UpdateWithExemplar(value, tags);
             }
             else
             {

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -949,9 +949,10 @@ internal sealed class AggregatorStore
             }
 
             // TODO: can special case built-in filters to be bit faster.
-            if (this.IsExemplarEnabled() && this.exemplarFilter.ShouldSample(value, tags))
+            if (this.IsExemplarEnabled())
             {
-                this.metricPoints[index].UpdateWithExemplar(value, tags: default);
+                var shouldSample = this.exemplarFilter.ShouldSample(value, tags);
+                this.metricPoints[index].UpdateWithExemplar(value, tags: default, shouldSample);
             }
             else
             {
@@ -992,9 +993,10 @@ internal sealed class AggregatorStore
             }
 
             // TODO: can special case built-in filters to be bit faster.
-            if (this.IsExemplarEnabled() && this.exemplarFilter.ShouldSample(value, tags))
+            if (this.IsExemplarEnabled())
             {
-                this.metricPoints[index].UpdateWithExemplar(value, tags);
+                var shouldSample = this.exemplarFilter.ShouldSample(value, tags);
+                this.metricPoints[index].UpdateWithExemplar(value, tags, shouldSample);
             }
             else
             {
@@ -1035,9 +1037,10 @@ internal sealed class AggregatorStore
             }
 
             // TODO: can special case built-in filters to be bit faster.
-            if (this.IsExemplarEnabled() && this.exemplarFilter.ShouldSample(value, tags))
+            if (this.IsExemplarEnabled())
             {
-                this.metricPoints[index].UpdateWithExemplar(value, tags: default);
+                var shouldSample = this.exemplarFilter.ShouldSample(value, tags);
+                this.metricPoints[index].UpdateWithExemplar(value, tags: default, shouldSample);
             }
             else
             {
@@ -1078,9 +1081,10 @@ internal sealed class AggregatorStore
             }
 
             // TODO: can special case built-in filters to be bit faster.
-            if (this.IsExemplarEnabled() && this.exemplarFilter.ShouldSample(value, tags))
+            if (this.IsExemplarEnabled())
             {
-                this.metricPoints[index].UpdateWithExemplar(value, tags);
+                var shouldSample = this.exemplarFilter.ShouldSample(value, tags);
+                this.metricPoints[index].UpdateWithExemplar(value, tags, shouldSample);
             }
             else
             {

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -949,10 +949,9 @@ internal sealed class AggregatorStore
             }
 
             // TODO: can special case built-in filters to be bit faster.
-            if (this.IsExemplarEnabled())
+            if (this.IsExemplarEnabled() && this.exemplarFilter.ShouldSample(value, tags))
             {
-                var shouldSample = this.exemplarFilter.ShouldSample(value, tags);
-                this.metricPoints[index].UpdateWithExemplar(value, tags: default, shouldSample);
+                this.metricPoints[index].UpdateWithExemplar(value, tags: default);
             }
             else
             {
@@ -993,10 +992,9 @@ internal sealed class AggregatorStore
             }
 
             // TODO: can special case built-in filters to be bit faster.
-            if (this.IsExemplarEnabled())
+            if (this.IsExemplarEnabled() && this.exemplarFilter.ShouldSample(value, tags))
             {
-                var shouldSample = this.exemplarFilter.ShouldSample(value, tags);
-                this.metricPoints[index].UpdateWithExemplar(value, tags: tags, shouldSample);
+                this.metricPoints[index].UpdateWithExemplar(value, tags: tags);
             }
             else
             {
@@ -1037,10 +1035,9 @@ internal sealed class AggregatorStore
             }
 
             // TODO: can special case built-in filters to be bit faster.
-            if (this.IsExemplarEnabled())
+            if (this.IsExemplarEnabled() && this.exemplarFilter.ShouldSample(value, tags))
             {
-                var shouldSample = this.exemplarFilter.ShouldSample(value, tags);
-                this.metricPoints[index].UpdateWithExemplar(value, tags: default, shouldSample);
+                this.metricPoints[index].UpdateWithExemplar(value, tags: default);
             }
             else
             {
@@ -1081,10 +1078,9 @@ internal sealed class AggregatorStore
             }
 
             // TODO: can special case built-in filters to be bit faster.
-            if (this.IsExemplarEnabled())
+            if (this.IsExemplarEnabled() && this.exemplarFilter.ShouldSample(value, tags))
             {
-                var shouldSample = this.exemplarFilter.ShouldSample(value, tags);
-                this.metricPoints[index].UpdateWithExemplar(value, tags: tags, shouldSample);
+                this.metricPoints[index].UpdateWithExemplar(value, tags: tags);
             }
             else
             {

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -448,7 +448,7 @@ public struct MetricPoint
         this.CompleteUpdate();
     }
 
-    internal void UpdateWithExemplar(long number, ReadOnlySpan<KeyValuePair<string, object?>> tags)
+    internal void UpdateWithExemplar(long number, ReadOnlySpan<KeyValuePair<string, object?>> tags, bool isSampled)
     {
         Debug.Assert(this.mpComponents != null, "this.mpComponents was null");
 
@@ -463,7 +463,7 @@ public struct MetricPoint
                         this.runningValue.AsLong += number;
                     }
 
-                    this.OfferExemplar(number, tags);
+                    this.OfferExemplarIfSampled(number, tags, isSampled);
 
                     this.mpComponents.ReleaseLock();
 
@@ -476,7 +476,7 @@ public struct MetricPoint
 
                     this.runningValue.AsLong = number;
 
-                    this.OfferExemplar(number, tags);
+                    this.OfferExemplarIfSampled(number, tags, isSampled);
 
                     this.mpComponents.ReleaseLock();
 
@@ -489,7 +489,7 @@ public struct MetricPoint
 
                     this.runningValue.AsLong = number;
 
-                    this.OfferExemplar(number, tags);
+                    this.OfferExemplarIfSampled(number, tags, isSampled);
 
                     this.mpComponents.ReleaseLock();
 
@@ -498,37 +498,37 @@ public struct MetricPoint
 
             case AggregationType.Histogram:
                 {
-                    this.UpdateHistogram((double)number, tags);
+                    this.UpdateHistogram((double)number, tags, isSampled);
                     break;
                 }
 
             case AggregationType.HistogramWithMinMax:
                 {
-                    this.UpdateHistogramWithMinMax((double)number, tags);
+                    this.UpdateHistogramWithMinMax((double)number, tags, isSampled);
                     break;
                 }
 
             case AggregationType.HistogramWithBuckets:
                 {
-                    this.UpdateHistogramWithBuckets((double)number, tags);
+                    this.UpdateHistogramWithBuckets((double)number, tags, isSampled);
                     break;
                 }
 
             case AggregationType.HistogramWithMinMaxBuckets:
                 {
-                    this.UpdateHistogramWithBucketsAndMinMax((double)number, tags);
+                    this.UpdateHistogramWithBucketsAndMinMax((double)number, tags, isSampled);
                     break;
                 }
 
             case AggregationType.Base2ExponentialHistogram:
                 {
-                    this.UpdateBase2ExponentialHistogram((double)number, tags);
+                    this.UpdateBase2ExponentialHistogram((double)number, tags, isSampled);
                     break;
                 }
 
             case AggregationType.Base2ExponentialHistogramWithMinMax:
                 {
-                    this.UpdateBase2ExponentialHistogramWithMinMax((double)number, tags);
+                    this.UpdateBase2ExponentialHistogramWithMinMax((double)number, tags, isSampled);
                     break;
                 }
         }
@@ -598,7 +598,7 @@ public struct MetricPoint
         this.CompleteUpdate();
     }
 
-    internal void UpdateWithExemplar(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags)
+    internal void UpdateWithExemplar(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags, bool isSampled)
     {
         Debug.Assert(this.mpComponents != null, "this.mpComponents was null");
 
@@ -613,7 +613,7 @@ public struct MetricPoint
                         this.runningValue.AsDouble += number;
                     }
 
-                    this.OfferExemplar(number, tags);
+                    this.OfferExemplarIfSampled(number, tags, isSampled);
 
                     this.mpComponents.ReleaseLock();
 
@@ -629,7 +629,7 @@ public struct MetricPoint
                         this.runningValue.AsDouble = number;
                     }
 
-                    this.OfferExemplar(number, tags);
+                    this.OfferExemplarIfSampled(number, tags, isSampled);
 
                     this.mpComponents.ReleaseLock();
 
@@ -645,7 +645,7 @@ public struct MetricPoint
                         this.runningValue.AsDouble = number;
                     }
 
-                    this.OfferExemplar(number, tags);
+                    this.OfferExemplarIfSampled(number, tags, isSampled);
 
                     this.mpComponents.ReleaseLock();
 
@@ -654,37 +654,37 @@ public struct MetricPoint
 
             case AggregationType.Histogram:
                 {
-                    this.UpdateHistogram(number, tags);
+                    this.UpdateHistogram(number, tags, isSampled);
                     break;
                 }
 
             case AggregationType.HistogramWithMinMax:
                 {
-                    this.UpdateHistogramWithMinMax(number, tags);
+                    this.UpdateHistogramWithMinMax(number, tags, isSampled);
                     break;
                 }
 
             case AggregationType.HistogramWithBuckets:
                 {
-                    this.UpdateHistogramWithBuckets(number, tags);
+                    this.UpdateHistogramWithBuckets(number, tags, isSampled);
                     break;
                 }
 
             case AggregationType.HistogramWithMinMaxBuckets:
                 {
-                    this.UpdateHistogramWithBucketsAndMinMax(number, tags);
+                    this.UpdateHistogramWithBucketsAndMinMax(number, tags, isSampled);
                     break;
                 }
 
             case AggregationType.Base2ExponentialHistogram:
                 {
-                    this.UpdateBase2ExponentialHistogram(number, tags);
+                    this.UpdateBase2ExponentialHistogram(number, tags, isSampled);
                     break;
                 }
 
             case AggregationType.Base2ExponentialHistogramWithMinMax:
                 {
-                    this.UpdateBase2ExponentialHistogramWithMinMax(number, tags);
+                    this.UpdateBase2ExponentialHistogramWithMinMax(number, tags, isSampled);
                     break;
                 }
         }
@@ -1195,7 +1195,7 @@ public struct MetricPoint
         }
     }
 
-    private void UpdateHistogram(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default)
+    private void UpdateHistogram(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool isSampled = false)
     {
         Debug.Assert(this.mpComponents?.HistogramBuckets != null, "HistogramBuckets was null");
 
@@ -1209,12 +1209,12 @@ public struct MetricPoint
             histogramBuckets.RunningSum += number;
         }
 
-        this.OfferExemplar(number, tags);
+        this.OfferExemplarIfSampled(number, tags, isSampled);
 
         this.mpComponents.ReleaseLock();
     }
 
-    private void UpdateHistogramWithMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default)
+    private void UpdateHistogramWithMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool isSampled = false)
     {
         Debug.Assert(this.mpComponents?.HistogramBuckets != null, "HistogramBuckets was null");
 
@@ -1230,12 +1230,12 @@ public struct MetricPoint
             histogramBuckets.RunningMax = Math.Max(histogramBuckets.RunningMax, number);
         }
 
-        this.OfferExemplar(number, tags);
+        this.OfferExemplarIfSampled(number, tags, isSampled);
 
         this.mpComponents.ReleaseLock();
     }
 
-    private void UpdateHistogramWithBuckets(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default)
+    private void UpdateHistogramWithBuckets(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool isSampled = false)
     {
         Debug.Assert(this.mpComponents?.HistogramBuckets != null, "HistogramBuckets was null");
 
@@ -1252,12 +1252,12 @@ public struct MetricPoint
             histogramBuckets.BucketCounts[bucketIndex].RunningValue++;
         }
 
-        this.OfferExplicitBucketHistogramExemplar(number, tags, bucketIndex);
+        this.OfferExplicitBucketHistogramExemplarIfSampled(number, tags, bucketIndex, isSampled);
 
         this.mpComponents.ReleaseLock();
     }
 
-    private void UpdateHistogramWithBucketsAndMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default)
+    private void UpdateHistogramWithBucketsAndMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool isSampled = false)
     {
         Debug.Assert(this.mpComponents?.HistogramBuckets != null, "histogramBuckets was null");
 
@@ -1277,12 +1277,12 @@ public struct MetricPoint
             histogramBuckets.RunningMax = Math.Max(histogramBuckets.RunningMax, number);
         }
 
-        this.OfferExplicitBucketHistogramExemplar(number, tags, bucketIndex);
+        this.OfferExplicitBucketHistogramExemplarIfSampled(number, tags, bucketIndex, isSampled);
 
         this.mpComponents.ReleaseLock();
     }
 
-    private void UpdateBase2ExponentialHistogram(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default)
+    private void UpdateBase2ExponentialHistogram(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool isSampled = false)
     {
         if (number < 0)
         {
@@ -1302,12 +1302,12 @@ public struct MetricPoint
             histogram.Record(number);
         }
 
-        this.OfferExemplar(number, tags);
+        this.OfferExemplarIfSampled(number, tags, isSampled);
 
         this.mpComponents.ReleaseLock();
     }
 
-    private void UpdateBase2ExponentialHistogramWithMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default)
+    private void UpdateBase2ExponentialHistogramWithMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool isSampled = false)
     {
         if (number < 0)
         {
@@ -1330,49 +1330,56 @@ public struct MetricPoint
             histogram.RunningMax = Math.Max(histogram.RunningMax, number);
         }
 
-        this.OfferExemplar(number, tags);
+        this.OfferExemplarIfSampled(number, tags, isSampled);
 
         this.mpComponents.ReleaseLock();
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private readonly void OfferExemplar<T>(T number, ReadOnlySpan<KeyValuePair<string, object?>> tags)
+    private readonly void OfferExemplarIfSampled<T>(T number, ReadOnlySpan<KeyValuePair<string, object?>> tags, bool isSampled)
         where T : struct
     {
-        Debug.Assert(this.mpComponents?.ExemplarReservoir != null, "ExemplarReservoir was null");
+        if (isSampled)
+        {
+            Debug.Assert(this.mpComponents?.ExemplarReservoir != null, "ExemplarReservoir was null");
 
-        // TODO: Need to ensure that the lock is always released.
-        // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
-        if (typeof(T) == typeof(long))
-        {
-            this.mpComponents!.ExemplarReservoir!.Offer(
-                new ExemplarMeasurement<long>((long)(object)number, tags));
-        }
-        else if (typeof(T) == typeof(double))
-        {
-            this.mpComponents!.ExemplarReservoir!.Offer(
-                new ExemplarMeasurement<double>((double)(object)number, tags));
-        }
-        else
-        {
-            Debug.Fail("Unexpected type");
-            this.mpComponents!.ExemplarReservoir!.Offer(
-                new ExemplarMeasurement<double>(Convert.ToDouble(number), tags));
+            // TODO: Need to ensure that the lock is always released.
+            // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
+            if (typeof(T) == typeof(long))
+            {
+                this.mpComponents!.ExemplarReservoir!.Offer(
+                    new ExemplarMeasurement<long>((long)(object)number, tags));
+            }
+            else if (typeof(T) == typeof(double))
+            {
+                this.mpComponents!.ExemplarReservoir!.Offer(
+                    new ExemplarMeasurement<double>((double)(object)number, tags));
+            }
+            else
+            {
+                Debug.Fail("Unexpected type");
+                this.mpComponents!.ExemplarReservoir!.Offer(
+                    new ExemplarMeasurement<double>(Convert.ToDouble(number), tags));
+            }
         }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private readonly void OfferExplicitBucketHistogramExemplar(
+    private readonly void OfferExplicitBucketHistogramExemplarIfSampled(
         double number,
         ReadOnlySpan<KeyValuePair<string, object?>> tags,
-        int bucketIndex)
+        int bucketIndex,
+        bool isSampled)
     {
-        Debug.Assert(this.mpComponents?.ExemplarReservoir != null, "ExemplarReservoir was null");
+        if (isSampled)
+        {
+            Debug.Assert(this.mpComponents?.ExemplarReservoir != null, "ExemplarReservoir was null");
 
-        // TODO: Need to ensure that the lock is always released.
-        // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
-        this.mpComponents!.ExemplarReservoir!.Offer(
-            new ExemplarMeasurement<double>(number, tags, bucketIndex));
+            // TODO: Need to ensure that the lock is always released.
+            // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
+            this.mpComponents!.ExemplarReservoir!.Offer(
+                new ExemplarMeasurement<double>(number, tags, bucketIndex));
+        }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -463,15 +463,7 @@ public struct MetricPoint
                         this.runningValue.AsLong += number;
                     }
 
-                    if (isSampled)
-                    {
-                        Debug.Assert(this.mpComponents.ExemplarReservoir != null, "ExemplarReservoir was null");
-
-                        // TODO: Need to ensure that the lock is always released.
-                        // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
-                        this.mpComponents.ExemplarReservoir!.Offer(
-                            new ExemplarMeasurement<long>(number, tags));
-                    }
+                    this.OfferExemplarIfSampled(number, tags, isSampled);
 
                     this.mpComponents.ReleaseLock();
 
@@ -484,15 +476,7 @@ public struct MetricPoint
 
                     this.runningValue.AsLong = number;
 
-                    if (isSampled)
-                    {
-                        Debug.Assert(this.mpComponents.ExemplarReservoir != null, "ExemplarReservoir was null");
-
-                        // TODO: Need to ensure that the lock is always released.
-                        // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
-                        this.mpComponents.ExemplarReservoir!.Offer(
-                            new ExemplarMeasurement<long>(number, tags));
-                    }
+                    this.OfferExemplarIfSampled(number, tags, isSampled);
 
                     this.mpComponents.ReleaseLock();
 
@@ -505,15 +489,7 @@ public struct MetricPoint
 
                     this.runningValue.AsLong = number;
 
-                    if (isSampled)
-                    {
-                        Debug.Assert(this.mpComponents.ExemplarReservoir != null, "ExemplarReservoir was null");
-
-                        // TODO: Need to ensure that the lock is always released.
-                        // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
-                        this.mpComponents.ExemplarReservoir!.Offer(
-                            new ExemplarMeasurement<long>(number, tags));
-                    }
+                    this.OfferExemplarIfSampled(number, tags, isSampled);
 
                     this.mpComponents.ReleaseLock();
 
@@ -522,37 +498,37 @@ public struct MetricPoint
 
             case AggregationType.Histogram:
                 {
-                    this.UpdateHistogram((double)number, tags, reportExemplar: true, isSampled);
+                    this.UpdateHistogram((double)number, tags, isSampled);
                     break;
                 }
 
             case AggregationType.HistogramWithMinMax:
                 {
-                    this.UpdateHistogramWithMinMax((double)number, tags, reportExemplar: true, isSampled);
+                    this.UpdateHistogramWithMinMax((double)number, tags, isSampled);
                     break;
                 }
 
             case AggregationType.HistogramWithBuckets:
                 {
-                    this.UpdateHistogramWithBuckets((double)number, tags, reportExemplar: true, isSampled);
+                    this.UpdateHistogramWithBuckets((double)number, tags, isSampled);
                     break;
                 }
 
             case AggregationType.HistogramWithMinMaxBuckets:
                 {
-                    this.UpdateHistogramWithBucketsAndMinMax((double)number, tags, reportExemplar: true, isSampled);
+                    this.UpdateHistogramWithBucketsAndMinMax((double)number, tags, isSampled);
                     break;
                 }
 
             case AggregationType.Base2ExponentialHistogram:
                 {
-                    this.UpdateBase2ExponentialHistogram((double)number, tags, reportExemplar: true, isSampled);
+                    this.UpdateBase2ExponentialHistogram((double)number, tags, isSampled);
                     break;
                 }
 
             case AggregationType.Base2ExponentialHistogramWithMinMax:
                 {
-                    this.UpdateBase2ExponentialHistogramWithMinMax((double)number, tags, reportExemplar: true, isSampled);
+                    this.UpdateBase2ExponentialHistogramWithMinMax((double)number, tags, isSampled);
                     break;
                 }
         }
@@ -637,15 +613,7 @@ public struct MetricPoint
                         this.runningValue.AsDouble += number;
                     }
 
-                    if (isSampled)
-                    {
-                        Debug.Assert(this.mpComponents.ExemplarReservoir != null, "ExemplarReservoir was null");
-
-                        // TODO: Need to ensure that the lock is always released.
-                        // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
-                        this.mpComponents.ExemplarReservoir!.Offer(
-                            new ExemplarMeasurement<double>(number, tags));
-                    }
+                    this.OfferExemplarIfSampled(number, tags, isSampled);
 
                     this.mpComponents.ReleaseLock();
 
@@ -661,15 +629,7 @@ public struct MetricPoint
                         this.runningValue.AsDouble = number;
                     }
 
-                    if (isSampled)
-                    {
-                        Debug.Assert(this.mpComponents.ExemplarReservoir != null, "ExemplarReservoir was null");
-
-                        // TODO: Need to ensure that the lock is always released.
-                        // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
-                        this.mpComponents.ExemplarReservoir!.Offer(
-                            new ExemplarMeasurement<double>(number, tags));
-                    }
+                    this.OfferExemplarIfSampled(number, tags, isSampled);
 
                     this.mpComponents.ReleaseLock();
 
@@ -685,15 +645,7 @@ public struct MetricPoint
                         this.runningValue.AsDouble = number;
                     }
 
-                    if (isSampled)
-                    {
-                        Debug.Assert(this.mpComponents.ExemplarReservoir != null, "ExemplarReservoir was null");
-
-                        // TODO: Need to ensure that the lock is always released.
-                        // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
-                        this.mpComponents.ExemplarReservoir!.Offer(
-                            new ExemplarMeasurement<double>(number, tags));
-                    }
+                    this.OfferExemplarIfSampled(number, tags, isSampled);
 
                     this.mpComponents.ReleaseLock();
 
@@ -702,37 +654,37 @@ public struct MetricPoint
 
             case AggregationType.Histogram:
                 {
-                    this.UpdateHistogram(number, tags, reportExemplar: true, isSampled);
+                    this.UpdateHistogram(number, tags, isSampled);
                     break;
                 }
 
             case AggregationType.HistogramWithMinMax:
                 {
-                    this.UpdateHistogramWithMinMax(number, tags, reportExemplar: true, isSampled);
+                    this.UpdateHistogramWithMinMax(number, tags, isSampled);
                     break;
                 }
 
             case AggregationType.HistogramWithBuckets:
                 {
-                    this.UpdateHistogramWithBuckets(number, tags, reportExemplar: true, isSampled);
+                    this.UpdateHistogramWithBuckets(number, tags, isSampled);
                     break;
                 }
 
             case AggregationType.HistogramWithMinMaxBuckets:
                 {
-                    this.UpdateHistogramWithBucketsAndMinMax(number, tags, reportExemplar: true, isSampled);
+                    this.UpdateHistogramWithBucketsAndMinMax(number, tags, isSampled);
                     break;
                 }
 
             case AggregationType.Base2ExponentialHistogram:
                 {
-                    this.UpdateBase2ExponentialHistogram(number, tags, reportExemplar: true, isSampled);
+                    this.UpdateBase2ExponentialHistogram(number, tags, isSampled);
                     break;
                 }
 
             case AggregationType.Base2ExponentialHistogramWithMinMax:
                 {
-                    this.UpdateBase2ExponentialHistogramWithMinMax(number, tags, reportExemplar: true, isSampled);
+                    this.UpdateBase2ExponentialHistogramWithMinMax(number, tags, isSampled);
                     break;
                 }
         }
@@ -1243,7 +1195,7 @@ public struct MetricPoint
         }
     }
 
-    private void UpdateHistogram(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool reportExemplar = false, bool isSampled = false)
+    private void UpdateHistogram(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool isSampled = false)
     {
         Debug.Assert(this.mpComponents?.HistogramBuckets != null, "HistogramBuckets was null");
 
@@ -1257,20 +1209,12 @@ public struct MetricPoint
             histogramBuckets.RunningSum += number;
         }
 
-        if (reportExemplar && isSampled)
-        {
-            Debug.Assert(this.mpComponents.ExemplarReservoir != null, "ExemplarReservoir was null");
-
-            // TODO: Need to ensure that the lock is always released.
-            // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
-            this.mpComponents.ExemplarReservoir!.Offer(
-                new ExemplarMeasurement<double>(number, tags));
-        }
+        this.OfferExemplarIfSampled(number, tags, isSampled);
 
         this.mpComponents.ReleaseLock();
     }
 
-    private void UpdateHistogramWithMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool reportExemplar = false, bool isSampled = false)
+    private void UpdateHistogramWithMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool isSampled = false)
     {
         Debug.Assert(this.mpComponents?.HistogramBuckets != null, "HistogramBuckets was null");
 
@@ -1286,26 +1230,18 @@ public struct MetricPoint
             histogramBuckets.RunningMax = Math.Max(histogramBuckets.RunningMax, number);
         }
 
-        if (reportExemplar && isSampled)
-        {
-            Debug.Assert(this.mpComponents.ExemplarReservoir != null, "ExemplarReservoir was null");
-
-            // TODO: Need to ensure that the lock is always released.
-            // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
-            this.mpComponents.ExemplarReservoir!.Offer(
-                new ExemplarMeasurement<double>(number, tags));
-        }
+        this.OfferExemplarIfSampled(number, tags, isSampled);
 
         this.mpComponents.ReleaseLock();
     }
 
-    private void UpdateHistogramWithBuckets(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool reportExemplar = false, bool isSampled = false)
+    private void UpdateHistogramWithBuckets(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool isSampled = false)
     {
         Debug.Assert(this.mpComponents?.HistogramBuckets != null, "HistogramBuckets was null");
 
         var histogramBuckets = this.mpComponents!.HistogramBuckets;
 
-        int i = histogramBuckets!.FindBucketIndex(number);
+        int bucketIndex = histogramBuckets!.FindBucketIndex(number);
 
         this.mpComponents.AcquireLock();
 
@@ -1313,29 +1249,21 @@ public struct MetricPoint
         {
             this.runningValue.AsLong++;
             histogramBuckets.RunningSum += number;
-            histogramBuckets.BucketCounts[i].RunningValue++;
+            histogramBuckets.BucketCounts[bucketIndex].RunningValue++;
         }
 
-        if (reportExemplar && isSampled)
-        {
-            Debug.Assert(this.mpComponents.ExemplarReservoir != null, "ExemplarReservoir was null");
-
-            // TODO: Need to ensure that the lock is always released.
-            // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
-            this.mpComponents.ExemplarReservoir!.Offer(
-                new ExemplarMeasurement<double>(number, tags, i));
-        }
+        this.OfferExplicitBucketHistogramExemplarIfSampled(number, tags, bucketIndex, isSampled);
 
         this.mpComponents.ReleaseLock();
     }
 
-    private void UpdateHistogramWithBucketsAndMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool reportExemplar = false, bool isSampled = false)
+    private void UpdateHistogramWithBucketsAndMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool isSampled = false)
     {
         Debug.Assert(this.mpComponents?.HistogramBuckets != null, "histogramBuckets was null");
 
         var histogramBuckets = this.mpComponents!.HistogramBuckets;
 
-        int i = histogramBuckets!.FindBucketIndex(number);
+        int bucketIndex = histogramBuckets!.FindBucketIndex(number);
 
         this.mpComponents.AcquireLock();
 
@@ -1343,26 +1271,18 @@ public struct MetricPoint
         {
             this.runningValue.AsLong++;
             histogramBuckets.RunningSum += number;
-            histogramBuckets.BucketCounts[i].RunningValue++;
+            histogramBuckets.BucketCounts[bucketIndex].RunningValue++;
 
             histogramBuckets.RunningMin = Math.Min(histogramBuckets.RunningMin, number);
             histogramBuckets.RunningMax = Math.Max(histogramBuckets.RunningMax, number);
         }
 
-        if (reportExemplar && isSampled)
-        {
-            Debug.Assert(this.mpComponents.ExemplarReservoir != null, "ExemplarReservoir was null");
-
-            // TODO: Need to ensure that the lock is always released.
-            // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
-            this.mpComponents.ExemplarReservoir!.Offer(
-                new ExemplarMeasurement<double>(number, tags, i));
-        }
+        this.OfferExplicitBucketHistogramExemplarIfSampled(number, tags, bucketIndex, isSampled);
 
         this.mpComponents.ReleaseLock();
     }
 
-    private void UpdateBase2ExponentialHistogram(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool reportExemplar = false, bool isSampled = false)
+    private void UpdateBase2ExponentialHistogram(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool isSampled = false)
     {
         if (number < 0)
         {
@@ -1382,20 +1302,12 @@ public struct MetricPoint
             histogram.Record(number);
         }
 
-        if (reportExemplar && isSampled)
-        {
-            Debug.Assert(this.mpComponents.ExemplarReservoir != null, "ExemplarReservoir was null");
-
-            // TODO: Need to ensure that the lock is always released.
-            // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
-            this.mpComponents.ExemplarReservoir!.Offer(
-                new ExemplarMeasurement<double>(number, tags));
-        }
+        this.OfferExemplarIfSampled(number, tags, isSampled);
 
         this.mpComponents.ReleaseLock();
     }
 
-    private void UpdateBase2ExponentialHistogramWithMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool reportExemplar = false, bool isSampled = false)
+    private void UpdateBase2ExponentialHistogramWithMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool isSampled = false)
     {
         if (number < 0)
         {
@@ -1418,17 +1330,56 @@ public struct MetricPoint
             histogram.RunningMax = Math.Max(histogram.RunningMax, number);
         }
 
-        if (reportExemplar && isSampled)
+        this.OfferExemplarIfSampled(number, tags, isSampled);
+
+        this.mpComponents.ReleaseLock();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private readonly void OfferExemplarIfSampled<T>(T number, ReadOnlySpan<KeyValuePair<string, object?>> tags, bool isSampled)
+        where T : struct
+    {
+        if (isSampled)
         {
-            Debug.Assert(this.mpComponents.ExemplarReservoir != null, "ExemplarReservoir was null");
+            Debug.Assert(this.mpComponents?.ExemplarReservoir != null, "ExemplarReservoir was null");
 
             // TODO: Need to ensure that the lock is always released.
             // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
-            this.mpComponents.ExemplarReservoir!.Offer(
-                new ExemplarMeasurement<double>(number, tags));
+            if (typeof(T) == typeof(long))
+            {
+                this.mpComponents!.ExemplarReservoir!.Offer(
+                    new ExemplarMeasurement<long>((long)(object)number, tags));
+            }
+            else if (typeof(T) == typeof(double))
+            {
+                this.mpComponents!.ExemplarReservoir!.Offer(
+                    new ExemplarMeasurement<double>((double)(object)number, tags));
+            }
+            else
+            {
+                Debug.Fail("Unexpected type");
+                this.mpComponents!.ExemplarReservoir!.Offer(
+                    new ExemplarMeasurement<double>(Convert.ToDouble(number), tags));
+            }
         }
+    }
 
-        this.mpComponents.ReleaseLock();
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private readonly void OfferExplicitBucketHistogramExemplarIfSampled(
+        double number,
+        ReadOnlySpan<KeyValuePair<string, object?>> tags,
+        int bucketIndex,
+        bool isSampled)
+    {
+        if (isSampled)
+        {
+            Debug.Assert(this.mpComponents?.ExemplarReservoir != null, "ExemplarReservoir was null");
+
+            // TODO: Need to ensure that the lock is always released.
+            // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
+            this.mpComponents!.ExemplarReservoir!.Offer(
+                new ExemplarMeasurement<double>(number, tags, bucketIndex));
+        }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -448,7 +448,7 @@ public struct MetricPoint
         this.CompleteUpdate();
     }
 
-    internal void UpdateWithExemplar(long number, ReadOnlySpan<KeyValuePair<string, object?>> tags, bool isSampled)
+    internal void UpdateWithExemplar(long number, ReadOnlySpan<KeyValuePair<string, object?>> tags)
     {
         Debug.Assert(this.mpComponents != null, "this.mpComponents was null");
 
@@ -463,7 +463,7 @@ public struct MetricPoint
                         this.runningValue.AsLong += number;
                     }
 
-                    this.OfferExemplarIfSampled(number, tags, isSampled);
+                    this.OfferExemplar(number, tags);
 
                     this.mpComponents.ReleaseLock();
 
@@ -476,7 +476,7 @@ public struct MetricPoint
 
                     this.runningValue.AsLong = number;
 
-                    this.OfferExemplarIfSampled(number, tags, isSampled);
+                    this.OfferExemplar(number, tags);
 
                     this.mpComponents.ReleaseLock();
 
@@ -489,7 +489,7 @@ public struct MetricPoint
 
                     this.runningValue.AsLong = number;
 
-                    this.OfferExemplarIfSampled(number, tags, isSampled);
+                    this.OfferExemplar(number, tags);
 
                     this.mpComponents.ReleaseLock();
 
@@ -498,37 +498,37 @@ public struct MetricPoint
 
             case AggregationType.Histogram:
                 {
-                    this.UpdateHistogram((double)number, tags, isSampled);
+                    this.UpdateHistogram((double)number, tags);
                     break;
                 }
 
             case AggregationType.HistogramWithMinMax:
                 {
-                    this.UpdateHistogramWithMinMax((double)number, tags, isSampled);
+                    this.UpdateHistogramWithMinMax((double)number, tags);
                     break;
                 }
 
             case AggregationType.HistogramWithBuckets:
                 {
-                    this.UpdateHistogramWithBuckets((double)number, tags, isSampled);
+                    this.UpdateHistogramWithBuckets((double)number, tags);
                     break;
                 }
 
             case AggregationType.HistogramWithMinMaxBuckets:
                 {
-                    this.UpdateHistogramWithBucketsAndMinMax((double)number, tags, isSampled);
+                    this.UpdateHistogramWithBucketsAndMinMax((double)number, tags);
                     break;
                 }
 
             case AggregationType.Base2ExponentialHistogram:
                 {
-                    this.UpdateBase2ExponentialHistogram((double)number, tags, isSampled);
+                    this.UpdateBase2ExponentialHistogram((double)number, tags);
                     break;
                 }
 
             case AggregationType.Base2ExponentialHistogramWithMinMax:
                 {
-                    this.UpdateBase2ExponentialHistogramWithMinMax((double)number, tags, isSampled);
+                    this.UpdateBase2ExponentialHistogramWithMinMax((double)number, tags);
                     break;
                 }
         }
@@ -598,7 +598,7 @@ public struct MetricPoint
         this.CompleteUpdate();
     }
 
-    internal void UpdateWithExemplar(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags, bool isSampled)
+    internal void UpdateWithExemplar(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags)
     {
         Debug.Assert(this.mpComponents != null, "this.mpComponents was null");
 
@@ -613,7 +613,7 @@ public struct MetricPoint
                         this.runningValue.AsDouble += number;
                     }
 
-                    this.OfferExemplarIfSampled(number, tags, isSampled);
+                    this.OfferExemplar(number, tags);
 
                     this.mpComponents.ReleaseLock();
 
@@ -629,7 +629,7 @@ public struct MetricPoint
                         this.runningValue.AsDouble = number;
                     }
 
-                    this.OfferExemplarIfSampled(number, tags, isSampled);
+                    this.OfferExemplar(number, tags);
 
                     this.mpComponents.ReleaseLock();
 
@@ -645,7 +645,7 @@ public struct MetricPoint
                         this.runningValue.AsDouble = number;
                     }
 
-                    this.OfferExemplarIfSampled(number, tags, isSampled);
+                    this.OfferExemplar(number, tags);
 
                     this.mpComponents.ReleaseLock();
 
@@ -654,37 +654,37 @@ public struct MetricPoint
 
             case AggregationType.Histogram:
                 {
-                    this.UpdateHistogram(number, tags, isSampled);
+                    this.UpdateHistogram(number, tags);
                     break;
                 }
 
             case AggregationType.HistogramWithMinMax:
                 {
-                    this.UpdateHistogramWithMinMax(number, tags, isSampled);
+                    this.UpdateHistogramWithMinMax(number, tags);
                     break;
                 }
 
             case AggregationType.HistogramWithBuckets:
                 {
-                    this.UpdateHistogramWithBuckets(number, tags, isSampled);
+                    this.UpdateHistogramWithBuckets(number, tags);
                     break;
                 }
 
             case AggregationType.HistogramWithMinMaxBuckets:
                 {
-                    this.UpdateHistogramWithBucketsAndMinMax(number, tags, isSampled);
+                    this.UpdateHistogramWithBucketsAndMinMax(number, tags);
                     break;
                 }
 
             case AggregationType.Base2ExponentialHistogram:
                 {
-                    this.UpdateBase2ExponentialHistogram(number, tags, isSampled);
+                    this.UpdateBase2ExponentialHistogram(number, tags);
                     break;
                 }
 
             case AggregationType.Base2ExponentialHistogramWithMinMax:
                 {
-                    this.UpdateBase2ExponentialHistogramWithMinMax(number, tags, isSampled);
+                    this.UpdateBase2ExponentialHistogramWithMinMax(number, tags);
                     break;
                 }
         }
@@ -1195,7 +1195,7 @@ public struct MetricPoint
         }
     }
 
-    private void UpdateHistogram(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool isSampled = false)
+    private void UpdateHistogram(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default)
     {
         Debug.Assert(this.mpComponents?.HistogramBuckets != null, "HistogramBuckets was null");
 
@@ -1209,12 +1209,12 @@ public struct MetricPoint
             histogramBuckets.RunningSum += number;
         }
 
-        this.OfferExemplarIfSampled(number, tags, isSampled);
+        this.OfferExemplar(number, tags);
 
         this.mpComponents.ReleaseLock();
     }
 
-    private void UpdateHistogramWithMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool isSampled = false)
+    private void UpdateHistogramWithMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default)
     {
         Debug.Assert(this.mpComponents?.HistogramBuckets != null, "HistogramBuckets was null");
 
@@ -1230,12 +1230,12 @@ public struct MetricPoint
             histogramBuckets.RunningMax = Math.Max(histogramBuckets.RunningMax, number);
         }
 
-        this.OfferExemplarIfSampled(number, tags, isSampled);
+        this.OfferExemplar(number, tags);
 
         this.mpComponents.ReleaseLock();
     }
 
-    private void UpdateHistogramWithBuckets(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool isSampled = false)
+    private void UpdateHistogramWithBuckets(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default)
     {
         Debug.Assert(this.mpComponents?.HistogramBuckets != null, "HistogramBuckets was null");
 
@@ -1252,12 +1252,12 @@ public struct MetricPoint
             histogramBuckets.BucketCounts[bucketIndex].RunningValue++;
         }
 
-        this.OfferExplicitBucketHistogramExemplarIfSampled(number, tags, bucketIndex, isSampled);
+        this.OfferExplicitBucketHistogramExemplar(number, tags, bucketIndex);
 
         this.mpComponents.ReleaseLock();
     }
 
-    private void UpdateHistogramWithBucketsAndMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool isSampled = false)
+    private void UpdateHistogramWithBucketsAndMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default)
     {
         Debug.Assert(this.mpComponents?.HistogramBuckets != null, "histogramBuckets was null");
 
@@ -1277,12 +1277,12 @@ public struct MetricPoint
             histogramBuckets.RunningMax = Math.Max(histogramBuckets.RunningMax, number);
         }
 
-        this.OfferExplicitBucketHistogramExemplarIfSampled(number, tags, bucketIndex, isSampled);
+        this.OfferExplicitBucketHistogramExemplar(number, tags, bucketIndex);
 
         this.mpComponents.ReleaseLock();
     }
 
-    private void UpdateBase2ExponentialHistogram(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool isSampled = false)
+    private void UpdateBase2ExponentialHistogram(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default)
     {
         if (number < 0)
         {
@@ -1302,12 +1302,12 @@ public struct MetricPoint
             histogram.Record(number);
         }
 
-        this.OfferExemplarIfSampled(number, tags, isSampled);
+        this.OfferExemplar(number, tags);
 
         this.mpComponents.ReleaseLock();
     }
 
-    private void UpdateBase2ExponentialHistogramWithMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool isSampled = false)
+    private void UpdateBase2ExponentialHistogramWithMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default)
     {
         if (number < 0)
         {
@@ -1330,56 +1330,49 @@ public struct MetricPoint
             histogram.RunningMax = Math.Max(histogram.RunningMax, number);
         }
 
-        this.OfferExemplarIfSampled(number, tags, isSampled);
+        this.OfferExemplar(number, tags);
 
         this.mpComponents.ReleaseLock();
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private readonly void OfferExemplarIfSampled<T>(T number, ReadOnlySpan<KeyValuePair<string, object?>> tags, bool isSampled)
+    private readonly void OfferExemplar<T>(T number, ReadOnlySpan<KeyValuePair<string, object?>> tags)
         where T : struct
     {
-        if (isSampled)
-        {
-            Debug.Assert(this.mpComponents?.ExemplarReservoir != null, "ExemplarReservoir was null");
+        Debug.Assert(this.mpComponents?.ExemplarReservoir != null, "ExemplarReservoir was null");
 
-            // TODO: Need to ensure that the lock is always released.
-            // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
-            if (typeof(T) == typeof(long))
-            {
-                this.mpComponents!.ExemplarReservoir!.Offer(
-                    new ExemplarMeasurement<long>((long)(object)number, tags));
-            }
-            else if (typeof(T) == typeof(double))
-            {
-                this.mpComponents!.ExemplarReservoir!.Offer(
-                    new ExemplarMeasurement<double>((double)(object)number, tags));
-            }
-            else
-            {
-                Debug.Fail("Unexpected type");
-                this.mpComponents!.ExemplarReservoir!.Offer(
-                    new ExemplarMeasurement<double>(Convert.ToDouble(number), tags));
-            }
+        // TODO: Need to ensure that the lock is always released.
+        // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
+        if (typeof(T) == typeof(long))
+        {
+            this.mpComponents!.ExemplarReservoir!.Offer(
+                new ExemplarMeasurement<long>((long)(object)number, tags));
+        }
+        else if (typeof(T) == typeof(double))
+        {
+            this.mpComponents!.ExemplarReservoir!.Offer(
+                new ExemplarMeasurement<double>((double)(object)number, tags));
+        }
+        else
+        {
+            Debug.Fail("Unexpected type");
+            this.mpComponents!.ExemplarReservoir!.Offer(
+                new ExemplarMeasurement<double>(Convert.ToDouble(number), tags));
         }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private readonly void OfferExplicitBucketHistogramExemplarIfSampled(
+    private readonly void OfferExplicitBucketHistogramExemplar(
         double number,
         ReadOnlySpan<KeyValuePair<string, object?>> tags,
-        int bucketIndex,
-        bool isSampled)
+        int bucketIndex)
     {
-        if (isSampled)
-        {
-            Debug.Assert(this.mpComponents?.ExemplarReservoir != null, "ExemplarReservoir was null");
+        Debug.Assert(this.mpComponents?.ExemplarReservoir != null, "ExemplarReservoir was null");
 
-            // TODO: Need to ensure that the lock is always released.
-            // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
-            this.mpComponents!.ExemplarReservoir!.Offer(
-                new ExemplarMeasurement<double>(number, tags, bucketIndex));
-        }
+        // TODO: Need to ensure that the lock is always released.
+        // A custom implementation of `ExemplarReservoir.Offer` might throw an exception.
+        this.mpComponents!.ExemplarReservoir!.Offer(
+            new ExemplarMeasurement<double>(number, tags, bucketIndex));
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
## Changes

* Fix a few more violations of [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) in `MetricPoint` by introducing helper methods for exemplar offer code.
