### PR TITLE
Clean up infinite explicit bucket bounds to prevent duplicate histogram bucket output

### DIFF
--- a/src/OpenTelemetry/Metrics/MetricPoint/HistogramBuckets.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint/HistogramBuckets.cs
@@ -63,9 +63,6 @@ public class HistogramBuckets
         this.BucketCounts = explicitBounds != null ? new HistogramBucketValues[explicitBounds.Length + 1] : Array.Empty<HistogramBucketValues>();
     }
 
-    private static double[]? CleanUpInfinitiesFromExplicitBounds(double[]? explicitBounds) => explicitBounds
-        ?.Where(b => !double.IsNegativeInfinity(b) && !double.IsPositiveInfinity(b)).ToArray();
-
     /// <summary>
     /// Returns an enumerator that iterates through the <see cref="HistogramBuckets"/>.
     /// </summary>
@@ -161,6 +158,9 @@ public class HistogramBuckets
             }
         }
     }
+
+    private static double[]? CleanUpInfinitiesFromExplicitBounds(double[]? explicitBounds) => explicitBounds
+        ?.Where(b => !double.IsNegativeInfinity(b) && !double.IsPositiveInfinity(b)).ToArray();
 
     /// <summary>
     /// Enumerates the elements of a <see cref="HistogramBuckets"/>.

--- a/src/OpenTelemetry/Metrics/MetricPoint/HistogramBuckets.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint/HistogramBuckets.cs
@@ -33,6 +33,7 @@ public class HistogramBuckets
 
     internal HistogramBuckets(double[]? explicitBounds)
     {
+        explicitBounds = CleanUpInfinitiesFromExplicitBounds(explicitBounds);
         this.ExplicitBounds = explicitBounds;
         this.findHistogramBucketIndex = this.FindBucketIndexLinear;
         if (explicitBounds != null && explicitBounds.Length >= DefaultBoundaryCountForBinarySearch)
@@ -61,6 +62,9 @@ public class HistogramBuckets
 
         this.BucketCounts = explicitBounds != null ? new HistogramBucketValues[explicitBounds.Length + 1] : Array.Empty<HistogramBucketValues>();
     }
+
+    private static double[]? CleanUpInfinitiesFromExplicitBounds(double[]? explicitBounds) => explicitBounds
+        ?.Where(b => !double.IsNegativeInfinity(b) && !double.IsPositiveInfinity(b)).ToArray();
 
     /// <summary>
     /// Returns an enumerator that iterates through the <see cref="HistogramBuckets"/>.

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetry.Extensions.Hosting.Tests.csproj
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetry.Extensions.Hosting.Tests.csproj
@@ -23,6 +23,7 @@
     IMetricsBuilder/IMetricsListener API added at the host level in .NET 8
     instead of the direct lower-level MeterListener API added in .NET 6. -->
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Metrics\AggregatorTests.cs" Link="Includes\Metrics\AggregatorTests.cs" />
+    <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Metrics\HistogramBoundaryTestCase.cs" Link="Includes\Metrics\HistogramBoundaryTestCase.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Metrics\HostingMeterProviderBuilder.cs" Link="Includes\Metrics\HostingMeterProviderBuilder.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Metrics\KnownHistogramBuckets.cs" Link="Includes\Metrics\KnownHistogramBuckets.cs" />
     <Compile Include="$(RepoRoot)\test\OpenTelemetry.Tests\Metrics\MetricApiTests.cs" Link="Includes\Metrics\MetricApiTests.cs" />

--- a/test/OpenTelemetry.Tests/Metrics/HistogramBoundaryTestCase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/HistogramBoundaryTestCase.cs
@@ -69,4 +69,3 @@ public class HistogramBoundaryTestCase(
     }
 }
 
-

--- a/test/OpenTelemetry.Tests/Metrics/HistogramBoundaryTestCase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/HistogramBoundaryTestCase.cs
@@ -68,4 +68,3 @@ public class HistogramBoundaryTestCase(
         return data;
     }
 }
-

--- a/test/OpenTelemetry.Tests/Metrics/HistogramBoundaryTestCase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/HistogramBoundaryTestCase.cs
@@ -1,0 +1,27 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+namespace OpenTelemetry.Metrics.Tests;
+
+
+#pragma warning disable CA1819 // Properties should not return arrays
+#pragma warning disable CA1515 // Consider making public types internal
+public class HistogramBoundaryTestCase(
+#pragma warning restore CA1515 // Consider making public types internal
+    string testName,
+    double[] inputBoundaries,
+    double[] inputValues,
+    long[] expectedBucketCounts,
+    double[] expectedBucketBounds)
+{
+    public double[] InputBoundaries { get;  } = inputBoundaries;
+
+    public double[] InputValues { get; } = inputValues;
+
+    public long[] ExpectedBucketCounts { get; } = expectedBucketCounts;
+
+    public double[] ExpectedBucketBounds { get;  } = expectedBucketBounds;
+
+    public string TestName { get; set; } = testName;
+}
+

--- a/test/OpenTelemetry.Tests/Metrics/HistogramBoundaryTestCase.cs
+++ b/test/OpenTelemetry.Tests/Metrics/HistogramBoundaryTestCase.cs
@@ -1,8 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-namespace OpenTelemetry.Metrics.Tests;
+using Xunit;
 
+namespace OpenTelemetry.Metrics.Tests;
 
 #pragma warning disable CA1819 // Properties should not return arrays
 #pragma warning disable CA1515 // Consider making public types internal
@@ -14,14 +15,58 @@ public class HistogramBoundaryTestCase(
     long[] expectedBucketCounts,
     double[] expectedBucketBounds)
 {
-    public double[] InputBoundaries { get;  } = inputBoundaries;
+    public double[] InputBoundaries { get; } = inputBoundaries;
 
     public double[] InputValues { get; } = inputValues;
 
     public long[] ExpectedBucketCounts { get; } = expectedBucketCounts;
 
-    public double[] ExpectedBucketBounds { get;  } = expectedBucketBounds;
+    public double[] ExpectedBucketBounds { get; } = expectedBucketBounds;
 
     public string TestName { get; set; } = testName;
+
+    public static TheoryData<HistogramBoundaryTestCase> HistogramInfinityBoundariesTestCases()
+    {
+        var data = new TheoryData<HistogramBoundaryTestCase>
+        {
+            new(
+                testName: "Custom boundaries with no infinity in explicit boundaries",
+                inputBoundaries: [0, 10],
+                inputValues: [-10, 0, 5, 10, 100],
+                expectedBucketCounts: [2, 2, 1],
+                expectedBucketBounds: [0, 10, double.PositiveInfinity]),
+
+            new(
+                testName: "Custom boundaries with positive infinity",
+                inputBoundaries: [0, double.PositiveInfinity],
+                inputValues: [-10, 0, 10, 100],
+                expectedBucketCounts: [2, 2],
+                expectedBucketBounds: [0, double.PositiveInfinity]),
+
+            new(
+                testName: "Custom boundaries with negative infinity",
+                inputBoundaries: [double.NegativeInfinity, 0, 10],
+                inputValues: [-100, -10, 0, 5, 10, 100],
+                expectedBucketCounts: [3, 2, 1],
+                expectedBucketBounds: [0, 10, double.PositiveInfinity]),
+
+            new(
+                testName: "Custom boundaries with both infinities",
+                inputBoundaries: [double.NegativeInfinity, 0, 10, double.PositiveInfinity],
+                inputValues: [-100, -10, 0, 5, 10, 100],
+                expectedBucketCounts: [3, 2, 1],
+                expectedBucketBounds: [0, 10, double.PositiveInfinity]),
+
+            new(
+                testName: "Custom boundaries with infinities only",
+                inputBoundaries: [double.NegativeInfinity, double.PositiveInfinity],
+                inputValues: [-10, 0, 10],
+                expectedBucketCounts: [3],
+                expectedBucketBounds: [double.PositiveInfinity]),
+        };
+
+        return data;
+    }
 }
+
 


### PR DESCRIPTION
Fixes #5938

The change ensures that providing `double.NegativeInfinity` or `double.PositiveInfinity` in explicit bucket bounds parameter no longer outputs duplicate infinity buckets .

> Note: the issue only reported the duplicated buckets with PositiveInfinity, however, upon implementation, I've come across the fact that the NegativeInfinity causes incorrect output as well. The proposed change adresses both cases.

## Changes

The implementation:
1. Adds a `CleanUpInfinitiesFromExplicitBounds` method to filter out both negative and positive infinities from `explicitBounds` input parameter explicit bucket boundaries during initialisation in a constructor of HistogramBuckets.cs
2. This prevents duplicate infinity buckets in histogram outputs
3. The fix is more efficient than checking for infinity during enumeration since it performs the check only once during construction

## Testing
* In addition to unit test changes in the PR, I've run the below code based on a code sample from the original issue to observe buckets output with negative and positive infinity passed(`new double[] { double.NegativeInfinity, -2500, 0, 2500, double.PositiveInfinity }`):
  ```csharp
  using System.Diagnostics.Metrics;
  using OpenTelemetry;
  using OpenTelemetry.Metrics;
  
  namespace CustomizingTheSdk;
  
  public class Program
  {
      private static readonly Meter Meter = new("CompanyA.ProductA.LibraryA", "1.0");
  
      public static void Main()
      {
          using var meterProvider = Sdk.CreateMeterProviderBuilder()
              .AddMeter(Meter.Name)
              .AddView(instrumentName: "MyHistogram", new ExplicitBucketHistogramConfiguration() { Boundaries = new double[] { double.NegativeInfinity, -2500, 0, 2500, double.PositiveInfinity } })
              .AddConsoleExporter()
              .Build();
  
          var histogram = Meter.CreateHistogram<long>("MyHistogram");
          for (int i = 0; i < 15000; i++)
          {
              histogram.Record(i - 5000, new("tag1", "value1"), new("tag2", "value2"));
          }
      }
  }
  ```

* Compared the console outputs side by side:
  ![image](https://github.com/user-attachments/assets/8a85f659-15b1-408c-870b-1ba6607d5c80)

  * As can be seen on the comparison screenshot no duplicated buckets are present in the output after the change:
    ```
    (-Infinity,-2500]:2501
    (-2500,0]:2500
    (0,2500]:2500
    (2500,+Infinity]:7499
    ```

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
