### PR TITLE
Add OpCode for activity started and stop in OpenTelemetry-Sdk eventsource

### DIFF
--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -185,14 +185,14 @@ internal sealed class OpenTelemetrySdkEventSource : EventSource, IConfigurationE
         this.WriteEvent(16, exception);
     }
 
-    [Event(24, Message = "Activity started. Name = '{0}', Id = '{1}'.", Level = EventLevel.Verbose, Opcode = EventOpcode.Start)]
-    public void ActivityStarted(string name, string id)
+    [Event(24, Message = "Activity started. Name = '{0}', Id = '{1}'.", Level = EventLevel.Verbose)]
+    public void ActivityStart(string name, string id)
     {
         this.WriteEvent(24, name, id);
     }
 
-    [Event(25, Message = "Activity stopped. Name = '{0}', Id = '{1}'.", Level = EventLevel.Verbose, Opcode = EventOpcode.Stop)]
-    public void ActivityStopped(string name, string? id)
+    [Event(25, Message = "Activity stopped. Name = '{0}', Id = '{1}'.", Level = EventLevel.Verbose)]
+    public void ActivityStop(string name, string? id)
     {
         this.WriteEvent(25, name, id);
     }

--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -185,13 +185,13 @@ internal sealed class OpenTelemetrySdkEventSource : EventSource, IConfigurationE
         this.WriteEvent(16, exception);
     }
 
-    [Event(24, Message = "Activity started. Name = '{0}', Id = '{1}'.", Level = EventLevel.Verbose)]
+    [Event(24, Message = "Activity started. Name = '{0}', Id = '{1}'.", Level = EventLevel.Verbose, Opcode = EventOpcode.Start)]
     public void ActivityStarted(string name, string id)
     {
         this.WriteEvent(24, name, id);
     }
 
-    [Event(25, Message = "Activity stopped. Name = '{0}', Id = '{1}'.", Level = EventLevel.Verbose)]
+    [Event(25, Message = "Activity stopped. Name = '{0}', Id = '{1}'.", Level = EventLevel.Verbose, Opcode = EventOpcode.Stop)]
     public void ActivityStopped(string name, string? id)
     {
         this.WriteEvent(25, name, id);


### PR DESCRIPTION
Hi maintainers,

`OpenTelemetry-Sdk` provides activity started / stopped events. How about adding `OpCode` on those events, making it easier to be discovered by the analysis tools?

## Changes

Add opcode for activity start / stop to `OpenTelemetry-Sdk` event source.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
