### PR TITLE
[sdk-metrics] Update Exemplars before MetricPoint CompleteUpdate fires

### DIFF
--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -492,9 +492,9 @@ public struct MetricPoint
                 }
         }
 
-        this.CompleteUpdate();
-
         this.UpdateExemplar(number, tags, offerExemplar);
+
+        this.CompleteUpdate();
     }
 
     internal void Update(double number)
@@ -608,9 +608,9 @@ public struct MetricPoint
                 }
         }
 
-        this.CompleteUpdate();
-
         this.UpdateExemplar(number, tags, offerExemplar);
+
+        this.CompleteUpdate();
     }
 
     internal void TakeSnapshot(bool outputDelta)
@@ -899,9 +899,9 @@ public struct MetricPoint
 
         this.mpComponents.ReleaseLock();
 
-        this.CompleteUpdate();
-
         this.UpdateExemplar(number, tags, offerExemplar);
+
+        this.CompleteUpdate();
     }
 
     private void UpdateHistogramWithMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool offerExemplar = false)
@@ -923,9 +923,9 @@ public struct MetricPoint
 
         this.mpComponents.ReleaseLock();
 
-        this.CompleteUpdate();
-
         this.UpdateExemplar(number, tags, offerExemplar);
+
+        this.CompleteUpdate();
     }
 
     private void UpdateHistogramWithBuckets(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool offerExemplar = false)
@@ -947,9 +947,9 @@ public struct MetricPoint
 
         this.mpComponents.ReleaseLock();
 
-        this.CompleteUpdate();
-
         this.UpdateExemplar(number, tags, offerExemplar, bucketIndex);
+
+        this.CompleteUpdate();
     }
 
     private void UpdateHistogramWithBucketsAndMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool offerExemplar = false)
@@ -974,9 +974,9 @@ public struct MetricPoint
 
         this.mpComponents.ReleaseLock();
 
-        this.CompleteUpdate();
-
         this.UpdateExemplar(number, tags, offerExemplar, bucketIndex);
+
+        this.CompleteUpdate();
     }
 
     private void UpdateBase2ExponentialHistogram(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool offerExemplar = false)
@@ -1002,9 +1002,9 @@ public struct MetricPoint
 
         this.mpComponents.ReleaseLock();
 
-        this.CompleteUpdate();
-
         this.UpdateExemplar(number, tags, offerExemplar);
+
+        this.CompleteUpdate();
     }
 
     private void UpdateBase2ExponentialHistogramWithMinMax(double number, ReadOnlySpan<KeyValuePair<string, object?>> tags = default, bool offerExemplar = false)
@@ -1033,9 +1033,9 @@ public struct MetricPoint
 
         this.mpComponents.ReleaseLock();
 
-        this.CompleteUpdate();
-
         this.UpdateExemplar(number, tags, offerExemplar);
+
+        this.CompleteUpdate();
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
## Changes

* Switches the order of `UpdateExemplar` & `CompleteUpdate` inside `MetricPoint`. According to @utpilla this is required for the delta `MetricPoint` reclaim feature to function correctly with exemplars enabled.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
