### PR TITLE
[repo] cleanup #nullable disable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -308,23 +308,6 @@ analysis](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/overview
 [Common.props](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/build/Common.props)
 new projects must NOT manually override these settings.
 
-## New code
-
-New code files MUST enable [nullable reference
-types](https://learn.microsoft.com/dotnet/csharp/language-reference/builtin-types/nullable-reference-types)
-manually in projects where it is not automatically enabled project-wide. This is
-done by specifying `#nullable enable` towards the top of the file (usually after
-the copyright header). We are currently working towards enabling nullable
-context in every project by updating code as it is worked on, this requirement
-is to make sure the surface area of code needing updates is shrinking and not
-expanding.
-
-> [!NOTE]
-> The first time a project is updated to use nullable context in public APIs
-some housekeeping needs to be done in public API definitions (`.publicApi`
-folder). This can be done automatically via a code fix offered by the public API
-analyzer.
-
 ## License requirements
 
 OpenTelemetry .NET is licensed under the [Apache License, Version

--- a/src/OpenTelemetry.Exporter.Console/Implementation/ConsoleTagWriter.cs
+++ b/src/OpenTelemetry.Exporter.Console/Implementation/ConsoleTagWriter.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 using System.Text;
 using OpenTelemetry.Internal;

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinTagWriter.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinTagWriter.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Buffers.Text;
 using System.Globalization;
 using System.Text.Json;

--- a/src/Shared/ActivityHelperExtensions.cs
+++ b/src/Shared/ActivityHelperExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using OpenTelemetry.Internal;

--- a/src/Shared/AssemblyVersionExtensions.cs
+++ b/src/Shared/AssemblyVersionExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;

--- a/src/Shared/Configuration/IConfigurationExtensionsLogger.cs
+++ b/src/Shared/Configuration/IConfigurationExtensionsLogger.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 namespace Microsoft.Extensions.Configuration;
 
 internal interface IConfigurationExtensionsLogger

--- a/src/Shared/Configuration/OpenTelemetryConfigurationExtensions.cs
+++ b/src/Shared/Configuration/OpenTelemetryConfigurationExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 #if !NETFRAMEWORK && !NETSTANDARD2_0
 using System.Diagnostics.CodeAnalysis;

--- a/src/Shared/DiagnosticDefinitions.cs
+++ b/src/Shared/DiagnosticDefinitions.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 namespace OpenTelemetry.Internal;
 
 internal static class DiagnosticDefinitions

--- a/src/Shared/ExceptionExtensions.cs
+++ b/src/Shared/ExceptionExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Globalization;
 
 namespace OpenTelemetry.Internal;

--- a/src/Shared/Guard.cs
+++ b/src/Shared/Guard.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;

--- a/src/Shared/Metrics/Base2ExponentialBucketHistogramHelper.cs
+++ b/src/Shared/Metrics/Base2ExponentialBucketHistogramHelper.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 namespace OpenTelemetry.Metrics;
 
 /// <summary>

--- a/src/Shared/Options/DelegatingOptionsFactory.cs
+++ b/src/Shared/Options/DelegatingOptionsFactory.cs
@@ -13,8 +13,6 @@
  example of how that works.
 */
 
-#nullable enable
-
 using System.Diagnostics;
 #if NET
 using System.Diagnostics.CodeAnalysis;

--- a/src/Shared/Options/DelegatingOptionsFactoryServiceCollectionExtensions.cs
+++ b/src/Shared/Options/DelegatingOptionsFactoryServiceCollectionExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 #if NET
 using System.Diagnostics.CodeAnalysis;

--- a/src/Shared/Options/SingletonOptionsManager.cs
+++ b/src/Shared/Options/SingletonOptionsManager.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 #if NET
 using System.Diagnostics.CodeAnalysis;
 #endif

--- a/src/Shared/PeerServiceResolver.cs
+++ b/src/Shared/PeerServiceResolver.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Runtime.CompilerServices;
 using OpenTelemetry.Trace;
 

--- a/src/Shared/PeriodicExportingMetricReaderHelper.cs
+++ b/src/Shared/PeriodicExportingMetricReaderHelper.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 namespace OpenTelemetry.Metrics;
 
 internal static class PeriodicExportingMetricReaderHelper

--- a/src/Shared/PooledList.cs
+++ b/src/Shared/PooledList.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Buffers;
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;

--- a/src/Shared/ResourceSemanticConventions.cs
+++ b/src/Shared/ResourceSemanticConventions.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 namespace OpenTelemetry.Resources;
 
 internal static class ResourceSemanticConventions

--- a/src/Shared/SemanticConventions.cs
+++ b/src/Shared/SemanticConventions.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 namespace OpenTelemetry.Trace;
 
 /// <summary>

--- a/src/Shared/SpanAttributeConstants.cs
+++ b/src/Shared/SpanAttributeConstants.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 namespace OpenTelemetry.Trace;
 
 /// <summary>

--- a/src/Shared/StatusHelper.cs
+++ b/src/Shared/StatusHelper.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Runtime.CompilerServices;
 using OpenTelemetry.Trace;
 

--- a/src/Shared/TagWriter/ArrayTagWriter.cs
+++ b/src/Shared/TagWriter/ArrayTagWriter.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 namespace OpenTelemetry.Internal;
 
 internal abstract class ArrayTagWriter<TArrayState>

--- a/src/Shared/TagWriter/JsonStringArrayTagWriter.cs
+++ b/src/Shared/TagWriter/JsonStringArrayTagWriter.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 using System.Text.Json;
 

--- a/src/Shared/TagWriter/TagWriter.cs
+++ b/src/Shared/TagWriter/TagWriter.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 using System.Globalization;
 

--- a/test/OpenTelemetry.Api.Tests/BaggageTests.cs
+++ b/test/OpenTelemetry.Api.Tests/BaggageTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using Xunit;
 
 namespace OpenTelemetry.Tests;

--- a/test/OpenTelemetry.Api.Tests/Context/RuntimeContextTest.cs
+++ b/test/OpenTelemetry.Api.Tests/Context/RuntimeContextTest.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using Xunit;
 
 namespace OpenTelemetry.Context.Tests;

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpRetryTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpRetryTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Net;
 using System.Net.Http.Headers;
 #if NETFRAMEWORK

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpSpecConfigDefinitionTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpSpecConfigDefinitionTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Collections;
 using Microsoft.Extensions.Configuration;
 using OpenTelemetry.Metrics;

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/UseOtlpExporterExtensionTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/UseOtlpExporterExtensionTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/VersionHelper.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/VersionHelper.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using NuGet.Versioning;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Trace;

--- a/test/OpenTelemetry.Tests/Internal/AssemblyVersionExtensionsTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/AssemblyVersionExtensionsTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Reflection;
 using Xunit;
 

--- a/test/OpenTelemetry.Tests/Internal/JsonStringArrayTagWriterTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/JsonStringArrayTagWriterTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Text;
 using Xunit;
 

--- a/test/OpenTelemetry.Tests/Internal/PeriodicExportingMetricReaderHelperTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/PeriodicExportingMetricReaderHelperTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using Microsoft.Extensions.Configuration;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Metrics;

--- a/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsConfigRefresherTest.cs
+++ b/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsConfigRefresherTest.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 using System.Text;
 using OpenTelemetry.Tests;

--- a/test/OpenTelemetry.Tests/Logs/BatchExportLogRecordProcessorOptionsTest.cs
+++ b/test/OpenTelemetry.Tests/Logs/BatchExportLogRecordProcessorOptionsTest.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using Microsoft.Extensions.Configuration;
 using Xunit;
 

--- a/test/OpenTelemetry.Tests/Logs/LogRecordSharedPoolTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/LogRecordSharedPoolTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using Xunit;
 
 namespace OpenTelemetry.Logs.Tests;

--- a/test/OpenTelemetry.Tests/Logs/LogRecordStateProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/LogRecordStateProcessorTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using Xunit;

--- a/test/OpenTelemetry.Tests/Logs/LogRecordThreadStaticPoolTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/LogRecordThreadStaticPoolTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using Xunit;
 
 namespace OpenTelemetry.Logs.Tests;

--- a/test/OpenTelemetry.Tests/Logs/LoggerProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/LoggerProviderBuilderExtensionsTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Resources;
 using Xunit;

--- a/test/OpenTelemetry.Tests/Logs/LoggerProviderExtensionsTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/LoggerProviderExtensionsTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using OpenTelemetry.Exporter;
 using Xunit;
 

--- a/test/OpenTelemetry.Tests/Logs/LoggerProviderSdkTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/LoggerProviderSdkTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Exporter;

--- a/test/OpenTelemetry.Tests/Logs/OpenTelemetryLoggingExtensionsTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/OpenTelemetryLoggingExtensionsTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/test/OpenTelemetry.Tests/Metrics/AggregatorTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/AggregatorTestsBase.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using Xunit;

--- a/test/OpenTelemetry.Tests/Metrics/MetricApiTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricApiTestsBase.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using Microsoft.Extensions.Configuration;

--- a/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using Microsoft.Extensions.Configuration;

--- a/test/OpenTelemetry.Tests/Metrics/MetricTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricTestsBase.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 #if BUILDING_HOSTING_TESTS
 using System.Diagnostics;
 #endif

--- a/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics.Metrics;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Tests;

--- a/test/OpenTelemetry.Tests/OpenTelemetrySdkTests.cs
+++ b/test/OpenTelemetry.Tests/OpenTelemetrySdkTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using Microsoft.Extensions.Logging.Abstractions;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;

--- a/test/OpenTelemetry.Tests/Shared/EventSourceTestHelper.cs
+++ b/test/OpenTelemetry.Tests/Shared/EventSourceTestHelper.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics.Tracing;
 using System.Globalization;
 using System.Reflection;

--- a/test/OpenTelemetry.Tests/Shared/SkipUnlessEnvVarFoundFactAttribute.cs
+++ b/test/OpenTelemetry.Tests/Shared/SkipUnlessEnvVarFoundFactAttribute.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using Xunit;
 
 namespace OpenTelemetry.Tests;

--- a/test/OpenTelemetry.Tests/Shared/SkipUnlessEnvVarFoundTheoryAttribute.cs
+++ b/test/OpenTelemetry.Tests/Shared/SkipUnlessEnvVarFoundTheoryAttribute.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using Xunit;
 
 namespace OpenTelemetry.Tests;

--- a/test/OpenTelemetry.Tests/Shared/TestActivityProcessor.cs
+++ b/test/OpenTelemetry.Tests/Shared/TestActivityProcessor.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics;
 
 namespace OpenTelemetry.Tests;

--- a/test/OpenTelemetry.Tests/Shared/TestEventListener.cs
+++ b/test/OpenTelemetry.Tests/Shared/TestEventListener.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Diagnostics.Tracing;
 
 namespace OpenTelemetry.Tests;

--- a/test/OpenTelemetry.Tests/Shared/TestHttpServer.cs
+++ b/test/OpenTelemetry.Tests/Shared/TestHttpServer.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using System.Net;
 
 namespace OpenTelemetry.Tests;

--- a/test/OpenTelemetry.Tests/Trace/TracerProviderBuilderBaseTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/TracerProviderBuilderBaseTests.cs
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#nullable enable
-
 using Xunit;
 
 namespace OpenTelemetry.Trace.Tests;


### PR DESCRIPTION
Towards #3958

Please merge after #5900

## Changes

[repo] cleanup #nullable disable + update contributing guide

There is couple (3) of leftovers of `#nullable disable`. It is needed for auto-generated files.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
