### PR TITLE
[otlp] Refactor shared protobuf otlp export client code into a base class

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/ProtobufOtlpExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/ProtobufOtlpExportClient.cs
@@ -67,9 +67,9 @@ internal abstract class ProtobufOtlpExportClient : IProtobufExportClient
         {
             request.Version = Http2RequestVersion;
 
-    #if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
             request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
-    #endif
+#endif
         }
 
         foreach (var header in this.Headers)

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/ProtobufOtlpExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/ProtobufOtlpExportClient.cs
@@ -1,0 +1,100 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if NETFRAMEWORK
+using System.Net.Http;
+#endif
+using System.Net.Http.Headers;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
+
+internal abstract class ProtobufOtlpExportClient : IProtobufExportClient
+{
+    private static readonly Version Http2RequestVersion = new(2, 0);
+
+#if NET
+    private static readonly bool SynchronousSendSupportedByCurrentPlatform;
+
+    static ProtobufOtlpExportClient()
+    {
+#if NET
+        // See: https://github.com/dotnet/runtime/blob/280f2a0c60ce0378b8db49adc0eecc463d00fe5d/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs#L767
+        SynchronousSendSupportedByCurrentPlatform = !OperatingSystem.IsAndroid()
+            && !OperatingSystem.IsIOS()
+            && !OperatingSystem.IsTvOS()
+            && !OperatingSystem.IsBrowser();
+#endif
+    }
+#endif
+
+    public ProtobufOtlpExportClient(OtlpExporterOptions options, HttpClient httpClient, string signalPath)
+    {
+        Guard.ThrowIfNull(options);
+        Guard.ThrowIfNull(httpClient);
+        Guard.ThrowIfNull(signalPath);
+
+        Uri exporterEndpoint = options.Endpoint.AppendPathIfNotPresent(signalPath);
+        this.Endpoint = new UriBuilder(exporterEndpoint).Uri;
+        this.Headers = options.GetHeaders<Dictionary<string, string>>((d, k, v) => d.Add(k, v));
+        this.HttpClient = httpClient;
+    }
+
+    internal HttpClient HttpClient { get; }
+
+    internal Uri Endpoint { get; }
+
+    internal IReadOnlyDictionary<string, string> Headers { get; }
+
+    internal abstract MediaTypeHeaderValue MediaTypeHeader { get; }
+
+    internal virtual bool RequireHttp2 => false;
+
+    public abstract ExportClientResponse SendExportRequest(byte[] buffer, int contentLength, DateTime deadlineUtc, CancellationToken cancellationToken = default);
+
+    /// <inheritdoc/>
+    public bool Shutdown(int timeoutMilliseconds)
+    {
+        this.HttpClient.CancelPendingRequests();
+        return true;
+    }
+
+    protected HttpRequestMessage CreateHttpRequest(byte[] buffer, int contentLength)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, this.Endpoint);
+
+        if (this.RequireHttp2)
+        {
+            request.Version = Http2RequestVersion;
+
+    #if NET6_0_OR_GREATER
+            request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
+    #endif
+        }
+
+        foreach (var header in this.Headers)
+        {
+            request.Headers.Add(header.Key, header.Value);
+        }
+
+        // TODO: Support compression.
+
+        request.Content = new ByteArrayContent(buffer, 0, contentLength);
+        request.Content.Headers.ContentType = this.MediaTypeHeader;
+
+        return request;
+    }
+
+    protected HttpResponseMessage SendHttpRequest(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+#if NET
+        // Note: SendAsync must be used with HTTP/2 because synchronous send is
+        // not supported.
+        return this.RequireHttp2 || !SynchronousSendSupportedByCurrentPlatform
+            ? this.HttpClient.SendAsync(request, cancellationToken).GetAwaiter().GetResult()
+            : this.HttpClient.Send(request, cancellationToken);
+#else
+        return this.HttpClient.SendAsync(request, cancellationToken).GetAwaiter().GetResult();
+#endif
+    }
+}

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/ProtobufOtlpExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/ProtobufOtlpExportClient.cs
@@ -28,7 +28,7 @@ internal abstract class ProtobufOtlpExportClient : IProtobufExportClient
     }
 #endif
 
-    public ProtobufOtlpExportClient(OtlpExporterOptions options, HttpClient httpClient, string signalPath)
+    protected ProtobufOtlpExportClient(OtlpExporterOptions options, HttpClient httpClient, string signalPath)
     {
         Guard.ThrowIfNull(options);
         Guard.ThrowIfNull(httpClient);

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/ProtobufOtlpHttpExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/ProtobufOtlpHttpExportClient.cs
@@ -5,48 +5,24 @@
 using System.Net.Http;
 #endif
 using System.Net.Http.Headers;
-using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClient;
 
 /// <summary>Class for sending OTLP trace export request over HTTP.</summary>
-internal sealed class ProtobufOtlpHttpExportClient : IProtobufExportClient
+internal sealed class ProtobufOtlpHttpExportClient : ProtobufOtlpExportClient
 {
     private static readonly MediaTypeHeaderValue MediaHeaderValue = new("application/x-protobuf");
     private static readonly ExportClientHttpResponse SuccessExportResponse = new(success: true, deadlineUtc: default, response: null, exception: null);
-#if NET
-    private readonly bool synchronousSendSupportedByCurrentPlatform;
-#endif
 
     internal ProtobufOtlpHttpExportClient(OtlpExporterOptions options, HttpClient httpClient, string signalPath)
+        : base(options, httpClient, signalPath)
     {
-        Guard.ThrowIfNull(options);
-        Guard.ThrowIfNull(httpClient);
-        Guard.ThrowIfNull(signalPath);
-        Guard.ThrowIfInvalidTimeout(options.TimeoutMilliseconds);
-
-        Uri exporterEndpoint = options.Endpoint.AppendPathIfNotPresent(signalPath);
-        this.Endpoint = new UriBuilder(exporterEndpoint).Uri;
-        this.Headers = options.GetHeaders<Dictionary<string, string>>((d, k, v) => d.Add(k, v));
-        this.HttpClient = httpClient;
-
-#if NET
-        // See: https://github.com/dotnet/runtime/blob/280f2a0c60ce0378b8db49adc0eecc463d00fe5d/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs#L767
-        this.synchronousSendSupportedByCurrentPlatform = !OperatingSystem.IsAndroid()
-            && !OperatingSystem.IsIOS()
-            && !OperatingSystem.IsTvOS()
-            && !OperatingSystem.IsBrowser();
-#endif
     }
 
-    internal HttpClient HttpClient { get; }
-
-    internal Uri Endpoint { get; set; }
-
-    internal IReadOnlyDictionary<string, string> Headers { get; }
+    internal override MediaTypeHeaderValue MediaTypeHeader => MediaHeaderValue;
 
     /// <inheritdoc/>
-    public ExportClientResponse SendExportRequest(byte[] buffer, int contentLength, DateTime deadlineUtc, CancellationToken cancellationToken = default)
+    public override ExportClientResponse SendExportRequest(byte[] buffer, int contentLength, DateTime deadlineUtc, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -70,39 +46,5 @@ internal sealed class ProtobufOtlpHttpExportClient : IProtobufExportClient
             OpenTelemetryProtocolExporterEventSource.Log.FailedToReachCollector(this.Endpoint, ex);
             return new ExportClientHttpResponse(success: false, deadlineUtc: deadlineUtc, response: null, exception: ex);
         }
-    }
-
-    /// <inheritdoc/>
-    public bool Shutdown(int timeoutMilliseconds)
-    {
-        this.HttpClient.CancelPendingRequests();
-        return true;
-    }
-
-    public HttpRequestMessage CreateHttpRequest(byte[] exportRequest, int contentLength)
-    {
-        var request = new HttpRequestMessage(HttpMethod.Post, this.Endpoint);
-
-        foreach (var header in this.Headers)
-        {
-            request.Headers.Add(header.Key, header.Value);
-        }
-
-        var content = new ByteArrayContent(exportRequest, 0, contentLength);
-        content.Headers.ContentType = MediaHeaderValue;
-        request.Content = content;
-
-        return request;
-    }
-
-    public HttpResponseMessage SendHttpRequest(HttpRequestMessage request, CancellationToken cancellationToken)
-    {
-#if NET
-        return this.synchronousSendSupportedByCurrentPlatform
-        ? this.HttpClient.Send(request, cancellationToken)
-        : this.HttpClient.SendAsync(request, cancellationToken).GetAwaiter().GetResult();
-#else
-        return this.HttpClient.SendAsync(request, cancellationToken).GetAwaiter().GetResult();
-#endif
     }
 }


### PR DESCRIPTION
## Changes

* Introduce a base class for `ProtobufOtlpGrpcExportClient` & `ProtobufOtlpHttpExportClient` to share to reduce code duplication
* Add a comment explaining why `ProtobufOtlpGrpcExportClient` doesn't try to do synchronous send

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
