### PR TITLE
Demonstrate compile-time logging source gen without message template

### DIFF
--- a/docs/logs/getting-started-console/Program.cs
+++ b/docs/logs/getting-started-console/Program.cs
@@ -32,7 +32,7 @@ internal static partial class LoggerExtensions
     [LoggerMessage(LogLevel.Information, "Food `{name}` price changed to `{price}`.")]
     public static partial void FoodPriceChanged(this ILogger logger, string name, double price);
 
-    [LoggerMessage(LogLevel.Critical, "A `{productType}` recall notice was published for `{brandName} {productDescription}` produced by `{companyName}` ({recallReasonDescription}).")]
+    [LoggerMessage(LogLevel.Critical)]
     public static partial void FoodRecallNotice(
         this ILogger logger,
         string brandName,

--- a/docs/logs/getting-started-console/README.md
+++ b/docs/logs/getting-started-console/README.md
@@ -49,14 +49,13 @@ LogRecord.Timestamp:               2023-09-15T06:07:03.5683511Z
 LogRecord.CategoryName:            Program
 LogRecord.Severity:                Fatal
 LogRecord.SeverityText:            Critical
-LogRecord.Body:                    A `{productType}` recall notice was published for `{brandName} {productDescription}` produced by `{companyName}` ({recallReasonDescription}).
+LogRecord.Body:
 LogRecord.Attributes (Key:Value):
     brandName: Contoso
     productDescription: Salads
     productType: Food & Beverages
     recallReasonDescription: due to a possible health risk from Listeria monocytogenes
     companyName: Contoso Fresh Vegetables, Inc.
-    OriginalFormat (a.k.a Body): A `{productType}` recall notice was published for `{brandName} {productDescription}` produced by `{companyName}` ({recallReasonDescription}).
 LogRecord.EventId:                 1338249384
 LogRecord.EventName:               FoodRecallNotice
 


### PR DESCRIPTION
Updating the doc/example to show that it is possible to have structured logging without requiring a message template string.

For users who don't need the format string, this could save computation and networking cost.