### PR TITLE
[Infra] Ensure .NET 8 is installed

### DIFF
--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -53,7 +53,13 @@ jobs:
         # retrieve them all.
         fetch-depth: 0
 
-    - name: Setup dotnet
+    - name: Setup previous .NET runtimes
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+      with:
+        dotnet-version: |
+          8.0.x
+
+    - name: Setup .NET
       uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
 
     - name: dotnet restore ${{ inputs.project-name }}


### PR DESCRIPTION
## Changes

Ensure that .NET 8 is installed on the runner. The workflows currently assume it is installed, which causes failures on ARM64 runners where it is not installed by default.

Found in open-telemetry/opentelemetry-dotnet-contrib#2832 and also #6307.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
