### PR TITLE
[docs] Update verb tense grammar for CHANGELOGs

### DIFF
--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
@@ -25,8 +25,8 @@ Released 2024-Jun-07
 
 * The experimental APIs previously covered by `OTEL1000`
   (`LoggerProviderBuilder` `AddInstrumentation` & `ConfigureServices` extensions
-  and `IServiceCollection.ConfigureOpenTelemetryLoggerProvider` extension) will
-  now be part of the public API and supported in stable builds.
+  and `IServiceCollection.ConfigureOpenTelemetryLoggerProvider` extension) are
+  now part of the public API and supported in stable builds.
   ([#5648](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5648))
 
 ## 1.9.0-alpha.1

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -52,8 +52,8 @@ Released 2024-Jun-14
 Released 2024-Jun-07
 
 * The experimental APIs previously covered by `OTEL1000` (`LoggerProvider`,
-  `LoggerProviderBuilder`, & `IDeferredLoggerProviderBuilder`) will now be part
-  of the public API and supported in stable builds.
+  `LoggerProviderBuilder`, & `IDeferredLoggerProviderBuilder`) are now part of
+  the public API and supported in stable builds.
   ([#5648](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5648))
 
 ## 1.9.0-alpha.1

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -31,7 +31,7 @@ Released 2024-Jun-14
 Released 2024-Jun-07
 
 * The experimental APIs previously covered by `OTEL1000`
-  (`LoggerProviderBuilder.AddConsoleExporter` extension) will now be part of the
+  (`LoggerProviderBuilder.AddConsoleExporter` extension) are now part of the
   public API and supported in stable builds.
   ([#5648](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5648))
 

--- a/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
@@ -19,8 +19,8 @@ Released 2024-Jun-14
 Released 2024-Jun-07
 
 * The experimental APIs previously covered by `OTEL1000`
-  (`LoggerProviderBuilder.AddInMemoryExporter` extension) will now be part of
-  the public API and supported in stable builds.
+  (`LoggerProviderBuilder.AddInMemoryExporter` extension) are now part of the
+  public API and supported in stable builds.
   ([#5648](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5648))
 
 ## 1.9.0-alpha.1

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -43,8 +43,8 @@ Released 2024-Jun-14
 Released 2024-Jun-07
 
 * The experimental APIs previously covered by `OTEL1000`
-  (`LoggerProviderBuilder.AddOtlpExporter` extension) will now be part of the
-  public API and supported in stable builds.
+  (`LoggerProviderBuilder.AddOtlpExporter` extension) are now part of the public
+  API and supported in stable builds.
   ([#5648](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5648))
 
 ## 1.9.0-alpha.1

--- a/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
@@ -23,7 +23,7 @@ Released 2024-Jun-14
 Released 2024-Jun-07
 
 * The experimental APIs previously covered by `OTEL1000`
-  (`OpenTelemetryBuilder.WithLogging` method) will now be part of the public API
+  (`OpenTelemetryBuilder.WithLogging` method) are now be part of the public API
   and supported in stable builds.
   ([#5648](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5648))
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -7,8 +7,8 @@ Notes](../../RELEASENOTES.md).
 ## Unreleased
 
 * The experimental APIs previously covered by `OTEL1003`
-  (`MetricStreamConfiguration.CardinalityLimit`) will now be part of the public
-  API and supported in stable builds.
+  (`MetricStreamConfiguration.CardinalityLimit`) are now part of the public API
+  and supported in stable builds.
   ([#5926](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5926))
 
 * Promoted overflow attribute from experimental to stable and removed the
@@ -80,7 +80,7 @@ Released 2024-Jun-07
 
 * The experimental APIs previously covered by `OTEL1000`
   (`LoggerProviderBuilder` `AddProcessor` & `ConfigureResource` extensions, and
-  `LoggerProvider` `ForceFlush` & `Shutdown` extensions) will now be part of the
+  `LoggerProvider` `ForceFlush` & `Shutdown` extensions) are now part of the
   public API and supported in stable builds.
   ([#5648](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5648))
 
@@ -107,8 +107,8 @@ Released 2024-May-20
 * The experimental APIs previously covered by `OTEL1002` (`Exemplar`,
   `ExemplarFilterType`, `MeterProviderBuilder.SetExemplarFilter`,
   `ReadOnlyExemplarCollection`, `ReadOnlyFilteredTagCollection`, &
-  `MetricPoint.TryGetExemplars`) will now be part of the public API and
-  supported in stable builds.
+  `MetricPoint.TryGetExemplars`) are now part of the public API and supported in
+  stable builds.
   ([#5607](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5607))
 
 * Fixed the nullable annotations for the `SamplingResult` constructors


### PR DESCRIPTION
Address feedbacks at https://github.com/open-telemetry/opentelemetry-dotnet/pull/5926#discussion_r1817685484.

## Changes

Updated the verb tense grammar for CHANGELOGs.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated: N/A
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes: N/A
* [x] Changes in public API reviewed (if applicable): N/A
