### PR TITLE
[sdk] Switch a couple guard calls to debug.assert in CircularBuffer

### DIFF
--- a/src/OpenTelemetry/Internal/CircularBuffer.cs
+++ b/src/OpenTelemetry/Internal/CircularBuffer.cs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace OpenTelemetry.Internal;
@@ -65,7 +66,7 @@ internal sealed class CircularBuffer<T>
     /// </returns>
     public bool Add(T value)
     {
-        Guard.ThrowIfNull(value);
+        Debug.Assert(value != null, "value was null");
 
         while (true)
         {
@@ -104,7 +105,7 @@ internal sealed class CircularBuffer<T>
             return this.Add(value);
         }
 
-        Guard.ThrowIfNull(value);
+        Debug.Assert(value != null, "value was null");
 
         var spinCountDown = maxSpinCount;
 

--- a/test/OpenTelemetry.Tests/Internal/CircularBufferTest.cs
+++ b/test/OpenTelemetry.Tests/Internal/CircularBufferTest.cs
@@ -23,14 +23,6 @@ public class CircularBufferTest
     }
 
     [Fact]
-    public void CheckNullValueWhenAdding()
-    {
-        int capacity = 1;
-        var circularBuffer = new CircularBuffer<string>(capacity);
-        Assert.Throws<ArgumentNullException>(() => circularBuffer.Add(null));
-    }
-
-    [Fact]
     public void CheckValueWhenAdding()
     {
         int capacity = 1;


### PR DESCRIPTION
Relates to #2495

## Changes

* `CircularBuffer<T>` is an `internal` class where our practice is to use `Debug.Assert` over `Guard.*`

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
