### PR TITLE
[repo] Release notes automation

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -156,7 +156,6 @@ jobs:
         token: ${{ secrets[needs.automation.outputs.token-secret-name] }}
 
     - name: Update release date
-      id: create-tag
       shell: pwsh
       run: |
         Import-Module .\build\scripts\prepare-release.psm1
@@ -169,3 +168,42 @@ jobs:
           -gitUserName '${{ needs.automation.outputs.username }}' `
           -gitUserEmail '${{ needs.automation.outputs.email }}'
 
+  update-releasenotes-on-prepare-pr-post-notice:
+    runs-on: ubuntu-22.04
+
+    needs: automation
+
+    if: |
+      github.event_name == 'issue_comment'
+      && github.event.issue.pull_request
+      && github.event.issue.state == 'open'
+      && github.event.comment.user.login != needs.automation.outputs.username
+      && contains(github.event.comment.body, '/UpdateReleaseNotes')
+      && startsWith(github.event.issue.title, '[release] Prepare release ')
+      && github.event.issue.pull_request.merged_at == null
+      && needs.automation.outputs.enabled
+
+    env:
+      GH_TOKEN: ${{ secrets[needs.automation.outputs.token-secret-name] }}
+
+    steps:
+    - name: check out code
+      uses: actions/checkout@v4
+      with:
+        # Note: By default GitHub only fetches 1 commit which fails the git tag operation below
+        fetch-depth: 0
+        token: ${{ secrets[needs.automation.outputs.token-secret-name] }}
+
+    - name: Update release notes
+      shell: pwsh
+      run: |
+        Import-Module .\build\scripts\prepare-release.psm1
+
+        UpdateReleaseNotesAndPostNoticeOnPullRequest `
+          -gitRepository '${{ github.repository }}' `
+          -pullRequestNumber '${{ github.event.issue.number }}' `
+          -botUserName '${{ needs.automation.outputs.username }}' `
+          -commentUserName '${{ github.event.comment.user.login }}' `
+          -commentBody '${{ github.event.comment.body }}'
+          -gitUserName '${{ needs.automation.outputs.username }}' `
+          -gitUserEmail '${{ needs.automation.outputs.email }}'

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -204,6 +204,6 @@ jobs:
           -pullRequestNumber '${{ github.event.issue.number }}' `
           -botUserName '${{ needs.automation.outputs.username }}' `
           -commentUserName '${{ github.event.comment.user.login }}' `
-          -commentBody '${{ github.event.comment.body }}'
+          -commentBody '${{ github.event.comment.body }}' `
           -gitUserName '${{ needs.automation.outputs.username }}' `
           -gitUserEmail '${{ needs.automation.outputs.email }}'

--- a/build/scripts/prepare-release.psm1
+++ b/build/scripts/prepare-release.psm1
@@ -76,7 +76,6 @@ Requested by: @$requestedByUserName
   $body +=
 @"
 
-``/UpdateReleaseDates``: Use to update release dates in CHANGELOGs before merging [``approvers``, ``maintainers``]
 ``/CreateReleaseTag``: Use after merging to push the release tag and trigger the job to create packages [``approvers``, ``maintainers``]
 ``/PushPackages``: Use after the created packages have been validated to push to NuGet [``maintainers``]
 "@

--- a/build/scripts/prepare-release.psm1
+++ b/build/scripts/prepare-release.psm1
@@ -383,7 +383,7 @@ function UpdateReleaseNotesAndPostNoticeOnPullRequest {
     return
   }
 
-  if ($tagPrefix -ne 'core-' -or $$isPrerelease -eq $true)
+  if ($tagPrefix -ne 'core-' -or $isPrerelease -eq $true)
   {
     gh pr comment $pullRequestNumber `
       --body "I'm sorry @$commentUserName but we don't typically add release notes for prereleases or unstable packages."

--- a/build/scripts/prepare-release.psm1
+++ b/build/scripts/prepare-release.psm1
@@ -68,12 +68,14 @@ Requested by: @$requestedByUserName
   {
     $body +=
 @"
+
 ``/UpdateReleaseNotes``: Use to update ``RELEASENOTES.md`` before merging [``approvers``, ``maintainers``]
 "@
   }
 
   $body +=
 @"
+
 ``/UpdateReleaseDates``: Use to update release dates in CHANGELOGs before merging [``approvers``, ``maintainers``]
 ``/CreateReleaseTag``: Use after merging to push the release tag and trigger the job to create packages [``approvers``, ``maintainers``]
 ``/PushPackages``: Use after the created packages have been validated to push to NuGet [``maintainers``]

--- a/build/scripts/prepare-release.psm1
+++ b/build/scripts/prepare-release.psm1
@@ -408,7 +408,7 @@ function UpdateReleaseNotesAndPostNoticeOnPullRequest {
       throw 'Could not find release notes content'
   }
 
-  $content = $match.Groups[1].Value.Trim()
+  $content = $match.Groups[1].Value.Trim() -replace "`r`n", "`n"
 
   $body =
 @"
@@ -423,7 +423,7 @@ $content
   if ($match.Success -eq $true)
   {
     $content = [regex]::Replace($releaseNotesContent, "(## $version[\w\W\s]*?)##", $body, [Text.RegularExpressions.RegexOptions]::Multiline)
-    Set-Content -Path "RELEASENOTES.md" -Value $content
+    Set-Content -Path "RELEASENOTES.md" -Value $content.TrimEnd()
   }
   else {
     $match = [regex]::Match($releaseNotesContent, '(# Release Notes[\w\W\s]*?)##', [Text.RegularExpressions.RegexOptions]::Multiline)
@@ -434,7 +434,7 @@ $content
 
     $body = $match.Groups[1].Value + $body
     $content = [regex]::Replace($releaseNotesContent, '(# Release Notes[\w\W\s]*?)##', $body, [Text.RegularExpressions.RegexOptions]::Multiline)
-    Set-Content -Path "RELEASENOTES.md" -Value $content
+    Set-Content -Path "RELEASENOTES.md" -Value $content.TrimEnd()
   }
 
   git commit -a -m "Update RELEASENOTES for $tag." 2>&1 | % ToString


### PR DESCRIPTION
## Changes

* Adds automation for updating `RELEASENOTES.md` when performing stable `core-` releases

## Details

`RELEASENOTES.md` should be updated before creating the release tag because a permalink is included in packages. To help make sure this is done correctly the bot/automation will now detect missing content and remind users to add something. It also now has a command to help do this right from the PR discussion.

## Test runs

* Stable release run without content: https://github.com/CodeBlanchOrg/opentelemetry-dotnet/pull/66
  Bot reminds user to add release note content and then has a command to help.

* Stable release run with content: https://github.com/CodeBlanchOrg/opentelemetry-dotnet/pull/65
  Bot doesn't nag to do anything but the command is still available.

* Prerelease run: https://github.com/CodeBlanchOrg/opentelemetry-dotnet/pull/64
  No reminder, updates ignored for prerelease builds.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
