### PR TITLE
Cleanup W3CTraceContextTests

### DIFF
--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/W3CTraceContextTests.cs
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/W3CTraceContextTests.cs
@@ -20,8 +20,7 @@ public class W3CTraceContextTests : IDisposable
         To run the tests, invoke docker-compose.yml from the root of the repo:
         opentelemetry>docker compose --file=test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/docker-compose.yml --project-directory=. up --exit-code-from=tests --build
      */
-    private const string W3cTraceContextEnvVarName = "OTEL_W3CTRACECONTEXT";
-    private static readonly Version? AspNetCoreHostingVersion = typeof(Microsoft.AspNetCore.Hosting.Builder.IApplicationBuilderFactory).Assembly.GetName().Version;
+    private const string W3CTraceContextEnvVarName = "OTEL_W3CTRACECONTEXT";
     private readonly HttpClient httpClient = new();
     private readonly ITestOutputHelper output;
 
@@ -31,13 +30,13 @@ public class W3CTraceContextTests : IDisposable
     }
 
     [Trait("CategoryName", "W3CTraceContextTests")]
-    [SkipUnlessEnvVarFoundTheory(W3cTraceContextEnvVarName)]
+    [SkipUnlessEnvVarFoundTheory(W3CTraceContextEnvVarName)]
     [InlineData("placeholder")]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1026:Theory methods should use all of their parameters", Justification = "Need to use SkipUnlessEnvVarFoundTheory")]
     public void W3CTraceContextTestSuiteAsync(string value)
     {
         // configure SDK
-        using var tracerprovider = Sdk.CreateTracerProviderBuilder()
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
         .AddAspNetCoreInstrumentation()
         .Build();
 
@@ -51,13 +50,11 @@ public class W3CTraceContextTests : IDisposable
             {
                 foreach (var argument in data)
                 {
-                    using var request = new HttpRequestMessage(HttpMethod.Post, argument.Url)
-                    {
-                        Content = new StringContent(
-                            JsonSerializer.Serialize(argument.Arguments),
-                            Encoding.UTF8,
-                            "application/json"),
-                    };
+                    using var request = new HttpRequestMessage(HttpMethod.Post, argument.Url);
+                    request.Content = new StringContent(
+                        JsonSerializer.Serialize(argument.Arguments),
+                        Encoding.UTF8,
+                        "application/json");
                     await this.httpClient.SendAsync(request);
                 }
             }
@@ -79,19 +76,7 @@ public class W3CTraceContextTests : IDisposable
         this.output.WriteLine("result:" + result);
 
         // Assert on the last line
-
-        // TODO: Investigate failures on .NET6 vs .NET7. To see the details
-        // run the tests with console logger (done automatically by the CI
-        // jobs).
-
-        if (AspNetCoreHostingVersion!.Major <= 6)
-        {
-            Assert.StartsWith("FAILED (failures=3)", lastLine);
-        }
-        else
-        {
-            Assert.StartsWith("OK", lastLine);
-        }
+        Assert.StartsWith("OK", lastLine);
     }
 
     public void Dispose()


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-dotnet/pull/5832#pullrequestreview-2314388778 - part 3.

## Changes

Cleanup W3CTraceContextTests after dropping support for .NET6
+ semi automatic cleanup of suggestions in this file.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
