### PR TITLE
[infra] Remove obsolete compose attribute

### DIFF
--- a/build/docker-compose.net8.0.yml
+++ b/build/docker-compose.net8.0.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   tests:
     build:

--- a/build/docker-compose.net9.0.yml
+++ b/build/docker-compose.net9.0.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   tests:
     build:

--- a/examples/AspNetCore/docker-compose.yaml
+++ b/examples/AspNetCore/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
 
   # OTEL Collector to receive logs, metrics and traces from the application

--- a/examples/MicroserviceExample/docker-compose.yml
+++ b/examples/MicroserviceExample/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   zipkin:
     image: openzipkin/zipkin

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTest/docker-compose.yml
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTest/docker-compose.yml
@@ -2,8 +2,6 @@
 # This should be run from the root of the repo:
 #    docker compose --file=test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTest/docker-compose.yml --project-directory=. up --exit-code-from=tests --build
 
-version: '3.7'
-
 services:
   init-service:
     image: otel-test-image

--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/docker-compose.yml
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/docker-compose.yml
@@ -1,7 +1,6 @@
 # Start a container and then run OpenTelemetry W3C Trace Context tests.
 # This should be run from the root of the repo:
 #  opentelemetry>docker compose --file=test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/docker-compose.yml --project-directory=. up --exit-code-from=tests --build
-version: '3.7'
 
 services:
   tests:


### PR DESCRIPTION
## Changes

Avoid warnings from docker compose by removing the obsolete `version` attribute.

> the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
