### PR TITLE
[repo] Update stale.yml - reduce days before stale to 600

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
           close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
           operations-per-run: 400
           days-before-pr-stale: 7
-          days-before-issue-stale: 900
+          days-before-issue-stale: 600
           days-before-pr-close: 7
           days-before-issue-close: 7
           exempt-all-issue-milestones: true


### PR DESCRIPTION
Follow up to https://github.com/open-telemetry/opentelemetry-dotnet/issues/5776

This PR moves the days-before-issue-stale from 900 to 600.
The ultimate goal is to get this down to 300 days.

## Counts of issues

- Currently 309 open issues (Sept 23, 2024).
- older than 300 days (Nov 28, 2023) = 136 issues
- older than 600 days (Feb 1, 2023) = 57 issues ([link](https://github.com/open-telemetry/opentelemetry-dotnet/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-asc+updated%3A%3C%3D2023-02-01+))

## Screenshot of affected issues

<details>
  <summary>Click here to expand</summary>
  
![image](https://github.com/user-attachments/assets/afa77227-2236-4212-9b24-dc036ee256a9)

![image](https://github.com/user-attachments/assets/aa32107e-4857-4dd7-8642-f366267ddd63)

![image](https://github.com/user-attachments/assets/342b69ff-ce2e-429e-90f7-1d49c190cea8)

</details>


