### PR TITLE
Add an experimental configuration which disables the automatic export…

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExperimentalOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExperimentalOptions.cs
@@ -17,6 +17,8 @@ internal sealed class ExperimentalOptions
 
     public const string OtlpDiskRetryDirectoryPathEnvVar = "OTEL_DOTNET_EXPERIMENTAL_OTLP_DISK_RETRY_DIRECTORY_PATH";
 
+    public const string DisableAddingScopeLogAttributesEnvVar = "OTEL_DOTNET_EXPERIMENTAL_OTLP_DISABLE_ADDING_SCOPE_LOG";
+
     public ExperimentalOptions()
         : this(new ConfigurationBuilder().AddEnvironmentVariables().Build())
     {
@@ -24,6 +26,12 @@ internal sealed class ExperimentalOptions
 
     public ExperimentalOptions(IConfiguration configuration)
     {
+
+        if (configuration.TryGetBoolValue(OpenTelemetryProtocolExporterEventSource.Log, DisableAddingScopeLogAttributesEnvVar, out var disableAddingScopeLogAttributes))
+        {
+            this.DisableAddingScopeLogAttributes = disableAddingScopeLogAttributes;
+        }
+
         if (configuration.TryGetBoolValue(OpenTelemetryProtocolExporterEventSource.Log, EmitLogEventEnvVar, out var emitLogEventAttributes))
         {
             this.EmitLogEventAttributes = emitLogEventAttributes;
@@ -68,6 +76,8 @@ internal sealed class ExperimentalOptions
     /// href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#retry"/>.
     /// </remarks>
     public bool EnableInMemoryRetry { get; }
+
+    public bool DisableAddingScopeLogAttributes { get; }
 
     /// <summary>
     /// Gets a value indicating whether or not retry via disk should be enabled for transient errors.

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
@@ -254,7 +254,10 @@ internal static class ProtobufOtlpLogSerializer
             otlpTagWriterState.WritePosition = ProtobufSerializer.WriteFixed32WithTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpLogFieldNumberConstants.LogRecord_Flags, (uint)logRecord.TraceFlags);
         }
 
-        logRecord.ForEachScope(ProcessScope, state);
+        if (!experimentalOptions.DisableAddingScopeLogAttributes)
+        {
+            logRecord.ForEachScope(ProcessScope, state);
+        }
 
         if (otlpTagWriterState.DroppedTagCount > 0)
         {


### PR DESCRIPTION
### What:
Add an experimental configuration which disables the automatic export of scope log kv attributes for OTLP

### Why:
Now, the scoped log kv attributes are either not exported at all with IncludeScopes=false or are all exported for OTLP.
There is no way to export the 'scoped log kv attributes' in a controlled manner while it is possible to do it with LogRecord attributes.
'scoped log kv attributes' are fully read-only while the LogRecord attributes can be modified.
Especially, the OTL exporter is failing with the lack of log kv attributes de-duplication.

### How to solve it for now:
The client can decide to add the scope log attributes into the LogRecord using the IncludeScopes=true, config 'OTEL_DOTNET_EXPERIMENTAL_OTLP_DISABLE_ADDING_SCOPE_LOG'=1 and uses a custom BaseProcessor to deal with scope log kv attributes of the LogRecord: add only some of them to the LogRecord attributes, perform de-duplication, sanitization,...

```csharp
public class ExampleScopeLogKvAttributeProcessor : BaseProcessor<LogRecord>
{
	public override void OnEnd(LogRecord logRecord)
	{
		var attributes = new Dictionary<string, object?>(logRecord.Attributes?.ToList() ?? new List<KeyValuePair<string, object?>>());

		logRecord.ForEachScope<object?>((scope, _) =>
		{
			if (scope.Scope is not IEnumerable<KeyValuePair<string, object>> scopeKvs) return;

			foreach (var scopeKv in scopeKvs)
			{
				// Sanitization
				if (scopeKv.Key.Equals("UserId", StringComparison.OrdinalIgnoreCase))
				{
					attributes[scopeKv.Key] = "Obfuscated ";
					return;
				}

				// Sanitization
				if (scopeKv.Key.Contains("password", StringComparison.OrdinalIgnoreCase))
				{
					return;
				}

				// Business logic filtering
				if (scopeKv.Key.StartsWith("Internal_"))
				{
					return;
				}

				// Add scope log KV attributes in attributes with some sort of de-duplication
				attributes[scopeKv.Key] = scopeKv.Value;
			}
		}, null);

		logRecord.Attributes = attributes.ToList();
		base.OnEnd(logRecord);
	}
}
```

### Note:
An experimental configuration is used for now until a more solid solution is found/available.