### PR TITLE
[sdk] Remove redundant NotNullWhen in SelfDiagnosticsConfigParser.TryParseLogDirectory

### DIFF
--- a/src/OpenTelemetry/Internal/SelfDiagnosticsConfigParser.cs
+++ b/src/OpenTelemetry/Internal/SelfDiagnosticsConfigParser.cs
@@ -118,7 +118,6 @@ internal sealed class SelfDiagnosticsConfigParser
 
     internal static bool TryParseLogDirectory(
         string configJson,
-        [NotNullWhen(true)]
         out string logDirectory)
     {
         var logDirectoryResult = LogDirectoryRegex.Match(configJson);


### PR DESCRIPTION
## Changes

`logDirectoryResult.Groups["LogDirectory"].Value;` can never return null. which is clear by the fact that `string logDirectory` is not `string? logDirectory` and it doesnt warn.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
