### PR TITLE
[tests] Clean up class structure in metrics tests

### DIFF
--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetry.Extensions.Hosting.Tests.csproj
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetry.Extensions.Hosting.Tests.csproj
@@ -22,9 +22,9 @@
     <!-- Note: These are SDK tests which we link and run here using the
     IMetricsBuilder/IMetricsListener API added at the host level in .NET 8
     instead of the direct lower-level MeterListener API added in .NET 6. -->
-    <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Metrics\AggregatorTestsBase.cs" Link="Includes\Metrics\AggregatorTestsBase.cs" />
+    <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Metrics\AggregatorTests.cs" Link="Includes\Metrics\AggregatorTests.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Metrics\KnownHistogramBuckets.cs" Link="Includes\Metrics\KnownHistogramBuckets.cs" />
-    <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Metrics\MetricApiTestsBase.cs" Link="Includes\Metrics\MetricApiTestsBase.cs" />
+    <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Metrics\MetricApiTests.cs" Link="Includes\Metrics\MetricApiTests.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Metrics\MetricExemplarTests.cs" Link="Includes\Metrics\MetricExemplarTests.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Metrics\MetricTestData.cs" Link="Includes\Metrics\MetricTestData.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Metrics\MetricTestsBase.cs" Link="Includes\Metrics\MetricTestsBase.cs" />

--- a/test/OpenTelemetry.Tests/Metrics/AggregatorTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/AggregatorTests.cs
@@ -7,9 +7,7 @@ using Xunit;
 
 namespace OpenTelemetry.Metrics.Tests;
 
-#pragma warning disable SA1402
-
-public abstract class AggregatorTestsBase
+public class AggregatorTests
 {
     private static readonly Meter Meter = new("testMeter");
     private static readonly Instrument Instrument = Meter.CreateHistogram<long>("testInstrument");
@@ -18,7 +16,7 @@ public abstract class AggregatorTestsBase
 
     private readonly AggregatorStore aggregatorStore;
 
-    protected AggregatorTestsBase()
+    public AggregatorTests()
     {
         this.aggregatorStore = new(MetricStreamIdentity, AggregationType.HistogramWithBuckets, AggregationTemporality.Cumulative, 1024);
     }
@@ -508,13 +506,5 @@ public abstract class AggregatorTestsBase
             this.HistogramPoint = histogramPoint;
             this.MreToEnsureAllThreadsStart = mreToEnsureAllThreadsStart;
         }
-    }
-}
-
-public class AggregatorTests : AggregatorTestsBase
-{
-    public AggregatorTests()
-        : base()
-    {
     }
 }

--- a/test/OpenTelemetry.Tests/Metrics/MetricApiTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricApiTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
-using Microsoft.Extensions.Configuration;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Tests;
@@ -12,9 +11,7 @@ using Xunit.Abstractions;
 
 namespace OpenTelemetry.Metrics.Tests;
 
-#pragma warning disable SA1402
-
-public abstract class MetricApiTestsBase : MetricTestsBase
+public class MetricApiTests : MetricTestsBase
 {
     private const int MaxTimeToAllowForFlush = 10000;
     private static readonly int NumberOfThreads = Environment.ProcessorCount;
@@ -23,8 +20,7 @@ public abstract class MetricApiTestsBase : MetricTestsBase
     private static readonly int NumberOfMetricUpdateByEachThread = 100000;
     private readonly ITestOutputHelper output;
 
-    protected MetricApiTestsBase(ITestOutputHelper output)
-        : base(BuildConfiguration())
+    public MetricApiTests(ITestOutputHelper output)
     {
         this.output = output;
     }
@@ -1703,14 +1699,6 @@ public abstract class MetricApiTestsBase : MetricTestsBase
         }
     }
 
-    internal static IConfiguration BuildConfiguration()
-    {
-        var configurationData = new Dictionary<string, string?>();
-        return new ConfigurationBuilder()
-            .AddInMemoryCollection(configurationData)
-            .Build();
-    }
-
     private static void CounterUpdateThread<T>(object? obj)
         where T : struct, IComparable
     {
@@ -1876,13 +1864,5 @@ public abstract class MetricApiTestsBase : MetricTestsBase
             this.Instrument = instrument;
             this.ValuesToRecord = valuesToRecord;
         }
-    }
-}
-
-public class MetricApiTest : MetricApiTestsBase
-{
-    public MetricApiTest(ITestOutputHelper output)
-        : base(output)
-    {
     }
 }

--- a/test/OpenTelemetry.Tests/Metrics/MetricOverflowAttributeTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricOverflowAttributeTests.cs
@@ -2,30 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics.Metrics;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Tests;
 using Xunit;
 
 namespace OpenTelemetry.Metrics.Tests;
 
-#pragma warning disable SA1402
-
-public abstract class MetricOverflowAttributeTestsBase
+public class MetricOverflowAttributeTests
 {
-    private readonly Dictionary<string, string?> configurationData = new()
-    {
-    };
-
-    private readonly IConfiguration configuration;
-
-    public MetricOverflowAttributeTestsBase()
-    {
-        this.configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(this.configurationData)
-            .Build();
-    }
-
     [Theory]
     [InlineData(MetricReaderTemporalityPreference.Delta)]
     [InlineData(MetricReaderTemporalityPreference.Cumulative)]
@@ -37,10 +20,6 @@ public abstract class MetricOverflowAttributeTestsBase
         var counter = meter.CreateCounter<long>("TestCounter");
 
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
-            .ConfigureServices(services =>
-            {
-                services.AddSingleton(this.configuration);
-            })
             .AddMeter(meter.Name)
             .AddInMemoryExporter(exportedItems, metricReaderOptions => metricReaderOptions.TemporalityPreference = temporalityPreference)
             .Build();
@@ -181,10 +160,6 @@ public abstract class MetricOverflowAttributeTestsBase
         var histogram = meter.CreateHistogram<long>("TestHistogram");
 
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
-            .ConfigureServices(services =>
-            {
-                services.AddSingleton(this.configuration);
-            })
             .AddMeter(meter.Name)
             .AddInMemoryExporter(exportedItems, metricReaderOptions => metricReaderOptions.TemporalityPreference = temporalityPreference)
             .Build();
@@ -316,13 +291,5 @@ public abstract class MetricOverflowAttributeTestsBase
             Assert.Equal(50, zeroTagsMetricPoint.GetHistogramSum());
             Assert.Equal(12505, overflowMetricPoint.GetHistogramSum());
         }
-    }
-}
-
-public class MetricOverflowAttributeTests : MetricOverflowAttributeTestsBase
-{
-    public MetricOverflowAttributeTests()
-        : base()
-    {
     }
 }

--- a/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTests.cs
@@ -2,30 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics.Metrics;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Tests;
 using Xunit;
 
 namespace OpenTelemetry.Metrics.Tests;
 
-#pragma warning disable SA1402
-
-public abstract class MetricPointReclaimTestsBase
+public class MetricPointReclaimTests
 {
-    private readonly Dictionary<string, string?> configurationData = new()
-    {
-    };
-
-    private readonly IConfiguration configuration;
-
-    protected MetricPointReclaimTestsBase()
-    {
-        this.configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(this.configurationData)
-            .Build();
-    }
-
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
@@ -44,10 +27,6 @@ public abstract class MetricPointReclaimTestsBase
         };
 
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
-            .ConfigureServices(services =>
-            {
-                services.AddSingleton(this.configuration);
-            })
             .AddMeter(Utils.GetCurrentMethodName())
             .AddReader(metricReader)
             .Build();
@@ -137,10 +116,6 @@ public abstract class MetricPointReclaimTestsBase
         };
 
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
-            .ConfigureServices(services =>
-            {
-                services.AddSingleton(this.configuration);
-            })
             .AddMeter(Utils.GetCurrentMethodName())
             .SetMaxMetricPointsPerMetricStream(10) // Set max MetricPoints limit to 10
             .AddReader(metricReader)
@@ -260,13 +235,5 @@ public abstract class MetricPointReclaimTestsBase
 
             return ExportResult.Success;
         }
-    }
-}
-
-public class MetricPointReclaimTests : MetricPointReclaimTestsBase
-{
-    public MetricPointReclaimTests()
-        : base()
-    {
     }
 }

--- a/test/OpenTelemetry.Tests/Metrics/MetricSnapshotTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricSnapshotTests.cs
@@ -2,25 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Diagnostics.Metrics;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Tests;
 
 using Xunit;
 
 namespace OpenTelemetry.Metrics.Tests;
 
-#pragma warning disable SA1402
-
-public abstract class MetricSnapshotTestsBase
+public class MetricSnapshotTests
 {
-    private readonly IConfiguration configuration;
-
-    protected MetricSnapshotTestsBase()
-    {
-        this.configuration = MetricApiTestsBase.BuildConfiguration();
-    }
-
     [Fact]
     public void VerifySnapshot_Counter()
     {
@@ -30,10 +19,6 @@ public abstract class MetricSnapshotTestsBase
         using var meter = new Meter(Utils.GetCurrentMethodName());
         var counter = meter.CreateCounter<long>("meter");
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
-            .ConfigureServices(services =>
-            {
-                services.AddSingleton(this.configuration);
-            })
             .AddMeter(meter.Name)
             .AddInMemoryExporter(exportedMetrics)
             .AddInMemoryExporter(exportedSnapshots)
@@ -103,10 +88,6 @@ public abstract class MetricSnapshotTestsBase
         using var meter = new Meter(Utils.GetCurrentMethodName());
         var histogram = meter.CreateHistogram<int>("histogram");
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
-            .ConfigureServices(services =>
-            {
-                services.AddSingleton(this.configuration);
-            })
             .AddMeter(meter.Name)
             .AddInMemoryExporter(exportedMetrics)
             .AddInMemoryExporter(exportedSnapshots)
@@ -199,10 +180,6 @@ public abstract class MetricSnapshotTestsBase
         using var meter = new Meter(Utils.GetCurrentMethodName());
         var histogram = meter.CreateHistogram<int>("histogram");
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
-            .ConfigureServices(services =>
-            {
-                services.AddSingleton(this.configuration);
-            })
             .AddMeter(meter.Name)
             .AddView("histogram", new Base2ExponentialBucketHistogramConfiguration())
             .AddInMemoryExporter(exportedMetrics)
@@ -225,7 +202,7 @@ public abstract class MetricSnapshotTestsBase
         metricPoint1.TryGetHistogramMinMaxValues(out var min, out var max);
         Assert.Equal(10, min);
         Assert.Equal(10, max);
-        AggregatorTestsBase.AssertExponentialBucketsAreCorrect(expectedHistogram, metricPoint1.GetExponentialHistogramData());
+        AggregatorTests.AssertExponentialBucketsAreCorrect(expectedHistogram, metricPoint1.GetExponentialHistogramData());
 
         // Verify Snapshot 1
         Assert.Single(exportedSnapshots);
@@ -236,7 +213,7 @@ public abstract class MetricSnapshotTestsBase
         snapshot1.MetricPoints[0].TryGetHistogramMinMaxValues(out min, out max);
         Assert.Equal(10, min);
         Assert.Equal(10, max);
-        AggregatorTestsBase.AssertExponentialBucketsAreCorrect(expectedHistogram, snapshot1.MetricPoints[0].GetExponentialHistogramData());
+        AggregatorTests.AssertExponentialBucketsAreCorrect(expectedHistogram, snapshot1.MetricPoints[0].GetExponentialHistogramData());
 
         // Verify Metric == Snapshot
         Assert.Equal(metric1.Name, snapshot1.Name);
@@ -270,7 +247,7 @@ public abstract class MetricSnapshotTestsBase
         metricPoint1.TryGetHistogramMinMaxValues(out min, out max);
         Assert.Equal(5, min);
         Assert.Equal(10, max);
-        AggregatorTestsBase.AssertExponentialBucketsAreCorrect(expectedHistogram, metricPoint2.GetExponentialHistogramData());
+        AggregatorTests.AssertExponentialBucketsAreCorrect(expectedHistogram, metricPoint2.GetExponentialHistogramData());
 
         // Verify Snapshot 1 after second export
         // This value is expected to be unchanged.
@@ -289,14 +266,6 @@ public abstract class MetricSnapshotTestsBase
         snapshot2.MetricPoints[0].TryGetHistogramMinMaxValues(out min, out max);
         Assert.Equal(5, min);
         Assert.Equal(10, max);
-        AggregatorTestsBase.AssertExponentialBucketsAreCorrect(expectedHistogram, snapshot2.MetricPoints[0].GetExponentialHistogramData());
-    }
-}
-
-public class MetricSnapshotTests : MetricSnapshotTestsBase
-{
-    public MetricSnapshotTests()
-        : base()
-    {
+        AggregatorTests.AssertExponentialBucketsAreCorrect(expectedHistogram, snapshot2.MetricPoints[0].GetExponentialHistogramData());
     }
 }

--- a/test/OpenTelemetry.Tests/Metrics/MetricTestsBase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricTestsBase.cs
@@ -4,9 +4,9 @@
 #if BUILDING_HOSTING_TESTS
 using System.Diagnostics;
 #endif
+#if BUILDING_HOSTING_TESTS
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-#if BUILDING_HOSTING_TESTS
 using Microsoft.Extensions.Diagnostics.Metrics;
 using Microsoft.Extensions.Hosting;
 #endif
@@ -14,17 +14,10 @@ using Xunit;
 
 namespace OpenTelemetry.Metrics.Tests;
 
-public class MetricTestsBase
+public abstract class MetricTestsBase
 {
-    protected readonly IConfiguration? configuration;
-
     protected MetricTestsBase()
     {
-    }
-
-    protected MetricTestsBase(IConfiguration configuration)
-    {
-        this.configuration = configuration;
     }
 
 #if BUILDING_HOSTING_TESTS
@@ -204,25 +197,13 @@ public class MetricTestsBase
 #if BUILDING_HOSTING_TESTS
         var host = BuildHost(
             useWithMetricsStyle: false,
-            configureMeterProviderBuilder: configure,
-            configureServices: services =>
-            {
-                if (this.configuration != null)
-                {
-                    services.AddSingleton(this.configuration);
-                }
-            });
+            configureMeterProviderBuilder: configure);
 
         meterProvider = host.Services.GetRequiredService<MeterProvider>();
 
         return host;
 #else
         var builder = Sdk.CreateMeterProviderBuilder();
-
-        if (this.configuration != null)
-        {
-            builder.ConfigureServices(services => services.AddSingleton(this.configuration));
-        }
 
         configure(builder);
 

--- a/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
@@ -784,7 +784,7 @@ public class MetricViewTests : MetricTestsBase
         var count = metricPoint.GetHistogramCount();
         var sum = metricPoint.GetHistogramSum();
 
-        AggregatorTestsBase.AssertExponentialBucketsAreCorrect(expectedHistogram, metricPoint.GetExponentialHistogramData());
+        AggregatorTests.AssertExponentialBucketsAreCorrect(expectedHistogram, metricPoint.GetExponentialHistogramData());
         Assert.Equal(50, sum);
         Assert.Equal(6, count);
     }


### PR DESCRIPTION
Follow-up to #5956

## Changes

* A bunch of class structure was introduced to be able to test everything with and without delta metricpoint reclaim being enabled. Now that it is always enabled, this structure isn't required.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
