### PR TITLE
[baggage-api] allow metadata storage in baggage

### DIFF
--- a/docs/trace/extending-the-sdk/MyEnrichingProcessor.cs
+++ b/docs/trace/extending-the-sdk/MyEnrichingProcessor.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using OpenTelemetry;
+#pragma warning disable CS0618 // Type or member is obsolete
 
 internal class MyEnrichingProcessor : BaseProcessor<Activity>
 {

--- a/src/OpenTelemetry.Api/.publicApi/Experimental/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/Experimental/PublicAPI.Unshipped.txt
@@ -1,23 +1,4 @@
 abstract OpenTelemetry.Logs.Logger.EmitLog(in OpenTelemetry.Logs.LogRecordData data, in OpenTelemetry.Logs.LogRecordAttributeList attributes) -> void
-OpenTelemetry.Baggage.Enumerator
-OpenTelemetry.Baggage.Enumerator.Current.get -> System.Collections.Generic.KeyValuePair<string!, OpenTelemetry.BaggageEntry>
-OpenTelemetry.Baggage.Enumerator.Dispose() -> void
-OpenTelemetry.Baggage.Enumerator.Enumerator() -> void
-OpenTelemetry.Baggage.Enumerator.MoveNext() -> bool
-OpenTelemetry.Baggage.Enumerator.Reset() -> void
-OpenTelemetry.Baggage.GetEnumeratorWithMetadata() -> OpenTelemetry.Baggage.Enumerator
-OpenTelemetry.Baggage.SetBaggage(string! name, string? value, string? metadata) -> OpenTelemetry.Baggage
-OpenTelemetry.BaggageEntry
-OpenTelemetry.BaggageEntry.BaggageEntry() -> void
-OpenTelemetry.BaggageEntry.BaggageEntry(string! value, OpenTelemetry.BaggageEntryMetadata? metadata = null) -> void
-OpenTelemetry.BaggageEntry.Equals(OpenTelemetry.BaggageEntry other) -> bool
-OpenTelemetry.BaggageEntry.Metadata.get -> OpenTelemetry.BaggageEntryMetadata?
-OpenTelemetry.BaggageEntry.Value.get -> string!
-OpenTelemetry.BaggageEntryMetadata
-OpenTelemetry.BaggageEntryMetadata.BaggageEntryMetadata() -> void
-OpenTelemetry.BaggageEntryMetadata.BaggageEntryMetadata(string? value) -> void
-OpenTelemetry.BaggageEntryMetadata.Equals(OpenTelemetry.BaggageEntryMetadata other) -> bool
-OpenTelemetry.BaggageEntryMetadata.Value.get -> string?
 OpenTelemetry.Logs.Logger
 OpenTelemetry.Logs.Logger.EmitLog(in OpenTelemetry.Logs.LogRecordData data) -> void
 OpenTelemetry.Logs.Logger.Logger(string? name) -> void
@@ -87,17 +68,6 @@ OpenTelemetry.Logs.LogRecordSeverity.Warn2 = 14 -> OpenTelemetry.Logs.LogRecordS
 OpenTelemetry.Logs.LogRecordSeverity.Warn3 = 15 -> OpenTelemetry.Logs.LogRecordSeverity
 OpenTelemetry.Logs.LogRecordSeverity.Warn4 = 16 -> OpenTelemetry.Logs.LogRecordSeverity
 OpenTelemetry.Logs.LogRecordSeverityExtensions
-override OpenTelemetry.BaggageEntry.Equals(object? obj) -> bool
-override OpenTelemetry.BaggageEntry.GetHashCode() -> int
-override OpenTelemetry.BaggageEntryMetadata.Equals(object? obj) -> bool
-override OpenTelemetry.BaggageEntryMetadata.GetHashCode() -> int
-static OpenTelemetry.Baggage.CreateWithMetadata(System.Collections.Generic.Dictionary<string!, OpenTelemetry.BaggageEntry>! baggageItems) -> OpenTelemetry.Baggage
-static OpenTelemetry.Baggage.GetEnumeratorWithMetadata(OpenTelemetry.Baggage baggage) -> OpenTelemetry.Baggage.Enumerator
-static OpenTelemetry.Baggage.SetBaggage(string! name, string? value, string? metadata, OpenTelemetry.Baggage baggage) -> OpenTelemetry.Baggage
-static OpenTelemetry.BaggageEntry.operator !=(OpenTelemetry.BaggageEntry left, OpenTelemetry.BaggageEntry right) -> bool
-static OpenTelemetry.BaggageEntry.operator ==(OpenTelemetry.BaggageEntry left, OpenTelemetry.BaggageEntry right) -> bool
-static OpenTelemetry.BaggageEntryMetadata.operator !=(OpenTelemetry.BaggageEntryMetadata left, OpenTelemetry.BaggageEntryMetadata right) -> bool
-static OpenTelemetry.BaggageEntryMetadata.operator ==(OpenTelemetry.BaggageEntryMetadata left, OpenTelemetry.BaggageEntryMetadata right) -> bool
 static OpenTelemetry.Logs.LogRecordAttributeList.CreateFromEnumerable(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, object?>>! attributes) -> OpenTelemetry.Logs.LogRecordAttributeList
 static OpenTelemetry.Logs.LogRecordSeverityExtensions.ToShortName(this OpenTelemetry.Logs.LogRecordSeverity logRecordSeverity) -> string!
 virtual OpenTelemetry.Logs.LoggerProvider.TryCreateLogger(string? name, out OpenTelemetry.Logs.Logger? logger) -> bool

--- a/src/OpenTelemetry.Api/.publicApi/Experimental/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/Experimental/PublicAPI.Unshipped.txt
@@ -1,4 +1,23 @@
 abstract OpenTelemetry.Logs.Logger.EmitLog(in OpenTelemetry.Logs.LogRecordData data, in OpenTelemetry.Logs.LogRecordAttributeList attributes) -> void
+OpenTelemetry.Baggage.Enumerator
+OpenTelemetry.Baggage.Enumerator.Current.get -> System.Collections.Generic.KeyValuePair<string!, OpenTelemetry.BaggageEntry>
+OpenTelemetry.Baggage.Enumerator.Dispose() -> void
+OpenTelemetry.Baggage.Enumerator.Enumerator() -> void
+OpenTelemetry.Baggage.Enumerator.MoveNext() -> bool
+OpenTelemetry.Baggage.Enumerator.Reset() -> void
+OpenTelemetry.Baggage.GetEnumeratorWithMetadata() -> OpenTelemetry.Baggage.Enumerator
+OpenTelemetry.Baggage.SetBaggage(string! name, string? value, string? metadata) -> OpenTelemetry.Baggage
+OpenTelemetry.BaggageEntry
+OpenTelemetry.BaggageEntry.BaggageEntry() -> void
+OpenTelemetry.BaggageEntry.BaggageEntry(string! value, OpenTelemetry.BaggageEntryMetadata? metadata = null) -> void
+OpenTelemetry.BaggageEntry.Equals(OpenTelemetry.BaggageEntry other) -> bool
+OpenTelemetry.BaggageEntry.Metadata.get -> OpenTelemetry.BaggageEntryMetadata?
+OpenTelemetry.BaggageEntry.Value.get -> string!
+OpenTelemetry.BaggageEntryMetadata
+OpenTelemetry.BaggageEntryMetadata.BaggageEntryMetadata() -> void
+OpenTelemetry.BaggageEntryMetadata.BaggageEntryMetadata(string? value) -> void
+OpenTelemetry.BaggageEntryMetadata.Equals(OpenTelemetry.BaggageEntryMetadata other) -> bool
+OpenTelemetry.BaggageEntryMetadata.Value.get -> string?
 OpenTelemetry.Logs.Logger
 OpenTelemetry.Logs.Logger.EmitLog(in OpenTelemetry.Logs.LogRecordData data) -> void
 OpenTelemetry.Logs.Logger.Logger(string? name) -> void
@@ -68,6 +87,17 @@ OpenTelemetry.Logs.LogRecordSeverity.Warn2 = 14 -> OpenTelemetry.Logs.LogRecordS
 OpenTelemetry.Logs.LogRecordSeverity.Warn3 = 15 -> OpenTelemetry.Logs.LogRecordSeverity
 OpenTelemetry.Logs.LogRecordSeverity.Warn4 = 16 -> OpenTelemetry.Logs.LogRecordSeverity
 OpenTelemetry.Logs.LogRecordSeverityExtensions
+override OpenTelemetry.BaggageEntry.Equals(object? obj) -> bool
+override OpenTelemetry.BaggageEntry.GetHashCode() -> int
+override OpenTelemetry.BaggageEntryMetadata.Equals(object? obj) -> bool
+override OpenTelemetry.BaggageEntryMetadata.GetHashCode() -> int
+static OpenTelemetry.Baggage.CreateWithMetadata(System.Collections.Generic.Dictionary<string!, OpenTelemetry.BaggageEntry>! baggageItems) -> OpenTelemetry.Baggage
+static OpenTelemetry.Baggage.GetEnumeratorWithMetadata(OpenTelemetry.Baggage baggage) -> OpenTelemetry.Baggage.Enumerator
+static OpenTelemetry.Baggage.SetBaggage(string! name, string? value, string? metadata, OpenTelemetry.Baggage baggage) -> OpenTelemetry.Baggage
+static OpenTelemetry.BaggageEntry.operator !=(OpenTelemetry.BaggageEntry left, OpenTelemetry.BaggageEntry right) -> bool
+static OpenTelemetry.BaggageEntry.operator ==(OpenTelemetry.BaggageEntry left, OpenTelemetry.BaggageEntry right) -> bool
+static OpenTelemetry.BaggageEntryMetadata.operator !=(OpenTelemetry.BaggageEntryMetadata left, OpenTelemetry.BaggageEntryMetadata right) -> bool
+static OpenTelemetry.BaggageEntryMetadata.operator ==(OpenTelemetry.BaggageEntryMetadata left, OpenTelemetry.BaggageEntryMetadata right) -> bool
 static OpenTelemetry.Logs.LogRecordAttributeList.CreateFromEnumerable(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, object?>>! attributes) -> OpenTelemetry.Logs.LogRecordAttributeList
 static OpenTelemetry.Logs.LogRecordSeverityExtensions.ToShortName(this OpenTelemetry.Logs.LogRecordSeverity logRecordSeverity) -> string!
 virtual OpenTelemetry.Logs.LoggerProvider.TryCreateLogger(string? name, out OpenTelemetry.Logs.Logger? logger) -> bool

--- a/src/OpenTelemetry.Api/.publicApi/Stable/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/Stable/PublicAPI.Unshipped.txt
@@ -1,0 +1,30 @@
+OpenTelemetry.Baggage.Enumerator
+OpenTelemetry.Baggage.Enumerator.Current.get -> System.Collections.Generic.KeyValuePair<string!, OpenTelemetry.BaggageEntry>
+OpenTelemetry.Baggage.Enumerator.Dispose() -> void
+OpenTelemetry.Baggage.Enumerator.Enumerator() -> void
+OpenTelemetry.Baggage.Enumerator.MoveNext() -> bool
+OpenTelemetry.Baggage.Enumerator.Reset() -> void
+OpenTelemetry.Baggage.GetEnumeratorWithMetadata() -> OpenTelemetry.Baggage.Enumerator
+OpenTelemetry.Baggage.SetBaggage(string! name, string? value, string? metadata) -> OpenTelemetry.Baggage
+OpenTelemetry.BaggageEntry
+OpenTelemetry.BaggageEntry.BaggageEntry() -> void
+OpenTelemetry.BaggageEntry.BaggageEntry(string! value, OpenTelemetry.BaggageEntryMetadata? metadata = null) -> void
+OpenTelemetry.BaggageEntry.Equals(OpenTelemetry.BaggageEntry other) -> bool
+OpenTelemetry.BaggageEntry.Metadata.get -> OpenTelemetry.BaggageEntryMetadata?
+OpenTelemetry.BaggageEntry.Value.get -> string!
+OpenTelemetry.BaggageEntryMetadata
+OpenTelemetry.BaggageEntryMetadata.BaggageEntryMetadata() -> void
+OpenTelemetry.BaggageEntryMetadata.BaggageEntryMetadata(string? value) -> void
+OpenTelemetry.BaggageEntryMetadata.Equals(OpenTelemetry.BaggageEntryMetadata other) -> bool
+OpenTelemetry.BaggageEntryMetadata.Value.get -> string?
+override OpenTelemetry.BaggageEntry.Equals(object? obj) -> bool
+override OpenTelemetry.BaggageEntry.GetHashCode() -> int
+override OpenTelemetry.BaggageEntryMetadata.Equals(object? obj) -> bool
+override OpenTelemetry.BaggageEntryMetadata.GetHashCode() -> int
+static OpenTelemetry.Baggage.CreateWithMetadata(System.Collections.Generic.Dictionary<string!, OpenTelemetry.BaggageEntry>! baggageItems) -> OpenTelemetry.Baggage
+static OpenTelemetry.Baggage.GetEnumeratorWithMetadata(OpenTelemetry.Baggage baggage) -> OpenTelemetry.Baggage.Enumerator
+static OpenTelemetry.Baggage.SetBaggage(string! name, string? value, string? metadata, OpenTelemetry.Baggage baggage) -> OpenTelemetry.Baggage
+static OpenTelemetry.BaggageEntry.operator !=(OpenTelemetry.BaggageEntry left, OpenTelemetry.BaggageEntry right) -> bool
+static OpenTelemetry.BaggageEntry.operator ==(OpenTelemetry.BaggageEntry left, OpenTelemetry.BaggageEntry right) -> bool
+static OpenTelemetry.BaggageEntryMetadata.operator !=(OpenTelemetry.BaggageEntryMetadata left, OpenTelemetry.BaggageEntryMetadata right) -> bool
+static OpenTelemetry.BaggageEntryMetadata.operator ==(OpenTelemetry.BaggageEntryMetadata left, OpenTelemetry.BaggageEntryMetadata right) -> bool

--- a/src/OpenTelemetry.Api/.publicApi/Stable/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/Stable/PublicAPI.Unshipped.txt
@@ -4,6 +4,7 @@ OpenTelemetry.Baggage.Enumerator.Dispose() -> void
 OpenTelemetry.Baggage.Enumerator.Enumerator() -> void
 OpenTelemetry.Baggage.Enumerator.MoveNext() -> bool
 OpenTelemetry.Baggage.Enumerator.Reset() -> void
+OpenTelemetry.Baggage.GetBaggageWithMetadata(string! name) -> OpenTelemetry.BaggageEntry?
 OpenTelemetry.Baggage.GetEnumeratorWithMetadata() -> OpenTelemetry.Baggage.Enumerator
 OpenTelemetry.Baggage.SetBaggage(string! name, string? value, string? metadata) -> OpenTelemetry.Baggage
 OpenTelemetry.BaggageEntry

--- a/src/OpenTelemetry.Api/.publicApi/Stable/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/Stable/PublicAPI.Unshipped.txt
@@ -22,7 +22,7 @@ override OpenTelemetry.BaggageEntry.Equals(object? obj) -> bool
 override OpenTelemetry.BaggageEntry.GetHashCode() -> int
 override OpenTelemetry.BaggageEntryMetadata.Equals(object? obj) -> bool
 override OpenTelemetry.BaggageEntryMetadata.GetHashCode() -> int
-static OpenTelemetry.Baggage.CreateWithMetadata(System.Collections.Generic.Dictionary<string!, OpenTelemetry.BaggageEntry>? baggageItems) -> OpenTelemetry.Baggage
+static OpenTelemetry.Baggage.CreateWithMetadata(System.Collections.Generic.Dictionary<string!, OpenTelemetry.BaggageEntry>? baggageItems = null) -> OpenTelemetry.Baggage
 static OpenTelemetry.Baggage.GetEnumeratorWithMetadata(OpenTelemetry.Baggage baggage) -> OpenTelemetry.Baggage.Enumerator
 static OpenTelemetry.Baggage.SetBaggage(string! name, string? value, string? metadata, OpenTelemetry.Baggage baggage) -> OpenTelemetry.Baggage
 static OpenTelemetry.BaggageEntry.operator !=(OpenTelemetry.BaggageEntry left, OpenTelemetry.BaggageEntry right) -> bool

--- a/src/OpenTelemetry.Api/.publicApi/Stable/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/Stable/PublicAPI.Unshipped.txt
@@ -22,7 +22,7 @@ override OpenTelemetry.BaggageEntry.Equals(object? obj) -> bool
 override OpenTelemetry.BaggageEntry.GetHashCode() -> int
 override OpenTelemetry.BaggageEntryMetadata.Equals(object? obj) -> bool
 override OpenTelemetry.BaggageEntryMetadata.GetHashCode() -> int
-static OpenTelemetry.Baggage.CreateWithMetadata(System.Collections.Generic.Dictionary<string!, OpenTelemetry.BaggageEntry>! baggageItems) -> OpenTelemetry.Baggage
+static OpenTelemetry.Baggage.CreateWithMetadata(System.Collections.Generic.Dictionary<string!, OpenTelemetry.BaggageEntry>? baggageItems) -> OpenTelemetry.Baggage
 static OpenTelemetry.Baggage.GetEnumeratorWithMetadata(OpenTelemetry.Baggage baggage) -> OpenTelemetry.Baggage.Enumerator
 static OpenTelemetry.Baggage.SetBaggage(string! name, string? value, string? metadata, OpenTelemetry.Baggage baggage) -> OpenTelemetry.Baggage
 static OpenTelemetry.BaggageEntry.operator !=(OpenTelemetry.BaggageEntry left, OpenTelemetry.BaggageEntry right) -> bool

--- a/src/OpenTelemetry.Api/Baggage.cs
+++ b/src/OpenTelemetry.Api/Baggage.cs
@@ -157,6 +157,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// <param name="baggage">Optional <see cref="Baggage"/>. <see cref="Current"/> is used if not specified.</param>
     /// <returns>Baggage key/value pairs.</returns>
     [SuppressMessage("roslyn", "RS0026", Justification = "TODO: fix APIs that violate the backcompt requirement - multiple overloads with optional parameters: https://github.com/dotnet/roslyn/blob/main/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md.")]
+
     // [Obsolete("Call GetEnumeratorWithMetadata instead to iterate over the baggage.")]
     public static IReadOnlyDictionary<string, string> GetBaggage(Baggage baggage = default)
         => baggage == default ? Current.GetBaggage() : baggage.GetBaggage();
@@ -201,6 +202,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// <returns>New <see cref="Baggage"/> containing the key/value pair.</returns>
     /// <remarks>Note: The <see cref="Baggage"/> returned will be set as the new <see cref="Current"/> instance.</remarks>
     [SuppressMessage("roslyn", "RS0026", Justification = "TODO: fix APIs that violate the backcompt requirement - multiple overloads with optional parameters: https://github.com/dotnet/roslyn/blob/main/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md.")]
+    [SuppressMessage("roslyn", "RS0027", Justification = "TODO: fix APIs that violate the backcompt requirement - multiple overloads with optional parameters: https://github.com/dotnet/roslyn/blob/main/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md.")]
     public static Baggage SetBaggage(string name, string? value, Baggage baggage = default) => SetBaggage(name, value, null, baggage);
 
     /// <summary>
@@ -234,6 +236,8 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// <returns>New <see cref="Baggage"/> containing the new key/value pairs.</returns>
     /// <remarks>Note: The <see cref="Baggage"/> returned will be set as the new <see cref="Current"/> instance.</remarks>
     [SuppressMessage("roslyn", "RS0026", Justification = "TODO: fix APIs that violate the backcompt requirement - multiple overloads with optional parameters: https://github.com/dotnet/roslyn/blob/main/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md.")]
+    [SuppressMessage("roslyn", "RS0027", Justification = "TODO: fix APIs that violate the backcompt requirement - multiple overloads with optional parameters: https://github.com/dotnet/roslyn/blob/main/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md.")]
+
     // [Obsolete("This method is obsolete and will be removed in a future release.")]
     public static Baggage SetBaggage(IEnumerable<KeyValuePair<string, string?>> baggageItems, Baggage baggage = default)
     {

--- a/src/OpenTelemetry.Api/Baggage.cs
+++ b/src/OpenTelemetry.Api/Baggage.cs
@@ -98,7 +98,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// </remarks>
     /// <param name="baggageItems">Baggage key/value pairs.</param>
     /// <returns><see cref="Baggage"/>.</returns>
-    [Obsolete("Call CreateWithMetadata instead.")]
+    // [Obsolete("Call CreateWithMetadata instead.")]
     public static Baggage Create(Dictionary<string, string>? baggageItems = null)
     {
         if (baggageItems == null)
@@ -157,7 +157,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// <param name="baggage">Optional <see cref="Baggage"/>. <see cref="Current"/> is used if not specified.</param>
     /// <returns>Baggage key/value pairs.</returns>
     [SuppressMessage("roslyn", "RS0026", Justification = "TODO: fix APIs that violate the backcompt requirement - multiple overloads with optional parameters: https://github.com/dotnet/roslyn/blob/main/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md.")]
-    [Obsolete("Call GetEnumeratorWithMetadata instead to iterate over the baggage.")]
+    // [Obsolete("Call GetEnumeratorWithMetadata instead to iterate over the baggage.")]
     public static IReadOnlyDictionary<string, string> GetBaggage(Baggage baggage = default)
         => baggage == default ? Current.GetBaggage() : baggage.GetBaggage();
 
@@ -170,7 +170,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// </remarks>
     /// <param name="baggage">Optional <see cref="Baggage"/>. <see cref="Current"/> is used if not specified.</param>
     /// <returns><see cref="Dictionary{TKey, TValue}.Enumerator"/>.</returns>
-    [Obsolete("Call GetEnumeratorWithMetadata instead to iterate over the baggage.")]
+    // [Obsolete("Call GetEnumeratorWithMetadata instead to iterate over the baggage.")]
     public static Dictionary<string, string>.Enumerator GetEnumerator(Baggage baggage = default)
         => baggage == default ? Current.GetEnumerator() : baggage.GetEnumerator();
 
@@ -234,7 +234,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// <returns>New <see cref="Baggage"/> containing the new key/value pairs.</returns>
     /// <remarks>Note: The <see cref="Baggage"/> returned will be set as the new <see cref="Current"/> instance.</remarks>
     [SuppressMessage("roslyn", "RS0026", Justification = "TODO: fix APIs that violate the backcompt requirement - multiple overloads with optional parameters: https://github.com/dotnet/roslyn/blob/main/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md.")]
-    [Obsolete("This method is obsolete and will be removed in a future release.")]
+    // [Obsolete("This method is obsolete and will be removed in a future release.")]
     public static Baggage SetBaggage(IEnumerable<KeyValuePair<string, string?>> baggageItems, Baggage baggage = default)
     {
         var baggageHolder = EnsureBaggageHolder();
@@ -289,7 +289,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// Call the <see cref="Baggage.GetEnumeratorWithMetadata()"/> instead to iterate over the baggage.
     /// </remarks>
     /// <returns>Baggage key/value pairs.</returns>
-    [Obsolete("Call GetEnumeratorWithMetadata instead to iterate over the baggage.")]
+    // [Obsolete("Call GetEnumeratorWithMetadata instead to iterate over the baggage.")]
     public IReadOnlyDictionary<string, string> GetBaggage()
         =>
             this.baggage ?? EmptyBaggage;
@@ -303,7 +303,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// </remarks>>
     /// <param name="name">Baggage item name.</param>
     /// <returns>Baggage item or <see langword="null"/> if nothing was found.</returns>
-    [Obsolete("Call GetBaggageWithMetadata instead.")]
+    // [Obsolete("Call GetBaggageWithMetadata instead.")]
     public string? GetBaggage(string name) => this.GetBaggageWithMetadata(name)?.Value;
 
     /// <summary>
@@ -371,7 +371,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// </remarks>>
     /// <param name="baggageItems">Baggage key/value pairs.</param>
     /// <returns>New <see cref="Baggage"/> containing the key/value pairs.</returns>
-    [Obsolete("Call CreateWithMetadata instead.")]
+    // [Obsolete("Call CreateWithMetadata instead.")]
     public Baggage SetBaggage(params KeyValuePair<string, string?>[] baggageItems)
         => this.SetBaggage((IEnumerable<KeyValuePair<string, string?>>)baggageItems);
 
@@ -384,7 +384,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// </remarks>>
     /// <param name="baggageItems">Baggage key/value pairs.</param>
     /// <returns>New <see cref="Baggage"/> containing the key/value pairs.</returns>
-    [Obsolete("Call CreateWithMetadata instead.")]
+    // [Obsolete("Call CreateWithMetadata instead.")]
     public Baggage SetBaggage(IEnumerable<KeyValuePair<string, string?>> baggageItems)
     {
         if (baggageItems?.Any() != true)
@@ -444,7 +444,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// Note: This method is obsolete. Call the <see cref="Baggage.GetEnumeratorWithMetadata()"/>
     /// method instead.
     /// <returns><see cref="Dictionary{TKey, TValue}.Enumerator"/>.</returns>
-    [Obsolete("Call GetEnumeratorWithMetadata instead.")]
+    // [Obsolete("Call GetEnumeratorWithMetadata instead.")]
     public Dictionary<string, string>.Enumerator GetEnumerator()
         => (this.baggage ?? EmptyBaggage).GetEnumerator();
 

--- a/src/OpenTelemetry.Api/Baggage.cs
+++ b/src/OpenTelemetry.Api/Baggage.cs
@@ -93,7 +93,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// Create a <see cref="Baggage"/> instance from dictionary of baggage key/value pairs.
     /// </summary>
     /// <remarks>
-    /// Note: This method is obsolete. Call the <see cref="Baggage.CreateWithMetadata(System.Collections.Generic.Dictionary{string,BaggageEntry})"/>
+    /// Note: This method is obsolete. Call the <see cref="CreateWithMetadata(Dictionary{string,BaggageEntry})"/>
     /// method instead.
     /// </remarks>
     /// <param name="baggageItems">Baggage key/value pairs.</param>
@@ -151,7 +151,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// Returns the name/value pairs in the <see cref="Baggage"/>.
     /// </summary>
     /// <remarks>
-    /// Note: This method is obsolete. Call the <see cref="Baggage.GetEnumeratorWithMetadata(Baggage)"/>
+    /// Note: This method is obsolete. Call the <see cref="GetEnumeratorWithMetadata(Baggage)"/>
     /// method instead.
     /// </remarks>
     /// <param name="baggage">Optional <see cref="Baggage"/>. <see cref="Current"/> is used if not specified.</param>
@@ -166,7 +166,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// Returns an enumerator that iterates through the <see cref="Baggage"/>.
     /// </summary>
     /// <remarks>
-    /// Note: This method is obsolete. Call the <see cref="Baggage.GetEnumeratorWithMetadata(Baggage)"/>
+    /// Note: This method is obsolete. Call the <see cref="GetEnumeratorWithMetadata(Baggage)"/>
     /// method instead.
     /// </remarks>
     /// <param name="baggage">Optional <see cref="Baggage"/>. <see cref="Current"/> is used if not specified.</param>
@@ -179,7 +179,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// Returns an enumerator that iterates over the <see cref="Baggage"/>, returning keys, values and optional metadata.
     /// </summary>
     /// <param name="baggage">Optional <see cref="Baggage"/>. <see cref="Current"/> is used if not specified.</param>
-    /// <returns><see cref="Baggage.Enumerator"/>.</returns>
+    /// <returns><see cref="Enumerator"/>.</returns>
     public static Enumerator GetEnumeratorWithMetadata(Baggage baggage)
         => baggage == default ? Current.GetEnumeratorWithMetadata() : baggage.GetEnumeratorWithMetadata();
 
@@ -290,7 +290,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// </summary>
     /// <remarks>
     /// Note: This method is obsolete.
-    /// Call the <see cref="Baggage.GetEnumeratorWithMetadata()"/> instead to iterate over the baggage.
+    /// Call the <see cref="GetEnumeratorWithMetadata()"/> instead to iterate over the baggage.
     /// </remarks>
     /// <returns>Baggage key/value pairs.</returns>
     // [Obsolete("Call GetEnumeratorWithMetadata instead to iterate over the baggage.")]
@@ -302,7 +302,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// Returns the value associated with the given name, or <see langword="null"/> if the given name is not present.
     /// </summary>
     /// <remarks>
-    /// Note: This method is obsolete. Call the <see cref="Baggage.GetBaggageWithMetadata(string)"/>
+    /// Note: This method is obsolete. Call the <see cref="GetBaggageWithMetadata(string)"/>
     /// method instead.
     /// </remarks>>
     /// <param name="name">Baggage item name.</param>
@@ -370,7 +370,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// Returns a new <see cref="Baggage"/> which contains the new key/value pairs.
     /// </summary>
     /// <remarks>
-    /// Note: This method is obsolete. Call the <see cref="Baggage.CreateWithMetadata(System.Collections.Generic.Dictionary{string,BaggageEntry})"/>
+    /// Note: This method is obsolete. Call the <see cref="CreateWithMetadata(Dictionary{string,BaggageEntry})"/>
     /// method instead.
     /// </remarks>>
     /// <param name="baggageItems">Baggage key/value pairs.</param>
@@ -383,7 +383,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// Returns a new <see cref="Baggage"/> which contains the new key/value pairs.
     /// </summary>
     /// <remarks>
-    /// Note: This method is obsolete. Call the <see cref="Baggage.CreateWithMetadata(System.Collections.Generic.Dictionary{string,BaggageEntry})"/>
+    /// Note: This method is obsolete. Call the <see cref="CreateWithMetadata(Dictionary{string,BaggageEntry})"/>
     /// method instead.
     /// </remarks>>
     /// <param name="baggageItems">Baggage key/value pairs.</param>
@@ -445,7 +445,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// <summary>
     /// Returns an enumerator that iterates through the <see cref="Baggage"/>.
     /// </summary>
-    /// Note: This method is obsolete. Call the <see cref="Baggage.GetEnumeratorWithMetadata()"/>
+    /// Note: This method is obsolete. Call the <see cref="GetEnumeratorWithMetadata()"/>
     /// method instead.
     /// <returns><see cref="Dictionary{TKey, TValue}.Enumerator"/>.</returns>
     // [Obsolete("Call GetEnumeratorWithMetadata instead.")]
@@ -455,7 +455,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// <summary>
     /// Returns an enumerator that iterates through the <see cref="Baggage"/>, returning both values and metadata.
     /// </summary>
-    /// <returns><see cref="Baggage.Enumerator"/>.</returns>
+    /// <returns><see cref="Enumerator"/>.</returns>
     public Enumerator GetEnumeratorWithMetadata()
         => new(this.baggage ?? EmptyBaggage, this.metadata ?? EmptyMetadata);
 

--- a/src/OpenTelemetry.Api/Baggage.cs
+++ b/src/OpenTelemetry.Api/Baggage.cs
@@ -129,7 +129,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// </summary>
     /// <param name="baggageItems">Dictionary of baggage keys and values with optional metadata.</param>
     /// <returns><see cref="Baggage"/>.</returns>
-    public static Baggage CreateWithMetadata(Dictionary<string, BaggageEntry>? baggageItems)
+    public static Baggage CreateWithMetadata(Dictionary<string, BaggageEntry>? baggageItems = null)
     {
         if (baggageItems == null)
         {

--- a/src/OpenTelemetry.Api/Baggage.cs
+++ b/src/OpenTelemetry.Api/Baggage.cs
@@ -156,9 +156,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// </remarks>
     /// <param name="baggage">Optional <see cref="Baggage"/>. <see cref="Current"/> is used if not specified.</param>
     /// <returns>Baggage key/value pairs.</returns>
-    [SuppressMessage("roslyn", "RS0026",
-        Justification =
-            "TODO: fix APIs that violate the backcompt requirement - multiple overloads with optional parameters: https://github.com/dotnet/roslyn/blob/main/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md.")]
+    [SuppressMessage("roslyn", "RS0026", Justification = "TODO: fix APIs that violate the backcompt requirement - multiple overloads with optional parameters: https://github.com/dotnet/roslyn/blob/main/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md.")]
     [Obsolete("Call GetEnumeratorWithMetadata instead to iterate over the baggage.")]
     public static IReadOnlyDictionary<string, string> GetBaggage(Baggage baggage = default)
         => baggage == default ? Current.GetBaggage() : baggage.GetBaggage();
@@ -190,9 +188,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// <param name="name">Baggage item name.</param>
     /// <param name="baggage">Optional <see cref="Baggage"/>. <see cref="Current"/> is used if not specified.</param>
     /// <returns>Baggage item or <see langword="null"/> if nothing was found.</returns>
-    [SuppressMessage("roslyn", "RS0026",
-        Justification =
-            "TODO: fix APIs that violate the backcompt requirement - multiple overloads with optional parameters: https://github.com/dotnet/roslyn/blob/main/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md.")]
+    [SuppressMessage("roslyn", "RS0026", Justification = "TODO: fix APIs that violate the backcompt requirement - multiple overloads with optional parameters: https://github.com/dotnet/roslyn/blob/main/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md.")]
     public static string? GetBaggage(string name, Baggage baggage = default)
         => baggage == default ? Current.GetBaggage(name) : baggage.GetBaggage(name);
 
@@ -204,9 +200,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// <param name="baggage">Optional <see cref="Baggage"/>. <see cref="Current"/> is used if not specified.</param>
     /// <returns>New <see cref="Baggage"/> containing the key/value pair.</returns>
     /// <remarks>Note: The <see cref="Baggage"/> returned will be set as the new <see cref="Current"/> instance.</remarks>
-    [SuppressMessage("roslyn", "RS0026",
-        Justification =
-            "TODO: fix APIs that violate the backcompt requirement - multiple overloads with optional parameters: https://github.com/dotnet/roslyn/blob/main/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md.")]
+    [SuppressMessage("roslyn", "RS0026", Justification = "TODO: fix APIs that violate the backcompt requirement - multiple overloads with optional parameters: https://github.com/dotnet/roslyn/blob/main/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md.")]
     public static Baggage SetBaggage(string name, string? value, Baggage baggage = default) => SetBaggage(name, value, null, baggage);
 
     /// <summary>
@@ -239,9 +233,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// <param name="baggage">Optional <see cref="Baggage"/>. <see cref="Current"/> is used if not specified.</param>
     /// <returns>New <see cref="Baggage"/> containing the new key/value pairs.</returns>
     /// <remarks>Note: The <see cref="Baggage"/> returned will be set as the new <see cref="Current"/> instance.</remarks>
-    [SuppressMessage("roslyn", "RS0026",
-        Justification =
-            "TODO: fix APIs that violate the backcompt requirement - multiple overloads with optional parameters: https://github.com/dotnet/roslyn/blob/main/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md.")]
+    [SuppressMessage("roslyn", "RS0026", Justification = "TODO: fix APIs that violate the backcompt requirement - multiple overloads with optional parameters: https://github.com/dotnet/roslyn/blob/main/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md.")]
     [Obsolete("This method is obsolete and will be removed in a future release.")]
     public static Baggage SetBaggage(IEnumerable<KeyValuePair<string, string?>> baggageItems, Baggage baggage = default)
     {

--- a/src/OpenTelemetry.Api/Baggage.cs
+++ b/src/OpenTelemetry.Api/Baggage.cs
@@ -129,8 +129,13 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// </summary>
     /// <param name="baggageItems">Dictionary of baggage keys and values with optional metadata.</param>
     /// <returns><see cref="Baggage"/>.</returns>
-    public static Baggage CreateWithMetadata(Dictionary<string, BaggageEntry> baggageItems)
+    public static Baggage CreateWithMetadata(Dictionary<string, BaggageEntry>? baggageItems)
     {
+        if (baggageItems == null)
+        {
+            return default;
+        }
+
         Dictionary<string, string> baggageCopy =
             new Dictionary<string, string>(baggageItems.Count, StringComparer.OrdinalIgnoreCase);
 

--- a/src/OpenTelemetry.Api/Baggage.cs
+++ b/src/OpenTelemetry.Api/Baggage.cs
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma warning disable CS0618
+
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using OpenTelemetry.Context;
@@ -98,7 +100,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// </remarks>
     /// <param name="baggageItems">Baggage key/value pairs.</param>
     /// <returns><see cref="Baggage"/>.</returns>
-    // [Obsolete("Call CreateWithMetadata instead.")]
+    [Obsolete("Call CreateWithMetadata instead.")]
     public static Baggage Create(Dictionary<string, string>? baggageItems = null)
     {
         if (baggageItems == null)
@@ -157,8 +159,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// <param name="baggage">Optional <see cref="Baggage"/>. <see cref="Current"/> is used if not specified.</param>
     /// <returns>Baggage key/value pairs.</returns>
     [SuppressMessage("roslyn", "RS0026", Justification = "TODO: fix APIs that violate the backcompt requirement - multiple overloads with optional parameters: https://github.com/dotnet/roslyn/blob/main/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md.")]
-
-    // [Obsolete("Call GetEnumeratorWithMetadata instead to iterate over the baggage.")]
+    [Obsolete("Call GetEnumeratorWithMetadata instead to iterate over the baggage.")]
     public static IReadOnlyDictionary<string, string> GetBaggage(Baggage baggage = default)
         => baggage == default ? Current.GetBaggage() : baggage.GetBaggage();
 
@@ -171,7 +172,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// </remarks>
     /// <param name="baggage">Optional <see cref="Baggage"/>. <see cref="Current"/> is used if not specified.</param>
     /// <returns><see cref="Dictionary{TKey, TValue}.Enumerator"/>.</returns>
-    // [Obsolete("Call GetEnumeratorWithMetadata instead to iterate over the baggage.")]
+    [Obsolete("Call GetEnumeratorWithMetadata instead to iterate over the baggage.")]
     public static Dictionary<string, string>.Enumerator GetEnumerator(Baggage baggage = default)
         => baggage == default ? Current.GetEnumerator() : baggage.GetEnumerator();
 
@@ -228,17 +229,16 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// <summary>
     /// Returns a new <see cref="Baggage"/> which contains the new key/value pairs.
     /// </summary>
-    /// <remarks>
-    /// Note: This method is obsolete and will be removed in a future release.
-    /// </remarks>
     /// <param name="baggageItems">Baggage key/value pairs.</param>
     /// <param name="baggage">Optional <see cref="Baggage"/>. <see cref="Current"/> is used if not specified.</param>
     /// <returns>New <see cref="Baggage"/> containing the new key/value pairs.</returns>
-    /// <remarks>Note: The <see cref="Baggage"/> returned will be set as the new <see cref="Current"/> instance.</remarks>
+    /// <remarks>
+    /// Note: The <see cref="Baggage"/> returned will be set as the new <see cref="Current"/> instance.
+    /// This method is obsolete and will be removed in a future release.
+    /// </remarks>
     [SuppressMessage("roslyn", "RS0026", Justification = "TODO: fix APIs that violate the backcompt requirement - multiple overloads with optional parameters: https://github.com/dotnet/roslyn/blob/main/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md.")]
     [SuppressMessage("roslyn", "RS0027", Justification = "TODO: fix APIs that violate the backcompt requirement - multiple overloads with optional parameters: https://github.com/dotnet/roslyn/blob/main/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md.")]
-
-    // [Obsolete("This method is obsolete and will be removed in a future release.")]
+    [Obsolete("This method is obsolete and will be removed in a future release.")]
     public static Baggage SetBaggage(IEnumerable<KeyValuePair<string, string?>> baggageItems, Baggage baggage = default)
     {
         var baggageHolder = EnsureBaggageHolder();
@@ -293,7 +293,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// Call the <see cref="GetEnumeratorWithMetadata()"/> instead to iterate over the baggage.
     /// </remarks>
     /// <returns>Baggage key/value pairs.</returns>
-    // [Obsolete("Call GetEnumeratorWithMetadata instead to iterate over the baggage.")]
+    [Obsolete("Call GetEnumeratorWithMetadata instead to iterate over the baggage.")]
     public IReadOnlyDictionary<string, string> GetBaggage()
         =>
             this.baggage ?? EmptyBaggage;
@@ -304,10 +304,10 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// <remarks>
     /// Note: This method is obsolete. Call the <see cref="GetBaggageWithMetadata(string)"/>
     /// method instead.
-    /// </remarks>>
+    /// </remarks>
     /// <param name="name">Baggage item name.</param>
     /// <returns>Baggage item or <see langword="null"/> if nothing was found.</returns>
-    // [Obsolete("Call GetBaggageWithMetadata instead.")]
+    [Obsolete("Call GetBaggageWithMetadata instead.")]
     public string? GetBaggage(string name) => this.GetBaggageWithMetadata(name)?.Value;
 
     /// <summary>
@@ -375,10 +375,10 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// <remarks>
     /// Note: This method is obsolete. Call the <see cref="CreateWithMetadata(Dictionary{string,BaggageEntry})"/>
     /// method instead.
-    /// </remarks>>
+    /// </remarks>
     /// <param name="baggageItems">Baggage key/value pairs.</param>
     /// <returns>New <see cref="Baggage"/> containing the key/value pairs.</returns>
-    // [Obsolete("Call CreateWithMetadata instead.")]
+    [Obsolete("Call CreateWithMetadata instead.")]
     public Baggage SetBaggage(params KeyValuePair<string, string?>[] baggageItems)
         => this.SetBaggage((IEnumerable<KeyValuePair<string, string?>>)baggageItems);
 
@@ -388,10 +388,10 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// <remarks>
     /// Note: This method is obsolete. Call the <see cref="CreateWithMetadata(Dictionary{string,BaggageEntry})"/>
     /// method instead.
-    /// </remarks>>
+    /// </remarks>
     /// <param name="baggageItems">Baggage key/value pairs.</param>
     /// <returns>New <see cref="Baggage"/> containing the key/value pairs.</returns>
-    // [Obsolete("Call CreateWithMetadata instead.")]
+    [Obsolete("Call CreateWithMetadata instead.")]
     public Baggage SetBaggage(IEnumerable<KeyValuePair<string, string?>> baggageItems)
     {
         if (baggageItems?.Any() != true)
@@ -452,10 +452,12 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// <summary>
     /// Returns an enumerator that iterates through the <see cref="Baggage"/>.
     /// </summary>
+    /// <remarks>
     /// Note: This method is obsolete. Call the <see cref="GetEnumeratorWithMetadata()"/>
     /// method instead.
+    /// </remarks>
     /// <returns><see cref="Dictionary{TKey, TValue}.Enumerator"/>.</returns>
-    // [Obsolete("Call GetEnumeratorWithMetadata instead.")]
+    [Obsolete("Call GetEnumeratorWithMetadata instead.")]
     public Dictionary<string, string>.Enumerator GetEnumerator()
         => (this.baggage ?? EmptyBaggage).GetEnumerator();
 

--- a/src/OpenTelemetry.Api/BaggageEntry.cs
+++ b/src/OpenTelemetry.Api/BaggageEntry.cs
@@ -1,0 +1,54 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry;
+
+/// <summary>
+/// Baggage entry consisting of a value with optional metadata.
+/// </summary>
+public readonly struct BaggageEntry : IEquatable<BaggageEntry>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BaggageEntry"/> struct.
+    /// </summary>
+    /// <param name="value">Entry value.</param>
+    /// <param name="metadata">Entry metadata.</param>
+    public BaggageEntry(string value, BaggageEntryMetadata? metadata = null)
+    {
+        this.Value = value;
+        this.Metadata = metadata;
+    }
+
+    /// <summary>
+    /// Gets the value of the BaggageEntry.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Gets the metadata of the BaggageEntry.
+    /// </summary>
+    public BaggageEntryMetadata? Metadata { get; }
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+    public static bool operator ==(BaggageEntry left, BaggageEntry right) => left.Equals(right);
+
+    public static bool operator !=(BaggageEntry left, BaggageEntry right) => !left.Equals(right);
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+
+    /// <inheritdoc />
+    public bool Equals(BaggageEntry other) =>
+        string.Equals(this.Value, other.Value) &&
+        this.Metadata.Equals(other.Metadata);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is BaggageEntry other && this.Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            return (StringComparer.OrdinalIgnoreCase.GetHashCode(this.Value) * 397) ^ (this.Metadata != null ? this.Metadata.GetHashCode() : 0);
+        }
+    }
+}

--- a/src/OpenTelemetry.Api/BaggageEntry.cs
+++ b/src/OpenTelemetry.Api/BaggageEntry.cs
@@ -48,7 +48,7 @@ public readonly struct BaggageEntry : IEquatable<BaggageEntry>
     {
         unchecked
         {
-            return (StringComparer.OrdinalIgnoreCase.GetHashCode(this.Value) * 397) ^ (this.Metadata != null ? this.Metadata.GetHashCode() : 0);
+            return (this.Value.GetHashCode() * 397) ^ (this.Metadata != null ? this.Metadata.GetHashCode() : 0);
         }
     }
 }

--- a/src/OpenTelemetry.Api/BaggageEntry.cs
+++ b/src/OpenTelemetry.Api/BaggageEntry.cs
@@ -48,7 +48,7 @@ public readonly struct BaggageEntry : IEquatable<BaggageEntry>
     {
         unchecked
         {
-            return (this.Value.GetHashCode() * 397) ^ (this.Metadata != null ? this.Metadata.GetHashCode() : 0);
+            return (this.Value.GetHashCode() * 397) ^ (this.Metadata?.GetHashCode() ?? 0);
         }
     }
 }

--- a/src/OpenTelemetry.Api/BaggageEntryMetadata.cs
+++ b/src/OpenTelemetry.Api/BaggageEntryMetadata.cs
@@ -35,5 +35,5 @@ public readonly struct BaggageEntryMetadata : IEquatable<BaggageEntryMetadata>
     public override bool Equals(object? obj) => obj is BaggageEntryMetadata other && this.Equals(other);
 
     /// <inheritdoc />
-    public override int GetHashCode() => this.Value != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(this.Value) : 0;
+    public override int GetHashCode() => this.Value != null ? this.Value.GetHashCode() : 0;
 }

--- a/src/OpenTelemetry.Api/BaggageEntryMetadata.cs
+++ b/src/OpenTelemetry.Api/BaggageEntryMetadata.cs
@@ -4,7 +4,10 @@
 namespace OpenTelemetry;
 
 /// <summary>
-/// Wraps string value of metadata, as required by the spec: https://github.com/open-telemetry/opentelemetry-specification/blob/815598814f3cf461ad5493ccbddd53633fb5cf24/specification/baggage/api.md?plain=1#L117-L119.
+/// Wraps string value of metadata.
+/// <remarks>
+/// Spec reference: <a href="https://github.com/open-telemetry/opentelemetry-specification/blob/v1.42.0/specification/baggage/api.md?plain=1#L117-L119">metadata</a>.
+/// </remarks>
 /// </summary>
 public readonly struct BaggageEntryMetadata : IEquatable<BaggageEntryMetadata>
 {

--- a/src/OpenTelemetry.Api/BaggageEntryMetadata.cs
+++ b/src/OpenTelemetry.Api/BaggageEntryMetadata.cs
@@ -1,4 +1,4 @@
-﻿// Copyright The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
 namespace OpenTelemetry;

--- a/src/OpenTelemetry.Api/BaggageEntryMetadata.cs
+++ b/src/OpenTelemetry.Api/BaggageEntryMetadata.cs
@@ -1,0 +1,39 @@
+﻿// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry;
+
+/// <summary>
+/// Wraps string value of metadata, as required by the spec: https://github.com/open-telemetry/opentelemetry-specification/blob/815598814f3cf461ad5493ccbddd53633fb5cf24/specification/baggage/api.md?plain=1#L117-L119.
+/// </summary>
+public readonly struct BaggageEntryMetadata : IEquatable<BaggageEntryMetadata>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BaggageEntryMetadata"/> struct.
+    /// </summary>
+    /// <param name="value">Metadata value.</param>
+    public BaggageEntryMetadata(string? value)
+    {
+        this.Value = value;
+    }
+
+    /// <summary>
+    /// Gets the value.
+    /// </summary>
+    public string? Value { get; }
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+    public static bool operator ==(BaggageEntryMetadata left, BaggageEntryMetadata right) => left.Equals(right);
+
+    public static bool operator !=(BaggageEntryMetadata left, BaggageEntryMetadata right) => !left.Equals(right);
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+
+    /// <inheritdoc />
+    public bool Equals(BaggageEntryMetadata other) => string.Equals(this.Value, other.Value);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => obj is BaggageEntryMetadata other && this.Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => this.Value != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(this.Value) : 0;
+}

--- a/src/OpenTelemetry.Api/BaggageEntryMetadata.cs
+++ b/src/OpenTelemetry.Api/BaggageEntryMetadata.cs
@@ -35,5 +35,5 @@ public readonly struct BaggageEntryMetadata : IEquatable<BaggageEntryMetadata>
     public override bool Equals(object? obj) => obj is BaggageEntryMetadata other && this.Equals(other);
 
     /// <inheritdoc />
-    public override int GetHashCode() => this.Value != null ? this.Value.GetHashCode() : 0;
+    public override int GetHashCode() => this.Value?.GetHashCode() ?? 0;
 }

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -7,8 +7,8 @@ Notes](../../RELEASENOTES.md).
 ## Unreleased
 
 * Update `Baggage` implementation to allow
-[`metadata`](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.42.0/specification/baggage/api.md?plain=1#L117-L119)
-storage. ([#6144](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6144))
+  [`metadata`](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.42.0/specification/baggage/api.md?plain=1#L117-L119)
+  storage. ([#6144](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6144))
 
 ## 1.11.1
 

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -6,6 +6,8 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Update `Baggage` implementation to allow [`metadata`](https://github.com/open-telemetry/opentelemetry-specification/blob/815598814f3cf461ad5493ccbddd53633fb5cf24/specification/baggage/api.md?plain=1#L117-L119) storage.
+
 ## 1.11.1
 
 Released 2025-Jan-22

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -6,7 +6,9 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* Update `Baggage` implementation to allow [`metadata`](https://github.com/open-telemetry/opentelemetry-specification/blob/815598814f3cf461ad5493ccbddd53633fb5cf24/specification/baggage/api.md?plain=1#L117-L119) storage.
+* Update `Baggage` implementation to allow
+[`metadata`](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.42.0/specification/baggage/api.md?plain=1#L117-L119)
+storage. ([#6144](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6144))
 
 ## 1.11.1
 

--- a/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
@@ -83,7 +83,9 @@ public class BaggagePropagator : TextMapPropagator
             return;
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         using var e = context.Baggage.GetEnumerator();
+#pragma warning restore CS0618 // Type or member is obsolete
 
         if (e.MoveNext() == true)
         {

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanContextShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanContextShim.cs
@@ -21,5 +21,7 @@ internal sealed class SpanContextShim : ISpanContext
     public string SpanId => this.SpanContext.SpanId.ToString();
 
     public IEnumerable<KeyValuePair<string, string>> GetBaggageItems()
+#pragma warning disable CS0618 // Type or member is obsolete
         => Baggage.GetBaggage();
+#pragma warning restore CS0618 // Type or member is obsolete
 }

--- a/test/OpenTelemetry.Api.Tests/BaggageTests.cs
+++ b/test/OpenTelemetry.Api.Tests/BaggageTests.cs
@@ -77,14 +77,16 @@ public class BaggageTests
 
         Assert.Equal(expectedBaggageContents, returnedBaggage);
 
-        Assert.Equal(V1, Baggage.GetBaggage(K1));
-        Assert.Equal(V1, Baggage.GetBaggage(K1.ToLower()));
-        Assert.Equal(V1, Baggage.GetBaggage(K1.ToUpper()));
-        Assert.Null(Baggage.GetBaggage("NO_KEY"));
-        Assert.Equal(V2, Baggage.Current.GetBaggage(K2));
+        var expectedBaggageEntry1 = new BaggageEntry(V1, new BaggageEntryMetadata(M1));
+        var expectedBaggageEntry2 = new BaggageEntry(V2, new BaggageEntryMetadata(M2));
 
-        Assert.Equal(M1, Baggage.Current.GetBaggageWithMetadata(K1)?.Metadata?.Value);
-        Assert.Equal(M2, Baggage.Current.GetBaggageWithMetadata(K2)?.Metadata?.Value);
+        Assert.Equal(expectedBaggageEntry1, Baggage.Current.GetBaggageWithMetadata(K1));
+        Assert.Equal(expectedBaggageEntry1, Baggage.Current.GetBaggageWithMetadata(K1.ToLower()));
+        Assert.Equal(expectedBaggageEntry1, Baggage.Current.GetBaggageWithMetadata(K1.ToUpper()));
+
+        Assert.Null(Baggage.Current.GetBaggageWithMetadata("NO_KEY"));
+
+        Assert.Equal(expectedBaggageEntry2, Baggage.Current.GetBaggageWithMetadata(K2));
     }
 
     [Fact]
@@ -147,6 +149,33 @@ public class BaggageTests
         Assert.Equal(2, baggage2.Count);
 
         Assert.DoesNotContain(new KeyValuePair<string, string>(K1, V1), baggage2.GetBaggage());
+    }
+
+    [Fact]
+    public void RemoveWithMetadataTest()
+    {
+        var baggage = Baggage.CreateWithMetadata(new Dictionary<string, BaggageEntry>
+        {
+            [K1] = new(V1, new BaggageEntryMetadata(M1)),
+            [K2] = new(V2, new BaggageEntryMetadata(M2)),
+            [K3] = new(V3, new BaggageEntryMetadata(M3)),
+        });
+
+        var baggage2 = Baggage.RemoveBaggage(K1, baggage);
+
+        Assert.Equal(3, baggage.Count);
+        Assert.Equal(2, baggage2.Count);
+
+        Assert.Null(baggage2.GetBaggageWithMetadata(K1));
+
+        var b = new List<KeyValuePair<string, BaggageEntry>>();
+        var enumeratorWithMetadata = baggage2.GetEnumeratorWithMetadata();
+        while (enumeratorWithMetadata.MoveNext())
+        {
+            b.Add(enumeratorWithMetadata.Current);
+        }
+
+        Assert.DoesNotContain(new KeyValuePair<string, BaggageEntry>(K1, new BaggageEntry(V1, new BaggageEntryMetadata(M1))), b);
     }
 
     [Fact]

--- a/test/TestApp.AspNetCore/Controllers/ChildActivityController.cs
+++ b/test/TestApp.AspNetCore/Controllers/ChildActivityController.cs
@@ -32,7 +32,9 @@ public class ChildActivityController : Controller
     [Route("api/GetChildActivityBaggageContext")]
     public IReadOnlyDictionary<string, string> GetChildActivityBaggageContext()
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         var result = Baggage.Current.GetBaggage();
+#pragma warning restore CS0618 // Type or member is obsolete
         return result;
     }
 


### PR DESCRIPTION
Fixes #https://github.com/open-telemetry/opentelemetry-dotnet/issues/4152

## Changes

Allow for storage of metadata in baggage.

This is a prerequisite for fixing https://github.com/open-telemetry/opentelemetry-dotnet/issues/5677

Details:
- In order to efficiently support existing methods from public API (e.g. [this](https://github.com/open-telemetry/opentelemetry-dotnet/blob/c643b7fb22e2f6cda5cc95ca577ee7346cb01e95/src/OpenTelemetry.Api/Baggage.cs#L315) and [this](https://github.com/open-telemetry/opentelemetry-dotnet/blob/c643b7fb22e2f6cda5cc95ca577ee7346cb01e95/src/OpenTelemetry.Api/Baggage.cs#L118))
metadata is kept in a separate dictionary

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
