### PR TITLE
[repo] Release process tweaks & improvements 2

### DIFF
--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -51,10 +51,10 @@ jobs:
         name: ${{ github.ref_name }}-packages
         path: '**/bin/**/*.*nupkg'
 
-    #- name: Publish MyGet
-    #  run: |
-    #    nuget setApiKey ${{ secrets.MYGET_TOKEN }} -Source https://www.myget.org/F/opentelemetry/api/v2/package
-    #    nuget push **/bin/**/*.nupkg -Source https://www.myget.org/F/opentelemetry/api/v2/package
+    - name: Publish MyGet
+      run: |
+        nuget setApiKey ${{ secrets.MYGET_TOKEN }} -Source https://www.myget.org/F/opentelemetry/api/v2/package
+        nuget push **/bin/**/*.nupkg -Source https://www.myget.org/F/opentelemetry/api/v2/package
 
     - name: Create GitHub Release Draft
       if: github.ref_type == 'tag'

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -51,10 +51,10 @@ jobs:
         name: ${{ github.ref_name }}-packages
         path: '**/bin/**/*.*nupkg'
 
-    - name: Publish MyGet
-      run: |
-        nuget setApiKey ${{ secrets.MYGET_TOKEN }} -Source https://www.myget.org/F/opentelemetry/api/v2/package
-        nuget push **/bin/**/*.nupkg -Source https://www.myget.org/F/opentelemetry/api/v2/package
+    #- name: Publish MyGet
+    #  run: |
+    #    nuget setApiKey ${{ secrets.MYGET_TOKEN }} -Source https://www.myget.org/F/opentelemetry/api/v2/package
+    #    nuget push **/bin/**/*.nupkg -Source https://www.myget.org/F/opentelemetry/api/v2/package
 
     - name: Create GitHub Release Draft
       if: github.ref_type == 'tag'

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -100,7 +100,7 @@ jobs:
                 {
                     if ($started -eq $true -and ([string]::IsNullOrWhitespace($line) -eq $false -or $content.Length -gt 0))
                     {
-                        $content += "   " + $line + "`r`n"
+                        $content += "  " + $line + "`r`n"
                     }
             }
             }
@@ -118,7 +118,7 @@ jobs:
 
         $content
 
-           See [CHANGELOG](https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/src/$packageName/CHANGELOG.md) for details.
+          See [CHANGELOG](https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/src/$packageName/CHANGELOG.md) for details.
 
         "@
         }

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -73,14 +73,52 @@ jobs:
 
             if ($firstPackageVersion -eq '')
             {
-              $firstPackageVersion = $packageVersion
+                $firstPackageVersion = $packageVersion
             }
+
+            $changelogContent = Get-Content -Path "src/$packageName/CHANGELOG.md"
+
+            $headingWritten = $false
+            $started = $false
+            $content = ""
+
+            foreach ($line in $changelogContent)
+            {
+                if ($line -like "## ${{ github.ref_name }}" -and $started -ne $true)
+                {
+                    $started = $true
+                }
+                elseif ($line -like "Released *" -and $started -eq $true)
+                {
+                    continue
+                }
+                elseif ($line -like "## *" -and $started -eq $true)
+                {
+                    break
+                }
+                else
+                {
+                    if ($started -eq $true -and ([string]::IsNullOrWhitespace($line) -eq $false -or $content.Length -gt 0))
+                    {
+                        $content += "   " + $line + "`r`n"
+                    }
+            }
+            }
+
+            if ([string]::IsNullOrWhitespace($content) -eq $true)
+            {
+                $content = "   No notable changes."
+            }
+
+            $content = $content.trimend()
 
             $notes +=
         @"
         * NuGet: [$packageName v$packageVersion](https://www.nuget.org/packages/$packageName/$packageVersion)
 
-          See [CHANGELOG](https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/src/$packageName/CHANGELOG.md) for details.
+        $content
+
+           See [CHANGELOG](https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/src/$packageName/CHANGELOG.md) for details.
 
         "@
         }


### PR DESCRIPTION
Follow-up to #5584

## Changes

* Add the combined changelog entries automatically to the release draft created by the package workflow

## Details

#5584 removed the script which used to generate the combined changelog and the instructions for manually including the output on the release which used to be created manually. What this PR does is put that back in an automated way so the CHANGELOG entries are automatically included as part of release content.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
