### PR TITLE
[sdk-metrics] Pass all tags supplied at measurement to ExemplarReservoir.Offer methods

### DIFF
--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -959,7 +959,7 @@ internal sealed class AggregatorStore
     {
         var index = this.FindMetricAggregatorsDefault(tags);
 
-        this.UpdateLongMetricPoint(index, value, tags: default);
+        this.UpdateLongMetricPoint(index, value, tags);
     }
 
     private void UpdateLongCustomTags(long value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
@@ -1014,7 +1014,7 @@ internal sealed class AggregatorStore
     {
         var index = this.FindMetricAggregatorsDefault(tags);
 
-        this.UpdateDoubleMetricPoint(index, value, tags: default);
+        this.UpdateDoubleMetricPoint(index, value, tags);
     }
 
     private void UpdateDoubleCustomTags(double value, ReadOnlySpan<KeyValuePair<string, object?>> tags)

--- a/src/OpenTelemetry/Metrics/Exemplar/Exemplar.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/Exemplar.cs
@@ -131,7 +131,10 @@ internal
             this.SpanId = default;
         }
 
-        this.StoreRawTags(measurement.Tags);
+        if (this.ViewDefinedTagKeys != null)
+        {
+            this.StoreRawTags(measurement.Tags);
+        }
     }
 
     internal void Reset()


### PR DESCRIPTION
## Changes

* Pass all tags supplied at measurement to `ExemplarReservoir.Offer` methods to make [the promise true](https://github.com/open-telemetry/opentelemetry-dotnet/blob/123c0b4b6909ddc0dadbff1dbc9a612ae5555993/src/OpenTelemetry/Metrics/Exemplar/ExemplarMeasurement.cs#L55-L57).

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
