### PR TITLE
[repo] Switch to component label for tagging issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     id: package
     attributes:
       label: Package
-      description: Which NuGet Package does this bug report concern?
+      description: Which NuGet package does this bug report concern?
       multiple: false
       options:
         - OpenTelemetry

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,19 +10,24 @@ body:
         Before filing a bug, please be sure you have searched through [existing bugs](https://github.com/open-telemetry/opentelemetry-dotnet/issues?q=is%3Aissue+is%3Aopen+label%3Abug) to see if an existing issue covers the bug.
 
   - type: dropdown
-    id: area
+    id: component
     attributes:
-      label: Area
-      description: Which area does this bug report concern? If none fits, please select `area:other`
+      label: Component
+      description: Which component does this bug report concern?
       multiple: false
       options:
-        - area:other
-        - area:api
-        - area:exporter
-        - area:exporter:otlp
-        - area:exporter:prometheus
-        - area:ext:hosting
-        - area:sdk
+        - OpenTelemetry
+        - OpenTelemetry.Api
+        - OpenTelemetry.Api.ProviderBuilderExtensions
+        - OpenTelemetry.Exporter.Console
+        - OpenTelemetry.Exporter.InMemory
+        - OpenTelemetry.Exporter.OpenTelemetryProtocol
+        - OpenTelemetry.Exporter.Prometheus.AspNetCore
+        - OpenTelemetry.Exporter.Prometheus.HttpListener
+        - OpenTelemetry.Exporter.Zipkin
+        - OpenTelemetry.Extensions.Hosting
+        - OpenTelemetry.Extensions.Propagators
+        - OpenTelemetry.Shims.OpenTracing
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,10 +10,10 @@ body:
         Before filing a bug, please be sure you have searched through [existing bugs](https://github.com/open-telemetry/opentelemetry-dotnet/issues?q=is%3Aissue+is%3Aopen+label%3Abug) to see if an existing issue covers the bug.
 
   - type: dropdown
-    id: component
+    id: package
     attributes:
-      label: Component
-      description: Which component does this bug report concern?
+      label: Package
+      description: Which NuGet Package does this bug report concern?
       multiple: false
       options:
         - OpenTelemetry

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,6 +9,26 @@ body:
 
         Before opening a feature request, consider whether the feature should/could be implemented in the [other OpenTelemetry client libraries](https://github.com/open-telemetry/). If so, please [open an issue on opentelemetry-specification](https://github.com/open-telemetry/opentelemetry-specification/issues/new) first.
 
+  - type: dropdown
+    id: package
+    attributes:
+      label: Package
+      description: Which NuGet Package does this feature request concern?
+      multiple: false
+      options:
+        - OpenTelemetry
+        - OpenTelemetry.Api
+        - OpenTelemetry.Api.ProviderBuilderExtensions
+        - OpenTelemetry.Exporter.Console
+        - OpenTelemetry.Exporter.InMemory
+        - OpenTelemetry.Exporter.OpenTelemetryProtocol
+        - OpenTelemetry.Exporter.Prometheus.AspNetCore
+        - OpenTelemetry.Exporter.Prometheus.HttpListener
+        - OpenTelemetry.Exporter.Zipkin
+        - OpenTelemetry.Extensions.Hosting
+        - OpenTelemetry.Extensions.Propagators
+        - OpenTelemetry.Shims.OpenTracing
+
   - type: textarea
     attributes:
       label: Is your feature request related to a problem?

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -13,7 +13,7 @@ body:
     id: package
     attributes:
       label: Package
-      description: Which NuGet Package does this feature request concern?
+      description: Which NuGet package does this feature request concern?
       multiple: false
       options:
         - OpenTelemetry

--- a/build/scripts/add-labels.ps1
+++ b/build/scripts/add-labels.ps1
@@ -3,10 +3,10 @@ param(
   [Parameter(Mandatory=$true)][string]$issueBody
 )
 
-$match = [regex]::Match($issueBody, '^[#]+ Component\s*(OpenTelemetry(?:\.\w+)+)')
+$match = [regex]::Match($issueBody, '^[#]+ Package\s*(OpenTelemetry(?:\.\w+)*)')
 if ($match.Success -eq $false)
 {
     Return
 }
 
-gh issue edit $issueNumber --add-label $("comp:" + $match.Groups[1].Value)
+gh issue edit $issueNumber --add-label $("pkg:" + $match.Groups[1].Value)

--- a/build/scripts/add-labels.ps1
+++ b/build/scripts/add-labels.ps1
@@ -3,10 +3,10 @@ param(
   [Parameter(Mandatory=$true)][string]$issueBody
 )
 
-$match = [regex]::Match($issueBody, '^[#]+ Area\s*?(area:\w+)')
+$match = [regex]::Match($issueBody, '^[#]+ Component\s*(OpenTelemetry(?:\.\w+)+)')
 if ($match.Success -eq $false)
 {
     Return
 }
 
-gh issue edit $issueNumber --add-label $match.Groups[1].Value
+gh issue edit $issueNumber --add-label $("comp:" + $match.Groups[1].Value)


### PR DESCRIPTION
Instead of using the unclear "area", switch to component name (NuGet package name).
Apply the component labels to feature request as optional.