### PR TITLE
[repo] Clean up nits (s/can not/cannot/) in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -56,7 +56,7 @@ body:
   - type: textarea
     attributes:
       label: Steps to Reproduce
-      description: Create a self-contained project using the template of your choice, apply the minimum required code to result in the issue you are observing. We will close the issue if the repro project you share with us is complex or we cannot reproduce the behavior you are reporting. We can not investigate custom projects, so don't point us to such, please.
+      description: Create a self-contained project using the template of your choice, apply the minimum required code to result in the issue you are observing. We will close the issue if the repro project you share with us is complex or we cannot reproduce the behavior you are reporting. We cannot investigate custom projects, so don't point us to such, please.
     validations:
       required: true
 


### PR DESCRIPTION
@cijothomas discovered this https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1716#discussion_r1597291101