### PR TITLE
[repo] Add ReleaseNotes.md to include features shipped in stable release

### DIFF
--- a/OpenTelemetry.sln
+++ b/OpenTelemetry.sln
@@ -18,6 +18,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		LICENSE.TXT = LICENSE.TXT
 		NuGet.config = NuGet.config
 		README.md = README.md
+		RELEASENOTES.md = RELEASENOTES.md
 		THIRD-PARTY-NOTICES.TXT = THIRD-PARTY-NOTICES.TXT
 		VERSIONING.md = VERSIONING.md
 	EndProjectSection
@@ -123,6 +124,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmarks", "test\Benchmarks\Benchmarks.csproj", "{DE9130A4-F30A-49D7-8834-41DE3021218B}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{7C87CAF9-79D7-4C26-9FFB-F3F1FB6911F1}"
+	ProjectSection(SolutionItems) = preProject
+		docs\README.md = docs\README.md
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{2C7DD1DA-C229-4D9E-9AF0-BCD5CD3E4948}"
 	ProjectSection(SolutionItems) = preProject

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,6 +1,6 @@
 # RELEASE NOTES
 
-This file contains highlights and announcements covering all components.  
+This file contains highlights and announcements covering all components.
 For more details see `CHANGELOG.md` files maintained in the root source
 directory of each individual package.
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,9 +1,15 @@
 # RELEASE NOTES
 
+This file contains highlights and announcements covering all components.  
+For more details see `CHANGELOG.md` files maintained in the root source
+directory of each individual package.
+
 ## 1.9.0
 
-### OpenTelemetry
-
-* Exemplars are now part of the stable API! For details see: [customizing
+* `Exemplars` are now part of the stable API! For details see: [customizing
   exemplars
   collection](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/metrics/customizing-the-sdk#exemplars).
+
+* `WithLogging` is now part of the stable API! Logging, Metrics, and Tracing can
+  now all be configured using the `With` style and the builders finally have
+  parity in their APIs.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,4 +1,4 @@
-# RELEASE NOTES
+# Release Notes
 
 This file contains highlights and announcements covering all components.
 For more details see `CHANGELOG.md` files maintained in the root source
@@ -13,3 +13,41 @@ directory of each individual package.
 * `WithLogging` is now part of the stable API! Logging, Metrics, and Tracing can
   now all be configured using the `With` style and the builders finally have
   parity in their APIs.
+
+## 1.8.0
+
+* `TracerProvider` sampler can now be configured via the `OTEL_TRACES_SAMPLER` &
+  `OTEL_TRACES_SAMPLER_ARG` envvars.
+
+* A new `UseOtlpExporter` cross-cutting extension has been added to register the
+  `OtlpExporter` and enable all signals in a single call.  
+
+* `exception.type`, `exception.message`, `exception.stacktrace` will now
+  automatically be included by the `OtlpLogExporter` when logging exceptions.
+  Previously an experimental environment variable had to be set.
+
+## 1.7.0
+
+* Bumped the package versions of System.Diagnostic.DiagnosticSource and other
+  Microsoft.Extensions.* packages to `8.0.0`.
+
+* Added `net8.0` targets to all the components.
+
+* OTLP Exporter
+  * Updated to use `ILogger` `CategoryName` as the instrumentation scope for
+    logs.
+  * Added named options support for OTLP Log Exporter.
+  * Added support for instrumentation scope attributes in metrics.
+  * Added support under an experimental flag to emit log exception attributes.
+  * Added support under an experimental flag to emit log eventId and eventName.
+    attributes.
+
+* Added support for the
+  [IMetricsBuilder](https://learn.microsoft.com/dotnet/api/microsoft.extensions.diagnostics.metrics.imetricsbuilder)
+  API.
+
+* Added an experimental opt-in metrics feature to reclaim unused MetricPoints
+  which enables a higher number of unique dimension combinations to be emitted.
+  See [reclaim unused metric
+  points](https://github.com/open-telemetry/opentelemetry-dotnet/blob/32c64d04defb5c92d056fd8817638151168b10da/docs/metrics/README.md#cardinality-limits)
+  for more details.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -20,7 +20,7 @@ directory of each individual package.
   `OTEL_TRACES_SAMPLER_ARG` envvars.
 
 * A new `UseOtlpExporter` cross-cutting extension has been added to register the
-  `OtlpExporter` and enable all signals in a single call.  
+  `OtlpExporter` and enable all signals in a single call.
 
 * `exception.type`, `exception.message`, `exception.stacktrace` will now
   automatically be included by the `OtlpLogExporter` when logging exceptions.

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,0 +1,9 @@
+# RELEASE NOTES
+
+## 1.9.0
+
+### OpenTelemetry
+
+* Exemplars are now part of the stable API! For details see: [customizing
+  exemplars
+  collection](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/metrics/customizing-the-sdk#exemplars).

--- a/build/RELEASING.md
+++ b/build/RELEASING.md
@@ -203,6 +203,7 @@ Maintainers (admins) are needed to merge PRs and for the push to NuGet.**
     repository which opens a PR to update dependencies. Verify this PR was
     opened successfully.
 
- 8. Post an announcement in the [Slack
-    channel](https://cloud-native.slack.com/archives/C01N3BC2W7Q). Note any big
-    or interesting new features as part of the announcement.
+ 8. For stable releases, update [Release Notes](../RELEASENOTES.md) with any big
+    or interesting new features and then post an announcement in the [Slack
+    channel](https://cloud-native.slack.com/archives/C01N3BC2W7Q) with the same
+    information.

--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+This file contains individual changes for the
+OpenTelemetry.Api.ProviderBuilderExtensions package. For highlights and
+announcements covering all components see: [Release
+Notes](../../RELEASENOTES.md).
+
 ## Unreleased
 
 ## 1.9.0

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+This file contains individual changes for the OpenTelemetry.Api package. For
+highlights and announcements covering all components see: [Release
+Notes](../../RELEASENOTES.md).
+
 ## Unreleased
 
 * **Breaking change:** CompositeTextMapPropagator.Fields now returns a

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+This file contains individual changes for the OpenTelemetry.Exporter.Console
+package. For highlights and announcements covering all components see: [Release
+Notes](../../RELEASENOTES.md).
+
 ## Unreleased
 
 ## 1.9.0

--- a/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+This file contains individual changes for the OpenTelemetry.Exporter.InMemory
+package. For highlights and announcements covering all components see: [Release
+Notes](../../RELEASENOTES.md).
+
 ## Unreleased
 
 ## 1.9.0

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+This file contains individual changes for the
+OpenTelemetry.Exporter.OpenTelemetryProtocol package. For highlights and
+announcements covering all components see: [Release
+Notes](../../RELEASENOTES.md).
+
 ## Unreleased
 
 * **Breaking change**: Non-primitive attribute (logs) and tag (traces) values

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+This file contains individual changes for the
+OpenTelemetry.Exporter.Prometheus.AspNetCore package. For highlights and
+announcements covering all components see: [Release
+Notes](../../RELEASENOTES.md).
+
 ## Unreleased
 
 ## 1.9.0-beta.2

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+This file contains individual changes for the
+OpenTelemetry.Exporter.Prometheus.HttpListener package. For highlights and
+announcements covering all components see: [Release
+Notes](../../RELEASENOTES.md).
+
 ## Unreleased
 
 ## 1.9.0-beta.2

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+This file contains individual changes for the OpenTelemetry.Exporter.Zipkin
+package. For highlights and announcements covering all components see: [Release
+Notes](../../RELEASENOTES.md).
+
 ## Unreleased
 
 * **Breaking change**: Non-primitive tag values converted using

--- a/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+This file contains individual changes for the OpenTelemetry.Extensions.Hosting
+package. For highlights and announcements covering all components see: [Release
+Notes](../../RELEASENOTES.md).
+
 ## Unreleased
 
 ## 1.9.0

--- a/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+This file contains individual changes for the
+OpenTelemetry.Extensions.Propagators package. For highlights and announcements
+covering all components see: [Release Notes](../../RELEASENOTES.md).
+
 ## Unreleased
 
 ## 1.9.0

--- a/src/OpenTelemetry.Shims.OpenTracing/CHANGELOG.md
+++ b/src/OpenTelemetry.Shims.OpenTracing/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+This file contains individual changes for the OpenTelemetry.Shims.OpenTracing
+package. For highlights and announcements covering all components see: [Release
+Notes](../../RELEASENOTES.md).
+
 ## Unreleased
 
 ## 1.9.0-beta.2

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 Released 2024-Jun-14
 
-* Exemplars are now supported as a stable feature. Please note that the
+* Exemplars are now supported as a stable feature. Please note that
   Exemplars are disabled by default. Check [OpenTelemetry Metrics
   docs](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/metrics/customizing-the-sdk#exemplars)
   to learn how to enable and customize exemplars collection.

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-This file contains individual changes for the OpenTelemetry package.
-For highlights and announcements covering all components see: [Release Notes](../../RELEASENOTES.md).
+This file contains individual changes for the OpenTelemetry package. For
+highlights and announcements covering all components see: [Release
+Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+This file contains individual changes for the OpenTelemetry package.
+For highlights and announcements covering all components see: [Release Notes](../../RELEASENOTES.md).
+
 ## Unreleased
 
 * Added `OpenTelemetrySdk.Create` API for configuring OpenTelemetry .NET signals
@@ -11,11 +14,6 @@
 ## 1.9.0
 
 Released 2024-Jun-14
-
-* Exemplars are now supported as a stable feature. Please note that
-  Exemplars are disabled by default. Check [OpenTelemetry Metrics
-  docs](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/metrics/customizing-the-sdk#exemplars)
-  to learn how to enable and customize exemplars collection.
 
 ## 1.9.0-rc.1
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -12,6 +12,11 @@
 
 Released 2024-Jun-14
 
+* Exemplars are now supported as a stable feature. Please note that the
+  Exemplars are disabled by default. Check [OpenTelemetry Metrics
+  docs](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/metrics/customizing-the-sdk#exemplars)
+  to learn how to enable and customize exemplars collection.
+
 ## 1.9.0-rc.1
 
 Released 2024-Jun-07


### PR DESCRIPTION
Fixes #
Design discussion issue #

## Changes

Introduces a new file `ReleaseNotes.md` for adding the announcements related to the stable releases. This will help with easy access to information on new features added for that particular release. As an example, It's not obvious from the changelog that the exemplars support is now stable. ReleaseNotes.md will help with that.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
