### PR TITLE
[sdk-metrics] Tags perf improvements

### DIFF
--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -118,11 +118,15 @@ internal sealed class AggregatorStore
 
         this.OutputDeltaWithUnusedMetricPointReclaimEnabled = shouldReclaimUnusedMetricPoints && this.OutputDelta;
 
+        // Note: We reserve double the cardinalityLimit set by the user for
+        // storing unsorted & sorted tags for lookup
+        var lookupCapacity = cardinalityLimit * 2;
+
         if (this.OutputDeltaWithUnusedMetricPointReclaimEnabled)
         {
             this.availableMetricPoints = new Queue<int>(cardinalityLimit);
 
-            this.TagsToMetricPointIndexDictionaryDelta = new(concurrencyLevel: Environment.ProcessorCount, capacity: cardinalityLimit * 2);
+            this.TagsToMetricPointIndexDictionaryDelta = new(concurrencyLevel: Environment.ProcessorCount, capacity: lookupCapacity);
 
             // Add all the indices except for the reserved ones to the queue so that threads have
             // readily available access to these MetricPoints for their use.
@@ -136,7 +140,7 @@ internal sealed class AggregatorStore
         }
         else
         {
-            this.tagsToMetricPointIndexDictionary = new(concurrencyLevel: Environment.ProcessorCount, capacity: cardinalityLimit * 2);
+            this.tagsToMetricPointIndexDictionary = new(concurrencyLevel: Environment.ProcessorCount, capacity: lookupCapacity);
             this.lookupAggregatorStore = this.LookupAggregatorStore;
         }
     }

--- a/src/OpenTelemetry/Metrics/Tags.cs
+++ b/src/OpenTelemetry/Metrics/Tags.cs
@@ -53,7 +53,7 @@ internal readonly struct Tags : IEquatable<Tags>
             while (true)
             {
                 // Equality check for Keys
-                if (!StringComparer.OrdinalIgnoreCase.Equals(ours.Key, theirs.Key))
+                if (!ours.Key.Equals(theirs.Key))
                 {
                     return false;
                 }
@@ -82,7 +82,7 @@ internal readonly struct Tags : IEquatable<Tags>
             ref var theirs = ref theirKvps[i];
 
             // Equality check for Keys
-            if (!StringComparer.OrdinalIgnoreCase.Equals(ours.Key, theirs.Key))
+            if (!ours.Key.Equals(theirs.Key))
             {
                 return false;
             }
@@ -111,7 +111,7 @@ internal readonly struct Tags : IEquatable<Tags>
         for (int i = 0; i < keyValuePairs.Length; i++)
         {
             ref var item = ref keyValuePairs[i];
-            hashCode.Add(StringComparer.OrdinalIgnoreCase.GetHashCode(item.Key));
+            hashCode.Add(item.Key.GetHashCode());
             hashCode.Add(item.Value);
         }
 
@@ -124,7 +124,7 @@ internal readonly struct Tags : IEquatable<Tags>
             ref var item = ref keyValuePairs[i];
             unchecked
             {
-                hash = (hash * 31) + StringComparer.OrdinalIgnoreCase.GetHashCode(item.Key);
+                hash = (hash * 31) + item.Key.GetHashCode();
                 hash = (hash * 31) + (item.Value?.GetHashCode() ?? 0);
             }
         }

--- a/src/OpenTelemetry/Metrics/Tags.cs
+++ b/src/OpenTelemetry/Metrics/Tags.cs
@@ -52,13 +52,12 @@ internal readonly struct Tags : IEquatable<Tags>
             ref var theirs = ref MemoryMarshal.GetArrayDataReference(theirKvps);
             while (true)
             {
-                // Equality check for Keys
+                // Note: string.Equals performs an ordinal comparison
                 if (!ours.Key.Equals(theirs.Key))
                 {
                     return false;
                 }
 
-                // Equality check for Values
                 if (!ours.Value?.Equals(theirs.Value) ?? theirs.Value != null)
                 {
                     return false;
@@ -81,13 +80,12 @@ internal readonly struct Tags : IEquatable<Tags>
             // Note: Bounds check happens here for theirKvps element access
             ref var theirs = ref theirKvps[i];
 
-            // Equality check for Keys
+            // Note: string.Equals performs an ordinal comparison
             if (!ours.Key.Equals(theirs.Key))
             {
                 return false;
             }
 
-            // Equality check for Values
             if (!ours.Value?.Equals(theirs.Value) ?? theirs.Value != null)
             {
                 return false;

--- a/src/OpenTelemetry/Metrics/Tags.cs
+++ b/src/OpenTelemetry/Metrics/Tags.cs
@@ -37,7 +37,9 @@ internal readonly struct Tags : IEquatable<Tags>
         var ourKvps = this.KeyValuePairs;
         var theirKvps = other.KeyValuePairs;
 
-        if (ourKvps.Length != theirKvps.Length)
+        var length = ourKvps.Length;
+
+        if (length != theirKvps.Length)
         {
             return false;
         }
@@ -45,8 +47,7 @@ internal readonly struct Tags : IEquatable<Tags>
 #if NET6_0_OR_GREATER
         // Note: This loop uses unsafe code (pointers) to elide bounds checks on
         // two arrays we know to be of equal length.
-        var cursor = ourKvps.Length;
-        if (cursor > 0)
+        if (length > 0)
         {
             ref var ours = ref MemoryMarshal.GetArrayDataReference(ourKvps);
             ref var theirs = ref MemoryMarshal.GetArrayDataReference(theirKvps);
@@ -63,7 +64,7 @@ internal readonly struct Tags : IEquatable<Tags>
                     return false;
                 }
 
-                if (--cursor == 0)
+                if (--length == 0)
                 {
                     break;
                 }
@@ -73,7 +74,7 @@ internal readonly struct Tags : IEquatable<Tags>
             }
         }
 #else
-        for (int i = 0; i < ourKvps.Length; i++)
+        for (int i = 0; i < length; i++)
         {
             ref var ours = ref ourKvps[i];
 

--- a/src/OpenTelemetry/Metrics/Tags.cs
+++ b/src/OpenTelemetry/Metrics/Tags.cs
@@ -1,6 +1,11 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#if NET6_0_OR_GREATER
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+#endif
+
 namespace OpenTelemetry.Metrics;
 
 internal readonly struct Tags : IEquatable<Tags>
@@ -11,32 +16,31 @@ internal readonly struct Tags : IEquatable<Tags>
 
     public Tags(KeyValuePair<string, object?>[] keyValuePairs)
     {
-        this.KeyValuePairs = keyValuePairs;
-
 #if NET6_0_OR_GREATER
         HashCode hashCode = default;
-        for (int i = 0; i < this.KeyValuePairs.Length; i++)
+        for (int i = 0; i < keyValuePairs.Length; i++)
         {
-            ref var item = ref this.KeyValuePairs[i];
-            hashCode.Add(item.Key);
+            ref var item = ref keyValuePairs[i];
+            hashCode.Add(item.Key, StringComparer.OrdinalIgnoreCase);
             hashCode.Add(item.Value);
         }
 
         var hash = hashCode.ToHashCode();
 #else
         var hash = 17;
-        for (int i = 0; i < this.KeyValuePairs.Length; i++)
+        for (int i = 0; i < keyValuePairs.Length; i++)
         {
-            ref var item = ref this.KeyValuePairs[i];
+            ref var item = ref keyValuePairs[i];
             unchecked
             {
-                hash = (hash * 31) + (item.Key?.GetHashCode() ?? 0);
+                hash = (hash * 31) + StringComparer.OrdinalIgnoreCase.GetHashCode(item.Key);
                 hash = (hash * 31) + (item.Value?.GetHashCode() ?? 0);
             }
         }
 #endif
 
         this.hashCode = hash;
+        this.KeyValuePairs = keyValuePairs;
     }
 
     public readonly KeyValuePair<string, object?>[] KeyValuePairs { get; }
@@ -52,30 +56,59 @@ internal readonly struct Tags : IEquatable<Tags>
 
     public readonly bool Equals(Tags other)
     {
-        var length = this.KeyValuePairs.Length;
+        var ourKvps = this.KeyValuePairs;
+        var theirKvps = other.KeyValuePairs;
 
-        if (length != other.KeyValuePairs.Length)
+        if (ourKvps.Length != theirKvps.Length)
         {
             return false;
         }
 
-        for (int i = 0; i < length; i++)
+#if NET6_0_OR_GREATER
+        // Note: This loop uses unsafe code (pointers) to elide bounds checks on
+        // two arrays we know to be of equal length.
+        var cursor = ourKvps.Length;
+        ref var ours = ref MemoryMarshal.GetArrayDataReference(ourKvps);
+        ref var theirs = ref MemoryMarshal.GetArrayDataReference(theirKvps);
+        do
         {
-            ref var left = ref this.KeyValuePairs[i];
-            ref var right = ref other.KeyValuePairs[i];
-
             // Equality check for Keys
-            if (!left.Key.Equals(right.Key, StringComparison.Ordinal))
+            if (!StringComparer.OrdinalIgnoreCase.Equals(ours.Key, theirs.Key))
             {
                 return false;
             }
 
             // Equality check for Values
-            if (!left.Value?.Equals(right.Value) ?? right.Value != null)
+            if (!ours.Value?.Equals(theirs.Value) ?? theirs.Value != null)
+            {
+                return false;
+            }
+
+            ours = ref Unsafe.Add(ref ours, 1);
+            theirs = ref Unsafe.Add(ref theirs, 1);
+        }
+        while (--cursor > 0);
+#else
+        for (int i = 0; i < ourKvps.Length; i++)
+        {
+            ref var ours = ref ourKvps[i];
+
+            // Note: Bounds check happens here for theirKvps element access
+            ref var theirs = ref theirKvps[i];
+
+            // Equality check for Keys
+            if (!StringComparer.OrdinalIgnoreCase.Equals(ours.Key, theirs.Key))
+            {
+                return false;
+            }
+
+            // Equality check for Values
+            if (!ours.Value?.Equals(theirs.Value) ?? theirs.Value != null)
             {
                 return false;
             }
         }
+#endif
 
         return true;
     }


### PR DESCRIPTION
## Changes

* Elide bounds checks in `Tags` hash code computation and equality checks
* Call `string.Equals` without passing `StringComparison` (seems to inline better)

## Benchmarks

| Method                 | NumberOfTags | Mean       | Error     | StdDev    |
|----------------------- |------------- |-----------:|----------:|----------:|
| TagsGetHashCodeOld     | 1            |  13.520 ns | 0.1686 ns | 0.1577 ns |
| TagsGetHashCodeNew     | 1            |  11.989 ns | 0.1091 ns | 0.0967 ns |
| TagsEqualsOld          | 1            |   5.802 ns | 0.0405 ns | 0.0359 ns |
| TagsEqualsNew          | 1            |   4.962 ns | 0.0696 ns | 0.0617 ns |
| TagsGetHashCodeOld     | 3            |  46.325 ns | 0.4549 ns | 0.4033 ns |
| TagsGetHashCodeNew     | 3            |  37.827 ns | 0.4984 ns | 0.3891 ns |
| TagsEqualsOld          | 3            |  14.708 ns | 0.3192 ns | 0.3278 ns |
| TagsEqualsNew          | 3            |  12.526 ns | 0.2695 ns | 0.2884 ns |
| TagsGetHashCodeOld     | 5            |  79.541 ns | 0.8260 ns | 0.7727 ns |
| TagsGetHashCodeNew     | 5            |  59.275 ns | 0.4959 ns | 0.4639 ns |
| TagsEqualsOld          | 5            |  23.636 ns | 0.2285 ns | 0.2026 ns |
| TagsEqualsNew          | 5            |  18.615 ns | 0.1292 ns | 0.1146 ns |
| TagsGetHashCodeOld     | 10           | 162.381 ns | 1.4783 ns | 1.3828 ns |
| TagsGetHashCodeNew     | 10           | 128.601 ns | 1.7367 ns | 1.6245 ns |
| TagsEqualsOld          | 10           |  45.330 ns | 0.6802 ns | 0.6362 ns |
| TagsEqualsNew          | 10           |  35.216 ns | 0.5322 ns | 0.4978 ns |

<details>
<summary>Code</summary>

```csharp
#nullable enable

using System.Diagnostics;
using System.Runtime.CompilerServices;
#if NET6_0_OR_GREATER
using System.Runtime.InteropServices;
#endif
using BenchmarkDotNet.Attributes;

namespace Benchmarks.Metrics;

public class TagsBenchmarks
{
    private KeyValuePair<string, object?>[]? tags;
    private TagsNew tagsNew;
    private TagsOld tagsOld;

    [Params(/*1, 3, 5, */10/*, 100*/)]
    public int NumberOfTags { get; set; }

    [GlobalSetup]
    public void GlobalSetup()
    {
        var tags = new KeyValuePair<string, object?>[this.NumberOfTags];

        for (int i = 0; i < this.NumberOfTags; i++)
        {
            tags[i] = new KeyValuePair<string, object?>($"tag_key_name_{i}", i);
        }

        this.tags = tags;
        this.tagsNew = new(tags);
        this.tagsOld = new(tags);
    }

    [Benchmark]
    public int TagsGetHashCodeOld()
    {
        return new TagsOld(this.tags!).GetHashCode();
    }

    [Benchmark]
    public int TagsGetHashCodeNew()
    {
        return new TagsNew(this.tags!).GetHashCode();
    }

    [Benchmark]
    public bool TagsEqualsOld()
    {
        return this.tagsOld.Equals(this.tagsOld);
    }

    [Benchmark]
    public bool TagsEqualsNew()
    {
        return this.tagsNew.Equals(this.tagsNew);
    }

    internal readonly struct TagsNew : IEquatable<TagsNew>
    {
        public static readonly TagsNew EmptyTags = new(Array.Empty<KeyValuePair<string, object?>>());

        private readonly int hashCode;

        public TagsNew(KeyValuePair<string, object?>[] keyValuePairs)
        {
            this.KeyValuePairs = keyValuePairs;
            this.hashCode = ComputeHashCode(keyValuePairs);
        }

        public readonly KeyValuePair<string, object?>[] KeyValuePairs { get; }

        public static bool operator ==(TagsNew tag1, TagsNew tag2) => tag1.Equals(tag2);

        public static bool operator !=(TagsNew tag1, TagsNew tag2) => !tag1.Equals(tag2);

        public override readonly bool Equals(object? obj)
        {
            return obj is TagsNew other && this.Equals(other);
        }

        public readonly bool Equals(TagsNew other)
        {
            var ourKvps = this.KeyValuePairs;
            var theirKvps = other.KeyValuePairs;

            if (ourKvps.Length != theirKvps.Length)
            {
                return false;
            }

#if NET6_0_OR_GREATER
            // Note: This loop uses unsafe code (pointers) to elide bounds checks on
            // two arrays we know to be of equal length.
            var cursor = ourKvps.Length;
            if (cursor > 0)
            {
                ref var ours = ref MemoryMarshal.GetArrayDataReference(ourKvps);
                ref var theirs = ref MemoryMarshal.GetArrayDataReference(theirKvps);
                while (true)
                {
                    // Equality check for Keys
                    if (!ours.Key.Equals(theirs.Key))
                    {
                        return false;
                    }

                    // Equality check for Values
                    if (!ours.Value?.Equals(theirs.Value) ?? theirs.Value != null)
                    {
                        return false;
                    }

                    if (--cursor == 0)
                    {
                        break;
                    }

                    ours = ref Unsafe.Add(ref ours, 1);
                    theirs = ref Unsafe.Add(ref theirs, 1);
                }
            }
#else
            for (int i = 0; i < ourKvps.Length; i++)
            {
                ref var ours = ref ourKvps[i];

                // Note: Bounds check happens here for theirKvps element access
                ref var theirs = ref theirKvps[i];

                // Equality check for Keys
                if (!ours.Key.Equals(theirs.Key))
                {
                    return false;
                }

                // Equality check for Values
                if (!ours.Value?.Equals(theirs.Value) ?? theirs.Value != null)
                {
                    return false;
                }
            }
#endif

            return true;
        }

        public override readonly int GetHashCode() => this.hashCode;

        [MethodImpl(MethodImplOptions.AggressiveInlining)]
        private static int ComputeHashCode(KeyValuePair<string, object?>[] keyValuePairs)
        {
            Debug.Assert(keyValuePairs != null, "keyValuePairs was null");

#if NET6_0_OR_GREATER
            HashCode hashCode = default;

            for (int i = 0; i < keyValuePairs.Length; i++)
            {
                ref var item = ref keyValuePairs[i];
                hashCode.Add(item.Key.GetHashCode());
                hashCode.Add(item.Value);
            }

            return hashCode.ToHashCode();
#else
            var hash = 17;

            for (int i = 0; i < keyValuePairs!.Length; i++)
            {
                ref var item = ref keyValuePairs[i];
                unchecked
                {
                    hash = (hash * 31) + item.Key.GetHashCode();
                    hash = (hash * 31) + (item.Value?.GetHashCode() ?? 0);
                }
            }

            return hash;
#endif
        }
    }

    internal readonly struct TagsOld : IEquatable<TagsOld>
    {
        public static readonly TagsOld EmptyTags = new(Array.Empty<KeyValuePair<string, object?>>());

        private readonly int hashCode;

        public TagsOld(KeyValuePair<string, object?>[] keyValuePairs)
        {
            this.KeyValuePairs = keyValuePairs;

#if NET6_0_OR_GREATER
            HashCode hashCode = default;

            for (int i = 0; i < this.KeyValuePairs.Length; i++)
            {
                ref var item = ref this.KeyValuePairs[i];
                hashCode.Add(item.Key);
                hashCode.Add(item.Value);
            }

            var hash = hashCode.ToHashCode();
#else
            var hash = 17;
            for (int i = 0; i < this.KeyValuePairs.Length; i++)
            {
                ref var item = ref this.KeyValuePairs[i];
                unchecked
                {
                    hash = (hash * 31) + (item.Key?.GetHashCode() ?? 0);
                    hash = (hash * 31) + (item.Value?.GetHashCode() ?? 0);
                }
            }
#endif

            this.hashCode = hash;
        }

        public readonly KeyValuePair<string, object?>[] KeyValuePairs { get; }

        public static bool operator ==(TagsOld tag1, TagsOld tag2) => tag1.Equals(tag2);

        public static bool operator !=(TagsOld tag1, TagsOld tag2) => !tag1.Equals(tag2);

        public override readonly bool Equals(object? obj)
        {
            return obj is TagsOld other && this.Equals(other);
        }

        public readonly bool Equals(TagsOld other)
        {
            var length = this.KeyValuePairs.Length;

            if (length != other.KeyValuePairs.Length)
            {
                return false;
            }

            for (int i = 0; i < length; i++)
            {
                ref var left = ref this.KeyValuePairs[i];
                ref var right = ref other.KeyValuePairs[i];

                // Equality check for Keys
                if (!left.Key.Equals(right.Key, StringComparison.Ordinal))
                {
                    return false;
                }

                // Equality check for Values
                if (!left.Value?.Equals(right.Value) ?? right.Value != null)
                {
                    return false;
                }
            }

            return true;
        }

        public override readonly int GetHashCode() => this.hashCode;
    }
}
```
</details>

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
