### PR TITLE
[sdk-tracing] Allow samplers to set TraceState for propagation-only spans

### DIFF
--- a/test/OpenTelemetry.Tests/Trace/SamplersTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/SamplersTest.cs
@@ -100,37 +100,7 @@ public class SamplersTest
     [InlineData(SamplingDecision.RecordAndSample)]
     public void SamplersCanModifyTraceStateOnLegacyActivity(SamplingDecision samplingDecision)
     {
-        var existingTraceState = "a=1,b=2";
-        var newTraceState = "a=1,b=2,c=3,d=4";
-        var testSampler = new TestSampler
-        {
-            SamplingAction = (samplingParams) =>
-            {
-                Assert.Equal(existingTraceState, samplingParams.ParentContext.TraceState);
-                return new SamplingResult(samplingDecision, newTraceState);
-            },
-        };
-
-        var operationNameForLegacyActivity = Utils.GetCurrentMethodName();
-        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-                    .SetSampler(testSampler)
-                    .AddLegacySource(operationNameForLegacyActivity)
-                    .Build();
-
-        using var parentActivity = new Activity("Foo");
-        parentActivity.TraceStateString = existingTraceState;
-        parentActivity.Start();
-
-        using var activity = new Activity(operationNameForLegacyActivity);
-        activity.Start();
-        Assert.NotNull(activity);
-        if (samplingDecision != SamplingDecision.Drop)
-        {
-            Assert.Equal(newTraceState, activity.TraceStateString);
-        }
-
-        activity.Stop();
-        parentActivity.Stop();
+        RunLegacyActivitySamplerTest(samplingDecision, samplerTraceState: "a=1,b=2,c=3,d=4");
     }
 
     [Theory]
@@ -139,36 +109,7 @@ public class SamplersTest
     [InlineData(SamplingDecision.RecordAndSample)]
     public void SamplersDoesNotImpactTraceStateWhenUsingNullLegacyActivity(SamplingDecision samplingDecision)
     {
-        var existingTraceState = "a=1,b=2";
-        var testSampler = new TestSampler
-        {
-            SamplingAction = (samplingParams) =>
-            {
-                Assert.Equal(existingTraceState, samplingParams.ParentContext.TraceState);
-                return new SamplingResult(samplingDecision);
-            },
-        };
-
-        var operationNameForLegacyActivity = Utils.GetCurrentMethodName();
-        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-                    .SetSampler(testSampler)
-                    .AddLegacySource(operationNameForLegacyActivity)
-                    .Build();
-
-        using var parentActivity = new Activity("Foo");
-        parentActivity.TraceStateString = existingTraceState;
-        parentActivity.Start();
-
-        using var activity = new Activity(operationNameForLegacyActivity);
-        activity.Start();
-        Assert.NotNull(activity);
-        if (samplingDecision != SamplingDecision.Drop)
-        {
-            Assert.Equal(existingTraceState, activity.TraceStateString);
-        }
-
-        activity.Stop();
-        parentActivity.Stop();
+        RunLegacyActivitySamplerTest(samplingDecision, samplerTraceState: null);
     }
 
     [Theory]
@@ -183,7 +124,15 @@ public class SamplersTest
         {
             SamplingAction = (samplingParams) =>
             {
-                Assert.Equal(parentTraceState, samplingParams.ParentContext.TraceState);
+                if (samplingParams.Name == "root")
+                {
+                    Assert.Equal(parentTraceState, samplingParams.ParentContext.TraceState);
+                }
+                else
+                {
+                    Assert.Equal(newTraceState, samplingParams.ParentContext.TraceState);
+                }
+
                 return new SamplingResult(sampling, newTraceState);
             },
         };
@@ -195,13 +144,50 @@ public class SamplersTest
             .SetSampler(testSampler)
             .Build();
 
-        var parentContext = new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded, parentTraceState, true);
+        // Note: Remote parent is set as recorded
+        var parentContext = new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded, parentTraceState, isRemote: true);
 
-        using var activity = activitySource.StartActivity("root", ActivityKind.Server, parentContext);
+        using var root = activitySource.StartActivity("root", ActivityKind.Server, parentContext);
+
+        // Note: We always create a root even for Drop. When dropping the
+        // created root is for propagation only
+        Assert.NotNull(root);
+        Assert.Equal(newTraceState, root.TraceStateString);
+
+        if (sampling == SamplingDecision.RecordAndSample)
+        {
+            Assert.True(root.Recorded);
+            Assert.True(root.IsAllDataRequested);
+        }
+        else if (sampling == SamplingDecision.RecordOnly)
+        {
+            // Note: Seems to be a bug in DiagnosticSource. Root in this case
+            // inherits context from the remote parent and Recorded doesn't get
+            // cleared
+            // Assert.False(root.Recorded);
+
+            Assert.True(root.IsAllDataRequested);
+        }
+        else
+        {
+            // Note: Seems to be a bug in DiagnosticSource. Root in this case
+            // inherits context from the remote parent and Recorded doesn't get
+            // cleared
+            // Assert.False(root.Recorded);
+
+            Assert.False(root.IsAllDataRequested);
+        }
+
+        using var child = activitySource.StartActivity("child", ActivityKind.Server);
+
         if (sampling != SamplingDecision.Drop)
         {
-            Assert.NotNull(activity);
-            Assert.Equal(newTraceState, activity.TraceStateString);
+            Assert.NotNull(child);
+            Assert.Equal(newTraceState, child.TraceStateString);
+        }
+        else
+        {
+            Assert.Null(child);
         }
     }
 
@@ -258,6 +244,60 @@ public class SamplersTest
             .Build();
 
         Assert.Throws<InvalidOperationException>(() => activitySource.StartActivity("ThrowingSampler"));
+    }
+
+    private static void RunLegacyActivitySamplerTest(SamplingDecision samplingDecision, string? samplerTraceState)
+    {
+        var existingTraceState = "a=1,b=2";
+
+        var operationNameForLegacyActivity = Utils.GetCurrentMethodName();
+
+        var testSampler = new TestSampler
+        {
+            SamplingAction = (samplingParams) =>
+            {
+                Assert.Equal(samplingParams.Name, operationNameForLegacyActivity);
+                Assert.Equal(existingTraceState, samplingParams.ParentContext.TraceState);
+                return new SamplingResult(samplingDecision, samplerTraceState);
+            },
+        };
+
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .SetSampler(testSampler)
+            .AddLegacySource(operationNameForLegacyActivity)
+            .Build();
+
+        using var parentActivity = new Activity("Foo");
+        parentActivity.TraceStateString = existingTraceState;
+        parentActivity.Start();
+
+        using var childActivity = new Activity(operationNameForLegacyActivity);
+        childActivity.Start();
+
+        if (samplerTraceState != null)
+        {
+            Assert.Equal(samplerTraceState, childActivity.TraceStateString);
+        }
+        else
+        {
+            Assert.Equal(existingTraceState, childActivity.TraceStateString);
+        }
+
+        if (samplingDecision == SamplingDecision.RecordAndSample)
+        {
+            Assert.True(childActivity.Recorded);
+            Assert.True(childActivity.IsAllDataRequested);
+        }
+        else if (samplingDecision == SamplingDecision.RecordOnly)
+        {
+            Assert.False(childActivity.Recorded);
+            Assert.True(childActivity.IsAllDataRequested);
+        }
+        else
+        {
+            Assert.False(childActivity.Recorded);
+            Assert.False(childActivity.IsAllDataRequested);
+        }
     }
 
     private sealed class ThrowingSampler : Sampler


### PR DESCRIPTION
Fixes #6054

## Changes

* Adjusts the sampler logic so that the `TraceStateString` may be set when creating propagation-only spans.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
