### PR TITLE
[docs-metrics] Improve View documentation to show its additive nature

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,13 +203,19 @@ Open a pull request against the main `opentelemetry-dotnet` repo.
 * If the PR is not ready for review, please mark it as
   [`draft`](https://github.blog/2019-02-14-introducing-draft-pull-requests/).
 * Make sure CLA is signed and all required CI checks are clear.
-* Submit small, focused PRs addressing a single
-  concern/issue.
+* Submit small, focused PRs addressing a single concern/issue.
 * Make sure the PR title reflects the contribution.
 * Write a summary that helps understand the change.
 * Include usage examples in the summary, where applicable.
 * Include benchmarks (before/after) in the summary, for contributions that are
   performance enhancements.
+* We are open to bot generated PRs or AI/LLM assisted PRs. Actually, we are
+  using
+  [dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates)
+  to automate the security updates. However, if you use bots to generate spam
+  PRs (e.g. incorrect, noisy, non-improvements, unintelligible, trying to sell
+  your product, etc.), we might close the PR right away with a warning, and if
+  you keep doing so, we might block your user account.
 
 ### How to get pull requests merged
 

--- a/docs/metrics/customizing-the-sdk/Program.cs
+++ b/docs/metrics/customizing-the-sdk/Program.cs
@@ -40,6 +40,12 @@ public class Program
             // Drop the instrument "MyCounterDrop".
             .AddView(instrumentName: "MyCounterDrop", MetricStreamConfiguration.Drop)
 
+            // Configure the Explicit Bucket Histogram aggregation with custom boundaries and new name.
+            .AddView(instrumentName: "HistogramWithMultipleStream", new ExplicitBucketHistogramConfiguration() { Boundaries = new double[] { 10, 20 }, Name = "MyHistogramWithExplicitHistogram" })
+
+            // Use Base2 Exponential Bucket Histogram aggregation and new name.
+            .AddView(instrumentName: "HistogramWithMultipleStream", new Base2ExponentialBucketHistogramConfiguration() { Name = "MyHistogramWithBase2ExponentialBucketHistogram" })
+
             // An instrument which does not match any views
             // gets processed with default behavior. (SDK default)
             // Uncommenting the following line will
@@ -68,6 +74,12 @@ public class Program
         for (int i = 0; i < 20000; i++)
         {
             exponentialBucketHistogram.Record(random.Next(1, 1000), new("tag1", "value1"), new("tag2", "value2"));
+        }
+
+        var histogramWithMultipleStream = Meter1.CreateHistogram<long>("HistogramWithMultipleStream");
+        for (int i = 0; i < 20000; i++)
+        {
+            histogram.Record(random.Next(1, 1000), new("tag1", "value1"), new("tag2", "value2"));
         }
 
         var counterCustomTags = Meter1.CreateCounter<long>("MyCounterCustomTags");

--- a/docs/metrics/customizing-the-sdk/Program.cs
+++ b/docs/metrics/customizing-the-sdk/Program.cs
@@ -41,10 +41,10 @@ public class Program
             .AddView(instrumentName: "MyCounterDrop", MetricStreamConfiguration.Drop)
 
             // Configure the Explicit Bucket Histogram aggregation with custom boundaries and new name.
-            .AddView(instrumentName: "HistogramWithMultipleStreams", new ExplicitBucketHistogramConfiguration() { Boundaries = new double[] { 10, 20 }, Name = "MyHistogramWithExplicitHistogram" })
+            .AddView(instrumentName: "histogramWithMultipleAggregations", new ExplicitBucketHistogramConfiguration() { Boundaries = new double[] { 10, 20 }, Name = "MyHistogramWithExplicitHistogram" })
 
             // Use Base2 Exponential Bucket Histogram aggregation and new name.
-            .AddView(instrumentName: "HistogramWithMultipleStreams", new Base2ExponentialBucketHistogramConfiguration() { Name = "MyHistogramWithBase2ExponentialBucketHistogram" })
+            .AddView(instrumentName: "histogramWithMultipleAggregations", new Base2ExponentialBucketHistogramConfiguration() { Name = "MyHistogramWithBase2ExponentialBucketHistogram" })
 
             // An instrument which does not match any views
             // gets processed with default behavior. (SDK default)
@@ -76,10 +76,10 @@ public class Program
             exponentialBucketHistogram.Record(random.Next(1, 1000), new("tag1", "value1"), new("tag2", "value2"));
         }
 
-        var histogramWithMultipleStreams = Meter1.CreateHistogram<long>("HistogramWithMultipleStreams");
+        var histogramWithMultipleAggregations = Meter1.CreateHistogram<long>("histogramWithMultipleAggregations");
         for (int i = 0; i < 20000; i++)
         {
-            histogramWithMultipleStreams.Record(random.Next(1, 1000), new("tag1", "value1"), new("tag2", "value2"));
+            histogramWithMultipleAggregations.Record(random.Next(1, 1000), new("tag1", "value1"), new("tag2", "value2"));
         }
 
         var counterCustomTags = Meter1.CreateCounter<long>("MyCounterCustomTags");

--- a/docs/metrics/customizing-the-sdk/Program.cs
+++ b/docs/metrics/customizing-the-sdk/Program.cs
@@ -41,10 +41,10 @@ public class Program
             .AddView(instrumentName: "MyCounterDrop", MetricStreamConfiguration.Drop)
 
             // Configure the Explicit Bucket Histogram aggregation with custom boundaries and new name.
-            .AddView(instrumentName: "HistogramWithMultipleStream", new ExplicitBucketHistogramConfiguration() { Boundaries = new double[] { 10, 20 }, Name = "MyHistogramWithExplicitHistogram" })
+            .AddView(instrumentName: "HistogramWithMultipleStreams", new ExplicitBucketHistogramConfiguration() { Boundaries = new double[] { 10, 20 }, Name = "MyHistogramWithExplicitHistogram" })
 
             // Use Base2 Exponential Bucket Histogram aggregation and new name.
-            .AddView(instrumentName: "HistogramWithMultipleStream", new Base2ExponentialBucketHistogramConfiguration() { Name = "MyHistogramWithBase2ExponentialBucketHistogram" })
+            .AddView(instrumentName: "HistogramWithMultipleStreams", new Base2ExponentialBucketHistogramConfiguration() { Name = "MyHistogramWithBase2ExponentialBucketHistogram" })
 
             // An instrument which does not match any views
             // gets processed with default behavior. (SDK default)
@@ -76,10 +76,10 @@ public class Program
             exponentialBucketHistogram.Record(random.Next(1, 1000), new("tag1", "value1"), new("tag2", "value2"));
         }
 
-        var histogramWithMultipleStream = Meter1.CreateHistogram<long>("HistogramWithMultipleStream");
+        var histogramWithMultipleStreams = Meter1.CreateHistogram<long>("HistogramWithMultipleStreams");
         for (int i = 0; i < 20000; i++)
         {
-            histogram.Record(random.Next(1, 1000), new("tag1", "value1"), new("tag2", "value2"));
+            histogramWithMultipleStreams.Record(random.Next(1, 1000), new("tag1", "value1"), new("tag2", "value2"));
         }
 
         var counterCustomTags = Meter1.CreateCounter<long>("MyCounterCustomTags");

--- a/docs/metrics/customizing-the-sdk/README.md
+++ b/docs/metrics/customizing-the-sdk/README.md
@@ -253,7 +253,7 @@ will result in two separate metrics being produced from that single instrument.
 Below is an example demonstrating how to leverage this capability to create two
 independent metrics from a single instrument. In this example, a histogram
 instrument is used to report measurements, and views are configured to produce
-two metrics —one aggregated using `ExplicitBucketHistogramConfiguration` and the
+two metrics : one aggregated using `ExplicitBucketHistogramConfiguration` and the
 other using `Base2ExponentialBucketHistogramConfiguration`.
 
 ```csharp
@@ -272,13 +272,16 @@ other using `Base2ExponentialBucketHistogramConfiguration`.
     histogramWithMultipleAggregations.Record(10, new("tag1", "value1"), new("tag2", "value2"));
 ```
 
-When using additive views, it's crucial to rename the metric to prevent
-conflicts. For example, the following code does not rename the metric, leading
-to a name conflict. OpenTelemetry will emit an internal warning but will still
-export both metrics. The impact of this behavior depends on the backend or
-receiver being used. You can refer to [OpenTelemetry's
+When using views that produce multiple metrics from single instrument, it's
+crucial to rename the metric to prevent conflicts. For example, the following
+code does not rename the metric, leading to a name conflict. OpenTelemetry will
+emit an internal warning but will still export both metrics. The impact of this
+behavior depends on the backend or receiver being used. You can refer to
+[OpenTelemetry's
 specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md#opentelemetry-protocol-data-model-consumer-recommendations)
 for more details.
+
+Below example is showing the *BAD* practice. DO NOT FOLLOW it.
 
 ```csharp
     var histogram = meter.CreateHistogram<long>("MyHistogram");

--- a/docs/metrics/customizing-the-sdk/README.md
+++ b/docs/metrics/customizing-the-sdk/README.md
@@ -258,13 +258,13 @@ aggregated using `ExplicitBucketHistogramConfiguration` and the other using
 `Base2ExponentialBucketHistogramConfiguration`.
 
 ```csharp
-    var histogram = meter.CreateHistogram<long>("MyHistogram");
+    var histogram = meter.CreateHistogram<long>("HistogramWithMultipleStream");
 
     // Configure the Explicit Bucket Histogram aggregation with custom boundaries and new name.
-    .AddView(instrumentName: "MyHistogram", new ExplicitBucketHistogramConfiguration() { Boundaries = new double[] { 10, 20 }, Name = "MyHistogramWithExplicitHistogram" })
+    .AddView(instrumentName: "HistogramWithMultipleStream", new ExplicitBucketHistogramConfiguration() { Boundaries = new double[] { 10, 20 }, Name = "MyHistogramWithExplicitHistogram" })
 
     // Use Base2 Exponential Bucket Histogram aggregation and new name.
-    .AddView(instrumentName: "MyHistogram", new Base2ExponentialBucketHistogramConfiguration() { Name = "MyHistogramWithBase2ExponentialBucketHistogram" })
+    .AddView(instrumentName: "HistogramWithMultipleStream", new Base2ExponentialBucketHistogramConfiguration() { Name = "MyHistogramWithBase2ExponentialBucketHistogram" })
 
     // Both views rename the metric to avoid name conflicts. However, in this case,
     // renaming one would be sufficient.

--- a/docs/metrics/customizing-the-sdk/README.md
+++ b/docs/metrics/customizing-the-sdk/README.md
@@ -245,7 +245,7 @@ within the maximum number of buckets defined by `MaxSize`. The default
         new Base2ExponentialBucketHistogramConfiguration { MaxSize = 40 })
 ```
 
-#### Views are additive
+#### Produce multiple metric streams from single instrument
 
 When an instrument matches multiple views, it can generate multiple metric
 streams. For instance, if an instrument is matched by two different view

--- a/docs/metrics/customizing-the-sdk/README.md
+++ b/docs/metrics/customizing-the-sdk/README.md
@@ -284,22 +284,22 @@ for more details.
 ```csharp
     var histogram = meter.CreateHistogram<long>("MyHistogram");
 
-    // Configure a view to aggregate based only on the "name" tag.
+    // Configure a view to aggregate based only on the "location" tag.
     .AddView(instrumentName: "MyHistogram", metricStreamConfiguration: new MetricStreamConfiguration
         {
-            TagKeys = new string[] { "name" },
+            TagKeys = new string[] { "location" },
         })
 
-    // Configure another view to aggregate based only on the "age" tag.
+    // Configure another view to aggregate based only on the "status" tag.
     .AddView(instrumentName: "MyHistogram", metricStreamConfiguration: new MetricStreamConfiguration
         {
-            TagKeys = new string[] { "age" },
+            TagKeys = new string[] { "status" },
         })
 
     // The measurement below will be aggregated into two metric streams, but both will have the same name.
     // OpenTelemetry will issue a warning about this conflict and pass both streams to the exporter.
     // However, this may cause issues depending on the backend.
-    histogram.Record(10, new("name", "foo"), new("age", "20"));
+    histogram.Record(10, new("location", "seattle"), new("status", "OK"));
 ```
 
 > [!NOTE]

--- a/docs/metrics/customizing-the-sdk/README.md
+++ b/docs/metrics/customizing-the-sdk/README.md
@@ -245,38 +245,37 @@ within the maximum number of buckets defined by `MaxSize`. The default
         new Base2ExponentialBucketHistogramConfiguration { MaxSize = 40 })
 ```
 
-#### Produce multiple metric streams from single instrument
+#### Produce multiple metrics from single instrument
 
-When an instrument matches multiple views, it can generate multiple metric
-streams. For instance, if an instrument is matched by two different view
-configurations, it will result in two separate metric streams being produced
-from that single instrument. Below is an example demonstrating how to leverage
-this capability to create two independent metric streams from a single
-instrument. In this example, a histogram instrument is used to report
-measurements, and views are configured to produce two metric streams—one
-aggregated using `ExplicitBucketHistogramConfiguration` and the other using
-`Base2ExponentialBucketHistogramConfiguration`.
+When an instrument matches multiple views, it can generate multiple metrics. For
+instance, if an instrument is matched by two different view configurations, it
+will result in two separate metrics being produced from that single instrument.
+Below is an example demonstrating how to leverage this capability to create two
+independent metrics from a single instrument. In this example, a histogram
+instrument is used to report measurements, and views are configured to produce
+two metrics —one aggregated using `ExplicitBucketHistogramConfiguration` and the
+other using `Base2ExponentialBucketHistogramConfiguration`.
 
 ```csharp
-    var histogram = meter.CreateHistogram<long>("HistogramWithMultipleStream");
+    var histogramWithMultipleAggregations = meter.CreateHistogram<long>("HistogramWithMultipleAggregations");
 
     // Configure the Explicit Bucket Histogram aggregation with custom boundaries and new name.
-    .AddView(instrumentName: "HistogramWithMultipleStream", new ExplicitBucketHistogramConfiguration() { Boundaries = new double[] { 10, 20 }, Name = "MyHistogramWithExplicitHistogram" })
+    .AddView(instrumentName: "HistogramWithMultipleAggregations", new ExplicitBucketHistogramConfiguration() { Boundaries = new double[] { 10, 20 }, Name = "MyHistogramWithExplicitHistogram" })
 
     // Use Base2 Exponential Bucket Histogram aggregation and new name.
-    .AddView(instrumentName: "HistogramWithMultipleStream", new Base2ExponentialBucketHistogramConfiguration() { Name = "MyHistogramWithBase2ExponentialBucketHistogram" })
+    .AddView(instrumentName: "HistogramWithMultipleAggregations", new Base2ExponentialBucketHistogramConfiguration() { Name = "MyHistogramWithBase2ExponentialBucketHistogram" })
 
     // Both views rename the metric to avoid name conflicts. However, in this case,
     // renaming one would be sufficient.
 
-    // This measurement will be aggregated into two separate metric streams.
-    histogram.Record(10, new("tag1", "value1"), new("tag2", "value2"));
+    // This measurement will be aggregated into two separate metrics.
+    histogramWithMultipleAggregations.Record(10, new("tag1", "value1"), new("tag2", "value2"));
 ```
 
-When using additive views, it's crucial to rename the metric streams to prevent
-conflicts. For example, the following code does not rename the streams, leading
+When using additive views, it's crucial to rename the metric to prevent
+conflicts. For example, the following code does not rename the metric, leading
 to a name conflict. OpenTelemetry will emit an internal warning but will still
-export both streams. The impact of this behavior depends on the backend or
+export both metrics. The impact of this behavior depends on the backend or
 receiver being used. You can refer to [OpenTelemetry's
 specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md#opentelemetry-protocol-data-model-consumer-recommendations)
 for more details.


### PR DESCRIPTION
## Changes

View documentation has been improved to show its additive nature. This is a useful capability, but can cause issues when incorrectly applied. I call out the common issue in the doc now. More warnings may be added in the future, probably under [Advanced View](https://github.com/open-telemetry/opentelemetry-dotnet/issues/5557) doc, that is still pending.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
