### PR TITLE
[shared] Use CultureInfo.InvariantCulture in TagWriter

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* **Breaking change**: Non-primitive attribute (logs) and tag (traces) values
+  converted using `Convert.ToString` will now format using
+  `CultureInfo.InvariantCulture`.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.9.0
 
 Released 2024-Jun-14

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -5,7 +5,7 @@
 * **Breaking change**: Non-primitive attribute (logs) and tag (traces) values
   converted using `Convert.ToString` will now format using
   `CultureInfo.InvariantCulture`.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#5700](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5700))
 
 ## 1.9.0
 

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * **Breaking change**: Non-primitive tag values converted using
   `Convert.ToString` will now format using `CultureInfo.InvariantCulture`.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#5700](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5700))
 
 ## 1.9.0
 

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* **Breaking change**: Non-primitive tag values converted using
+  `Convert.ToString` will now format using `CultureInfo.InvariantCulture`.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.9.0
 
 Released 2024-Jun-14

--- a/src/Shared/TagWriter/TagWriter.cs
+++ b/src/Shared/TagWriter/TagWriter.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System.Diagnostics;
+using System.Globalization;
 
 namespace OpenTelemetry.Internal;
 
@@ -82,7 +83,7 @@ internal abstract class TagWriter<TTagState, TArrayState>
             default:
                 try
                 {
-                    var stringValue = Convert.ToString(tag.Value/*TODO: , CultureInfo.InvariantCulture*/);
+                    var stringValue = Convert.ToString(tag.Value, CultureInfo.InvariantCulture);
                     if (stringValue == null)
                     {
                         return this.LogUnsupportedTagTypeAndReturnFalse(tag.Key, tag.Value);
@@ -247,7 +248,7 @@ internal abstract class TagWriter<TTagState, TArrayState>
                 // case ulong:   May throw an exception on overflow.
                 // case decimal: Converting to double produces rounding errors.
                 default:
-                    var stringValue = Convert.ToString(item/*TODO: , CultureInfo.InvariantCulture*/);
+                    var stringValue = Convert.ToString(item, CultureInfo.InvariantCulture);
                     if (stringValue == null)
                     {
                         this.arrayWriter.WriteNullValue(ref arrayState);

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTestHelpers.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTestHelpers.cs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Globalization;
 using Google.Protobuf.Collections;
 using Xunit;
 using OtlpCommon = OpenTelemetry.Proto.Common.V1;
@@ -110,7 +111,7 @@ internal static class OtlpTestHelpers
                 Assert.Equal(i, actual.IntValue);
                 break;
             default:
-                Assert.Equal(expected.ToString(), actual.StringValue);
+                Assert.Equal(Convert.ToString(expected, CultureInfo.InvariantCulture), actual.StringValue);
                 break;
         }
     }


### PR DESCRIPTION
Relates to https://github.com/open-telemetry/opentelemetry-dotnet/pull/5585#discussion_r1588246527

## Changes

* Use `CultureInfo.InvariantCulture` when calling `Convert.ToString` for tag/attribute values without explicit handling.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
