### PR TITLE
[otlp] Change serialization of null protobuf values

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/Implementation/ConsoleTagWriter.cs
+++ b/src/OpenTelemetry.Exporter.Console/Implementation/ConsoleTagWriter.cs
@@ -73,6 +73,13 @@ internal sealed class ConsoleTagWriter : JsonStringArrayTagWriter<ConsoleTagWrit
         this.onUnsupportedTagDropped(tagKey, tagValueTypeFullName);
     }
 
+    protected override bool TryWriteEmptyTag(ref ConsoleTag consoleTag, string key, object? value)
+    {
+        consoleTag.Key = key;
+        consoleTag.Value = null;
+        return true;
+    }
+
     internal struct ConsoleTag
     {
         public string? Key;

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -16,7 +16,8 @@ Notes](../../RELEASENOTES.md).
   `Activity.StatusDescription` exceeds 127 bytes.
   ([#6119](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6119))
 
-* Fixed protobuf serialization handling of null values in OTLP exporter.
+* Fixed incorrect log serialization of attributes with null values, causing
+  some backends to reject logs when using OTLP exporter to output protobuf.
   ([#6149](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6149))
 
 ## 1.11.1

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -16,6 +16,9 @@ Notes](../../RELEASENOTES.md).
   `Activity.StatusDescription` exceeds 127 bytes.
   ([#6119](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6119))
 
+* Fixed protobuf serialization handling of null values in OTLP exporter.
+  ([#6149](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6149))
+
 ## 1.11.1
 
 Released 2025-Jan-22

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -17,6 +17,7 @@ Notes](../../RELEASENOTES.md).
   ([#6119](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6119))
 
 * Fixed incorrect log serialization of attributes with null values, causing
+  some backends to reject logs.
   some backends to reject logs when using OTLP exporter to output protobuf.
   ([#6149](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6149))
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTagWriter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTagWriter.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System;
 using System.Diagnostics;
 using OpenTelemetry.Internal;
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTagWriter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTagWriter.cs
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.Diagnostics;
 using OpenTelemetry.Internal;
 
@@ -80,6 +81,13 @@ internal sealed class ProtobufOtlpTagWriter : TagWriter<ProtobufOtlpTagWriter.Ot
         string tagValueTypeFullName) => OpenTelemetryProtocolExporterEventSource.Log.UnsupportedAttributeType(
             tagValueTypeFullName,
             tagKey);
+
+    protected override bool TryWriteEmptyTag(ref OtlpTagWriterState state, string key, object? value)
+    {
+        state.WritePosition = ProtobufSerializer.WriteStringWithTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Key, key);
+        state.WritePosition = ProtobufSerializer.WriteTagAndLength(state.Buffer, state.WritePosition, 0, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Value, ProtobufWireType.LEN);
+        return true;
+    }
 
     internal struct OtlpTagWriterState
     {

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinTagWriter.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinTagWriter.cs
@@ -64,4 +64,6 @@ internal sealed class ZipkinTagWriter : JsonStringArrayTagWriter<Utf8JsonWriter>
             tagValueTypeFullName,
             tagKey);
     }
+
+    protected override bool TryWriteEmptyTag(ref Utf8JsonWriter state, string key, object? value) => false;
 }

--- a/src/Shared/TagWriter/TagWriter.cs
+++ b/src/Shared/TagWriter/TagWriter.cs
@@ -36,7 +36,7 @@ internal abstract class TagWriter<TTagState, TArrayState>
     {
         if (value == null)
         {
-            return false;
+            return this.TryWriteEmptyTag(ref state, key, value);
         }
 
         switch (value)
@@ -116,6 +116,8 @@ internal abstract class TagWriter<TTagState, TArrayState>
 
         return true;
     }
+
+    protected abstract bool TryWriteEmptyTag(ref TTagState state, string key, object? value);
 
     protected abstract void WriteIntegralTag(ref TTagState state, string key, long value);
 

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpAttributeTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpAttributeTests.cs
@@ -14,7 +14,13 @@ public class OtlpAttributeTests
     public void NullValueAttribute()
     {
         var kvp = new KeyValuePair<string, object?>("key", null);
-        Assert.False(TryTransformTag(kvp, out _));
+        Assert.True(TryTransformTag(kvp, out var attribute));
+        Assert.Equal(OtlpCommon.AnyValue.ValueOneofCase.None, attribute.Value.ValueCase);
+        Assert.False(attribute.Value.HasBoolValue);
+        Assert.False(attribute.Value.HasBytesValue);
+        Assert.False(attribute.Value.HasDoubleValue);
+        Assert.False(attribute.Value.HasIntValue);
+        Assert.False(attribute.Value.HasStringValue);
     }
 
     [Fact]

--- a/test/OpenTelemetry.Tests/Internal/JsonStringArrayTagWriterTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/JsonStringArrayTagWriterTests.cs
@@ -193,6 +193,11 @@ public class JsonStringArrayTagWriterTests
         {
         }
 
+        protected override bool TryWriteEmptyTag(ref Tag state, string key, object? value)
+        {
+            throw new NotImplementedException();
+        }
+
         public struct Tag
         {
             public string? Key;


### PR DESCRIPTION
Fixes #6138

## Changes

The OTLP exporter generated protobuf payloads that Loki cannot consume when attributes contained null values.

PR extends `TagWriter` to include `TryWriteEmptyTag` method. When a null value is encountered, `TryWriteEmptyTag` is called in tag writer implementations instead of only returning false. 

Tag writers for console, OTLP, and Zipkin exporters have new `TryWriteEmptyTag` implementations

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
