### PR TITLE
Allow root action rewrites

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -241,7 +241,13 @@ internal class HttpInListener : ListenerHandler
                     context.GetEndpoint() as RouteEndpoint)?.RoutePattern.RawText;
             if (!string.IsNullOrEmpty(routePattern))
             {
-                activity.DisplayName = GetDisplayName(context.Request.Method, routePattern);
+                // only override the display name if it was not set by the user
+                var previousDisplayName = GetDisplayName(context.Request.Method);
+                if (activity.DisplayName == previousDisplayName)
+                {
+                    activity.DisplayName = GetDisplayName(context.Request.Method, routePattern);
+                }
+
                 activity.SetTag(SemanticConventions.AttributeHttpRoute, routePattern);
             }
 #endif

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/README.net6.0.md
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/README.net6.0.md
@@ -23,6 +23,7 @@
 | :green_heart: | MinimalApi | [Action without parameter](#minimalapi-action-without-parameter) |
 | :green_heart: | MinimalApi | [Action with parameter](#minimalapi-action-with-parameter) |
 | :green_heart: | ExceptionMiddleware | [Exception Handled by Exception Handler Middleware](#exceptionmiddleware-exception-handled-by-exception-handler-middleware) |
+| :broken_heart: | ConventionalRouting | [Overridden display name](#conventionalrouting-overridden-display-name) |
 
 ## ConventionalRouting: Root path
 
@@ -607,6 +608,39 @@
     "IRouteDiagnosticsMetadata.Route": null,
     "HttpContext.GetRouteData()": {},
     "ActionDescriptor": null
+  }
+}
+```
+
+## ConventionalRouting: Overridden display name
+
+```json
+{
+  "IdealHttpRoute": null,
+  "ActivityDisplayName": "Overwritten",
+  "ActivityHttpRoute": "{controller=ConventionalRoute}/{action=Default}/{id?}",
+  "MetricHttpRoute": "{controller=ConventionalRoute}/{action=Default}/{id?}",
+  "RouteInfo": {
+    "HttpMethod": "GET",
+    "Path": "/ConventionalRoute/OverwriteRootSpan?num=3",
+    "RoutePattern.RawText": "{controller=ConventionalRoute}/{action=Default}/{id?}",
+    "IRouteDiagnosticsMetadata.Route": null,
+    "HttpContext.GetRouteData()": {
+      "controller": "ConventionalRoute",
+      "action": "OverwriteRootSpan"
+    },
+    "ActionDescriptor": {
+      "AttributeRouteInfo.Template": null,
+      "Parameters": [
+        "id",
+        "num"
+      ],
+      "ControllerActionDescriptor": {
+        "ControllerName": "ConventionalRoute",
+        "ActionName": "OverwriteRootSpan"
+      },
+      "PageActionDescriptor": null
+    }
   }
 }
 ```

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/README.net7.0.md
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/README.net7.0.md
@@ -25,6 +25,7 @@
 | :green_heart: | MinimalApi | [Action without parameter (MapGroup)](#minimalapi-action-without-parameter-mapgroup) |
 | :green_heart: | MinimalApi | [Action with parameter (MapGroup)](#minimalapi-action-with-parameter-mapgroup) |
 | :green_heart: | ExceptionMiddleware | [Exception Handled by Exception Handler Middleware](#exceptionmiddleware-exception-handled-by-exception-handler-middleware) |
+| :broken_heart: | ConventionalRouting | [Overridden display name](#conventionalrouting-overridden-display-name) |
 
 ## ConventionalRouting: Root path
 
@@ -649,6 +650,39 @@
     "IRouteDiagnosticsMetadata.Route": null,
     "HttpContext.GetRouteData()": {},
     "ActionDescriptor": null
+  }
+}
+```
+
+## ConventionalRouting: Overridden display name
+
+```json
+{
+  "IdealHttpRoute": null,
+  "ActivityDisplayName": "Overwritten",
+  "ActivityHttpRoute": "{controller=ConventionalRoute}/{action=Default}/{id?}",
+  "MetricHttpRoute": "{controller=ConventionalRoute}/{action=Default}/{id?}",
+  "RouteInfo": {
+    "HttpMethod": "GET",
+    "Path": "/ConventionalRoute/OverwriteRootSpan?num=3",
+    "RoutePattern.RawText": "{controller=ConventionalRoute}/{action=Default}/{id?}",
+    "IRouteDiagnosticsMetadata.Route": null,
+    "HttpContext.GetRouteData()": {
+      "controller": "ConventionalRoute",
+      "action": "OverwriteRootSpan"
+    },
+    "ActionDescriptor": {
+      "AttributeRouteInfo.Template": null,
+      "Parameters": [
+        "id",
+        "num"
+      ],
+      "ControllerActionDescriptor": {
+        "ControllerName": "ConventionalRoute",
+        "ActionName": "OverwriteRootSpan"
+      },
+      "PageActionDescriptor": null
+    }
   }
 }
 ```

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/README.net8.0.md
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/README.net8.0.md
@@ -25,6 +25,7 @@
 | :green_heart: | MinimalApi | [Action without parameter (MapGroup)](#minimalapi-action-without-parameter-mapgroup) |
 | :green_heart: | MinimalApi | [Action with parameter (MapGroup)](#minimalapi-action-with-parameter-mapgroup) |
 | :green_heart: | ExceptionMiddleware | [Exception Handled by Exception Handler Middleware](#exceptionmiddleware-exception-handled-by-exception-handler-middleware) |
+| :broken_heart: | ConventionalRouting | [Overridden display name](#conventionalrouting-overridden-display-name) |
 
 ## ConventionalRouting: Root path
 
@@ -649,6 +650,39 @@
     "IRouteDiagnosticsMetadata.Route": "/Exception",
     "HttpContext.GetRouteData()": {},
     "ActionDescriptor": null
+  }
+}
+```
+
+## ConventionalRouting: Overridden display name
+
+```json
+{
+  "IdealHttpRoute": null,
+  "ActivityDisplayName": "Overwritten",
+  "ActivityHttpRoute": "{controller=ConventionalRoute}/{action=Default}/{id?}",
+  "MetricHttpRoute": "{controller=ConventionalRoute}/{action=Default}/{id?}",
+  "RouteInfo": {
+    "HttpMethod": "GET",
+    "Path": "/ConventionalRoute/OverwriteRootSpan?num=3",
+    "RoutePattern.RawText": "{controller=ConventionalRoute}/{action=Default}/{id?}",
+    "IRouteDiagnosticsMetadata.Route": "{controller=ConventionalRoute}/{action=Default}/{id?}",
+    "HttpContext.GetRouteData()": {
+      "controller": "ConventionalRoute",
+      "action": "OverwriteRootSpan"
+    },
+    "ActionDescriptor": {
+      "AttributeRouteInfo.Template": null,
+      "Parameters": [
+        "id",
+        "num"
+      ],
+      "ControllerActionDescriptor": {
+        "ControllerName": "ConventionalRoute",
+        "ActionName": "OverwriteRootSpan"
+      },
+      "PageActionDescriptor": null
+    }
   }
 }
 ```

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTestCases.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTestCases.cs
@@ -58,6 +58,8 @@ public static class RoutingTestCases
 
         public string? ExpectedHttpRoute { get; set; }
 
+        public string? ExpectedDisplayName { get; set; }
+
         public string? CurrentHttpRoute { get; set; }
 
         public override string ToString()

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTestCases.json
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTestCases.json
@@ -207,5 +207,15 @@
     "expectedStatusCode": 500,
     "currentHttpRoute": null,
     "expectedHttpRoute": "/Exception"
+  },
+  {
+    "name": "Overridden display name",
+    "testApplicationScenario": "ConventionalRouting",
+    "httpMethod": "GET",
+    "path": "/ConventionalRoute/OverwriteRootSpan?num=3",
+    "expectedStatusCode": 200,
+    "currentHttpRoute": "{controller=ConventionalRoute}/{action=Default}/{id?}",
+    "expectedHttpRoute": null,
+    "expectedDisplayName": "Overwritten"
   }
 ]

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTests.cs
@@ -85,9 +85,12 @@ public class RoutingTests : IClassFixture<RoutingTestFixture>
 
         // Activity.DisplayName should be a combination of http.method + http.route attributes, see:
         // https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#name
-        var expectedActivityDisplayName = string.IsNullOrEmpty(expectedHttpRoute)
-            ? testCase.HttpMethod
-            : $"{testCase.HttpMethod} {expectedHttpRoute}";
+        // unless the user has overriden the route name
+        var expectedActivityDisplayName = string.IsNullOrEmpty(testCase.ExpectedDisplayName)
+            ? string.IsNullOrEmpty(expectedHttpRoute)
+                ? testCase.HttpMethod
+                : $"{testCase.HttpMethod} {expectedHttpRoute}"
+            : testCase.ExpectedDisplayName;
 
         Assert.Equal(expectedActivityDisplayName, activity.DisplayName);
 

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/Controllers/ConventionalRouteController.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/TestApplication/Controllers/ConventionalRouteController.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 
 namespace RouteTests.Controllers;
@@ -14,4 +15,20 @@ public class ConventionalRouteController : Controller
     public IActionResult ActionWithParameter(int id) => this.Ok();
 
     public IActionResult ActionWithStringParameter(string id, int num) => this.Ok();
+
+    public IActionResult OverwriteRootSpan(string id, int num)
+    {
+        var currentActivity = Activity.Current;
+        while (currentActivity?.Parent != null)
+        {
+            currentActivity = currentActivity.Parent;
+        }
+
+        if (currentActivity != null)
+        {
+            currentActivity.DisplayName = "Overwritten";
+        }
+
+        return this.Ok();
+    }
 }


### PR DESCRIPTION
# Explanation 
Since https://github.com/open-telemetry/opentelemetry-dotnet/pull/5026 the activity name of the asp net core span is set on activity end. This means that any change that was done to the name of this span will be overwritten. Many monitoring solutions ( elastic, sentry, datadog et al) use the name of the root span to group similar spans. A tool to control this was to rename the root activity, which is the asp net core activity if you have it enabled. As #5026 overwrites any changes to the root activity on transaction end, this control is gone. 

## Example

The path (or route pattern) for a GraphQL request is always the same. For example `/graphql`. The open telemetry integration of HotChocolate rewrites the name of the root span to the operation that you are execution. Specficially into something like `query FindUserById { userById }`, `mutation updateUserName { updateUserName }` ... . As of #5026, all graphql operations are reported as `POST /graphql/{**slug}` which makes it impossible to properly trace different operations. 

The specific treatment of GRPC in the HttpInListener shows that it would have the same issue, it just happens to be included by default.  

## Why the hooks is not enough
There is a hook which you can use to change the properties of the span. Frameworks like HotChocolate (or others) that want to overwrite the naming of the AspNetCore trace could just use this hook. But this is not a good solution:

1. It requires all frameworks to have a dependency on `OpenTelemetry.Instrumentation.AspNetCore`.
1. It would require the user to add additional configuration to the `AddAspNetCoreInstrumentation`  registration, which leads to confusion. 

## Changes

Before overwriting the activity name on activity end, the `DisplayName` is compared to the one that is set on activity start. If the values are not the same, the user ( or a library), is interested in renaming the name of the span. In this case the name of the span in not modified on activity end. 

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [X] Changes in public API reviewed (if applicable)
