### PR TITLE
[otlp] Move spec envvar key definitions to a single spot

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpExporterSpecEnvVarKeyDefinitions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpExporterSpecEnvVarKeyDefinitions.cs
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Exporter;
+
+internal static class OtlpExporterSpecEnvVarKeyDefinitions
+{
+    public const string DefaultEndpointEnvVarName = "OTEL_EXPORTER_OTLP_ENDPOINT";
+    public const string DefaultHeadersEnvVarName = "OTEL_EXPORTER_OTLP_HEADERS";
+    public const string DefaultTimeoutEnvVarName = "OTEL_EXPORTER_OTLP_TIMEOUT";
+    public const string DefaultProtocolEnvVarName = "OTEL_EXPORTER_OTLP_PROTOCOL";
+
+    public const string MetricsTemporalityPreferenceEnvVarName = "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE";
+}

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpExporterSpecEnvVarKeyDefinitions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpExporterSpecEnvVarKeyDefinitions.cs
@@ -3,6 +3,12 @@
 
 namespace OpenTelemetry.Exporter;
 
+/// <summary>
+/// Contains spec environment variable key definitions for OpenTelemetry Protocol (OTLP) exporter.
+/// </summary>
+/// <remarks>
+/// Specification: <see href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md"/>.
+/// </remarks>
 internal static class OtlpExporterSpecEnvVarKeyDefinitions
 {
     public const string DefaultEndpointEnvVarName = "OTEL_EXPORTER_OTLP_ENDPOINT";

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -22,11 +22,6 @@ namespace OpenTelemetry.Exporter;
 /// </summary>
 public class OtlpExporterOptions
 {
-    internal const string EndpointEnvVarName = "OTEL_EXPORTER_OTLP_ENDPOINT";
-    internal const string HeadersEnvVarName = "OTEL_EXPORTER_OTLP_HEADERS";
-    internal const string TimeoutEnvVarName = "OTEL_EXPORTER_OTLP_TIMEOUT";
-    internal const string ProtocolEnvVarName = "OTEL_EXPORTER_OTLP_PROTOCOL";
-
     internal static readonly KeyValuePair<string, string>[] StandardHeaders = new KeyValuePair<string, string>[]
     {
         new KeyValuePair<string, string>("User-Agent", GetUserAgentString()),
@@ -56,23 +51,23 @@ public class OtlpExporterOptions
         Debug.Assert(configuration != null, "configuration was null");
         Debug.Assert(defaultBatchOptions != null, "defaultBatchOptions was null");
 
-        if (configuration.TryGetUriValue(EndpointEnvVarName, out var endpoint))
+        if (configuration.TryGetUriValue(OtlpExporterSpecEnvVarKeyDefinitions.DefaultEndpointEnvVarName, out var endpoint))
         {
             this.endpoint = endpoint;
         }
 
-        if (configuration.TryGetStringValue(HeadersEnvVarName, out var headers))
+        if (configuration.TryGetStringValue(OtlpExporterSpecEnvVarKeyDefinitions.DefaultHeadersEnvVarName, out var headers))
         {
             this.Headers = headers;
         }
 
-        if (configuration.TryGetIntValue(TimeoutEnvVarName, out var timeout))
+        if (configuration.TryGetIntValue(OtlpExporterSpecEnvVarKeyDefinitions.DefaultTimeoutEnvVarName, out var timeout))
         {
             this.TimeoutMilliseconds = timeout;
         }
 
         if (configuration.TryGetValue<OtlpExportProtocol>(
-            ProtocolEnvVarName,
+            OtlpExporterSpecEnvVarKeyDefinitions.DefaultProtocolEnvVarName,
             OtlpExportProtocolParser.TryParse,
             out var protocol))
         {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
@@ -16,8 +16,6 @@ namespace OpenTelemetry.Metrics;
 /// </summary>
 public static class OtlpMetricExporterExtensions
 {
-    internal const string OtlpMetricExporterTemporalityPreferenceEnvVarKey = "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE";
-
     /// <summary>
     /// Adds <see cref="OtlpMetricExporter"/> to the <see cref="MeterProviderBuilder"/> using default options.
     /// </summary>
@@ -65,7 +63,7 @@ public static class OtlpMetricExporterExtensions
             services.AddOptions<MetricReaderOptions>(finalOptionsName).Configure<IConfiguration>(
                 (readerOptions, config) =>
                 {
-                    var otlpTemporalityPreference = config[OtlpMetricExporterTemporalityPreferenceEnvVarKey];
+                    var otlpTemporalityPreference = config[OtlpExporterSpecEnvVarKeyDefinitions.MetricsTemporalityPreferenceEnvVarName];
                     if (!string.IsNullOrWhiteSpace(otlpTemporalityPreference)
                         && Enum.TryParse<MetricReaderTemporalityPreference>(otlpTemporalityPreference, ignoreCase: true, out var enumValue))
                     {
@@ -142,7 +140,7 @@ public static class OtlpMetricExporterExtensions
             services.AddOptions<MetricReaderOptions>(finalOptionsName).Configure<IConfiguration>(
                 (readerOptions, config) =>
                 {
-                    var otlpTemporalityPreference = config[OtlpMetricExporterTemporalityPreferenceEnvVarKey];
+                    var otlpTemporalityPreference = config[OtlpExporterSpecEnvVarKeyDefinitions.MetricsTemporalityPreferenceEnvVarName];
                     if (!string.IsNullOrWhiteSpace(otlpTemporalityPreference)
                         && Enum.TryParse<MetricReaderTemporalityPreference>(otlpTemporalityPreference, ignoreCase: true, out var enumValue))
                     {

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/BaseOtlpHttpExportClientTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/BaseOtlpHttpExportClientTests.cs
@@ -21,7 +21,7 @@ public class BaseOtlpHttpExportClientTests
     {
         try
         {
-            Environment.SetEnvironmentVariable(OtlpExporterOptions.EndpointEnvVarName, endpointEnvVar);
+            Environment.SetEnvironmentVariable(OtlpExporterSpecEnvVarKeyDefinitions.DefaultEndpointEnvVarName, endpointEnvVar);
 
             OtlpExporterOptions options = new() { Protocol = OtlpExportProtocol.HttpProtobuf };
 
@@ -35,7 +35,7 @@ public class BaseOtlpHttpExportClientTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable(OtlpExporterOptions.EndpointEnvVarName, null);
+            Environment.SetEnvironmentVariable(OtlpExporterSpecEnvVarKeyDefinitions.DefaultEndpointEnvVarName, null);
         }
     }
 

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsTests.cs
@@ -46,10 +46,10 @@ public class OtlpExporterOptionsTests : IDisposable
     [Fact]
     public void OtlpExporterOptions_EnvironmentVariableOverride()
     {
-        Environment.SetEnvironmentVariable(OtlpExporterOptions.EndpointEnvVarName, "http://test:8888");
-        Environment.SetEnvironmentVariable(OtlpExporterOptions.HeadersEnvVarName, "A=2,B=3");
-        Environment.SetEnvironmentVariable(OtlpExporterOptions.TimeoutEnvVarName, "2000");
-        Environment.SetEnvironmentVariable(OtlpExporterOptions.ProtocolEnvVarName, "http/protobuf");
+        Environment.SetEnvironmentVariable(OtlpExporterSpecEnvVarKeyDefinitions.DefaultEndpointEnvVarName, "http://test:8888");
+        Environment.SetEnvironmentVariable(OtlpExporterSpecEnvVarKeyDefinitions.DefaultHeadersEnvVarName, "A=2,B=3");
+        Environment.SetEnvironmentVariable(OtlpExporterSpecEnvVarKeyDefinitions.DefaultTimeoutEnvVarName, "2000");
+        Environment.SetEnvironmentVariable(OtlpExporterSpecEnvVarKeyDefinitions.DefaultProtocolEnvVarName, "http/protobuf");
 
         var options = new OtlpExporterOptions();
 
@@ -64,10 +64,10 @@ public class OtlpExporterOptionsTests : IDisposable
     {
         var values = new Dictionary<string, string>()
         {
-            [OtlpExporterOptions.EndpointEnvVarName] = "http://test:8888",
-            [OtlpExporterOptions.HeadersEnvVarName] = "A=2,B=3",
-            [OtlpExporterOptions.TimeoutEnvVarName] = "2000",
-            [OtlpExporterOptions.ProtocolEnvVarName] = "http/protobuf",
+            [OtlpExporterSpecEnvVarKeyDefinitions.DefaultEndpointEnvVarName] = "http://test:8888",
+            [OtlpExporterSpecEnvVarKeyDefinitions.DefaultHeadersEnvVarName] = "A=2,B=3",
+            [OtlpExporterSpecEnvVarKeyDefinitions.DefaultTimeoutEnvVarName] = "2000",
+            [OtlpExporterSpecEnvVarKeyDefinitions.DefaultProtocolEnvVarName] = "http/protobuf",
         };
 
         var configuration = new ConfigurationBuilder()
@@ -85,9 +85,9 @@ public class OtlpExporterOptionsTests : IDisposable
     [Fact]
     public void OtlpExporterOptions_InvalidEnvironmentVariableOverride()
     {
-        Environment.SetEnvironmentVariable(OtlpExporterOptions.EndpointEnvVarName, "invalid");
-        Environment.SetEnvironmentVariable(OtlpExporterOptions.TimeoutEnvVarName, "invalid");
-        Environment.SetEnvironmentVariable(OtlpExporterOptions.ProtocolEnvVarName, "invalid");
+        Environment.SetEnvironmentVariable(OtlpExporterSpecEnvVarKeyDefinitions.DefaultEndpointEnvVarName, "invalid");
+        Environment.SetEnvironmentVariable(OtlpExporterSpecEnvVarKeyDefinitions.DefaultTimeoutEnvVarName, "invalid");
+        Environment.SetEnvironmentVariable(OtlpExporterSpecEnvVarKeyDefinitions.DefaultProtocolEnvVarName, "invalid");
 
         var options = new OtlpExporterOptions();
 
@@ -99,10 +99,10 @@ public class OtlpExporterOptionsTests : IDisposable
     [Fact]
     public void OtlpExporterOptions_SetterOverridesEnvironmentVariable()
     {
-        Environment.SetEnvironmentVariable(OtlpExporterOptions.EndpointEnvVarName, "http://test:8888");
-        Environment.SetEnvironmentVariable(OtlpExporterOptions.HeadersEnvVarName, "A=2,B=3");
-        Environment.SetEnvironmentVariable(OtlpExporterOptions.TimeoutEnvVarName, "2000");
-        Environment.SetEnvironmentVariable(OtlpExporterOptions.ProtocolEnvVarName, "grpc");
+        Environment.SetEnvironmentVariable(OtlpExporterSpecEnvVarKeyDefinitions.DefaultEndpointEnvVarName, "http://test:8888");
+        Environment.SetEnvironmentVariable(OtlpExporterSpecEnvVarKeyDefinitions.DefaultHeadersEnvVarName, "A=2,B=3");
+        Environment.SetEnvironmentVariable(OtlpExporterSpecEnvVarKeyDefinitions.DefaultTimeoutEnvVarName, "2000");
+        Environment.SetEnvironmentVariable(OtlpExporterSpecEnvVarKeyDefinitions.DefaultProtocolEnvVarName, "grpc");
 
         var options = new OtlpExporterOptions
         {
@@ -121,7 +121,7 @@ public class OtlpExporterOptionsTests : IDisposable
     [Fact]
     public void OtlpExporterOptions_ProtocolSetterDoesNotOverrideCustomEndpointFromEnvVariables()
     {
-        Environment.SetEnvironmentVariable(OtlpExporterOptions.EndpointEnvVarName, "http://test:8888");
+        Environment.SetEnvironmentVariable(OtlpExporterSpecEnvVarKeyDefinitions.DefaultEndpointEnvVarName, "http://test:8888");
 
         var options = new OtlpExporterOptions { Protocol = OtlpExportProtocol.Grpc };
 
@@ -141,17 +141,17 @@ public class OtlpExporterOptionsTests : IDisposable
     [Fact]
     public void OtlpExporterOptions_EnvironmentVariableNames()
     {
-        Assert.Equal("OTEL_EXPORTER_OTLP_ENDPOINT", OtlpExporterOptions.EndpointEnvVarName);
-        Assert.Equal("OTEL_EXPORTER_OTLP_HEADERS", OtlpExporterOptions.HeadersEnvVarName);
-        Assert.Equal("OTEL_EXPORTER_OTLP_TIMEOUT", OtlpExporterOptions.TimeoutEnvVarName);
-        Assert.Equal("OTEL_EXPORTER_OTLP_PROTOCOL", OtlpExporterOptions.ProtocolEnvVarName);
+        Assert.Equal("OTEL_EXPORTER_OTLP_ENDPOINT", OtlpExporterSpecEnvVarKeyDefinitions.DefaultEndpointEnvVarName);
+        Assert.Equal("OTEL_EXPORTER_OTLP_HEADERS", OtlpExporterSpecEnvVarKeyDefinitions.DefaultHeadersEnvVarName);
+        Assert.Equal("OTEL_EXPORTER_OTLP_TIMEOUT", OtlpExporterSpecEnvVarKeyDefinitions.DefaultTimeoutEnvVarName);
+        Assert.Equal("OTEL_EXPORTER_OTLP_PROTOCOL", OtlpExporterSpecEnvVarKeyDefinitions.DefaultProtocolEnvVarName);
     }
 
     private static void ClearEnvVars()
     {
-        Environment.SetEnvironmentVariable(OtlpExporterOptions.EndpointEnvVarName, null);
-        Environment.SetEnvironmentVariable(OtlpExporterOptions.HeadersEnvVarName, null);
-        Environment.SetEnvironmentVariable(OtlpExporterOptions.TimeoutEnvVarName, null);
-        Environment.SetEnvironmentVariable(OtlpExporterOptions.ProtocolEnvVarName, null);
+        Environment.SetEnvironmentVariable(OtlpExporterSpecEnvVarKeyDefinitions.DefaultEndpointEnvVarName, null);
+        Environment.SetEnvironmentVariable(OtlpExporterSpecEnvVarKeyDefinitions.DefaultHeadersEnvVarName, null);
+        Environment.SetEnvironmentVariable(OtlpExporterSpecEnvVarKeyDefinitions.DefaultTimeoutEnvVarName, null);
+        Environment.SetEnvironmentVariable(OtlpExporterSpecEnvVarKeyDefinitions.DefaultProtocolEnvVarName, null);
     }
 }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
@@ -1517,7 +1517,7 @@ public class OtlpLogExporterTests : Http2UnencryptedSupportTests
     {
         var values = new Dictionary<string, string>()
         {
-            [OtlpExporterOptions.EndpointEnvVarName] = "http://test:8888",
+            [OtlpExporterSpecEnvVarKeyDefinitions.DefaultEndpointEnvVarName] = "http://test:8888",
         };
 
         var configuration = new ConfigurationBuilder()


### PR DESCRIPTION
[Originally part of #5400]

## Changes

* Moves spec envvar key definitions to a single spot in OtlpExporter project.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
