### PR TITLE
[repo] Take advantage of System.Threading.Lock when compiling against .NET9

### DIFF
--- a/OpenTelemetry.sln
+++ b/OpenTelemetry.sln
@@ -281,6 +281,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shims", "Shims", "{A0CB9A10-F22D-4E66-A449-74B3D0361A9C}"
 	ProjectSection(SolutionItems) = preProject
 		src\Shared\Shims\IsExternalInit.cs = src\Shared\Shims\IsExternalInit.cs
+		src\Shared\Shims\Lock.cs = src\Shared\Shims\Lock.cs
 		src\Shared\Shims\NullableAttributes.cs = src\Shared\Shims\NullableAttributes.cs
 	EndProjectSection
 EndProject

--- a/src/OpenTelemetry.Api/OpenTelemetry.Api.csproj
+++ b/src/OpenTelemetry.Api/OpenTelemetry.Api.csproj
@@ -19,6 +19,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\ExceptionExtensions.cs" Link="Includes\ExceptionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SemanticConventions.cs" Link="Includes\SemanticConventions.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\Shims\Lock.cs" Link="Includes\Shims\Lock.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\SpanAttributeConstants.cs" Link="Includes\SpanAttributeConstants.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\StatusHelper.cs" Link="Includes\StatusHelper.cs" />
   </ItemGroup>

--- a/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
@@ -10,7 +10,7 @@ namespace OpenTelemetry.Exporter;
 public class ConsoleLogRecordExporter : ConsoleExporter<LogRecord>
 {
     private const int RightPaddingLength = 35;
-    private readonly object syncObject = new();
+    private readonly Lock syncObject = new();
     private bool disposed;
     private string? disposedStackTrace;
     private bool isDisposeMessageSent;

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/OpenTelemetry.Exporter.Prometheus.HttpListener.csproj
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/OpenTelemetry.Exporter.Prometheus.HttpListener.csproj
@@ -19,6 +19,7 @@
     <Compile Include="$(RepoRoot)\src\Shared\ExceptionExtensions.cs" Link="Includes\ExceptionExtensions.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Guard.cs" Link="Includes\Guard.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\MathHelper.cs" Link="Includes\MathHelper.cs" />
+    <Compile Include="$(RepoRoot)\src\Shared\Shims\Lock.cs" Link="Includes\Shims\Lock.cs" />
     <Compile Include="$(RepoRoot)\src\Shared\Shims\NullableAttributes.cs" Link="Includes\Shims\NullableAttributes.cs" />
   </ItemGroup>
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
@@ -11,7 +11,7 @@ internal sealed class PrometheusHttpListener : IDisposable
 {
     private readonly PrometheusExporter exporter;
     private readonly HttpListener httpListener = new();
-    private readonly object syncObject = new();
+    private readonly Lock syncObject = new();
 
     private CancellationTokenSource? tokenSource;
     private Task? workerThread;

--- a/src/OpenTelemetry/Internal/SelfDiagnosticsEventListener.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnosticsEventListener.cs
@@ -16,7 +16,7 @@ internal sealed class SelfDiagnosticsEventListener : EventListener
     // Buffer size of the log line. A UTF-16 encoded character in C# can take up to 4 bytes if encoded in UTF-8.
     private const int BUFFERSIZE = 4 * 5120;
     private const string EventSourceNamePrefix = "OpenTelemetry-";
-    private readonly object lockObj = new();
+    private readonly Lock lockObj = new();
     private readonly EventLevel logLevel;
     private readonly SelfDiagnosticsConfigRefresher configRefresher;
     private readonly ThreadLocal<byte[]?> writeBuffer = new(() => null);

--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -31,8 +31,8 @@ internal sealed class AggregatorStore
     private static readonly string MetricPointCapHitFixMessage = "Consider opting in for the experimental SDK feature to emit all the throttled metrics under the overflow attribute by setting env variable OTEL_DOTNET_EXPERIMENTAL_METRICS_EMIT_OVERFLOW_ATTRIBUTE = true. You could also modify instrumentation to reduce the number of unique key/value pair combinations. Or use Views to drop unwanted tags. Or use MeterProviderBuilder.SetMaxMetricPointsPerMetricStream to set higher limit.";
     private static readonly Comparison<KeyValuePair<string, object?>> DimensionComparisonDelegate = (x, y) => x.Key.CompareTo(y.Key);
 
-    private readonly object lockZeroTags = new();
-    private readonly object lockOverflowTag = new();
+    private readonly Lock lockZeroTags = new();
+    private readonly Lock lockOverflowTag = new();
     private readonly int tagsKeysInterestingCount;
 
     // This holds the reclaimed MetricPoints that are available for reuse.

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -30,7 +30,7 @@ internal sealed class MeterProviderSdk : MeterProvider
 
     private readonly List<object> instrumentations = new();
     private readonly List<Func<Instrument, MetricStreamConfiguration?>> viewConfigs;
-    private readonly object collectLock = new();
+    private readonly Lock collectLock = new();
     private readonly MeterListener listener;
     private readonly MetricReader? reader;
     private readonly CompositeMetricReader? compositeMetricReader;

--- a/src/OpenTelemetry/Metrics/Reader/MetricReader.cs
+++ b/src/OpenTelemetry/Metrics/Reader/MetricReader.cs
@@ -36,8 +36,8 @@ public abstract partial class MetricReader : IDisposable
         };
     };
 
-    private readonly object newTaskLock = new();
-    private readonly object onCollectLock = new();
+    private readonly Lock newTaskLock = new();
+    private readonly Lock onCollectLock = new();
     private readonly TaskCompletionSource<bool> shutdownTcs = new();
     private MetricReaderTemporalityPreference temporalityPreference = MetricReaderTemporalityPreferenceUnspecified;
     private Func<Type, AggregationTemporality> temporalityFunc = CumulativeTemporalityPreferenceFunc;

--- a/src/OpenTelemetry/Metrics/Reader/MetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/Reader/MetricReaderExt.cs
@@ -16,7 +16,7 @@ public abstract partial class MetricReader
 {
     private readonly HashSet<string> metricStreamNames = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<MetricStreamIdentity, Metric> instrumentIdentityToMetric = new();
-    private readonly object instrumentCreationLock = new();
+    private readonly Lock instrumentCreationLock = new();
     private int metricLimit;
     private int cardinalityLimit;
     private Metric?[]? metrics;

--- a/src/OpenTelemetry/SimpleExportProcessor.cs
+++ b/src/OpenTelemetry/SimpleExportProcessor.cs
@@ -12,7 +12,7 @@ namespace OpenTelemetry;
 public abstract class SimpleExportProcessor<T> : BaseExportProcessor<T>
     where T : class
 {
-    private readonly object syncObject = new();
+    private readonly Lock syncObject = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SimpleExportProcessor{T}"/> class.

--- a/src/Shared/Shims/Lock.cs
+++ b/src/Shared/Shims/Lock.cs
@@ -1,0 +1,18 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if !NET9_0_OR_GREATER
+namespace OpenTelemetry;
+
+// Note: .NET9 added the System.Threading.Lock class. The goal here is when
+// compiling against .NET9+ code should use System.Threading.Lock class for
+// better perf. Legacy code can use this class which will perform a classic
+// monitor-based lock against a reference of this class. This type is not in the
+// System.Threading namespace so that the compiler doesn't get confused when it
+// sees it used. It is in OpenTelemetry namespace and not OpenTelemetry.Internal
+// namespace so that code should be able to use it without the presence of a
+// dedicated "using OpenTelemetry.Internal" just for the shim.
+internal sealed class Lock
+{
+}
+#endif


### PR DESCRIPTION
## Changes

* Updates the repo to use [System.Threading.Lock](https://learn.microsoft.com/dotnet/csharp/whats-new/csharp-13#new-lock-object) when compiling against .NET9

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
