### PR TITLE
[otlp] Remove the direct dependency on Microsoft.Extensions.Configuration.Binder

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,6 @@
           these packages even during major version bumps, so compatibility is not a concern here.
     -->
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="$(LatestRuntimeOutOfBandVer)" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="$(LatestRuntimeOutOfBandVer)" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(LatestRuntimeOutOfBandVer)" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Abstractions" Version="$(LatestRuntimeOutOfBandVer)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(LatestRuntimeOutOfBandVer)" />

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -8,7 +8,7 @@ Notes](../../RELEASENOTES.md).
 ## Unreleased
 
 * Removed the direct dependency on `Microsoft.Extensions.Configuration.Binder`.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#5951](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5951))
 
 ## 1.10.0-rc.1
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -7,9 +7,6 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* Removed the direct dependency on `Microsoft.Extensions.Configuration.Binder`.
-  ([#5951](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5951))
-
 ## 1.10.0-rc.1
 
 Released 2024-Nov-01

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -7,6 +7,9 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Removed the direct dependency on `Microsoft.Extensions.Configuration.Binder`.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.10.0-rc.1
 
 Released 2024-Nov-01

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OpenTelemetry.Exporter.OpenTelemetryProtocol.csproj
@@ -28,7 +28,6 @@
     <PackageReference Include="Grpc" Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == '$(NetFrameworkMinimumSupportedVersion)'" />
     <PackageReference Include="Google.Protobuf" />
     <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changes

* Remove the direct dependency on `Microsoft.Extensions.Configuration.Binder` from the OtlpExporter project.

## Details

The SDK depends on `Microsoft.Extensions.Logging.Configuration` which brings in `Microsoft.Extensions.Configuration.Binder`. The `1.9.0` version of SDK brought in `8.0.0` versions of those packages. It seems [OtlpExporter needed 8.0.1 to make AoT work correctly](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5520/files#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156R31). Now that SDK is bringing in `9.0.0` versions of packages this redirect is no longer required.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
