### PR TITLE
[repo] Simplify preprocessor directives after dropping support for .NET 6 and .NET7

### DIFF
--- a/src/OpenTelemetry.Api/Logs/LogRecordAttributeList.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordAttributeList.cs
@@ -6,7 +6,7 @@
 using System.Collections;
 using System.ComponentModel;
 using System.Diagnostics;
-#if NET8_0_OR_GREATER && EXPOSE_EXPERIMENTAL_FEATURES
+#if NET && EXPOSE_EXPERIMENTAL_FEATURES
 using System.Diagnostics.CodeAnalysis;
 #endif
 using OpenTelemetry.Internal;
@@ -19,7 +19,7 @@ namespace OpenTelemetry.Logs;
 /// Stores attributes to be added to a log message.
 /// </summary>
 /// <remarks><inheritdoc cref="Logger" path="/remarks"/></remarks>
-#if NET8_0_OR_GREATER
+#if NET
 [Experimental(DiagnosticDefinitions.LogsBridgeExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
 #endif
 public

--- a/src/OpenTelemetry.Api/Logs/LogRecordData.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordData.cs
@@ -4,7 +4,7 @@
 #nullable enable
 
 using System.Diagnostics;
-#if NET8_0_OR_GREATER && EXPOSE_EXPERIMENTAL_FEATURES
+#if NET && EXPOSE_EXPERIMENTAL_FEATURES
 using System.Diagnostics.CodeAnalysis;
 using OpenTelemetry.Internal;
 #endif
@@ -16,7 +16,7 @@ namespace OpenTelemetry.Logs;
 /// Stores details about a log message.
 /// </summary>
 /// <remarks><inheritdoc cref="Logger" path="/remarks"/></remarks>
-#if NET8_0_OR_GREATER
+#if NET
 [Experimental(DiagnosticDefinitions.LogsBridgeExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
 #endif
 public

--- a/src/OpenTelemetry.Api/Logs/LogRecordSeverity.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordSeverity.cs
@@ -3,7 +3,7 @@
 
 #nullable enable
 
-#if NET8_0_OR_GREATER && EXPOSE_EXPERIMENTAL_FEATURES
+#if NET && EXPOSE_EXPERIMENTAL_FEATURES
 using System.Diagnostics.CodeAnalysis;
 using OpenTelemetry.Internal;
 #endif
@@ -15,7 +15,7 @@ namespace OpenTelemetry.Logs;
 /// Describes the severity level of a log record.
 /// </summary>
 /// <remarks><inheritdoc cref="Logger" path="/remarks"/></remarks>
-#if NET8_0_OR_GREATER
+#if NET
 [Experimental(DiagnosticDefinitions.LogsBridgeExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
 #endif
 public

--- a/src/OpenTelemetry.Api/Logs/LogRecordSeverityExtensions.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordSeverityExtensions.cs
@@ -3,7 +3,7 @@
 
 #nullable enable
 
-#if NET8_0_OR_GREATER && EXPOSE_EXPERIMENTAL_FEATURES
+#if NET && EXPOSE_EXPERIMENTAL_FEATURES
 using System.Diagnostics.CodeAnalysis;
 using OpenTelemetry.Internal;
 #endif
@@ -15,7 +15,7 @@ namespace OpenTelemetry.Logs;
 /// Contains extension methods for the <see cref="LogRecordSeverity"/> enum.
 /// </summary>
 /// <remarks><inheritdoc cref="Logger" path="/remarks"/></remarks>
-#if NET8_0_OR_GREATER
+#if NET
 [Experimental(DiagnosticDefinitions.LogsBridgeExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
 #endif
 public

--- a/src/OpenTelemetry.Api/Logs/Logger.cs
+++ b/src/OpenTelemetry.Api/Logs/Logger.cs
@@ -3,7 +3,7 @@
 
 #nullable enable
 
-#if NET8_0_OR_GREATER && EXPOSE_EXPERIMENTAL_FEATURES
+#if NET && EXPOSE_EXPERIMENTAL_FEATURES
 using System.Diagnostics.CodeAnalysis;
 using OpenTelemetry.Internal;
 #endif
@@ -15,7 +15,7 @@ namespace OpenTelemetry.Logs;
 /// Logger is the class responsible for creating log records.
 /// </summary>
 /// <remarks><b>WARNING</b>: This is an experimental API which might change or be removed in the future. Use at your own risk.</remarks>
-#if NET8_0_OR_GREATER
+#if NET
 [Experimental(DiagnosticDefinitions.LogsBridgeExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
 #endif
 public

--- a/src/OpenTelemetry.Api/Logs/LoggerProvider.cs
+++ b/src/OpenTelemetry.Api/Logs/LoggerProvider.cs
@@ -6,7 +6,7 @@
 #if NETSTANDARD2_1_OR_GREATER || NET
 using System.Diagnostics.CodeAnalysis;
 #endif
-#if EXPOSE_EXPERIMENTAL_FEATURES && NET8_0_OR_GREATER
+#if EXPOSE_EXPERIMENTAL_FEATURES && NET
 using OpenTelemetry.Internal;
 #endif
 
@@ -32,7 +32,7 @@ public class LoggerProvider : BaseProvider
     /// </summary>
     /// <remarks><inheritdoc cref="Logger" path="/remarks"/></remarks>
     /// <returns><see cref="Logger"/> instance.</returns>
-#if NET8_0_OR_GREATER
+#if NET
     [Experimental(DiagnosticDefinitions.LogsBridgeExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
 #endif
     public
@@ -49,7 +49,7 @@ public class LoggerProvider : BaseProvider
     /// <remarks><inheritdoc cref="Logger" path="/remarks"/></remarks>
     /// <param name="name">Optional name identifying the instrumentation library.</param>
     /// <returns><see cref="Logger"/> instance.</returns>
-#if NET8_0_OR_GREATER
+#if NET
     [Experimental(DiagnosticDefinitions.LogsBridgeExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
 #endif
     public
@@ -67,7 +67,7 @@ public class LoggerProvider : BaseProvider
     /// <param name="name">Optional name identifying the instrumentation library.</param>
     /// <param name="version">Optional version of the instrumentation library.</param>
     /// <returns><see cref="Logger"/> instance.</returns>
-#if NET8_0_OR_GREATER
+#if NET
     [Experimental(DiagnosticDefinitions.LogsBridgeExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
 #endif
     public
@@ -94,7 +94,7 @@ public class LoggerProvider : BaseProvider
     /// <param name="name">Optional name identifying the instrumentation library.</param>
     /// <param name="logger"><see cref="Logger"/>.</param>
     /// <returns><see langword="true"/> if the logger was created.</returns>
-#if NET8_0_OR_GREATER
+#if NET
     [Experimental(DiagnosticDefinitions.LogsBridgeExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
 #endif
     protected

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusExporterMiddleware.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusExporterMiddleware.cs
@@ -65,7 +65,7 @@ internal sealed class PrometheusExporterMiddleware
                 if (dataView.Count > 0)
                 {
                     response.StatusCode = 200;
-#if NET8_0_OR_GREATER
+#if NET
                     response.Headers.Append("Last-Modified", collectionResponse.GeneratedAtUtc.ToString("R"));
 #else
                     response.Headers.Add("Last-Modified", collectionResponse.GeneratedAtUtc.ToString("R"));

--- a/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggingExtensions.cs
+++ b/src/OpenTelemetry/Logs/ILogger/OpenTelemetryLoggingExtensions.cs
@@ -71,7 +71,7 @@ public static class OpenTelemetryLoggingExtensions
     /// </remarks>
     /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
     /// <returns>The supplied <see cref="ILoggingBuilder"/> for call chaining.</returns>
-#if NET8_0_OR_GREATER
+#if NET
     [Experimental(DiagnosticDefinitions.LoggerProviderExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
 #endif
     public
@@ -90,7 +90,7 @@ public static class OpenTelemetryLoggingExtensions
     /// <param name="builder">The <see cref="ILoggingBuilder"/> to use.</param>
     /// <param name="configure"><see cref="LoggerProviderBuilder"/> configuration action.</param>
     /// <returns>The supplied <see cref="ILoggingBuilder"/> for call chaining.</returns>
-#if NET8_0_OR_GREATER
+#if NET
     [Experimental(DiagnosticDefinitions.LoggerProviderExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
 #endif
     public
@@ -115,7 +115,7 @@ public static class OpenTelemetryLoggingExtensions
     /// <param name="configureBuilder">Optional <see cref="LoggerProviderBuilder"/> configuration action.</param>
     /// <param name="configureOptions">Optional <see cref="OpenTelemetryLoggerOptions"/> configuration action.</param>
     /// <returns>The supplied <see cref="ILoggingBuilder"/> for call chaining.</returns>
-#if NET8_0_OR_GREATER
+#if NET
     [Experimental(DiagnosticDefinitions.LoggerProviderExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
 #endif
     public

--- a/src/OpenTelemetry/Logs/LogRecord.cs
+++ b/src/OpenTelemetry/Logs/LogRecord.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
-#if EXPOSE_EXPERIMENTAL_FEATURES && NET8_0_OR_GREATER
+#if EXPOSE_EXPERIMENTAL_FEATURES && NET
 using System.Diagnostics.CodeAnalysis;
 #endif
 using System.Runtime.CompilerServices;
@@ -355,7 +355,7 @@ public sealed class LogRecord
     /// known at the source.
     /// </summary>
     /// <remarks><inheritdoc cref="Sdk.CreateLoggerProviderBuilder" path="/remarks"/></remarks>
-#if NET8_0_OR_GREATER
+#if NET
     [Experimental(DiagnosticDefinitions.LogsBridgeExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
 #endif
     public
@@ -377,7 +377,7 @@ public sealed class LogRecord
     /// Gets or sets the log <see cref="LogRecordSeverity"/>.
     /// </summary>
     /// <remarks><inheritdoc cref="Sdk.CreateLoggerProviderBuilder" path="/remarks"/></remarks>
-#if NET8_0_OR_GREATER
+#if NET
     [Experimental(DiagnosticDefinitions.LogsBridgeExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
 #endif
     public
@@ -405,7 +405,7 @@ public sealed class LogRecord
     /// typically the <see cref="Logs.Logger"/> which emitted the <see
     /// cref="LogRecord"/> however the value may be different if <see
     /// cref="CategoryName"/> is modified.</remarks>
-#if NET8_0_OR_GREATER
+#if NET
     [Experimental(DiagnosticDefinitions.LogsBridgeExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
 #endif
     public Logger Logger { get; internal set; } = InstrumentationScopeLogger.Default;

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Collections.Concurrent;
-#if NET8_0_OR_GREATER
+#if NET
 using System.Collections.Frozen;
 #endif
 using System.Diagnostics;
@@ -14,7 +14,7 @@ namespace OpenTelemetry.Metrics;
 
 internal sealed class AggregatorStore
 {
-#if NET8_0_OR_GREATER
+#if NET
     internal readonly FrozenSet<string>? TagKeysInteresting;
 #else
     internal readonly HashSet<string>? TagKeysInteresting;
@@ -96,7 +96,7 @@ internal sealed class AggregatorStore
         {
             this.updateLongCallback = this.UpdateLongCustomTags;
             this.updateDoubleCallback = this.UpdateDoubleCustomTags;
-#if NET8_0_OR_GREATER
+#if NET
             var hs = FrozenSet.ToFrozenSet(metricStreamIdentity.TagKeys, StringComparer.Ordinal);
 #else
             var hs = new HashSet<string>(metricStreamIdentity.TagKeys, StringComparer.Ordinal);

--- a/src/OpenTelemetry/Metrics/Exemplar/Exemplar.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/Exemplar.cs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#if NET8_0_OR_GREATER
+#if NET
 using System.Collections.Frozen;
 #endif
 using System.Diagnostics;
@@ -17,7 +17,7 @@ namespace OpenTelemetry.Metrics;
 /// </remarks>
 public struct Exemplar
 {
-#if NET8_0_OR_GREATER
+#if NET
     internal FrozenSet<string>? ViewDefinedTagKeys;
 #else
     internal HashSet<string>? ViewDefinedTagKeys;

--- a/src/OpenTelemetry/Metrics/Exemplar/ExemplarMeasurement.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/ExemplarMeasurement.cs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#if EXPOSE_EXPERIMENTAL_FEATURES && NET8_0_OR_GREATER
+#if EXPOSE_EXPERIMENTAL_FEATURES && NET
 using System.Diagnostics.CodeAnalysis;
 using OpenTelemetry.Internal;
 #endif
@@ -14,7 +14,7 @@ namespace OpenTelemetry.Metrics;
 /// </summary>
 /// <remarks><inheritdoc cref="ExemplarReservoir" path="/remarks/para[@experimental-warning='true']"/></remarks>
 /// <typeparam name="T">Measurement type.</typeparam>
-#if NET8_0_OR_GREATER
+#if NET
 [Experimental(DiagnosticDefinitions.ExemplarReservoirExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
 #endif
 public

--- a/src/OpenTelemetry/Metrics/Exemplar/ExemplarReservoir.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/ExemplarReservoir.cs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#if EXPOSE_EXPERIMENTAL_FEATURES && NET8_0_OR_GREATER
+#if EXPOSE_EXPERIMENTAL_FEATURES && NET
 using System.Diagnostics.CodeAnalysis;
 using OpenTelemetry.Internal;
 #endif
@@ -17,7 +17,7 @@ namespace OpenTelemetry.Metrics;
 /// Specification: <see
 /// href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#exemplarreservoir"/>.
 /// </remarks>
-#if NET8_0_OR_GREATER
+#if NET
 [Experimental(DiagnosticDefinitions.ExemplarReservoirExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
 #endif
 public

--- a/src/OpenTelemetry/Metrics/Exemplar/FixedSizeExemplarReservoir.cs
+++ b/src/OpenTelemetry/Metrics/Exemplar/FixedSizeExemplarReservoir.cs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#if EXPOSE_EXPERIMENTAL_FEATURES && NET8_0_OR_GREATER
+#if EXPOSE_EXPERIMENTAL_FEATURES && NET
 using System.Diagnostics.CodeAnalysis;
 #endif
 using OpenTelemetry.Internal;
@@ -14,7 +14,7 @@ namespace OpenTelemetry.Metrics;
 /// number of <see cref="Exemplar"/>s.
 /// </summary>
 /// <remarks><inheritdoc cref="ExemplarReservoir" path="/remarks/para[@experimental-warning='true']"/></remarks>
-#if NET8_0_OR_GREATER
+#if NET
 [Experimental(DiagnosticDefinitions.ExemplarReservoirExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
 #endif
 public

--- a/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
+++ b/src/OpenTelemetry/Metrics/ThreadStaticStorage.cs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#if NET8_0_OR_GREATER
+#if NET
 using System.Collections.Frozen;
 #endif
 using System.Diagnostics;
@@ -57,7 +57,7 @@ internal sealed class ThreadStaticStorage
     internal void SplitToKeysAndValues(
         ReadOnlySpan<KeyValuePair<string, object?>> tags,
         int tagLength,
-#if NET8_0_OR_GREATER
+#if NET
         FrozenSet<string> tagKeysInteresting,
 #else
         HashSet<string> tagKeysInteresting,

--- a/src/OpenTelemetry/Metrics/View/MetricStreamConfiguration.cs
+++ b/src/OpenTelemetry/Metrics/View/MetricStreamConfiguration.cs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#if EXPOSE_EXPERIMENTAL_FEATURES && NET8_0_OR_GREATER
+#if EXPOSE_EXPERIMENTAL_FEATURES && NET
 using System.Diagnostics.CodeAnalysis;
 #endif
 using OpenTelemetry.Internal;
@@ -116,7 +116,7 @@ public class MetricStreamConfiguration
     /// If not set the default
     /// MeterProvider cardinality limit of 2000 will apply.
     /// </remarks>
-#if NET8_0_OR_GREATER
+#if NET
     [Experimental(DiagnosticDefinitions.CardinalityLimitExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
 #endif
     public
@@ -151,7 +151,7 @@ public class MetricStreamConfiguration
     /// Specification: <see
     /// href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#stream-configuration"/>.
     /// </remarks>
-#if NET8_0_OR_GREATER
+#if NET
     [Experimental(DiagnosticDefinitions.ExemplarReservoirExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
 #endif
     public Func<ExemplarReservoir?>? ExemplarReservoirFactory { get; set; }

--- a/src/OpenTelemetry/ReadOnlyFilteredTagCollection.cs
+++ b/src/OpenTelemetry/ReadOnlyFilteredTagCollection.cs
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#if NET8_0_OR_GREATER
+#if NET
 using System.Collections.Frozen;
 #endif
 using System.Diagnostics;
@@ -16,7 +16,7 @@ namespace OpenTelemetry;
 // prevent accidental boxing.
 public readonly struct ReadOnlyFilteredTagCollection
 {
-#if NET8_0_OR_GREATER
+#if NET
     private readonly FrozenSet<string>? excludedKeys;
 #else
     private readonly HashSet<string>? excludedKeys;
@@ -25,7 +25,7 @@ public readonly struct ReadOnlyFilteredTagCollection
     private readonly int count;
 
     internal ReadOnlyFilteredTagCollection(
-#if NET8_0_OR_GREATER
+#if NET
         FrozenSet<string>? excludedKeys,
 #else
         HashSet<string>? excludedKeys,

--- a/src/OpenTelemetry/Sdk.cs
+++ b/src/OpenTelemetry/Sdk.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
-#if EXPOSE_EXPERIMENTAL_FEATURES && NET8_0_OR_GREATER
+#if EXPOSE_EXPERIMENTAL_FEATURES && NET
 using System.Diagnostics.CodeAnalysis;
 #endif
 using OpenTelemetry.Context.Propagation;
@@ -89,7 +89,7 @@ public static class Sdk
     /// <remarks><b>WARNING</b>: This is an experimental API which might change or be removed in the future. Use at your own risk.</remarks>
     /// <returns><see cref="LoggerProviderBuilder"/> instance, which is used
     /// to build a <see cref="LoggerProvider"/>.</returns>
-#if NET8_0_OR_GREATER
+#if NET
     [Experimental(DiagnosticDefinitions.LogsBridgeExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
 #endif
     public

--- a/src/OpenTelemetry/Trace/Builder/TracerProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Trace/Builder/TracerProviderBuilderExtensions.cs
@@ -27,7 +27,7 @@ public static class TracerProviderBuilderExtensions
     /// <remarks>
     /// This method is not supported in native AOT or Mono Runtime as of .NET 8.
     /// </remarks>
-#if NET7_0_OR_GREATER
+#if NET
     [RequiresDynamicCode("The code for detecting exception and setting error status might not be available.")]
 #endif
     public static TracerProviderBuilder SetErrorStatusOnException(this TracerProviderBuilder tracerProviderBuilder, bool enabled = true)


### PR DESCRIPTION
Fixes #5848
Follow up to #5712

## Changes

Simplify preprocessor directives after dropping support for .NET 6 and .NET7

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
