### PR TITLE
[sdk-metrics] Support setting exemplar filter from spec envvar key

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -70,6 +70,12 @@
   Specification](https://github.com/open-telemetry/opentelemetry-specification/pull/3820).
   ([#5404](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5404))
 
+* **Experimental (pre-release builds only):** The `ExemplarFilter` used by SDK
+  `MeterProvider`s can now be controlled via the `OTEL_METRICS_EXEMPLAR_FILTER`
+  environment variable. For details see: [OpenTelemetry Environment Variable
+  Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#exemplar).
+  ([#5412](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5412))
+
 ## 1.7.0
 
 Released 2023-Dec-08

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -72,7 +72,8 @@
 
 * **Experimental (pre-release builds only):** The `ExemplarFilter` used by SDK
   `MeterProvider`s can now be controlled via the `OTEL_METRICS_EXEMPLAR_FILTER`
-  environment variable. For details see: [OpenTelemetry Environment Variable
+  environment variable. The supported values are: `always_off`, `always_on`, and
+  `trace_based`. For details see: [OpenTelemetry Environment Variable
   Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#exemplar).
   ([#5412](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5412))
 

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -523,6 +523,12 @@ internal sealed class MeterProviderSdk : MeterProvider
 
             OpenTelemetrySdkEventSource.Log.MeterProviderSdkEvent($"Exemplar filter set to '{exemplarFilter}' from configuration.");
         }
+#else
+        if (configuration.TryGetStringValue(ExemplarFilterConfigKey, out var configValue))
+        {
+            OpenTelemetrySdkEventSource.Log.MeterProviderSdkEvent(
+                $"Exemplar filter configuration value '{configValue}' has been ignored because exemplars are an experimental feature not available in stable builds.");
+        }
 #endif
     }
 }

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -15,7 +15,7 @@ internal sealed class MeterProviderSdk : MeterProvider
 {
     internal const string EmitOverFlowAttributeConfigKey = "OTEL_DOTNET_EXPERIMENTAL_METRICS_EMIT_OVERFLOW_ATTRIBUTE";
     internal const string ReclaimUnusedMetricPointsConfigKey = "OTEL_DOTNET_EXPERIMENTAL_METRICS_RECLAIM_UNUSED_METRIC_POINTS";
-    internal const string ExemplarFilterConfigKey = "OTEL_DOTNET_EXPERIMENTAL_METRICS_EXEMPLAR_FILTER";
+    internal const string ExemplarFilterConfigKey = "OTEL_METRICS_EXEMPLAR_FILTER";
 
     internal readonly IServiceProvider ServiceProvider;
     internal readonly IDisposable? OwnedServiceProvider;
@@ -490,6 +490,7 @@ internal sealed class MeterProviderSdk : MeterProvider
             OpenTelemetrySdkEventSource.Log.MeterProviderSdkEvent("Reclaim unused metric point feature enabled via configuration.");
         }
 
+#if EXPOSE_EXPERIMENTAL_FEATURES
         if (configuration.TryGetStringValue(ExemplarFilterConfigKey, out var configValue))
         {
             if (this.ExemplarFilter.HasValue)
@@ -522,5 +523,6 @@ internal sealed class MeterProviderSdk : MeterProvider
 
             OpenTelemetrySdkEventSource.Log.MeterProviderSdkEvent($"Exemplar filter set to '{exemplarFilter}' from configuration.");
         }
+#endif
     }
 }

--- a/src/OpenTelemetry/Metrics/MetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/MetricReaderExt.cs
@@ -23,7 +23,7 @@ public abstract partial class MetricReader
     private Metric[]? metricsCurrentBatch;
     private int metricIndex = -1;
     private bool emitOverflowAttribute;
-
+    private bool reclaimUnusedMetricPoints;
     private ExemplarFilterType? exemplarFilter;
 
     internal static void DeactivateMetric(Metric metric)
@@ -72,8 +72,7 @@ public abstract partial class MetricReader
                 Metric? metric = null;
                 try
                 {
-                    bool shouldReclaimUnusedMetricPoints = this.parentProvider is MeterProviderSdk meterProviderSdk && meterProviderSdk.ShouldReclaimUnusedMetricPoints;
-                    metric = new Metric(metricStreamIdentity, this.GetAggregationTemporality(metricStreamIdentity.InstrumentType), this.cardinalityLimit, this.emitOverflowAttribute, shouldReclaimUnusedMetricPoints, this.exemplarFilter);
+                    metric = new Metric(metricStreamIdentity, this.GetAggregationTemporality(metricStreamIdentity.InstrumentType), this.cardinalityLimit, this.emitOverflowAttribute, this.reclaimUnusedMetricPoints, this.exemplarFilter);
                 }
                 catch (NotSupportedException nse)
                 {
@@ -145,14 +144,12 @@ public abstract partial class MetricReader
                 }
                 else
                 {
-                    bool shouldReclaimUnusedMetricPoints = this.parentProvider is MeterProviderSdk meterProviderSdk && meterProviderSdk.ShouldReclaimUnusedMetricPoints;
-
                     Metric metric = new(
                         metricStreamIdentity,
                         this.GetAggregationTemporality(metricStreamIdentity.InstrumentType),
                         metricStreamConfig?.CardinalityLimit ?? this.cardinalityLimit,
                         this.emitOverflowAttribute,
-                        shouldReclaimUnusedMetricPoints,
+                        this.reclaimUnusedMetricPoints,
                         this.exemplarFilter,
                         metricStreamConfig?.ExemplarReservoirFactory);
 
@@ -171,16 +168,18 @@ public abstract partial class MetricReader
     internal void ApplyParentProviderSettings(
         int metricLimit,
         int cardinalityLimit,
-        ExemplarFilterType? exemplarFilter,
-        bool isEmitOverflowAttributeKeySet)
+        bool emitOverflowAttribute,
+        bool reclaimUnusedMetricPoints,
+        ExemplarFilterType? exemplarFilter)
     {
         this.metricLimit = metricLimit;
         this.metrics = new Metric[metricLimit];
         this.metricsCurrentBatch = new Metric[metricLimit];
         this.cardinalityLimit = cardinalityLimit;
+        this.reclaimUnusedMetricPoints = reclaimUnusedMetricPoints;
         this.exemplarFilter = exemplarFilter;
 
-        if (isEmitOverflowAttributeKeySet)
+        if (emitOverflowAttribute)
         {
             // We need at least two metric points. One is reserved for zero tags and the other one for overflow attribute
             if (cardinalityLimit > 1)

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetry.Extensions.Hosting.Tests.csproj
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetry.Extensions.Hosting.Tests.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\EventSourceTestHelper.cs" Link="Includes\EventSourceTestHelper.cs" />
+    <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\SkipUnlessTrueTheoryAttribute.cs" Link="Includes\SkipUnlessTrueTheoryAttribute.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestEventListener.cs" Link="Includes\TestEventListener.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\Utils.cs" Link="Includes\Utils.cs" />
   </ItemGroup>

--- a/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
@@ -18,15 +18,15 @@ public class MetricExemplarTests : MetricTestsBase
 
     [Theory]
     [InlineData(null, null, null)]
-    [InlineData(null, "always_off", ExemplarFilterType.AlwaysOff)]
-    [InlineData(null, "ALWays_ON", ExemplarFilterType.AlwaysOn)]
-    [InlineData(null, "trace_based", ExemplarFilterType.TraceBased)]
+    [InlineData(null, "always_off", (int)ExemplarFilterType.AlwaysOff)]
+    [InlineData(null, "ALWays_ON", (int)ExemplarFilterType.AlwaysOn)]
+    [InlineData(null, "trace_based", (int)ExemplarFilterType.TraceBased)]
     [InlineData(null, "invalid", null)]
-    [InlineData(ExemplarFilterType.AlwaysOn, "trace_based", ExemplarFilterType.AlwaysOn)]
+    [InlineData((int)ExemplarFilterType.AlwaysOn, "trace_based", (int)ExemplarFilterType.AlwaysOn)]
     public void TestExemplarFilterSetFromConfiguration(
-        ExemplarFilterType? programmaticValue,
+        int? programmaticValue,
         string? configValue,
-        ExemplarFilterType? expectedValue)
+        int? expectedValue)
     {
         var configBuilder = new ConfigurationBuilder();
         if (!string.IsNullOrEmpty(configValue))
@@ -44,14 +44,14 @@ public class MetricExemplarTests : MetricTestsBase
 
             if (programmaticValue.HasValue)
             {
-                b.SetExemplarFilter(programmaticValue.Value);
+                b.SetExemplarFilter(((ExemplarFilterType?)programmaticValue).Value);
             }
         });
 
         var meterProviderSdk = meterProvider as MeterProviderSdk;
 
         Assert.NotNull(meterProviderSdk);
-        Assert.Equal(expectedValue, meterProviderSdk.ExemplarFilter);
+        Assert.Equal((ExemplarFilterType?)expectedValue, meterProviderSdk.ExemplarFilter);
     }
 
     [Theory]

--- a/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
@@ -15,8 +15,9 @@ namespace OpenTelemetry.Metrics.Tests;
 public class MetricExemplarTests : MetricTestsBase
 {
     private const int MaxTimeToAllowForFlush = 10000;
+    private static readonly Func<bool> IsExemplarApiExposed = () => typeof(ExemplarFilterType).IsVisible;
 
-    [Theory]
+    [SkipUnlessTrueTheory(typeof(MetricExemplarTests), nameof(IsExemplarApiExposed), "ExemplarFilter config tests skipped for stable builds")]
     [InlineData(null, null, null)]
     [InlineData(null, "always_off", (int)ExemplarFilterType.AlwaysOff)]
     [InlineData(null, "ALWays_ON", (int)ExemplarFilterType.AlwaysOn)]

--- a/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTestsBase.cs
@@ -57,7 +57,7 @@ public abstract class MetricPointReclaimTestsBase
             .Build();
 
         var meterProviderSdk = meterProvider as MeterProviderSdk;
-        Assert.Equal(isReclaimAttributeKeySet, meterProviderSdk.ShouldReclaimUnusedMetricPoints);
+        Assert.Equal(isReclaimAttributeKeySet, meterProviderSdk.ReclaimUnusedMetricPoints);
     }
 
     [Theory]
@@ -87,7 +87,7 @@ public abstract class MetricPointReclaimTestsBase
             .Build();
 
         var meterProviderSdk = meterProvider as MeterProviderSdk;
-        Assert.Equal(isReclaimAttributeKeySet, meterProviderSdk.ShouldReclaimUnusedMetricPoints);
+        Assert.Equal(isReclaimAttributeKeySet, meterProviderSdk.ReclaimUnusedMetricPoints);
     }
 
     [Theory]

--- a/test/OpenTelemetry.Tests/Shared/SkipUnlessTrueTheoryAttribute.cs
+++ b/test/OpenTelemetry.Tests/Shared/SkipUnlessTrueTheoryAttribute.cs
@@ -1,0 +1,33 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Reflection;
+using OpenTelemetry.Internal;
+using Xunit;
+
+namespace OpenTelemetry.Tests;
+
+internal sealed class SkipUnlessTrueTheoryAttribute : TheoryAttribute
+{
+    public SkipUnlessTrueTheoryAttribute(Type typeContainingTest, string testFieldName, string skipMessage)
+    {
+        Guard.ThrowIfNull(typeContainingTest);
+        Guard.ThrowIfNullOrEmpty(testFieldName);
+        Guard.ThrowIfNullOrEmpty(skipMessage);
+
+        var field = typeContainingTest.GetField(testFieldName, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException($"Static field '{testFieldName}' could not be found on '{typeContainingTest}' type.");
+
+        if (field.FieldType != typeof(Func<bool>))
+        {
+            throw new InvalidOperationException($"Field '{testFieldName}' on '{typeContainingTest}' type should be defined as '{typeof(Func<bool>)}'.");
+        }
+
+        var testFunc = (Func<bool>)field.GetValue(null);
+
+        if (!testFunc())
+        {
+            this.Skip = skipMessage;
+        }
+    }
+}


### PR DESCRIPTION
## Changes

* Adds support for configuring exemplar filter via `OTEL_METRICS_EXEMPLAR_FILTER`.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
