### PR TITLE
[benchmarks] Add LogBenchmark when BatchProcessor is used

### DIFF
--- a/test/Benchmarks/Logs/LogBenchmarks.cs
+++ b/test/Benchmarks/Logs/LogBenchmarks.cs
@@ -150,7 +150,7 @@ public class LogBenchmarks
         this.loggerWithThreeProcessors.SayHello(FoodName, FoodPrice);
     }
 
-    internal class NoOpProcessor : BaseProcessor<LogRecord>
+    internal class NoOpLogProcessor : BaseProcessor<LogRecord>
     {
     }
 

--- a/test/Benchmarks/Logs/LogBenchmarks.cs
+++ b/test/Benchmarks/Logs/LogBenchmarks.cs
@@ -150,7 +150,7 @@ public class LogBenchmarks
         this.loggerWithThreeProcessors.SayHello(FoodName, FoodPrice);
     }
 
-    internal class NoOpLogProcessor : BaseProcessor<LogRecord>
+    internal class NoopLogProcessor : BaseProcessor<LogRecord>
     {
     }
 

--- a/test/Benchmarks/Logs/LogBenchmarks.cs
+++ b/test/Benchmarks/Logs/LogBenchmarks.cs
@@ -150,7 +150,7 @@ public class LogBenchmarks
         this.loggerWithThreeProcessors.SayHello(FoodName, FoodPrice);
     }
 
-    internal class NoOpLogProcessor : BaseProcessor<LogRecord>
+    internal class NoOpProcessor : BaseProcessor<LogRecord>
     {
     }
 

--- a/test/Benchmarks/Logs/LogBenchmarks.cs
+++ b/test/Benchmarks/Logs/LogBenchmarks.cs
@@ -150,7 +150,7 @@ public class LogBenchmarks
         this.loggerWithThreeProcessors.SayHello(FoodName, FoodPrice);
     }
 
-    internal class NoopLogProcessor : BaseProcessor<LogRecord>
+    internal class NoOpLogProcessor: BaseProcessor<LogRecord>
     {
     }
 

--- a/test/Benchmarks/Logs/LogBenchmarks.cs
+++ b/test/Benchmarks/Logs/LogBenchmarks.cs
@@ -150,7 +150,7 @@ public class LogBenchmarks
         this.loggerWithThreeProcessors.SayHello(FoodName, FoodPrice);
     }
 
-    internal class NoOpLogProcessor: BaseProcessor<LogRecord>
+    internal class NoOpLogProcessor : BaseProcessor<LogRecord>
     {
     }
 


### PR DESCRIPTION
Added a Log Benchmark when `BatchExportProcessor` is used instead of a normal NoOpProcessor. SDK [special cases](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry/Logs/LoggerProviderSdk.cs#L99-L101) our `BatchExportProcessor` (not 3rd party authored), to use a different  LogRecord pooling mechanism. 

This benchmark will show the perf difference, when using that pooling mechanism. (It is much higher than the ThreadLocal based pooling, only useable in sync exporters like etw)

Also renamed Dummy -> NoOp processor, as the processor is a no-op, with no ability to accept alternate behavior.

The following shows the cost when BatchingProcessor is used (compared to other processor), which has to copy all the Log state+scope.

```
| OneProcessor                  | 111.558 ns | 2.9821 ns |  8.5082 ns | 109.311 ns | 0.0063 |      - |      40 B |
| BatchProcessor                | 263.650 ns | 5.2908 ns | 14.1223 ns | 258.984 ns | 0.0200 | 0.0043 |     128 B |
```