### PR TITLE
[otlp] Correct initial write position for gRPC in .NET Framework OTLP exporters

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -7,6 +7,13 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Fixed a bug related to gRPC protocol errors in .NET Framework: OtlpLogExporter,
+  OtlpMetricExporter, and OtlpTraceExporter did not set startWritePosition
+  using GrpcStartWritePosition.
+* Fixed an issue in .NET Framework where OTLP export of traces, logs, and
+  metrics using `OtlpExportProtocol.Grpc` did not correctly set the initial
+  write position, resulting in gRPC protocol errors.
+
 ## 1.12.0
 
 Released 2025-Apr-29

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -13,6 +13,7 @@ Notes](../../RELEASENOTES.md).
 * Fixed an issue in .NET Framework where OTLP export of traces, logs, and
   metrics using `OtlpExportProtocol.Grpc` did not correctly set the initial
   write position, resulting in gRPC protocol errors.
+  ([#6280](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6280))
 
 ## 1.12.0
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -7,9 +7,6 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* Fixed a bug related to gRPC protocol errors in .NET Framework: OtlpLogExporter,
-  OtlpMetricExporter, and OtlpTraceExporter did not set startWritePosition
-  using GrpcStartWritePosition.
 * Fixed an issue in .NET Framework where OTLP export of traces, logs, and
   metrics using `OtlpExportProtocol.Grpc` did not correctly set the initial
   write position, resulting in gRPC protocol errors.

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporter.cs
@@ -58,11 +58,9 @@ public sealed class OtlpLogExporter : BaseExporter<LogRecord>
 
         this.experimentalOptions = experimentalOptions!;
         this.sdkLimitOptions = sdkLimitOptions!;
-#if NET462_OR_GREATER || NETSTANDARD2_0
-        this.startWritePosition = 0;
-#else
+#pragma warning disable CS0618 // Suppressing gRPC obsolete warning
         this.startWritePosition = exporterOptions!.Protocol == OtlpExportProtocol.Grpc ? GrpcStartWritePosition : 0;
-#endif
+#pragma warning restore CS0618 // Suppressing gRPC obsolete warning
         this.transmissionHandler = transmissionHandler ?? exporterOptions!.GetExportTransmissionHandler(experimentalOptions!, OtlpSignalType.Logs);
     }
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporter.cs
@@ -51,11 +51,9 @@ public class OtlpMetricExporter : BaseExporter<Metric>
         Debug.Assert(exporterOptions != null, "exporterOptions was null");
         Debug.Assert(experimentalOptions != null, "experimentalOptions was null");
 
-#if NET462_OR_GREATER || NETSTANDARD2_0
-        this.startWritePosition = 0;
-#else
+#pragma warning disable CS0618 // Suppressing gRPC obsolete warning
         this.startWritePosition = exporterOptions!.Protocol == OtlpExportProtocol.Grpc ? GrpcStartWritePosition : 0;
-#endif
+#pragma warning restore CS0618 // Suppressing gRPC obsolete warning
         this.transmissionHandler = transmissionHandler ?? exporterOptions!.GetExportTransmissionHandler(experimentalOptions!, OtlpSignalType.Metrics);
     }
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporter.cs
@@ -54,11 +54,9 @@ public class OtlpTraceExporter : BaseExporter<Activity>
         Debug.Assert(sdkLimitOptions != null, "sdkLimitOptions was null");
 
         this.sdkLimitOptions = sdkLimitOptions!;
-#if NET462_OR_GREATER || NETSTANDARD2_0
-        this.startWritePosition = 0;
-#else
+#pragma warning disable CS0618 // Suppressing gRPC obsolete warning
         this.startWritePosition = exporterOptions!.Protocol == OtlpExportProtocol.Grpc ? GrpcStartWritePosition : 0;
-#endif
+#pragma warning restore CS0618 // Suppressing gRPC obsolete warning
         this.transmissionHandler = transmissionHandler ?? exporterOptions!.GetExportTransmissionHandler(experimentalOptions, OtlpSignalType.Traces);
     }
 


### PR DESCRIPTION
…l.Grpc`.

Fixes #6273
Replaces: #6277

## Changes

Please provide a brief description of the changes here.

## Verify
1. Start the [opentelemetry-collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases) with the OTLP receiver enabled and TLS configured..
2. Debug the `Examples.Console.csproj` project with `-f net48` and the following arguments: `otlp -e "https://localhost:4317" -p "grpc"`
3. Set a breakpoint in [OtlpExporterTransmissionHandler.TrySubmitRequest](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/OtlpExporterTransmissionHandler.cs#L38), and `response.Success` should return `true`.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
