### PR TITLE
[repo] Add needs-triage label to new issues created via templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug report
+title: "[bug] "
 description: Create a report to help us improve
-labels: ["bug"]
+labels: [bug,needs-triage]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,7 @@
 name: Feature request
+title: "[feature request] "
 description: Suggest an idea for this project
-labels: ["enhancement"]
+labels: [enhancement,needs-triage]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,6 +1,7 @@
 name: Question
+title: "[question] "
 description: Ask a question to help us improve our knowledge base and documentation
-labels: ["question"]
+labels: [question,needs-triage]
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,4 +22,4 @@ jobs:
           days-before-pr-close: 7
           days-before-issue-close: 7
           exempt-all-issue-milestones: true
-          exempt-issue-labels: needs-runtime-change,needs-spec-change,needs-majorversion-bump,needs-triage,help wanted,good first issue
+          exempt-issue-labels: needs-triage

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           stale-issue-message: 'This issue was marked stale due to lack of activity and will be closed in 7 days. Commenting will instruct the bot to automatically remove the label. This bot runs once per day.'
           close-issue-message: 'Closed as inactive. Feel free to reopen if this issue is still a concern.'
-          stale-pr-message: 'This PR was marked stale due to lack of activity and will be closed in 7 days. Commenting or Pushing will instruct the bot to automatically remove the label. This bot runs once per day.'
+          stale-pr-message: 'This PR was marked stale due to lack of activity and will be closed in 7 days. Commenting or pushing will instruct the bot to automatically remove the label. This bot runs once per day.'
           close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
           operations-per-run: 400
           days-before-pr-stale: 7
@@ -22,4 +22,4 @@ jobs:
           days-before-pr-close: 7
           days-before-issue-close: 7
           exempt-all-issue-milestones: true
-          exempt-issue-labels: need-runtime-change,await-spec,help wanted,needs-triage
+          exempt-issue-labels: needs-runtime-change,needs-spec-change,needs-majorversion-bump,needs-triage,help wanted,good first issue


### PR DESCRIPTION
Resolves #5776

## Changes

* Automatically add `needs-triage` label on new issues created using templates to prevent things from going stale without anyone ever looking at them
* Reduce the list of label exemptions in stale workflow down to just `needs-triage`

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
