### PR TITLE
[repo] Improve the scripts used in the release process

### DIFF
--- a/OpenTelemetry.sln
+++ b/OpenTelemetry.sln
@@ -35,19 +35,20 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{7CB2F02E
 		build\docker-compose.net7.0.yml = build\docker-compose.net7.0.yml
 		build\docker-compose.net8.0.yml = build\docker-compose.net8.0.yml
 		build\finalize-publicapi.ps1 = build\finalize-publicapi.ps1
+		build\generate-combined-changelog.ps1 = build\generate-combined-changelog.ps1
 		build\GlobalAttrExclusions.txt = build\GlobalAttrExclusions.txt
 		build\InstrumentationLibraries.proj = build\InstrumentationLibraries.proj
 		build\opentelemetry-icon-color.png = build\opentelemetry-icon-color.png
 		build\OpenTelemetry.prod.loose.ruleset = build\OpenTelemetry.prod.loose.ruleset
 		build\OpenTelemetry.prod.ruleset = build\OpenTelemetry.prod.ruleset
 		build\OpenTelemetry.test.ruleset = build\OpenTelemetry.test.ruleset
-		build\process-codecoverage.ps1 = build\process-codecoverage.ps1
 		build\RELEASING.md = build\RELEASING.md
 		build\stylecop.json = build\stylecop.json
 		build\test-aot-compatibility.ps1 = build\test-aot-compatibility.ps1
 		build\test-threadSafety.ps1 = build\test-threadSafety.ps1
-		build\xunit.runner.json = build\xunit.runner.json
 		build\UnstableCoreLibraries.proj = build\UnstableCoreLibraries.proj
+		build\update-changelogs.ps1 = build\update-changelogs.ps1
+		build\xunit.runner.json = build\xunit.runner.json
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTelemetry.Exporter.Zipkin", "src\OpenTelemetry.Exporter.Zipkin\OpenTelemetry.Exporter.Zipkin.csproj", "{7EDAE7FA-B44E-42CA-80FA-7DF2FAA2C5DD}"
@@ -531,10 +532,6 @@ Global
 		{41B784AA-3301-4126-AF9F-1D59BD04B0BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{41B784AA-3301-4126-AF9F-1D59BD04B0BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{41B784AA-3301-4126-AF9F-1D59BD04B0BF}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D4519DF6-CC72-4AC4-A851-E21383098D11}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D4519DF6-CC72-4AC4-A851-E21383098D11}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D4519DF6-CC72-4AC4-A851-E21383098D11}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D4519DF6-CC72-4AC4-A851-E21383098D11}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6C7A1595-36D6-4229-BBB5-5A6B5791791D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6C7A1595-36D6-4229-BBB5-5A6B5791791D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6C7A1595-36D6-4229-BBB5-5A6B5791791D}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/build/finalize-publicapi.ps1
+++ b/build/finalize-publicapi.ps1
@@ -1,31 +1,39 @@
-# After every stable release, all PublicApi text files (Shipped & Unshipped) should be merged.
-$path = "src\*\.publicApi\**\";
-$directory = Split-Path -Path $PSScriptRoot -Parent;
+param(
+  [Parameter(Mandatory=$true)][string]$minVerTagPrefix
+)
 
-$searchPath = Join-Path -Path $directory -ChildPath $path;
-Write-Host "Search Directory: $searchPath";
-Write-Host "";
+# For stable releases "Unshipped" PublicApi text files are merged into "Shipped" versions.
 
-Get-ChildItem -Path $searchPath -Recurse -Filter *.Shipped.txt | 
-    ForEach-Object {
-        Write-Host $_.FullName;
+$projectDirs = Get-ChildItem -Path src/**/*.csproj | Select-String "<MinVerTagPrefix>$minVerTagPrefix</MinVerTagPrefix>" -List | Select Path | Split-Path -Parent
 
-        [string]$shipped = $_.FullName;
-        [string]$unshipped = $shipped -replace ".shipped.txt", ".Unshipped.txt";
+$path = "\.publicApi\**\PublicAPI.Shipped.txt";
 
-        if (Test-Path $unshipped) {
-            Write-Host $unshipped;
+foreach ($projectDir in $projectDirs) {
+    $searchPath = Join-Path -Path $projectDir -ChildPath $path;
 
-            Get-Content $shipped, $unshipped |  # get contents of both text files
-                Where-Object {$_ -ne ""} |      # filter empty lines
-                Sort-Object |                   # sort lines
-                Get-Unique |                    # filter duplicates
-                Set-Content $shipped;           # write to shipped.txt
+    Write-Host "Search glob: $searchPath";
 
-            Clear-Content $unshipped;           # empty unshipped.txt
+    Get-ChildItem -Path $searchPath -Recurse |
+        ForEach-Object {
+            Write-Host "Shipped: $_";
 
-            Write-Host "...MERGED and SORTED";
+            [string]$shipped = $_.FullName;
+            [string]$unshipped = $shipped -replace ".shipped.txt", ".Unshipped.txt";
+
+            if (Test-Path $unshipped) {
+                Write-Host "Unshipped: $unshipped";
+
+                Get-Content $shipped, $unshipped |  # get contents of both text files
+                    Where-Object {$_ -ne ""} |      # filter empty lines
+                    Sort-Object |                   # sort lines
+                    Get-Unique |                    # filter duplicates
+                    Set-Content $shipped;           # write to shipped.txt
+
+                Clear-Content $unshipped;           # empty unshipped.txt
+
+                Write-Host "...MERGED and SORTED";
+            }
+
+            Write-Host "";
         }
-
-        Write-Host "";
-    }
+}

--- a/build/generate-combined-changelog.ps1
+++ b/build/generate-combined-changelog.ps1
@@ -1,0 +1,42 @@
+param(
+  [Parameter(Mandatory=$true)][string]$minVerTagPrefix
+)
+
+$projectDirs = Get-ChildItem -Path src/**/*.csproj | Select-String "<MinVerTagPrefix>$minVerTagPrefix</MinVerTagPrefix>" -List | Select Path | Split-Path -Parent
+
+foreach ($projectDir in $projectDirs) {
+  $path = Join-Path -Path $projectDir -ChildPath "CHANGELOG.md"
+
+  $directory = Split-Path $Path -Parent | Split-Path -Leaf
+
+    $lines = Get-Content -Path $path
+
+  $headingWritten = $false
+  $started = $false
+  $content = ""
+
+  foreach ($line in $lines)
+  {
+    if ($line -like "## Unreleased" -and $started -ne $true)
+    {
+      $started = $true
+    }
+    elseif ($line -like "## *" -and $started -eq $true)
+    {
+      break
+    }
+    else
+    {
+        if ($started -eq $true)
+        {
+            $content += $line + "`r`n"
+        }
+    }
+  }
+
+  if ([string]::IsNullOrWhitespace($content) -eq $false)
+  {
+    Add-Content -Path ".\$($minVerTagPrefix)combinedchangelog.md" -Value "**$($directory)**"
+    Add-Content -Path ".\$($minVerTagPrefix)combinedchangelog.md" -NoNewline -Value $content
+  }
+}

--- a/build/update-changelogs.ps1
+++ b/build/update-changelogs.ps1
@@ -1,0 +1,20 @@
+param(
+  [Parameter(Mandatory=$true)][string]$minVerTagPrefix,
+  [Parameter(Mandatory=$true)][string]$version
+)
+
+$projectDirs = Get-ChildItem -Path src/**/*.csproj | Select-String "<MinVerTagPrefix>$minVerTagPrefix</MinVerTagPrefix>" -List | Select Path | Split-Path -Parent
+
+$content = "Unreleased
+
+## $version
+
+Released $(Get-Date -UFormat '%Y-%b-%d')"
+
+foreach ($projectDir in $projectDirs) {
+  $path = Join-Path -Path $projectDir -ChildPath "CHANGELOG.md"
+
+  Write-Host "Updating $path"
+
+  (Get-Content -Path $path) -replace "Unreleased", $content | Set-Content -Path $path
+}


### PR DESCRIPTION
## Changes

* Move the inline scripts in releasing doc into dedicated files
* Improve the scripts to be aware of `MinVerTagPrefix`

## Details

This is an incremental improvement to the scripts used in the release process. Previously they ran over all the projects in the repo. When working on a release the output has to be massaged manually for what is actually being released. Now the scripts will marry up to the `MinVerTagPrefix` being used so the output matches automatically. That makes things a bit easier and less error prone.