### PR TITLE
[otlp] Fix .NET Framework gRPC Export Client Default Success Response Status

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -10,7 +10,7 @@ Notes](../../RELEASENOTES.md).
 * Fixed a bug in .NET Framework gRPC export client where the default success
   export response was incorrectly marked as false, now changed to true, ensuring
   exports are correctly marked as successful.
-  ([#](https://github.com/open-telemetry/opentelemetry-dotnet/pull/))
+  ([#6099](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6099))
 
 ## 1.11.1
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -7,13 +7,18 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Fixed a bug in .NET Framework gRPC export client where the default success
+  export response was incorrectly marked as false, now changed to true, ensuring
+  exports are correctly marked as successful.
+  ([#](https://github.com/open-telemetry/opentelemetry-dotnet/pull/))
+
 ## 1.11.1
 
 Released 2025-Jan-22
 
 * Fixed an issue where the OTLP gRPC exporter did not export logs, metrics, or
   traces in .NET Framework projects.
-  ([#6067](https://github.com/open-telemetry/opentelemetry-dotnet/issues/6067))
+  ([#6083](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6083))
 
 ## 1.11.0
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/GrpcExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/GrpcExportClient.cs
@@ -15,7 +15,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.ExportClie
 internal sealed class GrpcExportClient : IExportClient
 {
     private static readonly ExportClientGrpcResponse SuccessExportResponse = new(
-        success: false,
+        success: true,
         deadlineUtc: default,
         exception: null,
         status: null,


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-dotnet/pull/6083#discussion_r1926857889
Design discussion issue #

## Changes

Please provide a brief description of the changes here.

* Modified the incorrect status value set in `ExportClientGrpcResponse`.
* Existing bug does not impact the telemetry data to be exported. This could be part of next release.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
