### PR TITLE
fix incorrect as usage in MessageReceiver

### DIFF
--- a/examples/MicroserviceExample/Utils/Messaging/MessageReceiver.cs
+++ b/examples/MicroserviceExample/Utils/Messaging/MessageReceiver.cs
@@ -75,7 +75,7 @@ public class MessageReceiver : IDisposable
         {
             if (props.Headers.TryGetValue(key, out var value))
             {
-                var bytes = value as byte[];
+                var bytes = (byte[])value;
                 return new[] { Encoding.UTF8.GetString(bytes) };
             }
         }


### PR DESCRIPTION
Fixes #
Design discussion issue #

## Changes

`as` should only be used when unsure of the type and then a null check must follow it. in this case i assume since there is no null check, the type is therefore known, and a direct cast will prevent a potential null ref exception

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
