### PR TITLE
[Instrumentation.AspNetCore] Fix span names when http.request.method is reporter as _OTHER

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -13,6 +13,10 @@
   the original value `Get` will be stored in `http.request.method_original`.
   ([#5471](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5471))
 
+* Fixed an issue for span names when `http.request.method` is reporter as `_OTHER`.
+  Now, span names starts with `HTTP`, previously it was started by `_OTHER`.
+  ([#5484](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5484))
+
 ## 1.7.1
 
 Released 2024-Feb-09

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -14,7 +14,7 @@
   ([#5471](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5471))
 
 * Fixed the name of spans that have `http.request.method` attribute set to `_OTHER`.
-  Now, the span name have `HTTP` prefix, previously it was `_OTHER`.
+  The span name will be set as `HTTP {http.route}` as per the [specification](https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/http/http-spans.md#name).
   ([#5484](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5484))
 
 ## 1.7.1

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -13,8 +13,8 @@
   the original value `Get` will be stored in `http.request.method_original`.
   ([#5471](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5471))
 
-* Fixed an issue for span names when `http.request.method` is reporter as `_OTHER`.
-  Now, span names starts with `HTTP`, previously it was started by `_OTHER`.
+* Fixed the name of spans that have `http.request.method` attribute set to `_OTHER`.
+  Now, the span name have `HTTP` prefix, previously it was `_OTHER`.
   ([#5484](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5484))
 
 ## 1.7.1

--- a/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/Implementation/HttpInListener.cs
@@ -177,7 +177,7 @@ internal class HttpInListener : ListenerHandler
             }
 
             var path = (request.PathBase.HasValue || request.Path.HasValue) ? (request.PathBase + request.Path).ToString() : "/";
-            activity.DisplayName = GetDisplayName(request.Method);
+            RequestMethodHelper.SetActivityDisplayName(activity, request.Method);
 
             // see the spec https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/http/http-spans.md
 
@@ -241,7 +241,7 @@ internal class HttpInListener : ListenerHandler
                     context.GetEndpoint() as RouteEndpoint)?.RoutePattern.RawText;
             if (!string.IsNullOrEmpty(routePattern))
             {
-                activity.DisplayName = GetDisplayName(context.Request.Method, routePattern);
+                RequestMethodHelper.SetActivityDisplayName(activity, context.Request.Method, routePattern);
                 activity.SetTag(SemanticConventions.AttributeHttpRoute, routePattern);
             }
 #endif
@@ -387,14 +387,5 @@ internal class HttpInListener : ListenerHandler
                 activity.SetTag(SemanticConventions.AttributeRpcGrpcStatusCode, status);
             }
         }
-    }
-
-    private static string GetDisplayName(string httpMethod, string httpRoute = null)
-    {
-        var normalizedMethod = RequestMethodHelper.GetNormalizedHttpMethod(httpMethod);
-
-        return string.IsNullOrEmpty(httpRoute)
-            ? normalizedMethod
-            : $"{normalizedMethod} {httpRoute}";
     }
 }

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs
@@ -135,7 +135,7 @@ internal sealed class HttpHandlerDiagnosticListener : ListenerHandler
                 return;
             }
 
-            RequestMethodHelper.SetHttpClientActivityDisplayName(activity, request.Method.Method);
+            RequestMethodHelper.SetActivityDisplayName(activity, request.Method.Method);
 
             if (!IsNet7OrGreater)
             {

--- a/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
+++ b/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpWebRequestActivitySource.netfx.cs
@@ -95,7 +95,7 @@ internal static class HttpWebRequestActivitySource
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void AddRequestTagsAndInstrumentRequest(HttpWebRequest request, Activity activity)
     {
-        RequestMethodHelper.SetHttpClientActivityDisplayName(activity, request.Method);
+        RequestMethodHelper.SetActivityDisplayName(activity, request.Method);
 
         if (activity.IsAllDataRequested)
         {

--- a/src/Shared/RequestMethodHelper.cs
+++ b/src/Shared/RequestMethodHelper.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable enable
+
 #if NET8_0_OR_GREATER
 using System.Collections.Frozen;
 #endif
@@ -62,9 +64,11 @@ internal static class RequestMethodHelper
         }
     }
 
-    public static void SetHttpClientActivityDisplayName(Activity activity, string method)
+    public static void SetActivityDisplayName(Activity activity, string method, string? httpRoute = null)
     {
-        // https://github.com/open-telemetry/semantic-conventions/blob/v1.23.0/docs/http/http-spans.md#name
-        activity.DisplayName = KnownMethods.TryGetValue(method, out var httpMethod) ? httpMethod : "HTTP";
+        // https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/http/http-spans.md#name
+
+        var namePrefix = KnownMethods.TryGetValue(method, out var httpMethod) ? httpMethod : "HTTP";
+        activity.DisplayName = string.IsNullOrEmpty(httpRoute) ? namePrefix : $"{namePrefix} {httpRoute}";
     }
 }

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
@@ -640,7 +640,7 @@ public sealed class BasicTests
     [InlineData("POST", "POST", null, "POST")]
     [InlineData("TRACE", "TRACE", null, "TRACE")]
     [InlineData("CUSTOM", "_OTHER", "CUSTOM", "HTTP")]
-    public async Task HttpRequestMethodIsSetAsPerSpec(string originalMethod, string expectedMethod, string expectedOriginalMethod, string expectedDisplayName)
+    public async Task HttpRequestMethodAndActivityDisplayIsSetAsPerSpec(string originalMethod, string expectedMethod, string expectedOriginalMethod, string expectedDisplayName)
     {
         var exportedItems = new List<Activity>();
 

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/BasicTests.cs
@@ -629,18 +629,18 @@ public sealed class BasicTests
     }
 
     [Theory]
-    [InlineData("CONNECT", "CONNECT", null)]
-    [InlineData("DELETE", "DELETE", null)]
-    [InlineData("GET", "GET", null)]
-    [InlineData("PUT", "PUT", null)]
-    [InlineData("HEAD", "HEAD", null)]
-    [InlineData("OPTIONS", "OPTIONS", null)]
-    [InlineData("PATCH", "PATCH", null)]
-    [InlineData("Get", "GET", "Get")]
-    [InlineData("POST", "POST", null)]
-    [InlineData("TRACE", "TRACE", null)]
-    [InlineData("CUSTOM", "_OTHER", "CUSTOM")]
-    public async Task HttpRequestMethodIsSetAsPerSpec(string originalMethod, string expectedMethod, string expectedOriginalMethod)
+    [InlineData("CONNECT", "CONNECT", null, "CONNECT")]
+    [InlineData("DELETE", "DELETE", null, "DELETE")]
+    [InlineData("GET", "GET", null, "GET")]
+    [InlineData("PUT", "PUT", null, "PUT")]
+    [InlineData("HEAD", "HEAD", null, "HEAD")]
+    [InlineData("OPTIONS", "OPTIONS", null, "OPTIONS")]
+    [InlineData("PATCH", "PATCH", null, "PATCH")]
+    [InlineData("Get", "GET", "Get", "GET")]
+    [InlineData("POST", "POST", null, "POST")]
+    [InlineData("TRACE", "TRACE", null, "TRACE")]
+    [InlineData("CUSTOM", "_OTHER", "CUSTOM", "HTTP")]
+    public async Task HttpRequestMethodIsSetAsPerSpec(string originalMethod, string expectedMethod, string expectedOriginalMethod, string expectedDisplayName)
     {
         var exportedItems = new List<Activity>();
 
@@ -683,6 +683,7 @@ public sealed class BasicTests
 
         Assert.Equal(expectedMethod, activity.GetTagValue(SemanticConventions.AttributeHttpRequestMethod));
         Assert.Equal(expectedOriginalMethod, activity.GetTagValue(SemanticConventions.AttributeHttpRequestMethodOriginal));
+        Assert.Equal(expectedDisplayName, activity.DisplayName);
     }
 
     [Fact]

--- a/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTests.cs
+++ b/test/OpenTelemetry.Instrumentation.AspNetCore.Tests/RouteTests/RoutingTests.cs
@@ -14,8 +14,6 @@ namespace RouteTests;
 
 public class RoutingTests : IClassFixture<RoutingTestFixture>
 {
-    private const string OldHttpStatusCode = "http.status_code";
-    private const string OldHttpMethod = "http.method";
     private const string HttpStatusCode = "http.response.status_code";
     private const string HttpMethod = "http.request.method";
     private const string HttpRoute = "http.route";


### PR DESCRIPTION
Fixes #5461
Design discussion issue #

## Changes

* Fixed an issue for span names when `http.request.method` is reporter as `_OTHER`.
  Now, span names starts with `HTTP`, previously it was started by `_OTHER`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* ~~[ ] Changes in public API reviewed (if applicable)~~
