### PR TITLE
[repo] Add Raj as approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ you're more than welcome to participate!
 ([@open-telemetry/dotnet-approvers](https://github.com/orgs/open-telemetry/teams/dotnet-approvers)):
 
 * [Cijo Thomas](https://github.com/cijothomas), Microsoft
+* [Rajkumar Rangaraj](https://github.com/rajkumar-rangaraj), Microsoft
 * [Reiley Yang](https://github.com/reyang), Microsoft
 * [Utkarsh Umesan Pillai](https://github.com/utpilla), Microsoft
 * [Vishwesh Bankwar](https://github.com/vishweshbankwar), Microsoft


### PR DESCRIPTION
@rajkumar-rangaraj has been active in the OpenTelemetry .NET community and AppInsights community for a long time. He is a maintainer on the https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation repo, works on the [AzureMonitor](https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/monitor) components, and has years of experience in telemetry working on [AppInsights](https://github.com/microsoft/ApplicationInsights-dotnet/commits/main/?author=rajkumar-rangaraj). I am proposing @rajkumar-rangaraj for the approver role because he has made many [direct contributions](https://github.com/open-telemetry/opentelemetry-dotnet/pulls?q=is%3Apr+author%3Arajkumar-rangaraj+is%3Aclosed) to the repo but also he brings a lot of knowledge, wisdom, and experience into discussions which will benefit the review process.
