### PR TITLE
Bump OTLP proto files to 1.2.0

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/metrics/v1/metrics.proto
@@ -188,6 +188,15 @@ message Metric {
     ExponentialHistogram exponential_histogram = 10;
     Summary summary = 11;
   }
+
+  // Additional metadata attributes that describe the metric. [Optional].
+  // Attributes are non-identifying.
+  // Consumers SHOULD NOT need to be aware of these attributes.
+  // These attributes MAY be used to encode information allowing
+  // for lossless roundtrip translation to / from another data model.
+  // Attribute keys MUST be unique (it is not allowed to have more than one
+  // attribute with the same key).
+  repeated opentelemetry.proto.common.v1.KeyValue metadata = 12;
 }
 
 // Gauge represents the type of a scalar metric that always exports the

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/trace/v1/trace.proto
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/opentelemetry/proto/trace/v1/trace.proto
@@ -109,20 +109,27 @@ message Span {
   // field must be empty. The ID is an 8-byte array.
   bytes parent_span_id = 4;
 
-  // Flags, a bit field. 8 least significant bits are the trace
-  // flags as defined in W3C Trace Context specification. Readers
-  // MUST not assume that 24 most significant bits will be zero.
-  // To read the 8-bit W3C trace flag, use `flags & SPAN_FLAGS_TRACE_FLAGS_MASK`.
+  // Flags, a bit field.
+  //
+  // Bits 0-7 (8 least significant bits) are the trace flags as defined in W3C Trace
+  // Context specification. To read the 8-bit W3C trace flag, use
+  // `flags & SPAN_FLAGS_TRACE_FLAGS_MASK`.
+  //
+  // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
+  //
+  // Bits 8 and 9 represent the 3 states of whether a span's parent
+  // is remote. The states are (unknown, is not remote, is remote).
+  // To read whether the value is known, use `(flags & SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK) != 0`.
+  // To read whether the span is remote, use `(flags & SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK) != 0`.
   //
   // When creating span messages, if the message is logically forwarded from another source
   // with an equivalent flags fields (i.e., usually another OTLP span message), the field SHOULD
   // be copied as-is. If creating from a source that does not have an equivalent flags field
-  // (such as a runtime representation of an OpenTelemetry span), the high 24 bits MUST
+  // (such as a runtime representation of an OpenTelemetry span), the high 22 bits MUST
   // be set to zero.
+  // Readers MUST NOT assume that bits 10-31 (22 most significant bits) will be zero.
   //
   // [Optional].
-  //
-  // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
   fixed32 flags = 16;
 
   // A description of the span's operation.
@@ -259,14 +266,23 @@ message Span {
     // then no attributes were dropped.
     uint32 dropped_attributes_count = 5;
 
-    // Flags, a bit field. 8 least significant bits are the trace
-    // flags as defined in W3C Trace Context specification. Readers
-    // MUST not assume that 24 most significant bits will be zero.
-    // When creating new spans, the most-significant 24-bits MUST be
-    // zero.  To read the 8-bit W3C trace flag (use flags &
-    // SPAN_FLAGS_TRACE_FLAGS_MASK).  [Optional].
+    // Flags, a bit field.
+    //
+    // Bits 0-7 (8 least significant bits) are the trace flags as defined in W3C Trace
+    // Context specification. To read the 8-bit W3C trace flag, use
+    // `flags & SPAN_FLAGS_TRACE_FLAGS_MASK`.
     //
     // See https://www.w3.org/TR/trace-context-2/#trace-flags for the flag definitions.
+    //
+    // Bits 8 and 9 represent the 3 states of whether the link is remote.
+    // The states are (unknown, is not remote, is remote).
+    // To read whether the value is known, use `(flags & SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK) != 0`.
+    // To read whether the link is remote, use `(flags & SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK) != 0`.
+    //
+    // Readers MUST NOT assume that bits 10-31 (22 most significant bits) will be zero.
+    // When creating new spans, bits 10-31 (most-significant 22-bits) MUST be zero.
+    //
+    // [Optional].
     fixed32 flags = 6;
   }
 
@@ -329,5 +345,11 @@ enum SpanFlags {
   // Bits 0-7 are used for trace flags.
   SPAN_FLAGS_TRACE_FLAGS_MASK = 0x000000FF;
 
-  // Bits 8-31 are reserved for future use.
+  // Bits 8 and 9 are used to indicate that the parent span or link span is remote.
+  // Bit 8 (`HAS_IS_REMOTE`) indicates whether the value is known.
+  // Bit 9 (`IS_REMOTE`) indicates whether the span or link is remote.
+  SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK = 0x00000100;
+  SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK = 0x00000200;
+
+  // Bits 10-31 are reserved for future use.
 }


### PR DESCRIPTION
Fixes N/A
Design discussion issue N/A

## Changes

Bump OTLP proto files to [1.2.0](https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v1.2.0).

Support for OTLP new features can be handled separately, as for https://github.com/open-telemetry/opentelemetry-dotnet/pull/5215
* Indicate if a Span's parent or link is remote using 2 bit flag. https://github.com/open-telemetry/opentelemetry-proto/pull/484
* Add metric.metadata for supporting additional metadata on metrics https://github.com/open-telemetry/opentelemetry-proto/pull/514

Done while working on [test update for auto-instrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/3354).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
