### PR TITLE
[sdk-logs] Include instrumentation version in debug log

### DIFF
--- a/src/OpenTelemetry/Logs/LoggerProviderSdk.cs
+++ b/src/OpenTelemetry/Logs/LoggerProviderSdk.cs
@@ -69,7 +69,7 @@ internal sealed class LoggerProviderSdk : LoggerProvider
                 this.instrumentations.Add(instrumentation.Instance);
             }
 
-            instrumentationFactoriesAdded.Append(instrumentation.Name);
+            instrumentationFactoriesAdded.Append($"{instrumentation.Name} {instrumentation.Version}");
             instrumentationFactoriesAdded.Append(';');
         }
 

--- a/test/OpenTelemetry.Tests/Logs/LoggerProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Tests/Logs/LoggerProviderBuilderExtensionsTests.cs
@@ -45,7 +45,7 @@ public sealed class LoggerProviderBuilderExtensionsTests
     }
 
     [Fact]
-    public void LoggerProviderBuilderAddInstrumentationLogsCorrectlyTest()
+    public void LoggerProviderBuilderAddInstrumentationLogsTest()
     {
         using var inMemoryEventListener = new InMemoryEventListener(OpenTelemetrySdkEventSource.Log);
         using (Sdk.CreateLoggerProviderBuilder()


### PR DESCRIPTION
## Changes

Given Instrumentation version is being captured in AddInstrumentation

```
    public override LoggerProviderBuilder AddInstrumentation<TInstrumentation>(Func<TInstrumentation> instrumentationFactory)
    {
        Debug.Assert(instrumentationFactory != null, "instrumentationFactory was null");

        this.Instrumentation.Add(
            new InstrumentationRegistration(
                typeof(TInstrumentation).Name,
                typeof(TInstrumentation).Assembly.GetName().Version?.ToString() ?? DefaultInstrumentationVersion,
                instrumentationFactory!()));

        return this;
    }
```

I assume the intent is to use it in the logs?  So i added it there and added a test to assert it.

If u think Instrumentation version has no value in the logs, do you want another PR that removes the redundant version detection?

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
