### PR TITLE
[api] Better obsolete message for Activity.SetStatus extension method

### DIFF
--- a/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
@@ -29,7 +29,7 @@ public static class ActivityExtensions
     /// <param name="activity">Activity instance.</param>
     /// <param name="status">Activity execution status.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [Obsolete("Call Activity.SetStatus instead this method will be removed in a future version.")]
+    [Obsolete("Call Activity.SetStatus(ActivityStatusCode code, string? description = null) instead. This method will be removed in a future version.")]
     public static void SetStatus(this Activity? activity, Status status)
     {
         if (activity != null)


### PR DESCRIPTION
Follow up: #5781
Found while working on errors in https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2121

## Changes

Previous message was not user friednly:

```
opentelemetry-dotnet-contrib\test\OpenTelemetry.Exporter.Geneva.Tests\GenevaTraceExporterTests.cs(180,17,180,49): error CS0618: 'ActivityExtensions.SetStatus(Activity?, Status)' is obsolete: 'Call Activity.SetStatus instead this method will be removed in a future version.'
```

It was referring to the method with the same same without any signature.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
