### PR TITLE
[docs] Add getting started docs showing how to set up OTLP exporter with Aspire dashboard

### DIFF
--- a/OpenTelemetry.sln
+++ b/OpenTelemetry.sln
@@ -347,6 +347,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{4498
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "exemplars", "docs\metrics\exemplars\exemplars.csproj", "{79C12C80-B27B-41FB-AE79-A3BB74CFA782}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "otlp", "otlp", "{008EB375-5849-4F9B-8FB5-7429192B8D1F}"
+	ProjectSection(SolutionItems) = preProject
+		docs\otlp\README.md = docs\otlp\README.md
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "getting-started-aspnetcore", "docs\otlp\getting-started-aspnetcore\getting-started-aspnetcore.csproj", "{9A5B3340-2776-4653-8FEC-B797951FDE8B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "getting-started-console", "docs\otlp\getting-started-console\getting-started-console.csproj", "{3ADE2F7C-1BC4-40F5-9FCF-163DD59A9386}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -605,6 +614,14 @@ Global
 		{79C12C80-B27B-41FB-AE79-A3BB74CFA782}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{79C12C80-B27B-41FB-AE79-A3BB74CFA782}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{79C12C80-B27B-41FB-AE79-A3BB74CFA782}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9A5B3340-2776-4653-8FEC-B797951FDE8B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9A5B3340-2776-4653-8FEC-B797951FDE8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9A5B3340-2776-4653-8FEC-B797951FDE8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9A5B3340-2776-4653-8FEC-B797951FDE8B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3ADE2F7C-1BC4-40F5-9FCF-163DD59A9386}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3ADE2F7C-1BC4-40F5-9FCF-163DD59A9386}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3ADE2F7C-1BC4-40F5-9FCF-163DD59A9386}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3ADE2F7C-1BC4-40F5-9FCF-163DD59A9386}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -663,6 +680,9 @@ Global
 		{993E65E5-E71B-40FD-871C-60A9EBD59724} = {A49299FB-C5CD-4E0E-B7E1-B7867BBD67CC}
 		{44982E0D-C8C6-42DC-9F8F-714981F27CE6} = {7CB2F02E-03FA-4FFF-89A5-C51F107623FD}
 		{79C12C80-B27B-41FB-AE79-A3BB74CFA782} = {3277B1C0-BDFE-4460-9B0D-D9A661FB48DB}
+		{008EB375-5849-4F9B-8FB5-7429192B8D1F} = {7C87CAF9-79D7-4C26-9FFB-F3F1FB6911F1}
+		{9A5B3340-2776-4653-8FEC-B797951FDE8B} = {008EB375-5849-4F9B-8FB5-7429192B8D1F}
+		{3ADE2F7C-1BC4-40F5-9FCF-163DD59A9386} = {008EB375-5849-4F9B-8FB5-7429192B8D1F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {55639B5C-0770-4A22-AB56-859604650521}

--- a/docs/otlp/README.md
+++ b/docs/otlp/README.md
@@ -25,7 +25,7 @@ guide to get up and running.
 * [DataDog](https://www.datadoghq.com/): [OTLP Ingestion by the Datadog
   Agent](https://docs.datadoghq.com/opentelemetry/interoperability/otlp_ingest_in_the_agent/)
 
-* [Grafana](https://grafana.com/): [Send data using OpenTelemetry Protocol
+* [Grafana Labs](https://grafana.com/): [Send data using OpenTelemetry Protocol
   (OTLP)](https://grafana.com/docs/grafana-cloud/send-data/otlp/send-data-otlp/)
 
 * [Honeycomb](https://www.honeycomb.io/): [Send Data with the OpenTelemetry .NET
@@ -37,3 +37,7 @@ guide to get up and running.
 * [Splunk](https://www.splunk.com/): [Send traces to Splunk Observability Cloud
   using the gRPC
   endpoint](https://docs.splunk.com/observability/en/gdi/other-ingestion-methods/grpc-data-ingest.html)
+
+For more vendors see [Vendors who natively support
+OpenTelemetry](https://opentelemetry.io/ecosystem/vendors/). Any vendor with
+"Native OTLP" column set to "Yes" should support OTLP ingestion.

--- a/docs/otlp/README.md
+++ b/docs/otlp/README.md
@@ -38,6 +38,6 @@ guide to get up and running.
   using the gRPC
   endpoint](https://docs.splunk.com/observability/en/gdi/other-ingestion-methods/grpc-data-ingest.html)
 
-For more vendors see [Vendors who natively support
+For more vendors see: [Vendors who natively support
 OpenTelemetry](https://opentelemetry.io/ecosystem/vendors/). Any vendor with
 "Native OTLP" column set to "Yes" should support OTLP ingestion.

--- a/docs/otlp/README.md
+++ b/docs/otlp/README.md
@@ -1,0 +1,26 @@
+# OpenTelemetry Protocol (OTLP)
+
+The [OpenTelemetry
+Specification](https://github.com/open-telemetry/opentelemetry-specification)
+defines the [OpenTelemetry Protocol
+(OTLP)](https://github.com/open-telemetry/opentelemetry-proto/tree/main/docs)
+which is a standard for exporting telemetry in a vendor agnostic way.
+OpenTelemetry .NET ships
+[OpenTelemetry.Exporter.OpenTelemetryProtocol](../../src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md)
+which is an implementation of OTLP and may be used to export telemetry to any
+backend with OTLP support or to the [OpenTelemetry
+Collector](https://github.com/open-telemetry/opentelemetry-collector).
+
+## Getting started
+
+If you are new to the [OpenTelemetry Protocol
+(OTLP)](https://github.com/open-telemetry/opentelemetry-proto/tree/main/docs),
+it is recommended to first follow the [getting started in 5 minutes - ASP.NET
+Core Application](./getting-started-aspnetcore/README.md) guide or the [getting
+started in 5 minutes - Console Application](./getting-started-console/README.md)
+guide to get up and running.
+
+## Vendor support
+
+* [NewRelic](https://newrelic.com/): [Getting Started Guide -
+  .NET](https://github.com/newrelic/newrelic-opentelemetry-examples/tree/main/getting-started-guides/dotnet)

--- a/docs/otlp/README.md
+++ b/docs/otlp/README.md
@@ -22,10 +22,18 @@ guide to get up and running.
 
 ## Vendor support
 
+* [DataDog](https://www.datadoghq.com/): [OTLP Ingestion by the Datadog
+  Agent](https://docs.datadoghq.com/opentelemetry/interoperability/otlp_ingest_in_the_agent/)
+
+* [Grafana](https://grafana.com/): [Send data using OpenTelemetry Protocol
+  (OTLP)](https://grafana.com/docs/grafana-cloud/send-data/otlp/send-data-otlp/)
+
 * [Honeycomb](https://www.honeycomb.io/): [Send Data with the OpenTelemetry .NET
   SDK](https://docs.honeycomb.io/send-data/dotnet/opentelemetry-sdk/)
+
 * [NewRelic](https://newrelic.com/): [Getting Started Guide -
   .NET](https://github.com/newrelic/newrelic-opentelemetry-examples/tree/main/getting-started-guides/dotnet)
+
 * [Splunk](https://www.splunk.com/): [Send traces to Splunk Observability Cloud
   using the gRPC
   endpoint](https://docs.splunk.com/observability/en/gdi/other-ingestion-methods/grpc-data-ingest.html)

--- a/docs/otlp/README.md
+++ b/docs/otlp/README.md
@@ -22,5 +22,10 @@ guide to get up and running.
 
 ## Vendor support
 
+* [Honeycomb](https://www.honeycomb.io/): [Send Data with the OpenTelemetry .NET
+  SDK](https://docs.honeycomb.io/send-data/dotnet/opentelemetry-sdk/)
 * [NewRelic](https://newrelic.com/): [Getting Started Guide -
   .NET](https://github.com/newrelic/newrelic-opentelemetry-examples/tree/main/getting-started-guides/dotnet)
+* [Splunk](https://www.splunk.com/): [Send traces to Splunk Observability Cloud
+  using the gRPC
+  endpoint](https://docs.splunk.com/observability/en/gdi/other-ingestion-methods/grpc-data-ingest.html)

--- a/docs/otlp/getting-started-aspnetcore/Program.cs
+++ b/docs/otlp/getting-started-aspnetcore/Program.cs
@@ -9,20 +9,14 @@ using OpenTelemetry.Trace;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Clear default log providers added by the host.
-builder.Logging.ClearProviders();
-
-// Configure OpenTelemetry with logs, metrics, & tracing and auto-start.
+// Configure OpenTelemetry to start with the host and to send logs, metrics, and
+// distributed traces via OTLP.
 builder.Services.AddOpenTelemetry()
     .ConfigureResource(resource => resource
         .AddService(serviceName: builder.Environment.ApplicationName))
     .WithTracing(tracing => tracing.AddAspNetCoreInstrumentation())
     .WithMetrics(metrics => metrics.AddAspNetCoreInstrumentation())
     .UseOtlpExporter();
-
-// Set OpenTelemetry metrics to use delta temporality.
-builder.Services.Configure<MetricReaderOptions>(
-    o => o.TemporalityPreference = MetricReaderTemporalityPreference.Delta);
 
 var app = builder.Build();
 

--- a/docs/otlp/getting-started-aspnetcore/Program.cs
+++ b/docs/otlp/getting-started-aspnetcore/Program.cs
@@ -1,0 +1,31 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Clear default log providers added by the host.
+builder.Logging.ClearProviders();
+
+// Configure OpenTelemetry with logs, metrics, & tracing and auto-start.
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(resource => resource
+        .AddService(serviceName: builder.Environment.ApplicationName))
+    .WithTracing(tracing => tracing.AddAspNetCoreInstrumentation())
+    .WithMetrics(metrics => metrics.AddAspNetCoreInstrumentation())
+    .UseOtlpExporter();
+
+// Set OpenTelemetry metrics to use delta temporality.
+builder.Services.Configure<MetricReaderOptions>(
+    o => o.TemporalityPreference = MetricReaderTemporalityPreference.Delta);
+
+var app = builder.Build();
+
+app.MapGet("/", () => $"Hello World! OpenTelemetry Trace: {Activity.Current?.Id}");
+
+app.Run();

--- a/docs/otlp/getting-started-aspnetcore/README.md
+++ b/docs/otlp/getting-started-aspnetcore/README.md
@@ -75,6 +75,18 @@ Update the `Program.cs` file with the code from [Program.cs](./Program.cs).
 Run the application (using `dotnet run`) and then browse to the .NET Aspire
 dashboard (eg `http://localhost:18888/`) to view your telemetry.
 
+Logs:
+
+![image](https://github.com/user-attachments/assets/6149f41a-c227-47c1-be00-98c56fbcf481)
+
+Metrics:
+
+![image](https://github.com/user-attachments/assets/ba88ba94-9897-4d9b-9cb7-7d8f91821ae1)
+
+Traces:
+
+![image](https://github.com/user-attachments/assets/a6f41a9a-ceef-4325-9306-a46a2a26bfb0)
+
 Congratulations! You are now collecting logs, metrics, and traces using
 OpenTelemetry.
 

--- a/docs/otlp/getting-started-aspnetcore/README.md
+++ b/docs/otlp/getting-started-aspnetcore/README.md
@@ -1,0 +1,96 @@
+# Getting Started with OpenTelemetry Protocol (OTLP) in 5 Minutes - ASP.NET Core Application
+
+If you haven't already, download and install the [.NET
+SDK](https://dotnet.microsoft.com/download) and
+[Docker](https://www.docker.com/) on your computer.
+
+Install and run the [Standalone .NET Aspire
+dashboard](https://learn.microsoft.com/dotnet/aspire/fundamentals/dashboard/standalone)
+using Docker:
+
+```sh
+docker run --rm -it -p 18888:18888 -p 4317:18889 -p 4318:18890 -d --name aspire-dashboard mcr.microsoft.com/dotnet/aspire-dashboard:latest
+```
+
+> [!CAUTION]
+> The .NET Aspire dashboard is being used to view telemetry locally. It is a
+> developer tool and not meant for production usage.
+
+Create a new web application:
+
+```sh
+dotnet new web -o aspnetcoreapp
+cd aspnetcoreapp
+```
+
+Install the
+[OpenTelemetry.Exporter.OpenTelemetryProtocol](../../../src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md),
+[OpenTelemetry.Extensions.Hosting](../../../src/OpenTelemetry.Extensions.Hosting/README.md),
+and
+[OpenTelemetry.Instrumentation.AspNetCore](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.AspNetCore/README.md)
+packages:
+
+```sh
+dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
+dotnet add package OpenTelemetry.Extensions.Hosting
+dotnet add package OpenTelemetry.Instrumentation.AspNetCore
+```
+
+Update the `Program.cs` file with the code from [Program.cs](./Program.cs).
+
+Run the application (using `dotnet run`) and then browse to the .NET Aspire
+dashboard (eg `http://localhost:18888/`) to view your telemetry.
+
+Congratulations! You are now collecting traces using OpenTelemetry.
+
+What does the above program do?
+
+The program uses the
+[OpenTelemetry.Instrumentation.AspNetCore](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.AspNetCore/README.md)
+package to automatically create traces and metrics for incoming ASP.NET Core
+requests and uses the
+[OpenTelemetry.Exporter.OpenTelemetryProtocol](../../../src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md)
+package to export telemetry via OTLP to the .NET Aspire dashboard. This is done
+by configuring the OpenTelemetry SDK using extension methods and setting it to
+auto-start when the host is started:
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(resource => resource
+        .AddService(serviceName: builder.Environment.ApplicationName))
+    .WithTracing(tracing => tracing.AddAspNetCoreInstrumentation())
+    .WithMetrics(metrics => metrics.AddAspNetCoreInstrumentation())
+    .UseOtlpExporter();
+```
+
+> [!NOTE]
+> The `AddOpenTelemetry` extension is part of the
+[OpenTelemetry.Extensions.Hosting](../../../src/OpenTelemetry.Extensions.Hosting/README.md)
+package.
+
+> [!NOTE]
+> The `UseOtlpExporter` extension configures the OpenTelemetry .NET OTLP
+> exporter for logging, metrics, and tracing. For details see: [Enable OTLP
+> Exporter for all
+> signals](../../../src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md#enable-otlp-exporter-for-all-signals).
+
+The index route ("/") is set up to write out the OpenTelemetry trace information
+on the response:
+
+```csharp
+app.MapGet("/", () => $"Hello World! OpenTelemetry Trace: {Activity.Current?.Id}");
+```
+
+In OpenTelemetry .NET the [Activity
+class](https://learn.microsoft.com/dotnet/api/system.diagnostics.activity?view=net-7.0)
+represents the OpenTelemetry Specification
+[Span](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#span).
+For more details about how the OpenTelemetry Specification is implemented in
+.NET see: [Introduction to OpenTelemetry .NET Tracing
+API](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Api#introduction-to-opentelemetry-net-tracing-api).
+
+## Learn more
+
+* [OpenTelemetry .NET Logs](../../logs/README.md)
+* [OpenTelemetry .NET Metrics](../../metrics/README.md)
+* [OpenTelemetry .NET Traces](../../trace/README.md)

--- a/docs/otlp/getting-started-aspnetcore/README.md
+++ b/docs/otlp/getting-started-aspnetcore/README.md
@@ -16,7 +16,7 @@ using Docker:
 > output of the OpenTelemetry .NET SDK. For a list of vendors with support for
 > ingestion of [OpenTelemetry Protocol
 (OTLP)](https://github.com/open-telemetry/opentelemetry-proto/tree/main/docs)
-> see: [Vendors](../README.md#vendors).
+> see: [Vendors](../README.md#vendor-support).
 
 PowerShell:
 
@@ -126,7 +126,7 @@ represents the OpenTelemetry Specification
 [Span](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#span).
 For more details about how the OpenTelemetry Specification is implemented in
 .NET see: [Introduction to OpenTelemetry .NET Tracing
-API](../../../src/OpenTelemetry.Api#introduction-to-opentelemetry-net-tracing-api).
+API](../../../src/OpenTelemetry.Api/README.md#introduction-to-opentelemetry-net-tracing-api).
 
 ## Next steps
 
@@ -153,12 +153,13 @@ Started with OpenTelemetry Protocol (OTLP) in 5 Minutes - Console
 Application](../getting-started-console/README.md) guide contains an example for
 how to add telemetry manually.
 
-Explore how to use [samplers](../../trace/customizing-the-sdk#samplers) to
-control distributed tracing costs.
+Explore how to use
+[samplers](../../trace/customizing-the-sdk/README.md#samplers) to control
+distributed tracing costs.
 
 Consider turning on advanced features such as
-[exemplars](../../metrics/customizing-the-sdk#exemplars) to correlate metrics to
-distributed traces.
+[exemplars](../../metrics/customizing-the-sdk/README.md#exemplars) to correlate
+metrics to distributed traces.
 
 Deploy your application to production. This guide uses OpenTelemetry Protocol
 (OTLP) defaults which means all telemetry will be sent to

--- a/docs/otlp/getting-started-aspnetcore/README.md
+++ b/docs/otlp/getting-started-aspnetcore/README.md
@@ -128,6 +128,45 @@ For more details about how the OpenTelemetry Specification is implemented in
 .NET see: [Introduction to OpenTelemetry .NET Tracing
 API](../../../src/OpenTelemetry.Api#introduction-to-opentelemetry-net-tracing-api).
 
+## Next steps
+
+Explore and add relevant [instrumentation
+libraries](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/glossary.md#instrumentation-library)
+and resource detectors to your OpenTelemetry configuration by visiting the
+[opentelemetry-dotnet-contrib
+repository](https://github.com/open-telemetry/opentelemetry-dotnet-contrib)
+and/or the [OpenTelemetry
+registry](https://opentelemetry.io/ecosystem/registry/?language=dotnet).
+Instrumentation libraries help automatically generate telemetry for common
+application tasks such as making an [outgoing HTTP
+call](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.Http).
+Resource detectors help decorate telemetry with information about the hosting
+environment.
+
+Use the
+[ActivitySource](https://learn.microsoft.com/dotnet/api/system.diagnostics.activitysource),
+[Meter](https://learn.microsoft.com/dotnet/api/system.diagnostics.metrics.meter),
+and
+[ILogger&lt;T&gt;](https://learn.microsoft.com/dotnet/api/microsoft.extensions.logging.ilogger-1)
+APIs to add custom telemetry to your application and/or libraries. The [Getting
+Started with OpenTelemetry Protocol (OTLP) in 5 Minutes - Console
+Application](../getting-started-console/README.md) guide contains an example for
+how to add telemetry manually.
+
+Explore how to use [samplers](../../trace/customizing-the-sdk#samplers) to
+control distributed tracing costs.
+
+Consider turning on advanced features such as
+[exemplars](../../metrics/customizing-the-sdk#exemplars) to correlate metrics to
+distributed traces.
+
+Deploy your application to production. This guide uses OpenTelemetry Protocol
+(OTLP) defaults which means all telemetry will be sent to
+`http://localhost:4317` using the `OtlpExportProtocol.Grpc` protocol. But these
+settings may be configured using a variety of mechanisms. For details about how
+to configure the `OpenTelemetry.Exporter.OpenTelemetryProtocol` package see:
+[Configuration](../../../src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md#configuration).
+
 ## Learn more
 
 * [OpenTelemetry .NET Logs](../../logs/README.md)

--- a/docs/otlp/getting-started-aspnetcore/README.md
+++ b/docs/otlp/getting-started-aspnetcore/README.md
@@ -1,4 +1,6 @@
+<!-- markdownlint-disable MD013 -->
 # Getting Started with OpenTelemetry Protocol (OTLP) in 5 Minutes - ASP.NET Core Application
+<!-- markdownlint-enable MD013 -->
 
 If you haven't already, download and install the [.NET
 SDK](https://dotnet.microsoft.com/download) and
@@ -67,7 +69,7 @@ builder.Services.AddOpenTelemetry()
 > The `AddOpenTelemetry` extension is part of the
 [OpenTelemetry.Extensions.Hosting](../../../src/OpenTelemetry.Extensions.Hosting/README.md)
 package.
-
+<!-- This comment is to make sure the two notes above and below are not merged -->
 > [!NOTE]
 > The `UseOtlpExporter` extension configures the OpenTelemetry .NET OTLP
 > exporter for logging, metrics, and tracing. For details see: [Enable OTLP

--- a/docs/otlp/getting-started-aspnetcore/README.md
+++ b/docs/otlp/getting-started-aspnetcore/README.md
@@ -10,13 +10,45 @@ Install and run the [Standalone .NET Aspire
 dashboard](https://learn.microsoft.com/dotnet/aspire/fundamentals/dashboard/standalone)
 using Docker:
 
-```sh
-docker run --rm -it -p 18888:18888 -p 4317:18889 -p 4318:18890 -d --name aspire-dashboard mcr.microsoft.com/dotnet/aspire-dashboard:latest
+> [!NOTE]
+> The .NET Aspire dashboard is being used to view telemetry locally. For the
+> purposes of this guide it is being used as a visualization tool to verify the
+> output of the OpenTelemetry .NET SDK. For a list of vendors with support for
+> ingestion of [OpenTelemetry Protocol
+(OTLP)](https://github.com/open-telemetry/opentelemetry-proto/tree/main/docs)
+> see: [Vendors](../README.md#vendors).
+
+PowerShell:
+
+```powershell
+docker run --rm -it `
+    -p 18888:18888 `
+    -p 4317:18889 `
+    -p 4318:18890 `
+    -e DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS=true `
+    -d `
+    --name aspire-dashboard `
+    mcr.microsoft.com/dotnet/aspire-dashboard:latest
+```
+
+Bash:
+
+```bash
+docker run --rm -it \
+    -p 18888:18888 \
+    -p 4317:18889 \
+    -p 4318:18890 \
+    -e DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS=true \
+    -d \
+    --name aspire-dashboard \
+    mcr.microsoft.com/dotnet/aspire-dashboard:latest
 ```
 
 > [!CAUTION]
-> The .NET Aspire dashboard is being used to view telemetry locally. It is a
-> developer tool and not meant for production usage.
+> `DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS` is being used to disable
+> authentication for the Aspire dashboard. For instructions on how to run with
+> authentication enabled see: [Login to the
+> dashboard](https://learn.microsoft.com/dotnet/aspire/fundamentals/dashboard/standalone?#login-to-the-dashboard).
 
 Create a new web application:
 
@@ -43,7 +75,8 @@ Update the `Program.cs` file with the code from [Program.cs](./Program.cs).
 Run the application (using `dotnet run`) and then browse to the .NET Aspire
 dashboard (eg `http://localhost:18888/`) to view your telemetry.
 
-Congratulations! You are now collecting traces using OpenTelemetry.
+Congratulations! You are now collecting logs, metrics, and traces using
+OpenTelemetry.
 
 What does the above program do?
 
@@ -65,31 +98,35 @@ builder.Services.AddOpenTelemetry()
     .UseOtlpExporter();
 ```
 
-> [!NOTE]
-> The `AddOpenTelemetry` extension is part of the
+The `AddOpenTelemetry` extension is part of the
 [OpenTelemetry.Extensions.Hosting](../../../src/OpenTelemetry.Extensions.Hosting/README.md)
-package.
-<!-- This comment is to make sure the two notes above and below are not merged -->
-> [!NOTE]
-> The `UseOtlpExporter` extension configures the OpenTelemetry .NET OTLP
-> exporter for logging, metrics, and tracing. For details see: [Enable OTLP
-> Exporter for all
-> signals](../../../src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md#enable-otlp-exporter-for-all-signals).
+package and registers the OpenTelemetry SDK into the host. For more details see:
+[Initialize the SDK using a host](../../README.md#initialize-the-sdk-using-a-host).
 
-The index route ("/") is set up to write out the OpenTelemetry trace information
-on the response:
+The `tracing.AddAspNetCoreInstrumentation()` and
+`metrics.AddAspNetCoreInstrumentation()` calls register AspNetCore
+instrumentation. For more details see:
+[OpenTelemetry.Instrumentation.AspNetCore](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.AspNetCore/README.md).
+
+The `UseOtlpExporter` extension configures the OpenTelemetry .NET OTLP exporter
+for logging, metrics, and tracing. For more details see: [Enable OTLP Exporter
+for all
+signals](../../../src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md#enable-otlp-exporter-for-all-signals).
+
+The programs maps the index route ("/") to write out the OpenTelemetry trace
+information on the response:
 
 ```csharp
 app.MapGet("/", () => $"Hello World! OpenTelemetry Trace: {Activity.Current?.Id}");
 ```
 
 In OpenTelemetry .NET the [Activity
-class](https://learn.microsoft.com/dotnet/api/system.diagnostics.activity?view=net-7.0)
+class](https://learn.microsoft.com/dotnet/api/system.diagnostics.activity)
 represents the OpenTelemetry Specification
 [Span](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#span).
 For more details about how the OpenTelemetry Specification is implemented in
 .NET see: [Introduction to OpenTelemetry .NET Tracing
-API](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Api#introduction-to-opentelemetry-net-tracing-api).
+API](../../../src/OpenTelemetry.Api#introduction-to-opentelemetry-net-tracing-api).
 
 ## Learn more
 

--- a/docs/otlp/getting-started-aspnetcore/appsettings.Development.json
+++ b/docs/otlp/getting-started-aspnetcore/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "DetailedErrors": true,
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/docs/otlp/getting-started-aspnetcore/appsettings.json
+++ b/docs/otlp/getting-started-aspnetcore/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/docs/otlp/getting-started-aspnetcore/getting-started-aspnetcore.csproj
+++ b/docs/otlp/getting-started-aspnetcore/getting-started-aspnetcore.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.OpenTelemetryProtocol\OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj" />
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Extensions.Hosting\OpenTelemetry.Extensions.Hosting.csproj" />
+  </ItemGroup>
+</Project>

--- a/docs/otlp/getting-started-console/Program.cs
+++ b/docs/otlp/getting-started-console/Program.cs
@@ -17,7 +17,9 @@ public class Program
 
     public static void Main()
     {
-        // Note: OpenTelemetrySdk.Create was added in 1.10.0
+        // Note: OpenTelemetrySdk.Create in a new API being added in 1.10.0.
+        // This code will not compile using stable packages released to NuGet
+        // until 1.10.0 is released.
 
         // Configure OpenTelemetry to send logs, metrics, and distributed traces
         // via OTLP.

--- a/docs/otlp/getting-started-console/Program.cs
+++ b/docs/otlp/getting-started-console/Program.cs
@@ -1,0 +1,60 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+public class Program
+{
+    private static readonly ActivitySource MyActivitySource = new("MyCompany.MyProduct.MyLibrary");
+    private static readonly Meter MyMeter = new("MyCompany.MyProduct.MyLibrary");
+    private static readonly Counter<int> MyCounter = MyMeter.CreateCounter<int>("execution.count");
+
+    public static void Main()
+    {
+        // Note: OpenTelemetrySdk.Create was added in 1.10.0
+
+        // Configure OpenTelemetry with logs, metrics, & tracing.
+        var openTelemetrySdk = OpenTelemetrySdk.Create(builder =>
+        {
+            builder
+                .ConfigureResource(resource => resource.AddService(serviceName: "ConsoleApp"))
+                .WithTracing(tracing => tracing.AddSource(MyActivitySource.Name))
+                .WithMetrics(metrics => metrics.AddMeter(MyMeter.Name))
+                .UseOtlpExporter();
+
+            // Set OpenTelemetry metrics to use delta temporality.
+            builder.Services.Configure<MetricReaderOptions>(
+                o => o.TemporalityPreference = MetricReaderTemporalityPreference.Delta);
+        });
+
+        var logger = openTelemetrySdk.GetLoggerFactory().CreateLogger<Program>();
+
+        logger.LogInformation("Application starting");
+
+        using (var activity = MyActivitySource.StartActivity("SayHello"))
+        {
+            if (activity?.IsAllDataRequested == true)
+            {
+                activity.SetTag("foo", 1);
+                activity.SetTag("bar", "Hello, World!");
+                activity.SetTag("baz", new int[] { 1, 2, 3 });
+                activity.SetStatus(ActivityStatusCode.Ok);
+            }
+        }
+
+        MyCounter.Add(1);
+
+        logger.LogInformation("Application stopping");
+
+        // Dispose openTelemetrySdk before the application ends.
+        // This will flush the remaining telemetry and shutdown pipelines.
+        openTelemetrySdk.Dispose();
+    }
+}

--- a/docs/otlp/getting-started-console/README.md
+++ b/docs/otlp/getting-started-console/README.md
@@ -1,5 +1,11 @@
 # Getting Started with OpenTelemetry Protocol (OTLP) in 5 Minutes - Console Application
 
+> [!IMPORTANT]
+> This document and coressponding code is a work in progess and uses APIs being
+> introduced in `1.10.0`. It may only be possible to run this guide from the
+> cloned repository or using prerelease packages. Once `1.10.0` is released
+> stable this guide will be updated.
+
 If you haven't already, download and install the [.NET
 SDK](https://dotnet.microsoft.com/download) and
 [Docker](https://www.docker.com/) on your computer.
@@ -159,13 +165,51 @@ manually](../../README.md#initialize-the-sdk-manually).
 The `tracing.AddSource` and `metrics.AddMeter` calls tell the OpenTelemetry SDK
 to listen to the custom `ActivitySource` and `Meter` created by the app to emit
 telemetry. For more details see:
-  * [Activity Source](../../trace/customizing-the-sdk#activity-source)
-  * [Meter](../../metrics/customizing-the-sdk#meter)
+
+* [Activity Source](../../trace/customizing-the-sdk#activity-source)
+
+* [Meter](../../metrics/customizing-the-sdk#meter)
 
 The `UseOtlpExporter` extension configures the OpenTelemetry .NET OTLP exporter
 for logging, metrics, and tracing. For more details see: [Enable OTLP Exporter
 for all
 signals](../../../src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md#enable-otlp-exporter-for-all-signals).
+
+## Next steps
+
+Explore and add relevant [instrumentation
+libraries](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/glossary.md#instrumentation-library)
+and resource detectors to your OpenTelemetry configuration by visiting the
+[opentelemetry-dotnet-contrib
+repository](https://github.com/open-telemetry/opentelemetry-dotnet-contrib)
+and/or the [OpenTelemetry
+registry](https://opentelemetry.io/ecosystem/registry/?language=dotnet).
+Instrumentation libraries help automatically generate telemetry for common
+application tasks such as making an [outgoing HTTP
+call](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/tree/main/src/OpenTelemetry.Instrumentation.Http).
+Resource detectors help decorate telemetry with information about the hosting
+environment.
+
+Use the
+[ActivitySource](https://learn.microsoft.com/dotnet/api/system.diagnostics.activitysource),
+[Meter](https://learn.microsoft.com/dotnet/api/system.diagnostics.metrics.meter),
+and
+[ILogger&lt;T&gt;](https://learn.microsoft.com/dotnet/api/microsoft.extensions.logging.ilogger-1)
+APIs to add custom telemetry to your application and/or libraries.
+
+Explore how to use [samplers](../../trace/customizing-the-sdk#samplers) to
+control distributed tracing costs.
+
+Consider turning on advanced features such as
+[exemplars](../../metrics/customizing-the-sdk#exemplars) to correlate metrics to
+distributed traces.
+
+Deploy your application to production. This guide uses OpenTelemetry Protocol
+(OTLP) defaults which means all telemetry will be sent to
+`http://localhost:4317` using the `OtlpExportProtocol.Grpc` protocol. But these
+settings may be configured using a variety of mechanisms. For details about how
+to configure the `OpenTelemetry.Exporter.OpenTelemetryProtocol` package see:
+[Configuration](../../../src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md#configuration).
 
 ## Learn more
 

--- a/docs/otlp/getting-started-console/README.md
+++ b/docs/otlp/getting-started-console/README.md
@@ -20,7 +20,7 @@ using Docker:
 > output of the OpenTelemetry .NET SDK. For a list of vendors with support for
 > ingestion of [OpenTelemetry Protocol
 (OTLP)](https://github.com/open-telemetry/opentelemetry-proto/tree/main/docs)
-> see: [Vendors](../README.md#vendors).
+> see: [Vendors](../README.md#vendor-support).
 
 PowerShell:
 
@@ -166,9 +166,9 @@ The `tracing.AddSource` and `metrics.AddMeter` calls tell the OpenTelemetry SDK
 to listen to the custom `ActivitySource` and `Meter` created by the app to emit
 telemetry. For more details see:
 
-* [Activity Source](../../trace/customizing-the-sdk#activity-source)
+* [Activity Source](../../trace/customizing-the-sdk/README.md#activity-source)
 
-* [Meter](../../metrics/customizing-the-sdk#meter)
+* [Meter](../../metrics/customizing-the-sdk/README.md#meter)
 
 The `UseOtlpExporter` extension configures the OpenTelemetry .NET OTLP exporter
 for logging, metrics, and tracing. For more details see: [Enable OTLP Exporter
@@ -197,12 +197,13 @@ and
 [ILogger&lt;T&gt;](https://learn.microsoft.com/dotnet/api/microsoft.extensions.logging.ilogger-1)
 APIs to add custom telemetry to your application and/or libraries.
 
-Explore how to use [samplers](../../trace/customizing-the-sdk#samplers) to
-control distributed tracing costs.
+Explore how to use
+[samplers](../../trace/customizing-the-sdk/README.md#samplers) to control
+distributed tracing costs.
 
 Consider turning on advanced features such as
-[exemplars](../../metrics/customizing-the-sdk#exemplars) to correlate metrics to
-distributed traces.
+[exemplars](../../metrics/customizing-the-sdk/README.md#exemplars) to correlate
+metrics to distributed traces.
 
 Deploy your application to production. This guide uses OpenTelemetry Protocol
 (OTLP) defaults which means all telemetry will be sent to

--- a/docs/otlp/getting-started-console/README.md
+++ b/docs/otlp/getting-started-console/README.md
@@ -1,0 +1,126 @@
+# Getting Started with OpenTelemetry Protocol (OTLP) in 5 Minutes - Console Application
+
+If you haven't already, download and install the [.NET
+SDK](https://dotnet.microsoft.com/download) and
+[Docker](https://www.docker.com/) on your computer.
+
+Install and run the [Standalone .NET Aspire
+dashboard](https://learn.microsoft.com/dotnet/aspire/fundamentals/dashboard/standalone)
+using Docker:
+
+```sh
+docker run --rm -it -p 18888:18888 -p 4317:18889 -p 4318:18890 -d --name aspire-dashboard mcr.microsoft.com/dotnet/aspire-dashboard:latest
+```
+
+> [!CAUTION]
+> The .NET Aspire dashboard is being used to view telemetry locally. It is a
+> developer tool and not meant for production usage.
+
+Create a new console application:
+
+```sh
+dotnet new console --output getting-started
+cd getting-started
+```
+
+Install the
+[OpenTelemetry.Exporter.OpenTelemetryProtocol](../../../src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md)
+package:
+
+```sh
+dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
+```
+
+Update the `Program.cs` file with the code from [Program.cs](./Program.cs).
+
+Run the application (using `dotnet run`) and then browse to the .NET Aspire
+dashboard (eg `http://localhost:18888/`) to view your telemetry.
+
+Congratulations! You are now collecting traces using OpenTelemetry.
+
+What does the above program do?
+
+The program creates an `ActivitySource` which represents an [OpenTelemetry
+Tracer](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#tracer).
+
+```csharp
+private static readonly ActivitySource MyActivitySource = new("MyCompany.MyProduct.MyLibrary");
+```
+
+The `ActivitySource` instance is used to start an `Activity` which represents an
+[OpenTelemetry
+Span](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#span)
+and set several `Tags`, which represents
+[Attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-attributes)
+on it. It also sets the [Status](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status)
+to be `Ok`.
+
+```csharp
+using (var activity = MyActivitySource.StartActivity("SayHello"))
+{
+    if (activity?.IsAllDataRequested == true)
+    {
+        activity.SetTag("foo", 1);
+        activity.SetTag("bar", "Hello, World!");
+        activity.SetTag("baz", new int[] { 1, 2, 3 });
+        activity.SetStatus(ActivityStatusCode.Ok);
+    }
+}
+```
+
+The program creates a `Meter` which represents an [OpenTelemetry
+Meter](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#meter)
+and a `Counter<int>` which represents an [OpenTelemetry
+Counter](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#counter).
+
+```csharp
+private static readonly Meter MyMeter = new("MyCompany.MyProduct.MyLibrary");
+private static readonly Counter<int> MyCounter = MyMeter.CreateCounter<int>("execution.count");
+```
+
+The `Counter<int>` is used to record a measurement:
+
+```csharp
+MyCounter.Add(1);
+```
+
+The program creates an `ILogger<Program>` instance to emit logs:
+
+```csharp
+var logger = openTelemetrySdk.GetLoggerFactory().CreateLogger<Program>();
+
+logger.LogInformation("Application starting");
+```
+
+The program uses the
+[OpenTelemetry.Exporter.OpenTelemetryProtocol](../../../src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md)
+package to export telemetry via OTLP to the .NET Aspire dashboard. This is done
+by configuring and starting the OpenTelemetry SDK using the
+`OpenTelemetrySdk.Create` API (added in `1.10.0`) and extension methods:
+
+```csharp
+var openTelemetrySdk = OpenTelemetrySdk.Create(builder =>
+{
+    builder
+        .ConfigureResource(resource => resource.AddService(serviceName: "ConsoleApp"))
+        .WithTracing(tracing => tracing.AddSource(MyActivitySource.Name))
+        .WithMetrics(metrics => metrics.AddMeter(MyMeter.Name))
+        .UseOtlpExporter();
+}
+```
+
+> [!NOTE]
+> The `UseOtlpExporter` extension configures the OpenTelemetry .NET OTLP
+> exporter for logging, metrics, and tracing. For details see: [Enable OTLP
+> Exporter for all
+> signals](../../../src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md#enable-otlp-exporter-for-all-signals).
+
+The `tracing.AddSource` and `metrics.AddMeter` calls tell the OpenTelemetry SDK
+to listen to the custom `ActivitySource` and `Meter` created by the app to emit
+telemetry.
+
+## Learn more
+
+* [OpenTelemetry .NET Logs](../../logs/README.md)
+* [OpenTelemetry .NET Metrics](../../metrics/README.md)
+* [OpenTelemetry .NET Traces](../../trace/README.md)

--- a/docs/otlp/getting-started-console/README.md
+++ b/docs/otlp/getting-started-console/README.md
@@ -74,6 +74,18 @@ Update the `Program.cs` file with the code from [Program.cs](./Program.cs).
 Run the application (using `dotnet run`) and then browse to the .NET Aspire
 dashboard (eg `http://localhost:18888/`) to view your telemetry.
 
+Logs:
+
+![image](https://github.com/user-attachments/assets/47f20945-114d-401f-81ac-3d1638b3610c)
+
+Metrics:
+
+![image](https://github.com/user-attachments/assets/52906dba-1f92-44d1-a4db-ecc1707b8d65)
+
+Traces:
+
+![image](https://github.com/user-attachments/assets/c468ed33-1533-4c41-81d4-5c529d66b55d)
+
 Congratulations! You are now collecting logs, metrics, and traces using
 OpenTelemetry.
 

--- a/docs/otlp/getting-started-console/getting-started-console.csproj
+++ b/docs/otlp/getting-started-console/getting-started-console.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.OpenTelemetryProtocol\OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Changes

* Add getting started docs which show how to use the OtlpExporter with Aspire dashboard

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
