### PR TITLE
[docs-traces] Added version info to the OTEL_TRACES_SAMPLER doc

### DIFF
--- a/docs/trace/customizing-the-sdk/README.md
+++ b/docs/trace/customizing-the-sdk/README.md
@@ -363,8 +363,8 @@ var tracerProvider = Sdk.CreateTracerProviderBuilder()
     .Build();
 ```
 
-It is also possible to configure the sampler by using the following
-environmental variables:
+If using `1.8.0-rc.1` or newer it is also possible to configure the sampler by
+using the following environmental variables:
 
 | Environment variable       | Description                                        |
 | -------------------------- | -------------------------------------------------- |

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -407,12 +407,7 @@ internal sealed class TracerProviderSdk : TracerProvider
 
     private static Sampler GetSampler(IConfiguration configuration, Sampler? stateSampler)
     {
-        Sampler? sampler = null;
-
-        if (stateSampler != null)
-        {
-            sampler = stateSampler;
-        }
+        var sampler = stateSampler;
 
         if (configuration.TryGetStringValue(TracesSamplerConfigKey, out var configValue))
         {


### PR DESCRIPTION
Follow-up to #5448

## Changes

* Adds release version info to the `OTEL_TRACES_SAMPLER` doc.
* Improve the code ever so slightly.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
