### PR TITLE
[infra] Ensure test-threadSafety.ps1 fails

### DIFF
--- a/build/scripts/test-threadSafety.ps1
+++ b/build/scripts/test-threadSafety.ps1
@@ -1,20 +1,30 @@
 param(
-  [Parameter()][string]$coyoteVersion="1.7.10",
+  [Parameter()][string]$coyoteVersion="1.7.11",
   [Parameter(Mandatory=$true)][string]$testProjectName,
   [Parameter(Mandatory=$true)][string]$targetFramework,
   [Parameter()][string]$categoryName="CoyoteConcurrencyTests",
   [Parameter()][string]$configuration="Release"
 )
 
+$ErrorActionPreference = "Stop"
+
 $env:OTEL_RUN_COYOTE_TESTS = 'true'
 
 $rootDirectory = Get-Location
 
 Write-Host "Install Coyote CLI."
-dotnet tool install --global Microsoft.Coyote.CLI
+dotnet tool install --global Microsoft.Coyote.CLI --version $coyoteVersion
+
+if ($LASTEXITCODE -ne 0) {
+    throw "Microsoft.Coyote.CLI installation failed with exit code $LASTEXITCODE"
+}
 
 Write-Host "Build $testProjectName project."
 dotnet build "$rootDirectory/test/$testProjectName/$testProjectName.csproj" --configuration $configuration
+
+if ($LASTEXITCODE -ne 0) {
+    throw "dotnet build failed with exit code $LASTEXITCODE"
+}
 
 $artifactsPath = Join-Path $rootDirectory "test/$testProjectName/bin/$configuration/$targetFramework"
 
@@ -29,6 +39,13 @@ $RewriteOptionsJson | ConvertTo-Json -Compress | Set-Content -Path "$rootDirecto
 Write-Host "Run Coyote rewrite."
 coyote rewrite "$rootDirectory/test/$testProjectName/rewrite.coyote.json"
 
+if ($LASTEXITCODE -ne 0) {
+    throw "coyote rewrite failed with exit code $LASTEXITCODE"
+}
+
 Write-Host "Execute re-written binary."
 dotnet test "$artifactsPath/$testProjectName.dll" --framework $targetFramework --filter CategoryName=$categoryName
 
+if ($LASTEXITCODE -ne 0) {
+    throw "dotnet test failed with exit code $LASTEXITCODE"
+}


### PR DESCRIPTION
## Changes

- Ensure that `test-threadSafety.ps1` fails if any specific step fails (e.g. `coyote rewrite`).
- Use `$coyoteVersion` to pin the version so it does not automatically rollforward.
- Bump `$coyoteVersion` to `1.7.11`.

I noticed while working on #6301 I made a change that broke coyote, [but the job still succeeded](https://github.com/open-telemetry/opentelemetry-dotnet/actions/runs/15420469265/job/43393948881?pr=6301#step:4:40):

```
Run Coyote rewrite.
You must install or update .NET to run this application.

App: C:\Users\runneradmin\.dotnet\tools\coyote.exe
Architecture: x64
Framework: 'Microsoft.NETCore.App', version '7.0.0' (x64)
.NET location: C:\Program Files\dotnet

The following frameworks were found:
  6.0.5 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  6.0.26 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  6.0.36 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  6.0.38 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  8.0.6 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  8.0.13 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  8.0.16 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  9.0.2 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  9.0.5 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]

Learn more:
https://aka.ms/dotnet/app-launch-failed

To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=7.0.0&arch=x64&rid=win-x64&os=win10
Execute re-written binary.
VSTest version 17.14.0 (x64)

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:     1, Skipped:     0, Total:     1, Duration: 806 ms - OpenTelemetry.Tests.dll (net8.0)
```

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
