### PR TITLE
[sdk-traces] Add support for OTEL_TRACES_SAMPLER and OTEL_TRACES_SAMPLER_ARG

### DIFF
--- a/docs/trace/customizing-the-sdk/README.md
+++ b/docs/trace/customizing-the-sdk/README.md
@@ -372,6 +372,7 @@ environmental variables:
 | `OTEL_TRACES_SAMPLER_ARG`        | String value to be used as the sampler argument. |
 
 The supported values for `OTEL_TRACES_SAMPLER` are:
+
 * `always_off`
 * `always_on`
 * `traceidratio`

--- a/docs/trace/customizing-the-sdk/README.md
+++ b/docs/trace/customizing-the-sdk/README.md
@@ -363,6 +363,14 @@ var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .Build();
 ```
 
+It is also possible to configure the sampler by using the following
+environmental variables:
+
+| Environment variable       | Description                                        |
+| -------------------------- | -------------------------------------------------- |
+| `OTEL_TRACES_SAMPLER` | Sampler to be used for traces. See the [General SDK Configuration specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration) for more details. |
+| `OTEL_TRACES_SAMPLER_ARG`        | String value to be used as the sampler argument. |
+
 Follow [this](../extending-the-sdk/README.md#sampler) document
 to learn about writing custom samplers.
 

--- a/docs/trace/customizing-the-sdk/README.md
+++ b/docs/trace/customizing-the-sdk/README.md
@@ -371,6 +371,17 @@ environmental variables:
 | `OTEL_TRACES_SAMPLER` | Sampler to be used for traces. See the [General SDK Configuration specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration) for more details. |
 | `OTEL_TRACES_SAMPLER_ARG`        | String value to be used as the sampler argument. |
 
+The supported values for `OTEL_TRACES_SAMPLER` are:
+* `always_off`
+* `always_on`
+* `traceidratio`
+* `parentbased_always_on`,
+* `parentbased_always_off`
+* `parentbased_traceidratio`
+
+The options `traceidratio` and `parentbased_traceidratio` may have the sampler
+probability configured via the `OTEL_TRACES_SAMPLER_ARG` environment variable.
+
 Follow [this](../extending-the-sdk/README.md#sampler) document
 to learn about writing custom samplers.
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -47,16 +47,6 @@
   [IMetricsListener](https://learn.microsoft.com/dotNet/api/microsoft.extensions.diagnostics.metrics.imetricslistener).
   ([#5265](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5265))
 
-* `TracerProvider`s can now have a sampler configured via the
-  `OTEL_TRACES_SAMPLER` environment variable. The supported values are:
-  `always_off`, `always_on`, `traceidratio`, `parentbased_always_on`,
-  `parentbased_always_off`, and `parentbased_traceidratio`. The options
-  `traceidratio` and `parentbased_traceidratio` may have the sampler probability
-  configured via the `OTEL_TRACES_SAMPLER_ARG` environment variable.
-  For details see: [OpenTelemetry Environment Variable
-  Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration).
-  ([#3601](https://github.com/open-telemetry/opentelemetry-dotnet/issues/3601))
-
 * **Experimental (pre-release builds only):** The `Exemplar.FilteredTags`
   property now returns a `ReadOnlyFilteredTagCollection` instance and the
   `Exemplar.LongValue` property has been added. The `MetricPoint.GetExemplars`
@@ -86,6 +76,16 @@
   `trace_based`. For details see: [OpenTelemetry Environment Variable
   Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#exemplar).
   ([#5412](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5412))
+
+* `TracerProvider`s can now have a sampler configured via the
+  `OTEL_TRACES_SAMPLER` environment variable. The supported values are:
+  `always_off`, `always_on`, `traceidratio`, `parentbased_always_on`,
+  `parentbased_always_off`, and `parentbased_traceidratio`. The options
+  `traceidratio` and `parentbased_traceidratio` may have the sampler probability
+  configured via the `OTEL_TRACES_SAMPLER_ARG` environment variable.
+  For details see: [OpenTelemetry Environment Variable
+  Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration).
+  ([#5448](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5448))
 
 ## 1.7.0
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -47,6 +47,16 @@
   [IMetricsListener](https://learn.microsoft.com/dotNet/api/microsoft.extensions.diagnostics.metrics.imetricslistener).
   ([#5265](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5265))
 
+* `TracerProvider`s can now have a sampler configured via the
+  `OTEL_TRACES_SAMPLER` environment variable. The supported values are:
+  `always_off`, `always_on`, `traceidratio`, `parentbased_always_on`,
+  `parentbased_always_off`, and `parentbased_traceidratio`. The options
+  `traceidratio` and `parentbased_traceidratio` may have the sampler probability
+  configured via the `OTEL_TRACES_SAMPLER_ARG` environment variable.
+  For details see: [OpenTelemetry Environment Variable
+  Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration).
+  ([#3601](https://github.com/open-telemetry/opentelemetry-dotnet/issues/3601))
+
 * **Experimental (pre-release builds only):** The `Exemplar.FilteredTags`
   property now returns a `ReadOnlyFilteredTagCollection` instance and the
   `Exemplar.LongValue` property has been added. The `MetricPoint.GetExemplars`

--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -355,7 +355,7 @@ internal sealed class OpenTelemetrySdkEventSource : EventSource
     [Event(55, Message = "OTEL_TRACES_SAMPLER_ARG configuration was found but the value '{0}' is invalid and will be ignored, default of value of '1.0' will be used.", Level = EventLevel.Warning)]
     public void TracesSamplerArgConfigInvalid(string configValue)
     {
-        this.WriteEvent(54, configValue);
+        this.WriteEvent(55, configValue);
     }
 
 #if DEBUG

--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -346,6 +346,18 @@ internal sealed class OpenTelemetrySdkEventSource : EventSource
         this.WriteEvent(53, instrumentName, meterName);
     }
 
+    [Event(54, Message = "OTEL_TRACES_SAMPLER configuration was found but the value '{0}' is invalid and will be ignored.", Level = EventLevel.Warning)]
+    public void TracesSamplerConfigInvalid(string configValue)
+    {
+        this.WriteEvent(54, configValue);
+    }
+
+    [Event(55, Message = "OTEL_TRACES_SAMPLER_ARG configuration was found but the value '{0}' is invalid and will be ignored, default of value of '1.0' will be used.", Level = EventLevel.Warning)]
+    public void TracesSamplerArgConfigInvalid(string configValue)
+    {
+        this.WriteEvent(54, configValue);
+    }
+
 #if DEBUG
     public class OpenTelemetryEventListener : EventListener
     {

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -414,44 +414,44 @@ internal sealed class TracerProviderSdk : TracerProvider
             sampler = stateSampler;
         }
 
-        if (configuration.TryGetStringValue(TracesSamplerConfigKey, out var tracesSampler))
+        if (configuration.TryGetStringValue(TracesSamplerConfigKey, out var configValue))
         {
             if (sampler != null)
             {
                 OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent(
-                    $"Trace sampler configuration value '{tracesSampler}' has been ignored because a value '{sampler.GetType().FullName}' was set previously.");
+                    $"Trace sampler configuration value '{configValue}' has been ignored because a value '{sampler.GetType().FullName}' was set previously.");
                 return sampler;
             }
 
-            if (string.Equals(tracesSampler, "always_on", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(configValue, "always_on", StringComparison.OrdinalIgnoreCase))
             {
                 sampler = new AlwaysOnSampler();
             }
-            else if (string.Equals(tracesSampler, "always_off", StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(configValue, "always_off", StringComparison.OrdinalIgnoreCase))
             {
                 sampler = new AlwaysOffSampler();
             }
-            else if (string.Equals(tracesSampler, "traceidratio", StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(configValue, "traceidratio", StringComparison.OrdinalIgnoreCase))
             {
                 var traceIdRatio = ReadTraceIdRatio(configuration);
                 sampler = new TraceIdRatioBasedSampler(traceIdRatio);
             }
-            else if (string.Equals(tracesSampler, "parentbased_always_on", StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(configValue, "parentbased_always_on", StringComparison.OrdinalIgnoreCase))
             {
                 sampler = new ParentBasedSampler(new AlwaysOnSampler());
             }
-            else if (string.Equals(tracesSampler, "parentbased_always_off", StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(configValue, "parentbased_always_off", StringComparison.OrdinalIgnoreCase))
             {
                 sampler = new ParentBasedSampler(new AlwaysOffSampler());
             }
-            else if (string.Equals(tracesSampler, "parentbased_traceidratio", StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(configValue, "parentbased_traceidratio", StringComparison.OrdinalIgnoreCase))
             {
                 var traceIdRatio = ReadTraceIdRatio(configuration);
                 sampler = new ParentBasedSampler(new TraceIdRatioBasedSampler(traceIdRatio));
             }
             else
             {
-                OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Trace sampler configuration was found but the value '{tracesSampler}' is invalid and will be ignored.");
+                OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Trace sampler configuration was found but the value '{configValue}' is invalid and will be ignored.");
             }
 
             if (sampler != null)

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -453,6 +453,7 @@ internal sealed class TracerProviderSdk : TracerProvider
             {
                 OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Trace sampler configuration was found but the value '{tracesSampler}' is invalid and will be ignored.");
             }
+
             if (sampler != null)
             {
                 OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Trace sampler set to '{sampler.Description}' from configuration.");

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -472,7 +472,7 @@ internal sealed class TracerProviderSdk : TracerProvider
         }
         else
         {
-            OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Trace sampler argument configuration was found but the value '{configValue}' is invalid and will be ignored.");
+            OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Trace sampler argument configuration was found but the value '{configValue}' is invalid and will be ignored, default of value of '1.0' will be used.");
         }
 
         return 1.0;

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -451,7 +451,7 @@ internal sealed class TracerProviderSdk : TracerProvider
             }
             else
             {
-                OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Trace sampler configuration was found but the value '{configValue}' is invalid and will be ignored.");
+                OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"OTEL_TRACES_SAMPLER configuration was found but the value '{configValue}' is invalid and will be ignored.");
             }
 
             if (sampler != null)

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -405,7 +405,7 @@ internal sealed class TracerProviderSdk : TracerProvider
         base.Dispose(disposing);
     }
 
-    private static Sampler ResolveSamplerFromSpecificationConfigurationKeys(IConfiguration configuration, Sampler stateSampler)
+    private static Sampler ResolveSamplerFromSpecificationConfigurationKeys(IConfiguration configuration, Sampler? stateSampler)
     {
         Sampler? sampler = null;
 

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -457,7 +457,7 @@ internal sealed class TracerProviderSdk : TracerProvider
 
         if (sampler != null)
         {
-            OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Sampler set to '{sampler.Description}' from configuration.");
+            OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Trace sampler set to '{sampler.Description}' from configuration.");
         }
 
         return sampler ?? new ParentBasedSampler(new AlwaysOnSampler());

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -419,7 +419,7 @@ internal sealed class TracerProviderSdk : TracerProvider
             if (sampler != null)
             {
                 OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent(
-                    $"Trace sampler configuration value '{configValue}' has been ignored because a value '{sampler.GetType().FullName}' was set previously.");
+                    $"Trace sampler configuration value '{configValue}' has been ignored because a value '{sampler.GetType().FullName}' was set programmatically.");
                 return sampler;
             }
 

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -452,7 +452,7 @@ internal sealed class TracerProviderSdk : TracerProvider
                     }
 
                 default:
-                    OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"OTEL_TRACES_SAMPLER configuration was found but the value '{configValue}' is invalid and will be ignored.");
+                    OpenTelemetrySdkEventSource.Log.TracesSamplerConfigInvalid(configValue);
                     break;
             }
 
@@ -474,7 +474,7 @@ internal sealed class TracerProviderSdk : TracerProvider
         }
         else
         {
-            OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Trace sampler argument configuration was found but the value '{configValue}' is invalid and will be ignored, default of value of '1.0' will be used.");
+            OpenTelemetrySdkEventSource.Log.TracesSamplerArgConfigInvalid(configValue ?? string.Empty);
         }
 
         return 1.0;

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -419,7 +419,7 @@ internal sealed class TracerProviderSdk : TracerProvider
             if (sampler != null)
             {
                 OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent(
-                    $"Trace sampler configuration value '{tracesSampler}' has been ignored because a value '{sampler.Description}' was set previously.");
+                    $"Trace sampler configuration value '{tracesSampler}' has been ignored because a value '{sampler.GetType().FullName}' was set previously.");
                 return sampler;
             }
 
@@ -456,7 +456,7 @@ internal sealed class TracerProviderSdk : TracerProvider
 
             if (sampler != null)
             {
-                OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Trace sampler set to '{sampler.Description}' from configuration.");
+                OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Trace sampler set to '{sampler.GetType().FullName}' from configuration.");
             }
         }
 

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -457,7 +457,7 @@ internal sealed class TracerProviderSdk : TracerProvider
             {
                 OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Trace sampler set to '{sampler.Description}' from configuration.");
             }
-        }        
+        }
 
         return sampler ?? new ParentBasedSampler(new AlwaysOnSampler());
     }

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -423,35 +423,37 @@ internal sealed class TracerProviderSdk : TracerProvider
                 return sampler;
             }
 
-            if (string.Equals(configValue, "always_on", StringComparison.OrdinalIgnoreCase))
+            switch (configValue)
             {
-                sampler = new AlwaysOnSampler();
-            }
-            else if (string.Equals(configValue, "always_off", StringComparison.OrdinalIgnoreCase))
-            {
-                sampler = new AlwaysOffSampler();
-            }
-            else if (string.Equals(configValue, "traceidratio", StringComparison.OrdinalIgnoreCase))
-            {
-                var traceIdRatio = ReadTraceIdRatio(configuration);
-                sampler = new TraceIdRatioBasedSampler(traceIdRatio);
-            }
-            else if (string.Equals(configValue, "parentbased_always_on", StringComparison.OrdinalIgnoreCase))
-            {
-                sampler = new ParentBasedSampler(new AlwaysOnSampler());
-            }
-            else if (string.Equals(configValue, "parentbased_always_off", StringComparison.OrdinalIgnoreCase))
-            {
-                sampler = new ParentBasedSampler(new AlwaysOffSampler());
-            }
-            else if (string.Equals(configValue, "parentbased_traceidratio", StringComparison.OrdinalIgnoreCase))
-            {
-                var traceIdRatio = ReadTraceIdRatio(configuration);
-                sampler = new ParentBasedSampler(new TraceIdRatioBasedSampler(traceIdRatio));
-            }
-            else
-            {
-                OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"OTEL_TRACES_SAMPLER configuration was found but the value '{configValue}' is invalid and will be ignored.");
+                case var _ when string.Equals(configValue, "always_on", StringComparison.OrdinalIgnoreCase):
+                    sampler = new AlwaysOnSampler();
+                    break;
+                case var _ when string.Equals(configValue, "always_off", StringComparison.OrdinalIgnoreCase):
+                    sampler = new AlwaysOffSampler();
+                    break;
+                case var _ when string.Equals(configValue, "traceidratio", StringComparison.OrdinalIgnoreCase):
+                    {
+                        var traceIdRatio = ReadTraceIdRatio(configuration);
+                        sampler = new TraceIdRatioBasedSampler(traceIdRatio);
+                        break;
+                    }
+
+                case var _ when string.Equals(configValue, "parentbased_always_on", StringComparison.OrdinalIgnoreCase):
+                    sampler = new ParentBasedSampler(new AlwaysOnSampler());
+                    break;
+                case var _ when string.Equals(configValue, "parentbased_always_off", StringComparison.OrdinalIgnoreCase):
+                    sampler = new ParentBasedSampler(new AlwaysOffSampler());
+                    break;
+                case var _ when string.Equals(configValue, "parentbased_traceidratio", StringComparison.OrdinalIgnoreCase):
+                    {
+                        var traceIdRatio = ReadTraceIdRatio(configuration);
+                        sampler = new ParentBasedSampler(new TraceIdRatioBasedSampler(traceIdRatio));
+                        break;
+                    }
+
+                default:
+                    OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"OTEL_TRACES_SAMPLER configuration was found but the value '{configValue}' is invalid and will be ignored.");
+                    break;
             }
 
             if (sampler != null)

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -453,12 +453,11 @@ internal sealed class TracerProviderSdk : TracerProvider
             {
                 OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Trace sampler configuration was found but the value '{tracesSampler}' is invalid and will be ignored.");
             }
-        }
-
-        if (sampler != null)
-        {
-            OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Trace sampler set to '{sampler.Description}' from configuration.");
-        }
+            if (sampler != null)
+            {
+                OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Trace sampler set to '{sampler.Description}' from configuration.");
+            }
+        }        
 
         return sampler ?? new ParentBasedSampler(new AlwaysOnSampler());
     }

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -61,7 +61,7 @@ internal sealed class TracerProviderSdk : TracerProvider
         resourceBuilder.ServiceProvider = serviceProvider;
         this.Resource = resourceBuilder.Build();
 
-        this.sampler = ResolveSamplerFromSpecificationConfigurationKeys(serviceProvider!.GetRequiredService<IConfiguration>(), state.Sampler);
+        this.sampler = GetSampler(serviceProvider!.GetRequiredService<IConfiguration>(), state.Sampler);
         OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Sampler added = \"{this.sampler.GetType()}\".");
 
         this.supportLegacyActivity = state.LegacyActivityOperationNames.Count > 0;
@@ -405,7 +405,7 @@ internal sealed class TracerProviderSdk : TracerProvider
         base.Dispose(disposing);
     }
 
-    private static Sampler ResolveSamplerFromSpecificationConfigurationKeys(IConfiguration configuration, Sampler? stateSampler)
+    private static Sampler GetSampler(IConfiguration configuration, Sampler? stateSampler)
     {
         Sampler? sampler = null;
 

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -452,7 +452,7 @@ internal sealed class TracerProviderSdk : TracerProvider
                     }
 
                 default:
-                    OpenTelemetrySdkEventSource.Log.TracesSamplerConfigInvalid(configValue);
+                    OpenTelemetrySdkEventSource.Log.TracesSamplerConfigInvalid(configValue ?? string.Empty);
                     break;
             }
 

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -443,6 +443,11 @@ internal sealed class TracerProviderSdk : TracerProvider
             }
         }
 
+        if (sampler != null)
+        {
+            OpenTelemetrySdkEventSource.Log.TracerProviderSdkEvent($"Sampler set to '{sampler.Description}' from configuration.");
+        }
+
         return sampler ?? new ParentBasedSampler(new AlwaysOnSampler());
     }
 

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
@@ -1083,6 +1083,27 @@ public class TracerProviderSdkTest : IDisposable
     }
 
     [Fact]
+    public void TestSamplerConfigurationIgnoredWhenSetProgrammatically()
+    {
+        var configBuilder = new ConfigurationBuilder();
+        configBuilder.AddInMemoryCollection(new Dictionary<string, string>
+        {
+            [TracerProviderSdk.TracesSamplerConfigKey] = "always_off",
+        });
+
+        var builder = Sdk.CreateTracerProviderBuilder();
+        builder.ConfigureServices(s => s.AddSingleton<IConfiguration>(configBuilder.Build()));
+        builder.SetSampler(new AlwaysOnSampler());
+
+        using var tracerProvider = builder.Build();
+        var tracerProviderSdk = tracerProvider as TracerProviderSdk;
+
+        Assert.NotNull(tracerProviderSdk);
+        Assert.NotNull(tracerProviderSdk.Sampler);
+        Assert.Equal("AlwaysOnSampler", tracerProviderSdk.Sampler.Description);
+    }
+
+    [Fact]
     public void TracerProvideSdkCreatesAndDiposesInstrumentation()
     {
         TestInstrumentation testInstrumentation = null;

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
@@ -1052,13 +1052,13 @@ public class TracerProviderSdkTest : IDisposable
     [InlineData("parentbased_always_off", null, "ParentBased{AlwaysOffSampler}")]
     [InlineData("parentbased_traceidratio", "0.111", "ParentBased{TraceIdRatioBasedSampler{0.111000}}")]
     [InlineData("ParentBased_TraceIdRatio", "0.000001", "ParentBased{TraceIdRatioBasedSampler{0.000001}}")]
-    public void TestSamplerSetFromConfiguration(string? configValue, string? argValue, string samplerDescription)
+    public void TestSamplerSetFromConfiguration(string configValue, string argValue, string samplerDescription)
     {
         var configBuilder = new ConfigurationBuilder();
 
         if (!string.IsNullOrEmpty(configValue))
         {
-            configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+            configBuilder.AddInMemoryCollection(new Dictionary<string, string>
             {
                 [TracerProviderSdk.TracesSamplerConfigKey] = configValue,
             });
@@ -1066,7 +1066,7 @@ public class TracerProviderSdkTest : IDisposable
 
         if (!string.IsNullOrEmpty(argValue))
         {
-            configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+            configBuilder.AddInMemoryCollection(new Dictionary<string, string>
             {
                 [TracerProviderSdk.TracesSamplerArgConfigKey] = argValue,
             });

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
@@ -1057,21 +1057,11 @@ public class TracerProviderSdkTest : IDisposable
     {
         var configBuilder = new ConfigurationBuilder();
 
-        if (!string.IsNullOrEmpty(configValue))
+        configBuilder.AddInMemoryCollection(new Dictionary<string, string>
         {
-            configBuilder.AddInMemoryCollection(new Dictionary<string, string>
-            {
-                [TracerProviderSdk.TracesSamplerConfigKey] = configValue,
-            });
-        }
-
-        if (!string.IsNullOrEmpty(argValue))
-        {
-            configBuilder.AddInMemoryCollection(new Dictionary<string, string>
-            {
-                [TracerProviderSdk.TracesSamplerArgConfigKey] = argValue,
-            });
-        }
+            [TracerProviderSdk.TracesSamplerConfigKey] = configValue,
+            [TracerProviderSdk.TracesSamplerArgConfigKey] = argValue,
+        });
 
         var builder = Sdk.CreateTracerProviderBuilder();
         builder.ConfigureServices(s => s.AddSingleton<IConfiguration>(configBuilder.Build()));

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
@@ -1051,6 +1051,7 @@ public class TracerProviderSdkTest : IDisposable
     [InlineData("parentbased_always_on", null, "ParentBased{AlwaysOnSampler}")]
     [InlineData("parentbased_always_off", null, "ParentBased{AlwaysOffSampler}")]
     [InlineData("parentbased_traceidratio", "0.111", "ParentBased{TraceIdRatioBasedSampler{0.111000}}")]
+    [InlineData("parentbased_traceidratio", "not_a_double", "ParentBased{TraceIdRatioBasedSampler{1.000000}}")]
     [InlineData("ParentBased_TraceIdRatio", "0.000001", "ParentBased{TraceIdRatioBasedSampler{0.000001}}")]
     public void TestSamplerSetFromConfiguration(string configValue, string argValue, string samplerDescription)
     {

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderSdkTest.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Instrumentation;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Resources.Tests;
@@ -1037,6 +1039,47 @@ public class TracerProviderSdkTest : IDisposable
         using var activity = new Activity(operationNameForLegacyActivity);
         activity.Start();
         activity.Stop();
+    }
+
+    [Theory]
+    [InlineData(null, null, "ParentBased{AlwaysOnSampler}")]
+    [InlineData("always_on", null, "AlwaysOnSampler")]
+    [InlineData("always_off", null, "AlwaysOffSampler")]
+    [InlineData("always_OFF", null, "AlwaysOffSampler")]
+    [InlineData("traceidratio", "0.5", "TraceIdRatioBasedSampler{0.500000}")]
+    [InlineData("traceidratio", "not_a_double", "TraceIdRatioBasedSampler{1.000000}")]
+    [InlineData("parentbased_always_on", null, "ParentBased{AlwaysOnSampler}")]
+    [InlineData("parentbased_always_off", null, "ParentBased{AlwaysOffSampler}")]
+    [InlineData("parentbased_traceidratio", "0.111", "ParentBased{TraceIdRatioBasedSampler{0.111000}}")]
+    [InlineData("ParentBased_TraceIdRatio", "0.000001", "ParentBased{TraceIdRatioBasedSampler{0.000001}}")]
+    public void TestSamplerSetFromConfiguration(string? configValue, string? argValue, string samplerDescription)
+    {
+        var configBuilder = new ConfigurationBuilder();
+
+        if (!string.IsNullOrEmpty(configValue))
+        {
+            configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [TracerProviderSdk.TracesSamplerConfigKey] = configValue,
+            });
+        }
+
+        if (!string.IsNullOrEmpty(argValue))
+        {
+            configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [TracerProviderSdk.TracesSamplerArgConfigKey] = argValue,
+            });
+        }
+
+        var builder = Sdk.CreateTracerProviderBuilder();
+        builder.ConfigureServices(s => s.AddSingleton<IConfiguration>(configBuilder.Build()));
+        using var tracerProvider = builder.Build();
+        var tracerProviderSdk = tracerProvider as TracerProviderSdk;
+
+        Assert.NotNull(tracerProviderSdk);
+        Assert.NotNull(tracerProviderSdk.Sampler);
+        Assert.Equal(samplerDescription, tracerProviderSdk.Sampler.Description);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #3601 

## Changes

`TracerProvider`s can now have a sampler configured via the `OTEL_TRACES_SAMPLER` environment variable.

The supported values are: `always_off`, `always_on`, `traceidratio`, `parentbased_always_on`, `parentbased_always_off`, and `parentbased_traceidratio`.

The options `traceidratio` and `parentbased_traceidratio` may have the sampler probability configured via the `OTEL_TRACES_SAMPLER_ARG` environment variable.

For details see: [OpenTelemetry Environment Variable Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
