### PR TITLE
[repo] Mitigate vulnerabilities in System.Text.Json 8.0.0 packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,4 +1,5 @@
 <Project>
+
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <OTelLatestStableVer>1.9.0</OTelLatestStableVer>
@@ -11,12 +12,6 @@
       vulnerability in the NuGet packages that are published from this repository.
   -->
   <ItemGroup>
-    <PackageVersion Include="Google.Protobuf" Version="[3.22.5,4.0)" />
-    <PackageVersion Include="Grpc" Version="[2.44.0,3.0)" />
-    <PackageVersion Include="Grpc.Net.Client" Version="[2.52.0,3.0)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.1.1,6.0)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Http.Features" Version="[2.1.1,6.0)" />
-
     <!--
         Typically, for the Microsoft.Extensions.* packages relating to DI Abstractions, Hosting Abstractions, and Logging,
         the latest stable version should be used because:
@@ -36,13 +31,15 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="$(LatestRuntimeOutOfBandVer)" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="$(LatestRuntimeOutOfBandVer)" />
 
+    <!--
+        OTel packages always point to latest stable release.
+    -->
     <PackageVersion Include="OpenTelemetry" Version="[$(OTelLatestStableVer),2.0)" />
     <PackageVersion Include="OpenTelemetry.Api" Version="[$(OTelLatestStableVer),2.0)" />
     <PackageVersion Include="OpenTelemetry.Api.ProviderBuilderExtensions" Version="[$(OTelLatestStableVer),2.0)" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="[$(OTelLatestStableVer),2.0)" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="[$(OTelLatestStableVer),2.0)" />
     <PackageVersion Include="OpenTelemetry.Extensions.Propagators" Version="[$(OTelLatestStableVer),2.0)" />
-    <PackageVersion Include="OpenTracing" Version="[0.12.1,0.13)" />
 
     <!--
         Typically, the latest stable version of System.Diagnostics.DiagnosticSource should be used here because:
@@ -54,16 +51,19 @@
           even during major version bumps, so compatibility is not a concern here.
     -->
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="$(LatestRuntimeOutOfBandVer)" />
-  </ItemGroup>
 
-  <ItemGroup>
-    <!-- We use conservative versions of these packages for older runtimes where an upgrade might introduce breaking changes -->
-    <PackageVersion Include="System.Text.Encodings.Web" Version="4.7.2" />
-    <PackageVersion Include="System.Text.Json" Version="4.7.2" />
+    <!--
+        We use conservative versions of the following because there is
+        concern/uncertainty that an upgrade might introduce breaking changes.
+    -->
+    <PackageVersion Include="Google.Protobuf" Version="[3.22.5,4.0)" />
+    <PackageVersion Include="Grpc" Version="[2.44.0,3.0)" />
+    <PackageVersion Include="Grpc.Net.Client" Version="[2.52.0,3.0)" />
+    <PackageVersion Include="OpenTracing" Version="[0.12.1,0.13)" />
 
-    <!-- Bump System.Text.Json on NETCoreApp targets to mitigate https://github.com/advisories/GHSA-hh2w-p6rv-4g7w -->
-    <PackageVersion Update="System.Text.Encodings.Web" Version="8.0.0" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
-    <PackageVersion Update="System.Text.Json" Version="8.0.4" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
+    <!-- Note: v8.0.4 is used for System.Text.Json to mitigate
+    https://github.com/advisories/GHSA-hh2w-p6rv-4g7w. -->
+    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
   <!--
@@ -104,7 +104,9 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.8" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.0-rc.1.24452.1" />
   </ItemGroup>
+
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <OTelLatestStableVer>1.9.0</OTelLatestStableVer>
+    <LatestRuntimeOutOfBandVer>9.0.0-rc.1.24431.7</LatestRuntimeOutOfBandVer>
   </PropertyGroup>
 
   <!--
@@ -26,14 +27,14 @@
           these packages even during major version bumps, so compatibility is not a concern here.
     -->
 
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0-rc.1.24431.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0-rc.1.24431.7" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0-rc.1.24431.7" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Abstractions" Version="9.0.0-rc.1.24431.7" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0-rc.1.24431.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0-rc.1.24431.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="9.0.0-rc.1.24431.7" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.0-rc.1.24431.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="$(LatestRuntimeOutOfBandVer)" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="$(LatestRuntimeOutOfBandVer)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(LatestRuntimeOutOfBandVer)" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Abstractions" Version="$(LatestRuntimeOutOfBandVer)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(LatestRuntimeOutOfBandVer)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(LatestRuntimeOutOfBandVer)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="$(LatestRuntimeOutOfBandVer)" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="$(LatestRuntimeOutOfBandVer)" />
 
     <PackageVersion Include="OpenTelemetry" Version="[$(OTelLatestStableVer),2.0)" />
     <PackageVersion Include="OpenTelemetry.Api" Version="[$(OTelLatestStableVer),2.0)" />
@@ -52,23 +53,23 @@
         3) The .NET runtime team provides extra backward compatibility guarantee to System.Diagnostics.DiagnosticSource
           even during major version bumps, so compatibility is not a concern here.
     -->
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.0-rc.1.24431.7" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="$(LatestRuntimeOutOfBandVer)" />
+  </ItemGroup>
 
-    <!-- A conservative version of System.Text.Encodings.Web must be used here since there is no backward compatibility guarantee during major version bumps. -->
+  <ItemGroup>
+    <!-- We use conservative versions of these packages for older runtimes where an upgrade might introduce breaking changes -->
     <PackageVersion Include="System.Text.Encodings.Web" Version="4.7.2" />
-
-    <!-- A conservative version of System.Text.Json must be used here since there is no backward compatibility guarantee during major version bumps. -->
     <PackageVersion Include="System.Text.Json" Version="4.7.2" />
 
-    <!-- A conservative version of System.Threading.Tasks.Extensions must be used here since there is no backward compatibility guarantee during major version bumps. -->
-    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <!-- Bump System.Text.Json on NETCoreApp targets to mitigate https://github.com/advisories/GHSA-hh2w-p6rv-4g7w -->
+    <PackageVersion Update="System.Text.Encodings.Web" Version="8.0.0" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
+    <PackageVersion Update="System.Text.Json" Version="8.0.4" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
   </ItemGroup>
 
   <!--
       This section covers packages that are **not** directly referenced by the NuGet packages published from this repository.
-      For example, these packages are used in the tests, examples or referenced as "PrivateAssets", but not in the NuGet packages themselves.
+      These packages are referenced as "PrivateAssets" or used in tests/examples.
   -->
-  <!-- 'net9.0' is the default `TargetFramework`. Use `VersionOverride` in the project to override the package versions from a different `TargetFramework` -->
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="[0.13.12,0.14)" />
     <PackageVersion Include="CommandLineParser" Version="[2.9.1,3.0)" />
@@ -77,15 +78,17 @@
     <PackageVersion Include="Grpc.Tools" Version="[2.59.0,3.0)" />
     <PackageVersion Include="Microsoft.CSharp" Version="[4.7.0]" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="[3.11.0-beta1.23525.2]" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="[9.0.0-rc.1.24431.7,)" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[9.0.0-rc.1.24431.7,)" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="[9.0.0-rc.1.24431.7,)" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="[9.0.0-rc.1.24431.7,)" />
+    <PackageVersion Include="Microsoft.Coyote" Version="1.7.11" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(LatestRuntimeOutOfBandVer)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(LatestRuntimeOutOfBandVer)" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="$(LatestRuntimeOutOfBandVer)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(LatestRuntimeOutOfBandVer)" />
     <PackageVersion Include="Microsoft.Extensions.Telemetry.Abstractions" Version="[9.0.0-preview.8.24460.1,)" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="[1.0.3,2.0)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="[17.11.0,18.0.0)" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="[8.0.0,9.0)" />
     <PackageVersion Include="MinVer" Version="[5.0.0,6.0)" />
+    <PackageVersion Include="NuGet.Versioning" Version="6.11.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="[1.9.0,2.0)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="[1.9.0-beta.1,2.0)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="[1.9.0,2.0)" />
@@ -93,6 +96,7 @@
     <PackageVersion Include="RabbitMQ.Client" Version="[6.8.1,7.0)" />
     <PackageVersion Include="StyleCop.Analyzers" Version="[1.2.0-beta.556,2.0)" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="[6.7.3,)" />
+    <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageVersion Include="xunit" Version="[2.9.0,3.0)" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="[2.8.2,3.0)" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <OTelLatestStableVer>1.9.0</OTelLatestStableVer>
-    <LatestRuntimeOutOfBandVer>9.0.0-rc.1.24431.7</LatestRuntimeOutOfBandVer>
   </PropertyGroup>
 
   <!--
@@ -12,6 +11,12 @@
       vulnerability in the NuGet packages that are published from this repository.
   -->
   <ItemGroup>
+    <PackageVersion Include="Google.Protobuf" Version="[3.22.5,4.0)" />
+    <PackageVersion Include="Grpc" Version="[2.44.0,3.0)" />
+    <PackageVersion Include="Grpc.Net.Client" Version="[2.52.0,3.0)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.1.1,6.0)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Http.Features" Version="[2.1.1,6.0)" />
+
     <!--
         Typically, for the Microsoft.Extensions.* packages relating to DI Abstractions, Hosting Abstractions, and Logging,
         the latest stable version should be used because:
@@ -22,24 +27,22 @@
           these packages even during major version bumps, so compatibility is not a concern here.
     -->
 
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="$(LatestRuntimeOutOfBandVer)" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="$(LatestRuntimeOutOfBandVer)" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(LatestRuntimeOutOfBandVer)" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Abstractions" Version="$(LatestRuntimeOutOfBandVer)" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(LatestRuntimeOutOfBandVer)" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(LatestRuntimeOutOfBandVer)" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="$(LatestRuntimeOutOfBandVer)" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="$(LatestRuntimeOutOfBandVer)" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0-rc.1.24431.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0-rc.1.24431.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0-rc.1.24431.7" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Abstractions" Version="9.0.0-rc.1.24431.7" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0-rc.1.24431.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0-rc.1.24431.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="9.0.0-rc.1.24431.7" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.0-rc.1.24431.7" />
 
-    <!--
-        OTel packages always point to latest stable release.
-    -->
     <PackageVersion Include="OpenTelemetry" Version="[$(OTelLatestStableVer),2.0)" />
     <PackageVersion Include="OpenTelemetry.Api" Version="[$(OTelLatestStableVer),2.0)" />
     <PackageVersion Include="OpenTelemetry.Api.ProviderBuilderExtensions" Version="[$(OTelLatestStableVer),2.0)" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="[$(OTelLatestStableVer),2.0)" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="[$(OTelLatestStableVer),2.0)" />
     <PackageVersion Include="OpenTelemetry.Extensions.Propagators" Version="[$(OTelLatestStableVer),2.0)" />
+    <PackageVersion Include="OpenTracing" Version="[0.12.1,0.13)" />
 
     <!--
         Typically, the latest stable version of System.Diagnostics.DiagnosticSource should be used here because:
@@ -50,16 +53,12 @@
         3) The .NET runtime team provides extra backward compatibility guarantee to System.Diagnostics.DiagnosticSource
           even during major version bumps, so compatibility is not a concern here.
     -->
-    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="$(LatestRuntimeOutOfBandVer)" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.0-rc.1.24431.7" />
 
     <!--
         We use conservative versions of the following because there is
         concern/uncertainty that an upgrade might introduce breaking changes.
     -->
-    <PackageVersion Include="Google.Protobuf" Version="[3.22.5,4.0)" />
-    <PackageVersion Include="Grpc" Version="[2.44.0,3.0)" />
-    <PackageVersion Include="Grpc.Net.Client" Version="[2.52.0,3.0)" />
-    <PackageVersion Include="OpenTracing" Version="[0.12.1,0.13)" />
 
     <!-- Note: v8.0.4 is used for System.Text.Json to mitigate
     https://github.com/advisories/GHSA-hh2w-p6rv-4g7w. -->
@@ -79,10 +78,10 @@
     <PackageVersion Include="Microsoft.CSharp" Version="[4.7.0]" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="[3.11.0-beta1.23525.2]" />
     <PackageVersion Include="Microsoft.Coyote" Version="1.7.11" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(LatestRuntimeOutOfBandVer)" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(LatestRuntimeOutOfBandVer)" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="$(LatestRuntimeOutOfBandVer)" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(LatestRuntimeOutOfBandVer)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="[9.0.0-rc.1.24431.7,)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[9.0.0-rc.1.24431.7,)" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="[9.0.0-rc.1.24431.7,)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="[9.0.0-rc.1.24431.7,)" />
     <PackageVersion Include="Microsoft.Extensions.Telemetry.Abstractions" Version="[9.0.0-preview.8.24460.1,)" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="[1.0.3,2.0)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="[17.11.0,18.0.0)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -59,9 +59,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- We use conservative versions of these packages for older runtimes where
-    an upgrade might introduce breaking changes. For example see:
-    https://learn.microsoft.com/dotnet/core/compatibility/serialization/7.0/reflection-fallback#type-of-breaking-change.
+    <!--
+        We use conservative versions of these packages for older runtimes where
+        an upgrade might introduce breaking changes. For example see:
+        https://devblogs.microsoft.com/dotnet/system-text-json-in-dotnet-7/#breaking-changes.
     -->
     <PackageVersion Include="System.Text.Encodings.Web" Version="4.7.2" />
     <PackageVersion Include="System.Text.Json" Version="4.7.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <OTelLatestStableVer>1.9.0</OTelLatestStableVer>
+    <SystemTextEncodingsWebOutOfBandMinimumCoreAppVer>8.0.0</SystemTextEncodingsWebOutOfBandMinimumCoreAppVer>
+    <SystemTextJsonOutOfBandMinimumCoreAppVer>8.0.4</SystemTextJsonOutOfBandMinimumCoreAppVer>
   </PropertyGroup>
 
   <!--
@@ -54,15 +56,19 @@
           even during major version bumps, so compatibility is not a concern here.
     -->
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.0-rc.1.24431.7" />
+  </ItemGroup>
 
-    <!--
-        We use conservative versions of the following because there is
-        concern/uncertainty that an upgrade might introduce breaking changes.
+  <ItemGroup>
+    <!-- We use conservative versions of these packages for older runtimes where
+    an upgrade might introduce breaking changes. For example see:
+    https://learn.microsoft.com/dotnet/core/compatibility/serialization/7.0/reflection-fallback#type-of-breaking-change.
     -->
+    <PackageVersion Include="System.Text.Encodings.Web" Version="4.7.2" />
+    <PackageVersion Include="System.Text.Json" Version="4.7.2" />
 
-    <!-- Note: v8.0.4 is used for System.Text.Json to mitigate
-    https://github.com/advisories/GHSA-hh2w-p6rv-4g7w. -->
-    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
+    <!-- Bump System.Text.Json on NETCoreApp targets to mitigate https://github.com/advisories/GHSA-hh2w-p6rv-4g7w. -->
+    <PackageVersion Update="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebOutOfBandMinimumCoreAppVer)" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
+    <PackageVersion Update="System.Text.Json" Version="$(SystemTextJsonOutOfBandMinimumCoreAppVer)" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
   </ItemGroup>
 
   <!--

--- a/OpenTelemetry.sln
+++ b/OpenTelemetry.sln
@@ -28,6 +28,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{7CB2F02E
 		build\Common.nonprod.props = build\Common.nonprod.props
 		build\Common.prod.props = build\Common.prod.props
 		build\Common.props = build\Common.props
+		build\Common.targets = build\Common.targets
 		build\debug.snk = build\debug.snk
 		Directory.Packages.props = Directory.Packages.props
 		build\docfx.cmd = build\docfx.cmd
@@ -112,7 +113,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{D2E73927-5
 	ProjectSection(SolutionItems) = preProject
 		test\Directory.Build.props = test\Directory.Build.props
 		test\Directory.Build.targets = test\Directory.Build.targets
-		test\Directory.Packages.props = test\Directory.Packages.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Examples.Console", "examples\Console\Examples.Console.csproj", "{FF3E6E08-E8E4-4523-B526-847CD989279F}"
@@ -129,7 +129,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{2C7DD1DA-C229-4D9E-9AF0-BCD5CD3E4948}"
 	ProjectSection(SolutionItems) = preProject
 		examples\Directory.Build.props = examples\Directory.Build.props
-		examples\Directory.Packages.props = examples\Directory.Packages.props
+		examples\Directory.Build.targets = examples\Directory.Build.targets
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "trace", "trace", "{5B7FB835-3FFF-4BC2-99C5-A5B5FAE3C818}"

--- a/build/Common.props
+++ b/build/Common.props
@@ -31,6 +31,7 @@
     <TargetFrameworksForLibraries>net9.0;net8.0;netstandard2.0;$(NetFrameworkMinimumSupportedVersion)</TargetFrameworksForLibraries>
     <TargetFrameworksForLibrariesExtended>net9.0;net8.0;netstandard2.1;netstandard2.0;$(NetFrameworkMinimumSupportedVersion)</TargetFrameworksForLibrariesExtended>
     <TargetFrameworksForPrometheusAspNetCore>net9.0;net8.0</TargetFrameworksForPrometheusAspNetCore>
+    <TargetFrameworksRequiringSystemTextJsonDirectReference>net8.0;netstandard2.1;netstandard2.0;$(NetFrameworkMinimumSupportedVersion)</TargetFrameworksRequiringSystemTextJsonDirectReference>
 
     <!-- non-production TFMs -->
     <TargetFrameworksForAspNetCoreTests>net9.0;net8.0</TargetFrameworksForAspNetCoreTests>

--- a/build/Common.targets
+++ b/build/Common.targets
@@ -1,7 +1,6 @@
 <Project>
 
   <ItemGroup Condition="'$(ReferenceSystemTextJsonPackages)' == 'true' AND $(TargetFrameworksRequiringSystemTextJsonDirectReference.Contains('$(TargetFramework)'))">
-    <PackageReference Include="System.Text.Encodings.Web" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 

--- a/build/Common.targets
+++ b/build/Common.targets
@@ -1,0 +1,8 @@
+<Project>
+
+  <ItemGroup Condition="'$(ReferenceSystemTextJsonPackages)' == 'true' AND $(TargetFrameworksRequiringSystemTextJsonDirectReference.Contains('$(TargetFramework)'))">
+    <PackageReference Include="System.Text.Encodings.Web" />
+    <PackageReference Include="System.Text.Json" />
+  </ItemGroup>
+
+</Project>

--- a/build/Common.targets
+++ b/build/Common.targets
@@ -1,6 +1,11 @@
 <Project>
 
   <ItemGroup Condition="'$(ReferenceSystemTextJsonPackages)' == 'true' AND $(TargetFrameworksRequiringSystemTextJsonDirectReference.Contains('$(TargetFramework)'))">
+    <!-- Note: System.Text.Encodings.Web is referenced on NET Framework & NET
+    Standard targets because System.Text.Json v4.7.2 uses
+    System.Text.Encodings.Web >= v4.7.1 but System.Text.Encodings.Web needs to
+    be at v4.7.2 to be safe. -->
+    <PackageReference Include="System.Text.Encodings.Web" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 

--- a/examples/Directory.Build.targets
+++ b/examples/Directory.Build.targets
@@ -1,0 +1,5 @@
+<Project>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.targets" />
+
+</Project>

--- a/examples/Directory.Packages.props
+++ b/examples/Directory.Packages.props
@@ -1,6 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
-  <ItemGroup>
-    <PackageVersion Update="System.Text.Json" Version="9.0.0-rc.1.24431.7" />
-  </ItemGroup>
-</Project>

--- a/examples/MicroserviceExample/WorkerService/WorkerService.csproj
+++ b/examples/MicroserviceExample/WorkerService/WorkerService.csproj
@@ -6,8 +6,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="RabbitMQ.Client" />
-    <!-- System.Text.Json is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-hh2w-p6rv-4g7w -->
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -16,6 +16,15 @@
     <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)'=='$(NetFrameworkMinimumSupportedVersion)'">
+    <!--ImplicitUsings will add this namespace that is not available for NetFX.
+    https://github.com/dotnet/sdk/issues/24146
+    https://github.com/dotnet/runtime/issues/59163
+    https://github.com/dotnet/sdk/issues/22515
+    -->
+    <Using Remove="System.Net.Http" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(IsPackable)' == 'true'">
     <None Include="$(PackagePrimaryLicenseFile)"
           PackagePath="$([System.IO.Path]::GetFileName('$(PackagePrimaryLicenseFile)'))"

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,5 +1,7 @@
 <Project>
 
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.targets" />
+
   <PropertyGroup>
     <!-- Note: PackageValidationBaselineVersion and IsPackable are defined in
     targets because $(MinVerTagPrefix) is not available in props files as they
@@ -12,15 +14,6 @@
 
   <ItemGroup>
     <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='$(NetFrameworkMinimumSupportedVersion)'">
-    <!--ImplicitUsings will add this namespace that is not available for NetFX.
-    https://github.com/dotnet/sdk/issues/24146
-    https://github.com/dotnet/runtime/issues/59163
-    https://github.com/dotnet/sdk/issues/22515
-    -->
-    <Using Remove="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsPackable)' == 'true'">

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -6,9 +6,8 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* Added direct reference to `System.Text.Encodings.Web` and `System.Text.Json`
-  for the `net8.0` target with minimum version of `8.0.0` and `8.0.4`
-  (respectively) in response to
+* Added a direct reference to `System.Text.Json` for all targets < `net9.0` with
+  a minimum version of `8.0.4` in response to
   [CVE-2024-30105](https://github.com/advisories/GHSA-hh2w-p6rv-4g7w).
   ([#5874](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5874))
 

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -6,8 +6,8 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* Added a direct reference to `System.Text.Json` for all targets < `net9.0` with
-  a minimum version of `8.0.4` in response to
+* Added direct reference to `System.Text.Json` for the `net8.0` target with
+  minimum version of `8.0.4` (respectively) in response to
   [CVE-2024-30105](https://github.com/advisories/GHSA-hh2w-p6rv-4g7w).
   ([#5874](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5874))
 

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -6,6 +6,12 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Added direct reference to `System.Text.Encodings.Web` and `System.Text.Json`
+  for the `net8.0` target with minimum version of `8.0.0` and `8.0.4`
+  (respectively) in response to
+  [CVE-2024-30105](https://github.com/advisories/GHSA-hh2w-p6rv-4g7w).
+  ([#5874](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5874))
+
 ## 1.10.0-beta.1
 
 Released 2024-Sep-30
@@ -114,7 +120,8 @@ Released 2023-May-25
   ([#4507](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4507))
 
 * Added direct reference to `System.Text.Encodings.Web` with minimum version of
-`4.7.2` in response to [CVE-2021-26701](https://github.com/dotnet/runtime/issues/49377).
+  `4.7.2` in response to
+  [CVE-2021-26701](https://github.com/dotnet/runtime/issues/49377).
   ([#4390](https://github.com/open-telemetry/opentelemetry-dotnet/pull/4390))
 
 * Updated `LogRecord` console output: `Body` is now shown (if set),

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -7,7 +7,7 @@ Notes](../../RELEASENOTES.md).
 ## Unreleased
 
 * Added direct reference to `System.Text.Json` for the `net8.0` target with
-  minimum version of `8.0.4` (respectively) in response to
+  minimum version of `8.0.4` in response to
   [CVE-2024-30105](https://github.com/advisories/GHSA-hh2w-p6rv-4g7w).
   ([#5874](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5874))
 

--- a/src/OpenTelemetry.Exporter.Console/OpenTelemetry.Exporter.Console.csproj
+++ b/src/OpenTelemetry.Exporter.Console/OpenTelemetry.Exporter.Console.csproj
@@ -5,16 +5,12 @@
     <Description>Console exporter for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);Console;distributed-tracing</PackageTags>
     <MinVerTagPrefix>core-</MinVerTagPrefix>
+    <ReferenceSystemTextJsonPackages>true</ReferenceSystemTextJsonPackages>
   </PropertyGroup>
 
   <PropertyGroup>
     <NoWarn>$(NoWarn),1591</NoWarn>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == '$(NetFrameworkMinimumSupportedVersion)'">
-    <PackageReference Include="System.Text.Encodings.Web" />
-    <PackageReference Include="System.Text.Json" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry\OpenTelemetry.csproj" />

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -6,6 +6,12 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Added direct reference to `System.Text.Encodings.Web` and `System.Text.Json`
+  for the `net8.0` target with minimum version of `8.0.0` and `8.0.4`
+  (respectively) in response to
+  [CVE-2024-30105](https://github.com/advisories/GHSA-hh2w-p6rv-4g7w).
+  ([#5874](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5874))
+
 ## 1.10.0-beta.1
 
 Released 2024-Sep-30

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -6,9 +6,8 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* Added direct reference to `System.Text.Encodings.Web` and `System.Text.Json`
-  for the `net8.0` target with minimum version of `8.0.0` and `8.0.4`
-  (respectively) in response to
+* Added a direct reference to `System.Text.Json` for all targets < `net9.0` with
+  a minimum version of `8.0.4` in response to
   [CVE-2024-30105](https://github.com/advisories/GHSA-hh2w-p6rv-4g7w).
   ([#5874](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5874))
 

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -6,8 +6,8 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* Added a direct reference to `System.Text.Json` for all targets < `net9.0` with
-  a minimum version of `8.0.4` in response to
+* Added direct reference to `System.Text.Json` for the `net8.0` target with
+  minimum version of `8.0.4` (respectively) in response to
   [CVE-2024-30105](https://github.com/advisories/GHSA-hh2w-p6rv-4g7w).
   ([#5874](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5874))
 

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -7,7 +7,7 @@ Notes](../../RELEASENOTES.md).
 ## Unreleased
 
 * Added direct reference to `System.Text.Json` for the `net8.0` target with
-  minimum version of `8.0.4` (respectively) in response to
+  minimum version of `8.0.4` in response to
   [CVE-2024-30105](https://github.com/advisories/GHSA-hh2w-p6rv-4g7w).
   ([#5874](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5874))
 

--- a/src/OpenTelemetry.Exporter.Zipkin/OpenTelemetry.Exporter.Zipkin.csproj
+++ b/src/OpenTelemetry.Exporter.Zipkin/OpenTelemetry.Exporter.Zipkin.csproj
@@ -1,9 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworksForLibraries)</TargetFrameworks>
     <Description>Zipkin exporter for OpenTelemetry .NET</Description>
     <PackageTags>$(PackageTags);Zipkin;distributed-tracing</PackageTags>
     <MinVerTagPrefix>core-</MinVerTagPrefix>
+    <ReferenceSystemTextJsonPackages>true</ReferenceSystemTextJsonPackages>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,11 +27,6 @@
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry\OpenTelemetry.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == '$(NetFrameworkMinimumSupportedVersion)'">
-    <PackageReference Include="System.Text.Encodings.Web" />
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -2,6 +2,15 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.targets" />
 
+  <ItemGroup Condition="'$(TargetFramework)'=='$(NetFrameworkMinimumSupportedVersion)'">
+    <!--ImplicitUsings will add this namespace that is not available for NetFX.
+    https://github.com/dotnet/sdk/issues/24146
+    https://github.com/dotnet/runtime/issues/59163
+    https://github.com/dotnet/sdk/issues/22515
+    -->
+    <Using Remove="System.Net.Http" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(ReferenceCoyotePackages)' == 'true'">
     <PackageReference Include="Microsoft.Coyote" />
 

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -1,10 +1,15 @@
 <Project>
-  <ItemGroup Condition="'$(TargetFramework)'=='$(NetFrameworkMinimumSupportedVersion)'">
-    <!--ImplicitUsings will add this namespace that is not available for NetFX.
-    https://github.com/dotnet/sdk/issues/24146
-    https://github.com/dotnet/runtime/issues/59163
-    https://github.com/dotnet/sdk/issues/22515
-    -->
-    <Using Remove="System.Net.Http" />
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.targets" />
+
+  <ItemGroup Condition="'$(ReferenceCoyotePackages)' == 'true'">
+    <PackageReference Include="Microsoft.Coyote" />
+
+    <!-- System.Text.Json is an indirect reference through Coyote. This
+    reference is needed to mitigate:
+    https://github.com/advisories/GHSA-hh2w-p6rv-4g7w. Remove this if Coyote
+    publishes a fixed version. -->
+    <PackageReference Include="System.Text.Json" VersionOverride="$(LatestRuntimeOutOfBandVer)" />
   </ItemGroup>
+
 </Project>

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -18,7 +18,7 @@
     reference is needed to mitigate:
     https://github.com/advisories/GHSA-hh2w-p6rv-4g7w. Remove this if Coyote
     publishes a fixed version. -->
-    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="System.Text.Json" VersionOverride="$(SystemTextJsonOutOfBandMinimumCoreAppVer)" />
   </ItemGroup>
 
 </Project>

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -18,7 +18,7 @@
     reference is needed to mitigate:
     https://github.com/advisories/GHSA-hh2w-p6rv-4g7w. Remove this if Coyote
     publishes a fixed version. -->
-    <PackageReference Include="System.Text.Json" VersionOverride="$(LatestRuntimeOutOfBandVer)" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
 </Project>

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -1,9 +1,0 @@
-<Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
-  <ItemGroup>
-    <PackageVersion Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-    <PackageVersion Update="System.Text.Json" Version="9.0.0-rc.1.24431.7" />
-    <PackageVersion Include="NuGet.Versioning" Version="6.11.0" />
-    <PackageVersion Include="Microsoft.Coyote" Version="1.7.11" />
-  </ItemGroup>
-</Project>

--- a/test/OpenTelemetry.Api.Tests/OpenTelemetry.Api.Tests.csproj
+++ b/test/OpenTelemetry.Api.Tests/OpenTelemetry.Api.Tests.csproj
@@ -1,8 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Description>Unit test project for OpenTelemetry.Api</Description>
     <TargetFrameworks>$(TargetFrameworksForTests)</TargetFrameworks>
     <NoWarn>$(NoWarn),CS0618</NoWarn>
+    <ReferenceCoyotePackages>true</ReferenceCoyotePackages>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,11 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Coyote" />
-    <!-- System.Text.Json is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-hh2w-p6rv-4g7w -->
-    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
   </ItemGroup>
+
 </Project>

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.csproj
@@ -11,11 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <!-- System.Text.Json is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-hh2w-p6rv-4g7w -->
-    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Description>Unit test project for Prometheus Exporter AspNetCore for OpenTelemetry</Description>
     <TargetFrameworks>$(TargetFrameworksForAspNetCoreTests)</TargetFrameworks>
@@ -9,11 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <!-- System.Text.Json is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-hh2w-p6rv-4g7w -->
-    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
@@ -39,4 +36,5 @@
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\TestEventListener.cs" Link="Includes\TestEventListener.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Shared\Utils.cs" Link="Includes\Utils.cs" />
   </ItemGroup>
+
 </Project>

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Description>Unit test project for Prometheus Exporter HttpListener for OpenTelemetry</Description>
     <TargetFrameworks>$(TargetFrameworksForTests)</TargetFrameworks>
@@ -8,11 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <!-- System.Text.Json is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-hh2w-p6rv-4g7w -->
-    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/OpenTelemetry.Exporter.Zipkin.Tests.csproj
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/OpenTelemetry.Exporter.Zipkin.Tests.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Description>Unit test project for Zipkin Exporter for OpenTelemetry</Description>
     <TargetFrameworks>$(TargetFrameworksForTests)</TargetFrameworks>
@@ -17,11 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
     <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <!-- System.Text.Json is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-hh2w-p6rv-4g7w -->
-    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetry.Extensions.Hosting.Tests.csproj
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetry.Extensions.Hosting.Tests.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Description>Unit test project for OpenTelemetry .NET Core hosting library</Description>
     <TargetFrameworks>$(TargetFrameworksForTests)</TargetFrameworks>
@@ -36,10 +37,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <!-- System.Text.Json is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-hh2w-p6rv-4g7w -->
-    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
   </ItemGroup>
+
 </Project>

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/OpenTelemetry.Shims.OpenTracing.Tests.csproj
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/OpenTelemetry.Shims.OpenTracing.Tests.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Description>Unit test project for OpenTelemetry.Shims.OpenTracing</Description>
     <TargetFrameworks>$(TargetFrameworksForTests)</TargetFrameworks>
@@ -10,8 +11,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
-    <!-- System.Text.Json is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-hh2w-p6rv-4g7w -->
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>
@@ -25,4 +24,5 @@
   <ItemGroup Condition="'$(RunningDotNetPack)' == 'true'">
     <PackageReference Include="OpenTelemetry.Exporter.InMemory" />
   </ItemGroup>
+
 </Project>

--- a/test/OpenTelemetry.Tests.Stress/OpenTelemetry.Tests.Stress.csproj
+++ b/test/OpenTelemetry.Tests.Stress/OpenTelemetry.Tests.Stress.csproj
@@ -1,17 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(TargetFrameworksForTests)</TargetFrameworks>
+    <ReferenceSystemTextJsonPackages>true</ReferenceSystemTextJsonPackages>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Condition="'$(TargetFramework)' == '$(NetFrameworkMinimumSupportedVersion)'" />
-    <PackageReference Include="System.Text.Json" Condition="'$(TargetFramework)' == '$(NetFrameworkMinimumSupportedVersion)'" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)\src\OpenTelemetry.Exporter.Prometheus.HttpListener\OpenTelemetry.Exporter.Prometheus.HttpListener.csproj" />
   </ItemGroup>
+
 </Project>

--- a/test/OpenTelemetry.Tests/OpenTelemetry.Tests.csproj
+++ b/test/OpenTelemetry.Tests/OpenTelemetry.Tests.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>$(TargetFrameworksForTests)</TargetFrameworks>
     <NoWarn>$(NoWarn),CS0618</NoWarn>
     <ReferenceCoyotePackages>true</ReferenceCoyotePackages>
-    
+
     <!-- this is temporary. will remove in future PR. -->
     <Nullable>disable</Nullable>
   </PropertyGroup>

--- a/test/OpenTelemetry.Tests/OpenTelemetry.Tests.csproj
+++ b/test/OpenTelemetry.Tests/OpenTelemetry.Tests.csproj
@@ -1,9 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <Description>Unit test project for OpenTelemetry</Description>
     <TargetFrameworks>$(TargetFrameworksForTests)</TargetFrameworks>
     <NoWarn>$(NoWarn),CS0618</NoWarn>
-
+    <ReferenceCoyotePackages>true</ReferenceCoyotePackages>
+    
     <!-- this is temporary. will remove in future PR. -->
     <Nullable>disable</Nullable>
   </PropertyGroup>
@@ -27,11 +29,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Coyote" />
-    <!-- System.Text.Json is indirect reference. It is needed to upgrade it directly to avoid https://github.com/advisories/GHSA-hh2w-p6rv-4g7w -->
-    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
   </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Changes

* Mitigate vulnerabilities in System.Text.Json v8.0.0 - 8.0.3

## Details

ConsoleExporter and ZipkinExporter use System.Text.Json (STJ) but don't have a reference to it for `net8.0`+ targets. What happens is they get STJ transitively via `Microsoft.NETCore.App` framework reference. The final version will depend on the runtime version deployed with the app.

The problem is STJ v8.0.0 - 8.0.3 have been deprecated due to a [deserialization vulnerability](https://github.com/advisories/GHSA-hh2w-p6rv-4g7w).

The goal here is to redirect STJ to v8.0.4 for `net8.0` targets. Older targets should stay on v4.7.2. Newer targets (`net9.0`) will continue to use the transitive reference.

### Today:

#### 1.9.0 stable:

|Target|Direct reference(s)|Framework reference|Version|Vulnerable|Notes|
|---|---|---|---|---|---|
|net462|System.Text.Encodings.Web & System.Text.Json||v4.7.2|No||
|netstandard2.0|System.Text.Encodings.Web & System.Text.Json||v4.7.2|No||
|net6.0||System.Text.Json|Runtime version (6.0.0 - 6.0.9)|No|Version depends on patch level of runtime|
|net8.0||System.Text.Json|Runtime version (8.0.0 - 8.0.4)|When <= 8.0.3|Version depends on patch level of runtime|

#### 1.10.0-beta.1:
|Target|Direct reference(s)|Framework reference|Version|Vulnerable|Notes|
|---|---|---|---|---|---|
|net462|System.Text.Encodings.Web & System.Text.Json||v4.7.2|No||
|netstandard2.0|System.Text.Encodings.Web & System.Text.Json||v4.7.2|No||
|net8.0||System.Text.Json|Runtime version (8.0.0 - 8.0.4)|When <= 8.0.3|Version depends on patch level of runtime|
|net9.0||System.Text.Json|Runtime version (9.0.0)|No|No patches yet for .NET 9|

### Going forward:

#### 1.9.0 stable:

No hot patch currently planned. The vulnerability is about deserialization of untrusted input which neither ConsoleExporter nor ZipkinExporter is susceptible to. I'm approaching this as a low severity issue but some work needs to be done to agree on a severity and publish an advisory. If we determine there is a higher severity we will do a hot patch for 1.9.0, possibly other releases.

#### Next release of 1.10.0:
|Target|Direct reference(s)|Framework reference|Version|Vulnerable|Notes|
|---|---|---|---|---|---|
|net462|System.Text.Encodings.Web & System.Text.Json||v4.7.2|No||
|netstandard2.0|System.Text.Encodings.Web & System.Text.Json||v4.7.2|No||
|net8.0|System.Text.Json||v8.0.4|No||
|net9.0||System.Text.Json|Runtime version (9.0.0)|No|No patches yet for .NET 9|

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
