### PR TITLE
[Infra] Remove Source Link package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -103,7 +103,6 @@
     <PackageVersion Include="Microsoft.Extensions.Telemetry.Abstractions" Version="[9.0.0,)" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="[1.0.3,2.0)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="[17.13.0,18.0.0)" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="[8.0.0,9.0)" />
     <PackageVersion Include="MinVer" Version="[5.0.0,6.0)" />
     <PackageVersion Include="NuGet.Versioning" Version="6.11.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="[1.9.0,2.0)" />

--- a/build/Common.prod.props
+++ b/build/Common.prod.props
@@ -45,7 +45,6 @@
 
   <ItemGroup>
     <PackageReference Include="MinVer" PrivateAssets="All" Condition="'$(IntegrationBuild)' != 'true'" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" Condition="'$(IntegrationBuild)' != 'true'" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
## Changes

Source Link is now built into the .NET SDK [since .NET 8](https://learn.microsoft.com/dotnet/core/compatibility/sdk/8.0/source-link).

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
