### PR TITLE
[Exporter.Zipkin] Unskip ErrorGettingUriFromEnvVarSetsDefaultEndpointValue test

### DIFF
--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
@@ -170,7 +170,7 @@ public sealed class ZipkinExporterTests : IDisposable
         }
     }
 
-    [Fact(Skip = "https://github.com/open-telemetry/opentelemetry-dotnet/issues/3690")]
+    [Fact]
     public void ErrorGettingUriFromEnvVarSetsDefaultEndpointValue()
     {
         try


### PR DESCRIPTION
#3690 was fixed in scope of #4095

## Changes

[Exporter.Zipkin] Unskip ErrorGettingUriFromEnvVarSetsDefaultEndpointValue test

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
