### PR TITLE
[api] Fix Baggage XML documentation

### DIFF
--- a/src/OpenTelemetry.Api/Baggage.cs
+++ b/src/OpenTelemetry.Api/Baggage.cs
@@ -157,11 +157,11 @@ public readonly struct Baggage : IEquatable<Baggage>
     }
 
     /// <summary>
-    /// Returns a new <see cref="Baggage"/> which contains the new key/value pair.
+    /// Returns a new <see cref="Baggage"/> which contains the new key/value pairs.
     /// </summary>
     /// <param name="baggageItems">Baggage key/value pairs.</param>
     /// <param name="baggage">Optional <see cref="Baggage"/>. <see cref="Current"/> is used if not specified.</param>
-    /// <returns>New <see cref="Baggage"/> containing the key/value pair.</returns>
+    /// <returns>New <see cref="Baggage"/> containing the new key/value pairs.</returns>
     /// <remarks>Note: The <see cref="Baggage"/> returned will be set as the new <see cref="Current"/> instance.</remarks>
     [SuppressMessage("roslyn", "RS0026", Justification = "TODO: fix APIs that violate the backcompt requirement - multiple overloads with optional parameters: https://github.com/dotnet/roslyn/blob/main/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md.")]
     public static Baggage SetBaggage(IEnumerable<KeyValuePair<string, string>> baggageItems, Baggage baggage = default)
@@ -180,7 +180,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// </summary>
     /// <param name="name">Baggage item name.</param>
     /// <param name="baggage">Optional <see cref="Baggage"/>. <see cref="Current"/> is used if not specified.</param>
-    /// <returns>New <see cref="Baggage"/> containing the key/value pair.</returns>
+    /// <returns>New <see cref="Baggage"/> with the key/value pair removed.</returns>
     /// <remarks>Note: The <see cref="Baggage"/> returned will be set as the new <see cref="Current"/> instance.</remarks>
     public static Baggage RemoveBaggage(string name, Baggage baggage = default)
     {
@@ -197,7 +197,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// Returns a new <see cref="Baggage"/> with all the key/value pairs removed.
     /// </summary>
     /// <param name="baggage">Optional <see cref="Baggage"/>. <see cref="Current"/> is used if not specified.</param>
-    /// <returns>New <see cref="Baggage"/> containing the key/value pair.</returns>
+    /// <returns>New <see cref="Baggage"/> with all the key/value pairs removed.</returns>
     /// <remarks>Note: The <see cref="Baggage"/> returned will be set as the new <see cref="Current"/> instance.</remarks>
     public static Baggage ClearBaggage(Baggage baggage = default)
     {
@@ -252,18 +252,18 @@ public readonly struct Baggage : IEquatable<Baggage>
     }
 
     /// <summary>
-    /// Returns a new <see cref="Baggage"/> which contains the new key/value pair.
+    /// Returns a new <see cref="Baggage"/> which contains the new key/value pairs.
     /// </summary>
     /// <param name="baggageItems">Baggage key/value pairs.</param>
-    /// <returns>New <see cref="Baggage"/> containing the key/value pair.</returns>
+    /// <returns>New <see cref="Baggage"/> containing the key/value pairs.</returns>
     public Baggage SetBaggage(params KeyValuePair<string, string>[] baggageItems)
         => this.SetBaggage((IEnumerable<KeyValuePair<string, string>>)baggageItems);
 
     /// <summary>
-    /// Returns a new <see cref="Baggage"/> which contains the new key/value pair.
+    /// Returns a new <see cref="Baggage"/> which contains the new key/value pairs.
     /// </summary>
     /// <param name="baggageItems">Baggage key/value pairs.</param>
-    /// <returns>New <see cref="Baggage"/> containing the key/value pair.</returns>
+    /// <returns>New <see cref="Baggage"/> containing the key/value pairs.</returns>
     public Baggage SetBaggage(IEnumerable<KeyValuePair<string, string>> baggageItems)
     {
         if (baggageItems?.Any() != true)
@@ -292,7 +292,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// Returns a new <see cref="Baggage"/> with the key/value pair removed.
     /// </summary>
     /// <param name="name">Baggage item name.</param>
-    /// <returns>New <see cref="Baggage"/> containing the key/value pair.</returns>
+    /// <returns>New <see cref="Baggage"/> with the key/value pair removed.</returns>
     public Baggage RemoveBaggage(string name)
     {
         var baggage = new Dictionary<string, string>(this.baggage ?? EmptyBaggage, StringComparer.OrdinalIgnoreCase);
@@ -304,7 +304,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// <summary>
     /// Returns a new <see cref="Baggage"/> with all the key/value pairs removed.
     /// </summary>
-    /// <returns>New <see cref="Baggage"/> containing the key/value pair.</returns>
+    /// <returns>New <see cref="Baggage"/> with all the key/value pairs removed.</returns>
     public Baggage ClearBaggage()
         => default;
 


### PR DESCRIPTION
## Changes

Fix XML documentation for the following `Baggage` methods:
- `SetBaggage` that accepts multiple key/value pair
- `RemoveBaggage`
- `ClearBaggage`

Looks like previously docs were copy-pasted from `SetBaggage` method with a single key/value pair.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated -- not applicable
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes -- not applicable
* [ ] Changes in public API reviewed (if applicable) -- not applicable
