### PR TITLE
[repo] Fix a couple issues in automation workflows/scripts

### DIFF
--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -13,7 +13,7 @@ on:
         value: ${{ vars.AUTOMATION_EMAIL }}
     secrets:
       OPENTELEMETRYBOT_GITHUB_TOKEN:
-        required: true
+        required: false
 
 jobs:
   resolve-automation:

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -212,7 +212,7 @@ function PushPackagesPublishReleaseUnlockAndPostNoticeOnPrepareReleasePullReques
     gh pr comment $pullRequestNumber `
       --body "I am uploading the packages for ``$tag`` to NuGet and then I will publish the release."
 
-    nuget push "$artifactDownloadPath/**/*.nupkg" -Source https://api.nuget.org/v3/index.json -ApiKey "$env.NUGET_TOKEN" -SymbolApiKey "$env.NUGET_TOKEN"
+    nuget push "$artifactDownloadPath/**/*.nupkg" -Source https://api.nuget.org/v3/index.json -ApiKey "$env:NUGET_TOKEN" -SymbolApiKey "$env:NUGET_TOKEN"
 
     if ($LASTEXITCODE -gt 0)
     {


### PR DESCRIPTION
## Changes

* Don't require `OPENTELEMETRYBOT_GITHUB_TOKEN` secret in `automation.yml`. It is designed to work without it but because it is required all workflows which use automation blow up when run on forks if they don't have the secret defined.

* Use proper PowerShell envvar syntax in `post-release.psm1`.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
