### PR TITLE
[repo] Extend NugetAudit by indirect references

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -81,9 +81,9 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[8.0.0,)" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="[8.0.0,)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.0,)" />
-    <PackageVersion Include="Microsoft.Extensions.Telemetry.Abstractions" Version="[8.6.0,)" />
+    <PackageVersion Include="Microsoft.Extensions.Telemetry.Abstractions" Version="[8.8.0,)" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="[1.0.3,2.0)" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="[17.10.0,18.0.0)" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="[17.11.0,18.0.0)" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="[8.0.0,9.0)" />
     <PackageVersion Include="MinVer" Version="[5.0.0,6.0)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="[1.9.0,2.0)" />
@@ -92,15 +92,15 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="[1.9.0,2.0)" />
     <PackageVersion Include="RabbitMQ.Client" Version="[6.8.1,7.0)" />
     <PackageVersion Include="StyleCop.Analyzers" Version="[1.2.0-beta.556,2.0)" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="[6.6.2,)" />
-    <PackageVersion Include="xunit" Version="[2.8.1,3.0)" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="[2.8.1,3.0)" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="[6.7.3,)" />
+    <PackageVersion Include="xunit" Version="[2.9.0,3.0)" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="[2.8.2,3.0)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.31" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.33" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.8" />
   </ItemGroup>
 </Project>

--- a/build/Common.props
+++ b/build/Common.props
@@ -10,6 +10,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <NuGetAuditLevel>low</NuGetAuditLevel>
     <!-- Suppress warnings for repo code using experimental features -->
     <NoWarn>$(NoWarn);OTEL1000;OTEL1001;OTEL1002;OTEL1003;OTEL1004</NoWarn>
     <!--temporarily disable. See 3958-->

--- a/examples/MicroserviceExample/WorkerService/WorkerService.csproj
+++ b/examples/MicroserviceExample/WorkerService/WorkerService.csproj
@@ -6,6 +6,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="RabbitMQ.Client" />
+    <!-- System.Text.Json is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-hh2w-p6rv-4g7w -->
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -4,6 +4,6 @@
     <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageVersion Update="System.Text.Json" Version="8.0.4" />
     <PackageVersion Include="NuGet.Versioning" Version="6.11.0" />
-    <PackageVersion Include="Microsoft.Coyote" Version="1.7.10" />
+    <PackageVersion Include="Microsoft.Coyote" Version="1.7.11" />
   </ItemGroup>
 </Project>

--- a/test/OpenTelemetry.Api.Tests/OpenTelemetry.Api.Tests.csproj
+++ b/test/OpenTelemetry.Api.Tests/OpenTelemetry.Api.Tests.csproj
@@ -27,5 +27,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Coyote" />
+    <!-- System.Text.Json is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-hh2w-p6rv-4g7w -->
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 </Project>

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.csproj
@@ -14,6 +14,8 @@
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <!-- System.Text.Json is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-hh2w-p6rv-4g7w -->
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests.csproj
@@ -15,6 +15,8 @@
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <!-- System.Text.Json is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-hh2w-p6rv-4g7w -->
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests.csproj
@@ -14,6 +14,8 @@
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <!-- System.Text.Json is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-hh2w-p6rv-4g7w -->
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/OpenTelemetry.Exporter.Zipkin.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/OpenTelemetry.Exporter.Zipkin.Tests.csproj
@@ -22,6 +22,8 @@
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <!-- System.Text.Json is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-hh2w-p6rv-4g7w -->
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetry.Extensions.Hosting.Tests.csproj
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetry.Extensions.Hosting.Tests.csproj
@@ -41,5 +41,7 @@
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <!-- System.Text.Json is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-hh2w-p6rv-4g7w -->
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 </Project>

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/OpenTelemetry.Shims.OpenTracing.Tests.csproj
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/OpenTelemetry.Shims.OpenTracing.Tests.csproj
@@ -12,6 +12,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
+    <!-- System.Text.Json is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-hh2w-p6rv-4g7w -->
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Tests/Metrics/MetricApiTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricApiTestsBase.cs
@@ -236,7 +236,7 @@ public abstract class MetricApiTestsBase : MetricTestsBase
         Assert.Equal(meterVersion, metric.MeterVersion);
 
         Assert.Single(metric.MeterTags.Where(kvp => kvp.Key == meterTags1[0].Key && kvp.Value == meterTags1[0].Value));
-        Assert.Empty(metric.MeterTags.Where(kvp => kvp.Key == meterTags2[0].Key && kvp.Value == meterTags2[0].Value));
+        Assert.DoesNotContain(metric.MeterTags, kvp => kvp.Key == meterTags2[0].Key && kvp.Value == meterTags2[0].Value);
 
         List<MetricPoint> metricPoints = new List<MetricPoint>();
         foreach (ref readonly var mp in metric.GetMetricPoints())

--- a/test/OpenTelemetry.Tests/OpenTelemetry.Tests.csproj
+++ b/test/OpenTelemetry.Tests/OpenTelemetry.Tests.csproj
@@ -15,7 +15,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetFrameworkMinimumSupportedVersion)'">
     <PackageReference Include="Microsoft.CSharp" />
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>
@@ -32,5 +31,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Coyote" />
+    <!-- System.Text.Json is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-hh2w-p6rv-4g7w -->
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Follow up #5784

## Changes

Brings defaults from .NET9.
Opportunistic update of other tests packages.

System.Text.Json references can be removed when Microsoft.Coyote will be released https://github.com/microsoft/coyote/pull/507

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
