### PR TITLE
[repo] Bump MinVer to 5.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -85,7 +85,7 @@
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="[1.0.3,2.0)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="[17.8.0,18.0.0)" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="[1.1.1,2.0)" />
-    <PackageVersion Include="MinVer" Version="[4.3.0,5.0)" />
+    <PackageVersion Include="MinVer" Version="[5.0.0,6.0)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="[1.5.1,2.0)" />
     <PackageVersion Include="RabbitMQ.Client" Version="[6.6.0,7.0)" />
     <PackageVersion Include="StyleCop.Analyzers" Version="[1.2.0-beta.556,2.0)" />


### PR DESCRIPTION
Propagates changes from https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1633

## Changes

Bump MinVer to 5.0.0 - itnernal package.
Breaking changes seems to be no bad impact on OTel packages.~

Upgraded in AutoInstrumentaiton repo some time ago. No issues so far.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
