### PR TITLE
[repo-shared] Remove the new() constraint from Options API helpers

### DIFF
--- a/src/Shared/Options/ConfigurationExtensions.cs
+++ b/src/Shared/Options/ConfigurationExtensions.cs
@@ -129,7 +129,7 @@ internal static class ConfigurationExtensions
     public static IServiceCollection RegisterOptionsFactory<T>(
         this IServiceCollection services,
         Func<IConfiguration, T> optionsFactoryFunc)
-        where T : class, new()
+        where T : class
     {
         Debug.Assert(services != null, "services was null");
         Debug.Assert(optionsFactoryFunc != null, "optionsFactoryFunc was null");
@@ -150,7 +150,7 @@ internal static class ConfigurationExtensions
     public static IServiceCollection RegisterOptionsFactory<T>(
         this IServiceCollection services,
         Func<IServiceProvider, IConfiguration, string, T> optionsFactoryFunc)
-        where T : class, new()
+        where T : class
     {
         Debug.Assert(services != null, "services was null");
         Debug.Assert(optionsFactoryFunc != null, "optionsFactoryFunc was null");

--- a/src/Shared/Options/DelegatingOptionsFactory.cs
+++ b/src/Shared/Options/DelegatingOptionsFactory.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Extensions.Options
     /// <typeparam name="TOptions">The type of options being requested.</typeparam>
     internal sealed class DelegatingOptionsFactory<TOptions> :
         IOptionsFactory<TOptions>
-        where TOptions : class, new()
+        where TOptions : class
     {
         private readonly Func<IConfiguration, string, TOptions> optionsFactoryFunc;
         private readonly IConfiguration configuration;


### PR DESCRIPTION
[Originally part of #5400]

## Changes

* Remove the `new()` constraint from Options API helpers. This [was required on TOptions when using `IOptionsFactory<TOptions>` v3.1](https://learn.microsoft.com/dotnet/api/microsoft.extensions.options.ioptionsfactory-1?view=dotnet-plat-ext-3.1) but was later removed [`IOptionsFactory<TOptions>` v5.0](https://learn.microsoft.com/dotnet/api/microsoft.extensions.options.ioptionsfactory-1?view=dotnet-plat-ext-5.0).

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
