### PR TITLE
[Exporter.OpenTelemetryProtocol] User agent changed to OTel-OTLP-Exporter-Dotnet/{NuGet Package Version}

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -5,6 +5,11 @@
 * Fix native AoT warnings in `OpenTelemetry.Exporter.OpenTelemetryProtocol`.
   ([#5520](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5520))
 
+* `User-Agent` header changed from
+  `OTel-OTLP-Exporter-Dotnet-{NuGet Package Version}+{Commit Hash}`
+  to `OTel-OTLP-Exporter-Dotnet-{NuGet Package Version}`.
+  ([#5528](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5528))
+
 ## 1.8.0
 
 Released 2024-Apr-02

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Fix native AoT warnings in `OpenTelemetry.Exporter.OpenTelemetryProtocol`.
   ([#5520](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5520))
 
-* `User-Agent` header changed from
+* `User-Agent` header format changed from
   `OTel-OTLP-Exporter-Dotnet/{NuGet Package Version}+{Commit Hash}`
   to `OTel-OTLP-Exporter-Dotnet/{NuGet Package Version}`.
   ([#5528](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5528))

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -6,8 +6,8 @@
   ([#5520](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5520))
 
 * `User-Agent` header changed from
-  `OTel-OTLP-Exporter-Dotnet-{NuGet Package Version}+{Commit Hash}`
-  to `OTel-OTLP-Exporter-Dotnet-{NuGet Package Version}`.
+  `OTel-OTLP-Exporter-Dotnet/{NuGet Package Version}+{Commit Hash}`
+  to `OTel-OTLP-Exporter-Dotnet/{NuGet Package Version}`.
   ([#5528](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5528))
 
 ## 1.8.0

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -37,8 +37,6 @@ public class OtlpExporterOptions : IOtlpExporterOptions
 
     internal readonly Func<HttpClient> DefaultHttpClientFactory;
 
-    private const string UserAgentProduct = "OTel-OTLP-Exporter-Dotnet";
-
     private OtlpExportProtocol? protocol;
     private Uri? endpoint;
     private int? timeoutMilliseconds;
@@ -226,15 +224,8 @@ public class OtlpExporterOptions : IOtlpExporterOptions
 
     private static string GetUserAgentString()
     {
-        try
-        {
-            var assembly = typeof(OtlpExporterOptions).Assembly;
-            return $"{UserAgentProduct}/{assembly.GetPackageVersion()}";
-        }
-        catch (Exception)
-        {
-            return UserAgentProduct;
-        }
+        var assembly = typeof(OtlpExporterOptions).Assembly;
+        return $"OTel-OTLP-Exporter-Dotnet/{assembly.GetPackageVersion()}";
     }
 
     private void ApplyConfiguration(

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 #if NETFRAMEWORK
 using System.Net.Http;
 #endif
-using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -229,9 +228,8 @@ public class OtlpExporterOptions : IOtlpExporterOptions
     {
         try
         {
-            var assemblyVersion = typeof(OtlpExporterOptions).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
-            var informationalVersion = assemblyVersion?.InformationalVersion;
-            return string.IsNullOrEmpty(informationalVersion) ? UserAgentProduct : $"{UserAgentProduct}/{informationalVersion}";
+            var assembly = typeof(OtlpExporterOptions).Assembly;
+            return $"{UserAgentProduct}/{assembly.GetPackageVersion()}";
         }
         catch (Exception)
         {

--- a/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
+++ b/src/OpenTelemetry.Instrumentation.GrpcNetClient/Implementation/GrpcClientDiagnosticListener.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Instrumentation.Http;
+using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.GrpcNetClient.Implementation;

--- a/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
+++ b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Reflection;
+using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;
 
 namespace OpenTelemetry.Instrumentation.SqlClient.Implementation;

--- a/src/OpenTelemetry/Sdk.cs
+++ b/src/OpenTelemetry/Sdk.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 #endif
 using OpenTelemetry.Context.Propagation;
-using OpenTelemetry.Instrumentation;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;

--- a/src/Shared/AssemblyVersionExtensions.cs
+++ b/src/Shared/AssemblyVersionExtensions.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System.Diagnostics;
 using System.Reflection;
 
 namespace OpenTelemetry.Internal;
@@ -19,7 +20,9 @@ internal static class AssemblyVersionExtensions
         // The following parts are optional: pre-release label, pre-release version, git height, Git SHA of current commit
         // For package version, value of AssemblyInformationalVersionAttribute without commit hash is returned.
 
-        var informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;
+        var informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        Debug.Assert(!string.IsNullOrEmpty(informationalVersion), "AssemblyInformationalVersionAttribute was not found in assembly");
+
         var indexOfPlusSign = informationalVersion!.IndexOf('+');
         return indexOfPlusSign > 0
             ? informationalVersion.Substring(0, indexOfPlusSign)

--- a/src/Shared/AssemblyVersionExtensions.cs
+++ b/src/Shared/AssemblyVersionExtensions.cs
@@ -5,7 +5,7 @@
 
 using System.Reflection;
 
-namespace OpenTelemetry.Instrumentation;
+namespace OpenTelemetry.Internal;
 
 internal static class AssemblyVersionExtensions
 {

--- a/test/OpenTelemetry.Tests/Shared/AssemblyVersionExtensionsTests.cs
+++ b/test/OpenTelemetry.Tests/Shared/AssemblyVersionExtensionsTests.cs
@@ -4,7 +4,7 @@
 #nullable enable
 
 using System.Reflection;
-using OpenTelemetry.Instrumentation;
+using OpenTelemetry.Internal;
 using Xunit;
 
 namespace OpenTelemetry.Tests;


### PR DESCRIPTION
Follow up to #5498

## Changes

Handles following comments:

* https://github.com/open-telemetry/opentelemetry-dotnet/pull/5498#discussion_r1554197469 (User-Agent part, other was handled previously)
* https://github.com/open-telemetry/opentelemetry-dotnet/pull/5498#discussion_r1558073568
* https://github.com/open-telemetry/opentelemetry-dotnet/pull/5498#discussion_r1558076614


## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* ~~[ ] Changes in public API reviewed (if applicable)~~
