### PR TITLE
[OpenTelemetry] Fix assertion failures in debug

### DIFF
--- a/src/OpenTelemetry/Metrics/Reader/MetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/Reader/MetricReaderExt.cs
@@ -19,8 +19,8 @@ public abstract partial class MetricReader
     private readonly Lock instrumentCreationLock = new();
     private int metricLimit;
     private int cardinalityLimit;
-    private Metric?[]? metrics;
-    private Metric[]? metricsCurrentBatch;
+    private Metric?[] metrics = [];
+    private Metric[] metricsCurrentBatch = [];
     private int metricIndex = -1;
     private ExemplarFilterType? exemplarFilter;
     private ExemplarFilterType? exemplarFilterForHistograms;

--- a/src/OpenTelemetry/Metrics/Reader/PeriodicExportingMetricReader.cs
+++ b/src/OpenTelemetry/Metrics/Reader/PeriodicExportingMetricReader.cs
@@ -47,7 +47,7 @@ public class PeriodicExportingMetricReader : BaseExportingMetricReader
         this.ExportIntervalMilliseconds = exportIntervalMilliseconds;
         this.ExportTimeoutMilliseconds = exportTimeoutMilliseconds;
 
-        this.exporterThread = new Thread(new ThreadStart(this.ExporterProc))
+        this.exporterThread = new Thread(this.ExporterProc)
         {
             IsBackground = true,
 #pragma warning disable CA1062 // Validate arguments of public methods - needed for netstandard2.1


### PR DESCRIPTION
Fixes #6300

## Changes

Avoid failing assertions in debug by skipping collecting a metrics batch if the `MeterProvider` has not yet been initialized.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
