### PR TITLE
[OpenTelemetry] Fix CA1305 warning

### DIFF
--- a/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
+++ b/src/OpenTelemetry/Internal/OpenTelemetrySdkEventSource.cs
@@ -416,7 +416,7 @@ internal sealed class OpenTelemetrySdkEventSource : EventSource, IConfigurationE
             string? message;
             if (e.Message != null && e.Payload != null && e.Payload.Count > 0)
             {
-                message = string.Format(e.Message, e.Payload.ToArray());
+                message = string.Format(System.Globalization.CultureInfo.CurrentCulture, e.Message, e.Payload.ToArray());
             }
             else
             {


### PR DESCRIPTION
## Changes

Fix `CA1305` warning by explicitly specifying the culture to use.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
