### PR TITLE
[sdk-logs] Support enrichment of LogRecords

### DIFF
--- a/src/OpenTelemetry/.publicApi/Stable/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/Stable/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
+OpenTelemetry.Logs.LogRecord.AddAttribute(System.Collections.Generic.KeyValuePair<string!, object?> attribute) -> void
+OpenTelemetry.Logs.LogRecord.AddAttributes(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, object?>>! attributes) -> void
 OpenTelemetry.OpenTelemetryBuilderSdkExtensions
 OpenTelemetry.Trace.ActivityExportProcessorOptions
 OpenTelemetry.Trace.ActivityExportProcessorOptions.ActivityExportProcessorOptions() -> void

--- a/src/OpenTelemetry/Logs/LogRecord.cs
+++ b/src/OpenTelemetry/Logs/LogRecord.cs
@@ -573,9 +573,9 @@ public sealed class LogRecord
     {
         if (this.Attributes is not LogRecordEnrichedAttributes enrichedAttributes)
         {
-            enrichedAttributes = this.EnrichedAttributeStorage ??= new();
+            enrichedAttributes = this.EnrichedAttributeStorage ??= new(this);
 
-            enrichedAttributes.Reset(this.Attributes);
+            enrichedAttributes.Reset();
 
             this.Attributes = enrichedAttributes;
         }

--- a/src/OpenTelemetry/Logs/LogRecordEnrichedAttributes.cs
+++ b/src/OpenTelemetry/Logs/LogRecordEnrichedAttributes.cs
@@ -1,0 +1,69 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Collections;
+using System.Diagnostics;
+
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Logs;
+
+internal sealed class LogRecordEnrichedAttributes : IReadOnlyList<KeyValuePair<string, object?>>
+{
+    private readonly List<KeyValuePair<string, object?>> enrichedAttributes = new();
+    private IReadOnlyList<KeyValuePair<string, object?>> initialAttributes;
+
+    public LogRecordEnrichedAttributes()
+    {
+        this.initialAttributes = Array.Empty<KeyValuePair<string, object?>>();
+    }
+
+    public int Count => this.initialAttributes.Count + this.enrichedAttributes.Count;
+
+    public KeyValuePair<string, object?> this[int index]
+    {
+        get
+        {
+            Guard.ThrowIfNegative(index);
+
+            var initialAttributes = this.initialAttributes;
+
+            var count = initialAttributes.Count;
+            if (index < count)
+            {
+                return initialAttributes[index];
+            }
+
+            return this.enrichedAttributes[index - count];
+        }
+    }
+
+    public void Reset(IReadOnlyList<KeyValuePair<string, object?>>? initialAttributes)
+    {
+        this.initialAttributes = initialAttributes ?? Array.Empty<KeyValuePair<string, object?>>();
+        this.enrichedAttributes.Clear();
+    }
+
+    public void Add(KeyValuePair<string, object?> attribute)
+    {
+        this.enrichedAttributes.Add(attribute);
+    }
+
+    public void Add(IEnumerable<KeyValuePair<string, object?>> attributes)
+    {
+        Debug.Assert(attributes != null, "attributes was null");
+
+        this.enrichedAttributes.AddRange(attributes);
+    }
+
+    public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
+    {
+        for (var i = 0; i < this.Count; i++)
+        {
+            yield return this[i];
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+        => this.GetEnumerator();
+}

--- a/src/OpenTelemetry/Logs/LogRecordEnrichedAttributes.cs
+++ b/src/OpenTelemetry/Logs/LogRecordEnrichedAttributes.cs
@@ -11,14 +11,25 @@ namespace OpenTelemetry.Logs;
 internal sealed class LogRecordEnrichedAttributes : IReadOnlyList<KeyValuePair<string, object?>>
 {
     private readonly List<KeyValuePair<string, object?>> enrichedAttributes = new();
-    private IReadOnlyList<KeyValuePair<string, object?>> initialAttributes;
+    private readonly LogRecord logRecord;
+    private IReadOnlyList<KeyValuePair<string, object?>>? initialAttributes;
 
-    public LogRecordEnrichedAttributes()
+    public LogRecordEnrichedAttributes(LogRecord logRecord)
     {
-        this.initialAttributes = Array.Empty<KeyValuePair<string, object?>>();
+        Debug.Assert(logRecord != null, "logRecord was null");
+
+        this.logRecord = logRecord!;
     }
 
-    public int Count => this.initialAttributes.Count + this.enrichedAttributes.Count;
+    public int Count
+    {
+        get
+        {
+            Debug.Assert(this.initialAttributes != null, "this.initialAttributes was null");
+
+            return this.initialAttributes!.Count + this.enrichedAttributes.Count;
+        }
+    }
 
     public KeyValuePair<string, object?> this[int index]
     {
@@ -26,7 +37,9 @@ internal sealed class LogRecordEnrichedAttributes : IReadOnlyList<KeyValuePair<s
         {
             Guard.ThrowIfNegative(index);
 
-            var initialAttributes = this.initialAttributes;
+            Debug.Assert(this.initialAttributes != null, "this.initialAttributes was null");
+
+            var initialAttributes = this.initialAttributes!;
 
             var count = initialAttributes.Count;
             if (index < count)
@@ -38,9 +51,12 @@ internal sealed class LogRecordEnrichedAttributes : IReadOnlyList<KeyValuePair<s
         }
     }
 
-    public void Reset(IReadOnlyList<KeyValuePair<string, object?>>? initialAttributes)
+    public void Reset()
     {
-        this.initialAttributes = initialAttributes ?? Array.Empty<KeyValuePair<string, object?>>();
+        this.initialAttributes = this.logRecord.Attributes ?? Array.Empty<KeyValuePair<string, object?>>();
+
+        // Note: Clear sets the count/size to 0 but it maintains the underlying
+        // array(capacity).
         this.enrichedAttributes.Clear();
     }
 

--- a/src/Shared/Guard.cs
+++ b/src/Shared/Guard.cs
@@ -39,6 +39,11 @@ namespace System.Diagnostics.CodeAnalysis
     internal sealed class NotNullAttribute : Attribute
     {
     }
+
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    internal sealed class DoesNotReturnAttribute : Attribute
+    {
+    }
 }
 #endif
 
@@ -112,6 +117,16 @@ namespace OpenTelemetry.Internal
             if (value == 0)
             {
                 throw new ArgumentException(message, paramName);
+            }
+        }
+
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfNegative(int value, [CallerArgumentExpression("value")] string? paramName = null)
+        {
+            if (value < 0)
+            {
+                ThrowNegative(paramName);
             }
         }
 
@@ -199,5 +214,9 @@ namespace OpenTelemetry.Internal
                 throw new ArgumentOutOfRangeException(paramName, value, exMessage);
             }
         }
+
+        [DoesNotReturn]
+        private static void ThrowNegative(string? paramName) =>
+            throw new ArgumentOutOfRangeException(paramName, "Must be a non-negative value");
     }
 }


### PR DESCRIPTION
[Opening as a draft to discuss if this is something we want to do.]

## Changes

* Adds `AddAtribute` API on `LogRecord` to give users wanting to do enrichment a very efficient way to do it

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
