### PR TITLE
Use set -e in shell scripts

### DIFF
--- a/src/OpenTelemetry.SemanticConventions/scripts/semantic-conventions/generate.sh
+++ b/src/OpenTelemetry.SemanticConventions/scripts/semantic-conventions/generate.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/../../"

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTest/create-cert.sh
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTest/create-cert.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Generate self-signed certificate for the collector
 openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 \

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTest/run-test.sh
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTest/run-test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Trust the self-signed certificated used by the collector
 cp /cfg/otel-collector.crt /usr/local/share/ca-certificates/


### PR DESCRIPTION
## Changes

Use `set -e` in all shell scripts, to fail on errors.

