### PR TITLE
[repo/tests] use some utf8 string literals

### DIFF
--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/Serializer/ProtobufSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/Serializer/ProtobufSerializerTests.cs
@@ -246,7 +246,7 @@ public class ProtobufSerializerTests
         Assert.Equal(10, buffer[0]); // Tag
         Assert.Equal(5, buffer[1]); // Length
 
-        byte[] expectedContent = Encoding.ASCII.GetBytes("Hello");
+        byte[] expectedContent = "Hello"u8.ToArray();
         byte[] actualContent = new byte[5];
         Array.Copy(buffer, 2, actualContent, 0, 5);
         Assert.True(expectedContent.SequenceEqual(actualContent));

--- a/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsEventListenerTest.cs
+++ b/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsEventListenerTest.cs
@@ -191,7 +191,7 @@ public class SelfDiagnosticsEventListenerTest
 
         // '\n' will be appended to the original string "abc" after EncodeInBuffer is called.
         // The byte where '\n' will be placed should not be touched within EncodeInBuffer, so it stays as '\0'.
-        byte[] expected = Encoding.UTF8.GetBytes("abc\0");
+        byte[] expected = "abc\0"u8.ToArray();
         AssertBufferOutput(expected, buffer, startPos, endPos + 1);
     }
 
@@ -204,7 +204,7 @@ public class SelfDiagnosticsEventListenerTest
         // It's a quick estimate by assumption that most Unicode characters takes up to 2 16-bit UTF-16 chars,
         // which can be up to 4 bytes when encoded in UTF-8.
         int endPos = SelfDiagnosticsEventListener.EncodeInBuffer("abc", false, buffer, startPos);
-        byte[] expected = Encoding.UTF8.GetBytes("ab...\0");
+        byte[] expected = "ab...\0"u8.ToArray();
         AssertBufferOutput(expected, buffer, startPos, endPos + 1);
     }
 
@@ -214,7 +214,7 @@ public class SelfDiagnosticsEventListenerTest
         byte[] buffer = new byte[20];
         int startPos = buffer.Length - Ellipses.Length;  // Just enough space for "...\n".
         int endPos = SelfDiagnosticsEventListener.EncodeInBuffer("abc", false, buffer, startPos);
-        byte[] expected = Encoding.UTF8.GetBytes("...\0");
+        byte[] expected = "...\0"u8.ToArray();
         AssertBufferOutput(expected, buffer, startPos, endPos + 1);
     }
 
@@ -233,7 +233,7 @@ public class SelfDiagnosticsEventListenerTest
         byte[] buffer = new byte[20];
         int startPos = buffer.Length - EllipsesWithBrackets.Length - 6;  // Just enough space for "abc" even if "...\n" need to be added.
         int endPos = SelfDiagnosticsEventListener.EncodeInBuffer("abc", true, buffer, startPos);
-        byte[] expected = Encoding.UTF8.GetBytes("{abc}\0");
+        byte[] expected = "{abc}\0"u8.ToArray();
         AssertBufferOutput(expected, buffer, startPos, endPos + 1);
     }
 
@@ -243,7 +243,7 @@ public class SelfDiagnosticsEventListenerTest
         byte[] buffer = new byte[20];
         int startPos = buffer.Length - EllipsesWithBrackets.Length - 5;  // Just not space for "...\n".
         int endPos = SelfDiagnosticsEventListener.EncodeInBuffer("abc", true, buffer, startPos);
-        byte[] expected = Encoding.UTF8.GetBytes("{ab...}\0");
+        byte[] expected = "{ab...}\0"u8.ToArray();
         AssertBufferOutput(expected, buffer, startPos, endPos + 1);
     }
 
@@ -253,7 +253,7 @@ public class SelfDiagnosticsEventListenerTest
         byte[] buffer = new byte[20];
         int startPos = buffer.Length - EllipsesWithBrackets.Length;  // Just enough space for "{...}\n".
         int endPos = SelfDiagnosticsEventListener.EncodeInBuffer("abc", true, buffer, startPos);
-        byte[] expected = Encoding.UTF8.GetBytes("{...}\0");
+        byte[] expected = "{...}\0"u8.ToArray();
         AssertBufferOutput(expected, buffer, startPos, endPos + 1);
     }
 

--- a/test/OpenTelemetry.Tests/Trace/SpanContextTest.cs
+++ b/test/OpenTelemetry.Tests/Trace/SpanContextTest.cs
@@ -8,10 +8,10 @@ namespace OpenTelemetry.Trace.Tests;
 
 public class SpanContextTest
 {
-    private static readonly byte[] FirstTraceIdBytes = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, (byte)'a' };
-    private static readonly byte[] SecondTraceIdBytes = { 0, 0, 0, 0, 0, 0, 0, (byte)'0', 0, 0, 0, 0, 0, 0, 0, 0 };
-    private static readonly byte[] FirstSpanIdBytes = { 0, 0, 0, 0, 0, 0, 0, (byte)'a' };
-    private static readonly byte[] SecondSpanIdBytes = { (byte)'0', 0, 0, 0, 0, 0, 0, 0 };
+    private static readonly byte[] FirstTraceIdBytes = "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0a"u8.ToArray();
+    private static readonly byte[] SecondTraceIdBytes = "\0\0\0\0\0\0\00\0\0\0\0\0\0\0\0"u8.ToArray();
+    private static readonly byte[] FirstSpanIdBytes = "\0\0\0\0\0\0\0a"u8.ToArray();
+    private static readonly byte[] SecondSpanIdBytes = "0\0\0\0\0\0\0\0"u8.ToArray();
 
     private static readonly SpanContext First =
       new(


### PR DESCRIPTION
## Changes

https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-11.0/utf8-string-literals

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
