### PR TITLE
Instrumentation packages - 1.8.0/1.8.0-beta.1 release

### DIFF
--- a/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.AspNetCore/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.8.0
+
+Released 2024-Apr-04
+
 * Fixed an issue for spans when `server.port` attribute was not set with
   `server.address` when it has default values (`80` for `HTTP` and
   `443` for `HTTPS` protocol).

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.8.0-beta.1
+
+Released 2024-Apr-04
+
 ## 1.7.0-beta.1
 
 Released 2024-Feb-09

--- a/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.Http/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.8.0
+
+Released 2024-Apr-04
+
 * Fixed an issue for spans when `server.port` attribute was not set with
   `server.address` when it has default values (`80` for `HTTP` and
   `443` for `HTTPS` protocol).

--- a/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.8.0-beta.1
+
+Released 2024-Apr-04
+
 ## 1.7.0-beta.1
 
 Released 2024-Feb-09


### PR DESCRIPTION
## Changes

Request release for instrumentation packages with OTel 1.8.0.

Needed for OpenTelemetry.AutoInsrumentation.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* ~~[ ] Changes in public API reviewed (if applicable)~~ No changes
