### PR TITLE
[hotfix-sdk] Fix reflection breaks introduced by new Batch ctor

### DIFF
--- a/src/OpenTelemetry/.publicApi/Stable/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/Stable/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+static OpenTelemetry.Batch<T>.Create(T! item) -> OpenTelemetry.Batch<T!>
+*REMOVED*OpenTelemetry.Batch<T>.Batch(T! item) -> void

--- a/src/OpenTelemetry/Batch.cs
+++ b/src/OpenTelemetry/Batch.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Logs;
 
@@ -35,13 +36,11 @@ public readonly struct Batch<T> : IDisposable
         this.Count = this.targetCount = count;
     }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="Batch{T}"/> struct.
-    /// </summary>
-    /// <param name="item">The item to store in the batch.</param>
-    public Batch(T item)
+    // Note: Some components call this ctor via reflection. Do not change or
+    // remove to be nice.
+    internal Batch(T item)
     {
-        Guard.ThrowIfNull(item);
+        Debug.Assert(item != null, "item was null");
 
         this.item = item;
         this.Count = this.targetCount = 1;
@@ -63,6 +62,19 @@ public readonly struct Batch<T> : IDisposable
     /// Gets the count of items in the batch.
     /// </summary>
     public long Count { get; }
+
+    /// <summary>
+    /// Create an instance of <see cref="Batch{T}"/> containing a single item.
+    /// </summary>
+    /// <param name="item">Item to store in the batch.</param>
+    /// <returns><see cref="Batch{T}"/> containing the supplied item.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Batch<T> Create(T item)
+    {
+        Guard.ThrowIfNull(item);
+
+        return new Batch<T>(item);
+    }
 
     /// <inheritdoc/>
     public void Dispose()

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -12,7 +12,7 @@ Notes](../../RELEASENOTES.md).
   released components calling the `internal` ctor via reflection. Instead a
   static method `Batch<T>.Create(T item)` is being introduced which offers the
   same functionality.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+  ([#5994](https://github.com/open-telemetry/opentelemetry-dotnet/pull/5994))
 
 ## 1.10.0
 

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -6,6 +6,14 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* **Breaking Change** The `public` constructor on `Batch<T>` which accepts a
+  single instance of `T` to be contained in the batch introduced in
+  `1.10.0-rc.1` has been set back to `internal` because this change broke
+  released components calling the `internal` ctor via reflection. Instead a
+  static method `Batch<T>.Create(T item)` is being introduced which offers the
+  same functionality.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-dotnet/pull/XXXX))
+
 ## 1.10.0
 
 Released 2024-Nov-12

--- a/src/OpenTelemetry/CompatibilitySuppressions.xml
+++ b/src/OpenTelemetry/CompatibilitySuppressions.xml
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:OpenTelemetry.Batch`1.#ctor(`0)</Target>
+    <Left>lib/net462/OpenTelemetry.dll</Left>
+    <Right>lib/net462/OpenTelemetry.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:OpenTelemetry.Batch`1.#ctor(`0)</Target>
+    <Left>lib/net8.0/OpenTelemetry.dll</Left>
+    <Right>lib/net8.0/OpenTelemetry.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:OpenTelemetry.Batch`1.#ctor(`0)</Target>
+    <Left>lib/net9.0/OpenTelemetry.dll</Left>
+    <Right>lib/net9.0/OpenTelemetry.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:OpenTelemetry.Batch`1.#ctor(`0)</Target>
+    <Left>lib/netstandard2.0/OpenTelemetry.dll</Left>
+    <Right>lib/netstandard2.0/OpenTelemetry.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:OpenTelemetry.Batch`1.#ctor(`0)</Target>
+    <Left>lib/netstandard2.1/OpenTelemetry.dll</Left>
+    <Right>lib/netstandard2.1/OpenTelemetry.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+</Suppressions>


### PR DESCRIPTION
## Changes

* Switch the `public Batch(T item)` ctor introduced in `1.10.0-rc.1` back to `internal`
* Introduce `static Batch<T> Create(T item)` instead

## Details

We promoted the `internal` `Batch<T>` ctor which accepts on single item to `public` so that components like GenevaExporter wouldn't need to call it with reflection. The problem is the shipped versions which call it with reflection now break if the `1.10.0` SDK is present. To fix this we are putting the ctor back to `internal` and introducing a static method instead. The plan is to release 1.10.1 with this fix. Then obsolete/unlist GenevaExporter 1.10.0 and replace it with a 1.10.1 version which will call the new static method. We will probably also obsolete/unlist 1.10.0 SDK but need to discuss first.
 
## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
