### PR TITLE
[repo] Mitigate vulnerabilities in System.Text.Json 8.0.4 package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <OTelLatestStableVer>1.9.0</OTelLatestStableVer>
     <SystemTextEncodingsWebOutOfBandMinimumCoreAppVer>8.0.0</SystemTextEncodingsWebOutOfBandMinimumCoreAppVer>
-    <SystemTextJsonOutOfBandMinimumCoreAppVer>8.0.4</SystemTextJsonOutOfBandMinimumCoreAppVer>
+    <SystemTextJsonOutOfBandMinimumCoreAppVer>8.0.5</SystemTextJsonOutOfBandMinimumCoreAppVer>
   </PropertyGroup>
 
   <!--

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <OTelLatestStableVer>1.9.0</OTelLatestStableVer>
+
+    <!-- Mitigate https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485. -->
     <SystemTextEncodingsWebOutOfBandMinimumCoreAppVer>8.0.0</SystemTextEncodingsWebOutOfBandMinimumCoreAppVer>
     <SystemTextJsonOutOfBandMinimumCoreAppVer>8.0.5</SystemTextJsonOutOfBandMinimumCoreAppVer>
   </PropertyGroup>
@@ -60,6 +62,11 @@
 
   <ItemGroup>
     <!--
+        Note: See TargetFrameworksRequiringSystemTextJsonDirectReference for the
+        list of targets where System.Text.Json direct reference is applied.
+    -->
+
+    <!--
         We use conservative versions of these packages for older runtimes where
         an upgrade might introduce breaking changes. For example see:
         https://devblogs.microsoft.com/dotnet/system-text-json-in-dotnet-7/#breaking-changes.
@@ -67,7 +74,7 @@
     <PackageVersion Include="System.Text.Encodings.Web" Version="4.7.2" />
     <PackageVersion Include="System.Text.Json" Version="4.7.2" />
 
-    <!-- Bump System.Text.Json on NETCoreApp targets to mitigate https://github.com/advisories/GHSA-hh2w-p6rv-4g7w. -->
+    <!-- Newer NETCoreApp runtimes need to be redirected to safe versions. -->
     <PackageVersion Update="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWebOutOfBandMinimumCoreAppVer)" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
     <PackageVersion Update="System.Text.Json" Version="$(SystemTextJsonOutOfBandMinimumCoreAppVer)" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
   </ItemGroup>

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -7,9 +7,11 @@ Notes](../../RELEASENOTES.md).
 ## Unreleased
 
 * Added direct reference to `System.Text.Json` for the `net8.0` target with
-  minimum version of `8.0.4` in response to
-  [CVE-2024-30105](https://github.com/advisories/GHSA-hh2w-p6rv-4g7w).
-  ([#5874](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5874))
+  minimum version of `8.0.5` in response to
+  [CVE-2024-30105](https://github.com/advisories/GHSA-hh2w-p6rv-4g7w) &
+  [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
+  ([#5874](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5874),
+  [#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
 
 ## 1.10.0-beta.1
 

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -11,7 +11,7 @@ Notes](../../RELEASENOTES.md).
   [CVE-2024-30105](https://github.com/advisories/GHSA-hh2w-p6rv-4g7w) &
   [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
   ([#5874](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5874),
-  [#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  [#5891](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5891))
 
 ## 1.10.0-beta.1
 

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -7,9 +7,11 @@ Notes](../../RELEASENOTES.md).
 ## Unreleased
 
 * Added direct reference to `System.Text.Json` for the `net8.0` target with
-  minimum version of `8.0.4` in response to
-  [CVE-2024-30105](https://github.com/advisories/GHSA-hh2w-p6rv-4g7w).
-  ([#5874](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5874))
+  minimum version of `8.0.5` in response to
+  [CVE-2024-30105](https://github.com/advisories/GHSA-hh2w-p6rv-4g7w) &
+  [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
+  ([#5874](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5874),
+  [#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
 
 ## 1.10.0-beta.1
 

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -11,7 +11,7 @@ Notes](../../RELEASENOTES.md).
   [CVE-2024-30105](https://github.com/advisories/GHSA-hh2w-p6rv-4g7w) &
   [CVE-2024-43485](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).
   ([#5874](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5874),
-  [#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  [#5891](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5891))
 
 ## 1.10.0-beta.1
 


### PR DESCRIPTION
## Changes

* Mitigate vulnerabilities in System.Text.Json v8.0.4

## Details

We just [bumped STJ to 8.0.4](#5874) for `net8.0` targets but a [new vulnerability was published today](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-43485).

This PR bumps STJ to `8.0.5` for `net8.0` targets.

Unlike the previous CVE, **`net6.0` is also impacted** and a new version `6.0.10` was published for `net6.0`. **No action is being taken for `net6.0`**. Because we have already removed `net6.0` targets for `1.10.0` (`net6.0` is going out of support). Users upgrading to `1.10.0` and running on `net6.0` will fallback to the `netstandard2.0` target which uses `4.7.2` with no known vulnerabilities. We could hot-patch older versions, but this vulnerability deals with de-serialization of untrusted user input which we don't do in the components using STJ. Treating this as a low severity issue where a hot-patch is not needed. If this changes or new information comes to light we can do a patch, just not planning to do one at this time.

### Today:

#### 1.9.0 stable:

|Target|Direct reference(s)|Framework reference|Version|Vulnerable|Notes|
|---|---|---|---|---|---|
|net462|System.Text.Encodings.Web & System.Text.Json||v4.7.2|No||
|netstandard2.0|System.Text.Encodings.Web & System.Text.Json||v4.7.2|No||
|net6.0||System.Text.Json|Runtime version (6.0.0 - 6.0.10)|When <= 6.0.9|Version depends on patch level of runtime|
|net8.0||System.Text.Json|Runtime version (8.0.0 - 8.0.5)|When <= 8.0.4|Version depends on patch level of runtime|

#### 1.10.0-beta.1:
|Target|Direct reference(s)|Framework reference|Version|Vulnerable|Notes|
|---|---|---|---|---|---|
|net462|System.Text.Encodings.Web & System.Text.Json||v4.7.2|No||
|netstandard2.0|System.Text.Encodings.Web & System.Text.Json||v4.7.2|No||
|net8.0||System.Text.Json|Runtime version (8.0.0 - 8.0.5)|When <= 8.0.4|Version depends on patch level of runtime|
|net9.0||System.Text.Json|Runtime version (9.0.0)|No|No patches yet for .NET 9|

### Going forward:

#### 1.9.0 stable:

No hot patch currently planned. The vulnerability is about deserialization of untrusted input which neither ConsoleExporter nor ZipkinExporter is susceptible to. I'm approaching this as a low severity issue. If we determine there is a higher severity we will do a hot patch for 1.9.0, possibly other releases.

#### Next release of 1.10.0:
|Target|Direct reference(s)|Framework reference|Version|Vulnerable|Notes|
|---|---|---|---|---|---|
|net462|System.Text.Encodings.Web & System.Text.Json||v4.7.2|No||
|netstandard2.0|System.Text.Encodings.Web & System.Text.Json||v4.7.2|No||
|net8.0|System.Text.Json||v8.0.5|No||
|net9.0||System.Text.Json|Runtime version (9.0.0)|No|No patches yet for .NET 9|

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
