### PR TITLE
Reuse dictionaries in `ActivityExtensions`, `MetricItemExtensions` and `OtlpLogExporter`

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -6,6 +6,15 @@
   converted using `Convert.ToString` will now format using
   `CultureInfo.InvariantCulture`.
   ([#5700](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5700))
+* Reuse `spansByLibrary` dictionary in `ActivityExtensions` to reduce memory
+  allocation.
+  ([#4943](https://github.com/open-telemetry/opentelemetry-dotnet/issues/4943))
+* Reuse `metricsByLibrary` dictionary in `MetricItemExtensions` to reduce memory
+  allocation.
+  ([#4943](https://github.com/open-telemetry/opentelemetry-dotnet/issues/4943))
+* Reuse `logsByCategory` dictionary in `OtlpLogExporter` to reduce memory
+  allocation.
+  ([#4943](https://github.com/open-telemetry/opentelemetry-dotnet/issues/4943))
 
 ## 1.9.0
 


### PR DESCRIPTION
Fixes #4943

I have to admit I don't know enough of the usage to know if this is really the best option, but it will reduce the number of allocations and dictionary internal growths.

## Changes

Tries to use a single instance of a dictionary for `ActivityExtensions`, `MetricItemExtensions` and `OtlpLogExporter`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
