### PR TITLE
[w3c] Remove redundant RUN command

### DIFF
--- a/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/Dockerfile
+++ b/test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests/Dockerfile
@@ -31,7 +31,5 @@ RUN apt-get update \
   && cd /usr/local/bin \
   && ln -s /usr/bin/python3 python
 
-# net6.0 image uses Python 3.9, which doesn't have `--break-system-packages` option.
-RUN pip3 install --upgrade pip --break-system-packages || pip3 install --upgrade pip
 RUN pip3 install aiohttp --break-system-packages
 ENTRYPOINT ["dotnet", "vstest", "OpenTelemetry.Instrumentation.W3cTraceContext.Tests.dll", "--logger:console;verbosity=detailed"]


### PR DESCRIPTION
## Changes

Remove redundant `RUN` command from the integration tests' Dockerfile as .NET 8 and 9 use Python 3.11.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
