### PR TITLE
[sdk] Add ActivityExportProcessorOptions and clean up MetricReaderOptions

### DIFF
--- a/src/OpenTelemetry/.publicApi/Stable/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/Stable/PublicAPI.Unshipped.txt
@@ -1,4 +1,10 @@
 OpenTelemetry.OpenTelemetryBuilderSdkExtensions
+OpenTelemetry.Trace.ActivityExportProcessorOptions
+OpenTelemetry.Trace.ActivityExportProcessorOptions.ActivityExportProcessorOptions() -> void
+OpenTelemetry.Trace.ActivityExportProcessorOptions.BatchExportProcessorOptions.get -> OpenTelemetry.Trace.BatchExportActivityProcessorOptions!
+OpenTelemetry.Trace.ActivityExportProcessorOptions.BatchExportProcessorOptions.set -> void
+OpenTelemetry.Trace.ActivityExportProcessorOptions.ExportProcessorType.get -> OpenTelemetry.ExportProcessorType
+OpenTelemetry.Trace.ActivityExportProcessorOptions.ExportProcessorType.set -> void
 static OpenTelemetry.OpenTelemetryBuilderSdkExtensions.ConfigureResource(this OpenTelemetry.IOpenTelemetryBuilder! builder, System.Action<OpenTelemetry.Resources.ResourceBuilder!>! configure) -> OpenTelemetry.IOpenTelemetryBuilder!
 static OpenTelemetry.OpenTelemetryBuilderSdkExtensions.WithMetrics(this OpenTelemetry.IOpenTelemetryBuilder! builder) -> OpenTelemetry.IOpenTelemetryBuilder!
 static OpenTelemetry.OpenTelemetryBuilderSdkExtensions.WithMetrics(this OpenTelemetry.IOpenTelemetryBuilder! builder, System.Action<OpenTelemetry.Metrics.MeterProviderBuilder!>! configure) -> OpenTelemetry.IOpenTelemetryBuilder!

--- a/src/OpenTelemetry/Internal/Builder/ProviderBuilderServiceCollectionExtensions.cs
+++ b/src/OpenTelemetry/Internal/Builder/ProviderBuilderServiceCollectionExtensions.cs
@@ -21,13 +21,6 @@ internal static class ProviderBuilderServiceCollectionExtensions
 
         services!.TryAddSingleton<LoggerProviderBuilderSdk>();
         services!.RegisterOptionsFactory(configuration => new BatchExportLogRecordProcessorOptions(configuration));
-
-        // Note: This registers a factory so that when
-        // sp.GetRequiredService<IOptionsMonitor<LogRecordExportProcessorOptions>>().Get(name)))
-        // is executed the SDK internal
-        // BatchExportLogRecordProcessorOptions(IConfiguration) ctor is used
-        // correctly which allows users to control the OTEL_BLRP_* keys using
-        // IConfiguration (envvars, appSettings, cli, etc.).
         services!.RegisterOptionsFactory(
             (sp, configuration, name) => new LogRecordExportProcessorOptions(
                 sp.GetRequiredService<IOptionsMonitor<BatchExportLogRecordProcessorOptions>>().Get(name)));
@@ -40,7 +33,10 @@ internal static class ProviderBuilderServiceCollectionExtensions
         Debug.Assert(services != null, "services was null");
 
         services!.TryAddSingleton<MeterProviderBuilderSdk>();
-        services!.RegisterOptionsFactory(configuration => new MetricReaderOptions(configuration));
+        services!.RegisterOptionsFactory(configuration => new PeriodicExportingMetricReaderOptions(configuration));
+        services!.RegisterOptionsFactory(
+            (sp, configuration, name) => new MetricReaderOptions(
+                sp.GetRequiredService<IOptionsMonitor<PeriodicExportingMetricReaderOptions>>().Get(name)));
 
         return services!;
     }
@@ -51,6 +47,9 @@ internal static class ProviderBuilderServiceCollectionExtensions
 
         services!.TryAddSingleton<TracerProviderBuilderSdk>();
         services!.RegisterOptionsFactory(configuration => new BatchExportActivityProcessorOptions(configuration));
+        services!.RegisterOptionsFactory(
+            (sp, configuration, name) => new ActivityExportProcessorOptions(
+                sp.GetRequiredService<IOptionsMonitor<BatchExportActivityProcessorOptions>>().Get(name)));
 
         return services!;
     }

--- a/src/OpenTelemetry/Metrics/MetricReaderOptions.cs
+++ b/src/OpenTelemetry/Metrics/MetricReaderOptions.cs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using Microsoft.Extensions.Configuration;
+using System.Diagnostics;
 using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Metrics;
@@ -17,13 +17,16 @@ public class MetricReaderOptions
     /// Initializes a new instance of the <see cref="MetricReaderOptions"/> class.
     /// </summary>
     public MetricReaderOptions()
-        : this(new ConfigurationBuilder().AddEnvironmentVariables().Build())
+        : this(new())
     {
     }
 
-    internal MetricReaderOptions(IConfiguration configuration)
+    internal MetricReaderOptions(
+        PeriodicExportingMetricReaderOptions defaultPeriodicExportingMetricReaderOptions)
     {
-        this.periodicExportingMetricReaderOptions = new PeriodicExportingMetricReaderOptions(configuration);
+        Debug.Assert(defaultPeriodicExportingMetricReaderOptions != null, "defaultPeriodicExportingMetricReaderOptions was null");
+
+        this.periodicExportingMetricReaderOptions = defaultPeriodicExportingMetricReaderOptions ?? new();
     }
 
     /// <summary>

--- a/src/OpenTelemetry/Trace/ActivityExportProcessorOptions.cs
+++ b/src/OpenTelemetry/Trace/ActivityExportProcessorOptions.cs
@@ -1,0 +1,49 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Trace;
+
+/// <summary>
+/// Options for configuring either a <see cref="SimpleActivityExportProcessor"/> or <see cref="BatchActivityExportProcessor"/>.
+/// </summary>
+public class ActivityExportProcessorOptions
+{
+    private BatchExportActivityProcessorOptions batchExportProcessorOptions;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ActivityExportProcessorOptions"/> class.
+    /// </summary>
+    public ActivityExportProcessorOptions()
+        : this(new())
+    {
+    }
+
+    internal ActivityExportProcessorOptions(
+        BatchExportActivityProcessorOptions defaultBatchExportActivityProcessorOptions)
+    {
+        Debug.Assert(defaultBatchExportActivityProcessorOptions != null, "defaultBatchExportActivityProcessorOptions was null");
+
+        this.batchExportProcessorOptions = defaultBatchExportActivityProcessorOptions ?? new();
+    }
+
+    /// <summary>
+    /// Gets or sets the export processor type to be used. The default value is <see cref="ExportProcessorType.Batch"/>.
+    /// </summary>
+    public ExportProcessorType ExportProcessorType { get; set; } = ExportProcessorType.Batch;
+
+    /// <summary>
+    /// Gets or sets the batch export options. Ignored unless <see cref="ExportProcessorType"/> is <see cref="ExportProcessorType.Batch"/>.
+    /// </summary>
+    public BatchExportActivityProcessorOptions BatchExportProcessorOptions
+    {
+        get => this.batchExportProcessorOptions;
+        set
+        {
+            Guard.ThrowIfNull(value);
+            this.batchExportProcessorOptions = value;
+        }
+    }
+}

--- a/test/OpenTelemetry.Tests/Internal/PeriodicExportingMetricReaderHelperTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/PeriodicExportingMetricReaderHelperTests.cs
@@ -109,10 +109,10 @@ public sealed class PeriodicExportingMetricReaderHelperTests : IDisposable
             .AddInMemoryCollection(values)
             .Build();
 
-        var options = new MetricReaderOptions(configuration);
+        var options = new PeriodicExportingMetricReaderOptions(configuration);
 
-        Assert.Equal(18, options.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds);
-        Assert.Equal(19, options.PeriodicExportingMetricReaderOptions.ExportTimeoutMilliseconds);
+        Assert.Equal(18, options.ExportIntervalMilliseconds);
+        Assert.Equal(19, options.ExportTimeoutMilliseconds);
     }
 
     [Fact]


### PR DESCRIPTION
[Originally part of #5400]

## Changes

* Adds `ActivityExportProcessorOptions` for tracing. This brings tracing in line with logging (`LogRecordExportProcessorOptions`) and metrics (`MetricReaderOptions`).
* Fixes options registrations so that all three signals work the same way:
  * Logging users can access\bind `LogRecordExportProcessorOptions` (already in place) or `BatchExportLogRecordProcessorOptions` (already in place)
  * Metrics users can access\bind `MetricReaderOptions` (already in place) or `PeriodicExportingMetricReaderOptions` (added on this pr)
  * Tracing users can access\bind `ActivityExportProcessorOptions` (added on this pr) or `BatchExportActivityProcessorOptions` (already in place)

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
