### PR TITLE
[repo] Add Mothra as a triager

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ you're more than welcome to participate!
 ([@open-telemetry/dotnet-triagers](https://github.com/orgs/open-telemetry/teams/dotnet-triagers)):
 
 * [Martin Thwaites](https://github.com/martinjt), Honeycomb
+* [Timothy "Mothra" Lee](https://github.com/TimothyMothra), Microsoft
 
 [Emeritus
 Maintainer/Approver/Triager](https://github.com/open-telemetry/community/blob/main/community-membership.md#emeritus-maintainerapprovertriager):


### PR DESCRIPTION
@TimothyMothra has recently been working to implement a stale workflow and cleanup issues in the repo. Adding him as a triager will enable him to more easily clean up the issues. This was discussed and approved on the 9/24/2024 SIG meeting.

PRs: https://github.com/open-telemetry/opentelemetry-dotnet/pulls?q=is%3Apr+is%3Aclosed+author%3ATimothyMothra