### PR TITLE
[repo] Always execute build-test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,8 +171,8 @@ jobs:
 
   build-test:
     needs: [
-      lint-misspell-sanitycheck,
       detect-changes,
+      lint-misspell-sanitycheck,
       lint-md,
       lint-dotnet-format,
       build-test-solution,
@@ -186,7 +186,8 @@ jobs:
       verify-aot-compat,
       concurrency-tests
       ]
-    if: always() && !cancelled() && !contains(needs.*.result, 'failure')
-    runs-on: windows-latest
+    if: always() && !cancelled()
+    runs-on: ubuntu-latest
     steps:
-    - run: echo 'build complete'
+    - run: |
+          if ( ${{ contains(needs.*.result, 'failure') }} == true ); then echo 'build failed ✗'; exit 1; else echo 'build complete ✓'; fi


### PR DESCRIPTION
Propagates https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2054

## Changes

Always execute build-tests step. It is used to determine if all steps passed.
Before changes there were possibility to merge changes even if previous steps were failing.
More details in https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2054#discussion_r1753106842

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
