### PR TITLE
[otlp] Avoid filling new buffer on expansion

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufSerializer.cs
@@ -359,9 +359,7 @@ internal static class ProtobufSerializer
         try
         {
             var newBufferSize = buffer.Length * 2;
-            var newBuffer = new byte[newBufferSize];
-            buffer.CopyTo(newBuffer, 0);
-            buffer = newBuffer;
+            buffer = new byte[newBufferSize];
             return true;
         }
         catch (OutOfMemoryException)


### PR DESCRIPTION
Fixes #
Design discussion issue #

## Changes

Please provide a brief description of the changes here.

This update optimizes the buffer expansion logic by preventing unnecessary re-filling of the newly allocated buffer during retries.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
