### PR TITLE
[repo] Release notes automation tweak

### DIFF
--- a/build/scripts/prepare-release.psm1
+++ b/build/scripts/prepare-release.psm1
@@ -420,6 +420,8 @@ function UpdateReleaseNotesAndPostNoticeOnPullRequest {
 @"
 ## $version
 
+Release details: [$version](https://github.com/$gitRepository/releases/tag/$tagPrefix$version)
+
 $content
 
 ##


### PR DESCRIPTION
## Changes

* Add a link to the GitHub release/tag when generating release notes using automation

## Details

I thought linking to the GitHub Release from release notes would be useful because it has the combined CHANGELOG entries for users who want to quickly see _everything_ in a release.

Demo: https://github.com/CodeBlanchOrg/opentelemetry-dotnet/pull/67

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
