### PR TITLE
[repo] Bump Microsoft.SourceLink.GitHub to 8.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -84,7 +84,7 @@
     <PackageVersion Include="Microsoft.Extensions.Telemetry.Abstractions" Version="[8.6.0,)" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="[1.0.3,2.0)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="[17.10.0,18.0.0)" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="[1.1.1,2.0)" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="[8.0.0,9.0)" />
     <PackageVersion Include="MinVer" Version="[5.0.0,6.0)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="[1.8.1,2.0)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="[1.8.0-beta.1,2.0)" />


### PR DESCRIPTION
Fixes N/A
Design discussion issue N/A

## Changes

Bump Microsoft.SourceLink.GitHub to 8.0.0

I am playing locally with OTel Exporter package directly included into AutoInstrumentation project and I have some conficts.
There should be no problem with this upgrade as it is fully internal package. Contrib already references this version.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
