### PR TITLE
[main] Updates for 1.8.1 release

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <OTelLatestStableVer>1.8.0</OTelLatestStableVer>
+    <OTelLatestStableVer>1.8.1</OTelLatestStableVer>
   </PropertyGroup>
 
   <!--

--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.8.1
+
+Released 2024-Apr-17
+
 ## 1.8.0
 
 Released 2024-Apr-02

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -7,6 +7,10 @@
   [W3C Baggage propagation format specification](https://www.w3.org/TR/baggage/).
   ([#5303](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5303))
 
+## 1.8.1
+
+Released 2024-Apr-17
+
 ## 1.8.0
 
 Released 2024-Apr-02

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.8.1
+
+Released 2024-Apr-17
+
 ## 1.8.0
 
 Released 2024-Apr-02

--- a/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.8.1
+
+Released 2024-Apr-17
+
 ## 1.8.0
 
 Released 2024-Apr-02

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 ## Unreleased
 
-* Fix native AoT warnings in `OpenTelemetry.Exporter.OpenTelemetryProtocol`.
-  ([#5520](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5520))
-
 * `User-Agent` header format changed from
   `OTel-OTLP-Exporter-Dotnet/{NuGet Package Version}+{Commit Hash}`
   to `OTel-OTLP-Exporter-Dotnet/{NuGet Package Version}`.
   ([#5528](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5528))
+
+## 1.8.1
+
+Released 2024-Apr-17
+
+* Fix native AoT warnings in `OpenTelemetry.Exporter.OpenTelemetryProtocol`.
+  ([#5520](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5520))
 
 ## 1.8.0
 

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.8.1
+
+Released 2024-Apr-17
+
 ## 1.8.0
 
 Released 2024-Apr-02

--- a/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.8.1
+
+Released 2024-Apr-17
+
 ## 1.8.0
 
 Released 2024-Apr-02

--- a/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.8.1
+
+Released 2024-Apr-17
+
 ## 1.8.0
 
 Released 2024-Apr-02

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -2,15 +2,19 @@
 
 ## Unreleased
 
-* Fixed an issue in Logging where unwanted objects (processors, exporters, etc.)
-  could be created inside delegates automatically executed by the Options API
-  during configuration reload.
-  ([#5514](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5514))
-
 * **Experimental (pre-release builds only):** Exposed `ExemplarReservoir` as a
   public API and added support for setting an `ExemplarReservoir` factory
   function when configuring a view (applies to individual metrics).
   ([#5542](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5542))
+
+## 1.8.1
+
+Released 2024-Apr-17
+
+* Fixed an issue in Logging where unwanted objects (processors, exporters, etc.)
+  could be created inside delegates automatically executed by the Options API
+  during configuration reload.
+  ([#5514](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5514))
 
 ## 1.8.0
 


### PR DESCRIPTION
## Changes

* Update CHANGELOGs in `main` to reflect `1.8.1` release from `main-1.8.0` (#5544)
* Bump `OTelLatestStableVer` to `1.8.1`
