### PR TITLE
Minor doc structure improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,9 @@ repo.
 
 If you are new here, please read the getting started docs:
 
-* [Logs](./docs/logs/README.md): [ASP.NET
-  Core](./docs/logs/getting-started-aspnetcore/README.md) |
-  [Console](./docs/logs/getting-started-console/README.md)
-* [Metrics](./docs/metrics/README.md): [ASP.NET
-  Core](./docs/metrics/getting-started-aspnetcore/README.md) |
-  [Console](./docs/metrics/getting-started-console/README.md)
-* [Traces](./docs/trace/README.md): [ASP.NET
-  Core](./docs/trace/getting-started-aspnetcore/README.md) |
-  [Console](./docs/trace/getting-started-console/README.md)
+* [Logs](./docs/logs/README.md)
+* [Metrics](./docs/metrics/README.md)
+* [Traces](./docs/trace/README.md)
 
 This repository includes multiple installable components, available on
 [NuGet](https://www.nuget.org/profiles/OpenTelemetry). Each component has its

--- a/src/OpenTelemetry.Exporter.Console/README.md
+++ b/src/OpenTelemetry.Exporter.Console/README.md
@@ -20,9 +20,11 @@ dotnet add package OpenTelemetry.Exporter.Console
 See the individual "getting started" examples depending on the signal being
 used:
 
-* Logs: [Console](../../docs/logs/getting-started-console/README.md)
-* Metrics: [ASP.NET Core](../../docs/metrics/getting-started-aspnetcore/README.md)
-  | [Console](../../docs/metrics/getting-started-console/README.md)
+* Logs: [ASP.NET Core](../../docs/logs/getting-started-aspnetcore/README.md) |
+  [Console](../../docs/logs/getting-started-console/README.md)
+* Metrics: [ASP.NET
+  Core](../../docs/metrics/getting-started-aspnetcore/README.md) |
+  [Console](../../docs/metrics/getting-started-console/README.md)
 * Traces: [ASP.NET Core](../../docs/trace/getting-started-aspnetcore/README.md)
   | [Console](../../docs/trace/getting-started-console/README.md)
 


### PR DESCRIPTION
* Cleaned up the main README as the links to ASP.NET Core / Console examples are already included in the logs/metrics/traces doc.
* Updated the console exporter README to include ASP.NET Core example.