### PR TITLE
[Exporter.Console] Update otel-collector version to be compatible with debug exporter

### DIFF
--- a/examples/Console/TestLogs.cs
+++ b/examples/Console/TestLogs.cs
@@ -28,10 +28,10 @@ internal class TestLogs
                      * launch the OpenTelemetry Collector with an OTLP receiver, by running:
                      *
                      *  - On Unix based systems use:
-                     *     docker run --rm -it -p 4317:4317 -p 4318:4318 -v $(pwd):/cfg otel/opentelemetry-collector:0.48.0 --config=/cfg/otlp-collector-example/config.yaml
+                     *     docker run --rm -it -p 4317:4317 -p 4318:4318 -v $(pwd):/cfg otel/opentelemetry-collector:latest --config=/cfg/otlp-collector-example/config.yaml
                      *
                      *  - On Windows use:
-                     *     docker run --rm -it -p 4317:4317 -p 4318:4318 -v "%cd%":/cfg otel/opentelemetry-collector:0.48.0 --config=/cfg/otlp-collector-example/config.yaml
+                     *     docker run --rm -it -p 4317:4317 -p 4318:4318 -v "%cd%":/cfg otel/opentelemetry-collector:latest --config=/cfg/otlp-collector-example/config.yaml
                      *
                      * Open another terminal window at the examples/Console/ directory and
                      * launch the OTLP example by running:

--- a/examples/Console/TestLogs.cs
+++ b/examples/Console/TestLogs.cs
@@ -28,10 +28,10 @@ internal class TestLogs
                      * launch the OpenTelemetry Collector with an OTLP receiver, by running:
                      *
                      *  - On Unix based systems use:
-                     *     docker run --rm -it -p 4317:4317 -p 4318:4318 -v $(pwd):/cfg otel/opentelemetry-collector:latest --config=/cfg/otlp-collector-example/config.yaml
+                     *     docker run --rm -it -p 4317:4317 -p 4318:4318 -v $(pwd):/cfg otel/opentelemetry-collector:0.123.0 --config=/cfg/otlp-collector-example/config.yaml
                      *
                      *  - On Windows use:
-                     *     docker run --rm -it -p 4317:4317 -p 4318:4318 -v "%cd%":/cfg otel/opentelemetry-collector:latest --config=/cfg/otlp-collector-example/config.yaml
+                     *     docker run --rm -it -p 4317:4317 -p 4318:4318 -v "%cd%":/cfg otel/opentelemetry-collector:0.123.0 --config=/cfg/otlp-collector-example/config.yaml
                      *
                      * Open another terminal window at the examples/Console/ directory and
                      * launch the OTLP example by running:

--- a/examples/Console/TestMetrics.cs
+++ b/examples/Console/TestMetrics.cs
@@ -37,10 +37,10 @@ internal class TestMetrics
              * launch the OpenTelemetry Collector with an OTLP receiver, by running:
              *
              *  - On Unix based systems use:
-             *     docker run --rm -it -p 4317:4317 -v $(pwd):/cfg otel/opentelemetry-collector:0.33.0 --config=/cfg/otlp-collector-example/config.yaml
+             *     docker run --rm -it -p 4317:4317 -v $(pwd):/cfg otel/opentelemetry-collector:latest --config=/cfg/otlp-collector-example/config.yaml
              *
              *  - On Windows use:
-             *     docker run --rm -it -p 4317:4317 -v "%cd%":/cfg otel/opentelemetry-collector:0.33.0 --config=/cfg/otlp-collector-example/config.yaml
+             *     docker run --rm -it -p 4317:4317 -v "%cd%":/cfg otel/opentelemetry-collector:latest --config=/cfg/otlp-collector-example/config.yaml
              *
              * Open another terminal window at the examples/Console/ directory and
              * launch the OTLP example by running:

--- a/examples/Console/TestMetrics.cs
+++ b/examples/Console/TestMetrics.cs
@@ -37,10 +37,10 @@ internal class TestMetrics
              * launch the OpenTelemetry Collector with an OTLP receiver, by running:
              *
              *  - On Unix based systems use:
-             *     docker run --rm -it -p 4317:4317 -v $(pwd):/cfg otel/opentelemetry-collector:latest --config=/cfg/otlp-collector-example/config.yaml
+             *     docker run --rm -it -p 4317:4317 -v $(pwd):/cfg otel/opentelemetry-collector:0.123.0 --config=/cfg/otlp-collector-example/config.yaml
              *
              *  - On Windows use:
-             *     docker run --rm -it -p 4317:4317 -v "%cd%":/cfg otel/opentelemetry-collector:latest --config=/cfg/otlp-collector-example/config.yaml
+             *     docker run --rm -it -p 4317:4317 -v "%cd%":/cfg otel/opentelemetry-collector:0.123.0 --config=/cfg/otlp-collector-example/config.yaml
              *
              * Open another terminal window at the examples/Console/ directory and
              * launch the OTLP example by running:

--- a/examples/Console/TestOtlpExporter.cs
+++ b/examples/Console/TestOtlpExporter.cs
@@ -20,10 +20,10 @@ internal static class TestOtlpExporter
          * launch the OpenTelemetry Collector with an OTLP receiver, by running:
          *
          *  - On Unix based systems use:
-         *     docker run --rm -it -p 4317:4317 -p 4318:4318 -v $(pwd):/cfg otel/opentelemetry-collector:latest --config=/cfg/otlp-collector-example/config.yaml
+         *     docker run --rm -it -p 4317:4317 -p 4318:4318 -v $(pwd):/cfg otel/opentelemetry-collector:0.123.0 --config=/cfg/otlp-collector-example/config.yaml
          *
          *  - On Windows use:
-         *     docker run --rm -it -p 4317:4317 -p 4318:4318 -v "%cd%":/cfg otel/opentelemetry-collector:latest --config=/cfg/otlp-collector-example/config.yaml
+         *     docker run --rm -it -p 4317:4317 -p 4318:4318 -v "%cd%":/cfg otel/opentelemetry-collector:0.123.0 --config=/cfg/otlp-collector-example/config.yaml
          *
          * Open another terminal window at the examples/Console/ directory and
          * launch the OTLP example by running:


### PR DESCRIPTION
This a follow up to the fix in #5685, which replaced Logging Exporter with Debug Exporter in otel-collector configs.

After that fix, otel-collector of version `0.48.0` will fail with an error (until an update in version `0.86.0`):

```powershell
PS C:\repos\opentelemetry-dotnet\examples\Console> docker run --rm -it -p 4317:4317 -v ${pwd}:/cfg otel/opentelemetry-collector:0.48.0 --config=/cfg/otlp-collector-example/config.yaml
Error: failed to get config: cannot unmarshal the configuration: unknown exporters type "debug" for "debug" (valid values: [logging otlp jaeger prometheusremotewrite zipkin otlphttp file kafka opencensus prometheus])
2025/04/02 01:31:40 collector server run finished with error: failed to get config: cannot unmarshal the configuration: unknown exporters type "debug" for "debug" (valid values: [logging otlp jaeger prometheusremotewrite zipkin otlphttp file kafka opencensus prometheus])
```

## Changes

Please provide a brief description of the changes here.

* Update otel-collector version to be compatible with the otel-collector config.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
