### PR TITLE
[repo] Update stale.yml - reduce days before stale to 450

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
           close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
           operations-per-run: 400
           days-before-pr-stale: 7
-          days-before-issue-stale: 600
+          days-before-issue-stale: 450
           days-before-pr-close: 7
           days-before-issue-close: 7
           exempt-all-issue-milestones: true


### PR DESCRIPTION
Follow up to https://github.com/open-telemetry/opentelemetry-dotnet/issues/5776

The ultimate goal is to get this down to 300 days.
This PR moves the days-before-issue-stale from 600 to 450 days and split the remaining issues in half.

## Counts of issues

- Currently 260 open issues (Oct 07, 2024).
- older than 450 days (07/15) = 38 issues [link](https://github.com/open-telemetry/opentelemetry-dotnet/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-asc+updated%3A%3C%3D2023-07-15)
- older than 300 days (12/12) = 73 issues [link](https://github.com/open-telemetry/opentelemetry-dotnet/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-asc+updated%3A%3C%3D2023-12-12)



## Screenshot of affected issues

<details>
  <summary>Click here to expand</summary>
  
![image](https://github.com/user-attachments/assets/10f14a4e-9233-4686-9fa0-aedd737bc95f)

![image](https://github.com/user-attachments/assets/13d5bdad-2a88-4cde-b1b0-d8dffc158e58)



</details>


