### PR TITLE
[infra] Fix a couple paths in PR auto-label file change detection

### DIFF
--- a/build/scripts/add-labels.psm1
+++ b/build/scripts/add-labels.psm1
@@ -99,12 +99,12 @@ function AddLabelsOnPullRequestsBasedOnFilesChanged {
         $rootInfraFiles.Contains($fullFileName) -or
         $fileExtension -eq ".props" -or
         $fileExtension -eq ".targets" -or
-        $fileChanged.StartsWith('test\openTelemetry.aotcompatibility'))
+        $fileChanged.StartsWith('test/openTelemetry.aotcompatibility'))
     {
         $added = $labelsToAdd.Add("infra")
     }
 
-    if ($fileChanged.StartsWith('test\benchmarks'))
+    if ($fileChanged.StartsWith('test/benchmarks'))
     {
         $added = $labelsToAdd.Add("perf")
     }


### PR DESCRIPTION
## Changes

* Switch to `/` for all paths in PR auto-label script

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
