### PR TITLE
ScopeManagerShim - do not store not recorded spans

### DIFF
--- a/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
@@ -59,10 +59,15 @@ internal sealed class ScopeManagerShim : IScopeManager
                 scope!.Dispose();
             });
 
-        SpanScopeTable.Add(shim.Span, instrumentation);
+        // not recorded span is static TelemetrySpan.NoopInstance
+        // we do not return the instrumentation if the span is not recorded anyway
+        if (shim.Span.IsRecording)
+        {
+            SpanScopeTable.Add(shim.Span, instrumentation);
 #if DEBUG
-        Interlocked.Increment(ref this.spanScopeTableCount);
+            Interlocked.Increment(ref this.spanScopeTableCount);
 #endif
+        }
 
         return instrumentation;
     }

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/ScopeManagerShimNotRecordedTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/ScopeManagerShimNotRecordedTests.cs
@@ -1,0 +1,31 @@
+﻿// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+using OpenTelemetry.Trace;
+using Xunit;
+
+namespace OpenTelemetry.Shims.OpenTracing.Tests;
+
+public class ScopeManagerShimNotRecordedTests
+{
+    [Fact]
+    public void MultipleNotRecordedSpans_ReturnNoopInstance_DoNotThrow()
+    {
+        var tracer = TracerProvider.Default.GetTracer("TracerName");
+        var scopeManagerShim = new ScopeManagerShim();
+        var span1 = new SpanShim(tracer.StartSpan("Span-1"));
+        var span2 = new SpanShim(tracer.StartSpan("Span-2"));
+
+        var exception = Record.Exception(() =>
+        {
+            using var scope1 = scopeManagerShim.Activate(span1, true);
+            using var scope2 = scopeManagerShim.Activate(span1, true);
+        });
+
+        Assert.Same(TelemetrySpan.NoopInstance, span1.Span);
+        Assert.Same(TelemetrySpan.NoopInstance, span2.Span);
+        Assert.False(span1.Span.IsRecording);
+        Assert.False(span2.Span.IsRecording);
+        Assert.Null(exception);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-dotnet/issues/4728

## Changes

Do not store not recorded spans in `ScopeManagerShim` - they are not returned anyway and those spans were often static field `TelemetrySpan.NoopInstance` that throws exception **_Key already has been added_**.
