### PR TITLE
[repo] Update stale.yml - reduce days before stale to 1000

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
           close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
           operations-per-run: 400
           days-before-pr-stale: 7
-          days-before-issue-stale: 1200
+          days-before-issue-stale: 1000
           days-before-pr-close: 7
           days-before-issue-close: 7
           exempt-all-issue-milestones: true


### PR DESCRIPTION
Follow up to #5776

The stale issue automation is working well. This PR moves the days-before-issue-stale from 1200 to 1000.


### Counts of issues

- Currently 342 open issues (Aug 20, 2024).
- older than 300 days (Oct 25 2023) = 174 issues
- older than 600 days (Dec 29 2022) = 83 issues
- older than 900 days (Mar 4 2022) = 33 issues
- older than 1000 days (Nov 24 2021) = 17 issues
- older than 1100 days (Aug 16 2021) = 8 issues
- older than 1200 days (May 8 2021) = 0 issues