### PR TITLE
[documentation] fix links to internal example

### DIFF
--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -59,7 +59,7 @@ too frequently. `Meter` is fairly expensive and meant to be reused throughout
 the application. For most applications, it can be modeled as static readonly
 field (e.g. [Program.cs](./getting-started-console/Program.cs)) or singleton via
 dependency injection (e.g.
-[Instrumentation.cs](../../examples/AspNetCore/Instrumentation.cs)).
+[InstrumentationSource.cs](../../examples/AspNetCore/InstrumentationSource.cs)).
 
 :heavy_check_mark: You should use dot-separated
 [UpperCamelCase](https://en.wikipedia.org/wiki/Camel_case) as the
@@ -97,7 +97,7 @@ frequently. Instruments are fairly expensive and meant to be reused throughout
 the application. For most applications, instruments can be modeled as static
 readonly fields (e.g. [Program.cs](./getting-started-console/Program.cs)) or
 singleton via dependency injection (e.g.
-[Instrumentation.cs](../../examples/AspNetCore/Instrumentation.cs)).
+[InstrumentationSource.cs](../../examples/AspNetCore/InstrumentationSource.cs)).
 
 :stop_sign: You should avoid invalid instrument names.
 

--- a/docs/trace/README.md
+++ b/docs/trace/README.md
@@ -49,7 +49,7 @@ too frequently. `ActivitySource` is fairly expensive and meant to be reused
 throughout the application. For most applications, it can be modeled as static
 readonly field (e.g. [Program.cs](./getting-started-console/Program.cs)) or
 singleton via dependency injection (e.g.
-[Instrumentation.cs](../../examples/AspNetCore/Instrumentation.cs)).
+[InstrumentationSource.cs](../../examples/AspNetCore/InstrumentationSource.cs)).
 
 :heavy_check_mark: You should use dot-separated
 [UpperCamelCase](https://en.wikipedia.org/wiki/Camel_case) as the


### PR DESCRIPTION
Follow up to #6193
## Changes

It was not detected during CI.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
