### PR TITLE
[otlp] Rename key for enabling retries during transient failures

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -13,7 +13,7 @@
 * **Removed** `OTEL_DOTNET_EXPERIMENTAL_OTLP_ENABLE_INMEMORY_RETRY` and added
   `OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY`. `OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY`
   when set to `in_memory` will enable automatic retries in case of transient
-  failures during data export to otlp endpoint.
+  failures during data export to an OTLP endpoint.
   ([#5495](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5495))
 
 ## 1.8.0-rc.1

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -10,7 +10,8 @@
   is not required to be set [when using .NET 5 or newer](https://learn.microsoft.com/aspnet/core/grpc/troubleshoot?view=aspnetcore-8.0#call-insecure-grpc-services-with-net-core-client).
   ([#5486](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5486))
 
-* Replaced environment variable `OTEL_DOTNET_EXPERIMENTAL_OTLP_ENABLE_INMEMORY_RETRY` with
+* Replaced environment variable
+  `OTEL_DOTNET_EXPERIMENTAL_OTLP_ENABLE_INMEMORY_RETRY` with
   `OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY`. `OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY`
   when set to `in_memory` will enable automatic retries in case of transient
   failures during data export to an OTLP endpoint.

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -10,7 +10,7 @@
   is not required to be set [when using .NET 5 or newer](https://learn.microsoft.com/aspnet/core/grpc/troubleshoot?view=aspnetcore-8.0#call-insecure-grpc-services-with-net-core-client).
   ([#5486](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5486))
 
-* **Removed** `OTEL_DOTNET_EXPERIMENTAL_OTLP_ENABLE_INMEMORY_RETRY` and added
+* Replaced environment variable `OTEL_DOTNET_EXPERIMENTAL_OTLP_ENABLE_INMEMORY_RETRY` with
   `OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY`. `OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY`
   when set to `in_memory` will enable automatic retries in case of transient
   failures during data export to an OTLP endpoint.

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -10,6 +10,12 @@
   is not required to be set [when using .NET 5 or newer](https://learn.microsoft.com/aspnet/core/grpc/troubleshoot?view=aspnetcore-8.0#call-insecure-grpc-services-with-net-core-client).
   ([#5486](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5486))
 
+* **Removed** `OTEL_DOTNET_EXPERIMENTAL_OTLP_ENABLE_INMEMORY_RETRY`. Added
+  `OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY`. `OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY`
+  when set to `in_memory` will enable automatic retries in case of transient
+  failures during data export to otlp endpoint.
+  ([#5495](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5495))
+
 ## 1.8.0-rc.1
 
 Released 2024-Mar-27

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -10,7 +10,7 @@
   is not required to be set [when using .NET 5 or newer](https://learn.microsoft.com/aspnet/core/grpc/troubleshoot?view=aspnetcore-8.0#call-insecure-grpc-services-with-net-core-client).
   ([#5486](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5486))
 
-* **Removed** `OTEL_DOTNET_EXPERIMENTAL_OTLP_ENABLE_INMEMORY_RETRY`. Added
+* **Removed** `OTEL_DOTNET_EXPERIMENTAL_OTLP_ENABLE_INMEMORY_RETRY` and added
   `OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY`. `OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY`
   when set to `in_memory` will enable automatic retries in case of transient
   failures during data export to otlp endpoint.

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExperimentalOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExperimentalOptions.cs
@@ -29,7 +29,7 @@ internal sealed class ExperimentalOptions
             this.EmitLogEventAttributes = emitLogEventAttributes;
         }
 
-        if (configuration.TryGetStringValue(OtlpRetryEnvVar, out var retryPolicy) && retryPolicy.Equals("in_memory", StringComparison.OrdinalIgnoreCase))
+        if (configuration.TryGetStringValue(OtlpRetryEnvVar, out var retryPolicy) && retryPolicy != null && retryPolicy.Equals("in_memory", StringComparison.OrdinalIgnoreCase))
         {
             this.EnableInMemoryRetry = true;
         }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExperimentalOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExperimentalOptions.cs
@@ -29,7 +29,7 @@ internal sealed class ExperimentalOptions
             this.EmitLogEventAttributes = emitLogEventAttributes;
         }
 
-        if (configuration.TryGetStringValue(OtlpRetryEnvVar, out var retryPolicy) && retryPolicy != null && retryPolicy.Equals("in_memory", StringComparison.OrdinalIgnoreCase))
+        if (configuration.TryGetStringValue(OtlpRetryEnvVar, out var retryPolicy) && retryPolicy.Equals("in_memory", StringComparison.OrdinalIgnoreCase))
         {
             this.EnableInMemoryRetry = true;
         }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExperimentalOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExperimentalOptions.cs
@@ -15,7 +15,7 @@ internal sealed class ExperimentalOptions
 
     public const string EmitLogEventEnvVar = "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES";
 
-    public const string EnableInMemoryRetryEnvVar = "OTEL_DOTNET_EXPERIMENTAL_OTLP_ENABLE_INMEMORY_RETRY";
+    public const string OtlpRetryEnvVar = "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY";
 
     public ExperimentalOptions()
         : this(new ConfigurationBuilder().AddEnvironmentVariables().Build())
@@ -29,9 +29,9 @@ internal sealed class ExperimentalOptions
             this.EmitLogEventAttributes = emitLogEventAttributes;
         }
 
-        if (configuration.TryGetBoolValue(OpenTelemetryProtocolExporterEventSource.Log, EnableInMemoryRetryEnvVar, out var enableInMemoryRetry))
+        if (configuration.TryGetStringValue(OpenTelemetryProtocolExporterEventSource.Log, OtlpRetryEnvVar, out var retryPolicy) && retryPolicy != null && retryPolicy.Equals("in_memory", StringComparison.OrdinalIgnoreCase))
         {
-            this.EnableInMemoryRetry = enableInMemoryRetry;
+            this.EnableInMemoryRetry = true;
         }
     }
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExperimentalOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExperimentalOptions.cs
@@ -29,7 +29,7 @@ internal sealed class ExperimentalOptions
             this.EmitLogEventAttributes = emitLogEventAttributes;
         }
 
-        if (configuration.TryGetStringValue(OpenTelemetryProtocolExporterEventSource.Log, OtlpRetryEnvVar, out var retryPolicy) && retryPolicy != null && retryPolicy.Equals("in_memory", StringComparison.OrdinalIgnoreCase))
+        if (configuration.TryGetStringValue(OtlpRetryEnvVar, out var retryPolicy) && retryPolicy != null && retryPolicy.Equals("in_memory", StringComparison.OrdinalIgnoreCase))
         {
             this.EnableInMemoryRetry = true;
         }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
@@ -625,9 +625,9 @@ want to solicit feedback from the community.
 
 * All signals
 
-  * `OTEL_DOTNET_EXPERIMENTAL_OTLP_ENABLE_INMEMORY_RETRY`
+  * `OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY`
 
-    When set to `true`, it enables in-memory retry for transient errors
+    When set to `in_memory`, it enables in-memory retry for transient errors
     encountered while sending telemetry.
 
     Added in `1.8.0-beta.1`.

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
@@ -630,7 +630,7 @@ want to solicit feedback from the community.
     When set to `in_memory`, it enables in-memory retry for transient errors
     encountered while sending telemetry.
 
-    Added in `1.8.0-beta.1`.
+    Added in `1.8.0`.
 
 * Logs
 

--- a/src/Shared/Configuration/OpenTelemetryConfigurationExtensions.cs
+++ b/src/Shared/Configuration/OpenTelemetryConfigurationExtensions.cs
@@ -107,6 +107,24 @@ internal static class OpenTelemetryConfigurationExtensions
         return true;
     }
 
+    public static bool TryGetStringValue(
+       this IConfiguration configuration,
+       IConfigurationExtensionsLogger logger,
+       string key,
+       out string? value)
+    {
+        Debug.Assert(logger != null, "logger was null");
+
+        if (!configuration.TryGetStringValue(key, out var stringValue))
+        {
+            value = null;
+            return false;
+        }
+
+        value = stringValue;
+        return true;
+    }
+
     public static bool TryGetValue<T>(
         this IConfiguration configuration,
         IConfigurationExtensionsLogger logger,

--- a/src/Shared/Configuration/OpenTelemetryConfigurationExtensions.cs
+++ b/src/Shared/Configuration/OpenTelemetryConfigurationExtensions.cs
@@ -107,24 +107,6 @@ internal static class OpenTelemetryConfigurationExtensions
         return true;
     }
 
-    public static bool TryGetStringValue(
-       this IConfiguration configuration,
-       IConfigurationExtensionsLogger logger,
-       string key,
-       out string? value)
-    {
-        Debug.Assert(logger != null, "logger was null");
-
-        if (!configuration.TryGetStringValue(key, out var stringValue))
-        {
-            value = null;
-            return false;
-        }
-
-        value = stringValue;
-        return true;
-    }
-
     public static bool TryGetValue<T>(
         this IConfiguration configuration,
         IConfigurationExtensionsLogger logger,

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/MockCollectorIntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/MockCollectorIntegrationTests.cs
@@ -179,7 +179,7 @@ public sealed class MockCollectorIntegrationTests
         var exporterOptions = new OtlpExporterOptions() { Endpoint = endpoint, TimeoutMilliseconds = 20000, Protocol = OtlpExportProtocol.Grpc };
 
         var configuration = new ConfigurationBuilder()
-         .AddInMemoryCollection(new Dictionary<string, string> { [ExperimentalOptions.EnableInMemoryRetryEnvVar] = useRetryTransmissionHandler.ToString() })
+         .AddInMemoryCollection(new Dictionary<string, string> { [ExperimentalOptions.OtlpRetryEnvVar] = useRetryTransmissionHandler ? "in_memory" : null })
          .Build();
 
         var otlpExporter = new OtlpTraceExporter(exporterOptions, new SdkLimitOptions(), new ExperimentalOptions(configuration));
@@ -263,7 +263,7 @@ public sealed class MockCollectorIntegrationTests
         var exporterOptions = new OtlpExporterOptions() { Endpoint = endpoint, TimeoutMilliseconds = 20000, Protocol = OtlpExportProtocol.HttpProtobuf };
 
         var configuration = new ConfigurationBuilder()
-         .AddInMemoryCollection(new Dictionary<string, string> { [ExperimentalOptions.EnableInMemoryRetryEnvVar] = useRetryTransmissionHandler.ToString() })
+         .AddInMemoryCollection(new Dictionary<string, string> { [ExperimentalOptions.OtlpRetryEnvVar] = useRetryTransmissionHandler ? "in_memory" : null })
          .Build();
 
         var otlpExporter = new OtlpTraceExporter(exporterOptions, new SdkLimitOptions(), new ExperimentalOptions(configuration));


### PR DESCRIPTION
Fixes #
Design discussion issue #

## Changes

Previously, `OTEL_DOTNET_EXPERIMENTAL_OTLP_ENABLE_INMEMORY_RETRY` was introduced to offer an in-memory retry strategy as an experimental feature. 

For adding support for a persistent storage-based retry strategy, we need an additional setting.

To avoid having multiple settings for enabling different retry strategies, introducing a single setting, `OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY`. When `OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY` is set to `in_memory`, it will enable the in-memory-based retry strategy. When the support for persistent storage-based retry is added in future, it could be set to `disk`.

This is a temporary setting to offer the experimental feature and will be removed in the future when the features are marked as stable. At present, OTLP exporters does not retry requests during transient failures by default.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
