### PR TITLE
[infra] Use PublicApiAnalyzers from NuGet.org

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -3,18 +3,13 @@
   <packageSources>
     <clear />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-    <add key="dotnet8" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet8/nuget/v3/index.json" />
   </packageSources>
 
   <!-- Define mappings by adding package patterns beneath the target source. -->
-  <!-- *.Tools packages will be restored from ".Net Core Tools", everything else from nuget.org. -->
   <packageSourceMapping>
     <!-- key value for <packageSource> should match key values from <packageSources> element -->
     <packageSource key="NuGet">
       <package pattern="*" />
-    </packageSource>
-    <packageSource key="dotnet8">
-      <package pattern="Microsoft.CodeAnalysis.PublicApiAnalyzers" />
     </packageSource>
   </packageSourceMapping>
 


### PR DESCRIPTION
## Changes

Remove use of Microsoft.CodeAnalysis.PublicApiAnalyzers from internal engineering feed and instead source from NuGet.org.

I looked into upgrading it to a more recent version too, but that generates warnings because the baseline contains all the entries for the experimental APIs, but the non-experimental build generates warnings because those entries are in the baselines but aren't in the API surface area.

The fix for that would be to move the experimental entries to their own custom files, but then that makes updating the baselines a manual task rather than something that the code fixer can do.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
