### PR TITLE
[Exporter.OpenTelemetryProtocol] fix event source throws `System.FormatException`

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## Unreleased
 
-* Fix `System.FormatException` thrown by `PersistentStorageEventSource`.
-  [#5451](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5451)
-
 * **Experimental (pre-release builds only):** Added
   `LoggerProviderBuilder.AddOtlpExporter` registration extensions.
   [#5103](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5103)

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Fix `System.FormatException`.
+  [#5451](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5451)
+
 * **Experimental (pre-release builds only):** Added
   `LoggerProviderBuilder.AddOtlpExporter` registration extensions.
   [#5103](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5103)

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Fix `System.FormatException`.
+* Fix `System.FormatException` thrown by `PersistentStorageEventSource`.
   [#5451](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5451)
 
 * **Experimental (pre-release builds only):** Added

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/PersistentStorage/PersistentStorageEventSource.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/PersistentStorage/PersistentStorageEventSource.cs
@@ -145,7 +145,7 @@ internal sealed class PersistentStorageEventSource : EventSource
         this.WriteEvent(8, srcFilePath, destFilePath, ex);
     }
 
-    [Event(9, Message = "{0}: Error Message: {1}. Exception: {3}", Level = EventLevel.Error)]
+    [Event(9, Message = "{0}: Error Message: {1}. Exception: {2}", Level = EventLevel.Error)]
     public void PersistentStorageException(string className, string message, string ex)
     {
         this.WriteEvent(9, className, message, ex);

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/EventSourceTest.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/EventSourceTest.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
+using OpenTelemetry.PersistentStorage.Abstractions;
+using OpenTelemetry.PersistentStorage.FileSystem;
 using OpenTelemetry.Tests;
 using Xunit;
 
@@ -13,5 +15,17 @@ public class EventSourceTest
     public void EventSourceTest_OpenTelemetryProtocolExporterEventSource()
     {
         EventSourceTestHelper.MethodsAreImplementedConsistentlyWithTheirAttributes(OpenTelemetryProtocolExporterEventSource.Log);
+    }
+
+    [Fact]
+    public void EventSourceTest_PersistentStorageAbstractionsEventSource()
+    {
+        EventSourceTestHelper.MethodsAreImplementedConsistentlyWithTheirAttributes(PersistentStorageAbstractionsEventSource.Log);
+    }
+
+    [Fact]
+    public void EventSourceTest_PersistentStorageEventSource()
+    {
+        EventSourceTestHelper.MethodsAreImplementedConsistentlyWithTheirAttributes(PersistentStorageEventSource.Log);
     }
 }


### PR DESCRIPTION
This PR fixes a bug in the PersistentStorageEventSource class. 

```
System.FormatException
  HResult=0x80131537
  Message=Index (zero based) must be greater than or equal to zero and less than the size of the argument list.
  Source=System.Private.CoreLib
  StackTrace:
   at System.ThrowHelper.ThrowFormatIndexOutOfRange()
   at System.Text.ValueStringBuilder.AppendFormatHelper(IFormatProvider provider, String format, ReadOnlySpan`1 args)
   at System.String.FormatHelper(IFormatProvider provider, String format, ReadOnlySpan`1 args)
   at System.String.Format(IFormatProvider provider, String format, Object[] args)
   at Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.OpenTelemetryEventListener.OnEventWritten(EventWrittenEventArgs eventData) in C:\Users\Rohit Ranjan\source\repos\azure-functions-host\src\WebJobs.Script.WebHost\Diagnostics\OpenTelemetryEventListener.cs:line 54
   at System.Diagnostics.Tracing.EventSource.DispatchToAllListeners(EventWrittenEventArgs eventCallbackArgs)
```




### Changes
- fix index in Event attribute.
- Update test class to verify all event source classes in this project.