### PR TITLE
[repo-ci] Switch to using dotnet tool install in docfx workflow

### DIFF
--- a/.github/workflows/docfx.yml
+++ b/.github/workflows/docfx.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: install docfx
-      run: choco install docfx -y
+      run: dotnet tool install -g docfx
 
     - name: run .\build\docfx.cmd
       shell: cmd


### PR DESCRIPTION
## Changes

* Switch to using `dotnet tool install` instead of `choco install` to obtain docfx in `docfx.yml`

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
