### PR TITLE
[otlp] Fix ProtobufOtlpLogSerializer pool handling

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System.Diagnostics;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Trace;
@@ -34,6 +35,15 @@ internal static class ProtobufOtlpLogSerializer
                 ScopeLogsList[scopeName] = logRecords;
             }
 
+            if (logRecord.Source == LogRecord.LogRecordSource.FromSharedPool)
+            {
+                Debug.Assert(logRecord.PoolReferenceCount > 0, "logRecord PoolReferenceCount value was unexpected");
+
+                // Note: AddReference call here prevents the LogRecord from
+                // being given back to the pool by Batch<LogRecord>.
+                logRecord.AddReference();
+            }
+
             logRecords.Add(logRecord);
         }
 
@@ -50,6 +60,18 @@ internal static class ProtobufOtlpLogSerializer
         {
             foreach (var entry in ScopeLogsList)
             {
+                foreach (var logRecord in entry.Value)
+                {
+                    if (logRecord.Source == LogRecord.LogRecordSource.FromSharedPool)
+                    {
+                        Debug.Assert(logRecord.PoolReferenceCount > 0, "logRecord PoolReferenceCount value was unexpected");
+
+                        // Note: Try to return the LogRecord to the shared pool
+                        // now that work is done.
+                        LogRecordSharedPool.Current.Return(logRecord);
+                    }
+                }
+
                 entry.Value.Clear();
                 LogsListPool.Push(entry.Value);
             }


### PR DESCRIPTION
## Changes

* Fix `ProtobufOtlpLogSerializer` so that it doesn't return `LogRecord`s to the pool before it has completed its work

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
