### PR TITLE
[repo] Stable version update automation tweaks

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -83,6 +83,9 @@ jobs:
         ref: ${{ github.event.repository.default_branch }}
         token: ${{ secrets[needs.automation.outputs.token-secret-name] }}
 
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v4
+
     - name: Create GitHub Pull Request to update stable build version in props
       if: |
           (github.ref_type == 'tag' && startsWith(github.ref_name, 'core-') && !contains(github.ref_name, '-alpha') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-rc'))

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <OTelLatestStableVer>[1.9.0,2.0)</OTelLatestStableVer>
+    <OTelLatestStableVer>1.9.0</OTelLatestStableVer>
   </PropertyGroup>
 
   <!--
@@ -35,12 +35,12 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.0" />
 
-    <PackageVersion Include="OpenTelemetry" Version="$(OTelLatestStableVer)" />
-    <PackageVersion Include="OpenTelemetry.Api" Version="$(OTelLatestStableVer)" />
-    <PackageVersion Include="OpenTelemetry.Api.ProviderBuilderExtensions" Version="$(OTelLatestStableVer)" />
-    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="$(OTelLatestStableVer)" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="$(OTelLatestStableVer)" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Propagators" Version="$(OTelLatestStableVer)" />
+    <PackageVersion Include="OpenTelemetry" Version="[$(OTelLatestStableVer),2.0)" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="[$(OTelLatestStableVer),2.0)" />
+    <PackageVersion Include="OpenTelemetry.Api.ProviderBuilderExtensions" Version="[$(OTelLatestStableVer),2.0)" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="[$(OTelLatestStableVer),2.0)" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="[$(OTelLatestStableVer),2.0)" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Propagators" Version="[$(OTelLatestStableVer),2.0)" />
     <PackageVersion Include="OpenTracing" Version="[0.12.1,0.13)" />
 
     <!--

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <OTelLatestStableVer>1.9.0</OTelLatestStableVer>
+    <OTelLatestStableVer>[1.9.0,2.0)</OTelLatestStableVer>
   </PropertyGroup>
 
   <!--

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -239,6 +239,7 @@ function CreateStableVersionUpdatePullRequest {
     [Parameter(Mandatory=$true)][string]$gitRepository,
     [Parameter(Mandatory=$true)][string]$tag,
     [Parameter()][string]$targetBranch="main",
+    [Parameter()][string]$lineEnding="`n",
     [Parameter()][string]$gitUserName,
     [Parameter()][string]$gitUserEmail
   )
@@ -249,7 +250,7 @@ function CreateStableVersionUpdatePullRequest {
       throw 'Could not parse version from tag'
   }
 
-  $packageVersion = $match.Groups[1].Value
+  $version = $match.Groups[1].Value
 
   $branch="release/post-stable-${tag}-update"
 
@@ -268,9 +269,30 @@ function CreateStableVersionUpdatePullRequest {
       throw 'git switch failure'
   }
 
+  $projectsAndDependenciesBefore = GetCoreDependenciesForProjects
+
   (Get-Content Directory.Packages.props) `
-      -replace '<OTelLatestStableVer>.*<\/OTelLatestStableVer>', "<OTelLatestStableVer>$packageVersion</OTelLatestStableVer>" |
+      -replace '<OTelLatestStableVer>.*<\/OTelLatestStableVer>', "<OTelLatestStableVer>[$version,2.0)</OTelLatestStableVer>" |
     Set-Content Directory.Packages.props
+
+  $projectsAndDependenciesAfter = GetCoreDependenciesForProjects
+
+  $changedProjects = @{}
+
+  $projectsAndDependenciesBefore.GetEnumerator() | ForEach-Object {
+    $projectDir = $_.Key
+    $projectDependenciesBefore = $_.Value
+    $projectDependenciesAfter = $projectsAndDependenciesAfter[$projectDir]
+
+    $projectDependenciesBefore.GetEnumerator() | ForEach-Object {
+      $packageName = $_.Key
+      $packageVersionBefore = $_.Value
+      if ($projectDependenciesAfter[$packageName] -ne $packageVersionBefore)
+      {
+          $changedProjects[$projectDir] = $true
+      }
+    }
+  }
 
   git add Directory.Packages.props 2>&1 | % ToString
   if ($LASTEXITCODE -gt 0)
@@ -278,7 +300,7 @@ function CreateStableVersionUpdatePullRequest {
       throw 'git add failure'
   }
 
-  git commit -m "Update OTelLatestStableVer in Directory.Packages.props to $packageVersion." 2>&1 | % ToString
+  git commit -m "Update OTelLatestStableVer in Directory.Packages.props to $version." 2>&1 | % ToString
   if ($LASTEXITCODE -gt 0)
   {
       throw 'git commit failure'
@@ -298,18 +320,176 @@ Merge once packages are available on NuGet and the build passes.
 
 ## Changes
 
-* Sets ``OTelLatestStableVer`` in ``Directory.Packages.props`` to ``$packageVersion``.
+* Sets ``OTelLatestStableVer`` in ``Directory.Packages.props`` to ``$version``.
 "@
 
-  gh pr create `
-    --title "[release] Core stable release $packageVersion updates" `
+  $createPullRequestResponse = gh pr create `
+    --title "[release] Core stable release $version updates" `
     --body $body `
     --base $targetBranch `
     --head $branch `
     --label release
+
+  Write-Host $createPullRequestResponse
+
+  $match = [regex]::Match($createPullRequestResponse, "\/pull\/(.*)$")
+  if ($match.Success -eq $false)
+  {
+      throw 'Could not parse pull request number from gh pr create response'
+  }
+
+  $pullRequestNumber = $match.Groups[1].Value
+
+  if ($changedProjects.Count -eq 0)
+  {
+    Return
+  }
+
+  $entry = @"
+* Updated OpenTelemetry core component version(s) to ``$version``.
+  ([#$pullRequestNumber](https://github.com/$gitRepository/pull/$pullRequestNumber))
+
+
+"@
+
+  $lastLineBlank = $true
+  $changelogFilesUpdated = 0
+
+  foreach ($projectDir in $changedProjects.Keys)
+  {
+      $path = Join-Path -Path $projectDir -ChildPath "CHANGELOG.md"
+
+      if ([System.IO.File]::Exists($path) -eq $false)
+      {
+        Write-Host "No CHANGELOG found in $projectDir"
+        continue
+      }
+
+      $changelogContent = Get-Content -Path $path
+
+      $started = $false
+      $isRemoving = $false
+      $content = ""
+
+      foreach ($line in $changelogContent)
+      {
+          if ($line -like "## Unreleased" -and $started -ne $true)
+          {
+              $started = $true
+          }
+          elseif ($line -like "## *" -and $started -eq $true)
+          {
+              if ($lastLineBlank -eq $false)
+              {
+                  $content += $lineEnding
+              }
+              $content += $entry
+              $started = $false
+              $isRemoving = $false
+          }
+          elseif ($started -eq $true -and ($line -like '*Update* OpenTelemetry SDK version to*' -or $line -like '*Updated OpenTelemetry core component version(s) to*'))
+          {
+            $isRemoving = $true
+            continue
+          }
+
+          if ($line.StartsWith('* '))
+          {
+              if ($isRemoving -eq $true)
+              {
+                  $isRemoving = $false
+              }
+
+              if ($lastLineBlank -eq $false)
+              {
+                  $content += $lineEnding
+              }
+          }
+
+          if ($isRemoving -eq $true)
+          {
+              continue
+          }
+
+          $content += $line + $lineEnding
+
+          $lastLineBlank = [string]::IsNullOrWhitespace($line)
+      }
+
+      if ($started -eq $true)
+      {
+        # Note: If we never wrote the entry it means the file ended in the unreleased section
+        if ($lastLineBlank -eq $false)
+        {
+            $content += $lineEnding
+        }
+        $content += $entry
+      }
+
+      Set-Content -Path $path -Value $content.TrimEnd()
+
+      git add $path 2>&1 | % ToString
+      if ($LASTEXITCODE -gt 0)
+      {
+          throw 'git add failure'
+      }
+
+      $changelogFilesUpdated++
+  }
+
+  if ($changelogFilesUpdated -gt 0)
+  {
+    git commit -m "Update CHANGELOGs for projects using OTelLatestStableVer." 2>&1 | % ToString
+    if ($LASTEXITCODE -gt 0)
+    {
+        throw 'git commit failure'
+    }
+
+    git push -u origin $branch 2>&1 | % ToString
+    if ($LASTEXITCODE -gt 0)
+    {
+        throw 'git push failure'
+    }
+  }
 }
 
 Export-ModuleMember -Function CreateStableVersionUpdatePullRequest
+
+function GetCoreDependenciesForProjects {
+    $projects = @(Get-ChildItem -Path 'src/*/*.csproj')
+
+    $projectsAndDependencies = @{}
+
+    foreach ($project in $projects)
+    {
+        # Note: dotnet restore may fail if the core packages aren't available yet but that is fine, we just want to generate project.assets.json for these projects.
+        $output = dotnet restore $project
+
+        $projectDir = $project | Split-Path -Parent
+
+        $content = (Get-Content "$projectDir/obj/project.assets.json" -Raw)
+
+        $projectDependencies = @{}
+
+        $matches = [regex]::Matches($content, '"(OpenTelemetry(?:.*))?": {[\S\s]*?"target": "Package",[\S\s]*?"version": "(.*)"[\S\s]*?}')
+        foreach ($match in $matches)
+        {
+            $packageName = $match.Groups[1].Value
+            $packageVersion = $match.Groups[2].Value
+            if ($packageName -eq 'OpenTelemetry' -or
+                $packageName -eq 'OpenTelemetry.Api' -or
+                $packageName -eq 'OpenTelemetry.Api.ProviderBuilderExtensions' -or
+                $packageName -eq 'OpenTelemetry.Extensions.Hosting' -or
+                $packageName -eq 'OpenTelemetry.Extensions.Propagators')
+            {
+                $projectDependencies[$packageName.ToString()] = $packageVersion.ToString()
+            }
+        }
+        $projectsAndDependencies[$projectDir.ToString()] = $projectDependencies
+    }
+
+    return $projectsAndDependencies
+}
 
 function InvokeCoreVersionUpdateWorkflowInRemoteRepository {
   param(

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -272,7 +272,7 @@ function CreateStableVersionUpdatePullRequest {
   $projectsAndDependenciesBefore = GetCoreDependenciesForProjects
 
   (Get-Content Directory.Packages.props) `
-      -replace '<OTelLatestStableVer>.*<\/OTelLatestStableVer>', "<OTelLatestStableVer>[$version,2.0)</OTelLatestStableVer>" |
+      -replace '<OTelLatestStableVer>.*<\/OTelLatestStableVer>', "<OTelLatestStableVer>$version</OTelLatestStableVer>" |
     Set-Content Directory.Packages.props
 
   $projectsAndDependenciesAfter = GetCoreDependenciesForProjects

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -463,7 +463,7 @@ function GetCoreDependenciesForProjects {
     foreach ($project in $projects)
     {
         # Note: dotnet restore may fail if the core packages aren't available yet but that is fine, we just want to generate project.assets.json for these projects.
-        $output = dotnet restore $project
+        $output = dotnet restore $project -p:RunningDotNetPack=true
 
         $projectDir = $project | Split-Path -Parent
 


### PR DESCRIPTION
## Changes

* Switch references using `OTelLatestStableVer` to constrain allowed versions to `1.9.0 <= x < 2.0.0`
* Update automation workflow to add CHANGELOG entries when `OTelLatestStableVer` is changed

## Details

Test PR: https://github.com/CodeBlanchOrg/opentelemetry-dotnet/pull/51

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
