### PR TITLE
Add net9.0 to AoT test matrix

### DIFF
--- a/.github/workflows/verifyaotcompat.yml
+++ b/.github/workflows/verifyaotcompat.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false # ensures the entire test matrix is run, even if one permutation fails
       matrix:
         os: [ ubuntu-latest ]
-        version: [ net8.0 ]
+        version: [ net8.0, net9.0 ]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -20,6 +20,10 @@ jobs:
 
     - name: Setup dotnet
       uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: |
+          8.0.x
+          9.0.x
 
     - name: publish AOT testApp, assert static analysis warning count, and run the app
       shell: pwsh

--- a/.github/workflows/verifyaotcompat.yml
+++ b/.github/workflows/verifyaotcompat.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false # ensures the entire test matrix is run, even if one permutation fails
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, windows-latest ]
         version: [ net8.0, net9.0 ]
 
     runs-on: ${{ matrix.os }}
@@ -28,4 +28,3 @@ jobs:
     - name: publish AOT testApp, assert static analysis warning count, and run the app
       shell: pwsh
       run: .\build\test-aot-compatibility.ps1 ${{ matrix.version }}
-

--- a/build/Common.props
+++ b/build/Common.props
@@ -29,7 +29,7 @@
 
     <!-- non-production TFMs -->
     <TargetFrameworksForAspNetCoreTests>net8.0;net7.0;net6.0</TargetFrameworksForAspNetCoreTests>
-    <TargetFrameworksForAotCompatibilityTests>net8.0</TargetFrameworksForAotCompatibilityTests>
+    <TargetFrameworksForAotCompatibilityTests>net9.0;net8.0</TargetFrameworksForAotCompatibilityTests>
     <TargetFrameworksForDocs>net8.0;net7.0;net6.0</TargetFrameworksForDocs>
     <TargetFrameworksForDocs Condition="$(OS) == 'Windows_NT' And '$(UsingMicrosoftNETSdkWeb)' != 'True'">
       $(TargetFrameworksForDocs);$(NetFrameworkSupportedVersions)

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "8.0.100"
+    "version": "9.0.100-preview.2.24157.14"
   }
 }

--- a/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
+++ b/test/OpenTelemetry.AotCompatibility.TestApp/OpenTelemetry.AotCompatibility.TestApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(TargetFrameworksForAotCompatibilityTests)</TargetFramework>
+    <TargetFrameworks>$(TargetFrameworksForAotCompatibilityTests)</TargetFrameworks>
     <PublishAot>true</PublishAot>
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
     <SelfContained>true</SelfContained>


### PR DESCRIPTION
Relates to #5518

## Changes

Add .NET 9 to the AoT test matrix to try and reproduce #5518.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
