### PR TITLE
[repo] Update stale.yml - reduce days before stale to 900

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
           close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
           operations-per-run: 400
           days-before-pr-stale: 7
-          days-before-issue-stale: 1000
+          days-before-issue-stale: 900
           days-before-pr-close: 7
           days-before-issue-close: 7
           exempt-all-issue-milestones: true


### PR DESCRIPTION
Follow up to https://github.com/open-telemetry/opentelemetry-dotnet/issues/5776

This PR moves the days-before-issue-stale from 1000 to 900.
The ultimate goal is to get this down to 300 days.

## Counts of issues

- Currently 320 open issues (Sept 9, 2024).
- older than 300 days (Nov 14, 2023) = 147 issues
- older than 600 days (Jan 18, 2023) = 65 issues
- older than 900 days (Mar 24 2022) = 14 issues