### PR TITLE
[repo] Move Microsoft.CSharp to non-prod section

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,6 @@
     <PackageVersion Include="Grpc.Net.Client" Version="[2.52.0,3.0)" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.1.1,6.0)" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Features" Version="[2.1.1,6.0)" />
-    <PackageVersion Include="Microsoft.CSharp" Version="[4.7.0]" />
 
     <!--
         Typically, for the Microsoft.Extensions.* packages relating to DI Abstractions, Hosting Abstractions, and Logging,
@@ -76,6 +75,7 @@
     <PackageVersion Include="Grpc.AspNetCore" Version="[2.59.0,3.0)" />
     <PackageVersion Include="Grpc.AspNetCore.Server" Version="[2.59.0, 3.0)" />
     <PackageVersion Include="Grpc.Tools" Version="[2.59.0,3.0)" />
+    <PackageVersion Include="Microsoft.CSharp" Version="[4.7.0]" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="[3.11.0-beta1.23525.2]" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="[8.0.0,)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[8.0.0,)" />


### PR DESCRIPTION
It seems Microsoft.CSharp is only used by test projects now https://github.com/search?q=repo%3Aopen-telemetry%2Fopentelemetry-dotnet%20Microsoft.CSharp&type=code.