### PR TITLE
Migrate to docker compose v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,8 +115,8 @@ jobs:
         version: [ net6.0, net7.0, net8.0 ]
     steps:
       - uses: actions/checkout@v4
-      - name: Run OTLP Exporter docker-compose
-        run: docker-compose --file=test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTest/docker-compose.yml --file=build/docker-compose.${{ matrix.version }}.yml --project-directory=. up --exit-code-from=tests --build
+      - name: Run OTLP Exporter docker compose
+        run: docker compose --file=test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTest/docker-compose.yml --file=build/docker-compose.${{ matrix.version }}.yml --project-directory=. up --exit-code-from=tests --build
 
   w3c-trace-context-integration-test:
     needs: detect-changes
@@ -133,8 +133,8 @@ jobs:
         version: [ net6.0, net7.0 ]
     steps:
       - uses: actions/checkout@v4
-      - name: Run W3C Trace Context docker-compose
-        run: docker-compose --file=test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/docker-compose.yml --file=build/docker-compose.${{ matrix.version }}.yml --project-directory=. up --exit-code-from=tests --build
+      - name: Run W3C Trace Context docker compose
+        run: docker compose --file=test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/docker-compose.yml --file=build/docker-compose.${{ matrix.version }}.yml --project-directory=. up --exit-code-from=tests --build
 
   validate-packages:
     needs: detect-changes

--- a/docs/metrics/exemplars/README.md
+++ b/docs/metrics/exemplars/README.md
@@ -20,8 +20,8 @@ Prometheus, traces to Tempo.
 
 All these components except the test app require additional configuration to
 enable Exemplar feature. To make it easy for users, these components are
-pre-configured to enable Exemplars, and a docker-compose is provided to spun
- them all up, in the required configurations.
+pre-configured to enable Exemplars, and a docker compose file is provided to
+ spun them all up, in the required configurations.
 
 ## Pre-requisite
 
@@ -36,7 +36,7 @@ spins all of them with the correct configurations to support Exemplars.
 Navigate to current directory and run the following:
 
 ```sh
-docker-compose up -d
+docker compose up -d
 ```
 
 If the above step succeeds, all dependencies would be spun up and ready now. To

--- a/examples/MicroserviceExample/README.md
+++ b/examples/MicroserviceExample/README.md
@@ -31,14 +31,14 @@ dotnet run --project WorkerService
 ```
 
 Instead of running the projects individually, if you are using Docker Desktop,
-a `docker-compose` file is provided. This makes standing up the Zipkin and
+a `docker compose` file is provided. This makes standing up the Zipkin and
 RabbitMQ dependencies easy, as well as starting both applications.
 
-To run the example using `docker-compose`, run the following from this
+To run the example using `docker compose`, run the following from this
 directory:
 
 ```shell
-docker-compose up --build
+docker compose up --build
 ```
 
 With everything running:

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTest/docker-compose.yml
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTest/docker-compose.yml
@@ -1,6 +1,6 @@
 # Starts an OpenTelemetry Collector and then runs the OTLP exporter integration tests.
 # This should be run from the root of the repo:
-#    docker-compose --file=test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTest/docker-compose.yml --project-directory=. up --exit-code-from=tests --build
+#    docker compose --file=test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTest/docker-compose.yml --project-directory=. up --exit-code-from=tests --build
 
 version: '3.7'
 

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/W3CTraceContextTests.cs
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/W3CTraceContextTests.cs
@@ -18,7 +18,7 @@ public class W3CTraceContextTests : IDisposable
 {
     /*
         To run the tests, invoke docker-compose.yml from the root of the repo:
-        opentelemetry>docker-compose --file=test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/docker-compose.yml --project-directory=. up --exit-code-from=tests --build
+        opentelemetry>docker compose --file=test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/docker-compose.yml --project-directory=. up --exit-code-from=tests --build
      */
     private const string W3cTraceContextEnvVarName = "OTEL_W3CTRACECONTEXT";
     private static readonly Version AspNetCoreHostingVersion = typeof(Microsoft.AspNetCore.Hosting.Builder.IApplicationBuilderFactory).Assembly.GetName().Version;

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/docker-compose.yml
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/docker-compose.yml
@@ -1,6 +1,6 @@
 # Start a container and then run OpenTelemetry W3C Trace Context tests.
 # This should be run from the root of the repo:
-#  opentelemetry>docker-compose --file=test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/docker-compose.yml --project-directory=. up --exit-code-from=tests --build
+#  opentelemetry>docker compose --file=test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/docker-compose.yml --project-directory=. up --exit-code-from=tests --build
 version: '3.7'
 
 services:


### PR DESCRIPTION
Fixes `docker-compose: command not found`. https://github.com/open-telemetry/opentelemetry-dotnet/actions/runs/8531517550/job/23371288271

## Changes

Switching the compose command to use V2 version in integration tests and examples.

docker compose v1 is now deprecated on GitHub: https://github.com/orgs/community/discussions/116610

Migration guide: https://docs.docker.com/compose/migrate/

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
