### PR TITLE
[Exporter.Console] use Environment.NewLine instead of hardcoded LF in console exporters

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
@@ -38,7 +38,7 @@ public class ConsoleLogRecordExporter : ConsoleExporter<LogRecord>
 
                 this.WriteLine("The console exporter is still being invoked after it has been disposed. This could be due to the application's incorrect lifecycle management of the LoggerFactory/OpenTelemetry .NET SDK.");
                 this.WriteLine(Environment.StackTrace);
-                this.WriteLine(Environment.NewLine + "Dispose was called on the following stack trace:");
+                this.WriteLine($"{Environment.NewLine}Dispose was called on the following stack trace:");
                 this.WriteLine(this.disposedStackTrace!);
             }
 
@@ -137,7 +137,7 @@ public class ConsoleLogRecordExporter : ConsoleExporter<LogRecord>
             var resource = this.ParentProvider.GetResource();
             if (resource != Resource.Empty)
             {
-                this.WriteLine(Environment.NewLine + "Resource associated with LogRecord:");
+                this.WriteLine($"{Environment.NewLine}Resource associated with LogRecord:");
                 foreach (var resourceAttribute in resource.Attributes)
                 {
                     if (this.TagWriter.TryTransformTag(resourceAttribute.Key, resourceAttribute.Value, out var result))

--- a/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
@@ -137,7 +137,7 @@ public class ConsoleLogRecordExporter : ConsoleExporter<LogRecord>
             var resource = this.ParentProvider.GetResource();
             if (resource != Resource.Empty)
             {
-                this.WriteLine("\nResource associated with LogRecord:");
+                this.WriteLine(Environment.NewLine + "Resource associated with LogRecord:");
                 foreach (var resourceAttribute in resource.Attributes)
                 {
                     if (this.TagWriter.TryTransformTag(resourceAttribute.Key, resourceAttribute.Value, out var result))

--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -19,7 +19,7 @@ public class ConsoleMetricExporter : ConsoleExporter<Metric>
     {
         foreach (var metric in batch)
         {
-            var msg = new StringBuilder($"\n");
+            var msg = new StringBuilder(Environment.NewLine);
 #if NET
             msg.Append(CultureInfo.InvariantCulture, $"Metric Name: {metric.Name}");
 #else


### PR DESCRIPTION
## Changes

Replace a hardcoded `LF` with `Environment.NewLine` in `ConsoleLogRecordExporter` and `ConsoleMetricExporter`.

The current code results in a mix if `CRLF` / `LF` being output on Windows, e.g. (see line 9 on the first screenshot and lines 9 and 29 on the second one):

![image](https://github.com/user-attachments/assets/551c0fb6-89c6-4ef1-96e8-0724fe678c48)

![image](https://github.com/user-attachments/assets/08f9934c-49b4-4d04-8fae-ecd86c85e207)


Any code that attempts to `string.Split(Environment.NewLine)` this will end up with `\nResource associated with LogRecord:` and `\nMetric Name: ...` as one of the lines, instead of just `Resource associated with LogRecord:` and `Metric Name: ...` (this has actually broken tests in one of the libraries we develop at work).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
