### PR TITLE
[WIP] Using ILogger instead of EventSource for logging OpenTelemetry Events in OTLP exporter

### DIFF
--- a/examples/AspNetCore/Program.cs
+++ b/examples/AspNetCore/Program.cs
@@ -29,7 +29,8 @@ var histogramAggregation = appBuilder.Configuration.GetValue("HistogramAggregati
 appBuilder.Services.AddSingleton<Instrumentation>();
 
 // Clear default logging providers used by WebApplication host.
-appBuilder.Logging.ClearProviders();
+//appBuilder.Logging.ClearProviders();
+appBuilder.Logging.ClearProviders().AddConsole();
 
 // Configure OpenTelemetry logging, metrics, & tracing with auto-start using the
 // AddOpenTelemetry extension from OpenTelemetry.Extensions.Hosting.

--- a/examples/AspNetCore/appsettings.json
+++ b/examples/AspNetCore/appsettings.json
@@ -11,15 +11,18 @@
   },
   "ServiceName": "otel-test",
   "AllowedHosts": "*",
-  "UseTracingExporter": "console",
-  "UseMetricsExporter": "console",
-  "UseLogExporter": "console",
+  "UseTracingExporter": "otlp",
+  "UseMetricsExporter": "otlp",
+  "UseLogExporter": "otlp",
   "HistogramAggregation": "explicit",
   "Zipkin": {
     "Endpoint": "http://localhost:9411/api/v2/spans"
   },
   "Otlp": {
     "Endpoint": "http://localhost:4317"
+  },
+  "Console": {
+    "OpenTelemetry": "Information"
   },
   "AspNetCoreInstrumentation": {
     "RecordException": "true"

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OpenTelemetryProtocolExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OpenTelemetryProtocolExporterEventSource.cs
@@ -73,12 +73,6 @@ internal sealed class OpenTelemetryProtocolExporterEventSource : EventSource, IC
         this.WriteEvent(5, className, methodName);
     }
 
-    [Event(8, Message = "Unsupported value for protocol '{0}' is configured, default protocol 'grpc' will be used.", Level = EventLevel.Warning)]
-    public void UnsupportedProtocol(string protocol)
-    {
-        this.WriteEvent(8, protocol);
-    }
-
     [Event(9, Message = "Could not translate LogRecord due to Exception: '{0}'. Log will not be exported.", Level = EventLevel.Warning)]
     public void CouldNotTranslateLogRecord(string exceptionMessage)
     {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OpenTelemetryProtocolExporterEvents.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OpenTelemetryProtocolExporterEvents.cs
@@ -13,5 +13,6 @@ internal static partial class OpenTelemetryProtocolExporterEvents
     // TODO: there's no concept of Event vs NonEvent in ILogger (as opposed to EventSource.)
     // Need to find a way to log "NonEvent" in ILogger to avoid the below situation:
     // When the Exception occurred in ExportMethod, the Export event got written to the pipe, and thus the Exporter keeps exporting.
-    public static partial void ExportMethodException(this ILogger logger, string message);
+    [LoggerMessage(LogLevel.Error, "Unknown error in export method. Message: `{ex}`.")]
+    public static partial void ExportMethodException(this ILogger logger, Exception ex);
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OpenTelemetryProtocolExporterEvents.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OpenTelemetryProtocolExporterEvents.cs
@@ -1,0 +1,17 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.Extensions.Logging;
+
+namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
+
+/// <summary>
+/// Methods for logging internal events in OpenTelemetryProtocolExporter.
+/// </summary>
+internal static partial class OpenTelemetryProtocolExporterEvents
+{
+    // TODO: there's no concept of Event vs NonEvent in ILogger (as opposed to EventSource.)
+    // Need to find a way to log "NonEvent" in ILogger to avoid the below situation:
+    // When the Exception occurred in ExportMethod, the Export event got written to the pipe, and thus the Exporter keeps exporting.
+    public static partial void ExportMethodException(this ILogger logger, string message);
+}

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporter.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Transmission;
 using OpenTelemetry.Logs;
@@ -18,6 +20,7 @@ public sealed class OtlpLogExporter : BaseExporter<LogRecord>
 {
     private readonly OtlpExporterTransmissionHandler<OtlpCollector.ExportLogsServiceRequest> transmissionHandler;
     private readonly OtlpLogRecordTransformer otlpLogRecordTransformer;
+    private readonly ILogger<OtlpLogExporter> logger;
 
     private OtlpResource.Resource? processResource;
 
@@ -26,7 +29,7 @@ public sealed class OtlpLogExporter : BaseExporter<LogRecord>
     /// </summary>
     /// <param name="options">Configuration options for the exporter.</param>
     public OtlpLogExporter(OtlpExporterOptions options)
-        : this(options, sdkLimitOptions: new(), experimentalOptions: new(), transmissionHandler: null)
+        : this(new NullLogger<OtlpLogExporter>(), options, sdkLimitOptions: new(), experimentalOptions: new(), transmissionHandler: null)
     {
     }
 
@@ -38,14 +41,20 @@ public sealed class OtlpLogExporter : BaseExporter<LogRecord>
     /// <param name="experimentalOptions"><see cref="ExperimentalOptions"/>.</param>
     /// <param name="transmissionHandler"><see cref="OtlpExporterTransmissionHandler{T}"/>.</param>
     internal OtlpLogExporter(
+        ILogger<OtlpLogExporter> logger,
         OtlpExporterOptions exporterOptions,
         SdkLimitOptions sdkLimitOptions,
         ExperimentalOptions experimentalOptions,
         OtlpExporterTransmissionHandler<OtlpCollector.ExportLogsServiceRequest>? transmissionHandler = null)
     {
+        Debug.Assert(logger != null, "logger was null");
         Debug.Assert(exporterOptions != null, "exporterOptions was null");
         Debug.Assert(sdkLimitOptions != null, "sdkLimitOptions was null");
         Debug.Assert(experimentalOptions != null, "experimentalOptions was null");
+
+        this.logger = logger!;
+
+        this.logger.LogInformation("Hello from Otlp ctor");
 
         this.transmissionHandler = transmissionHandler ?? exporterOptions!.GetLogsExportTransmissionHandler(experimentalOptions!);
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporter.cs
@@ -89,7 +89,7 @@ public sealed class OtlpLogExporter : BaseExporter<LogRecord>
         {
             OpenTelemetryProtocolExporterEventSource.Log.ExportMethodException(ex);
 
-            OpenTelemetryProtocolExporterEvents.ExportMethodException(this.openTelemetryEventLogger, ex.ToInvariantString());
+            OpenTelemetryProtocolExporterEvents.ExportMethodException(this.openTelemetryEventLogger, ex);
 
             return ExportResult.Failure;
         }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporterHelperExtensions.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
@@ -306,6 +307,7 @@ public static class OtlpLogExporterHelperExtensions
          */
 
         BaseExporter<LogRecord> otlpExporter = new OtlpLogExporter(
+            serviceProvider!.GetService<ILoggerFactory>()?.CreateLogger<OtlpLogExporter>() ?? new NullLogger<OtlpLogExporter>(),
             exporterOptions!,
             sdkLimitOptions!,
             experimentalOptions!);


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-dotnet/issues/3881

## Changes

Currently internal logging with ILogger is default on. 
Need to find a way to have the internal diagnostics off by default and a switch to turn the diagnostics on.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
