### PR TITLE
[repo] Auto label PR workflow permissions fix

### DIFF
--- a/.github/workflows/add-labels.yml
+++ b/.github/workflows/add-labels.yml
@@ -3,12 +3,11 @@ on:
   issues:
     types: [ opened ]
 
-  pull_request:
+  pull_request_target:
     branches: [ 'main*' ]
 
 permissions:
   issues: write
-  pull-requests: write
 
 jobs:
   add-labels-on-issues:
@@ -40,6 +39,8 @@ jobs:
     steps:
       - name: check out code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Add labels for files changed on pull requests
         shell: pwsh

--- a/.github/workflows/add-labels.yml
+++ b/.github/workflows/add-labels.yml
@@ -32,7 +32,7 @@ jobs:
           ISSUE_BODY: ${{ github.event.issue.body }}
 
   add-labels-on-pull-requests:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/add-labels.yml
+++ b/.github/workflows/add-labels.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   add-labels-on-issues:
@@ -40,7 +41,7 @@ jobs:
       - name: check out code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.event.repository.default_branch }} # Note: Do not run on the PR branch we want to execute add-labels.psm1 from main on the base repo only because pull_request_target can see secrets
 
       - name: Add labels for files changed on pull requests
         shell: pwsh


### PR DESCRIPTION
## Changes

* Fix `add-labels.yml` so that it is able to label PRs opened from forks

## Details

There is a bit of knowledge required to understand what is going on here. The `pull_request` trigger is special on GitHub. It is essentially executing code from untrusted sources (forks) so by default it only has `read` permission to everything. To label something you need `write` access. The `pull_request_target` trigger runs as the main repo and can have `write` permission. It also sees secrets which for this workflow is undesirable.

Info: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

What we don't want to do is execute anything from forks with a token granted under `pull_request_target` scope. If we did, someone could open a PR with some code to write out secrets and we would run it.

To mitigate this what this PR does is checkout the main branch (`github.event.repository.default_branch`) to execute the powershell to label PRs.

Here is a demo showing that whatever the user has for `add-labels.psm1` in their fork is NOT run: https://github.com/CodeBlanchOrg/opentelemetry-dotnet/pull/45/files

We can see the correct branch being checked out here: https://github.com/CodeBlanchOrg/opentelemetry-dotnet/actions/runs/9453234045/job/26038183882?pr=45#step:2:170

For a standard `pull_request` trigger notice the merge branch is checked out: https://github.com/open-telemetry/opentelemetry-dotnet/actions/runs/9415790656/job/25937523267?pr=5647#step:2:170

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
