### PR TITLE
Run CI on Windows ARM64

### DIFF
--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -20,7 +20,7 @@ on:
         required: false
         type: string
       os-list:
-        default: '[ "windows-latest", "ubuntu-22.04", "otel-linux-arm64" ]'
+        default: '[ "windows-latest", "ubuntu-22.04", "otel-windows-arm64", "otel-linux-arm64" ]'
         required: false
         type: string
       tfm-list:
@@ -43,9 +43,17 @@ jobs:
           version: net462
         - os: otel-linux-arm64
           version: net8.0
+        - os: otel-windows-arm64
+          version: net462
+        - os: otel-windows-arm64
+          version: net8.0
 
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Install git on otel-windows-arm64
+      run: choco install git
+      if: ${{ matrix.os == 'otel-windows-arm64' }}
+
     - uses: actions/checkout@v4
       with:
         # Note: By default GitHub only fetches 1 commit. MinVer needs to find


### PR DESCRIPTION
Fixes: #1859
Utilize https://github.com/open-telemetry/community/blob/bd89bb2ae41b768c4a405a2a40b65c1944187a6f/assets.md#L73-L74

## Changes

Run CI with .NET9 on Windows ARM64

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
