### PR TITLE
[repo] Replace Logging Exporter with Debug Exporter in otel-collector configs

### DIFF
--- a/examples/AspNetCore/otel-collector.yaml
+++ b/examples/AspNetCore/otel-collector.yaml
@@ -5,8 +5,8 @@ receivers:
       http:
 
 exporters:
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
   prometheus:
     endpoint: ":9201"
     send_timestamps: true
@@ -21,10 +21,10 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [logging,otlp]
+      exporters: [debug, otlp]
     metrics:
       receivers: [otlp]
-      exporters: [logging,prometheus]
+      exporters: [debug, prometheus]
     logs:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]

--- a/examples/Console/otlp-collector-example/config.yaml
+++ b/examples/Console/otlp-collector-example/config.yaml
@@ -11,17 +11,17 @@ receivers:
       http:
 
 exporters:
-  logging:
+  debug:
     verbosity: detailed
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]
     metrics:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]
     logs:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTest/otel-collector-config.yaml
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTest/otel-collector-config.yaml
@@ -25,17 +25,17 @@ receivers:
           key_file: /cfg/otel-collector.key
 
 exporters:
-  logging:
+  debug:
     verbosity: detailed
 
 service:
   pipelines:
     traces:
       receivers: [otlp, otlp/tls]
-      exporters: [logging]
+      exporters: [debug]
     metrics:
       receivers: [otlp, otlp/tls]
-      exporters: [logging]
+      exporters: [debug]
     logs:
       receivers: [otlp, otlp/tls]
-      exporters: [logging]
+      exporters: [debug]


### PR DESCRIPTION
## Changes

Replaces the logging exporter with the [debug exporter](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/debugexporter/README.md) as it is deprecated and will be removed in September 2024.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
