### PR TITLE
[repo] Add Rajkumar Rangaraj as approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ you're more than welcome to participate!
 
 * [Cijo Thomas](https://github.com/cijothomas), Microsoft
 * [Piotr Kie&#x142;kowicz](https://github.com/Kielek), Splunk
+* [Rajkumar Rangaraj](https://github.com/rajkumar-rangaraj), Microsoft
 * [Reiley Yang](https://github.com/reyang), Microsoft
 * [Utkarsh Umesan Pillai](https://github.com/utpilla), Microsoft
 


### PR DESCRIPTION
Dear Raj,

You've been involved with the OpenTelemetry .NET project for over 4 years.

You had a hand in laying some of the initial foundations of the SDK. For example, the [Zipkin exporter](https://github.com/open-telemetry/opentelemetry-dotnet/pull/738) and [batch export processor](https://github.com/open-telemetry/opentelemetry-dotnet/pull/755).

More recently, you have added support for new functionality introduced in .NET 9: [synchronous gauges](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5867) and the [advice API](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5854).

Currently, you're actively implementing custom protobuf serialization for the OTLP exporter.

As of today, you have aided in at least [273 PRs](https://github.com/search?q=commenter%3Arajkumar-rangaraj+repo%3Aopen-telemetry%2Fopentelemetry-dotnet+&type=pullrequests).

On top of all that, you have been an active member of both the opentelemetry-dotnet-contrib (contributor) and opentelemetry-dotnet-instrumentation (maintainer) projects, you have regularly attended our SIG meeting, and I know you have always been working in the background assisting and coaching other contributors.

We kindly ask that you join us in an official capacity as an approver.

Sincerely,

The maintainers of OpenTelemetry .NET