### PR TITLE
[docs-metrics] Add content for histogram bucket configuration via advice api

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -14,6 +14,9 @@ directory of each individual package.
 
   * [InstrumentAdvice&lt;T&gt;](https://learn.microsoft.com/dotnet/api/system.diagnostics.metrics.instrumentadvice-1)
 
+    For details see: [Explicit bucket histogram
+    aggregation](./docs/metrics/customizing-the-sdk/README.md#explicit-bucket-histogram-aggregation).
+
   * [Gauge&lt;T&gt;](https://learn.microsoft.com/dotnet/api/system.diagnostics.metrics.gauge-1)
 
   * [ActivitySource.Tags](https://learn.microsoft.com/dotnet/api/system.diagnostics.activitysource.tags)

--- a/docs/metrics/customizing-the-sdk/README.md
+++ b/docs/metrics/customizing-the-sdk/README.md
@@ -200,12 +200,28 @@ used.
 
 ##### Explicit bucket histogram aggregation
 
-By default, the boundaries used for a Histogram are [`{ 0, 5, 10, 25, 50, 75,
-100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000}`](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.14.0/specification/metrics/sdk.md#explicit-bucket-histogram-aggregation).
-Views can be used to provide custom boundaries for a Histogram. The measurements
-are then aggregated using the custom boundaries provided instead of the
-default boundaries. This requires the use of
-`ExplicitBucketHistogramConfiguration`.
+By default, the [OpenTelemetry
+Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.14.0/specification/metrics/sdk.md#explicit-bucket-histogram-aggregation)
+defines explicit buckets (aka boundaries) for Histograms as: `[ 0, 5, 10, 25,
+50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000 ]`.
+
+###### Customizing explicit buckets when using histogram aggregation
+
+There are two mechanisms available to configure explicit buckets when using histogram aggregation:
+
+* View API - Part of the OpenTelemetry .NET SDK.
+* Advice API - Part of the `System.Diagnostics.DiagnosticSource` package
+  starting with version `9.0.0`.
+
+> [!IMPORTANT]
+> When both the View API and Advice API are used, the View API takes
+  precendence. If explicit buckets are not provided by either the View API or
+  the Advice API than the SDK defaults apply.
+
+**View API**
+
+Views can be used to provide custom explicit buckets for a Histogram. This
+requires the use of `ExplicitBucketHistogramConfiguration`.
 
 ```csharp
     // Change Histogram boundaries to count measurements under the following buckets:
@@ -223,6 +239,16 @@ default boundaries. This requires the use of
         instrumentName: "MyHistogram",
         new ExplicitBucketHistogramConfiguration { Boundaries = Array.Empty<double>() })
 ```
+
+**Advice API**
+
+Starting with the `1.10.0` SDK, explicit buckets for a Histogram may be provided
+by instrumentation authors when the instrument is created. This is generally
+recommended to be used by library authors when the SDK defaults don't match the
+required granularity for the histogram being emitted.
+
+See:
+[InstrumentAdvice&lt;T&gt;](https://learn.microsoft.com/dotnet/api/system.diagnostics.metrics.instrumentadvice-1).
 
 ##### Base2 exponential bucket histogram aggregation
 

--- a/docs/metrics/customizing-the-sdk/README.md
+++ b/docs/metrics/customizing-the-sdk/README.md
@@ -223,7 +223,7 @@ histogram aggregation:
 
   Views can be used to provide custom explicit buckets for a Histogram. This
   requires the use of `ExplicitBucketHistogramConfiguration`.
-  
+
   ```csharp
    // Change Histogram boundaries to count measurements under the following buckets:
    // (-inf, 10]
@@ -232,7 +232,7 @@ histogram aggregation:
    .AddView(
        instrumentName: "MyHistogram",
        new ExplicitBucketHistogramConfiguration { Boundaries = new double[] { 10, 20 } })
-  
+
    // If you provide an empty `double` array as `Boundaries` to the `ExplicitBucketHistogramConfiguration`,
    // the SDK will only export the sum, count, min and max for the measurements.
    // There are no buckets exported in this case.
@@ -247,7 +247,7 @@ histogram aggregation:
   by instrumentation authors when the instrument is created. This is generally
   recommended to be used by library authors when the SDK defaults don't match the
   required granularity for the histogram being emitted.
-  
+
   See:
   [InstrumentAdvice&lt;T&gt;](https://learn.microsoft.com/dotnet/api/system.diagnostics.metrics.instrumentadvice-1).
 

--- a/docs/metrics/customizing-the-sdk/README.md
+++ b/docs/metrics/customizing-the-sdk/README.md
@@ -207,7 +207,8 @@ defines explicit buckets (aka boundaries) for Histograms as: `[ 0, 5, 10, 25,
 
 ###### Customizing explicit buckets when using histogram aggregation
 
-There are two mechanisms available to configure explicit buckets when using histogram aggregation:
+There are two mechanisms available to configure explicit buckets when using
+histogram aggregation:
 
 * View API - Part of the OpenTelemetry .NET SDK.
 * Advice API - Part of the `System.Diagnostics.DiagnosticSource` package
@@ -218,37 +219,37 @@ There are two mechanisms available to configure explicit buckets when using hist
   If explicit buckets are not provided by either the View API or the Advice API
   than the SDK defaults apply.
 
-**View API**
+* View API
 
-Views can be used to provide custom explicit buckets for a Histogram. This
-requires the use of `ExplicitBucketHistogramConfiguration`.
+  Views can be used to provide custom explicit buckets for a Histogram. This
+  requires the use of `ExplicitBucketHistogramConfiguration`.
+  
+  ```csharp
+   // Change Histogram boundaries to count measurements under the following buckets:
+   // (-inf, 10]
+   // (10, 20]
+   // (20, +inf)
+   .AddView(
+       instrumentName: "MyHistogram",
+       new ExplicitBucketHistogramConfiguration { Boundaries = new double[] { 10, 20 } })
+  
+   // If you provide an empty `double` array as `Boundaries` to the `ExplicitBucketHistogramConfiguration`,
+   // the SDK will only export the sum, count, min and max for the measurements.
+   // There are no buckets exported in this case.
+   .AddView(
+       instrumentName: "MyHistogram",
+       new ExplicitBucketHistogramConfiguration { Boundaries = Array.Empty<double>() })
+  ```
 
-```csharp
-    // Change Histogram boundaries to count measurements under the following buckets:
-    // (-inf, 10]
-    // (10, 20]
-    // (20, +inf)
-    .AddView(
-        instrumentName: "MyHistogram",
-        new ExplicitBucketHistogramConfiguration { Boundaries = new double[] { 10, 20 } })
+* Advice API
 
-    // If you provide an empty `double` array as `Boundaries` to the `ExplicitBucketHistogramConfiguration`,
-    // the SDK will only export the sum, count, min and max for the measurements.
-    // There are no buckets exported in this case.
-    .AddView(
-        instrumentName: "MyHistogram",
-        new ExplicitBucketHistogramConfiguration { Boundaries = Array.Empty<double>() })
-```
-
-**Advice API**
-
-Starting with the `1.10.0` SDK, explicit buckets for a Histogram may be provided
-by instrumentation authors when the instrument is created. This is generally
-recommended to be used by library authors when the SDK defaults don't match the
-required granularity for the histogram being emitted.
-
-See:
-[InstrumentAdvice&lt;T&gt;](https://learn.microsoft.com/dotnet/api/system.diagnostics.metrics.instrumentadvice-1).
+  Starting with the `1.10.0` SDK, explicit buckets for a Histogram may be provided
+  by instrumentation authors when the instrument is created. This is generally
+  recommended to be used by library authors when the SDK defaults don't match the
+  required granularity for the histogram being emitted.
+  
+  See:
+  [InstrumentAdvice&lt;T&gt;](https://learn.microsoft.com/dotnet/api/system.diagnostics.metrics.instrumentadvice-1).
 
 ##### Base2 exponential bucket histogram aggregation
 

--- a/docs/metrics/customizing-the-sdk/README.md
+++ b/docs/metrics/customizing-the-sdk/README.md
@@ -217,7 +217,7 @@ histogram aggregation:
 > [!IMPORTANT]
 > When both the View API and Advice API are used, the View API takes precedence.
   If explicit buckets are not provided by either the View API or the Advice API
-  than the SDK defaults apply.
+  then the SDK defaults apply.
 
 * View API
 

--- a/docs/metrics/customizing-the-sdk/README.md
+++ b/docs/metrics/customizing-the-sdk/README.md
@@ -214,9 +214,9 @@ There are two mechanisms available to configure explicit buckets when using hist
   starting with version `9.0.0`.
 
 > [!IMPORTANT]
-> When both the View API and Advice API are used, the View API takes
-  precendence. If explicit buckets are not provided by either the View API or
-  the Advice API than the SDK defaults apply.
+> When both the View API and Advice API are used, the View API takes precedence.
+  If explicit buckets are not provided by either the View API or the Advice API
+  than the SDK defaults apply.
 
 **View API**
 


### PR DESCRIPTION
Relates to #5911
Relates to #5855

## Changes

* Add some content explaining histogram explicit bucket configuration via View API and/or Advice API

## Details

This is going to step on #5911 sorry @Annosha! We're aiming to release `1.10.0` tomorrow and I feel it is important to have _something_ to link to from `RELEASENOTES.md`. We can work to add _more_ information, but the main thing I wanted to have clear is what happens when both View API and Advice API are used.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
