### PR TITLE
[infra] Use Artifacts Output layout

### DIFF
--- a/.github/workflows/package-validation.yml
+++ b/.github/workflows/package-validation.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: packages-stable
-        path: '.\src\**\*.*nupkg'
+        path: ./artifacts/package/release
         if-no-files-found: error
 
   run-package-validation-experimental:
@@ -54,5 +54,5 @@ jobs:
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: packages-experimental
-        path: '.\src\**\*.*nupkg'
+        path: ./artifacts/package/release
         if-no-files-found: error

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -92,7 +92,7 @@ jobs:
       if: env.MYGET_TOKEN_EXISTS == 'true' # Skip MyGet publish if run on a fork without the secret
       run: |
         nuget setApiKey ${{ secrets.MYGET_TOKEN }} -Source https://www.myget.org/F/opentelemetry/api/v2/package
-        nuget push ./artifacts/package/release -Source https://www.myget.org/F/opentelemetry/api/v2/package
+        nuget push ./artifacts/package/release/*.nupkg -Source https://www.myget.org/F/opentelemetry/api/v2/package
 
   post-build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -67,7 +67,7 @@ jobs:
         foreach ($projectFile in $projectFiles) {
             $projectName = [System.IO.Path]::GetFileNameWithoutExtension($projectFile)
 
-            Get-ChildItem -Path src/$projectName/bin/Release/*/$projectName.dll -File | ForEach-Object {
+            Get-ChildItem -Path artifacts/bin/$projectName/release_*/$projectName.dll -File | ForEach-Object {
                 $fileFullPath = $_.FullName
                 Write-Host "Signing $fileFullPath"
 

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -83,7 +83,8 @@ jobs:
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ github.ref_name }}-packages
-        path: 'src/**/*.*nupkg'
+        path: ./artifacts/package/release
+        if-no-files-found: error
 
     - name: Publish MyGet
       env:
@@ -91,7 +92,7 @@ jobs:
       if: env.MYGET_TOKEN_EXISTS == 'true' # Skip MyGet publish if run on a fork without the secret
       run: |
         nuget setApiKey ${{ secrets.MYGET_TOKEN }} -Source https://www.myget.org/F/opentelemetry/api/v2/package
-        nuget push src/**/*.nupkg -Source https://www.myget.org/F/opentelemetry/api/v2/package
+        nuget push ./artifacts/package/release -Source https://www.myget.org/F/opentelemetry/api/v2/package
 
   post-build:
     runs-on: ubuntu-22.04

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 x64/
 x86/
 bld/
+[Aa]rtifacts/
 [Bb]in/
 [Oo]bj/
 [Ll]og/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <ArtifactsPath>$([System.IO.Path]::Combine('$(MSBuildThisFileDirectory)', 'artifacts'))</ArtifactsPath>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+  </PropertyGroup>
+</Project>

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -18,7 +18,6 @@
     <PackageProjectUrl>https://opentelemetry.io</PackageProjectUrl>
     <Authors>OpenTelemetry Authors</Authors>
     <Copyright>Copyright The OpenTelemetry Authors</Copyright>
-    <PackageOutputPath Condition="$(Build_ArtifactStagingDirectory) != ''">$(Build_ArtifactStagingDirectory)</PackageOutputPath>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/build/scripts/test-aot-compatibility.ps1
+++ b/build/scripts/test-aot-compatibility.ps1
@@ -24,10 +24,9 @@ if ($LastExitCode -ne 0)
     Write-Host $publishOutput
 }
 
-$runtime = $IsWindows ? "win-x64" : ($IsMacOS ? "macos-x64" : "linux-x64")
 $app = $IsWindows ? "./OpenTelemetry.AotCompatibility.TestApp.exe" : "./OpenTelemetry.AotCompatibility.TestApp"
 
-Push-Location $rootDirectory/test/OpenTelemetry.AotCompatibility.TestApp/bin/Release/$targetNetFramework/$runtime
+Push-Location $rootDirectory/artifacts/publish/OpenTelemetry.AotCompatibility.TestApp/release_$targetNetFramework
 
 Write-Host "Executing test App..."
 $app

--- a/build/scripts/test-threadSafety.ps1
+++ b/build/scripts/test-threadSafety.ps1
@@ -13,7 +13,7 @@ $env:OTEL_RUN_COYOTE_TESTS = 'true'
 $rootDirectory = Get-Location
 
 Write-Host "Install Coyote CLI."
-dotnet tool install --global Microsoft.Coyote.CLI
+dotnet tool install --global Microsoft.Coyote.CLI --version $coyoteVersion
 
 if ($LASTEXITCODE -ne 0) {
     throw "Microsoft.Coyote.CLI installation failed with exit code $LASTEXITCODE"

--- a/build/scripts/test-threadSafety.ps1
+++ b/build/scripts/test-threadSafety.ps1
@@ -13,7 +13,7 @@ $env:OTEL_RUN_COYOTE_TESTS = 'true'
 $rootDirectory = Get-Location
 
 Write-Host "Install Coyote CLI."
-dotnet tool install --global Microsoft.Coyote.CLI --version $coyoteVersion
+dotnet tool install --global Microsoft.Coyote.CLI
 
 if ($LASTEXITCODE -ne 0) {
     throw "Microsoft.Coyote.CLI installation failed with exit code $LASTEXITCODE"

--- a/build/scripts/test-threadSafety.ps1
+++ b/build/scripts/test-threadSafety.ps1
@@ -26,7 +26,7 @@ if ($LASTEXITCODE -ne 0) {
     throw "dotnet build failed with exit code $LASTEXITCODE"
 }
 
-$artifactsPath = Join-Path $rootDirectory "test/$testProjectName/bin/$configuration/$targetFramework"
+$artifactsPath = Join-Path $rootDirectory "artifacts/bin/$testProjectName/$($configuration.ToLowerInvariant())_$targetFramework"
 
 Write-Host "Generate Coyote rewriting options JSON file."
 $assemblies = Get-ChildItem $artifactsPath -Filter OpenTelemetry*.dll | ForEach-Object {$_.Name}

--- a/docs/Directory.Build.props
+++ b/docs/Directory.Build.props
@@ -1,4 +1,5 @@
 <Project>
+  <Import Project="$([System.IO.Path]::Combine($(MSBuildThisFileDirectory), '..', 'Directory.Build.props'))" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.nonprod.props" />
 
   <PropertyGroup>

--- a/docs/Directory.Build.props
+++ b/docs/Directory.Build.props
@@ -5,5 +5,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(TargetFrameworksForDocs)</TargetFrameworks>
+    <!-- Opt-out of Artifacts Output for docs as there are duplicated project names -->
+    <UseArtifactsOutput>false</UseArtifactsOutput>
   </PropertyGroup>
 </Project>

--- a/examples/Directory.Build.props
+++ b/examples/Directory.Build.props
@@ -1,3 +1,4 @@
 <Project>
+  <Import Project="$([System.IO.Path]::Combine($(MSBuildThisFileDirectory), '..', 'Directory.Build.props'))" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.nonprod.props" />
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,3 +1,4 @@
 <Project>
+  <Import Project="$([System.IO.Path]::Combine($(MSBuildThisFileDirectory), '..', 'Directory.Build.props'))" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.prod.props" />
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,3 +1,4 @@
 <Project>
+  <Import Project="$([System.IO.Path]::Combine($(MSBuildThisFileDirectory), '..', 'Directory.Build.props'))" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenTelemetry.sln'))\build\Common.nonprod.props" />
 </Project>


### PR DESCRIPTION
Fixes #6256.

## Changes

Use [Artifacts Output layout](https://learn.microsoft.com/dotnet/core/sdk/artifacts-output) to make build output easy to locate.

This has the additional effect of de-nesting the structure of the ZIP files containing the packages that are uploaded to GitHub Actions artifacts.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
