### PR TITLE
WIP - Remove meters from storage list when removed and handle NoRecordedValue flag when removing meters

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/MetricItemExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/MetricItemExtensions.cs
@@ -169,6 +169,11 @@ internal static class MetricItemExtensions
                         }
 
                         sum.DataPoints.Add(dataPoint);
+
+                        if (metric.NoRecordedValueNeeded)
+                        {
+                            sum.DataPoints.Add(CreateNoRecordedValueNumberDataPoint(dataPoint.TimeUnixNano, metricPoint.Tags));
+                        }
                     }
 
                     otlpMetric.Sum = sum;
@@ -206,6 +211,11 @@ internal static class MetricItemExtensions
                         }
 
                         sum.DataPoints.Add(dataPoint);
+
+                        if (metric.NoRecordedValueNeeded)
+                        {
+                            sum.DataPoints.Add(CreateNoRecordedValueNumberDataPoint(dataPoint.TimeUnixNano, metricPoint.Tags));
+                        }
                     }
 
                     otlpMetric.Sum = sum;
@@ -237,6 +247,11 @@ internal static class MetricItemExtensions
                         }
 
                         gauge.DataPoints.Add(dataPoint);
+
+                        if (metric.NoRecordedValueNeeded)
+                        {
+                            gauge.DataPoints.Add(CreateNoRecordedValueNumberDataPoint(dataPoint.TimeUnixNano, metricPoint.Tags));
+                        }
                     }
 
                     otlpMetric.Gauge = gauge;
@@ -268,6 +283,11 @@ internal static class MetricItemExtensions
                         }
 
                         gauge.DataPoints.Add(dataPoint);
+
+                        if (metric.NoRecordedValueNeeded)
+                        {
+                            gauge.DataPoints.Add(CreateNoRecordedValueNumberDataPoint(dataPoint.TimeUnixNano, metricPoint.Tags));
+                        }
                     }
 
                     otlpMetric.Gauge = gauge;
@@ -318,6 +338,11 @@ internal static class MetricItemExtensions
                         }
 
                         histogram.DataPoints.Add(dataPoint);
+
+                        if (metric.NoRecordedValueNeeded)
+                        {
+                            histogram.DataPoints.Add(CreateNoRecordedValueHistogramDataPoint(dataPoint.TimeUnixNano, metricPoint.Tags));
+                        }
                     }
 
                     otlpMetric.Histogram = histogram;
@@ -370,6 +395,11 @@ internal static class MetricItemExtensions
                         }
 
                         histogram.DataPoints.Add(dataPoint);
+
+                        if (metric.NoRecordedValueNeeded)
+                        {
+                            histogram.DataPoints.Add(CreateNoRecordedValueExponentialHistogramDataPoint(dataPoint.TimeUnixNano, metricPoint.Tags));
+                        }
                     }
 
                     otlpMetric.ExponentialHistogram = histogram;
@@ -422,6 +452,45 @@ internal static class MetricItemExtensions
         }
 
         return otlpExemplar;
+    }
+
+    private static NumberDataPoint CreateNoRecordedValueNumberDataPoint(ulong timestamp, ReadOnlyTagCollection tags)
+    {
+        var lastDataPoint = new NumberDataPoint
+        {
+            StartTimeUnixNano = timestamp,
+            TimeUnixNano = timestamp,
+            Flags = (uint)DataPointFlags.NoRecordedValueMask,
+        };
+
+        AddAttributes(tags, lastDataPoint.Attributes);
+        return lastDataPoint;
+    }
+
+    private static HistogramDataPoint CreateNoRecordedValueHistogramDataPoint(ulong timestamp, ReadOnlyTagCollection tags)
+    {
+        var lastDataPoint = new HistogramDataPoint
+        {
+            StartTimeUnixNano = timestamp,
+            TimeUnixNano = timestamp,
+            Flags = (uint)DataPointFlags.NoRecordedValueMask,
+        };
+
+        AddAttributes(tags, lastDataPoint.Attributes);
+        return lastDataPoint;
+    }
+
+    private static ExponentialHistogramDataPoint CreateNoRecordedValueExponentialHistogramDataPoint(ulong timestamp, ReadOnlyTagCollection tags)
+    {
+        var lastDataPoint = new ExponentialHistogramDataPoint()
+        {
+            StartTimeUnixNano = timestamp,
+            TimeUnixNano = timestamp,
+            Flags = (uint)DataPointFlags.NoRecordedValueMask,
+        };
+
+        AddAttributes(tags, lastDataPoint.Attributes);
+        return lastDataPoint;
     }
 
     private static void AddAttributes(ReadOnlyTagCollection tags, RepeatedField<OtlpCommon.KeyValue> attributes)

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -243,6 +243,8 @@ public sealed class Metric
 
     internal bool Active { get; set; } = true;
 
+    internal bool NoRecordedValueNeeded { get; set; }
+
     /// <summary>
     /// Get the metric points for the metric stream.
     /// </summary>

--- a/src/OpenTelemetry/Metrics/Reader/MetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/Reader/MetricReaderExt.cs
@@ -254,7 +254,9 @@ public abstract partial class MetricReader
                                 this.metrics[j - 1] = this.metrics[j];
                             }
 
+                            this.metrics[target - 1] = null;
                             this.metricIndex--;
+                            i--;
                         }
                     }
                 }

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryMetricsBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryMetricsBuilderExtensionsTests.cs
@@ -140,8 +140,7 @@ public class OpenTelemetryMetricsBuilderExtensionsTests
 
         var duplicateMetricInstrumentEvents = inMemoryEventListener.Events.Where((e) => e.EventId == 38);
 
-        // Note: We currently log a duplicate warning anytime a metric is reactivated.
-        Assert.Single(duplicateMetricInstrumentEvents);
+        Assert.Empty(duplicateMetricInstrumentEvents);
 
         var metricInstrumentDeactivatedEvents = inMemoryEventListener.Events.Where((e) => e.EventId == 52);
 
@@ -211,7 +210,7 @@ public class OpenTelemetryMetricsBuilderExtensionsTests
 
         var duplicateMetricInstrumentEvents = inMemoryEventListener.Events.Where((e) => e.EventId == 38);
 
-        // Note: We currently log a duplicate warning anytime a metric is reactivated.
+        // Note: The old metric is only removed after a flush, so both duplicates lived for one collection cycle.
         Assert.Single(duplicateMetricInstrumentEvents);
 
         var metricInstrumentDeactivatedEvents = inMemoryEventListener.Events.Where((e) => e.EventId == 52);

--- a/test/OpenTelemetry.Tests/Metrics/MeterProviderSdkTest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MeterProviderSdkTest.cs
@@ -41,7 +41,7 @@ public class MeterProviderSdkTest
     [InlineData(true, true)]
     [InlineData(false, false)]
     [InlineData(true, false)]
-    public void TransientMeterExhaustsMetricStorageTest(bool withView, bool forceFlushAfterEachTest)
+    public void TransientMeterBetweenCollectionsExhaustsMetricStorageTest(bool withView, bool forceFlushAfterEachTest)
     {
         using var inMemoryEventListener = new InMemoryEventListener(OpenTelemetrySdkEventSource.Log);
 
@@ -74,7 +74,7 @@ public class MeterProviderSdkTest
 
         if (forceFlushAfterEachTest)
         {
-            Assert.Empty(exportedItems);
+            Assert.Single(exportedItems);
         }
         else
         {
@@ -85,7 +85,14 @@ public class MeterProviderSdkTest
 
         var metricInstrumentIgnoredEvents = inMemoryEventListener.Events.Where((e) => e.EventId == 33 && (e.Payload?.Count ?? 0) >= 2 && e.Payload![1] as string == meterName);
 
-        Assert.Single(metricInstrumentIgnoredEvents);
+        if (forceFlushAfterEachTest)
+        {
+            Assert.Empty(metricInstrumentIgnoredEvents);
+        }
+        else
+        {
+            Assert.Single(metricInstrumentIgnoredEvents);
+        }
 
         void RunTest()
         {


### PR DESCRIPTION
Fixes #5950
Design discussion issue #

## Changes

This allows clean Dispose of Meter objects which will send NoRecordedValue data points to close the series (e.g. send a staleness marker to prometheus). It also fixes the internal storage leak which would prevent frequent rotation of the metrics.

Note : The tests are passing, I'm create the draft PR to reach out and have something to show and talk about. Let me know if this isn't going along with the design direction. 

I have not done through the paperwork as I wasn't sure if it was a changelog worthy fix.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
