### PR TITLE
[repo] Post-release automation improvements

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -21,13 +21,7 @@ jobs:
     needs:
     - automation
 
-    if: |
-      needs.automation.outputs.enabled
-      &&
-      (
-        (github.ref_type == 'tag' && startsWith(github.ref_name, 'core-') && !contains(github.ref_name, '-alpha') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-rc'))
-        || (inputs.tag && startsWith(inputs.tag, 'core-') && !contains(inputs.tag, '-alpha') && !contains(inputs.tag, '-beta') && !contains(inputs.tag, '-rc'))
-      )
+    if: needs.automation.outputs.enabled
 
     env:
       GH_TOKEN: ${{ secrets[needs.automation.outputs.token-secret-name] }}
@@ -39,6 +33,9 @@ jobs:
         token: ${{ secrets[needs.automation.outputs.token-secret-name] }}
 
     - name: Create GitHub Pull Request to update stable build version in props
+      if: |
+          (github.ref_type == 'tag' && startsWith(github.ref_name, 'core-') && !contains(github.ref_name, '-alpha') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-rc'))
+          || (inputs.tag && startsWith(inputs.tag, 'core-') && !contains(inputs.tag, '-alpha') && !contains(inputs.tag, '-beta') && !contains(inputs.tag, '-rc'))
       shell: pwsh
       run: |
         Import-Module .\build\scripts\post-release.psm1
@@ -49,3 +46,13 @@ jobs:
           -targetBranch '${{ github.event.repository.default_branch }}' `
           -gitUserName '${{ needs.automation.outputs.username }}' `
           -gitUserEmail '${{ needs.automation.outputs.email }}'
+
+    - name: Invoke core version update workflow in opentelemetry-dotnet-contrib repository
+      if: vars.CONTRIB_REPO
+      shell: pwsh
+      run: |
+        Import-Module .\build\scripts\post-release.psm1
+
+        InvokeCoreVersionUpdateWorkflowInRemoteRepository `
+          -repository '${{ vars.CONTRIB_REPO }}' `
+          -tag '${{ inputs.tag || github.ref_name }}'

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -29,6 +29,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        # Note: By default GitHub only fetches 1 commit. We need all the tags
+        # for this work.
+        fetch-depth: 0
         ref: ${{ github.event.repository.default_branch }}
         token: ${{ secrets[needs.automation.outputs.token-secret-name] }}
 
@@ -54,5 +57,14 @@ jobs:
         Import-Module .\build\scripts\post-release.psm1
 
         InvokeCoreVersionUpdateWorkflowInRemoteRepository `
-          -repository '${{ vars.CONTRIB_REPO }}' `
+          -remoteGitRepository '${{ vars.CONTRIB_REPO }}' `
+          -tag '${{ inputs.tag || github.ref_name }}'
+
+    - name: Post notice when release is published
+      shell: pwsh
+      run: |
+        Import-Module .\build\scripts\post-release.psm1
+
+        TryPostReleasePublishedNoticeOnPrepareReleasePullRequest `
+          -gitRepository '${{ github.repository }}' `
           -tag '${{ inputs.tag || github.ref_name }}'

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -67,4 +67,5 @@ jobs:
 
         TryPostReleasePublishedNoticeOnPrepareReleasePullRequest `
           -gitRepository '${{ github.repository }}' `
+          -botUserName '${{ needs.automation.outputs.username }}' `
           -tag '${{ inputs.tag || github.ref_name }}'

--- a/build/RELEASING.md
+++ b/build/RELEASING.md
@@ -164,18 +164,21 @@
     workflow creates a draft release for the tag which was pushed. Edit the
     draft Release and click `Publish release`.
 
-14. If a new stable version of the core packages was released, a draft PR should
-    have been automatically created by the [Build, pack, and publish to
-    MyGet](https://github.com/open-telemetry/opentelemetry-dotnet/actions/workflows/publish-packages-1.0.yml)
+14. If a new stable version of the core packages was released, a PR should have
+    been automatically created by the [Complete
+    release](https://github.com/open-telemetry/opentelemetry-dotnet/actions/workflows/post-release.yml)
     workflow to update the `OTelLatestStableVer` property in
-    `Directory.Packages.props` to the just released stable version. Mark that PR
-    `Ready for review` and then merge it once the build passes (this requires
-    the packages be available on NuGet).
+    `Directory.Packages.props` to the just released stable version. Merge that
+    PR once the build passes (this requires the packages be available on NuGet).
 
-15. If a new stable version of the core packages was released, open an issue in
-    the
-    [opentelemetry-dotnet-contrib](https://github.com/open-telemetry/opentelemetry-dotnet-contrib)
-    repo to notify maintainers to begin upgrading dependencies.
+15. The [Complete
+    release](https://github.com/open-telemetry/opentelemetry-dotnet/actions/workflows/post-release.yml)
+    workflow should have invoked the [Core version
+    update](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions/workflows/core-version-update.yml)
+    workflow on the
+    [opentelemetry-dotnet-contrib](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/)
+    repository which opens a PR to update dependencies. Verify this PR was
+    opened successfully.
 
 16. Post an announcement in the [Slack
     channel](https://cloud-native.slack.com/archives/C01N3BC2W7Q). Note any big

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -227,3 +227,24 @@ Merge once packages are available on NuGet and the build passes.
 }
 
 Export-ModuleMember -Function CreateStableVersionUpdatePullRequest
+
+function InvokeCoreVersionUpdateWorkflowInRemoteRepository {
+  param(
+    [Parameter(Mandatory=$true)][string]$repository,
+    [Parameter(Mandatory=$true)][string]$tag,
+    [Parameter()][string]$targetBranch="main"
+  )
+
+  $match = [regex]::Match($tag, '^(.*?-)(.*)$')
+  if ($match.Success -eq $false)
+  {
+      throw 'Could not parse prefix or version from tag'
+  }
+
+  gh workflow run "core-version-update.yml" `
+    --repo $repository `
+    --ref $targetBranch `
+    --field "tag=$tag"
+}
+
+Export-ModuleMember -Function InvokeCoreVersionUpdateWorkflowInRemoteRepository

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -250,6 +250,7 @@ Export-ModuleMember -Function InvokeCoreVersionUpdateWorkflowInRemoteRepository
 function TryPostReleasePublishedNoticeOnPrepareReleasePullRequest {
   param(
     [Parameter(Mandatory=$true)][string]$gitRepository,
+    [Parameter(Mandatory=$true)][string]$botUserName,
     [Parameter(Mandatory=$true)][string]$tag
   )
 


### PR DESCRIPTION
## Changes

* When the GitHub Release is published at the end of the release process the automation will now perform two tasks:
  * Call the [Core version update](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/actions/workflows/core-version-update.yml) workflow on contrib
  * Post a final message on the prepare release PR announcing the packages are available on NuGet

## Details

Test runs:

* https://github.com/CodeBlanchOrg/opentelemetry-dotnet/pull/22 -> https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/1

* https://github.com/CodeBlanchOrg/opentelemetry-dotnet/pull/23 -> https://github.com/CodeBlanchOrg/opentelemetry-dotnet-contrib/pull/2
