### PR TITLE
[api] Baggage nullable annotations

### DIFF
--- a/src/OpenTelemetry.Api/.publicApi/Stable/PublicAPI.Shipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/Stable/PublicAPI.Shipped.txt
@@ -1,11 +1,4 @@
 #nullable enable
-~OpenTelemetry.Baggage.GetBaggage() -> System.Collections.Generic.IReadOnlyDictionary<string, string>
-~OpenTelemetry.Baggage.GetBaggage(string name) -> string
-~OpenTelemetry.Baggage.GetEnumerator() -> System.Collections.Generic.Dictionary<string, string>.Enumerator
-~OpenTelemetry.Baggage.RemoveBaggage(string name) -> OpenTelemetry.Baggage
-~OpenTelemetry.Baggage.SetBaggage(params System.Collections.Generic.KeyValuePair<string, string>[] baggageItems) -> OpenTelemetry.Baggage
-~OpenTelemetry.Baggage.SetBaggage(string name, string value) -> OpenTelemetry.Baggage
-~OpenTelemetry.Baggage.SetBaggage(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> baggageItems) -> OpenTelemetry.Baggage
 ~OpenTelemetry.Context.AsyncLocalRuntimeContextSlot<T>.AsyncLocalRuntimeContextSlot(string name) -> void
 ~OpenTelemetry.Context.AsyncLocalRuntimeContextSlot<T>.Value.get -> object
 ~OpenTelemetry.Context.AsyncLocalRuntimeContextSlot<T>.Value.set -> void
@@ -16,14 +9,6 @@
 ~OpenTelemetry.Context.ThreadLocalRuntimeContextSlot<T>.ThreadLocalRuntimeContextSlot(string name) -> void
 ~OpenTelemetry.Context.ThreadLocalRuntimeContextSlot<T>.Value.get -> object
 ~OpenTelemetry.Context.ThreadLocalRuntimeContextSlot<T>.Value.set -> void
-~override OpenTelemetry.Baggage.Equals(object obj) -> bool
-~static OpenTelemetry.Baggage.Create(System.Collections.Generic.Dictionary<string, string> baggageItems = null) -> OpenTelemetry.Baggage
-~static OpenTelemetry.Baggage.GetBaggage(OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> System.Collections.Generic.IReadOnlyDictionary<string, string>
-~static OpenTelemetry.Baggage.GetBaggage(string name, OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> string
-~static OpenTelemetry.Baggage.GetEnumerator(OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> System.Collections.Generic.Dictionary<string, string>.Enumerator
-~static OpenTelemetry.Baggage.RemoveBaggage(string name, OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> OpenTelemetry.Baggage
-~static OpenTelemetry.Baggage.SetBaggage(string name, string value, OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> OpenTelemetry.Baggage
-~static OpenTelemetry.Baggage.SetBaggage(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> baggageItems, OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> OpenTelemetry.Baggage
 ~static OpenTelemetry.Context.RuntimeContext.ContextSlotType.get -> System.Type
 ~static OpenTelemetry.Context.RuntimeContext.ContextSlotType.set -> void
 ~static OpenTelemetry.Context.RuntimeContext.GetSlot<T>(string slotName) -> OpenTelemetry.Context.RuntimeContextSlot<T>
@@ -49,6 +34,13 @@ OpenTelemetry.Baggage.Baggage() -> void
 OpenTelemetry.Baggage.ClearBaggage() -> OpenTelemetry.Baggage
 OpenTelemetry.Baggage.Count.get -> int
 OpenTelemetry.Baggage.Equals(OpenTelemetry.Baggage other) -> bool
+OpenTelemetry.Baggage.GetBaggage() -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
+OpenTelemetry.Baggage.GetBaggage(string! name) -> string?
+OpenTelemetry.Baggage.GetEnumerator() -> System.Collections.Generic.Dictionary<string!, string!>.Enumerator
+OpenTelemetry.Baggage.RemoveBaggage(string! name) -> OpenTelemetry.Baggage
+OpenTelemetry.Baggage.SetBaggage(params System.Collections.Generic.KeyValuePair<string!, string?>[]! baggageItems) -> OpenTelemetry.Baggage
+OpenTelemetry.Baggage.SetBaggage(string! name, string? value) -> OpenTelemetry.Baggage
+OpenTelemetry.Baggage.SetBaggage(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, string?>>! baggageItems) -> OpenTelemetry.Baggage
 OpenTelemetry.BaseProvider
 OpenTelemetry.BaseProvider.~BaseProvider() -> void
 OpenTelemetry.BaseProvider.BaseProvider() -> void
@@ -171,6 +163,7 @@ OpenTelemetry.Trace.TracerProvider.GetTracer(string! name, string? version = nul
 OpenTelemetry.Trace.TracerProvider.TracerProvider() -> void
 OpenTelemetry.Trace.TracerProviderBuilder
 OpenTelemetry.Trace.TracerProviderBuilder.TracerProviderBuilder() -> void
+override OpenTelemetry.Baggage.Equals(object? obj) -> bool
 override OpenTelemetry.Baggage.GetHashCode() -> int
 override OpenTelemetry.Context.AsyncLocalRuntimeContextSlot<T>.Get() -> T
 override OpenTelemetry.Context.AsyncLocalRuntimeContextSlot<T>.Set(T value) -> void
@@ -201,10 +194,17 @@ override OpenTelemetry.Trace.Status.ToString() -> string!
 override OpenTelemetry.Trace.TracerProvider.Dispose(bool disposing) -> void
 static OpenTelemetry.ActivityContextExtensions.IsValid(this System.Diagnostics.ActivityContext ctx) -> bool
 static OpenTelemetry.Baggage.ClearBaggage(OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> OpenTelemetry.Baggage
+static OpenTelemetry.Baggage.Create(System.Collections.Generic.Dictionary<string!, string!>? baggageItems = null) -> OpenTelemetry.Baggage
 static OpenTelemetry.Baggage.Current.get -> OpenTelemetry.Baggage
 static OpenTelemetry.Baggage.Current.set -> void
+static OpenTelemetry.Baggage.GetBaggage(OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
+static OpenTelemetry.Baggage.GetBaggage(string! name, OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> string?
+static OpenTelemetry.Baggage.GetEnumerator(OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> System.Collections.Generic.Dictionary<string!, string!>.Enumerator
 static OpenTelemetry.Baggage.operator !=(OpenTelemetry.Baggage left, OpenTelemetry.Baggage right) -> bool
 static OpenTelemetry.Baggage.operator ==(OpenTelemetry.Baggage left, OpenTelemetry.Baggage right) -> bool
+static OpenTelemetry.Baggage.RemoveBaggage(string! name, OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> OpenTelemetry.Baggage
+static OpenTelemetry.Baggage.SetBaggage(string! name, string? value, OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> OpenTelemetry.Baggage
+static OpenTelemetry.Baggage.SetBaggage(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, string?>>! baggageItems, OpenTelemetry.Baggage baggage = default(OpenTelemetry.Baggage)) -> OpenTelemetry.Baggage
 static OpenTelemetry.Context.Propagation.PropagationContext.operator !=(OpenTelemetry.Context.Propagation.PropagationContext left, OpenTelemetry.Context.Propagation.PropagationContext right) -> bool
 static OpenTelemetry.Context.Propagation.PropagationContext.operator ==(OpenTelemetry.Context.Propagation.PropagationContext left, OpenTelemetry.Context.Propagation.PropagationContext right) -> bool
 static OpenTelemetry.Context.Propagation.Propagators.DefaultTextMapPropagator.get -> OpenTelemetry.Context.Propagation.TextMapPropagator!

--- a/src/OpenTelemetry.Api/Baggage.cs
+++ b/src/OpenTelemetry.Api/Baggage.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable enable
+
 using System.Diagnostics.CodeAnalysis;
 using OpenTelemetry.Context;
 using OpenTelemetry.Internal;
@@ -87,7 +89,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// </summary>
     /// <param name="baggageItems">Baggage key/value pairs.</param>
     /// <returns><see cref="Baggage"/>.</returns>
-    public static Baggage Create(Dictionary<string, string> baggageItems = null)
+    public static Baggage Create(Dictionary<string, string>? baggageItems = null)
     {
         if (baggageItems == null)
         {
@@ -133,7 +135,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// <param name="baggage">Optional <see cref="Baggage"/>. <see cref="Current"/> is used if not specified.</param>
     /// <returns>Baggage item or <see langword="null"/> if nothing was found.</returns>
     [SuppressMessage("roslyn", "RS0026", Justification = "TODO: fix APIs that violate the backcompt requirement - multiple overloads with optional parameters: https://github.com/dotnet/roslyn/blob/main/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md.")]
-    public static string GetBaggage(string name, Baggage baggage = default)
+    public static string? GetBaggage(string name, Baggage baggage = default)
         => baggage == default ? Current.GetBaggage(name) : baggage.GetBaggage(name);
 
     /// <summary>
@@ -145,7 +147,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// <returns>New <see cref="Baggage"/> containing the key/value pair.</returns>
     /// <remarks>Note: The <see cref="Baggage"/> returned will be set as the new <see cref="Current"/> instance.</remarks>
     [SuppressMessage("roslyn", "RS0026", Justification = "TODO: fix APIs that violate the backcompt requirement - multiple overloads with optional parameters: https://github.com/dotnet/roslyn/blob/main/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md.")]
-    public static Baggage SetBaggage(string name, string value, Baggage baggage = default)
+    public static Baggage SetBaggage(string name, string? value, Baggage baggage = default)
     {
         var baggageHolder = EnsureBaggageHolder();
         lock (baggageHolder)
@@ -164,7 +166,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// <returns>New <see cref="Baggage"/> containing the new key/value pairs.</returns>
     /// <remarks>Note: The <see cref="Baggage"/> returned will be set as the new <see cref="Current"/> instance.</remarks>
     [SuppressMessage("roslyn", "RS0026", Justification = "TODO: fix APIs that violate the backcompt requirement - multiple overloads with optional parameters: https://github.com/dotnet/roslyn/blob/main/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md.")]
-    public static Baggage SetBaggage(IEnumerable<KeyValuePair<string, string>> baggageItems, Baggage baggage = default)
+    public static Baggage SetBaggage(IEnumerable<KeyValuePair<string, string?>> baggageItems, Baggage baggage = default)
     {
         var baggageHolder = EnsureBaggageHolder();
         lock (baggageHolder)
@@ -222,11 +224,11 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// </summary>
     /// <param name="name">Baggage item name.</param>
     /// <returns>Baggage item or <see langword="null"/> if nothing was found.</returns>
-    public string GetBaggage(string name)
+    public string? GetBaggage(string name)
     {
         Guard.ThrowIfNullOrEmpty(name);
 
-        return this.baggage != null && this.baggage.TryGetValue(name, out string value)
+        return this.baggage != null && this.baggage.TryGetValue(name, out string? value)
             ? value
             : null;
     }
@@ -237,7 +239,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// <param name="name">Baggage item name.</param>
     /// <param name="value">Baggage item value.</param>
     /// <returns>New <see cref="Baggage"/> containing the key/value pair.</returns>
-    public Baggage SetBaggage(string name, string value)
+    public Baggage SetBaggage(string name, string? value)
     {
         if (string.IsNullOrEmpty(value))
         {
@@ -247,7 +249,7 @@ public readonly struct Baggage : IEquatable<Baggage>
         return new Baggage(
             new Dictionary<string, string>(this.baggage ?? EmptyBaggage, StringComparer.OrdinalIgnoreCase)
             {
-                [name] = value,
+                [name] = value!,
             });
     }
 
@@ -256,15 +258,15 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// </summary>
     /// <param name="baggageItems">Baggage key/value pairs.</param>
     /// <returns>New <see cref="Baggage"/> containing the key/value pairs.</returns>
-    public Baggage SetBaggage(params KeyValuePair<string, string>[] baggageItems)
-        => this.SetBaggage((IEnumerable<KeyValuePair<string, string>>)baggageItems);
+    public Baggage SetBaggage(params KeyValuePair<string, string?>[] baggageItems)
+        => this.SetBaggage((IEnumerable<KeyValuePair<string, string?>>)baggageItems);
 
     /// <summary>
     /// Returns a new <see cref="Baggage"/> which contains the new key/value pairs.
     /// </summary>
     /// <param name="baggageItems">Baggage key/value pairs.</param>
     /// <returns>New <see cref="Baggage"/> containing the key/value pairs.</returns>
-    public Baggage SetBaggage(IEnumerable<KeyValuePair<string, string>> baggageItems)
+    public Baggage SetBaggage(IEnumerable<KeyValuePair<string, string?>> baggageItems)
     {
         if (baggageItems?.Any() != true)
         {
@@ -281,7 +283,7 @@ public readonly struct Baggage : IEquatable<Baggage>
             }
             else
             {
-                newBaggage[item.Key] = item.Value;
+                newBaggage[item.Key] = item.Value!;
             }
         }
 
@@ -325,11 +327,11 @@ public readonly struct Baggage : IEquatable<Baggage>
             return false;
         }
 
-        return baggageIsNullOrEmpty || this.baggage.SequenceEqual(other.baggage);
+        return baggageIsNullOrEmpty || this.baggage!.SequenceEqual(other.baggage!);
     }
 
     /// <inheritdoc/>
-    public override bool Equals(object obj)
+    public override bool Equals(object? obj)
         => (obj is Baggage baggage) && this.Equals(baggage);
 
     /// <inheritdoc/>

--- a/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
@@ -56,7 +56,7 @@ public class BaggagePropagator : TextMapPropagator
             {
                 if (TryExtractBaggage(baggageCollection.ToArray(), out var baggage))
                 {
-                    return new PropagationContext(context.ActivityContext, new Baggage(baggage));
+                    return new PropagationContext(context.ActivityContext, new Baggage(baggage!));
                 }
             }
 

--- a/test/OpenTelemetry.Api.Tests/BaggageTests.cs
+++ b/test/OpenTelemetry.Api.Tests/BaggageTests.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#nullable enable
+
 using Xunit;
 
 namespace OpenTelemetry.Tests;
@@ -27,8 +29,8 @@ public class BaggageTests
     {
         var list = new List<KeyValuePair<string, string>>(2)
         {
-            new KeyValuePair<string, string>(K1, V1),
-            new KeyValuePair<string, string>(K2, V2),
+            new(K1, V1),
+            new(K2, V2),
         };
 
         Baggage.SetBaggage(K1, V1);
@@ -44,7 +46,7 @@ public class BaggageTests
         Assert.Null(Baggage.GetBaggage("NO_KEY"));
         Assert.Equal(V2, Baggage.Current.GetBaggage(K2));
 
-        Assert.Throws<ArgumentException>(() => Baggage.GetBaggage(null));
+        Assert.Throws<ArgumentException>(() => Baggage.GetBaggage(null!));
     }
 
     [Fact]
@@ -52,12 +54,12 @@ public class BaggageTests
     {
         var list = new List<KeyValuePair<string, string>>(2)
         {
-            new KeyValuePair<string, string>(K1, V1),
+            new(K1, V1),
         };
 
-        Baggage.Current.SetBaggage(new KeyValuePair<string, string>(K1, V1));
+        Baggage.Current.SetBaggage(new KeyValuePair<string, string?>(K1, V1));
         var baggage = Baggage.SetBaggage(K1, V1);
-        Baggage.SetBaggage(new Dictionary<string, string> { [K1] = V1 }, baggage);
+        Baggage.SetBaggage(new Dictionary<string, string?> { [K1] = V1 }, baggage);
 
         Assert.Equal(list, Baggage.GetBaggage());
     }
@@ -78,7 +80,7 @@ public class BaggageTests
         Assert.Empty(Baggage.SetBaggage(K1, null).GetBaggage());
 
         Baggage.SetBaggage(K1, V1);
-        Baggage.SetBaggage(new Dictionary<string, string>
+        Baggage.SetBaggage(new Dictionary<string, string?>
         {
             [K1] = null,
             [K2] = V2,
@@ -94,7 +96,7 @@ public class BaggageTests
         var empty2 = Baggage.RemoveBaggage(K1);
         Assert.True(empty == empty2);
 
-        var baggage = Baggage.SetBaggage(new Dictionary<string, string>
+        var baggage = Baggage.SetBaggage(new Dictionary<string, string?>
         {
             [K1] = V1,
             [K2] = V2,
@@ -112,7 +114,7 @@ public class BaggageTests
     [Fact]
     public void ClearTest()
     {
-        var baggage = Baggage.SetBaggage(new Dictionary<string, string>
+        var baggage = Baggage.SetBaggage(new Dictionary<string, string?>
         {
             [K1] = V1,
             [K2] = V2,
@@ -151,8 +153,8 @@ public class BaggageTests
     {
         var list = new List<KeyValuePair<string, string>>(2)
         {
-            new KeyValuePair<string, string>(K1, V1),
-            new KeyValuePair<string, string>(K2, V2),
+            new(K1, V1),
+            new(K2, V2),
         };
 
         var baggage = Baggage.SetBaggage(K1, V1);
@@ -207,7 +209,7 @@ public class BaggageTests
             ["key2"] = "value2",
             ["KEY2"] = "VALUE2",
             ["KEY3"] = "VALUE3",
-            ["Key3"] = null,
+            ["Key3"] = null!,
         });
 
         Assert.Equal(2, baggage.Count);
@@ -232,7 +234,7 @@ public class BaggageTests
 
         baggage = Baggage.SetBaggage(K1, V1);
 
-        var baggage2 = Baggage.SetBaggage(null);
+        var baggage2 = Baggage.SetBaggage(null!);
 
         Assert.Equal(baggage, baggage2);
 

--- a/test/OpenTelemetry.Api.Tests/BaggageTests.cs
+++ b/test/OpenTelemetry.Api.Tests/BaggageTests.cs
@@ -209,7 +209,7 @@ public class BaggageTests
             ["key2"] = "value2",
             ["KEY2"] = "VALUE2",
             ["KEY3"] = "VALUE3",
-            ["Key3"] = null!,
+            ["Key3"] = null!, // Note: This causes Key3 to be removed
         });
 
         Assert.Equal(2, baggage.Count);


### PR DESCRIPTION
Relates to #5801

## Changes

* Adds nullable annotations for the Baggage API

## Details

This was split off from #5801 so it could be reviewed/discussed independently.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [ ] Changes in public API reviewed (if applicable)
