### PR TITLE
GetMetricsBatch fails while unit tests

### DIFF
--- a/src/OpenTelemetry/Metrics/MetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/MetricReaderExt.cs
@@ -201,8 +201,18 @@ public abstract partial class MetricReader
 
     private Batch<Metric> GetMetricsBatch()
     {
-        Debug.Assert(this.metrics != null, "this.metrics was null");
-        Debug.Assert(this.metricsCurrentBatch != null, "this.metricsCurrentBatch was null");
+        // if ApplyParentProviderSettings is not called
+        // the for loop condition is false and metricCountCurrentBatch is 0
+        // so removing the Asserts does not change anything.
+        // but for future changes guard if null and return.
+
+        // Debug.Assert(this.metrics != null, "this.metrics was null");
+        // Debug.Assert(this.metricsCurrentBatch != null, "this.metricsCurrentBatch was null");
+
+        if (this.metrics == null || this.metricsCurrentBatch == null)
+        {
+            return default;
+        }
 
         try
         {


### PR DESCRIPTION
Fixes #
Try to fix GetMetricsBatch. it failed from time to time. if I run the test.
The Assert is false if ApplyParentProviderSettings was not called before.
this also means metricLimit is 0 .. IMHO: so effectively return  default is called

Design discussion issue #

## Changes

Please provide a brief description of the changes here.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
