### PR TITLE
[sdk-metrics] Promote overflow attribute from experimental to stable

### DIFF
--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -390,7 +390,7 @@ for more information.
 
 Starting with version 1.10.0, given a metric, once the cardinality limit is
 reached, any new measurement which cannot be independently aggregated because of
-the limit will be dropped or aggregated using the [overflow
+the limit will be aggregated using the [overflow
 attribute](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#overflow-attribute).
 
 When [Delta Aggregation

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -10,11 +10,13 @@
   * [Instruments](#instruments)
 * [MeterProvider Management](#meterprovider-management)
 * [Memory Management](#memory-management)
+  * [Example](#example)
   * [Pre-Aggregation](#pre-aggregation)
   * [Cardinality Limits](#cardinality-limits)
   * [Memory Preallocation](#memory-preallocation)
 * [Metrics Correlation](#metrics-correlation)
 * [Metrics Enrichment](#metrics-enrichment)
+* [Common issues that lead to missing metrics](#common-issues-that-lead-to-missing-metrics)
 
 </details>
 
@@ -396,12 +398,13 @@ the first time an overflow is detected for a given metric.
 
 > [!NOTE]
 > Overflow attribute was introduced in OpenTelemetry .NET
-  [1.6.0-rc.1](../../src/OpenTelemetry/CHANGELOG.md#160-rc1). It is currently an
+  [1.6.0-rc.1](../../src/OpenTelemetry/CHANGELOG.md#160-rc1). It was an
   experimental feature which can be turned on by setting the environment
   variable `OTEL_DOTNET_EXPERIMENTAL_METRICS_EMIT_OVERFLOW_ATTRIBUTE=true`. After
   the [OpenTelemetry
   Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#overflow-attribute)
-  become stable, this feature has been turned on by default.
+  become stable, the environment variable is removed and this feature is enabled
+  by default.
 
 When [Delta Aggregation
 Temporality](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md#temporality)
@@ -413,10 +416,10 @@ SDK to reclaim unused metric points.
   [1.7.0-alpha.1](../../src/OpenTelemetry/CHANGELOG.md#170-alpha1). It is
   currently an experimental feature which can be turned on by setting the
   environment variable
-  `OTEL_DOTNET_EXPERIMENTAL_METRICS_RECLAIM_UNUSED_METRIC_POINTS=true`. After the
+  `OTEL_DOTNET_EXPERIMENTAL_METRICS_RECLAIM_UNUSED_METRIC_POINTS=true`. Once the
   [OpenTelemetry
   Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#overflow-attribute)
-  become stable, this feature has been turned on by default.
+  become stable, this feature will be turned on by default.
 
 ### Memory Preallocation
 

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -389,14 +389,12 @@ and the `MetricStreamConfiguration.CardinalityLimit` setting. Refer to this
 for more information.
 
 Given a metric, once the cardinality limit is reached, any new measurement
-cannot be independently aggregated. Previously, new measurements were dropped
-unless users opt-in to experimental overflow attribute feature introduced in
-version [1.6.0-rc.1](../../src/OpenTelemetry/CHANGELOG.md#160-rc1).
-Starting with version 1.10.0, this experimental feature is promoted to stable
-and will be the default behavior. New measurements will be aggregated using the
-[overflow
-attribute](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#overflow-attribute)
-when the limit is reached.
+that could not be independently aggregated will be aggregated using the
+[overflow attribute](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#overflow-attribute).
+In versions prior to 1.10.0, the default behavior when cardinality limit was
+reached was to drop the measurement. Users had the ability to opt-in to use
+overflow attribute instead, but this behavior is the default and the only
+allowed behavior starting with version 1.10.0.
 
 When [Delta Aggregation
 Temporality](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md#temporality)

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -388,10 +388,15 @@ and the `MetricStreamConfiguration.CardinalityLimit` setting. Refer to this
 [doc](../../docs/metrics/customizing-the-sdk/README.md#changing-the-cardinality-limit-for-a-metric)
 for more information.
 
-Starting with version 1.10.0, given a metric, once the cardinality limit is
-reached, any new measurement which cannot be independently aggregated because of
-the limit will be aggregated using the [overflow
-attribute](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#overflow-attribute).
+Given a metric, once the cardinality limit is reached, any new measurement
+cannot be independently aggregated. Previously, new measurements were dropped
+unless users opt-in to experimental overflow attribute feature introduced in
+version [1.6.0-rc.1](../../src/OpenTelemetry/CHANGELOG.md#160-rc1).
+Starting with version 1.10.0, this experimental feature is promoted to stable
+and will be the default behavior. New measurements will be aggregated using the
+[overflow
+attribute](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#overflow-attribute)
+when the limit is reached.
 
 When [Delta Aggregation
 Temporality](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md#temporality)

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -392,9 +392,9 @@ Given a metric, once the cardinality limit is reached, any new measurement which
 cannot be independently aggregated because of the limit will be dropped or
 aggregated using the [overflow
 attribute](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#overflow-attribute)
-(if enabled). When NOT using the overflow attribute feature a warning is written
-to the [self-diagnostic log](../../src/OpenTelemetry/README.md#self-diagnostics)
-the first time an overflow is detected for a given metric.
+(if enabled). A warning is written to the [self-diagnostic
+log](../../src/OpenTelemetry/README.md#self-diagnostics) the first time an
+overflow is detected for a given metric.
 
 > [!NOTE]
 > Overflow attribute was introduced in OpenTelemetry .NET

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -388,23 +388,10 @@ and the `MetricStreamConfiguration.CardinalityLimit` setting. Refer to this
 [doc](../../docs/metrics/customizing-the-sdk/README.md#changing-the-cardinality-limit-for-a-metric)
 for more information.
 
-Given a metric, once the cardinality limit is reached, any new measurement which
-cannot be independently aggregated because of the limit will be dropped or
-aggregated using the [overflow
-attribute](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#overflow-attribute)
-(if enabled). A warning is written to the [self-diagnostic
-log](../../src/OpenTelemetry/README.md#self-diagnostics) the first time an
-overflow is detected for a given metric.
-
-> [!NOTE]
-> Overflow attribute was introduced in OpenTelemetry .NET
-  [1.6.0-rc.1](../../src/OpenTelemetry/CHANGELOG.md#160-rc1). It was an
-  experimental feature which can be turned on by setting the environment
-  variable `OTEL_DOTNET_EXPERIMENTAL_METRICS_EMIT_OVERFLOW_ATTRIBUTE=true`. After
-  the [OpenTelemetry
-  Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#overflow-attribute)
-  become stable, the environment variable is removed and this feature is enabled
-  by default.
+Starting with version 1.10.0, given a metric, once the cardinality limit is
+reached, any new measurement which cannot be independently aggregated because of
+the limit will be dropped or aggregated using the [overflow
+attribute](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#overflow-attribute).
 
 When [Delta Aggregation
 Temporality](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md#temporality)

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -398,10 +398,10 @@ the first time an overflow is detected for a given metric.
 > Overflow attribute was introduced in OpenTelemetry .NET
   [1.6.0-rc.1](../../src/OpenTelemetry/CHANGELOG.md#160-rc1). It is currently an
   experimental feature which can be turned on by setting the environment
-  variable `OTEL_DOTNET_EXPERIMENTAL_METRICS_EMIT_OVERFLOW_ATTRIBUTE=true`. Once
+  variable `OTEL_DOTNET_EXPERIMENTAL_METRICS_EMIT_OVERFLOW_ATTRIBUTE=true`. After
   the [OpenTelemetry
   Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#overflow-attribute)
-  become stable, this feature will be turned on by default.
+  become stable, this feature has been turned on by default.
 
 When [Delta Aggregation
 Temporality](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md#temporality)
@@ -413,10 +413,10 @@ SDK to reclaim unused metric points.
   [1.7.0-alpha.1](../../src/OpenTelemetry/CHANGELOG.md#170-alpha1). It is
   currently an experimental feature which can be turned on by setting the
   environment variable
-  `OTEL_DOTNET_EXPERIMENTAL_METRICS_RECLAIM_UNUSED_METRIC_POINTS=true`. Once the
+  `OTEL_DOTNET_EXPERIMENTAL_METRICS_RECLAIM_UNUSED_METRIC_POINTS=true`. After the
   [OpenTelemetry
   Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#overflow-attribute)
-  become stable, this feature will be turned on by default.
+  become stable, this feature has been turned on by default.
 
 ### Memory Preallocation
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -6,9 +6,11 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* The opt-in overflow attribute feature which can be enabled by setting the
-  environment variable `OTEL_DOTNET_EXPERIMENTAL_METRICS_EMIT_OVERFLOW_ATTRIBUTE`
-  to `true` is now enabled by default and supported in stable builds.
+* Removed the `OTEL_DOTNET_EXPERIMENTAL_METRICS_EMIT_OVERFLOW_ATTRIBUTE`
+  environment variable since the feature has moved from experimental to stable.
+  The overflow attribute feature is now enabled by default.
+  No internal logs will be emitted when the limit is hit, as the
+  `otel.metric.overflow` attribute indicates when a cardinality cap has occurred..
   ([#5909](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5909))
 
 ## 1.10.0-beta.1

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -24,11 +24,9 @@ Notes](../../RELEASENOTES.md).
   approach of dropping measurements has been removed. No internal logs are
   emitted when the limit is hit.
 
-  The default cardinality limit remains 2000 per metric. To adjust this globally,
-  use the `SetMaxMetricPointsPerMetricStream()` API. However, we recommend
-  setting the limit on a per-metric basis for finer control. For details on
-  customizing limits per metric, refer to [changing cardinality
-  limit](../../docs/metrics/customizing-the-sdk/README.md#changing-the-cardinality-limit-for-a-metric).
+  The default cardinality limit remains 2000 per metric. To set the cardinality
+  limit for an individual metric, use the [changing cardinality limit for a
+  Metric](../../docs/metrics/customizing-the-sdk/README.md#changing-the-cardinality-limit-for-a-metric).
 
   There is NO ability to revert to old behavior.
   ([#5909](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5909))

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -10,7 +10,7 @@ Notes](../../RELEASENOTES.md).
   environment variable since the feature has moved from experimental to stable.
   The overflow attribute feature is now enabled by default.
   No internal logs will be emitted when the limit is hit, as the
-  `otel.metric.overflow` attribute indicates when a cardinality cap has occurred..
+  `otel.metric.overflow` attribute indicates when a cardinality cap has occurred.
   ([#5909](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5909))
 
 ## 1.10.0-beta.1

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -6,7 +6,7 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* Promote overflow attribute from experimental to stable and removed the
+* Promoted overflow attribute from experimental to stable and removed the
   `OTEL_DOTNET_EXPERIMENTAL_METRICS_EMIT_OVERFLOW_ATTRIBUTE` environment variable.
   The overflow attribute feature is now enabled by default.
   No internal logs will be emitted when the cardinality limit is reached, as the

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -8,9 +8,29 @@ Notes](../../RELEASENOTES.md).
 
 * Promoted overflow attribute from experimental to stable and removed the
   `OTEL_DOTNET_EXPERIMENTAL_METRICS_EMIT_OVERFLOW_ATTRIBUTE` environment variable.
-  The overflow attribute feature is now enabled by default.
-  No internal logs will be emitted when the cardinality limit is reached, as the
-  `otel.metric.overflow` attribute can be used to tell that the limit is reached.
+
+  **Previous Behavior:**
+  By default, when the cardinality limit was reached, measurements were dropped,
+  and an internal log was emitted the first time this occurred. Users could
+  opt-in to experimental overflow attribute feature with
+  `OTEL_DOTNET_EXPERIMENTAL_METRICS_EMIT_OVERFLOW_ATTRIBUTE=true`.
+  With this setting, the SDK would use an overflow attribute
+  (`otel.metric.overflow = true`) to aggregate measurements instead of dropping
+  measurements. No internal log was emitted in this case.
+
+  **New Behavior:**
+  The SDK now always uses the overflow attribute (`otel.metric.overflow = true`)
+  to aggregate measurements when the cardinality limit is reached. The previous
+  approach of dropping measurements has been removed. No internal logs are
+  emitted when the limit is hit.
+
+  The default cardinality limit remains 2000 per metric. To adjust this globally,
+  use the `SetMaxMetricPointsPerMetricStream()` API. However, we recommend
+  setting the limit on a per-metric basis for finer control. For details on
+  customizing limits per metric, refer to [changing cardinality
+  limit](../../docs/metrics/customizing-the-sdk/README.md#changing-the-cardinality-limit-for-a-metric).
+
+  There is NO ability to revert to old behavior.
   ([#5909](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5909))
 
 ## 1.10.0-beta.1

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -6,11 +6,11 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* Removed the `OTEL_DOTNET_EXPERIMENTAL_METRICS_EMIT_OVERFLOW_ATTRIBUTE`
-  environment variable since the feature has moved from experimental to stable.
+* Promote overflow attribute from experimental to stable and removed the
+  `OTEL_DOTNET_EXPERIMENTAL_METRICS_EMIT_OVERFLOW_ATTRIBUTE` environment variable.
   The overflow attribute feature is now enabled by default.
-  No internal logs will be emitted when the limit is hit, as the
-  `otel.metric.overflow` attribute indicates when a cardinality cap has occurred.
+  No internal logs will be emitted when the cardinality limit is reached, as the
+  `otel.metric.overflow` attribute can be used to tell that the limit is reached.
   ([#5909](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5909))
 
 ## 1.10.0-beta.1

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -6,6 +6,10 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* The opt-in overflow attribute feature which can be enabled by setting the
+  environment variable `OTEL_DOTNET_EXPERIMENTAL_METRICS_EMIT_OVERFLOW_ATTRIBUTE`
+  to `true` is now enabled by default and supported in stable builds.
+
 ## 1.10.0-beta.1
 
 Released 2024-Sep-30

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -9,6 +9,7 @@ Notes](../../RELEASENOTES.md).
 * The opt-in overflow attribute feature which can be enabled by setting the
   environment variable `OTEL_DOTNET_EXPERIMENTAL_METRICS_EMIT_OVERFLOW_ATTRIBUTE`
   to `true` is now enabled by default and supported in stable builds.
+  ([#5909](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5909))
 
 ## 1.10.0-beta.1
 

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -13,7 +13,6 @@ namespace OpenTelemetry.Metrics;
 
 internal sealed class MeterProviderSdk : MeterProvider
 {
-    internal const string EmitOverFlowAttributeConfigKey = "OTEL_DOTNET_EXPERIMENTAL_METRICS_EMIT_OVERFLOW_ATTRIBUTE";
     internal const string ReclaimUnusedMetricPointsConfigKey = "OTEL_DOTNET_EXPERIMENTAL_METRICS_RECLAIM_UNUSED_METRIC_POINTS";
     internal const string ExemplarFilterConfigKey = "OTEL_METRICS_EXEMPLAR_FILTER";
     internal const string ExemplarFilterHistogramsConfigKey = "OTEL_DOTNET_EXPERIMENTAL_METRICS_EXEMPLAR_FILTER_HISTOGRAMS";
@@ -22,7 +21,6 @@ internal sealed class MeterProviderSdk : MeterProvider
     internal readonly IDisposable? OwnedServiceProvider;
     internal int ShutdownCount;
     internal bool Disposed;
-    internal bool EmitOverflowAttribute;
     internal bool ReclaimUnusedMetricPoints;
     internal ExemplarFilterType? ExemplarFilter;
     internal ExemplarFilterType? ExemplarFilterForHistograms;
@@ -75,7 +73,7 @@ internal sealed class MeterProviderSdk : MeterProvider
         this.viewConfigs = state.ViewConfigs;
 
         OpenTelemetrySdkEventSource.Log.MeterProviderSdkEvent(
-            $"MeterProvider configuration: {{MetricLimit={state.MetricLimit}, CardinalityLimit={state.CardinalityLimit}, EmitOverflowAttribute={this.EmitOverflowAttribute}, ReclaimUnusedMetricPoints={this.ReclaimUnusedMetricPoints}, ExemplarFilter={this.ExemplarFilter}, ExemplarFilterForHistograms={this.ExemplarFilterForHistograms}}}.");
+            $"MeterProvider configuration: {{MetricLimit={state.MetricLimit}, CardinalityLimit={state.CardinalityLimit}, ReclaimUnusedMetricPoints={this.ReclaimUnusedMetricPoints}, ExemplarFilter={this.ExemplarFilter}, ExemplarFilterForHistograms={this.ExemplarFilterForHistograms}}}.");
 
         foreach (var reader in state.Readers)
         {
@@ -86,7 +84,6 @@ internal sealed class MeterProviderSdk : MeterProvider
             reader.ApplyParentProviderSettings(
                 state.MetricLimit,
                 state.CardinalityLimit,
-                this.EmitOverflowAttribute,
                 this.ReclaimUnusedMetricPoints,
                 this.ExemplarFilter,
                 this.ExemplarFilterForHistograms);
@@ -486,11 +483,6 @@ internal sealed class MeterProviderSdk : MeterProvider
 
     private void ApplySpecificationConfigurationKeys(IConfiguration configuration)
     {
-        if (configuration.TryGetBoolValue(OpenTelemetrySdkEventSource.Log, EmitOverFlowAttributeConfigKey, out this.EmitOverflowAttribute))
-        {
-            OpenTelemetrySdkEventSource.Log.MeterProviderSdkEvent("Overflow attribute feature enabled via configuration.");
-        }
-
         if (configuration.TryGetBoolValue(OpenTelemetrySdkEventSource.Log, ReclaimUnusedMetricPointsConfigKey, out this.ReclaimUnusedMetricPoints))
         {
             OpenTelemetrySdkEventSource.Log.MeterProviderSdkEvent("Reclaim unused metric point feature enabled via configuration.");

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -70,7 +70,6 @@ public sealed class Metric
         MetricStreamIdentity instrumentIdentity,
         AggregationTemporality temporality,
         int cardinalityLimit,
-        bool emitOverflowAttribute,
         bool shouldReclaimUnusedMetricPoints,
         ExemplarFilterType? exemplarFilter = null,
         Func<ExemplarReservoir?>? exemplarReservoirFactory = null)
@@ -193,7 +192,6 @@ public sealed class Metric
             aggType,
             temporality,
             cardinalityLimit,
-            emitOverflowAttribute,
             shouldReclaimUnusedMetricPoints,
             exemplarFilter,
             exemplarReservoirFactory);

--- a/src/OpenTelemetry/Metrics/Reader/MetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/Reader/MetricReaderExt.cs
@@ -22,7 +22,6 @@ public abstract partial class MetricReader
     private Metric?[]? metrics;
     private Metric[]? metricsCurrentBatch;
     private int metricIndex = -1;
-    private bool emitOverflowAttribute;
     private bool reclaimUnusedMetricPoints;
     private ExemplarFilterType? exemplarFilter;
     private ExemplarFilterType? exemplarFilterForHistograms;
@@ -82,7 +81,6 @@ public abstract partial class MetricReader
                         metricStreamIdentity,
                         this.GetAggregationTemporality(metricStreamIdentity.InstrumentType),
                         this.cardinalityLimit,
-                        this.emitOverflowAttribute,
                         this.reclaimUnusedMetricPoints,
                         exemplarFilter);
                 }
@@ -164,7 +162,6 @@ public abstract partial class MetricReader
                         metricStreamIdentity,
                         this.GetAggregationTemporality(metricStreamIdentity.InstrumentType),
                         metricStreamConfig?.CardinalityLimit ?? this.cardinalityLimit,
-                        this.emitOverflowAttribute,
                         this.reclaimUnusedMetricPoints,
                         exemplarFilter,
                         metricStreamConfig?.ExemplarReservoirFactory);
@@ -184,7 +181,6 @@ public abstract partial class MetricReader
     internal void ApplyParentProviderSettings(
         int metricLimit,
         int cardinalityLimit,
-        bool emitOverflowAttribute,
         bool reclaimUnusedMetricPoints,
         ExemplarFilterType? exemplarFilter,
         ExemplarFilterType? exemplarFilterForHistograms)
@@ -193,7 +189,6 @@ public abstract partial class MetricReader
         this.metrics = new Metric[metricLimit];
         this.metricsCurrentBatch = new Metric[metricLimit];
         this.cardinalityLimit = cardinalityLimit;
-        this.emitOverflowAttribute = emitOverflowAttribute;
         this.reclaimUnusedMetricPoints = reclaimUnusedMetricPoints;
         this.exemplarFilter = exemplarFilter;
         this.exemplarFilterForHistograms = exemplarFilterForHistograms;

--- a/test/OpenTelemetry.Tests/Metrics/AggregatorTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/AggregatorTestsBase.cs
@@ -16,16 +16,14 @@ public abstract class AggregatorTestsBase
     private static readonly ExplicitBucketHistogramConfiguration HistogramConfiguration = new() { Boundaries = Metric.DefaultHistogramBounds };
     private static readonly MetricStreamIdentity MetricStreamIdentity = new(Instrument, HistogramConfiguration);
 
-    private readonly bool emitOverflowAttribute;
     private readonly bool shouldReclaimUnusedMetricPoints;
     private readonly AggregatorStore aggregatorStore;
 
-    protected AggregatorTestsBase(bool emitOverflowAttribute, bool shouldReclaimUnusedMetricPoints)
+    protected AggregatorTestsBase(bool shouldReclaimUnusedMetricPoints)
     {
-        this.emitOverflowAttribute = emitOverflowAttribute;
         this.shouldReclaimUnusedMetricPoints = shouldReclaimUnusedMetricPoints;
 
-        this.aggregatorStore = new(MetricStreamIdentity, AggregationType.HistogramWithBuckets, AggregationTemporality.Cumulative, 1024, emitOverflowAttribute, this.shouldReclaimUnusedMetricPoints);
+        this.aggregatorStore = new(MetricStreamIdentity, AggregationType.HistogramWithBuckets, AggregationTemporality.Cumulative, 1024, this.shouldReclaimUnusedMetricPoints);
     }
 
     [Fact]
@@ -253,7 +251,6 @@ public abstract class AggregatorTestsBase
             AggregationType.Histogram,
             AggregationTemporality.Cumulative,
             cardinalityLimit: 1024,
-            this.emitOverflowAttribute,
             this.shouldReclaimUnusedMetricPoints);
 
         KnownHistogramBuckets actualHistogramBounds = KnownHistogramBuckets.Default;
@@ -330,7 +327,6 @@ public abstract class AggregatorTestsBase
             aggregationType,
             aggregationTemporality,
             cardinalityLimit: 1024,
-            this.emitOverflowAttribute,
             this.shouldReclaimUnusedMetricPoints,
             exemplarsEnabled ? ExemplarFilterType.AlwaysOn : null);
 
@@ -440,7 +436,6 @@ public abstract class AggregatorTestsBase
             AggregationType.Base2ExponentialHistogram,
             AggregationTemporality.Cumulative,
             cardinalityLimit: 1024,
-            this.emitOverflowAttribute,
             this.shouldReclaimUnusedMetricPoints);
 
         aggregatorStore.Update(10, Array.Empty<KeyValuePair<string, object?>>());
@@ -525,15 +520,7 @@ public abstract class AggregatorTestsBase
 public class AggregatorTests : AggregatorTestsBase
 {
     public AggregatorTests()
-        : base(emitOverflowAttribute: false, shouldReclaimUnusedMetricPoints: false)
-    {
-    }
-}
-
-public class AggregatorTestsWithOverflowAttribute : AggregatorTestsBase
-{
-    public AggregatorTestsWithOverflowAttribute()
-        : base(emitOverflowAttribute: true, shouldReclaimUnusedMetricPoints: false)
+        : base(shouldReclaimUnusedMetricPoints: false)
     {
     }
 }
@@ -541,15 +528,7 @@ public class AggregatorTestsWithOverflowAttribute : AggregatorTestsBase
 public class AggregatorTestsWithReclaimAttribute : AggregatorTestsBase
 {
     public AggregatorTestsWithReclaimAttribute()
-        : base(emitOverflowAttribute: false, shouldReclaimUnusedMetricPoints: true)
-    {
-    }
-}
-
-public class AggregatorTestsWithBothReclaimAndOverflowAttributes : AggregatorTestsBase
-{
-    public AggregatorTestsWithBothReclaimAndOverflowAttributes()
-        : base(emitOverflowAttribute: true, shouldReclaimUnusedMetricPoints: true)
+        : base(shouldReclaimUnusedMetricPoints: true)
     {
     }
 }

--- a/test/OpenTelemetry.Tests/Metrics/MetricApiTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricApiTestsBase.cs
@@ -23,8 +23,8 @@ public abstract class MetricApiTestsBase : MetricTestsBase
     private static readonly int NumberOfMetricUpdateByEachThread = 100000;
     private readonly ITestOutputHelper output;
 
-    protected MetricApiTestsBase(ITestOutputHelper output, bool emitOverflowAttribute, bool shouldReclaimUnusedMetricPoints)
-        : base(BuildConfiguration(emitOverflowAttribute, shouldReclaimUnusedMetricPoints))
+    protected MetricApiTestsBase(ITestOutputHelper output, bool shouldReclaimUnusedMetricPoints)
+        : base(BuildConfiguration(shouldReclaimUnusedMetricPoints))
     {
         this.output = output;
     }
@@ -1704,14 +1704,9 @@ public abstract class MetricApiTestsBase : MetricTestsBase
         }
     }
 
-    internal static IConfiguration BuildConfiguration(bool emitOverflowAttribute, bool shouldReclaimUnusedMetricPoints)
+    internal static IConfiguration BuildConfiguration(bool shouldReclaimUnusedMetricPoints)
     {
         var configurationData = new Dictionary<string, string?>();
-
-        if (emitOverflowAttribute)
-        {
-            configurationData[EmitOverFlowAttributeConfigKey] = "true";
-        }
 
         if (shouldReclaimUnusedMetricPoints)
         {
@@ -1894,15 +1889,7 @@ public abstract class MetricApiTestsBase : MetricTestsBase
 public class MetricApiTest : MetricApiTestsBase
 {
     public MetricApiTest(ITestOutputHelper output)
-        : base(output, emitOverflowAttribute: false, shouldReclaimUnusedMetricPoints: false)
-    {
-    }
-}
-
-public class MetricApiTestWithOverflowAttribute : MetricApiTestsBase
-{
-    public MetricApiTestWithOverflowAttribute(ITestOutputHelper output)
-        : base(output, emitOverflowAttribute: true, shouldReclaimUnusedMetricPoints: false)
+        : base(output, shouldReclaimUnusedMetricPoints: false)
     {
     }
 }
@@ -1910,15 +1897,7 @@ public class MetricApiTestWithOverflowAttribute : MetricApiTestsBase
 public class MetricApiTestWithReclaimAttribute : MetricApiTestsBase
 {
     public MetricApiTestWithReclaimAttribute(ITestOutputHelper output)
-        : base(output, emitOverflowAttribute: false, shouldReclaimUnusedMetricPoints: true)
-    {
-    }
-}
-
-public class MetricApiTestWithBothOverflowAndReclaimAttributes : MetricApiTestsBase
-{
-    public MetricApiTestWithBothOverflowAndReclaimAttributes(ITestOutputHelper output)
-        : base(output, emitOverflowAttribute: true, shouldReclaimUnusedMetricPoints: true)
+        : base(output, shouldReclaimUnusedMetricPoints: true)
     {
     }
 }

--- a/test/OpenTelemetry.Tests/Metrics/MetricApiTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricApiTestsBase.cs
@@ -1410,7 +1410,6 @@ public abstract class MetricApiTestsBase : MetricTestsBase
                 enumerator.MoveNext(); // Second element reserved for overflow attribute.
 
                 // Validate second element is overflow attribute.
-                // Overflow attribute is behind experimental flag. So, it is not guaranteed to be present.
                 var tagEnumerator = enumerator.Current.Tags.GetEnumerator();
                 tagEnumerator.MoveNext();
                 if (!tagEnumerator.Current.Key.Contains("otel.metric.overflow"))

--- a/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTestsBase.cs
@@ -208,8 +208,7 @@ public abstract class MetricPointReclaimTestsBase
             .Build();
 
         // Add 10 distinct combinations of dimensions to surpass the max metric points limit of 10.
-        // Note that one MetricPoint is reserved for zero tags and one MetricPoint is optionally
-        // reserved for the overflow tag depending on the user's input.
+        // Note that one MetricPoint is reserved for zero tags and one MetricPoint is reserved for the overflow tag.
         // This would lead to dropping a few measurements. We want to make sure that they can still be
         // aggregated later on when there are free MetricPoints available.
         for (int i = 0; i < 10; i++)

--- a/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTestsBase.cs
@@ -20,13 +20,8 @@ public abstract class MetricPointReclaimTestsBase
 
     private readonly IConfiguration configuration;
 
-    protected MetricPointReclaimTestsBase(bool emitOverflowAttribute)
+    protected MetricPointReclaimTestsBase()
     {
-        if (emitOverflowAttribute)
-        {
-            this.configurationData[MetricTestsBase.EmitOverFlowAttributeConfigKey] = "true";
-        }
-
         this.configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(this.configurationData)
             .Build();
@@ -333,15 +328,7 @@ public abstract class MetricPointReclaimTestsBase
 public class MetricPointReclaimTests : MetricPointReclaimTestsBase
 {
     public MetricPointReclaimTests()
-        : base(emitOverflowAttribute: false)
-    {
-    }
-}
-
-public class MetricPointReclaimTestsWithEmitOverflowAttribute : MetricPointReclaimTestsBase
-{
-    public MetricPointReclaimTestsWithEmitOverflowAttribute()
-        : base(emitOverflowAttribute: true)
+        : base()
     {
     }
 }

--- a/test/OpenTelemetry.Tests/Metrics/MetricSnapshotTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricSnapshotTestsBase.cs
@@ -16,10 +16,9 @@ public abstract class MetricSnapshotTestsBase
 {
     private readonly IConfiguration configuration;
 
-    protected MetricSnapshotTestsBase(bool emitOverflowAttribute, bool shouldReclaimUnusedMetricPoints)
+    protected MetricSnapshotTestsBase(bool shouldReclaimUnusedMetricPoints)
     {
         this.configuration = MetricApiTestsBase.BuildConfiguration(
-            emitOverflowAttribute,
             shouldReclaimUnusedMetricPoints);
     }
 
@@ -298,15 +297,7 @@ public abstract class MetricSnapshotTestsBase
 public class MetricSnapshotTests : MetricSnapshotTestsBase
 {
     public MetricSnapshotTests()
-        : base(emitOverflowAttribute: false, shouldReclaimUnusedMetricPoints: false)
-    {
-    }
-}
-
-public class MetricSnapshotTestsWithOverflowAttribute : MetricSnapshotTestsBase
-{
-    public MetricSnapshotTestsWithOverflowAttribute()
-        : base(emitOverflowAttribute: true, shouldReclaimUnusedMetricPoints: false)
+        : base(shouldReclaimUnusedMetricPoints: false)
     {
     }
 }
@@ -314,15 +305,7 @@ public class MetricSnapshotTestsWithOverflowAttribute : MetricSnapshotTestsBase
 public class MetricSnapshotTestsWithReclaimAttribute : MetricSnapshotTestsBase
 {
     public MetricSnapshotTestsWithReclaimAttribute()
-        : base(emitOverflowAttribute: false, shouldReclaimUnusedMetricPoints: true)
-    {
-    }
-}
-
-public class MetricSnapshotTestsWithBothAttributes : MetricSnapshotTestsBase
-{
-    public MetricSnapshotTestsWithBothAttributes()
-        : base(emitOverflowAttribute: true, shouldReclaimUnusedMetricPoints: true)
+        : base(shouldReclaimUnusedMetricPoints: true)
     {
     }
 }

--- a/test/OpenTelemetry.Tests/Metrics/MetricTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricTestsBase.cs
@@ -16,7 +16,6 @@ namespace OpenTelemetry.Metrics.Tests;
 
 public class MetricTestsBase
 {
-    public const string EmitOverFlowAttributeConfigKey = "OTEL_DOTNET_EXPERIMENTAL_METRICS_EMIT_OVERFLOW_ATTRIBUTE";
     public const string ReclaimUnusedMetricPointsConfigKey = "OTEL_DOTNET_EXPERIMENTAL_METRICS_RECLAIM_UNUSED_METRIC_POINTS";
 
     protected readonly IConfiguration? configuration;


### PR DESCRIPTION
Fixes #5641.
Design discussion issue #

## Changes

Remove the `OTEL_DOTNET_EXPERIMENTAL_METRICS_EMIT_OVERFLOW_ATTRIBUTE` variable and make the feature enabled by default.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
