### PR TITLE
[docs-metrics] Fix tuple vs KVP confusion in code sample

### DIFF
--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -127,7 +127,7 @@ There are two different ways of passing tags to an instrument API:
 * Pass the tags directly to the instrument API:
 
   ```csharp
-  counter.Add(100, ("Key1", "Value1"), ("Key2", "Value2"));
+  counter.Add(100, new("Key1", "Value1"), new("Key2", "Value2"));
   ```
 
 * Use


### PR DESCRIPTION
## Changes

The code sample used anonymous tuple syntax, whereas the OpenTelemetry .NET api actually doesn't support it. Fixed to use KeyValuePair syntax.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
