### PR TITLE
Adding an override to LoggerProvider.GetLogger

### DIFF
--- a/src/OpenTelemetry.Api/.publicApi/Stable/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/Stable/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+OpenTelemetry.Logs.Logger.Attributes.get -> System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, object?>>?
+OpenTelemetry.Logs.LoggerProvider.GetLogger(string? name, string? version, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, object?>>? attributes) -> OpenTelemetry.Logs.Logger!

--- a/src/OpenTelemetry.Api/Logs/Logger.cs
+++ b/src/OpenTelemetry.Api/Logs/Logger.cs
@@ -47,6 +47,11 @@ abstract class Logger
     public string? Version { get; private set; }
 
     /// <summary>
+    /// Gets the attributes of the instrumentation library.
+    /// </summary>
+    public IEnumerable<KeyValuePair<string, object?>>? Attributes { get; private set; }
+
+    /// <summary>
     /// Emit a log.
     /// </summary>
     /// <param name="data"><see cref="LogRecordData"/>.</param>
@@ -63,8 +68,10 @@ abstract class Logger
         in LogRecordAttributeList attributes);
 
     internal void SetInstrumentationScope(
-        string? version)
+        string? version,
+        IEnumerable<KeyValuePair<string, object?>>? attributes)
     {
         this.Version = version;
+        this.Attributes = attributes;
     }
 }

--- a/src/OpenTelemetry.Api/Logs/LoggerProvider.cs
+++ b/src/OpenTelemetry.Api/Logs/LoggerProvider.cs
@@ -38,7 +38,7 @@ public class LoggerProvider : BaseProvider
     internal
 #endif
         Logger GetLogger()
-        => this.GetLogger(name: null, version: null);
+        => this.GetLogger(name: null, version: null, attributes: null);
 
 #if EXPOSE_EXPERIMENTAL_FEATURES
     /// <summary>
@@ -55,7 +55,7 @@ public class LoggerProvider : BaseProvider
     internal
 #endif
         Logger GetLogger(string? name)
-        => this.GetLogger(name, version: null);
+        => this.GetLogger(name, version: null, attributes: null);
 
 #if EXPOSE_EXPERIMENTAL_FEATURES
     /// <summary>
@@ -73,13 +73,32 @@ public class LoggerProvider : BaseProvider
     internal
 #endif
         Logger GetLogger(string? name, string? version)
+        => this.GetLogger(name, version, attributes: null);
+
+#if EXPOSE_EXPERIMENTAL_FEATURES
+    /// <summary>
+    /// Gets a logger with the given name and version.
+    /// </summary>
+    /// <remarks><inheritdoc cref="Logger" path="/remarks"/></remarks>
+    /// <param name="name">Optional name identifying the instrumentation library.</param>
+    /// <param name="version">Optional version of the instrumentation library.</param>
+    /// <param name="attributes">Optional instrumentation scope attributes.</param>
+    /// <returns><see cref="Logger"/> instance.</returns>
+#if NET
+    [Experimental(DiagnosticDefinitions.LogsBridgeExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
+#endif
+    public
+#else
+    internal
+#endif
+        Logger GetLogger(string? name, string? version, IEnumerable<KeyValuePair<string, object?>>? attributes)
     {
         if (!this.TryCreateLogger(name, out var logger))
         {
             return NoopLogger;
         }
 
-        logger!.SetInstrumentationScope(version);
+        logger!.SetInstrumentationScope(version, attributes);
 
         return logger;
     }


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-dotnet/issues/4433
`LoggerProvider.GetLogger` should accept attributes according to the [spec.](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md#logs)

## Changes

I added an overload to the `LoggerProvider.GetLogger` method which accepts attributes and I modified the `ProtobufOtlpLogSerializer` so that it now exports both the version of instrumentation scope and the associated attributes.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
