### PR TITLE
[otlp] Workaround DI containers which create unregistered services

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Builder/OtlpExporterBuilder.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Builder/OtlpExporterBuilder.cs
@@ -174,9 +174,9 @@ internal sealed class OtlpExporterBuilder
         services!.AddOtlpExporterTracingServices();
 
         // Note: UseOtlpExporterRegistration is added to the service collection
-        // to detect repeated calls to "UseOtlpExporter" and to throw if
-        // "AddOtlpExporter" extensions are called
-        services!.AddSingleton<UseOtlpExporterRegistration>();
+        // for each invocation to detect repeated calls to "UseOtlpExporter" and
+        // to throw if "AddOtlpExporter" extensions are called
+        services!.AddSingleton(UseOtlpExporterRegistration.Instance);
 
         services!.RegisterOptionsFactory((sp, configuration, name) => new OtlpExporterBuilderOptions(
             configuration,

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Builder/UseOtlpExporterRegistration.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Builder/UseOtlpExporterRegistration.cs
@@ -8,4 +8,15 @@ namespace OpenTelemetry.Exporter;
 // calls to signal-specific AddOtlpExporter can throw.
 internal sealed class UseOtlpExporterRegistration
 {
+    public static readonly UseOtlpExporterRegistration Instance = new();
+
+    private UseOtlpExporterRegistration()
+    {
+        // Note: Some dependency injection containers (ex: Unity, Grace) will
+        // automatically create services if they have a public constructor even
+        // if the service was never registered into the IServiceCollection. The
+        // behavior of UseOtlpExporterRegistration requires that it should only
+        // exist if registered. This private constructor is intended to prevent
+        // automatic instantiation.
+    }
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -16,7 +16,7 @@ Notes](../../RELEASENOTES.md).
   `AddOtlpExporter` registration extensions are called while using custom
   dependency injection containers which automatically create services (Unity,
   Grace, etc.).
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#5808](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5808))
 
 ## 1.9.0
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -12,6 +12,12 @@ Notes](../../RELEASENOTES.md).
   `CultureInfo.InvariantCulture`.
   ([#5700](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5700))
 
+* Fixed an issue causing `NotSupportedException`s to be thrown on startup when
+  `AddOtlpExporter` registration extensions are called while using custom
+  dependency injection containers which automatically create services (Unity,
+  Grace, etc.).
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.9.0
 
 Released 2024-Jun-14


### PR DESCRIPTION
Fixes #5537
Fixes #5803

## Changes

* Prevent `UseOtlpExporterRegistration` from being instantiated without a registration when using Unity or Grace DI containers

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
