### PR TITLE
[repo] Allow dependabot to bump SDK patch version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,15 @@ updates:
       interval: "daily"
     labels:
       - "infra"
+  - package-ecosystem: "dotnet-sdk"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    labels:
+      - "infra"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"


### PR DESCRIPTION
## Changes

* Configure dependabot to bump SDK version to latest patch following: https://devblogs.microsoft.com/dotnet/using-dependabot-to-manage-dotnet-sdk-updates/.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
