### PR TITLE
📝 Move OTEL_TRACES_SAMPLER_* feature changelog from '1.8.0-beta.1' to 'Unreleased'

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+* `TracerProvider`s can now have a sampler configured via the
+  `OTEL_TRACES_SAMPLER` environment variable. The supported values are:
+  `always_off`, `always_on`, `traceidratio`, `parentbased_always_on`,
+  `parentbased_always_off`, and `parentbased_traceidratio`. The options
+  `traceidratio` and `parentbased_traceidratio` may have the sampler probability
+  configured via the `OTEL_TRACES_SAMPLER_ARG` environment variable.
+  For details see: [OpenTelemetry Environment Variable
+  Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration).
+  ([#5448](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5448))
+
 ## 1.8.0-beta.1
 
 Released 2024-Mar-14
@@ -80,16 +90,6 @@ Released 2024-Mar-14
   `trace_based`. For details see: [OpenTelemetry Environment Variable
   Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#exemplar).
   ([#5412](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5412))
-
-* `TracerProvider`s can now have a sampler configured via the
-  `OTEL_TRACES_SAMPLER` environment variable. The supported values are:
-  `always_off`, `always_on`, `traceidratio`, `parentbased_always_on`,
-  `parentbased_always_off`, and `parentbased_traceidratio`. The options
-  `traceidratio` and `parentbased_traceidratio` may have the sampler probability
-  configured via the `OTEL_TRACES_SAMPLER_ARG` environment variable.
-  For details see: [OpenTelemetry Environment Variable
-  Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration).
-  ([#5448](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5448))
 
 ## 1.7.0
 


### PR DESCRIPTION
Fixes #5480

## Changes

This PR fixes a minor inconsistency in the OpenTelemetry project's CHANGELOG file that listed the following feature in the incorrect release: the feature was not yet released and was wrongly mentioned as part of the `1.8.0-beta.1` release.
- https://github.com/open-telemetry/opentelemetry-dotnet/issues/3601

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
