### PR TITLE
[repo] Add Rajkumar Rangaraj as maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ you're more than welcome to participate!
 
 * [Alan West](https://github.com/alanwest), New Relic
 * [Mikel Blanchard](https://github.com/CodeBlanch), Microsoft
+* [Rajkumar Rangaraj](https://github.com/rajkumar-rangaraj), Microsoft
 
 [Emeritus Maintainers](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#emeritus-maintainerapprovertriager):
 
@@ -248,7 +249,6 @@ you're more than welcome to participate!
 
 * [Cijo Thomas](https://github.com/cijothomas), Microsoft
 * [Piotr Kie&#x142;kowicz](https://github.com/Kielek), Splunk
-* [Rajkumar Rangaraj](https://github.com/rajkumar-rangaraj), Microsoft
 
 [Emeritus Approvers](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#emeritus-maintainerapprovertriager):
 


### PR DESCRIPTION
Raj, your mission, should you choose to accept it: please join the OpenTelemetry .NET project as a maintainer.

You've _officially_ served as approver for a few months now, but if you ask me you've been serving the role for much longer than that. Since November we have pushed out two more great releases. Thank you especially for your help sliming down the OTLP exporter by removing its dependencies on the gRPC and Protobuf libraries. Also, thank you for taking lead on our SIG meetings ensuring that we triage and attend to open issues and PRs.

Looking forward to our continued work together!