### PR TITLE
[shared] Split options and configuration extensions into separate files

### DIFF
--- a/OpenTelemetry.sln
+++ b/OpenTelemetry.sln
@@ -297,8 +297,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "EnvironmentVariables", "Env
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Options", "Options", "{494902DD-C63F-48E0-BED3-B58EFB4051C8}"
 	ProjectSection(SolutionItems) = preProject
-		src\Shared\Options\ConfigurationExtensions.cs = src\Shared\Options\ConfigurationExtensions.cs
 		src\Shared\Options\DelegatingOptionsFactory.cs = src\Shared\Options\DelegatingOptionsFactory.cs
+		src\Shared\Options\DelegatingOptionsFactoryServiceCollectionExtensions.cs = src\Shared\Options\DelegatingOptionsFactoryServiceCollectionExtensions.cs
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shims", "Shims", "{A0CB9A10-F22D-4E66-A449-74B3D0361A9C}"
@@ -341,6 +341,11 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "extending-the-sdk", "docs\resources\extending-the-sdk\extending-the-sdk.csproj", "{7BE494FC-4B0D-4340-A62A-9C9F3E7389FE}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dedicated-pipeline", "docs\logs\dedicated-pipeline\dedicated-pipeline.csproj", "{19545B37-8518-4BDD-AD49-00C031FB3C2A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Configuration", "Configuration", "{87A20A76-D524-4AAC-AF92-8725BFED0415}"
+	ProjectSection(SolutionItems) = preProject
+		src\Shared\Configuration\OpenTelemetryConfigurationExtensions.cs = src\Shared\Configuration\OpenTelemetryConfigurationExtensions.cs
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -687,6 +692,7 @@ Global
 		{A115CE4C-71A8-4B95-96A5-C1DF46FD94C2} = {7C87CAF9-79D7-4C26-9FFB-F3F1FB6911F1}
 		{7BE494FC-4B0D-4340-A62A-9C9F3E7389FE} = {A115CE4C-71A8-4B95-96A5-C1DF46FD94C2}
 		{19545B37-8518-4BDD-AD49-00C031FB3C2A} = {3862190B-E2C5-418E-AFDC-DB281FB5C705}
+		{87A20A76-D524-4AAC-AF92-8725BFED0415} = {A49299FB-C5CD-4E0E-B7E1-B7867BBD67CC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {55639B5C-0770-4A22-AB56-859604650521}

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExperimentalOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExperimentalOptions.cs
@@ -4,7 +4,6 @@
 #nullable enable
 
 using Microsoft.Extensions.Configuration;
-using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpServiceCollectionExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpServiceCollectionExtensions.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
-using OpenTelemetry.Internal;
 using OpenTelemetry.Metrics;
 
 namespace OpenTelemetry.Exporter;

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/SdkLimitOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/SdkLimitOptions.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using Microsoft.Extensions.Configuration;
-using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporter.cs
@@ -4,9 +4,9 @@
 #nullable enable
 
 using System.Diagnostics;
+using Microsoft.Extensions.Configuration;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Transmission;
-using OpenTelemetry.Internal;
 using OpenTelemetry.Logs;
 using OtlpCollector = OpenTelemetry.Proto.Collector.Logs.V1;
 using OtlpResource = OpenTelemetry.Proto.Resource.V1;
@@ -57,10 +57,7 @@ public sealed class OtlpLogExporter : BaseExporter<LogRecord>
             OpenTelemetryProtocolExporterEventSource.Log.UnsupportedAttributeType(tagValueType, tagKey);
         };
 
-        ConfigurationExtensions.LogInvalidEnvironmentVariable = (string key, string value) =>
-        {
-            OpenTelemetryProtocolExporterEventSource.Log.InvalidEnvironmentVariable(key, value);
-        };
+        OpenTelemetryConfigurationExtensions.LogInvalidEnvironmentVariable = OpenTelemetryProtocolExporterEventSource.Log.InvalidEnvironmentVariable;
 
         this.transmissionHandler = transmissionHandler ?? exporterOptions.GetLogsExportTransmissionHandler(experimentalOptions!);
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporter.cs
@@ -1,9 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using Microsoft.Extensions.Configuration;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Transmission;
-using OpenTelemetry.Internal;
 using OpenTelemetry.Metrics;
 using OtlpCollector = OpenTelemetry.Proto.Collector.Metrics.V1;
 using OtlpResource = OpenTelemetry.Proto.Resource.V1;
@@ -47,10 +47,7 @@ public class OtlpMetricExporter : BaseExporter<Metric>
             OpenTelemetryProtocolExporterEventSource.Log.UnsupportedAttributeType(tagValueType, tagKey);
         };
 
-        ConfigurationExtensions.LogInvalidEnvironmentVariable = (string key, string value) =>
-        {
-            OpenTelemetryProtocolExporterEventSource.Log.InvalidEnvironmentVariable(key, value);
-        };
+        OpenTelemetryConfigurationExtensions.LogInvalidEnvironmentVariable = OpenTelemetryProtocolExporterEventSource.Log.InvalidEnvironmentVariable;
 
         this.transmissionHandler = transmissionHandler ?? options.GetMetricsExportTransmissionHandler(experimentalOptions);
     }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporter.cs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
+using Microsoft.Extensions.Configuration;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Transmission;
-using OpenTelemetry.Internal;
 using OtlpCollector = OpenTelemetry.Proto.Collector.Trace.V1;
 using OtlpResource = OpenTelemetry.Proto.Resource.V1;
 
@@ -50,7 +50,7 @@ public class OtlpTraceExporter : BaseExporter<Activity>
 
         OtlpKeyValueTransformer.LogUnsupportedAttributeType = OpenTelemetryProtocolExporterEventSource.Log.UnsupportedAttributeType;
 
-        ConfigurationExtensions.LogInvalidEnvironmentVariable = OpenTelemetryProtocolExporterEventSource.Log.InvalidEnvironmentVariable;
+        OpenTelemetryConfigurationExtensions.LogInvalidEnvironmentVariable = OpenTelemetryProtocolExporterEventSource.Log.InvalidEnvironmentVariable;
 
         this.transmissionHandler = transmissionHandler ?? exporterOptions.GetTraceExportTransmissionHandler(experimentalOptions);
     }

--- a/src/OpenTelemetry.Exporter.Zipkin/OpenTelemetry.Exporter.Zipkin.csproj
+++ b/src/OpenTelemetry.Exporter.Zipkin/OpenTelemetry.Exporter.Zipkin.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(RepoRoot)\src\Shared\Configuration\*.cs" Link="Includes\Configuration\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\PooledList.cs" Link="Includes\PooledList.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\ResourceSemanticConventions.cs" Link="Includes\ResourceSemanticConventions.cs" />

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporter.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporter.cs
@@ -10,6 +10,7 @@ using System.Net.Http.Headers;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
+using Microsoft.Extensions.Configuration;
 using OpenTelemetry.Exporter.Zipkin.Implementation;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Resources;
@@ -43,10 +44,7 @@ public class ZipkinExporter : BaseExporter<Activity>
             ZipkinExporterEventSource.Log.UnsupportedAttributeType(tagValueType, tagKey);
         };
 
-        ConfigurationExtensions.LogInvalidEnvironmentVariable = (string key, string value) =>
-        {
-            ZipkinExporterEventSource.Log.InvalidEnvironmentVariable(key, value);
-        };
+        OpenTelemetryConfigurationExtensions.LogInvalidEnvironmentVariable = ZipkinExporterEventSource.Log.InvalidEnvironmentVariable;
     }
 
     internal ZipkinEndpoint LocalEndpoint { get; private set; }

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporterOptions.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Net.Http;
 #endif
 using Microsoft.Extensions.Configuration;
-using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Exporter;

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreTraceInstrumentationOptions.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/AspNetCoreTraceInstrumentationOptions.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
-using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Instrumentation.AspNetCore;
 

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/OpenTelemetry.Instrumentation.AspNetCore.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(RepoRoot)\src\Shared\Configuration\*.cs" Link="Includes\Configuration\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\Shared\EnvironmentVariables\*.cs" Link="Includes\EnvironmentVariables\%(Filename).cs" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.GrpcNetClient\GrpcTagHelper.cs" Link="Includes\GrpcTagHelper.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Instrumentation.GrpcNetClient\StatusCanonicalCode.cs" Link="Includes\StatusCanonicalCode.cs" />

--- a/src/OpenTelemetry/Internal/Builder/ProviderBuilderServiceCollectionExtensions.cs
+++ b/src/OpenTelemetry/Internal/Builder/ProviderBuilderServiceCollectionExtensions.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using OpenTelemetry;
-using OpenTelemetry.Internal;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;

--- a/src/OpenTelemetry/Logs/BatchExportLogRecordProcessorOptions.cs
+++ b/src/OpenTelemetry/Logs/BatchExportLogRecordProcessorOptions.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using Microsoft.Extensions.Configuration;
-using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Logs;
 

--- a/src/OpenTelemetry/Metrics/PeriodicExportingMetricReaderOptions.cs
+++ b/src/OpenTelemetry/Metrics/PeriodicExportingMetricReaderOptions.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using Microsoft.Extensions.Configuration;
-using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Metrics;
 

--- a/src/OpenTelemetry/OpenTelemetry.csproj
+++ b/src/OpenTelemetry/OpenTelemetry.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(RepoRoot)\src\Shared\Configuration\*.cs" Link="Includes\Configuration\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\Shared\EnvironmentVariables\*.cs" Link="Includes\EnvironmentVariables\%(Filename).cs" />
     <Compile Include="$(RepoRoot)\src\Shared\MathHelper.cs" Link="Includes\MathHelper.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Options\*.cs" Link="Includes\Options\%(Filename).cs" />

--- a/src/OpenTelemetry/Resources/OtelEnvResourceDetector.cs
+++ b/src/OpenTelemetry/Resources/OtelEnvResourceDetector.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using Microsoft.Extensions.Configuration;
-using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Resources;
 

--- a/src/OpenTelemetry/Resources/OtelServiceNameEnvVarDetector.cs
+++ b/src/OpenTelemetry/Resources/OtelServiceNameEnvVarDetector.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using Microsoft.Extensions.Configuration;
-using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Resources;
 

--- a/src/OpenTelemetry/Sdk.cs
+++ b/src/OpenTelemetry/Sdk.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 #endif
 using System.Reflection;
+using Microsoft.Extensions.Configuration;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Logs;
@@ -34,10 +35,7 @@ public static class Sdk
         var assemblyInformationalVersion = typeof(Sdk).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
         InformationalVersion = ParseAssemblyInformationalVersion(assemblyInformationalVersion);
 
-        ConfigurationExtensions.LogInvalidEnvironmentVariable = (string key, string value) =>
-        {
-            OpenTelemetrySdkEventSource.Log.InvalidEnvironmentVariable(key, value);
-        };
+        OpenTelemetryConfigurationExtensions.LogInvalidEnvironmentVariable = OpenTelemetrySdkEventSource.Log.InvalidEnvironmentVariable;
     }
 
     /// <summary>

--- a/src/OpenTelemetry/Trace/BatchExportActivityProcessorOptions.cs
+++ b/src/OpenTelemetry/Trace/BatchExportActivityProcessorOptions.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using Microsoft.Extensions.Configuration;
-using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Trace;
 

--- a/src/Shared/Configuration/OpenTelemetryConfigurationExtensions.cs
+++ b/src/Shared/Configuration/OpenTelemetryConfigurationExtensions.cs
@@ -3,19 +3,14 @@
 
 #nullable enable
 
-using System.Diagnostics;
 #if !NETFRAMEWORK && !NETSTANDARD2_0
 using System.Diagnostics.CodeAnalysis;
 #endif
 using System.Globalization;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Options;
 
-namespace OpenTelemetry.Internal;
+namespace Microsoft.Extensions.Configuration;
 
-internal static class ConfigurationExtensions
+internal static class OpenTelemetryConfigurationExtensions
 {
     public static Action<string, string>? LogInvalidEnvironmentVariable = null;
 
@@ -124,47 +119,5 @@ internal static class ConfigurationExtensions
         }
 
         return true;
-    }
-
-    public static IServiceCollection RegisterOptionsFactory<T>(
-        this IServiceCollection services,
-        Func<IConfiguration, T> optionsFactoryFunc)
-        where T : class
-    {
-        Debug.Assert(services != null, "services was null");
-        Debug.Assert(optionsFactoryFunc != null, "optionsFactoryFunc was null");
-
-        services!.TryAddSingleton<IOptionsFactory<T>>(sp =>
-        {
-            return new DelegatingOptionsFactory<T>(
-                (c, n) => optionsFactoryFunc!(c),
-                sp.GetRequiredService<IConfiguration>(),
-                sp.GetServices<IConfigureOptions<T>>(),
-                sp.GetServices<IPostConfigureOptions<T>>(),
-                sp.GetServices<IValidateOptions<T>>());
-        });
-
-        return services!;
-    }
-
-    public static IServiceCollection RegisterOptionsFactory<T>(
-        this IServiceCollection services,
-        Func<IServiceProvider, IConfiguration, string, T> optionsFactoryFunc)
-        where T : class
-    {
-        Debug.Assert(services != null, "services was null");
-        Debug.Assert(optionsFactoryFunc != null, "optionsFactoryFunc was null");
-
-        services!.TryAddSingleton<IOptionsFactory<T>>(sp =>
-        {
-            return new DelegatingOptionsFactory<T>(
-                (c, n) => optionsFactoryFunc!(sp, c, n),
-                sp.GetRequiredService<IConfiguration>(),
-                sp.GetServices<IConfigureOptions<T>>(),
-                sp.GetServices<IPostConfigureOptions<T>>(),
-                sp.GetServices<IValidateOptions<T>>());
-        });
-
-        return services!;
     }
 }

--- a/src/Shared/Options/DelegatingOptionsFactory.cs
+++ b/src/Shared/Options/DelegatingOptionsFactory.cs
@@ -15,102 +15,98 @@
 
 #nullable enable
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Configuration;
 
-namespace Microsoft.Extensions.Options
+namespace Microsoft.Extensions.Options;
+
+/// <summary>
+/// Implementation of <see cref="IOptionsFactory{TOptions}"/>.
+/// </summary>
+/// <typeparam name="TOptions">The type of options being requested.</typeparam>
+internal sealed class DelegatingOptionsFactory<TOptions> :
+    IOptionsFactory<TOptions>
+    where TOptions : class
 {
+    private readonly Func<IConfiguration, string, TOptions> optionsFactoryFunc;
+    private readonly IConfiguration configuration;
+    private readonly IConfigureOptions<TOptions>[] _setups;
+    private readonly IPostConfigureOptions<TOptions>[] _postConfigures;
+    private readonly IValidateOptions<TOptions>[] _validations;
+
     /// <summary>
-    /// Implementation of <see cref="IOptionsFactory{TOptions}"/>.
+    /// Initializes a new instance with the specified options configurations.
     /// </summary>
-    /// <typeparam name="TOptions">The type of options being requested.</typeparam>
-    internal sealed class DelegatingOptionsFactory<TOptions> :
-        IOptionsFactory<TOptions>
-        where TOptions : class
+    /// <param name="optionsFactoryFunc">Factory delegate used to create <typeparamref name="TOptions"/> instances.</param>
+    /// <param name="configuration"><see cref="IConfiguration"/>.</param>
+    /// <param name="setups">The configuration actions to run.</param>
+    /// <param name="postConfigures">The initialization actions to run.</param>
+    /// <param name="validations">The validations to run.</param>
+    public DelegatingOptionsFactory(
+        Func<IConfiguration, string, TOptions> optionsFactoryFunc,
+        IConfiguration configuration,
+        IEnumerable<IConfigureOptions<TOptions>> setups,
+        IEnumerable<IPostConfigureOptions<TOptions>> postConfigures,
+        IEnumerable<IValidateOptions<TOptions>> validations)
     {
-        private readonly Func<IConfiguration, string, TOptions> optionsFactoryFunc;
-        private readonly IConfiguration configuration;
-        private readonly IConfigureOptions<TOptions>[] _setups;
-        private readonly IPostConfigureOptions<TOptions>[] _postConfigures;
-        private readonly IValidateOptions<TOptions>[] _validations;
+        // The default DI container uses arrays under the covers. Take advantage of this knowledge
+        // by checking for an array and enumerate over that, so we don't need to allocate an enumerator.
+        // When it isn't already an array, convert it to one, but don't use System.Linq to avoid pulling Linq in to
+        // small trimmed applications.
 
-        /// <summary>
-        /// Initializes a new instance with the specified options configurations.
-        /// </summary>
-        /// <param name="optionsFactoryFunc">Factory delegate used to create <typeparamref name="TOptions"/> instances.</param>
-        /// <param name="configuration"><see cref="IConfiguration"/>.</param>
-        /// <param name="setups">The configuration actions to run.</param>
-        /// <param name="postConfigures">The initialization actions to run.</param>
-        /// <param name="validations">The validations to run.</param>
-        public DelegatingOptionsFactory(
-            Func<IConfiguration, string, TOptions> optionsFactoryFunc,
-            IConfiguration configuration,
-            IEnumerable<IConfigureOptions<TOptions>> setups,
-            IEnumerable<IPostConfigureOptions<TOptions>> postConfigures,
-            IEnumerable<IValidateOptions<TOptions>> validations)
+        Debug.Assert(optionsFactoryFunc != null, "optionsFactoryFunc was null");
+        Debug.Assert(configuration != null, "configuration was null");
+
+        this.optionsFactoryFunc = optionsFactoryFunc!;
+        this.configuration = configuration!;
+        _setups = setups as IConfigureOptions<TOptions>[] ?? new List<IConfigureOptions<TOptions>>(setups).ToArray();
+        _postConfigures = postConfigures as IPostConfigureOptions<TOptions>[] ?? new List<IPostConfigureOptions<TOptions>>(postConfigures).ToArray();
+        _validations = validations as IValidateOptions<TOptions>[] ?? new List<IValidateOptions<TOptions>>(validations).ToArray();
+    }
+
+    /// <summary>
+    /// Returns a configured <typeparamref name="TOptions"/> instance with the given <paramref name="name"/>.
+    /// </summary>
+    /// <param name="name">The name of the <typeparamref name="TOptions"/> instance to create.</param>
+    /// <returns>The created <typeparamref name="TOptions"/> instance with the given <paramref name="name"/>.</returns>
+    /// <exception cref="OptionsValidationException">One or more <see cref="IValidateOptions{TOptions}"/> return failed <see cref="ValidateOptionsResult"/> when validating the <typeparamref name="TOptions"/> instance been created.</exception>
+    /// <exception cref="MissingMethodException">The <typeparamref name="TOptions"/> does not have a public parameterless constructor or <typeparamref name="TOptions"/> is <see langword="abstract"/>.</exception>
+    public TOptions Create(string name)
+    {
+        TOptions options = this.optionsFactoryFunc(this.configuration, name);
+        foreach (IConfigureOptions<TOptions> setup in _setups)
         {
-            // The default DI container uses arrays under the covers. Take advantage of this knowledge
-            // by checking for an array and enumerate over that, so we don't need to allocate an enumerator.
-            // When it isn't already an array, convert it to one, but don't use System.Linq to avoid pulling Linq in to
-            // small trimmed applications.
-
-            Debug.Assert(optionsFactoryFunc != null, "optionsFactoryFunc was null");
-            Debug.Assert(configuration != null, "configuration was null");
-
-            this.optionsFactoryFunc = optionsFactoryFunc!;
-            this.configuration = configuration!;
-            _setups = setups as IConfigureOptions<TOptions>[] ?? new List<IConfigureOptions<TOptions>>(setups).ToArray();
-            _postConfigures = postConfigures as IPostConfigureOptions<TOptions>[] ?? new List<IPostConfigureOptions<TOptions>>(postConfigures).ToArray();
-            _validations = validations as IValidateOptions<TOptions>[] ?? new List<IValidateOptions<TOptions>>(validations).ToArray();
+            if (setup is IConfigureNamedOptions<TOptions> namedSetup)
+            {
+                namedSetup.Configure(name, options);
+            }
+            else if (name == Options.DefaultName)
+            {
+                setup.Configure(options);
+            }
+        }
+        foreach (IPostConfigureOptions<TOptions> post in _postConfigures)
+        {
+            post.PostConfigure(name, options);
         }
 
-        /// <summary>
-        /// Returns a configured <typeparamref name="TOptions"/> instance with the given <paramref name="name"/>.
-        /// </summary>
-        /// <param name="name">The name of the <typeparamref name="TOptions"/> instance to create.</param>
-        /// <returns>The created <typeparamref name="TOptions"/> instance with the given <paramref name="name"/>.</returns>
-        /// <exception cref="OptionsValidationException">One or more <see cref="IValidateOptions{TOptions}"/> return failed <see cref="ValidateOptionsResult"/> when validating the <typeparamref name="TOptions"/> instance been created.</exception>
-        /// <exception cref="MissingMethodException">The <typeparamref name="TOptions"/> does not have a public parameterless constructor or <typeparamref name="TOptions"/> is <see langword="abstract"/>.</exception>
-        public TOptions Create(string name)
+        if (_validations.Length > 0)
         {
-            TOptions options = this.optionsFactoryFunc(this.configuration, name);
-            foreach (IConfigureOptions<TOptions> setup in _setups)
+            var failures = new List<string>();
+            foreach (IValidateOptions<TOptions> validate in _validations)
             {
-                if (setup is IConfigureNamedOptions<TOptions> namedSetup)
+                ValidateOptionsResult result = validate.Validate(name, options);
+                if (result is not null && result.Failed)
                 {
-                    namedSetup.Configure(name, options);
-                }
-                else if (name == Options.DefaultName)
-                {
-                    setup.Configure(options);
+                    failures.AddRange(result.Failures);
                 }
             }
-            foreach (IPostConfigureOptions<TOptions> post in _postConfigures)
+            if (failures.Count > 0)
             {
-                post.PostConfigure(name, options);
+                throw new OptionsValidationException(name, typeof(TOptions), failures);
             }
-
-            if (_validations.Length > 0)
-            {
-                var failures = new List<string>();
-                foreach (IValidateOptions<TOptions> validate in _validations)
-                {
-                    ValidateOptionsResult result = validate.Validate(name, options);
-                    if (result is not null && result.Failed)
-                    {
-                        failures.AddRange(result.Failures);
-                    }
-                }
-                if (failures.Count > 0)
-                {
-                    throw new OptionsValidationException(name, typeof(TOptions), failures);
-                }
-            }
-
-            return options;
         }
+
+        return options;
     }
 }

--- a/src/Shared/Options/DelegatingOptionsFactoryServiceCollectionExtensions.cs
+++ b/src/Shared/Options/DelegatingOptionsFactoryServiceCollectionExtensions.cs
@@ -1,0 +1,56 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#nullable enable
+
+using System.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+internal static class DelegatingOptionsFactoryServiceCollectionExtensions
+{
+    public static IServiceCollection RegisterOptionsFactory<T>(
+        this IServiceCollection services,
+        Func<IConfiguration, T> optionsFactoryFunc)
+        where T : class
+    {
+        Debug.Assert(services != null, "services was null");
+        Debug.Assert(optionsFactoryFunc != null, "optionsFactoryFunc was null");
+
+        services!.TryAddSingleton<IOptionsFactory<T>>(sp =>
+        {
+            return new DelegatingOptionsFactory<T>(
+                (c, n) => optionsFactoryFunc!(c),
+                sp.GetRequiredService<IConfiguration>(),
+                sp.GetServices<IConfigureOptions<T>>(),
+                sp.GetServices<IPostConfigureOptions<T>>(),
+                sp.GetServices<IValidateOptions<T>>());
+        });
+
+        return services!;
+    }
+
+    public static IServiceCollection RegisterOptionsFactory<T>(
+        this IServiceCollection services,
+        Func<IServiceProvider, IConfiguration, string, T> optionsFactoryFunc)
+        where T : class
+    {
+        Debug.Assert(services != null, "services was null");
+        Debug.Assert(optionsFactoryFunc != null, "optionsFactoryFunc was null");
+
+        services!.TryAddSingleton<IOptionsFactory<T>>(sp =>
+        {
+            return new DelegatingOptionsFactory<T>(
+                (c, n) => optionsFactoryFunc!(sp, c, n),
+                sp.GetRequiredService<IConfiguration>(),
+                sp.GetServices<IConfigureOptions<T>>(),
+                sp.GetServices<IPostConfigureOptions<T>>(),
+                sp.GetServices<IValidateOptions<T>>());
+        });
+
+        return services!;
+    }
+}


### PR DESCRIPTION
## Changes

* Split options and configuration extensions into separate files

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
