### PR TITLE
[repo] Remove implicit using tweak as it is no longer needed

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -16,15 +16,6 @@
     <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='$(NetFrameworkMinimumSupportedVersion)'">
-    <!--ImplicitUsings will add this namespace that is not available for NetFX.
-    https://github.com/dotnet/sdk/issues/24146
-    https://github.com/dotnet/runtime/issues/59163
-    https://github.com/dotnet/sdk/issues/22515
-    -->
-    <Using Remove="System.Net.Http" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(IsPackable)' == 'true'">
     <None Include="$(PackagePrimaryLicenseFile)"
           PackagePath="$([System.IO.Path]::GetFileName('$(PackagePrimaryLicenseFile)'))"

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -2,15 +2,6 @@
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.targets" />
 
-  <ItemGroup Condition="'$(TargetFramework)'=='$(NetFrameworkMinimumSupportedVersion)'">
-    <!--ImplicitUsings will add this namespace that is not available for NetFX.
-    https://github.com/dotnet/sdk/issues/24146
-    https://github.com/dotnet/runtime/issues/59163
-    https://github.com/dotnet/sdk/issues/22515
-    -->
-    <Using Remove="System.Net.Http" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(ReferenceCoyotePackages)' == 'true'">
     <PackageReference Include="Microsoft.Coyote" />
 


### PR DESCRIPTION
## Changes

* Removes the explicit removal of `System.Net.Http` from the implicit usings list for .NET Framework because this is now part of the targets shipped with SDK: https://github.com/dotnet/sdk/pull/32630

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
