### PR TITLE
[Infra] Remove redundant item

### DIFF
--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -37,13 +37,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Note: Disable net6.0 target for package validation because it has been
-    removed. It should be possible to remove this once a stable version has been
-    released to NuGet without net6.0. -->
-    <PackageValidationBaselineFrameworkToIgnore Include="net6.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="MinVer" PrivateAssets="All" Condition="'$(IntegrationBuild)' != 'true'" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" Condition="'$(IntegrationBuild)' != 'true'" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />


### PR DESCRIPTION
## Changes

`net6.0` is no longer built or tested for.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
