### PR TITLE
[docs] Refresh getting started with AspNetCore and Jaeger

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -86,10 +86,10 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="[17.10.0,18.0.0)" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="[8.0.0,9.0)" />
     <PackageVersion Include="MinVer" Version="[5.0.0,6.0)" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="[1.8.1,2.0)" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="[1.8.0-beta.1,2.0)" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="[1.8.1,2.0)" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="[1.8.1,2.0)" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="[1.9.0,2.0)" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="[1.9.0-beta.1,2.0)" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="[1.9.0,2.0)" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="[1.9.0,2.0)" />
     <PackageVersion Include="RabbitMQ.Client" Version="[6.8.1,7.0)" />
     <PackageVersion Include="StyleCop.Analyzers" Version="[1.2.0-beta.556,2.0)" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="[6.6.2,)" />

--- a/docs/trace/getting-started-aspnetcore/README.md
+++ b/docs/trace/getting-started-aspnetcore/README.md
@@ -30,30 +30,30 @@ in the console for your application (ex `http://localhost:5154`). You should see
 the trace output from the console.
 
 ```text
-Activity.TraceId:            c1572aa14ee9c0ac037dbdc3e91e5dd7
-Activity.SpanId:             45406137f33cc279
+Activity.TraceId:            c28f7b480d5c7dfc30cfbd80ad29028d
+Activity.SpanId:             27e478bbf9fdec10
 Activity.TraceFlags:         Recorded
-Activity.ActivitySourceName: OpenTelemetry.Instrumentation.AspNetCore
-Activity.DisplayName:        /
+Activity.ActivitySourceName: Microsoft.AspNetCore
+Activity.DisplayName:        GET /
 Activity.Kind:               Server
-Activity.StartTime:          2023-01-13T19:38:11.5417593Z
-Activity.Duration:           00:00:00.0167407
+Activity.StartTime:          2024-07-04T13:03:37.3318740Z
+Activity.Duration:           00:00:00.3693734
 Activity.Tags:
-    net.host.name: localhost
-    net.host.port: 5154
-    http.method: GET
-    http.scheme: http
-    http.target: /
-    http.url: http://localhost:5154/
-    http.flavor: 1.1
-    http.user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36 Edg/108.0.1462.76
-    http.status_code: 200
+    server.address: localhost
+    server.port: 5154
+    http.request.method: GET
+    url.scheme: https
+    url.path: /
+    network.protocol.version: 2
+    user_agent.original: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36
+    http.route: /
+    http.response.status_code: 200
 Resource associated with Activity:
     service.name: getting-started-aspnetcore
-    service.instance.id: 32c9371c-ed9d-474c-a698-b169e87a5577
+    service.instance.id: a388466b-4969-4bb0-ad96-8f39527fa66b
     telemetry.sdk.name: opentelemetry
     telemetry.sdk.language: dotnet
-    telemetry.sdk.version: 1.5.1
+    telemetry.sdk.version: 1.9.0
 ```
 
 Congratulations! You are now collecting traces using OpenTelemetry.

--- a/docs/trace/getting-started-jaeger/README.md
+++ b/docs/trace/getting-started-jaeger/README.md
@@ -47,25 +47,29 @@ Run the application again and we should see the trace output from the console:
 ```text
 > dotnet run
 
-Activity.TraceId:          a80c920e0aabb50b547e2bb7455cfd39
-Activity.SpanId:           4e45a1d51744f329
-Activity.TraceFlags:       Recorded
-Activity.ParentSpanId:     4f7e9b78c55dcfad
-Activity.ActivitySourceName: OpenTelemetry.Instrumentation.Http
-Activity.DisplayName: HTTP GET
-Activity.Kind:        Client
-Activity.StartTime:   2022-05-07T02:54:25.7840762Z
-Activity.Duration:    00:00:01.9615540
+Activity.TraceId:            693f1d15634bfe6ba3254d6f9d20df27
+Activity.SpanId:             429cc5a90a753fb3
+Activity.TraceFlags:         Recorded
+Activity.ParentSpanId:       0d64498b736c9a11
+Activity.ActivitySourceName: System.Net.Http
+Activity.DisplayName:        GET
+Activity.Kind:               Client
+Activity.StartTime:          2024-07-04T13:18:12.2408786Z
+Activity.Duration:           00:00:02.1028562
 Activity.Tags:
-    http.method: GET
-    http.host: httpstat.us
-    http.url: https://httpstat.us/200?sleep=1000
-    http.status_code: 200
+    http.request.method: GET
+    server.address: httpstat.us
+    server.port: 443
+    url.full: https://httpstat.us/200?sleep=Redacted
+    network.protocol.version: 1.1
+    http.response.status_code: 200
 Resource associated with Activity:
     service.name: DemoApp
     service.version: 1.0.0
-    service.instance.id: 1b3b3a6f-be43-46b0-819a-4db1200c633d
-
+    service.instance.id: 03ccafab-e9a7-440a-a9cd-9a0163e0d06c
+    telemetry.sdk.name: opentelemetry
+    telemetry.sdk.language: dotnet
+    telemetry.sdk.version: 1.9.0
 ...
 ```
 


### PR DESCRIPTION
Fixes #5739

## Changes

Refresh getting started with AspNetCore and Jaeger
Opportunistic update of Instrumentation packages from contrib repository.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
