### PR TITLE
Publish NuGet packages as GitHub Artifacts

### DIFF
--- a/.github/workflows/package-validation.yml
+++ b/.github/workflows/package-validation.yml
@@ -23,6 +23,13 @@ jobs:
     - name: dotnet pack
       run: dotnet pack ./build/OpenTelemetry.proj --configuration Release /p:EnablePackageValidation=true /p:ExposeExperimentalFeatures=false /p:RunningDotNetPack=true
 
+    - name: Publish stable NuGet packages to Artifacts
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: packages-stable
+        path: '.\src\**\*.*nupkg'
+        if-no-files-found: error
+
   run-package-validation-experimental:
     runs-on: windows-latest
 
@@ -39,3 +46,10 @@ jobs:
 
     - name: dotnet pack
       run: dotnet pack ./build/OpenTelemetry.proj --configuration Release /p:EnablePackageValidation=true /p:ExposeExperimentalFeatures=true /p:RunningDotNetPack=true
+
+    - name: Publish experimental NuGet packages to Artifacts
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: packages-experimental
+        path: '.\src\**\*.*nupkg'
+        if-no-files-found: error


### PR DESCRIPTION
## Changes

Publish NuGet packages from CI builds as workflow run artifacts for easy consumption of changes.

Equivalent change to open-telemetry/opentelemetry-dotnet-contrib#2658.

Artifact structure can be flattened if #6256 is implemented.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
