### PR TITLE
move for to foreach

### DIFF
--- a/src/OpenTelemetry.Api/Context/Propagation/CompositeTextMapPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/CompositeTextMapPropagator.cs
@@ -68,9 +68,9 @@ public class CompositeTextMapPropagator : TextMapPropagator
     /// <inheritdoc/>
     public override PropagationContext Extract<T>(PropagationContext context, T carrier, Func<T, string, IEnumerable<string>?> getter)
     {
-        for (int i = 0; i < this.propagators.Count; i++)
+        foreach (var propagator in this.propagators)
         {
-            context = this.propagators[i].Extract(context, carrier, getter);
+            context = propagator.Extract(context, carrier, getter);
         }
 
         return context;
@@ -79,9 +79,9 @@ public class CompositeTextMapPropagator : TextMapPropagator
     /// <inheritdoc/>
     public override void Inject<T>(PropagationContext context, T carrier, Action<T, string, string> setter)
     {
-        for (int i = 0; i < this.propagators.Count; i++)
+        foreach (var propagator in this.propagators)
         {
-            this.propagators[i].Inject(context, carrier, setter);
+            propagator.Inject(context, carrier, setter);
         }
     }
 }

--- a/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
@@ -84,14 +84,14 @@ public class ConsoleLogRecordExporter : ConsoleExporter<LogRecord>
             if (logRecord.Attributes != null)
             {
                 this.WriteLine("LogRecord.Attributes (Key:Value):");
-                for (int i = 0; i < logRecord.Attributes.Count; i++)
+                foreach (var attribute in logRecord.Attributes)
                 {
                     // Special casing {OriginalFormat}
                     // See https://github.com/open-telemetry/opentelemetry-dotnet/pull/3182
                     // for explanation.
-                    var valueToTransform = logRecord.Attributes[i].Key.Equals("{OriginalFormat}")
-                        ? new KeyValuePair<string, object?>("OriginalFormat (a.k.a Body)", logRecord.Attributes[i].Value)
-                        : logRecord.Attributes[i];
+                    var valueToTransform = attribute.Key.Equals("{OriginalFormat}")
+                        ? new KeyValuePair<string, object?>("OriginalFormat (a.k.a Body)", attribute.Value)
+                        : attribute;
 
                     if (this.TagWriter.TryTransformTag(valueToTransform, out var result))
                     {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
@@ -143,9 +143,9 @@ internal static class ProtobufOtlpLogSerializer
         writePosition = ProtobufSerializer.WriteTagAndLength(buffer, writePosition, numberOfUtf8CharsInString + 1 + serializedLengthSize, ProtobufOtlpLogFieldNumberConstants.ScopeLogs_Scope, ProtobufWireType.LEN);
         writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Name, numberOfUtf8CharsInString, value);
 
-        for (int i = 0; i < logRecords.Count; i++)
+        foreach (var logRecord in logRecords)
         {
-            writePosition = WriteLogRecord(buffer, writePosition, sdkLimitOptions, experimentalOptions, logRecords[i]);
+            writePosition = WriteLogRecord(buffer, writePosition, sdkLimitOptions, experimentalOptions, logRecord);
         }
 
         return writePosition;

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpResourceSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpResourceSerializer.cs
@@ -25,9 +25,9 @@ internal static class ProtobufOtlpResourceSerializer
         {
             if (resource.Attributes is IReadOnlyList<KeyValuePair<string, object>> resourceAttributesList)
             {
-                for (int i = 0; i < resourceAttributesList.Count; i++)
+                foreach (var attribute in resourceAttributesList)
                 {
-                    ProcessResourceAttribute(ref otlpTagWriterState, resourceAttributesList[i]);
+                    ProcessResourceAttribute(ref otlpTagWriterState, attribute);
                 }
             }
             else

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTraceSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTraceSerializer.cs
@@ -143,7 +143,7 @@ internal static class ProtobufOtlpTraceSerializer
 
             if (activitySource.Tags is IReadOnlyList<KeyValuePair<string, object?>> activitySourceTagsList)
             {
-                for (int i = 0; i < activitySourceTagsList.Count; i++)
+                foreach (var tag in activitySourceTagsList)
                 {
                     if (otlpTagWriterState.TagCount < maxAttributeCount)
                     {
@@ -151,7 +151,7 @@ internal static class ProtobufOtlpTraceSerializer
                         int instrumentationScopeAttributesLengthPosition = otlpTagWriterState.WritePosition;
                         otlpTagWriterState.WritePosition += ReserveSizeForLength;
 
-                        ProtobufOtlpTagWriter.Instance.TryWriteTag(ref otlpTagWriterState, activitySourceTagsList[i].Key, activitySourceTagsList[i].Value, maxAttributeValueLength);
+                        ProtobufOtlpTagWriter.Instance.TryWriteTag(ref otlpTagWriterState, tag.Key, tag.Value, maxAttributeValueLength);
 
                         var instrumentationScopeAttributesLength = otlpTagWriterState.WritePosition - (instrumentationScopeAttributesLengthPosition + ReserveSizeForLength);
                         ProtobufSerializer.WriteReservedLength(otlpTagWriterState.Buffer, instrumentationScopeAttributesLengthPosition, instrumentationScopeAttributesLength);
@@ -197,9 +197,9 @@ internal static class ProtobufOtlpTraceSerializer
 
         ProtobufSerializer.WriteReservedLength(buffer, instrumentationScopeLengthPosition, writePosition - (instrumentationScopeLengthPosition + ReserveSizeForLength));
 
-        for (int i = 0; i < activities.Count; i++)
+        foreach (var activity in activities)
         {
-            writePosition = WriteSpan(buffer, writePosition, sdkLimitOptions, activities[i]);
+            writePosition = WriteSpan(buffer, writePosition, sdkLimitOptions, activity);
         }
 
         return writePosition;

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializer.cs
@@ -82,9 +82,9 @@ internal static partial class PrometheusSerializer
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int WriteAsciiStringNoEscape(byte[] buffer, int cursor, string value)
     {
-        for (int i = 0; i < value.Length; i++)
+        foreach (var t in value)
         {
-            buffer[cursor++] = unchecked((byte)value[i]);
+            buffer[cursor++] = unchecked((byte)t);
         }
 
         return cursor;
@@ -116,9 +116,9 @@ internal static partial class PrometheusSerializer
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int WriteUnicodeString(byte[] buffer, int cursor, string value)
     {
-        for (int i = 0; i < value.Length; i++)
+        foreach (var ch in value)
         {
-            var ordinal = (ushort)value[i];
+            var ordinal = (ushort)ch;
             switch (ordinal)
             {
                 case ASCII_REVERSE_SOLIDUS:
@@ -150,9 +150,9 @@ internal static partial class PrometheusSerializer
             buffer[cursor++] = unchecked((byte)'_');
         }
 
-        for (int i = 0; i < value.Length; i++)
+        foreach (var ch in value)
         {
-            ordinal = (ushort)value[i];
+            ordinal = (ushort)ch;
 
             if ((ordinal >= (ushort)'A' && ordinal <= (ushort)'Z') ||
                 (ordinal >= (ushort)'a' && ordinal <= (ushort)'z') ||
@@ -234,9 +234,9 @@ internal static partial class PrometheusSerializer
 
         Debug.Assert(!string.IsNullOrWhiteSpace(name), "name was null or whitespace");
 
-        for (int i = 0; i < name.Length; i++)
+        foreach (var ch in name)
         {
-            var ordinal = (ushort)name[i];
+            var ordinal = (ushort)ch;
             buffer[cursor++] = unchecked((byte)ordinal);
         }
 
@@ -251,9 +251,9 @@ internal static partial class PrometheusSerializer
 
         Debug.Assert(!string.IsNullOrWhiteSpace(name), "name was null or whitespace");
 
-        for (int i = 0; i < name.Length; i++)
+        foreach (var ch in name)
         {
-            var ordinal = (ushort)name[i];
+            var ordinal = (ushort)ch;
             buffer[cursor++] = unchecked((byte)ordinal);
         }
 

--- a/src/OpenTelemetry/Metrics/MetricState.cs
+++ b/src/OpenTelemetry/Metrics/MetricState.cs
@@ -47,23 +47,23 @@ internal sealed class MetricState
         return new(
             completeMeasurement: () =>
             {
-                for (int i = 0; i < metricsArray.Length; i++)
+                foreach (var metric in metricsArray)
                 {
-                    MetricReader.DeactivateMetric(metricsArray[i]);
+                    MetricReader.DeactivateMetric(metric);
                 }
             },
             recordMeasurementLong: (v, t) =>
             {
-                for (int i = 0; i < metricsArray.Length; i++)
+                foreach (var metric in metricsArray)
                 {
-                    metricsArray[i].UpdateLong(v, t);
+                    metric.UpdateLong(v, t);
                 }
             },
             recordMeasurementDouble: (v, t) =>
             {
-                for (int i = 0; i < metricsArray.Length; i++)
+                foreach (var metric in metricsArray)
                 {
-                    metricsArray[i].UpdateDouble(v, t);
+                    metric.UpdateDouble(v, t);
                 }
             });
     }

--- a/src/OpenTelemetry/Metrics/MetricStreamIdentity.cs
+++ b/src/OpenTelemetry/Metrics/MetricStreamIdentity.cs
@@ -50,9 +50,9 @@ internal readonly struct MetricStreamIdentity : IEquatable<MetricStreamIdentity>
         hashCode.Add(this.ExponentialHistogramMaxScale);
         if (this.HistogramBucketBounds != null)
         {
-            for (var i = 0; i < this.HistogramBucketBounds.Length; ++i)
+            foreach (var bound in this.HistogramBucketBounds)
             {
-                hashCode.Add(this.HistogramBucketBounds[i]);
+                hashCode.Add(bound);
             }
         }
 

--- a/src/OpenTelemetry/Metrics/StringArrayEqualityComparer.cs
+++ b/src/OpenTelemetry/Metrics/StringArrayEqualityComparer.cs
@@ -44,9 +44,9 @@ internal sealed class StringArrayEqualityComparer : IEqualityComparer<string[]>
 #if NET
         HashCode hashCode = default;
 
-        for (int i = 0; i < strings.Length; i++)
+        foreach (var ch in strings)
         {
-            hashCode.Add(strings[i]);
+            hashCode.Add(ch);
         }
 
         var hash = hashCode.ToHashCode();

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/ExportClient/OtlpHttpTraceExportClientTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/ExportClient/OtlpHttpTraceExportClientTests.cs
@@ -52,9 +52,9 @@ public class OtlpHttpTraceExportClientTests
         Assert.Contains(client.Headers, kvp => kvp.Key == header1.Name && kvp.Value == header1.Value);
         Assert.Contains(client.Headers, kvp => kvp.Key == header2.Name && kvp.Value == header2.Value);
 
-        for (int i = 0; i < OtlpExporterOptions.StandardHeaders.Length; i++)
+        foreach (var header in OtlpExporterOptions.StandardHeaders)
         {
-            Assert.Contains(client.Headers, entry => entry.Key == OtlpExporterOptions.StandardHeaders[i].Key && entry.Value == OtlpExporterOptions.StandardHeaders[i].Value);
+            Assert.Contains(client.Headers, entry => entry.Key == header.Key && entry.Value == header.Value);
         }
     }
 
@@ -149,9 +149,9 @@ public class OtlpHttpTraceExportClientTests
             Assert.Contains(httpRequest.Headers, h => h.Key == header1.Name && h.Value.First() == header1.Value);
             Assert.Contains(httpRequest.Headers, h => h.Key == header2.Name && h.Value.First() == header2.Value);
 
-            for (int i = 0; i < OtlpExporterOptions.StandardHeaders.Length; i++)
+            foreach (var header in OtlpExporterOptions.StandardHeaders)
             {
-                Assert.Contains(httpRequest.Headers, entry => entry.Key == OtlpExporterOptions.StandardHeaders[i].Key && entry.Value.First() == OtlpExporterOptions.StandardHeaders[i].Value);
+                Assert.Contains(httpRequest.Headers, entry => entry.Key == header.Key && entry.Value.First() == header.Value);
             }
 
             Assert.NotNull(testHttpHandler.HttpRequestContent);

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
@@ -28,9 +28,9 @@ public class OtlpExporterOptionsExtensionsTests
 
         Assert.Equal(OtlpExporterOptions.StandardHeaders.Length, headers.Count);
 
-        for (int i = 0; i < OtlpExporterOptions.StandardHeaders.Length; i++)
+        foreach (var header in OtlpExporterOptions.StandardHeaders)
         {
-            Assert.Contains(headers, entry => entry.Key == OtlpExporterOptions.StandardHeaders[i].Key && entry.Value == OtlpExporterOptions.StandardHeaders[i].Value);
+            Assert.Contains(headers, entry => entry.Key == header.Key && entry.Value == header.Value);
         }
     }
 

--- a/test/OpenTelemetry.Tests/Metrics/MetricApiTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricApiTests.cs
@@ -1757,9 +1757,9 @@ public class MetricApiTests : MetricTestsBase
 
         for (int i = 0; i < NumberOfMetricUpdateByEachThread; i++)
         {
-            for (int j = 0; j < arguments.ValuesToRecord.Length; j++)
+            foreach (var value in arguments.ValuesToRecord)
             {
-                histogram!.Record(arguments.ValuesToRecord[j]);
+                histogram!.Record(value);
             }
         }
     }

--- a/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTests.cs
@@ -74,9 +74,9 @@ public class MetricPointReclaimTests
             threads[i].Start(threadArgs);
         }
 
-        for (int i = 0; i < threads.Length; i++)
+        foreach (var thread in threads)
         {
-            threads[i].Join();
+            thread.Join();
         }
 
         meterProvider.ForceFlush();
@@ -174,9 +174,9 @@ public class MetricPointReclaimTests
             threads[i].Start();
         }
 
-        for (int i = 0; i < threads.Length; i++)
+        foreach (var thread in threads)
         {
-            threads[i].Join();
+            thread.Join();
         }
 
         meterProvider.ForceFlush();

--- a/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricViewTests.cs
@@ -802,9 +802,9 @@ public class MetricViewTests : MetricTestsBase
             .AddView(histogram.Name, histogramConfiguration)
             .AddInMemoryExporter(exportedItems));
 
-        for (var i = 0; i < values.Length; i++)
+        foreach (var value in values)
         {
-            histogram.Record(values[i]);
+            histogram.Record(value);
         }
 
         meterProvider.ForceFlush(MaxTimeToAllowForFlush);
@@ -840,9 +840,9 @@ public class MetricViewTests : MetricTestsBase
             .AddView(histogram.Name, histogramConfiguration)
             .AddInMemoryExporter(exportedItems));
 
-        for (var i = 0; i < values.Length; i++)
+        foreach (var value in values)
         {
-            histogram.Record(values[i]);
+            histogram.Record(value);
         }
 
         meterProvider.ForceFlush(MaxTimeToAllowForFlush);


### PR DESCRIPTION
## Changes

given the majority of loops in the repo are written as foreach. i figure converting the remaining for loops to foreach makes sense.

also IMO foreach loops improve code readability compared to for loops

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
