### PR TITLE
Changed TraceIdRatioBasedSampler.GetLowerLong to use the correct bytes for sampling decision

### DIFF
--- a/src/OpenTelemetry/Trace/TraceIdRatioBasedSampler.cs
+++ b/src/OpenTelemetry/Trace/TraceIdRatioBasedSampler.cs
@@ -66,7 +66,10 @@ public sealed class TraceIdRatioBasedSampler
     private static long GetLowerLong(ReadOnlySpan<byte> bytes)
     {
         long result = 0;
-        for (var i = 0; i < 8; i++)
+
+        // Byte 0 is the most significant byte while byte 15 is the least significant byte.
+        // As a result, use bytes 8->16 as those are the lower long.
+        for (var i = 8; i < 16; i++)
         {
             result <<= 8;
 #pragma warning disable CS0675 // Bitwise-or operator used on a sign-extended operand

--- a/test/OpenTelemetry.Tests/Trace/TraceIdRatioBasedSamplerTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/TraceIdRatioBasedSamplerTest.cs
@@ -28,12 +28,20 @@ public class TraceIdRatioBasedSamplerTest
     {
         Sampler defaultProbability = new TraceIdRatioBasedSampler(0.0001);
 
-        // This traceId will not be sampled by the TraceIdRatioBasedSampler because the first 8 bytes as long
+        // This traceId will not be sampled by the TraceIdRatioBasedSampler because the last 8 bytes as long
         // is not less than probability * Long.MAX_VALUE;
         var notSampledtraceId =
             ActivityTraceId.CreateFromBytes(
                 new byte[]
                 {
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
                   0x8F,
                   0xFF,
                   0xFF,
@@ -42,25 +50,25 @@ public class TraceIdRatioBasedSamplerTest
                   0xFF,
                   0xFF,
                   0xFF,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
                 });
         Assert.Equal(
             SamplingDecision.Drop,
             defaultProbability.ShouldSample(new SamplingParameters(default, notSampledtraceId, ActivityDisplayName, ActivityKindServer, null, null)).Decision);
 
-        // This traceId will be sampled by the TraceIdRatioBasedSampler because the first 8 bytes as long
+        // This traceId will be sampled by the TraceIdRatioBasedSampler because the last 8 bytes as long
         // is less than probability * Long.MAX_VALUE;
         var sampledtraceId =
             ActivityTraceId.CreateFromBytes(
                 new byte[]
                 {
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
                   0x00,
                   0x00,
                   0xFF,
@@ -69,14 +77,6 @@ public class TraceIdRatioBasedSamplerTest
                   0xFF,
                   0xFF,
                   0xFF,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
                 });
         Assert.Equal(
             SamplingDecision.RecordAndSample,


### PR DESCRIPTION
## Changes

Changed TraceIdRatioBasedSampler.GetLowerLong to use the correct bytes for sampling decision. Previously it was using the first 8 bytes to base the sampling decision on. Byte 0 in this case is the most significant byte not the least significant byte. As a result, changed it to use bytes 8->16 as those are the actual `LowerLong`. I discovered this while testing the with XrayIds where the first 4 bytes aren't random (based on current timestamp). Looking at this issue, https://github.com/open-telemetry/opentelemetry-specification/issues/1413#issuecomment-1247145651, seems like we're supposed to use the last 8 bytes to maintain compatibility with 64-bit TraceIds since those are random. I also looked at the [Python Implementation](https://github.com/open-telemetry/opentelemetry-python/blob/00490522b613128f4bb460c5707359ab32e7c6f4/opentelemetry-sdk/src/opentelemetry/sdk/trace/sampling.py#L269) and the [Java Implementaiton](https://github.com/open-telemetry/opentelemetry-java/blob/12eb62659d50750755c3f7533b6ed3c028cf5b8c/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/samplers/TraceIdRatioBasedSampler.java#L111) of the TraceIdRatioBasedSampler and they both also seem to be using the last 8 bytes (least significant 8 bytes to byte 8->15 where byte 0 is the most significant byte). 

*Testing:*
I created a sample app and copied over the sampling code to verify that the bytes being used currently are the most significant bytes and this was the result:
```
This is traceID= 667493231b8d224048149519ddfa8382 (xray trace id)
this is byte 0 = 102
this is byte 1 = 116
this is byte 2 = 147
this is byte 3 = 35
this is byte 4 = 27
this is byte 5 = 141
this is byte 6 = 34
this is byte 7 = 64
This is traceID= 66749388460c471ecba96ae40d3bf1c9 (xray trace id)
this is byte 0 = 102
this is byte 1 = 116
this is byte 2 = 147
this is byte 3 = 136
this is byte 4 = 70
this is byte 5 = 12
this is byte 6 = 71
this is byte 7 = 30
```

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
