### PR TITLE
Add new option DisableAppendingUnitName in order to avoid appending the unit name in the metric name

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/.publicApi/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 Microsoft.AspNetCore.Builder.PrometheusExporterApplicationBuilderExtensions
 Microsoft.AspNetCore.Builder.PrometheusExporterEndpointRouteBuilderExtensions
 OpenTelemetry.Exporter.PrometheusAspNetCoreOptions
+OpenTelemetry.Exporter.PrometheusAspNetCoreOptions.DisableAppendingUnitName.get -> bool
+OpenTelemetry.Exporter.PrometheusAspNetCoreOptions.DisableAppendingUnitName.set -> void
 OpenTelemetry.Exporter.PrometheusAspNetCoreOptions.DisableTotalNameSuffixForCounters.get -> bool
 OpenTelemetry.Exporter.PrometheusAspNetCoreOptions.DisableTotalNameSuffixForCounters.set -> void
 OpenTelemetry.Exporter.PrometheusAspNetCoreOptions.PrometheusAspNetCoreOptions() -> void

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusAspNetCoreOptions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/PrometheusAspNetCoreOptions.cs
@@ -38,5 +38,14 @@ public class PrometheusAspNetCoreOptions
         set => this.ExporterOptions.ScrapeResponseCacheDurationMilliseconds = value;
     }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether addition of the unit name for metric names is disabled. Default value: <see langword="false"/>.
+    /// </summary>
+    public bool DisableAppendingUnitName
+    {
+        get => this.ExporterOptions.DisableAppendingUnitName;
+        set => this.ExporterOptions.DisableAppendingUnitName = value;
+    }
+
     internal PrometheusExporterOptions ExporterOptions { get; } = new();
 }

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/.publicApi/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/.publicApi/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions
+OpenTelemetry.Exporter.PrometheusHttpListenerOptions.DisableAppendingUnitName.get -> bool
+OpenTelemetry.Exporter.PrometheusHttpListenerOptions.DisableAppendingUnitName.set -> void
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.DisableTotalNameSuffixForCounters.get -> bool
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.DisableTotalNameSuffixForCounters.set -> void
 OpenTelemetry.Exporter.PrometheusHttpListenerOptions.UriPrefixes.get -> System.Collections.Generic.IReadOnlyCollection<string!>!

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusCollectionManager.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusCollectionManager.cs
@@ -361,7 +361,7 @@ internal sealed class PrometheusCollectionManager
         // Optimize writing metrics with bounded cache that has pre-calculated Prometheus names.
         if (!this.metricsCache.TryGetValue(metric, out var prometheusMetric))
         {
-            prometheusMetric = PrometheusMetric.Create(metric, this.exporter.DisableTotalNameSuffixForCounters);
+            prometheusMetric = PrometheusMetric.Create(metric, this.exporter.DisableTotalNameSuffixForCounters, this.exporter.DisableAppendingUnitName);
 
             // Add to the cache if there is space.
             if (this.metricsCacheCount < MaxCachedMetrics)

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusExporter.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusExporter.cs
@@ -27,6 +27,7 @@ internal sealed class PrometheusExporter : BaseExporter<Metric>, IPullMetricExpo
 
         this.ScrapeResponseCacheDurationMilliseconds = options.ScrapeResponseCacheDurationMilliseconds;
         this.DisableTotalNameSuffixForCounters = options.DisableTotalNameSuffixForCounters;
+        this.DisableAppendingUnitName = options.DisableAppendingUnitName;
 
         this.CollectionManager = new PrometheusCollectionManager(this);
     }
@@ -47,6 +48,8 @@ internal sealed class PrometheusExporter : BaseExporter<Metric>, IPullMetricExpo
     internal int ScrapeResponseCacheDurationMilliseconds { get; }
 
     internal bool DisableTotalNameSuffixForCounters { get; }
+
+    internal bool DisableAppendingUnitName { get; }
 
     internal bool OpenMetricsRequested { get; set; }
 

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusExporterOptions.cs
@@ -33,4 +33,9 @@ internal sealed class PrometheusExporterOptions
     /// Gets or sets a value indicating whether addition of _total suffix for counter metric names is disabled. Default value: <see langword="false"/>.
     /// </summary>
     public bool DisableTotalNameSuffixForCounters { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether addition of the unit name for metric names is disabled. Default value: <see langword="false"/>.
+    /// </summary>
+    public bool DisableAppendingUnitName { get; set; }
 }

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusMetric.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusMetric.cs
@@ -21,7 +21,7 @@ internal sealed class PrometheusMetric
         PrometheusType.Untyped, PrometheusType.Counter, PrometheusType.Gauge, PrometheusType.Summary, PrometheusType.Histogram, PrometheusType.Histogram, PrometheusType.Histogram, PrometheusType.Histogram, PrometheusType.Gauge,
     ];
 
-    public PrometheusMetric(string name, string unit, PrometheusType type, bool disableTotalNameSuffixForCounters)
+    public PrometheusMetric(string name, string unit, PrometheusType type, bool disableTotalNameSuffixForCounters, bool disableAppendingUnitName)
     {
         // The metric name is
         // required to match the regex: `[a-zA-Z_:]([a-zA-Z0-9_:])*`. Invalid characters
@@ -32,7 +32,7 @@ internal sealed class PrometheusMetric
         var openMetricsName = SanitizeOpenMetricsName(sanitizedName);
 
         string? sanitizedUnit = null;
-        if (!string.IsNullOrEmpty(unit))
+        if (!disableAppendingUnitName && !string.IsNullOrEmpty(unit))
         {
             sanitizedUnit = GetUnit(unit);
 
@@ -86,9 +86,9 @@ internal sealed class PrometheusMetric
 
     public PrometheusType Type { get; }
 
-    public static PrometheusMetric Create(Metric metric, bool disableTotalNameSuffixForCounters)
+    public static PrometheusMetric Create(Metric metric, bool disableTotalNameSuffixForCounters, bool disableAppendingUnitName)
     {
-        return new PrometheusMetric(metric.Name, metric.Unit, GetPrometheusType(metric), disableTotalNameSuffixForCounters);
+        return new PrometheusMetric(metric.Name, metric.Unit, GetPrometheusType(metric), disableTotalNameSuffixForCounters, disableAppendingUnitName);
     }
 
     internal static string SanitizeMetricName(string metricName)

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerMeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerMeterProviderBuilderExtensions.cs
@@ -69,6 +69,7 @@ public static class PrometheusHttpListenerMeterProviderBuilderExtensions
         {
             ScrapeResponseCacheDurationMilliseconds = 0,
             DisableTotalNameSuffixForCounters = options.DisableTotalNameSuffixForCounters,
+            DisableAppendingUnitName = options.DisableAppendingUnitName,
         });
 
         var reader = new BaseExportingMetricReader(exporter)

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerOptions.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListenerOptions.cs
@@ -25,6 +25,11 @@ public class PrometheusHttpListenerOptions
     public bool DisableTotalNameSuffixForCounters { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether addition of the unit name for metric names is disabled. Default value: <see langword="false"/>.
+    /// </summary>
+    public bool DisableAppendingUnitName { get; set; }
+
+    /// <summary>
     /// Gets or sets the URI (Uniform Resource Identifier) prefixes to use for the http listener.
     /// Default value: <c>["http://localhost:9464/"]</c>.
     /// </summary>

--- a/test/Benchmarks/Exporter/PrometheusSerializerBenchmarks.cs
+++ b/test/Benchmarks/Exporter/PrometheusSerializerBenchmarks.cs
@@ -66,7 +66,7 @@ public class PrometheusSerializerBenchmarks
     {
         if (!this.cache.TryGetValue(metric, out var prometheusMetric))
         {
-            prometheusMetric = PrometheusMetric.Create(metric, false);
+            prometheusMetric = PrometheusMetric.Create(metric, false, false);
             this.cache[metric] = prometheusMetric;
         }
 

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusMetricTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusMetricTests.cs
@@ -118,139 +118,271 @@ public sealed class PrometheusMetricTests
     [Fact]
     public void Name_GaugeWithUnit_NoAppendRatio()
     {
-        AssertName("sample", "unit", PrometheusType.Gauge, false, "sample_unit");
+        AssertName("sample", "unit", PrometheusType.Gauge, false, false, "sample_unit");
+    }
+
+    [Fact]
+    public void Name_GaugeWithUnit_NoAppendRatio_NoAppendUnitName()
+    {
+        AssertName("sample", "unit", PrometheusType.Gauge, false, true, "sample");
     }
 
     [Fact]
     public void Name_SpecialCaseCounter_AppendTotal()
     {
-        AssertName("sample", "unit", PrometheusType.Counter, false, "sample_unit_total");
+        AssertName("sample", "unit", PrometheusType.Counter, false, false, "sample_unit_total");
+    }
+
+    [Fact]
+    public void Name_SpecialCaseCounter_AppendTotal_NoAppendUnitName()
+    {
+        AssertName("sample", "unit", PrometheusType.Counter, false, true, "sample_total");
     }
 
     [Fact]
     public void Name_SpecialCaseCounterWithoutUnit_DropUnitAppendTotal()
     {
-        AssertName("sample", "1", PrometheusType.Counter, false, "sample_total");
+        AssertName("sample", "1", PrometheusType.Counter, false, false, "sample_total");
+    }
+
+    [Fact]
+    public void Name_SpecialCaseCounterWithoutUnit_DropUnitAppendTotal_NoAppendUnitName()
+    {
+        AssertName("sample", "1", PrometheusType.Counter, false, true, "sample_total");
     }
 
     [Fact]
     public void Name_DisableTotalSuffixAddition_TotalNotAppended()
     {
-        AssertName("sample", "1", PrometheusType.Counter, true, "sample");
+        AssertName("sample", "1", PrometheusType.Counter, true, false, "sample");
+    }
+
+    [Fact]
+    public void Name_DisableTotalSuffixAddition_TotalNotAppended_NoAppendUnitName()
+    {
+        AssertName("sample", "1", PrometheusType.Counter, true, true, "sample");
     }
 
     [Fact]
     public void Name_TotalSuffixAlreadyPresent_DisableTotalSuffixAddition_TotalNotRemoved()
     {
-        AssertName("sample_total", "1", PrometheusType.Counter, true, "sample_total");
+        AssertName("sample_total", "1", PrometheusType.Counter, true, false, "sample_total");
+    }
+
+    [Fact]
+    public void Name_TotalSuffixAlreadyPresent_DisableTotalSuffixAddition_TotalNotRemoved_NoAppendUnitName()
+    {
+        AssertName("sample_total", "1", PrometheusType.Counter, true, true, "sample_total");
     }
 
     [Fact]
     public void Name_SpecialCaseCounterWithNumber_AppendTotal()
     {
-        AssertName("sample", "2", PrometheusType.Counter, false, "sample_2_total");
+        AssertName("sample", "2", PrometheusType.Counter, false, false, "sample_2_total");
+    }
+
+    [Fact]
+    public void Name_SpecialCaseCounterWithNumber_AppendTotal_NoAppendUnitName()
+    {
+        AssertName("sample", "2", PrometheusType.Counter, false, true, "sample_total");
     }
 
     [Fact]
     public void Name_UnsupportedMetricNameChars_Drop()
     {
-        AssertName("s%%ple", "%/m", PrometheusType.Summary, false, "s_ple_percent_per_minute");
+        AssertName("s%%ple", "%/m", PrometheusType.Summary, false, false, "s_ple_percent_per_minute");
+    }
+
+    [Fact]
+    public void Name_UnsupportedMetricNameChars_Drop_NoAppendUnitName()
+    {
+        AssertName("s%%ple", "%/m", PrometheusType.Summary, false, true, "s_ple");
     }
 
     [Fact]
     public void Name_UnitOtherThanOne_Normal()
     {
-        AssertName("metric_name", "2", PrometheusType.Summary, false, "metric_name_2");
+        AssertName("metric_name", "2", PrometheusType.Summary, false, false, "metric_name_2");
+    }
+
+    [Fact]
+    public void Name_UnitOtherThanOne_Normal_NoAppendUnitName()
+    {
+        AssertName("metric_name", "2", PrometheusType.Summary, false, true, "metric_name");
     }
 
     [Fact]
     public void Name_UnitAlreadyPresentInName_NotAppended()
     {
-        AssertName("metric_name_total", "total", PrometheusType.Counter, false, "metric_name_total");
+        AssertName("metric_name_total", "total", PrometheusType.Counter, false, false, "metric_name_total");
+    }
+
+    [Fact]
+    public void Name_UnitAlreadyPresentInName_NotAppended_NoAppendUnitName()
+    {
+        AssertName("metric_name_total", "total", PrometheusType.Counter, false, true, "metric_name_total");
     }
 
     [Fact]
     public void Name_UnitAlreadyPresentInName_TotalNonCounterType_NotAppended()
     {
-        AssertName("metric_name_total", "total", PrometheusType.Summary, false, "metric_name_total");
+        AssertName("metric_name_total", "total", PrometheusType.Summary, false, false, "metric_name_total");
+    }
+
+    [Fact]
+    public void Name_UnitAlreadyPresentInName_TotalNonCounterType_NotAppended_NoAppendUnitName()
+    {
+        AssertName("metric_name_total", "total", PrometheusType.Summary, false, true, "metric_name_total");
     }
 
     [Fact]
     public void Name_UnitAlreadyPresentInName_CustomGauge_NotAppended()
     {
-        AssertName("metric_hertz", "hertz", PrometheusType.Gauge, false, "metric_hertz");
+        AssertName("metric_hertz", "hertz", PrometheusType.Gauge, false, false, "metric_hertz");
+    }
+
+    [Fact]
+    public void Name_UnitAlreadyPresentInName_CustomGauge_NotAppended_NoAppendUnitName()
+    {
+        AssertName("metric_hertz", "hertz", PrometheusType.Gauge, false, true, "metric_hertz");
     }
 
     [Fact]
     public void Name_UnitAlreadyPresentInName_CustomCounter_NotAppended()
     {
-        AssertName("metric_hertz_total", "hertz_total", PrometheusType.Counter, false, "metric_hertz_total");
+        AssertName("metric_hertz_total", "hertz_total", PrometheusType.Counter, false, false, "metric_hertz_total");
+    }
+
+    [Fact]
+    public void Name_UnitAlreadyPresentInName_CustomCounter_NotAppended_NoAppendUnitName()
+    {
+        AssertName("metric_hertz_total", "hertz_total", PrometheusType.Counter, false, true, "metric_hertz_total");
     }
 
     [Fact]
     public void Name_UnitAlreadyPresentInName_OrderMatters_Appended()
     {
-        AssertName("metric_total_hertz", "hertz_total", PrometheusType.Counter, false, "metric_total_hertz_hertz_total");
+        AssertName("metric_total_hertz", "hertz_total", PrometheusType.Counter, false, false, "metric_total_hertz_hertz_total");
+    }
+
+    [Fact]
+    public void Name_UnitAlreadyPresentInName_OrderMatters_Appended_NoAppendUnitName()
+    {
+        AssertName("metric_total_hertz", "hertz_total", PrometheusType.Counter, false, true, "metric_total_hertz_total");
     }
 
     [Fact]
     public void Name_StartWithNumber_UnderscoreStart()
     {
-        AssertName("2_metric_name", "By", PrometheusType.Summary, false, "_metric_name_bytes");
+        AssertName("2_metric_name", "By", PrometheusType.Summary, false, false, "_metric_name_bytes");
+    }
+
+    [Fact]
+    public void Name_StartWithNumber_UnderscoreStart_NoAppendUnitName()
+    {
+        AssertName("2_metric_name", "By", PrometheusType.Summary, false, true, "_metric_name");
     }
 
     [Fact]
     public void OpenMetricsName_UnitAlreadyPresentInName_Appended()
     {
-        AssertOpenMetricsName("db_bytes_written", "By", PrometheusType.Gauge, false, "db_bytes_written_bytes");
+        AssertOpenMetricsName("db_bytes_written", "By", PrometheusType.Gauge, false, false, "db_bytes_written_bytes");
+    }
+
+    [Fact]
+    public void OpenMetricsName_UnitAlreadyPresentInName_Appended_NoAppendUnitName()
+    {
+        AssertOpenMetricsName("db_bytes_written", "By", PrometheusType.Gauge, false, true, "db_bytes_written");
     }
 
     [Fact]
     public void OpenMetricsName_SuffixedWithUnit_NotAppended()
     {
-        AssertOpenMetricsName("db_written_bytes", "By", PrometheusType.Gauge, false, "db_written_bytes");
+        AssertOpenMetricsName("db_written_bytes", "By", PrometheusType.Gauge, false, false, "db_written_bytes");
+    }
+
+    [Fact]
+    public void OpenMetricsName_SuffixedWithUnit_NotAppended_NoAppendUnitName()
+    {
+        AssertOpenMetricsName("db_written_bytes", "By", PrometheusType.Gauge, false, true, "db_written_bytes");
     }
 
     [Fact]
     public void OpenMetricsName_Counter_AppendTotal()
     {
-        AssertOpenMetricsName("db_bytes_written", "By", PrometheusType.Counter, false, "db_bytes_written_bytes_total");
+        AssertOpenMetricsName("db_bytes_written", "By", PrometheusType.Counter, false, false, "db_bytes_written_bytes_total");
+    }
+
+    [Fact]
+    public void OpenMetricsName_Counter_AppendTotal_NoAppendUnitName()
+    {
+        AssertOpenMetricsName("db_bytes_written", "By", PrometheusType.Counter, false, true, "db_bytes_written_total");
     }
 
     [Fact]
     public void OpenMetricsName_Counter_DisableSuffixTotal_AppendTotal()
     {
-        AssertOpenMetricsName("db_bytes_written", "By", PrometheusType.Counter, true, "db_bytes_written_bytes_total");
+        AssertOpenMetricsName("db_bytes_written", "By", PrometheusType.Counter, true, false, "db_bytes_written_bytes_total");
+    }
+
+    [Fact]
+    public void OpenMetricsName_Counter_DisableSuffixTotal_AppendTotal_NoAppendUnitName()
+    {
+        AssertOpenMetricsName("db_bytes_written", "By", PrometheusType.Counter, true, true, "db_bytes_written_total");
     }
 
     [Fact]
     public void OpenMetricsName_CounterSuffixedWithTotal_AppendUnitAndTotal()
     {
-        AssertOpenMetricsName("db_bytes_written_total", "By", PrometheusType.Counter, false, "db_bytes_written_bytes_total");
+        AssertOpenMetricsName("db_bytes_written_total", "By", PrometheusType.Counter, false, false, "db_bytes_written_bytes_total");
+    }
+
+    [Fact]
+    public void OpenMetricsName_CounterSuffixedWithTotal_AppendUnitAndTotal_NoAppendUnitName()
+    {
+        AssertOpenMetricsName("db_bytes_written_total", "By", PrometheusType.Counter, false, true, "db_bytes_written_total");
     }
 
     [Fact]
     public void OpenMetricsName_CounterSuffixedWithTotal_DisableSuffixTotal_AppendTotal()
     {
-        AssertOpenMetricsName("db_bytes_written_total", "By", PrometheusType.Counter, false, "db_bytes_written_bytes_total");
+        AssertOpenMetricsName("db_bytes_written_total", "By", PrometheusType.Counter, false, false, "db_bytes_written_bytes_total");
+    }
+
+    [Fact]
+    public void OpenMetricsName_CounterSuffixedWithTotal_DisableSuffixTotal_AppendTotal_NoAppendUnitName()
+    {
+        AssertOpenMetricsName("db_bytes_written_total", "By", PrometheusType.Counter, false, true, "db_bytes_written_total");
     }
 
     [Fact]
     public void OpenMetricsMetadataName_Counter_NotAppendTotal()
     {
-        AssertOpenMetricsMetadataName("db_bytes_written", "By", PrometheusType.Counter, false, "db_bytes_written_bytes");
+        AssertOpenMetricsMetadataName("db_bytes_written", "By", PrometheusType.Counter, false, false, "db_bytes_written_bytes");
+    }
+
+    [Fact]
+    public void OpenMetricsMetadataName_Counter_NotAppendTotal_NoAppendUnitName()
+    {
+        AssertOpenMetricsMetadataName("db_bytes_written", "By", PrometheusType.Counter, false, true, "db_bytes_written");
     }
 
     [Fact]
     public void OpenMetricsMetadataName_Counter_DisableSuffixTotal_NotAppendTotal()
     {
-        AssertOpenMetricsMetadataName("db_bytes_written", "By", PrometheusType.Counter, true, "db_bytes_written_bytes");
+        AssertOpenMetricsMetadataName("db_bytes_written", "By", PrometheusType.Counter, true, false, "db_bytes_written_bytes");
+    }
+
+    [Fact]
+    public void OpenMetricsMetadataName_Counter_DisableSuffixTotal_NotAppendTotal_NoAppendUnitName()
+    {
+        AssertOpenMetricsMetadataName("db_bytes_written", "By", PrometheusType.Counter, true, true, "db_bytes_written");
     }
 
     private static void AssertName(
-        string name, string unit, PrometheusType type, bool disableTotalNameSuffixForCounters, string expected)
+        string name, string unit, PrometheusType type, bool disableTotalNameSuffixForCounters, bool disableAppendingUnitName, string expected)
     {
-        var prometheusMetric = new PrometheusMetric(name, unit, type, disableTotalNameSuffixForCounters);
+        var prometheusMetric = new PrometheusMetric(name, unit, type, disableTotalNameSuffixForCounters, disableAppendingUnitName);
         Assert.Equal(expected, prometheusMetric.Name);
     }
 
@@ -261,16 +393,16 @@ public sealed class PrometheusMetricTests
     }
 
     private static void AssertOpenMetricsName(
-        string name, string unit, PrometheusType type, bool disableTotalNameSuffixForCounters, string expected)
+        string name, string unit, PrometheusType type, bool disableTotalNameSuffixForCounters, bool disableAppendingUnitName, string expected)
     {
-        var prometheusMetric = new PrometheusMetric(name, unit, type, disableTotalNameSuffixForCounters);
+        var prometheusMetric = new PrometheusMetric(name, unit, type, disableTotalNameSuffixForCounters, disableAppendingUnitName);
         Assert.Equal(expected, prometheusMetric.OpenMetricsName);
     }
 
     private static void AssertOpenMetricsMetadataName(
-        string name, string unit, PrometheusType type, bool disableTotalNameSuffixForCounters, string expected)
+        string name, string unit, PrometheusType type, bool disableTotalNameSuffixForCounters, bool disableAppendingUnitName, string expected)
     {
-        var prometheusMetric = new PrometheusMetric(name, unit, type, disableTotalNameSuffixForCounters);
+        var prometheusMetric = new PrometheusMetric(name, unit, type, disableTotalNameSuffixForCounters, disableAppendingUnitName);
         Assert.Equal(expected, prometheusMetric.OpenMetricsMetadataName);
     }
 }

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusSerializerTests.cs
@@ -655,6 +655,6 @@ public sealed class PrometheusSerializerTests
 
     private static int WriteMetric(byte[] buffer, int cursor, Metric metric, bool useOpenMetrics = false)
     {
-        return PrometheusSerializer.WriteMetric(buffer, cursor, metric, PrometheusMetric.Create(metric, false), useOpenMetrics);
+        return PrometheusSerializer.WriteMetric(buffer, cursor, metric, PrometheusMetric.Create(metric, false, false), useOpenMetrics);
     }
 }


### PR DESCRIPTION
Fixes #
This PR is adding a new option named "DisableAppendingUnitName" in the PrometheusAspNetCoreOptions and the PrometheusExporterOptions classes, in order to support the creation of metric names without appending the unit name.
This is very useful for migrating existing implementations that use prometheus-net to the opentelemetry-dotnet as a drop-in replacement.
I believe that Go exporter already has the same functionality but this is missing from the dotnet exporter.
I know that this adds a new option in the public API, but I believe that it will help a lot with migrating from prometheus-net for a lot of projects as already mentioned.

## Changes

- Added DisableAppendingUnitName in PrometheusAspNetCoreOptions 
- Added DisableAppendingUnitName in PrometheusExporterOptions 
- Updated OpenTelemetry.Exporter.Prometheus.AspNetCore/.publicApi/PublicAPI.Unshipped.txt
- Updated OpenTelemetry.Exporter.Prometheus.HttpListener/.publicApi/PublicAPI.Unshipped.txt

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
