### PR TITLE
[sdk-metrics] Fix race condition for MemoryPoint Reclaim

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -7,8 +7,9 @@
   function when configuring a view (applies to individual metrics).
   ([#5542](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5542))
 
-* Fixed a race condition for MetricPoint reclaim scenario which could have led
-  to a measurement being dropped.
+* Fixed a race condition for the experimental MetricPoint reclaim scenario
+  (enabled via `OTEL_DOTNET_EXPERIMENTAL_METRICS_RECLAIM_UNUSED_METRIC_POINTS`)
+  which could have led to a measurement being dropped.
   ([#5546](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5546))
 
 ## 1.8.1

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -7,6 +7,10 @@
   function when configuring a view (applies to individual metrics).
   ([#5542](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5542))
 
+* Fixed a race condition for MetricPoint reclaim scenario which could have led
+  to a measurement being dropped.
+  ([#5546](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5546))
+
 ## 1.8.1
 
 Released 2024-Apr-17
@@ -15,10 +19,6 @@ Released 2024-Apr-17
   could be created inside delegates automatically executed by the Options API
   during configuration reload.
   ([#5514](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5514))
-
-* Fixed a race condition for MetricPoint reclaim scenario which could have led
-  to a measurement being dropped.
-  ([#5546](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5546))
 
 ## 1.8.0
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -7,6 +7,10 @@
   during configuration reload.
   ([#5514](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5514))
 
+* Fixed a race condition for MetricPoint reclaim scenario which could have led
+  to a measurement being dropped.
+  ([#5546](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5546))
+
 ## 1.8.0
 
 Released 2024-Apr-02

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -265,12 +265,41 @@ internal sealed class AggregatorStore
 
             if (metricPoint.MetricPointStatus == MetricPointStatus.NoCollectPending)
             {
+                // Reclaim the MetricPoint if it was marked for it in the previous collect cycle
+                if (metricPoint.LookupData != null && metricPoint.LookupData.DeferredReclaim == true)
+                {
+                    this.ReclaimMetricPoint(ref metricPoint, i);
+                    continue;
+                }
+
+                // Check if the MetricPoint could be reclaimed in the current Collect cycle.
                 // If metricPoint.LookupData is `null` then the MetricPoint is already reclaimed and in the queue.
                 // If the Collect thread is successfully able to compare and swap the reference count from zero to int.MinValue, it means that
                 // the MetricPoint can be reused for other tags.
                 if (metricPoint.LookupData != null && Interlocked.CompareExchange(ref metricPoint.ReferenceCount, int.MinValue, 0) == 0)
                 {
-                    this.ReclaimMetricPoint(ref metricPoint, i);
+                    // This is similar to double-checked locking. For some rare case, the Collect thread might read the status as `NoCollectPending`,
+                    // and then get switched out before it could set the ReferenceCount to `int.MinValue`. In the meantime, an Update thread could come in
+                    // and update the MetricPoint, thereby, setting its status to `CollectPending`. Note that the ReferenceCount would be 0 after the update.
+                    // If the Collect thread now wakes up, it would be able to set the ReferenceCount to `int.MinValue`, thereby, marking the MetricPoint
+                    // invalid for newer updates. In such cases, the MetricPoint, should not be reclaimed before taking its Snapshot.
+
+                    if (metricPoint.MetricPointStatus == MetricPointStatus.NoCollectPending)
+                    {
+                        this.ReclaimMetricPoint(ref metricPoint, i);
+                    }
+                    else
+                    {
+                        // MetricPoint's ReferenceCount is `int.MinValue` but it still has a collect pending. Take the MetricPoint's Snapshot
+                        // and mark it to be reclaimed in the next Collect cycle.
+
+                        metricPoint.LookupData.DeferredReclaim = true;
+
+                        this.TakeMetricPointSnapshot(ref metricPoint, outputDelta: true);
+
+                        this.currentMetricPointBatch[this.batchSize] = i;
+                        this.batchSize++;
+                    }
                 }
 
                 continue;

--- a/src/OpenTelemetry/Metrics/LookupData.cs
+++ b/src/OpenTelemetry/Metrics/LookupData.cs
@@ -5,12 +5,14 @@ namespace OpenTelemetry.Metrics;
 
 internal sealed class LookupData
 {
+    public bool DeferredReclaim;
     public int Index;
     public Tags SortedTags;
     public Tags GivenTags;
 
     public LookupData(int index, in Tags sortedTags, in Tags givenTags)
     {
+        this.DeferredReclaim = false;
         this.Index = index;
         this.SortedTags = sortedTags;
         this.GivenTags = givenTags;


### PR DESCRIPTION
## Changes

#### On the main branch:

An update thread does the following:
1. Get index for the `MetricPoint` array
2. Increment the `ReferenceCount` for the `MetricPoint` at that index
3.  Ensure the `MetricPoint` is valid for use
4. Update necessary values
5. Set the `MetricPointStatus` to `CollectPending`
6. Decrement the `ReferenceCount` for the `MetricPoint`

The collect thread does the following:
1. Enumerate over all the MetricPoints
2. If the `MetricPointStatus` for a given `MetricPoint` is `NoCollectPending`, then check if it can be marked invalid
4. Try marking the `MetricPoint` invalid (this happens by setting the `ReferenceCount` to `int.MinValue` when no one is using it)
5. If the 3rd step was successful, then reclaim the `MetricPoint`

#### Where's the race condition?

Consider this sequence of steps where both the Update thread and the Collect thread are working on the same MetricPoint

| Time | Update thread |  Collect thread |
|-----  |-----------------|------------------|
|    T1 | Get `MetricPoint` index        |           Enumerate over all `MetricPoints`                |
|    T2 |  Update thread gets switched out     |    Check `MetricPointStatus` for the `MetricPoint`                      |
|    T3 | Update thread is switched out      |   Collect thread finds that `MetricPointStatus` is `NoCollectPending`                      |
|    T4 | Update thread is back and it increments the `ReferenceCount` to `1`        |  Collect thread gets switched out              |
|    T5 | Ensure that the `MetricPoint` is valid for use        |   Switched out                         |
|    T6 | Update the required values          |                           Switched out |
|    T7 | Set `MetricPointStatus` to `CollectPending`  **(This is the update that we would miss)**       |   Switched out                        |
|    T8 | Decrement the `ReferenceCount` to `0`         |    Switched out                       |
|    T9 |        |   Collect thread is back and sets the `ReferenceCount` to `int.MinValue` as it finds the `ReferenceCount` to be `0`                     |
|    T10 |       |  Reclaims the `MetricPoint` and misses the update that happened at T7                      |

#### Fix

I'm introducing a double-checked locking type construct to recheck if the `MetricPointStatus` was changed to `CollectPending` before the Collect thread could mark the MetricPoint invalid for use. When that happens, we would now call `Snapshot` for that `MetricPoint` and mark it to be reclaimed in the next Collect cycle. Note that the `MetricPoint` would remain invalid for use until the next Collect cycle reclaims it.