### PR TITLE
[otlp] Custom serialzer resource tweaks

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpResourceSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpResourceSerializer.cs
@@ -37,7 +37,7 @@ internal static class ProtobufOtlpResourceSerializer
                         isServiceNamePresent = true;
                     }
 
-                    otlpTagWriterState = ProcessResourceAttribute(ref otlpTagWriterState, attribute);
+                    ProcessResourceAttribute(ref otlpTagWriterState, attribute);
                 }
             }
             else
@@ -49,14 +49,14 @@ internal static class ProtobufOtlpResourceSerializer
                         isServiceNamePresent = true;
                     }
 
-                    otlpTagWriterState = ProcessResourceAttribute(ref otlpTagWriterState, attribute);
+                    ProcessResourceAttribute(ref otlpTagWriterState, attribute);
                 }
             }
         }
 
         if (!isServiceNamePresent)
         {
-            otlpTagWriterState = ProcessResourceAttribute(ref otlpTagWriterState, new KeyValuePair<string, object>(ResourceSemanticConventions.AttributeServiceName, DefaultServiceName));
+            ProcessResourceAttribute(ref otlpTagWriterState, new KeyValuePair<string, object>(ResourceSemanticConventions.AttributeServiceName, DefaultServiceName));
         }
 
         var resourceLength = otlpTagWriterState.WritePosition - (resourceLengthPosition + ReserveSizeForLength);
@@ -65,7 +65,7 @@ internal static class ProtobufOtlpResourceSerializer
         return otlpTagWriterState.WritePosition;
     }
 
-    private static ProtobufOtlpTagWriter.OtlpTagWriterState ProcessResourceAttribute(ref ProtobufOtlpTagWriter.OtlpTagWriterState otlpTagWriterState, KeyValuePair<string, object> attribute)
+    private static void ProcessResourceAttribute(ref ProtobufOtlpTagWriter.OtlpTagWriterState otlpTagWriterState, KeyValuePair<string, object> attribute)
     {
         otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpTraceFieldNumberConstants.Resource_Attributes, ProtobufWireType.LEN);
         int resourceAttributesLengthPosition = otlpTagWriterState.WritePosition;
@@ -75,6 +75,5 @@ internal static class ProtobufOtlpResourceSerializer
 
         var resourceAttributesLength = otlpTagWriterState.WritePosition - (resourceAttributesLengthPosition + ReserveSizeForLength);
         ProtobufSerializer.WriteReservedLength(otlpTagWriterState.Buffer, resourceAttributesLengthPosition, resourceAttributesLength);
-        return otlpTagWriterState;
     }
 }


### PR DESCRIPTION
## Changes

* Updates `ProtobufOtlpResourceSerializer` so that it doesn't return `OtlpTagWriterState` from helper methods. This isn't needed because `OtlpTagWriterState` is passed in by `ref`

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
