### PR TITLE
[Infra] Update Dockerfiles with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,34 @@ updates:
       interval: "daily"
     labels:
       - "infra"
+  - package-ecosystem: "docker"
+    directory: "/examples/MicroserviceExample/WebApi"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    labels:
+      - "infra"
+  - package-ecosystem: "docker"
+    directory: "examples/MicroserviceExample/WorkerService"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    labels:
+      - "infra"
+  - package-ecosystem: "docker"
+    directory: "test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/IntegrationTest"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    labels:
+      - "infra"
+  - package-ecosystem: "docker"
+    directory: "test/OpenTelemetry.Instrumentation.W3cTraceContext.Tests"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    labels:
+      - "infra"
   - package-ecosystem: "dotnet-sdk"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Changes

Update dependabot configuration to keep the SDK versions in the Dockerfiles up-to-date on a weekly basis to match the .NET SDK in `global.json`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
