### PR TITLE
[repo] Add "release details" links in release notes

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -6,10 +6,14 @@ directory of each individual package.
 
 ## 1.11.1
 
+Release details: [1.11.1](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.11.1)
+
 * Fixed a bug preventing `OpenTelemetry.Exporter.OpenTelemetryProtocol` from
   exporting telemetry on .NET Framework.
 
 ## 1.11.0
+
+Release details: [1.11.0](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.11.0)
 
 * `OpenTelemetry.Exporter.OpenTelemetryProtocol` no longer depends on the
   `Google.Protobuf`, `Grpc`, or `Grpc.Net.Client` packages. Serialization and
@@ -17,6 +21,8 @@ directory of each individual package.
   performance.
 
 ## 1.10.0
+
+Release details: [1.10.0](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.10.0)
 
 * Bumped the package versions of `System.Diagnostic.DiagnosticSource` and other
   Microsoft.Extensions.* packages to `9.0.0`.
@@ -62,6 +68,8 @@ directory of each individual package.
 
 ## 1.9.0
 
+Release details: [1.9.0](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.9.0)
+
 * `Exemplars` are now part of the stable API! For details see: [customizing
   exemplars
   collection](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/docs/metrics/customizing-the-sdk#exemplars).
@@ -71,6 +79,8 @@ directory of each individual package.
   parity in their APIs.
 
 ## 1.8.0
+
+Release details: [1.8.0](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.8.0)
 
 * `TracerProvider` sampler can now be configured via the `OTEL_TRACES_SAMPLER` &
   `OTEL_TRACES_SAMPLER_ARG` envvars.
@@ -83,6 +93,8 @@ directory of each individual package.
   Previously an experimental environment variable had to be set.
 
 ## 1.7.0
+
+Release details: [1.7.0](https://github.com/open-telemetry/opentelemetry-dotnet/releases/tag/core-1.7.0)
 
 * Bumped the package versions of System.Diagnostic.DiagnosticSource and other
   Microsoft.Extensions.* packages to `8.0.0`.


### PR DESCRIPTION
Relates to #6087

## Changes

* Retrofit "release details" links into `RELEASENOTES.md`. These will be added by automation going forward

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
