### PR TITLE
[sdk-metrics] Clean up some malformed xml docs in exemplar code

### DIFF
--- a/src/OpenTelemetry/Metrics/Exemplar/ExemplarReservoir.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/ExemplarReservoir.cs
@@ -13,7 +13,7 @@ namespace OpenTelemetry.Metrics;
 /// ExemplarReservoir base implementation and contract.
 /// </summary>
 /// <remarks>
-/// <remarks><inheritdoc cref="Exemplar" path="/remarks/para[@experimental-warning='true']"/></remarks>
+/// <inheritdoc cref="Exemplar" path="/remarks/para[@experimental-warning='true']"/>
 /// Specification: <see
 /// href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#exemplarreservoir"/>.
 /// </remarks>

--- a/src/OpenTelemetry/Metrics/MetricStreamConfiguration.cs
+++ b/src/OpenTelemetry/Metrics/MetricStreamConfiguration.cs
@@ -144,7 +144,7 @@ public class MetricStreamConfiguration
     /// when storing <see cref="Exemplar"/>s.
     /// </summary>
     /// <remarks>
-    /// <remarks><inheritdoc cref="Exemplar" path="/remarks/para[@experimental-warning='true']"/></remarks>
+    /// <inheritdoc cref="Exemplar" path="/remarks/para[@experimental-warning='true']"/>
     /// <para>Note: Returning <see langword="null"/> from the factory function will
     /// result in the default <see cref="ExemplarReservoir"/> being chosen by
     /// the SDK based on the type of metric.</para>


### PR DESCRIPTION
## Changes

* Clean up XML comments in `Exemplar` code which had extra `<remarks>` elements

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
