### PR TITLE
Revert TraceContextPropagator performance refactor from 5749

### DIFF
--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -6,6 +6,9 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Revert optimize performance of `TraceContextPropagator.Extract` from #5749.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+
 ## 1.11.1
 
 Released 2025-Jan-22

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -7,7 +7,7 @@ Notes](../../RELEASENOTES.md).
 ## Unreleased
 
 * Revert optimize performance of `TraceContextPropagator.Extract` from #5749.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-dotnet/pull/TODO))
+  ([#6161](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6161))
 
 ## 1.11.1
 

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -6,7 +6,8 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* Revert optimize performance of `TraceContextPropagator.Extract` from #5749.
+* Revert optimize performance of `TraceContextPropagator.Extract` introduced
+  in #5749 to resolve #6158.
   ([#6161](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6161))
 
 ## 1.11.1


### PR DESCRIPTION
Fixes #6158

## Changes

As discussed in #6158, this reverts to previous performance optimizations until we have added more tests and hardened the implementation.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [] ~Changes in public API reviewed (if applicable)~
