### PR TITLE
[repo] Add packages to releases when created by automation

### DIFF
--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -88,7 +88,7 @@ jobs:
           -H "Authorization: token ${{ github.token }}" `
           -L `
           -o '${{ github.workspace }}/artifacts/${{ github.ref_name }}-packages.zip' `
-          "https://api.github.com/repos/${{ github.repository }}/actions/artifacts/${{ jobs.build-pack-publish.outputs.artifact-id }}/zip"
+          "https://api.github.com/repos/${{ github.repository }}/actions/artifacts/${{ needs.build-pack-publish.outputs.artifact-id }}/zip"
 
     - name: Display structure of downloaded files
       run: ls -R

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -87,6 +87,9 @@ jobs:
         name: ${{ github.ref_name }}-packages
         path: '${{ github.workspace }}/artifacts'
 
+    - name: Display structure of downloaded files
+      run: ls -R
+
     - name: Create GitHub Release draft
       shell: pwsh
       run: |

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -88,6 +88,7 @@ jobs:
           -H "Authorization: token ${{ github.token }}" \
           -L \
           -o '${{ github.workspace }}/artifacts/${{ github.ref_name }}-packages.zip' \
+          --create-dirs \
           "https://api.github.com/repos/${{ github.repository }}/actions/artifacts/${{ needs.build-pack-publish.outputs.artifact-id }}/zip"
 
     - name: Display structure of downloaded files

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -80,6 +80,12 @@ jobs:
       with:
         token: ${{ secrets[needs.automation.outputs.token-secret-name] }}
 
+    - name: Download Artifacts
+      id: download-artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ github.ref_name }}-packages
+
     - name: Create GitHub Release draft
       shell: pwsh
       run: |
@@ -87,7 +93,8 @@ jobs:
 
         CreateDraftRelease `
           -gitRepository '${{ github.repository }}' `
-          -tag '${{ github.ref_name }}'
+          -tag '${{ github.ref_name }}' `
+          -artifactsPath '${{ steps.download-artifacts.outputs.download-path }}'
 
     - name: Post notice when packages are ready
       shell: pwsh

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -83,11 +83,11 @@ jobs:
 
     - name: Download Artifacts
       run: |
-        curl `
-          -H "Accept: application/vnd.github+json" `
-          -H "Authorization: token ${{ github.token }}" `
-          -L `
-          -o '${{ github.workspace }}/artifacts/${{ github.ref_name }}-packages.zip' `
+        curl \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: token ${{ github.token }}" \
+          -L \
+          -o '${{ github.workspace }}/artifacts/${{ github.ref_name }}-packages.zip' \
           "https://api.github.com/repos/${{ github.repository }}/actions/artifacts/${{ needs.build-pack-publish.outputs.artifact-id }}/zip"
 
     - name: Display structure of downloaded files

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -85,6 +85,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: ${{ github.ref_name }}-packages
+        path: '${{ $GITHUB_WORKSPACE }}/artifacts'
 
     - name: Create GitHub Release draft
       shell: pwsh
@@ -94,7 +95,7 @@ jobs:
         CreateDraftRelease `
           -gitRepository '${{ github.repository }}' `
           -tag '${{ github.ref_name }}' `
-          -artifactsPath '${{ steps.download-artifacts.outputs.download-path }}/${{ github.ref_name }}-packages.zip'
+          -releaseFiles '${{ steps.download-artifacts.outputs.download-path }}/*.zip#Packages'
 
     - name: Post notice when packages are ready
       shell: pwsh

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -91,9 +91,6 @@ jobs:
           --create-dirs \
           "https://api.github.com/repos/${{ github.repository }}/actions/artifacts/${{ needs.build-pack-publish.outputs.artifact-id }}/zip"
 
-    - name: Display structure of downloaded files
-      run: ls -R
-
     - name: Create GitHub Release draft
       shell: pwsh
       run: |

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -85,7 +85,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: ${{ github.ref_name }}-packages
-        path: '${{ $GITHUB_WORKSPACE }}/artifacts'
+        path: '${{ github.workspace }}/artifacts'
 
     - name: Create GitHub Release draft
       shell: pwsh

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -94,7 +94,7 @@ jobs:
         CreateDraftRelease `
           -gitRepository '${{ github.repository }}' `
           -tag '${{ github.ref_name }}' `
-          -artifactsPath '${{ steps.download-artifacts.outputs.download-path }}'
+          -artifactsPath '${{ steps.download-artifacts.outputs.download-path }}/${{ github.ref_name }}-packages.zip'
 
     - name: Post notice when packages are ready
       shell: pwsh

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -26,6 +26,7 @@ jobs:
 
     outputs:
       artifact-url: ${{ steps.upload-artifacts.outputs.artifact-url }}
+      artifact-id: ${{ steps.upload-artifacts.outputs.artifact-id }}
 
     steps:
     - uses: actions/checkout@v4
@@ -81,11 +82,13 @@ jobs:
         token: ${{ secrets[needs.automation.outputs.token-secret-name] }}
 
     - name: Download Artifacts
-      id: download-artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: ${{ github.ref_name }}-packages
-        path: '${{ github.workspace }}/artifacts'
+      run: |
+        curl `
+          -H "Accept: application/vnd.github+json" `
+          -H "Authorization: token ${{ github.token }}" `
+          -L `
+          -o '${{ github.workspace }}/artifacts/${{ github.ref_name }}-packages.zip' `
+          "https://api.github.com/repos/${{ github.repository }}/actions/artifacts/${{ jobs.build-pack-publish.outputs.artifact-id }}/zip"
 
     - name: Display structure of downloaded files
       run: ls -R
@@ -98,7 +101,7 @@ jobs:
         CreateDraftRelease `
           -gitRepository '${{ github.repository }}' `
           -tag '${{ github.ref_name }}' `
-          -releaseFiles '${{ steps.download-artifacts.outputs.download-path }}/*.zip#Packages'
+          -releaseFiles '${{ github.workspace }}/artifacts/${{ github.ref_name }}-packages.zip#Packages'
 
     - name: Post notice when packages are ready
       shell: pwsh

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -75,7 +75,7 @@ $content
 
   if ($version -match '-alpha' -or $version -match '-beta' -or $version -match '-rc')
   {
-    gh release create $tag "$artifactsPath/**/*.*nupkg" `
+    gh release create $tag "$artifactsPath#Packages" `
       --title $tag `
       --verify-tag `
       --notes $notes `
@@ -84,7 +84,7 @@ $content
   }
   else
   {
-    gh release create $tag "$artifactsPath/**/*.*nupkg" `
+    gh release create $tag "$artifactsPath#Packages" `
       --title $tag `
       --verify-tag `
       --notes $notes `

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -1,7 +1,8 @@
 function CreateDraftRelease {
   param(
     [Parameter(Mandatory=$true)][string]$gitRepository,
-    [Parameter(Mandatory=$true)][string]$tag
+    [Parameter(Mandatory=$true)][string]$tag,
+    [Parameter()][string]$artifactsPath
   )
 
   $match = [regex]::Match($tag, '^(.*?-)(.*)$')
@@ -74,7 +75,7 @@ $content
 
   if ($version -match '-alpha' -or $version -match '-beta' -or $version -match '-rc')
   {
-    gh release create $tag `
+    gh release create $tag "$artifactsPath/**/*.*nupkg" `
       --title $tag `
       --verify-tag `
       --notes $notes `
@@ -83,7 +84,7 @@ $content
   }
   else
   {
-    gh release create $tag `
+    gh release create $tag "$artifactsPath/**/*.*nupkg" `
       --title $tag `
       --verify-tag `
       --notes $notes `

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -2,7 +2,7 @@ function CreateDraftRelease {
   param(
     [Parameter(Mandatory=$true)][string]$gitRepository,
     [Parameter(Mandatory=$true)][string]$tag,
-    [Parameter()][string]$artifactsPath
+    [Parameter()][string]$releaseFiles
   )
 
   $match = [regex]::Match($tag, '^(.*?-)(.*)$')
@@ -75,7 +75,7 @@ $content
 
   if ($version -match '-alpha' -or $version -match '-beta' -or $version -match '-rc')
   {
-    gh release create $tag "$artifactsPath#Packages" `
+    gh release create $tag $releaseFiles `
       --title $tag `
       --verify-tag `
       --notes $notes `
@@ -84,7 +84,7 @@ $content
   }
   else
   {
-    gh release create $tag "$artifactsPath#Packages" `
+    gh release create $tag $releaseFiles `
       --title $tag `
       --verify-tag `
       --notes $notes `


### PR DESCRIPTION
## Changes

* Adds the packages produced by the publish workflow as assets on the GitHub Release created by automation

## Details

It ends up like this:

![image](https://github.com/open-telemetry/opentelemetry-dotnet/assets/28367120/84ec3d62-a078-4fe2-a4f8-7dac8b2992cc)

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
