### PR TITLE
 [otlp] Fix incorrect length handling of Status.Description exceeding 127 bytes

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -12,11 +12,9 @@ Notes](../../RELEASENOTES.md).
   exports are correctly marked as successful.
   ([#6099](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6099))
 
-* Fixed an issue where `Status.Description` exceeding 127 bytes resulted in
-  incorrect length encoding, leading to serialization errors. The length
-  encoding now correctly handles descriptions longer than 127 bytes, ensuring
-  accurate serialization and preventing related failures.
-  ([#](https://github.com/open-telemetry/opentelemetry-dotnet/pull/))
+* Fixed an issues causing trace exports to fail when
+  `Activity.StatusDescription` exceeds 127 bytes.
+  ([#6119](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6119))
 
 ## 1.11.1
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -12,6 +12,12 @@ Notes](../../RELEASENOTES.md).
   exports are correctly marked as successful.
   ([#6099](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6099))
 
+* Fixed an issue where `Status.Description` exceeding 127 bytes resulted in
+  incorrect length encoding, leading to serialization errors. The length
+  encoding now correctly handles descriptions longer than 127 bytes, ensuring
+  accurate serialization and preventing related failures.
+  ([#](https://github.com/open-telemetry/opentelemetry-dotnet/pull/))
+
 ## 1.11.1
 
 Released 2025-Jan-22

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTraceSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTraceSerializer.cs
@@ -507,7 +507,10 @@ internal static class ProtobufOtlpTraceSerializer
         {
             var descriptionSpan = description.AsSpan();
             var numberOfUtf8CharsInString = ProtobufSerializer.GetNumberOfUtf8CharsInString(descriptionSpan);
-            position = ProtobufSerializer.WriteTagAndLength(buffer, position, numberOfUtf8CharsInString + 4, ProtobufOtlpTraceFieldNumberConstants.Span_Status, ProtobufWireType.LEN);
+            var serializedLengthSize = ProtobufSerializer.ComputeVarInt64Size((ulong)numberOfUtf8CharsInString);
+
+            // length = numberOfUtf8CharsInString + Status_Message tag size + serializedLengthSize field size + Span_Status tag size + Span_Status length size.
+            position = ProtobufSerializer.WriteTagAndLength(buffer, position, numberOfUtf8CharsInString + 1 + serializedLengthSize + 2, ProtobufOtlpTraceFieldNumberConstants.Span_Status, ProtobufWireType.LEN);
             position = ProtobufSerializer.WriteStringWithTag(buffer, position, ProtobufOtlpTraceFieldNumberConstants.Status_Message, numberOfUtf8CharsInString, descriptionSpan);
         }
         else


### PR DESCRIPTION
Fixes #6117
Design discussion issue #

## Changes

Please provide a brief description of the changes here.

Fixed an issue with incorrect length encoding of `Status.Description` when its byte length exceeds 127. The previous behavior resulted in incorrect reporting, causing serialization issues and potential payload corruption. The fix ensures proper length encoding and safe handling of longer descriptions.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [X] Appropriate `CHANGELOG.md` files updated for non-trivial changes
