### PR TITLE
[console] Support ActivitySource.Tags

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -13,6 +13,11 @@ Notes](../../RELEASENOTES.md).
   ([#5874](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5874),
   [#5891](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5891))
 
+* Added support for Instrumentation Scope Attributes (i.e
+  [ActivitySource.Tags](https://learn.microsoft.com/dotnet/api/system.diagnostics.activitysource.tags))
+  when writing traces to the console.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.10.0-beta.1
 
 Released 2024-Sep-30
@@ -61,9 +66,9 @@ Released 2023-Dec-08
 
 Released 2023-Nov-29
 
-* Add support for Instrumentation Scope Attributes (i.e [Meter
-  Tags](https://learn.microsoft.com/dotnet/api/system.diagnostics.metrics.meter.tags)),
-  fixing issue
+* Added support for Instrumentation Scope Attributes (i.e
+  [Meter.Tags](https://learn.microsoft.com/dotnet/api/system.diagnostics.metrics.meter.tags)),
+  when writing metrics to the console, fixing issue
   [#4563](https://github.com/open-telemetry/opentelemetry-dotnet/issues/4563).
   ([#5089](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5089))
 

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -16,7 +16,7 @@ Notes](../../RELEASENOTES.md).
 * Added support for Instrumentation Scope Attributes (i.e
   [ActivitySource.Tags](https://learn.microsoft.com/dotnet/api/system.diagnostics.activitysource.tags))
   when writing traces to the console.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#5935](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5935))
 
 ## 1.10.0-beta.1
 

--- a/src/OpenTelemetry.Exporter.Console/ConsoleActivityExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleActivityExporter.cs
@@ -31,24 +31,6 @@ public class ConsoleActivityExporter : ConsoleExporter<Activity>
                 this.WriteLine($"Activity.ParentSpanId:       {activity.ParentSpanId}");
             }
 
-            this.WriteLine($"Activity.ActivitySource.Name: {activity.Source.Name}");
-            if (!string.IsNullOrEmpty(activity.Source.Version))
-            {
-                this.WriteLine($"Activity.ActivitySource.Version: {activity.Source.Version}");
-            }
-
-            if (activity.Source.Tags?.Any() == true)
-            {
-                this.WriteLine("Activity.ActivitySource.Tags:");
-                foreach (var activitySourceTag in activity.Source.Tags)
-                {
-                    if (this.TagWriter.TryTransformTag(activitySourceTag, out var result))
-                    {
-                        this.WriteLine($"    {result.Key}: {result.Value}");
-                    }
-                }
-            }
-
             this.WriteLine($"Activity.DisplayName:        {activity.DisplayName}");
             this.WriteLine($"Activity.Kind:               {activity.Kind}");
             this.WriteLine($"Activity.StartTime:          {activity.StartTimeUtc:yyyy-MM-ddTHH:mm:ss.fffffffZ}");
@@ -125,6 +107,25 @@ public class ConsoleActivityExporter : ConsoleExporter<Activity>
                         {
                             this.WriteLine($"        {result.Key}: {result.Value}");
                         }
+                    }
+                }
+            }
+
+            this.WriteLine("Instrumentation scope (ActivitySource):");
+            this.WriteLine($"    Name: {activity.Source.Name}");
+            if (!string.IsNullOrEmpty(activity.Source.Version))
+            {
+                this.WriteLine($"    Version: {activity.Source.Version}");
+            }
+
+            if (activity.Source.Tags?.Any() == true)
+            {
+                this.WriteLine("    Tags:");
+                foreach (var activitySourceTag in activity.Source.Tags)
+                {
+                    if (this.TagWriter.TryTransformTag(activitySourceTag, out var result))
+                    {
+                        this.WriteLine($"        {result.Key}: {result.Value}");
                     }
                 }
             }

--- a/src/OpenTelemetry.Exporter.Console/ConsoleActivityExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleActivityExporter.cs
@@ -37,10 +37,10 @@ public class ConsoleActivityExporter : ConsoleExporter<Activity>
                 this.WriteLine($"Activity.ActivitySource.Version: {activity.Source.Version}");
             }
 
-            if (activity.Source.Tags != null)
+            if (activity.Source.Tags?.Any() == true)
             {
                 this.WriteLine("Activity.ActivitySource.Tags:");
-                foreach (var activitySourceTag in activity.Source.Tags ?? [])
+                foreach (var activitySourceTag in activity.Source.Tags)
                 {
                     if (this.TagWriter.TryTransformTag(activitySourceTag, out var result))
                     {

--- a/src/OpenTelemetry.Exporter.Console/ConsoleActivityExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleActivityExporter.cs
@@ -31,10 +31,22 @@ public class ConsoleActivityExporter : ConsoleExporter<Activity>
                 this.WriteLine($"Activity.ParentSpanId:       {activity.ParentSpanId}");
             }
 
-            this.WriteLine($"Activity.ActivitySourceName: {activity.Source.Name}");
+            this.WriteLine($"Activity.ActivitySource.Name: {activity.Source.Name}");
             if (!string.IsNullOrEmpty(activity.Source.Version))
             {
-                this.WriteLine($"Activity.ActivitySourceVersion: {activity.Source.Version}");
+                this.WriteLine($"Activity.ActivitySource.Version: {activity.Source.Version}");
+            }
+
+            if (activity.Source.Tags != null)
+            {
+                this.WriteLine("Activity.ActivitySource.Tags:");
+                foreach (var activitySourceTag in activity.Source.Tags ?? [])
+                {
+                    if (this.TagWriter.TryTransformTag(activitySourceTag, out var result))
+                    {
+                        this.WriteLine($"    {result.Key}: {result.Value}");
+                    }
+                }
             }
 
             this.WriteLine($"Activity.DisplayName:        {activity.DisplayName}");

--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -62,7 +62,7 @@ public class ConsoleMetricExporter : ConsoleExporter<Metric>
 
             this.WriteLine(msg.ToString());
 
-            if (metric.MeterTags != null)
+            if (metric.MeterTags?.Any() == true)
             {
                 this.WriteLine("\tMeter Tags:");
                 foreach (var meterTag in metric.MeterTags)

--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -179,7 +179,7 @@ public class ConsoleMetricExporter : ConsoleExporter<Metric>
                             {
                                 if (!appendedTagString)
                                 {
-                                    exemplarString.Append(" Filtered Tags : ");
+                                    exemplarString.Append(" Filtered Tags: ");
                                     appendedTagString = true;
                                 }
 
@@ -244,7 +244,7 @@ public class ConsoleMetricExporter : ConsoleExporter<Metric>
                     {
                         if (this.TagWriter.TryTransformTag(resourceAttribute.Key, resourceAttribute.Value, out var result))
                         {
-                            this.WriteLine($"    {result.Key}: {result.Value}");
+                            this.WriteLine($"\t{result.Key}: {result.Value}");
                         }
                     }
                 }

--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -64,9 +64,9 @@ public class ConsoleMetricExporter : ConsoleExporter<Metric>
 
             if (metric.MeterTags != null)
             {
+                this.WriteLine("\tMeter Tags:");
                 foreach (var meterTag in metric.MeterTags)
                 {
-                    this.WriteLine("\tMeter Tags:");
                     if (this.TagWriter.TryTransformTag(meterTag, out var result))
                     {
                         this.WriteLine($"\t\t{result.Key}: {result.Value}");

--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -10,8 +10,6 @@ namespace OpenTelemetry.Exporter;
 
 public class ConsoleMetricExporter : ConsoleExporter<Metric>
 {
-    private Resource? resource;
-
     public ConsoleMetricExporter(ConsoleExporterOptions options)
         : base(options)
     {
@@ -19,30 +17,13 @@ public class ConsoleMetricExporter : ConsoleExporter<Metric>
 
     public override ExportResult Export(in Batch<Metric> batch)
     {
-        if (this.resource == null)
-        {
-            this.resource = this.ParentProvider.GetResource();
-            if (this.resource != Resource.Empty)
-            {
-                this.WriteLine("Resource associated with Metric:");
-                foreach (var resourceAttribute in this.resource.Attributes)
-                {
-                    if (this.TagWriter.TryTransformTag(resourceAttribute.Key, resourceAttribute.Value, out var result))
-                    {
-                        this.WriteLine($"    {result.Key}: {result.Value}");
-                    }
-                }
-            }
-        }
-
         foreach (var metric in batch)
         {
             var msg = new StringBuilder($"\n");
             msg.Append($"Metric Name: {metric.Name}");
             if (metric.Description != string.Empty)
             {
-                msg.Append(", ");
-                msg.Append(metric.Description);
+                msg.Append($", Description: {metric.Description}");
             }
 
             if (metric.Unit != string.Empty)
@@ -50,29 +31,7 @@ public class ConsoleMetricExporter : ConsoleExporter<Metric>
                 msg.Append($", Unit: {metric.Unit}");
             }
 
-            if (!string.IsNullOrEmpty(metric.MeterName))
-            {
-                msg.Append($", Meter: {metric.MeterName}");
-
-                if (!string.IsNullOrEmpty(metric.MeterVersion))
-                {
-                    msg.Append($"/{metric.MeterVersion}");
-                }
-            }
-
             this.WriteLine(msg.ToString());
-
-            if (metric.MeterTags?.Any() == true)
-            {
-                this.WriteLine("\tMeter Tags:");
-                foreach (var meterTag in metric.MeterTags)
-                {
-                    if (this.TagWriter.TryTransformTag(meterTag, out var result))
-                    {
-                        this.WriteLine($"\t\t{result.Key}: {result.Value}");
-                    }
-                }
-            }
 
             foreach (ref readonly var metricPoint in metric.GetMetricPoints())
             {
@@ -257,6 +216,38 @@ public class ConsoleMetricExporter : ConsoleExporter<Metric>
                 }
 
                 this.WriteLine(msg.ToString());
+
+                this.WriteLine("Instrumentation scope (Meter):");
+                this.WriteLine($"\tName: {metric.MeterName}");
+                if (!string.IsNullOrEmpty(metric.MeterVersion))
+                {
+                    this.WriteLine($"\tVersion: {metric.MeterVersion}");
+                }
+
+                if (metric.MeterTags?.Any() == true)
+                {
+                    this.WriteLine("\tTags:");
+                    foreach (var meterTag in metric.MeterTags)
+                    {
+                        if (this.TagWriter.TryTransformTag(meterTag, out var result))
+                        {
+                            this.WriteLine($"\t\t{result.Key}: {result.Value}");
+                        }
+                    }
+                }
+
+                var resource = this.ParentProvider.GetResource();
+                if (resource != Resource.Empty)
+                {
+                    this.WriteLine("Resource associated with Metric:");
+                    foreach (var resourceAttribute in resource.Attributes)
+                    {
+                        if (this.TagWriter.TryTransformTag(resourceAttribute.Key, resourceAttribute.Value, out var result))
+                        {
+                            this.WriteLine($"    {result.Key}: {result.Value}");
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Relates to #5701

## Changes

* Display `ActivitySource.Tags` (if set) when exporting traces to console.

## Examples

### Traces:

![image](https://github.com/user-attachments/assets/992a64d6-d445-4751-bc3c-f775c3925ed7)

### Metrics (tweaked):

![image](https://github.com/user-attachments/assets/fb318d56-a68a-42d3-89c5-a058de034506)

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
