### PR TITLE
Fixing bridge API bug

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -12,9 +12,9 @@ Notes](../../RELEASENOTES.md).
   exports are correctly marked as successful.
   ([#6099](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6099))
 
-* Fixed a bug in logging bridge API where the \{OriginalFormat\} attribute would 
-overwrite `Body` of the emitted `LogRecordData`.
-([#6113](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6113))
+* Fixed a bug in logging bridge API where the \{OriginalFormat\} attribute would
+  overwrite `Body` of the emitted `LogRecordData`.
+  ([#6113](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6113))
 
 ## 1.11.1
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -12,6 +12,10 @@ Notes](../../RELEASENOTES.md).
   exports are correctly marked as successful.
   ([#6099](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6099))
 
+* Fixed a bug in logging bridge API where the \{OriginalFormat\} attribute would 
+overwrite `Body` of the emitted `LogRecordData`.
+([#6113](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6113))
+
 ## 1.11.1
 
 Released 2025-Jan-22

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
@@ -207,13 +207,11 @@ internal static class ProtobufOtlpLogSerializer
         }
 
         bool bodyPopulatedFromFormattedMessage = false;
-        bool isLogRecordBodySet = false;
 
         if (logRecord.FormattedMessage != null)
         {
             otlpTagWriterState.WritePosition = WriteLogRecordBody(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, logRecord.FormattedMessage.AsSpan());
             bodyPopulatedFromFormattedMessage = true;
-            isLogRecordBodySet = true;
         }
 
         if (logRecord.Attributes != null)
@@ -226,20 +224,11 @@ internal static class ProtobufOtlpLogSerializer
                 if (attribute.Key.Equals("{OriginalFormat}") && !bodyPopulatedFromFormattedMessage)
                 {
                     otlpTagWriterState.WritePosition = WriteLogRecordBody(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, (attribute.Value as string).AsSpan());
-                    isLogRecordBodySet = true;
                 }
                 else
                 {
                     AddLogAttribute(state, attribute);
                 }
-            }
-
-            // Supports setting Body directly on LogRecord for the Logs Bridge API.
-            if (!isLogRecordBodySet && logRecord.Body != null)
-            {
-                // If {OriginalFormat} is not present in the attributes,
-                // use logRecord.Body if it is set.
-                otlpTagWriterState.WritePosition = WriteLogRecordBody(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, logRecord.Body.AsSpan());
             }
         }
 

--- a/src/OpenTelemetry/Logs/LoggerSdk.cs
+++ b/src/OpenTelemetry/Logs/LoggerSdk.cs
@@ -39,6 +39,7 @@ internal sealed class LoggerSdk : Logger
             logRecord.Logger = this;
 
             logRecord.AttributeData = attributes.Export(ref logRecord.AttributeStorage);
+            logRecord.FormattedMessage = logRecord.Body;
 
             processor.OnEnd(logRecord);
 


### PR DESCRIPTION
Fixes #
Design discussion issues https://github.com/open-telemetry/opentelemetry-dotnet/issues/4433, https://github.com/open-telemetry/opentelemetry-dotnet/issues/6109

## Changes

This would change the behavior of the logging bridge API where body of the exported log would be set by the `Body` of the emitted `LogRecordData`. I'm not sure if this change would be OK with you, but I don't see another way of directly setting both the body and the {OriginalFormat} attribute. [This](https://github.com/juliuskoval/NLog.Targets.OpenTelemetryProtocol/blob/master/NLog.Targets.OpenTelemetryProtocol/LogRecordProcessor.cs) workaround is possible, but obviously not ideal. This scenario wasn't covered by unit tests, so I added one.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
