### PR TITLE
[repo] Trigger builds when SDK is changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         filters: |
           md: ['**.md']
-          build: ['build/**', '.github/**/*.yml', '**/*.targets', '**/*.props']
+          build: ['build/**', '.github/**/*.yml', '**/*.targets', '**/*.props', 'global.json']
           shared: ['src/Shared/**']
           code: ['**.cs', '**.csproj', '.editorconfig']
           solution: ['OpenTelemetry.sln']


### PR DESCRIPTION
## Changes

* Trigger a build if the SDK is changed via `global.json`. This was done over on contrib recently: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2427#issuecomment-2549429510

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
