### PR TITLE
Log Stress test to follow recommended logging practise

### DIFF
--- a/test/OpenTelemetry.Tests.Stress.Logs/LoggerExtensions.cs
+++ b/test/OpenTelemetry.Tests.Stress.Logs/LoggerExtensions.cs
@@ -1,0 +1,18 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.Extensions.Logging;
+
+namespace OpenTelemetry.Tests.Stress;
+
+internal static partial class LoggerExtensions
+{
+    [LoggerMessage(LogLevel.Critical, "A `{productType}` recall notice was published for `{brandName} {productDescription}` produced by `{companyName}` ({recallReasonDescription}).")]
+    public static partial void FoodRecallNotice(
+        this ILogger logger,
+        string brandName,
+        string productDescription,
+        string productType,
+        string recallReasonDescription,
+        string companyName);
+}

--- a/test/OpenTelemetry.Tests.Stress.Logs/Program.cs
+++ b/test/OpenTelemetry.Tests.Stress.Logs/Program.cs
@@ -34,12 +34,12 @@ public static class Program
 
         protected override void RunWorkItemInParallel()
         {
-            this.logger.Log(
-                logLevel: LogLevel.Information,
-                eventId: 2,
-                state: Payload,
-                exception: null,
-                formatter: (state, ex) => string.Empty);
+            this.logger.FoodRecallNotice(
+                brandName: "Contoso",
+                productDescription: "Salads",
+                productType: "Food & Beverages",
+                recallReasonDescription: "due to a possible health risk from Listeria monocytogenes",
+                companyName: "Contoso Fresh Vegetables, Inc.");
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
Stress test modified to use what we recommend in getting started guides.

In case anyone is curious, this gets ~46 M/sec for the machine below:
```
 OS: Ubuntu 22.04.4 LTS (5.15.153.1-microsoft-standard-WSL2)
  Hardware: AMD EPYC 7763 64-Core Processor - 2.44 GHz, 16vCPUs,
  RAM: 64.0 GB
```