### PR TITLE
[repo] Update stale.yml - reduce days before stale to 300

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
           close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
           operations-per-run: 400
           days-before-pr-stale: 7
-          days-before-issue-stale: 450
+          days-before-issue-stale: 300
           days-before-pr-close: 7
           days-before-issue-close: 7
           exempt-all-issue-milestones: true


### PR DESCRIPTION
Follow up to https://github.com/open-telemetry/opentelemetry-dotnet/issues/5776

The ultimate goal is to get this down to 300 days.
This PR moves the days-before-issue-stale from 450 to 300 days and split the remaining issues in half.

THIS WILL BE THE FINAL PR :)

## Counts of issues

- Currently 255 open issues (Oct 14, 2024).
- older than 300 days (12/19) = 35 issues [link](https://github.com/open-telemetry/opentelemetry-dotnet/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-asc+updated%3A%3C%3D2023-12-19)



## Screenshot of affected issues

<details>
  <summary>Click here to expand</summary>
  
![image](https://github.com/user-attachments/assets/1faefead-b887-40a3-90aa-9e882055c79b)

![image](https://github.com/user-attachments/assets/bbf8aad5-6006-4d11-9177-e492d7f71a9a)




</details>


