### PR TITLE
Ignore ShouldSample's argument for both AlwaysOnSample and AlwaysOffSampler

### DIFF
--- a/src/OpenTelemetry/Trace/Sampler/AlwaysOffSampler.cs
+++ b/src/OpenTelemetry/Trace/Sampler/AlwaysOffSampler.cs
@@ -9,7 +9,7 @@ namespace OpenTelemetry.Trace;
 public sealed class AlwaysOffSampler : Sampler
 {
     /// <inheritdoc />
-    public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
+    public override SamplingResult ShouldSample(in SamplingParameters _)
     {
         return new SamplingResult(SamplingDecision.Drop);
     }

--- a/src/OpenTelemetry/Trace/Sampler/AlwaysOnSampler.cs
+++ b/src/OpenTelemetry/Trace/Sampler/AlwaysOnSampler.cs
@@ -9,7 +9,7 @@ namespace OpenTelemetry.Trace;
 public sealed class AlwaysOnSampler : Sampler
 {
     /// <inheritdoc />
-    public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
+    public override SamplingResult ShouldSample(in SamplingParameters _)
     {
         return new SamplingResult(SamplingDecision.RecordAndSample);
     }


### PR DESCRIPTION
## Changes

Slightly more explicit about the AlwaysOn and Off samplers not using the argument in their overridden function.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
