### PR TITLE
[Do not merge] [otlp] Benchmarks comparison manual vs google protobuf serialization.

### DIFF
--- a/test/Benchmarks/Exporter/OtlpHttpExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/OtlpHttpExporterBenchmarks.cs
@@ -17,6 +17,7 @@ using OpenTelemetryProtocol::OpenTelemetry.Proto.Collector.Trace.V1;
 
 namespace Benchmarks.Exporter;
 
+[MemoryDiagnoser]
 public class OtlpHttpExporterBenchmarks
 {
     private readonly byte[] buffer = new byte[1024 * 1024];

--- a/test/Benchmarks/Exporter/ProtobufOtlpGrpcExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/ProtobufOtlpGrpcExporterBenchmarks.cs
@@ -12,14 +12,13 @@ using OpenTelemetryProtocol::OpenTelemetry.Exporter;
 using OpenTelemetryProtocol::OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetryProtocol::OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
 using OpenTelemetryProtocol::OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Transmission;
-using OpenTelemetryProtocol::OpenTelemetry.Proto.Collector.Trace.V1;
 
 namespace Benchmarks.Exporter;
 
 [MemoryDiagnoser]
-public class OtlpGrpcExporterBenchmarks
+public class ProtobufOtlpGrpcExporterBenchmarks
 {
-    private OtlpTraceExporter? exporter;
+    private ProtobufOtlpTraceExporter? exporter;
     private Activity? activity;
     private CircularBuffer<Activity>? activityBatch;
 
@@ -33,11 +32,11 @@ public class OtlpGrpcExporterBenchmarks
     public void GlobalSetup()
     {
         var options = new OtlpExporterOptions();
-        this.exporter = new OtlpTraceExporter(
+        this.exporter = new ProtobufOtlpTraceExporter(
             options,
             new SdkLimitOptions(),
             new ExperimentalOptions(),
-            new OtlpExporterTransmissionHandler<ExportTraceServiceRequest>(new OtlpGrpcTraceExportClient(options, new TestTraceServiceClient()), options.TimeoutMilliseconds));
+            new ProtobufOtlpExporterTransmissionHandler(new ProtobufOtlpGrpcExportClient(options, options.HttpClientFactory(), "opentelemetry.proto.collector.trace.v1.TraceService/Export"), options.TimeoutMilliseconds));
 
         this.activity = ActivityHelper.CreateTestActivity();
         this.activityBatch = new CircularBuffer<Activity>(this.NumberOfSpans);


### PR DESCRIPTION
## Benchmark results

```

BenchmarkDotNet v0.13.12, Windows 11 (10.0.22631.4460/23H2/2023Update/SunValley3) (Hyper-V)
AMD EPYC 7763, 1 CPU, 16 logical and 8 physical cores
.NET SDK 9.0.100
  [Host]     : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2
  DefaultJob : .NET 9.0.0 (9.0.24.52809), X64 RyuJIT AVX2

```
**OtlpHttpExporterBenchmarks - Old**

| Method                | NumberOfBatches | NumberOfSpans | Mean        | Error     | StdDev    | Gen0        | Gen1        | Gen2       | Allocated  |
|---------------------- |---------------- |-------------- |------------:|----------:|----------:|------------:|------------:|-----------:|-----------:|
| **OtlpExporter_Batching** | **1**               | **10000**         |    **49.02 ms** |  **0.272 ms** |  **0.212 ms** |   **1272.7273** |   **1181.8182** |   **181.8182** |   **20.47 MB** |
| **OtlpExporter_Batching** | **10**              | **10000**         |   **498.89 ms** |  **9.109 ms** |  **8.521 ms** |  **12000.0000** |  **11000.0000** |  **2000.0000** |  **204.66 MB** |
| **OtlpExporter_Batching** | **100**             | **10000**         | **5,128.04 ms** | **20.363 ms** | **17.004 ms** | **134000.0000** | **132000.0000** | **27000.0000** | **2046.63 MB** |

**ProtobufOtlpHttpExporterBenchmarks - New**

| Method                | NumberOfBatches | NumberOfSpans | Mean       | Error     | StdDev    | Allocated |
|---------------------- |---------------- |-------------- |-----------:|----------:|----------:|----------:|
| **OtlpExporter_Batching** | **1**               | **10000**         |   **1.725 ms** | **0.0328 ms** | **0.0365 ms** |   **1.85 KB** |
| **OtlpExporter_Batching** | **10**              | **10000**         |  **16.593 ms** | **0.1462 ms** | **0.1296 ms** |  **18.55 KB** |
| **OtlpExporter_Batching** | **100**             | **10000**         | **165.445 ms** | **0.6541 ms** | **0.5799 ms** | **185.83 KB** |


**OtlpGrpcExporterBenchmarks - Old**

| Method                | NumberOfBatches | NumberOfSpans | Mean        | Error     | StdDev    | Gen0        | Gen1        | Gen2       | Allocated  |
|---------------------- |---------------- |-------------- |------------:|----------:|----------:|------------:|------------:|-----------:|-----------:|
| **OtlpExporter_Batching** | **1**               | **10000**         |    **21.50 ms** |  **0.422 ms** |  **0.564 ms** |   **1312.5000** |   **1281.2500** |   **250.0000** |   **20.45 MB** |
| **OtlpExporter_Batching** | **10**              | **10000**         |   **203.13 ms** |  **3.879 ms** |  **3.628 ms** |  **13000.0000** |  **12666.6667** |  **2666.6667** |  **204.48 MB** |
| **OtlpExporter_Batching** | **100**             | **10000**         | **2,061.70 ms** | **23.189 ms** | **20.556 ms** | **133000.0000** | **131000.0000** | **26000.0000** | **2044.77 MB** |

**ProtobufOtlpGrpcExporterBenchmarks - New**

| Method                | NumberOfBatches | NumberOfSpans | Mean       | Error     | StdDev    | Allocated |
|---------------------- |---------------- |-------------- |-----------:|----------:|----------:|----------:|
| **OtlpExporter_Batching** | **1**               | **10000**         |   **1.693 ms** | **0.0065 ms** | **0.0058 ms** |   **1.85 KB** |
| **OtlpExporter_Batching** | **10**              | **10000**         |  **16.688 ms** | **0.1453 ms** | **0.1288 ms** |  **18.55 KB** |
| **OtlpExporter_Batching** | **100**             | **10000**         | **161.766 ms** | **0.2498 ms** | **0.2086 ms** | **185.58 KB** |


**OtlpTraceExporterBenchmarks**

| Method                         | Mean      | Error    | StdDev   | Median    | Gen0   | Gen1   | Allocated |
|------------------------------- |----------:|---------:|---------:|----------:|-------:|-------:|----------:|
| OtlpTraceExporter_Http         |  91.14 μs | 1.643 μs | 3.003 μs |  90.28 μs | 0.4883 | 0.2441 |   9.55 KB |
| OtlpTraceExporter_Grpc         | 138.50 μs | 2.740 μs | 7.453 μs | 135.60 μs | 0.4883 |      - |   8.99 KB |
| ProtobufOtlpTraceExporter_Http |  98.36 μs | 1.957 μs | 4.213 μs |  99.72 μs | 0.2441 |      - |   5.03 KB |
| ProtobufOtlpTraceExporter_Grpc | 117.71 μs | 1.323 μs | 1.173 μs | 117.78 μs |      - |      - |   6.56 KB |

**OtlpLogExporterBenchmarks**

| Method                       | Mean      | Error    | StdDev   | Gen0   | Gen1   | Allocated |
|----------------------------- |----------:|---------:|---------:|-------:|-------:|----------:|
| OtlpLogExporter_Http         |  91.62 μs | 1.162 μs | 0.970 μs | 0.4883 | 0.2441 |   9.55 KB |
| OtlpLogExporter_Grpc         | 140.87 μs | 2.774 μs | 4.558 μs | 0.4883 |      - |      9 KB |
| ProtobufOtlpLogExporter_Http |  90.45 μs | 1.735 μs | 2.255 μs | 0.2441 |      - |   5.03 KB |
| ProtobufOtlpLogExporter_Grpc | 111.99 μs | 2.232 μs | 3.130 μs |      - |      - |   5.08 KB |


### Note: 

`CreateHttpRequest` in `ProtobufOtlpHttpExportClient` and equivalent in Grpc are allocating memory with new implementation. I tried caching the `HttpRequestMessage` where the allocation went below 1 KB. But we cannot use caching here as `HttpRequestMessage` is designed to be recreated always. As a follow up we will work to enhance this method to avoid the allocation. **Reference**: https://github.com/open-telemetry/opentelemetry-dotnet/blob/f9a0b4c657e24cc8c52a54795e13801eb5548c22/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/ProtobufOtlpHttpExportClient.cs#L82
https://github.com/open-telemetry/opentelemetry-dotnet/blob/f9a0b4c657e24cc8c52a54795e13801eb5548c22/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/ProtobufOtlpGrpcExportClient.cs#L69

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
