### PR TITLE
feat(): Add mTLS Support for OTLP Exporter

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/Stable/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/.publicApi/Stable/PublicAPI.Unshipped.txt
@@ -1,0 +1,6 @@
+OpenTelemetry.Exporter.OtlpExporterOptions.CertificateFile.get -> string!
+OpenTelemetry.Exporter.OtlpExporterOptions.CertificateFile.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.ClientCertificateFile.get -> string!
+OpenTelemetry.Exporter.OtlpExporterOptions.ClientCertificateFile.set -> void
+OpenTelemetry.Exporter.OtlpExporterOptions.ClientKeyFile.get -> string!
+OpenTelemetry.Exporter.OtlpExporterOptions.ClientKeyFile.set -> void

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpHttpLogExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpHttpLogExportClient.cs
@@ -19,13 +19,33 @@ internal sealed class OtlpHttpLogExportClient : BaseOtlpHttpExportClient<OtlpCol
     private const string LogsExportPath = "v1/logs";
 
     public OtlpHttpLogExportClient(OtlpExporterOptions options, HttpClient httpClient)
-        : base(options, httpClient, LogsExportPath)
+        : base(options, ModifyHttpClient(options, httpClient), LogsExportPath)
     {
     }
 
     protected override HttpContent CreateHttpContent(OtlpCollector.ExportLogsServiceRequest exportRequest)
     {
         return new ExportRequestContent(exportRequest);
+    }
+
+    private static HttpClient ModifyHttpClient(OtlpExporterOptions options, HttpClient httpClient)
+    {
+        // Create a new handler using the existing method that configures mTLS
+        var handler = options.CreateDefaultHttpMessageHandler();
+
+        // Create a new HttpClient with the mTLS-enabled handler
+        var newHttpClient = new HttpClient(handler, disposeHandler: true);
+
+        // Copy existing headers from the original HttpClient
+        foreach (var header in httpClient.DefaultRequestHeaders)
+        {
+            newHttpClient.DefaultRequestHeaders.Add(header.Key, header.Value);
+        }
+
+        // Copy other properties, such as timeout, if needed
+        newHttpClient.Timeout = httpClient.Timeout;
+
+        return newHttpClient;
     }
 
     internal sealed class ExportRequestContent : HttpContent

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpHttpTraceExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpHttpTraceExportClient.cs
@@ -19,13 +19,33 @@ internal sealed class OtlpHttpTraceExportClient : BaseOtlpHttpExportClient<OtlpC
     private const string TracesExportPath = "v1/traces";
 
     public OtlpHttpTraceExportClient(OtlpExporterOptions options, HttpClient httpClient)
-        : base(options, httpClient, TracesExportPath)
+        : base(options, ModifyHttpClient(options, httpClient), TracesExportPath)
     {
     }
 
     protected override HttpContent CreateHttpContent(OtlpCollector.ExportTraceServiceRequest exportRequest)
     {
         return new ExportRequestContent(exportRequest);
+    }
+
+    private static HttpClient ModifyHttpClient(OtlpExporterOptions options, HttpClient httpClient)
+    {
+        // Create a new handler using the existing method that configures mTLS
+        var handler = options.CreateDefaultHttpMessageHandler();
+
+        // Create a new HttpClient with the mTLS-enabled handler
+        var newHttpClient = new HttpClient(handler, disposeHandler: true);
+
+        // Copy existing headers from the original HttpClient
+        foreach (var header in httpClient.DefaultRequestHeaders)
+        {
+            newHttpClient.DefaultRequestHeaders.Add(header.Key, header.Value);
+        }
+
+        // Copy other properties, such as timeout, if needed
+        newHttpClient.Timeout = httpClient.Timeout;
+
+        return newHttpClient;
     }
 
     internal sealed class ExportRequestContent : HttpContent


### PR DESCRIPTION
Fixes #2009   
Based on PR 
- https://github.com/open-telemetry/opentelemetry-dotnet/pull/4731
- https://github.com/open-telemetry/opentelemetry-dotnet/pull/5818

## Changes

This pull request introduces support for mutual TLS (mTLS) in the OpenTelemetry Protocol (OTLP) Exporter, allowing secure gRPC connections over HTTPS and mTLS supports for HTTP Protocol.

### Key Changes:
- Certificate file. `OTEL_EXPORTER_OTLP_CERTIFICATE`
- Client key file. `OTEL_EXPORTER_OTLP_CLIENT_KEY`
- Client certificate file. `OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE`

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)

## License Information

THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE APACHE LICENSE V.2.0. YOU MAY OBTAIN A COPY OF THE LICENSE AT https://github.com/open-telemetry/opentelemetry-python/blob/master/LICENSE.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.