### PR TITLE
Add missing invocations for BaseProcessor<LogRecord>.OnStart

### DIFF
--- a/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLogger.cs
+++ b/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLogger.cs
@@ -58,6 +58,7 @@ internal sealed class OpenTelemetryLogger : ILogger
             var pool = this.provider.LogRecordPool;
 
             var record = pool.Rent();
+            processor.OnStart(record);
 
             ref LogRecord.LogRecordILoggerData iloggerData = ref record.ILoggerData;
 

--- a/src/OpenTelemetry/Logs/LoggerSdk.cs
+++ b/src/OpenTelemetry/Logs/LoggerSdk.cs
@@ -32,6 +32,7 @@ internal sealed class LoggerSdk : Logger
             var pool = provider.LogRecordPool;
 
             var logRecord = pool.Rent();
+            processor.OnStart(logRecord);
 
             logRecord.Data = data;
             logRecord.ILoggerData = default;


### PR DESCRIPTION
Fixes #5834

## Changes

Add BaseProcessor<LogRecord>.OnStart to be paired with BaseProcessor<LogRecord>.OnEnd.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
