### PR TITLE
Reduce memory usage by reclaimed MetricPoint

### DIFF
--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -297,9 +297,7 @@ internal sealed class AggregatorStore
                 {
                     var lookupData = metricPoint.LookupData;
 
-                    // Setting `LookupData` to `null` to denote that this MetricPoint is reclaimed.
-                    // Snapshot method can use this to skip trying to reclaim indices which have already been reclaimed and added to the queue.
-                    metricPoint.LookupData = null;
+                    metricPoint.Reclaim();
 
                     Debug.Assert(this.TagsToMetricPointIndexDictionaryDelta != null, "this.tagsToMetricPointIndexDictionaryDelta was null");
 


### PR DESCRIPTION
## Changes

Current MetricPoint reclaim mechanism leaves lots of unused objects in memory (histogram buckets, exemplar). With this change these objects can be garbage collected.

Tested with a sample program:
1. Emits high cardinality (171x3x1000x2x593) metric.
2. Maximum number of metric points allowed per metric stream is 50000.
3. Histograms configured to use 165 fixed buckets.

Heap snapshot before the change:
![image](https://github.com/open-telemetry/opentelemetry-dotnet/assets/581410/e1d65ee7-43c9-4cd7-ae81-1498ad303cb0)

Heap snapshot after the change:
![image](https://github.com/open-telemetry/opentelemetry-dotnet/assets/581410/3f49b09b-db26-4d89-a4f8-a5d1880f9506)


## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
