### PR TITLE
[sdk-metrics] ReadOnlyExemplarCollection tweaks

### DIFF
--- a/src/OpenTelemetry/.publicApi/Experimental/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/Experimental/PublicAPI.Unshipped.txt
@@ -23,7 +23,7 @@ OpenTelemetry.Metrics.ExemplarMeasurement<T>
 OpenTelemetry.Metrics.ExemplarMeasurement<T>.ExemplarMeasurement() -> void
 OpenTelemetry.Metrics.ExemplarMeasurement<T>.Tags.get -> System.ReadOnlySpan<System.Collections.Generic.KeyValuePair<string!, object?>>
 OpenTelemetry.Metrics.ExemplarMeasurement<T>.Value.get -> T
-OpenTelemetry.Metrics.MetricPoint.TryGetExemplars(out OpenTelemetry.Metrics.ReadOnlyExemplarCollection? exemplars) -> bool
+OpenTelemetry.Metrics.MetricPoint.TryGetExemplars(out OpenTelemetry.Metrics.ReadOnlyExemplarCollection exemplars) -> bool
 OpenTelemetry.Metrics.MetricStreamConfiguration.CardinalityLimit.get -> int?
 OpenTelemetry.Metrics.MetricStreamConfiguration.CardinalityLimit.set -> void
 OpenTelemetry.Metrics.ReadOnlyExemplarCollection

--- a/src/OpenTelemetry/Metrics/Exemplar/ReadOnlyExemplarCollection.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/ReadOnlyExemplarCollection.cs
@@ -23,6 +23,7 @@ internal
 #endif
     readonly struct ReadOnlyExemplarCollection
 {
+    internal static readonly ReadOnlyExemplarCollection Empty = new(Array.Empty<Exemplar>());
     private readonly Exemplar[] exemplars;
 
     internal ReadOnlyExemplarCollection(Exemplar[] exemplars)
@@ -50,24 +51,39 @@ internal
 
     internal ReadOnlyExemplarCollection Copy()
     {
-        var exemplarCopies = new Exemplar[this.exemplars.Length];
+        var maximumCount = this.MaximumCount;
 
-        int i = 0;
-        foreach (ref readonly var exemplar in this)
+        if (maximumCount > 0)
         {
-            exemplar.Copy(ref exemplarCopies[i++]);
+            var exemplarCopies = new Exemplar[maximumCount];
+
+            int i = 0;
+            foreach (ref readonly var exemplar in this)
+            {
+                if (exemplar.IsUpdated())
+                {
+                    exemplar.Copy(ref exemplarCopies[i++]);
+                }
+            }
+
+            return new ReadOnlyExemplarCollection(exemplarCopies);
         }
 
-        return new ReadOnlyExemplarCollection(exemplarCopies);
+        return Empty;
     }
 
     internal IReadOnlyList<Exemplar> ToReadOnlyList()
     {
         var list = new List<Exemplar>(this.MaximumCount);
 
-        foreach (var item in this)
+        foreach (var exemplar in this)
         {
-            list.Add(item);
+            if (exemplar.IsUpdated())
+            {
+                var newExemplar = default(Exemplar);
+                exemplar.Copy(ref newExemplar);
+                list.Add(newExemplar);
+            }
         }
 
         return list;

--- a/src/OpenTelemetry/Metrics/Exemplar/ReadOnlyExemplarCollection.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/ReadOnlyExemplarCollection.cs
@@ -78,12 +78,10 @@ internal
 
         foreach (var exemplar in this)
         {
-            if (exemplar.IsUpdated())
-            {
-                var newExemplar = default(Exemplar);
-                exemplar.Copy(ref newExemplar);
-                list.Add(newExemplar);
-            }
+            // Note: If ToReadOnlyList is ever made public it should make sure
+            // to take copies of exemplars or make sure the instance was first
+            // copied using the Copy method above.
+            list.Add(exemplar);
         }
 
         return list;

--- a/src/OpenTelemetry/Metrics/MetricPointOptionalComponents.cs
+++ b/src/OpenTelemetry/Metrics/MetricPointOptionalComponents.cs
@@ -20,7 +20,7 @@ internal sealed class MetricPointOptionalComponents
 
     public ExemplarReservoir? ExemplarReservoir;
 
-    public ReadOnlyExemplarCollection? Exemplars;
+    public ReadOnlyExemplarCollection Exemplars = ReadOnlyExemplarCollection.Empty;
 
     private int isCriticalSectionOccupied = 0;
 
@@ -30,7 +30,7 @@ internal sealed class MetricPointOptionalComponents
         {
             HistogramBuckets = this.HistogramBuckets?.Copy(),
             Base2ExponentialBucketHistogram = this.Base2ExponentialBucketHistogram?.Copy(),
-            Exemplars = this.Exemplars?.Copy(),
+            Exemplars = this.Exemplars.Copy(),
         };
 
         return copy;

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
@@ -849,7 +849,7 @@ public class OtlpMetricsExporterTests : Http2UnencryptedSupportTests
             var result = metricPoint.TryGetExemplars(out var exemplars);
             Assert.True(result);
 
-            var exemplarEnumerator = exemplars.Value.GetEnumerator();
+            var exemplarEnumerator = exemplars.GetEnumerator();
             Assert.True(exemplarEnumerator.MoveNext());
 
             ref readonly var exemplar = ref exemplarEnumerator.Current;

--- a/test/OpenTelemetry.Tests/Metrics/MetricTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricTestsBase.cs
@@ -237,7 +237,7 @@ public class MetricTestsBase
     {
         if (mp.TryGetExemplars(out var exemplars))
         {
-            return exemplars.Value.ToReadOnlyList();
+            return exemplars.ToReadOnlyList();
         }
 
         return Array.Empty<Exemplar>();


### PR DESCRIPTION
## Changes

* Tweak the signature of `MetricPoint.TryGetExemplars` to not use `Nullable<ReadOnlyExemplarCollection>`:

   ```diff
   - bool TryGetExemplars(out ReadOnlyExemplarCollection? exemplars)
   + bool TryGetExemplars(out ReadOnlyExemplarCollection exemplars)
   ```

* Tweak `MetricPointOptionalComponents.Exemplars` to not use `Nullable<ReadOnlyExemplarCollection>`:

   ```diff
   - public ReadOnlyExemplarCollection? Exemplars;
   + public ReadOnlyExemplarCollection Exemplars = ReadOnlyExemplarCollection.Empty;
   ```

* Improve `ReadOnlyExemplarCollection.Copy` to skip exemplars without updates.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
