### PR TITLE
Synchronous requests for HTTP calls

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpExportClient.cs
@@ -4,6 +4,7 @@
 #if NETFRAMEWORK
 using System.Net.Http;
 #endif
+using System.Net;
 using System.Net.Http.Headers;
 using OpenTelemetry.Internal;
 
@@ -96,6 +97,37 @@ internal abstract class OtlpExportClient : IExportClient
         return request;
     }
 
+    protected (Uri Uri, HttpMethod Method, Dictionary<string, string> Headers, byte[] Content, string ContentType)
+    CreateSynchronousRequestParams(byte[] buffer, int contentLength)
+    {
+        Uri uri = this.Endpoint;
+
+
+        HttpMethod method = HttpMethod.Post;
+
+        var headers = new Dictionary<string, string>();
+        foreach (var header in this.Headers)
+        {
+            headers[header.Key] = header.Value;
+        }
+
+
+        byte[] content;
+        if (contentLength < buffer.Length)
+        {
+            content = new byte[contentLength];
+            Array.Copy(buffer, 0, content, 0, contentLength);
+        }
+        else
+        {
+            content = buffer;
+        }
+
+        string contentType = this.MediaTypeHeader.ToString();
+
+        return (uri, method, headers, content, contentType);
+    }
+
     protected HttpResponseMessage SendHttpRequest(HttpRequestMessage request, CancellationToken cancellationToken)
     {
 #if NET
@@ -107,5 +139,209 @@ internal abstract class OtlpExportClient : IExportClient
 #else
         return this.HttpClient.SendAsync(request, cancellationToken).GetAwaiter().GetResult();
 #endif
+    }
+
+    protected HttpResponseMessage SendHttpRequestSynchronous(Uri uri, HttpMethod method, Dictionary<string, string> headers = null, byte[] content = null, string contentType = null, CancellationToken cancellationToken = default)
+    {
+        var webRequest = (HttpWebRequest)WebRequest.Create(uri);
+        webRequest.Method = method.ToString();
+        webRequest.AllowAutoRedirect = true;
+
+        if (headers != null)
+        {
+            foreach (var header in headers)
+            {
+                if (WebHeaderCollection.IsRestricted(header.Key))
+                {
+                    switch (header.Key.ToLowerInvariant())
+                    {
+                        case "accept":
+                            webRequest.Accept = header.Value;
+                            break;
+                        case "connection":
+                            webRequest.Connection = header.Value;
+                            break;
+                        case "content-type":
+                            break;
+                        case "user-agent":
+                            webRequest.UserAgent = header.Value;
+                            break;
+                        case "content-length":
+                            break;
+                        case "expect":
+                            webRequest.Expect = header.Value;
+                            break;
+                        case "date":
+                            webRequest.Date = DateTime.Parse(header.Value);
+                            break;
+                        case "host":
+                            break;
+                        case "if-modified-since":
+                            webRequest.IfModifiedSince = DateTime.Parse(header.Value);
+                            break;
+                        case "range":
+                            string[] range = header.Value.Split('=', ',');
+                            if (range.Length >= 2 && range[0].Trim().Equals("bytes"))
+                            {
+                                string[] startEnd = range[1].Split('-');
+                                if (startEnd.Length >= 2)
+                                {
+                                    long start = long.Parse(startEnd[0]);
+                                    long end = long.Parse(startEnd[1]);
+                                    webRequest.AddRange(start, end);
+                                }
+                            }
+                            break;
+                        case "referer":
+                            webRequest.Referer = header.Value;
+                            break;
+                        case "transfer-encoding":
+                            webRequest.TransferEncoding = header.Value;
+                            break;
+                    }
+                }
+                else
+                {
+                    webRequest.Headers.Add(header.Key, header.Value);
+                }
+            }
+        }
+
+
+        if (!string.IsNullOrEmpty(contentType))
+        {
+            webRequest.ContentType = contentType;
+        }
+
+
+        if (content != null && content.Length > 0)
+        {
+            webRequest.ContentLength = content.Length;
+
+            using (var requestStream = webRequest.GetRequestStream())
+            {
+                requestStream.Write(content, 0, content.Length);
+            }
+        }
+        else
+        {
+            webRequest.ContentLength = 0;
+        }
+
+        cancellationToken.Register(webRequest.Abort);
+
+        try
+        {
+            using (var webResponse = (HttpWebResponse)webRequest.GetResponse())
+            {
+                return CreateResponseFromWebResponse(webResponse);
+            }
+        }
+        catch (WebException ex)
+        {
+            if (ex.Response is HttpWebResponse errorResponse)
+            {
+                return CreateResponseFromWebResponse(errorResponse);
+            }
+
+            // For cases where there's no response (timeout, etc.)
+            var response = new HttpResponseMessage(HttpStatusCode.InternalServerError)
+            {
+                ReasonPhrase = ex.Message,
+            };
+
+            return response;
+        }
+        catch (Exception ex)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.InternalServerError)
+            {
+                ReasonPhrase = ex.Message,
+            };
+
+            return response;
+        }
+    }
+
+    private static HttpResponseMessage CreateResponseFromWebResponse(HttpWebResponse webResponse)
+    {
+        var response = new HttpResponseMessage(webResponse.StatusCode)
+        {
+            ReasonPhrase = webResponse.StatusDescription,
+            Version = new Version(webResponse.ProtocolVersion.ToString()),
+        };
+
+        foreach (string headerName in webResponse.Headers.AllKeys)
+        {
+            if (headerName.Equals("Content-Length", StringComparison.OrdinalIgnoreCase) ||
+               headerName.Equals("Content-Type", StringComparison.OrdinalIgnoreCase) ||
+               headerName.Equals("Content-Encoding", StringComparison.OrdinalIgnoreCase) ||
+               headerName.Equals("Content-Language", StringComparison.OrdinalIgnoreCase) ||
+               headerName.Equals("Content-Location", StringComparison.OrdinalIgnoreCase) ||
+               headerName.Equals("Content-MD5", StringComparison.OrdinalIgnoreCase) ||
+               headerName.Equals("Content-Range", StringComparison.OrdinalIgnoreCase) ||
+               headerName.Equals("Content-Disposition", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            response.Headers.TryAddWithoutValidation(headerName, webResponse.Headers[headerName]);
+        }
+
+
+        if (webResponse.ContentLength != 0)
+        {
+            var responseStream = webResponse.GetResponseStream();
+            var memoryStream = new MemoryStream();
+
+            if (responseStream != null)
+            {
+                byte[] buffer = new byte[8192];
+                int bytesRead;
+                while ((bytesRead = responseStream.Read(buffer, 0, buffer.Length)) > 0)
+                {
+                    memoryStream.Write(buffer, 0, bytesRead);
+                }
+
+                memoryStream.Position = 0;
+            }
+
+            response.Content = new ByteArrayContent(memoryStream.ToArray());
+
+            if (!string.IsNullOrEmpty(webResponse.ContentType))
+            {
+                response.Content.Headers.ContentType = new MediaTypeHeaderValue(webResponse.ContentType);
+            }
+
+            if (webResponse.ContentLength > 0)
+            {
+                response.Content.Headers.ContentLength = webResponse.ContentLength;
+            }
+
+            var contentEncoding = webResponse.Headers["Content-Encoding"];
+            if (!string.IsNullOrEmpty(contentEncoding))
+            {
+                response.Content.Headers.TryAddWithoutValidation("Content-Encoding", contentEncoding);
+            }
+
+            var contentLanguage = webResponse.Headers["Content-Language"];
+            if (!string.IsNullOrEmpty(contentLanguage))
+            {
+                response.Content.Headers.TryAddWithoutValidation("Content-Language", contentLanguage);
+            }
+
+            // Add other content headers if needed
+            var contentDisposition = webResponse.Headers["Content-Disposition"];
+            if (!string.IsNullOrEmpty(contentDisposition))
+            {
+                response.Content.Headers.TryAddWithoutValidation("Content-Disposition", contentDisposition);
+            }
+        }
+        else
+        {
+            response.Content = new ByteArrayContent([]);
+        }
+
+        return response;
     }
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpHttpExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpHttpExportClient.cs
@@ -26,8 +26,15 @@ internal sealed class OtlpHttpExportClient : OtlpExportClient
     {
         try
         {
-            using var httpRequest = this.CreateHttpRequest(buffer, contentLength);
+#if NET
+            var httpRequest = this.CreateHttpRequest(buffer, contentLength);
             using var httpResponse = this.SendHttpRequest(httpRequest, cancellationToken);
+
+#else
+            var httpRequest = this.CreateSynchronousRequestParams(buffer, contentLength);
+            using var httpResponse = this.SendHttpRequestSynchronous(httpRequest.Uri, httpRequest.Method, httpRequest.Headers, httpRequest.Content, httpRequest.ContentType, cancellationToken);
+
+#endif
 
             try
             {


### PR DESCRIPTION
Proposed changes to perform truly synchronous calls for the HTTP protocol in .NET Framework and .NET (Core) versions less than .NET 5

Fixes #
Targets to remove the "synch-over-async" anti-pattern within `OtlExportClient`, mandated by the use of `HttpClient`. The `HttpClient` version only supports truly synchronous calls from .NET 5 upwards . 

This is only done for Otlp exporters over HTTP, since GRPC requests need HTTP/2, which is not supported except through the use of `HttpClient`. 

## Changes
The main changes are:
1. New method `SendHttpRequestSynchronous` in `OtlpExportClient` abstract class, that performs truly synchronous requests. This method avoids the use of `HttpClient` and instead uses the (obsolete) `WebRequest`. 
2. The return data from this method is converted to an `HttpResponseMessage` via the new method `CreateResponseFromWebResponse` to retain compatibility with the return type of the existing `SendHttpRequestSynchronous`
3. A new helper method `CreateSynchronousRequestParams` to build the arguments for `SendHttpRequestSynchronous`, equivalent to what is done in `CreateHttpRequest` 
4. Update of `OtlpHttpExportClient` such that `CreateSynchronousRequestParams` and `SendHttpRequestSynchronous` are used unless running under .NET 5.0 or upwards

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
