### PR TITLE
[prometheus] Update links to openmetrics to reference the v1.0.0 release

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -150,7 +150,7 @@ Released 2022-Sep-29
   ([#3651](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3651))
 
 * Added `"# EOF\n"` ending following the [OpenMetrics
-  specification](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md)
+  specification](https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md)
   ([#3654](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3654))
 
 ## 1.4.0-alpha.2

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -147,7 +147,7 @@ Released 2022-Sep-29
   ([#3651](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3651))
 
 * Added `"# EOF\n"` ending following the [OpenMetrics
-  specification](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md)
+  specification](https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md)
   ([#3654](https://github.com/open-telemetry/opentelemetry-dotnet/pull/3654))
 
 ## 1.4.0-alpha.2

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusMetric.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusMetric.cs
@@ -37,7 +37,7 @@ internal sealed class PrometheusMetric
             sanitizedUnit = GetUnit(unit);
 
             // The resulting unit SHOULD be added to the metric as
-            // [OpenMetrics UNIT metadata](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#metricfamily)
+            // [OpenMetrics UNIT metadata](https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#metricfamily)
             // and as a suffix to the metric name. The unit suffix comes before any type-specific suffixes.
             // https://github.com/open-telemetry/opentelemetry-specification/blob/3dfb383fe583e3b74a2365c5a1d90256b273ee76/specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1
             if (!sanitizedName.EndsWith(sanitizedUnit))
@@ -57,14 +57,14 @@ internal sealed class PrometheusMetric
         }
 
         // For counters requested using OpenMetrics format, the MetricFamily name MUST be suffixed with '_total', regardless of the setting to disable the 'total' suffix.
-        // https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#counter-1
+        // https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#counter-1
         if (type == PrometheusType.Counter && !openMetricsName.EndsWith("_total"))
         {
             openMetricsName += "_total";
         }
 
         // In OpenMetrics format, the UNIT, TYPE and HELP metadata must be suffixed with the unit (handled above), and not the '_total' suffix, as in the case for counters.
-        // https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#unit
+        // https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#unit
         var openMetricsMetadataName = type == PrometheusType.Counter
             ? SanitizeOpenMetricsName(openMetricsName)
             : sanitizedName;
@@ -241,7 +241,7 @@ internal sealed class PrometheusMetric
     // OTLP metrics use the c/s notation as specified at https://ucum.org/ucum.html
     // (See also https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metrics.md#instrument-units)
     // Prometheus best practices for units: https://prometheus.io/docs/practices/naming/#base-units
-    // OpenMetrics specification for units: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#units-and-base-units
+    // OpenMetrics specification for units: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#units-and-base-units
     private static string MapUnit(ReadOnlySpan<char> unit)
     {
         return unit switch

--- a/src/Shared/Proto/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/src/Shared/Proto/opentelemetry/proto/metrics/v1/metrics.proto
@@ -430,7 +430,7 @@ message HistogramDataPoint {
   // events, and is assumed to be monotonic over the values of these events.
   // Negative events *can* be recorded, but sum should not be filled out when
   // doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-  // see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
+  // see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#histogram
   optional double sum = 5;
 
   // bucket_counts is an optional field contains the count values of histogram
@@ -509,7 +509,7 @@ message ExponentialHistogramDataPoint {
   // events, and is assumed to be monotonic over the values of these events.
   // Negative events *can* be recorded, but sum should not be filled out when
   // doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-  // see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
+  // see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#histogram
   optional double sum = 5;
   
   // scale describes the resolution of the histogram.  Boundaries are
@@ -622,7 +622,7 @@ message SummaryDataPoint {
   // events, and is assumed to be monotonic over the values of these events.
   // Negative events *can* be recorded, but sum should not be filled out when
   // doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
-  // see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#summary
+  // see: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#summary
   double sum = 5;
 
   // Represents the value at a given quantile of a distribution.


### PR DESCRIPTION
Related to https://github.com/prometheus/OpenMetrics/issues/287

The OM 2.0 effort is kicked off, and will start developing on main. This updates the links to OpenMetrics to reference the 1.0 release. The OM project has also been moved into the prometheus github org.