### PR TITLE
[repo] Add minimal reproducible example link to the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -56,7 +56,7 @@ body:
   - type: textarea
     attributes:
       label: Steps to Reproduce
-      description: Create a self-contained project using the template of your choice, apply the minimum required code to result in the issue you are observing. We will close the issue if the repro project you share with us is complex or we cannot reproduce the behavior you are reporting. We cannot investigate custom projects, so don't point us to such, please.
+      description: Provide a [minimal reproducible example](https://stackoverflow.com/help/minimal-reproducible-example). We will close the issue if the repro project you share with us is complex or we cannot reproduce the behavior you are reporting. We cannot investigate custom projects, so don't point us to such, please.
     validations:
       required: true
 


### PR DESCRIPTION
Per suggestion from @Kielek https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1716#discussion_r1597876032.