### PR TITLE
[infra] Version validation in prepare release workflow

### DIFF
--- a/build/scripts/prepare-release.psm1
+++ b/build/scripts/prepare-release.psm1
@@ -9,6 +9,12 @@ function CreatePullRequestToUpdateChangelogsAndPublicApis {
     [Parameter()][string]$gitUserEmail
   )
 
+  $match = [regex]::Match($version, '^(\d+\.\d+\.\d+)(?:-((?:alpha)|(?:beta)|(?:rc))\.(\d+))?$')
+  if ($match.Success -eq $false)
+  {
+      throw 'Input version did not match expected format'
+  }
+
   $tag="${minVerTagPrefix}${version}"
   $branch="release/prepare-${tag}-release"
 


### PR DESCRIPTION
## Changes

* Adds a regex to validate the version passed to the prepare release workflow before kicking off the process
 
## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
