### PR TITLE
Include resource attributes as tags for Prometheus exporters

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/.publicApi/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 Microsoft.AspNetCore.Builder.PrometheusExporterApplicationBuilderExtensions
 Microsoft.AspNetCore.Builder.PrometheusExporterEndpointRouteBuilderExtensions
 OpenTelemetry.Exporter.PrometheusAspNetCoreOptions
+OpenTelemetry.Exporter.PrometheusAspNetCoreOptions.AllowedResourceAttributesFilter.get -> System.Predicate<string>
+OpenTelemetry.Exporter.PrometheusAspNetCoreOptions.AllowedResourceAttributesFilter.set -> void
 OpenTelemetry.Exporter.PrometheusAspNetCoreOptions.DisableTotalNameSuffixForCounters.get -> bool
 OpenTelemetry.Exporter.PrometheusAspNetCoreOptions.DisableTotalNameSuffixForCounters.set -> void
 OpenTelemetry.Exporter.PrometheusAspNetCoreOptions.PrometheusAspNetCoreOptions() -> void

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Add resource attributes as tags for Prometheus exporters with filter
+  ([#3087](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5407))
+
 ## 1.8.0-rc.1
 
 Released 2024-Mar-27

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Add resource attributes as tags for Prometheus exporters with filter
-  ([#3087](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5407))
+  ([#5489](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5489))
 
 ## 1.8.0-rc.1
 

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/OpenTelemetry.Exporter.Prometheus.AspNetCore.csproj
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/OpenTelemetry.Exporter.Prometheus.AspNetCore.csproj
@@ -24,6 +24,7 @@
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Prometheus.HttpListener\Internal\PrometheusExporter.cs" Link="Includes/PrometheusExporter.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Prometheus.HttpListener\Internal\PrometheusExporterEventSource.cs" Link="Includes/PrometheusExporterEventSource.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Prometheus.HttpListener\Internal\PrometheusExporterOptions.cs" Link="Includes/PrometheusExporterOptions.cs" />
+    <Compile Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Prometheus.HttpListener\Internal\PrometheusResourceTagCollection.cs" Link="Includes/PrometheusResourceTagCollection.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Prometheus.HttpListener\Internal\PrometheusSerializer.cs" Link="Includes/PrometheusSerializer.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Prometheus.HttpListener\Internal\PrometheusSerializerExt.cs" Link="Includes/PrometheusSerializerExt.cs" />
     <Compile Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Prometheus.HttpListener\Internal\PrometheusType.cs" Link="Includes/PrometheusType.cs" />

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusAspNetCoreOptions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusAspNetCoreOptions.cs
@@ -38,5 +38,14 @@ public class PrometheusAspNetCoreOptions
         set => this.ExporterOptions.ScrapeResponseCacheDurationMilliseconds = value;
     }
 
+    /// <summary>
+    /// Gets or sets the allowed resource attributes filter. Default value: null (no attributes allowed).
+    /// </summary>
+    public Predicate<string> AllowedResourceAttributesFilter
+    {
+        get => this.ExporterOptions.AllowedResourceAttributesFilter;
+        set => this.ExporterOptions.AllowedResourceAttributesFilter = value;
+    }
+
     internal PrometheusExporterOptions ExporterOptions { get; } = new();
 }

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/.publicApi/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions
+OpenTelemetry.Exporter.PrometheusHttpListenerOptions.AllowedResourceAttributesFilter.get -> System.Predicate<string>
+OpenTelemetry.Exporter.PrometheusHttpListenerOptions.AllowedResourceAttributesFilter.set -> void
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.DisableTotalNameSuffixForCounters.get -> bool
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.DisableTotalNameSuffixForCounters.set -> void
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.UriPrefixes.get -> System.Collections.Generic.IReadOnlyCollection<string>

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Add resource attributes as tags for Prometheus exporters with filter
+  ([#3087](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5407))
+
 ## 1.8.0-rc.1
 
 Released 2024-Mar-27

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Add resource attributes as tags for Prometheus exporters with filter
-  ([#3087](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5407))
+  ([#5489](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5489))
 
 ## 1.8.0-rc.1
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusCollectionManager.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusCollectionManager.cs
@@ -173,6 +173,8 @@ internal sealed class PrometheusCollectionManager
 
         try
         {
+            var resourceTags = new PrometheusResourceTagCollection(this.exporter.Resource, this.exporter.AllowedResourceAttributesFilter);
+
             if (this.exporter.OpenMetricsRequested)
             {
                 cursor = this.WriteTargetInfo();
@@ -230,6 +232,7 @@ internal sealed class PrometheusCollectionManager
                             cursor,
                             metric,
                             this.GetPrometheusMetric(metric),
+                            resourceTags,
                             this.exporter.OpenMetricsRequested);
 
                         break;

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusExporter.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusExporter.cs
@@ -28,6 +28,7 @@ internal sealed class PrometheusExporter : BaseExporter<Metric>, IPullMetricExpo
 
         this.ScrapeResponseCacheDurationMilliseconds = options.ScrapeResponseCacheDurationMilliseconds;
         this.DisableTotalNameSuffixForCounters = options.DisableTotalNameSuffixForCounters;
+        this.AllowedResourceAttributesFilter = options.AllowedResourceAttributesFilter;
 
         this.CollectionManager = new PrometheusCollectionManager(this);
     }
@@ -58,6 +59,8 @@ internal sealed class PrometheusExporter : BaseExporter<Metric>, IPullMetricExpo
     internal bool OpenMetricsRequested { get; set; }
 
     internal Resource Resource => this.resource ??= this.ParentProvider.GetResource();
+
+    internal Predicate<string> AllowedResourceAttributesFilter { get; set; }
 
     /// <inheritdoc/>
     public override ExportResult Export(in Batch<Metric> metrics)

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusExporterOptions.cs
@@ -33,4 +33,9 @@ internal sealed class PrometheusExporterOptions
     /// Gets or sets a value indicating whether addition of _total suffix for counter metric names is disabled. Default value: <see langword="false"/>.
     /// </summary>
     public bool DisableTotalNameSuffixForCounters { get; set; }
+
+    /// <summary>
+    /// Gets or sets the allowed resource attributes filter. Default value: null (no attributes allowed).
+    /// </summary>
+    public Predicate<string> AllowedResourceAttributesFilter { get; set; } = null;
 }

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusResourceTagCollection.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusResourceTagCollection.cs
@@ -1,0 +1,34 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.Resources;
+
+namespace OpenTelemetry.Exporter.Prometheus;
+
+internal readonly struct PrometheusResourceTagCollection
+{
+    private readonly Resource resource;
+    private readonly Predicate<string> resourceAttributeFilter;
+
+    public PrometheusResourceTagCollection(Resource resource, Predicate<string> resourceAttributeFilter = null)
+    {
+        this.resource = resource;
+        this.resourceAttributeFilter = resourceAttributeFilter;
+    }
+
+    public IEnumerable<KeyValuePair<string, object>> Attributes
+    {
+        get
+        {
+            if (this.resource == null || this.resourceAttributeFilter == null)
+            {
+                return Enumerable.Empty<KeyValuePair<string, object>>();
+            }
+
+            var attributeFilter = this.resourceAttributeFilter;
+
+            return this.resource?.Attributes
+                .Where(attribute => attributeFilter(attribute.Key));
+        }
+    }
+}

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializer.cs
@@ -367,11 +367,17 @@ internal static partial class PrometheusSerializer
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int WriteTags(byte[] buffer, int cursor, Metric metric, ReadOnlyTagCollection tags, bool writeEnclosingBraces = true)
+    public static int WriteTags(byte[] buffer, int cursor, Metric metric, ReadOnlyTagCollection tags, PrometheusResourceTagCollection resourceTags = default, bool writeEnclosingBraces = true)
     {
         if (writeEnclosingBraces)
         {
             buffer[cursor++] = unchecked((byte)'{');
+        }
+
+        foreach (var resourceAttribute in resourceTags.Attributes)
+        {
+            cursor = WriteLabel(buffer, cursor, resourceAttribute.Key, resourceAttribute.Value);
+            buffer[cursor++] = unchecked((byte)',');
         }
 
         cursor = WriteLabel(buffer, cursor, "otel_scope_name", metric.MeterName);

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializerExt.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializerExt.cs
@@ -22,7 +22,7 @@ internal static partial class PrometheusSerializer
         return true;
     }
 
-    public static int WriteMetric(byte[] buffer, int cursor, Metric metric, PrometheusMetric prometheusMetric, bool openMetricsRequested = false)
+    public static int WriteMetric(byte[] buffer, int cursor, Metric metric, PrometheusMetric prometheusMetric, PrometheusResourceTagCollection resourceTags = default, bool openMetricsRequested = false)
     {
         cursor = WriteTypeMetadata(buffer, cursor, prometheusMetric);
         cursor = WriteUnitMetadata(buffer, cursor, prometheusMetric);
@@ -36,7 +36,7 @@ internal static partial class PrometheusSerializer
 
                 // Counter and Gauge
                 cursor = WriteMetricName(buffer, cursor, prometheusMetric);
-                cursor = WriteTags(buffer, cursor, metric, metricPoint.Tags);
+                cursor = WriteTags(buffer, cursor, metric, metricPoint.Tags, resourceTags);
 
                 buffer[cursor++] = unchecked((byte)' ');
 
@@ -87,7 +87,7 @@ internal static partial class PrometheusSerializer
 
                     cursor = WriteMetricName(buffer, cursor, prometheusMetric);
                     cursor = WriteAsciiStringNoEscape(buffer, cursor, "_bucket{");
-                    cursor = WriteTags(buffer, cursor, metric, tags, writeEnclosingBraces: false);
+                    cursor = WriteTags(buffer, cursor, metric, tags, resourceTags, writeEnclosingBraces: false);
 
                     cursor = WriteAsciiStringNoEscape(buffer, cursor, "le=\"");
 
@@ -113,7 +113,7 @@ internal static partial class PrometheusSerializer
                 // Histogram sum
                 cursor = WriteMetricName(buffer, cursor, prometheusMetric);
                 cursor = WriteAsciiStringNoEscape(buffer, cursor, "_sum");
-                cursor = WriteTags(buffer, cursor, metric, metricPoint.Tags);
+                cursor = WriteTags(buffer, cursor, metric, metricPoint.Tags, resourceTags);
 
                 buffer[cursor++] = unchecked((byte)' ');
 
@@ -127,7 +127,7 @@ internal static partial class PrometheusSerializer
                 // Histogram count
                 cursor = WriteMetricName(buffer, cursor, prometheusMetric);
                 cursor = WriteAsciiStringNoEscape(buffer, cursor, "_count");
-                cursor = WriteTags(buffer, cursor, metric, metricPoint.Tags);
+                cursor = WriteTags(buffer, cursor, metric, metricPoint.Tags, resourceTags);
 
                 buffer[cursor++] = unchecked((byte)' ');
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerMeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerMeterProviderBuilderExtensions.cs
@@ -69,6 +69,7 @@ public static class PrometheusHttpListenerMeterProviderBuilderExtensions
         {
             ScrapeResponseCacheDurationMilliseconds = 0,
             DisableTotalNameSuffixForCounters = options.DisableTotalNameSuffixForCounters,
+            AllowedResourceAttributesFilter = options.AllowedResourceAttributesFilter,
         });
 
         var reader = new BaseExportingMetricReader(exporter)

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerOptions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerOptions.cs
@@ -41,4 +41,9 @@ public class PrometheusHttpListenerOptions
             this.uriPrefixes = value;
         }
     }
+
+    /// <summary>
+    /// Gets or sets the allowed resource attributes filter. Default value: null (no attributes allowed).
+    /// </summary>
+    public Predicate<string> AllowedResourceAttributesFilter { get; set; } = null;
 }

--- a/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMiddlewareTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMiddlewareTests.cs
@@ -248,6 +248,16 @@ public sealed class PrometheusExporterMiddlewareTests
             acceptHeader: "application/openmetrics-text; version=1.0.0");
     }
 
+    [Fact]
+    public Task PrometheusExporterMiddlewareIntegration_AddResourceAttributesAsTags()
+    {
+        return RunPrometheusExporterMiddlewareIntegrationTest(
+            "/metrics",
+            app => app.UseOpenTelemetryPrometheusScrapingEndpoint(),
+            configureOptions: o => o.AllowedResourceAttributesFilter = s => s == "service.name",
+            addServiceNameResourceTag: true);
+    }
+
     private static async Task RunPrometheusExporterMiddlewareIntegrationTest(
         string path,
         Action<IApplicationBuilder> configure,
@@ -256,7 +266,8 @@ public sealed class PrometheusExporterMiddlewareTests
         bool registerMeterProvider = true,
         Action<PrometheusAspNetCoreOptions> configureOptions = null,
         bool skipMetrics = false,
-        string acceptHeader = "application/openmetrics-text")
+        string acceptHeader = "application/openmetrics-text",
+        bool addServiceNameResourceTag = false)
     {
         var requestOpenMetrics = acceptHeader.StartsWith("application/openmetrics-text");
 
@@ -325,6 +336,10 @@ public sealed class PrometheusExporterMiddlewareTests
 
             string content = await response.Content.ReadAsStringAsync();
 
+            var resourceTagAttributes = addServiceNameResourceTag
+                ? "service_name='my_service',"
+                : string.Empty;
+
             string expected = requestOpenMetrics
                 ? "# TYPE target info\n"
                   + "# HELP target Target metadata\n"
@@ -333,10 +348,10 @@ public sealed class PrometheusExporterMiddlewareTests
                   + "# HELP otel_scope_info Scope metadata\n"
                   + $"otel_scope_info{{otel_scope_name='{MeterName}'}} 1\n"
                   + "# TYPE counter_double_total counter\n"
-                  + $"counter_double_total{{otel_scope_name='{MeterName}',otel_scope_version='{MeterVersion}',key1='value1',key2='value2'}} 101.17 (\\d+\\.\\d{{3}})\n"
+                  + $"counter_double_total{{{resourceTagAttributes}otel_scope_name='{MeterName}',otel_scope_version='{MeterVersion}',key1='value1',key2='value2'}} 101.17 (\\d+\\.\\d{{3}})\n"
                   + "# EOF\n"
                 : "# TYPE counter_double_total counter\n"
-                  + $"counter_double_total{{otel_scope_name='{MeterName}',otel_scope_version='{MeterVersion}',key1='value1',key2='value2'}} 101.17 (\\d+)\n"
+                  + $"counter_double_total{{{resourceTagAttributes}otel_scope_name='{MeterName}',otel_scope_version='{MeterVersion}',key1='value1',key2='value2'}} 101.17 (\\d+)\n"
                   + "# EOF\n";
 
             var matches = Regex.Matches(content, ("^" + expected + "$").Replace('\'', '"'));

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.Metrics;
 using System.Text;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
 using OpenTelemetry.Tests;
 using Xunit;
 
@@ -653,8 +654,38 @@ public sealed class PrometheusSerializerTests
             Encoding.UTF8.GetString(buffer, 0, cursor));
     }
 
-    private static int WriteMetric(byte[] buffer, int cursor, Metric metric, bool useOpenMetrics = false)
+    [Fact]
+    public void SumWithResourceAttributes()
     {
-        return PrometheusSerializer.WriteMetric(buffer, cursor, metric, PrometheusMetric.Create(metric, false), useOpenMetrics);
+        var buffer = new byte[85000];
+        var metrics = new List<Metric>();
+
+        var resource = ResourceBuilder.CreateEmpty().AddService("my_service");
+
+        using var meter = new Meter(Utils.GetCurrentMethodName());
+        using var provider = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(meter.Name)
+            .AddInMemoryExporter(metrics)
+            .SetResourceBuilder(resource)
+            .Build();
+
+        var counter = meter.CreateUpDownCounter<double>("test_updown_counter");
+        counter.Add(10);
+        counter.Add(-11);
+
+        provider.ForceFlush();
+
+        var cursor = WriteMetric(buffer, 0, metrics[0], true, new PrometheusResourceTagCollection(resource.Build(), s => s == "service.name"));
+        Assert.Matches(
+            ("^"
+             + "# TYPE test_updown_counter gauge\n"
+             + $"test_updown_counter{{service_name='my_service',otel_scope_name='{Utils.GetCurrentMethodName()}'}} -1 \\d+\\.\\d{{3}}\n"
+             + "$").Replace('\'', '"'),
+            Encoding.UTF8.GetString(buffer, 0, cursor));
+    }
+
+    private static int WriteMetric(byte[] buffer, int cursor, Metric metric, bool useOpenMetrics = false, PrometheusResourceTagCollection resourceTags = default)
+    {
+        return PrometheusSerializer.WriteMetric(buffer, cursor, metric, PrometheusMetric.Create(metric, false), resourceTags, useOpenMetrics);
     }
 }


### PR DESCRIPTION
Fixes #3087
Design discussion issue #

See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/compatibility/prometheus_and_openmetrics.md#resource-attributes-1

## Changes

This is an extension of [this](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5407) pull request which adds `target_info` to the output of Prometheus exporters. This PR adds the default resource attributes as tags to each metric. By default, resource attributes are not included, but can be opted in by using the optional filter. This mirrors the Java code functionality. 

_Note that OpenMetrics support is ignored here, since tags/labels are supported in non-OpenMetrics scrapers too._

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
