### PR TITLE
[repo] Bump tests and examples dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -89,7 +89,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="[1.8.1,2.0)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="[1.8.0-beta.1,2.0)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="[1.8.1,2.0)" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="[1.5.1,2.0)" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="[1.8.1,2.0)" />
     <PackageVersion Include="RabbitMQ.Client" Version="[6.8.1,7.0)" />
     <PackageVersion Include="StyleCop.Analyzers" Version="[1.2.0-beta.556,2.0)" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="[6.6.2,)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -99,17 +99,11 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.21" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.21" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.21" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="7.0.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="7.0.9" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -90,7 +90,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="[1.8.0-beta.1,2.0)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="[1.8.1,2.0)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="[1.5.1,2.0)" />
-    <PackageVersion Include="RabbitMQ.Client" Version="[6.6.0,7.0)" />
+    <PackageVersion Include="RabbitMQ.Client" Version="[6.8.1,7.0)" />
     <PackageVersion Include="StyleCop.Analyzers" Version="[1.2.0-beta.556,2.0)" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="[6.5.0,)" />
     <PackageVersion Include="xunit" Version="[2.8.1,3.0)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -81,7 +81,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[8.0.0,)" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="[8.0.0,)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.0,)" />
-    <PackageVersion Include="Microsoft.Extensions.Telemetry.Abstractions" Version="[8.2.0,)" />
+    <PackageVersion Include="Microsoft.Extensions.Telemetry.Abstractions" Version="[8.6.0,)" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="[1.0.3,2.0)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="[17.10.0,18.0.0)" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="[1.1.1,2.0)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -83,7 +83,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.0,)" />
     <PackageVersion Include="Microsoft.Extensions.Telemetry.Abstractions" Version="[8.2.0,)" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="[1.0.3,2.0)" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="[17.8.0,18.0.0)" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="[17.10.0,18.0.0)" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="[1.1.1,2.0)" />
     <PackageVersion Include="MinVer" Version="[5.0.0,6.0)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="[1.8.1,2.0)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -70,7 +70,7 @@
   -->
   <!-- 'net8.0' is the default `TargetFramework`. Use `VersionOverride` in the project to override the package versions from a different `TargetFramework` -->
   <ItemGroup>
-    <PackageVersion Include="BenchmarkDotNet" Version="[0.13.10,0.14)" />
+    <PackageVersion Include="BenchmarkDotNet" Version="[0.13.12,0.14)" />
     <PackageVersion Include="CommandLineParser" Version="[2.9.1,3.0)" />
     <PackageVersion Include="Grpc.AspNetCore" Version="[2.59.0,3.0)" />
     <PackageVersion Include="Grpc.AspNetCore.Server" Version="[2.59.0, 3.0)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -98,12 +98,12 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.21" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.31" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="7.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="7.0.20" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.6" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -93,8 +93,8 @@
     <PackageVersion Include="RabbitMQ.Client" Version="[6.6.0,7.0)" />
     <PackageVersion Include="StyleCop.Analyzers" Version="[1.2.0-beta.556,2.0)" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="[6.5.0,)" />
-    <PackageVersion Include="xunit" Version="[2.6.2,3.0)" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="[2.5.4,3.0)" />
+    <PackageVersion Include="xunit" Version="[2.8.1,3.0)" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="[2.8.1,3.0)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -92,7 +92,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="[1.5.1,2.0)" />
     <PackageVersion Include="RabbitMQ.Client" Version="[6.8.1,7.0)" />
     <PackageVersion Include="StyleCop.Analyzers" Version="[1.2.0-beta.556,2.0)" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="[6.5.0,)" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="[6.6.2,)" />
     <PackageVersion Include="xunit" Version="[2.8.1,3.0)" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="[2.8.1,3.0)" />
   </ItemGroup>

--- a/test/OpenTelemetry.Tests/SuppressInstrumentationTest.cs
+++ b/test/OpenTelemetry.Tests/SuppressInstrumentationTest.cs
@@ -51,7 +51,7 @@ public class SuppressInstrumentationTest
     }
 
     [Fact]
-    public async void SuppressInstrumentationScopeEnterIsLocalToAsyncFlow()
+    public async Task SuppressInstrumentationScopeEnterIsLocalToAsyncFlow()
     {
         Assert.False(Sdk.SuppressInstrumentation);
 


### PR DESCRIPTION
## Changes

Reason, update xunit as in https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1872. Less issues than in contrib repo.
Opportunistic update part of other dependencies.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests ~~added/~~updated
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
