### PR TITLE
Allow IEnumerable<KeyValuePair<string, string?>> enumeration in LogRecordScope

### DIFF
--- a/src/OpenTelemetry/Logs/LogRecordScope.cs
+++ b/src/OpenTelemetry/Logs/LogRecordScope.cs
@@ -49,6 +49,10 @@ public readonly struct LogRecordScope
             {
                 this.scope = new List<KeyValuePair<string, object?>>(scopeEnumerable);
             }
+            else if (scope is IEnumerable<KeyValuePair<string, string?>> otherScopeEnumerable)
+            {
+                this.scope = new List<KeyValuePair<string, object?>>(otherScopeEnumerable.Select(x => new KeyValuePair<string, object?>(x.Key, x.Value)));
+            }
             else
             {
                 this.scope = new List<KeyValuePair<string, object?>>


### PR DESCRIPTION
Fixes #5943

## Changes

Add a case where scope is IEnumerable<KeyValuePair<string, string?>> in order to be compatible with `Microsoft.Extensions.Telemetry`

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
