### PR TITLE
[repo] Use public ARM64 runners

### DIFF
--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -20,7 +20,7 @@ on:
         required: false
         type: string
       os-list:
-        default: '[ "windows-latest", "ubuntu-22.04", "otel-linux-arm64" ]'
+        default: '[ "windows-latest", "ubuntu-22.04", "ubuntu-22.04-arm" ]'
         required: false
         type: string
       tfm-list:
@@ -39,9 +39,9 @@ jobs:
         exclude:
         - os: ubuntu-22.04
           version: net462
-        - os: otel-linux-arm64
+        - os: ubuntu-22.04-arm
           version: net462
-        - os: otel-linux-arm64
+        - os: ubuntu-22.04-arm
           version: net8.0
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Handles https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

## Changes

Switches ARM64 runners to the public version.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
