### PR TITLE
[OTLP] Refactor ProtobufSerializer.WriteReservedLength() to improve performance

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -83,7 +83,7 @@
       These packages are referenced as "PrivateAssets" or used in tests/examples.
   -->
   <ItemGroup>
-    <PackageVersion Include="BenchmarkDotNet" Version="[0.13.12,0.14)" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />
     <PackageVersion Include="CommandLineParser" Version="[2.9.1,3.0)" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="Grpc.AspNetCore" Version="[2.59.0,3.0)" />

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufSerializer.cs
@@ -42,42 +42,11 @@ internal static class ProtobufSerializer
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void WriteReservedLength(byte[] buffer, int writePosition, int length)
     {
-        int byteLength = 0;
-        byte firstByte = 0;
-        byte secondByte = 0;
-        byte thirdByte = 0;
-        byte fourthByte = 0;
-
-        do
-        {
-            byte value = (byte)(length & 0x7F);
-
-            switch (byteLength)
-            {
-                case 0:
-                    firstByte = value;
-                    break;
-                case 1:
-                    secondByte = value;
-                    break;
-                case 2:
-                    thirdByte = value;
-                    break;
-                case 3:
-                    fourthByte = value;
-                    break;
-            }
-
-            length >>= 7;
-            byteLength++;
-        }
-        while (length > 0);
-
         var slice = buffer.AsSpan(writePosition, 4);
-        slice[0] = (byte)(firstByte | 0x80);
-        slice[1] = (byte)(secondByte | 0x80);
-        slice[2] = (byte)(thirdByte | 0x80);
-        slice[3] = fourthByte;
+        slice[0] = (byte)(((length >> 0) & 0x7F) | 0x80);
+        slice[1] = (byte)(((length >> 7) & 0x7F) | 0x80);
+        slice[2] = (byte)(((length >> 14) & 0x7F) | 0x80);
+        slice[3] = (byte)((length >> 21) & 0x7F);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufSerializer.cs
@@ -71,33 +71,35 @@ internal static class ProtobufSerializer
         }
         while (length > 0);
 
+        var slice = buffer.AsSpan(writePosition, 4);
+
         if (fourthByte.HasValue)
         {
-            buffer[writePosition++] = (byte)(firstByte!.Value | 0x80);
-            buffer[writePosition++] = (byte)(secondByte!.Value | 0x80);
-            buffer[writePosition++] = (byte)(thirdByte!.Value | 0x80);
-            buffer[writePosition++] = (byte)fourthByte!.Value;
+            slice[0] = (byte)(firstByte.GetValueOrDefault() | 0x80);
+            slice[1] = (byte)(secondByte.GetValueOrDefault() | 0x80);
+            slice[2] = (byte)(thirdByte.GetValueOrDefault() | 0x80);
+            slice[3] = (byte)fourthByte.GetValueOrDefault();
         }
         else if (thirdByte.HasValue)
         {
-            buffer[writePosition++] = (byte)(firstByte!.Value | 0x80);
-            buffer[writePosition++] = (byte)(secondByte!.Value | 0x80);
-            buffer[writePosition++] = (byte)(thirdByte!.Value | 0x80);
-            buffer[writePosition++] = 0;
+            slice[0] = (byte)(firstByte.GetValueOrDefault() | 0x80);
+            slice[1] = (byte)(secondByte.GetValueOrDefault() | 0x80);
+            slice[2] = (byte)(thirdByte.GetValueOrDefault() | 0x80);
+            slice[3] = 0;
         }
         else if (secondByte.HasValue)
         {
-            buffer[writePosition++] = (byte)(firstByte!.Value | 0x80);
-            buffer[writePosition++] = (byte)(secondByte!.Value | 0x80);
-            buffer[writePosition++] = 0x80;
-            buffer[writePosition++] = 0;
+            slice[0] = (byte)(firstByte.GetValueOrDefault() | 0x80);
+            slice[1] = (byte)(secondByte.GetValueOrDefault() | 0x80);
+            slice[2] = 0x80;
+            slice[3] = 0;
         }
         else
         {
-            buffer[writePosition++] = (byte)(firstByte!.Value | 0x80);
-            buffer[writePosition++] = 0x80;
-            buffer[writePosition++] = 0x80;
-            buffer[writePosition++] = 0;
+            slice[0] = (byte)(firstByte.GetValueOrDefault() | 0x80);
+            slice[1] = 0x80;
+            slice[2] = 0x80;
+            slice[3] = 0;
         }
     }
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufSerializer.cs
@@ -43,26 +43,28 @@ internal static class ProtobufSerializer
     internal static void WriteReservedLength(byte[] buffer, int writePosition, int length)
     {
         int byteLength = 0;
-        int firstByte = 0;
-        int secondByte = 0;
-        int thirdByte = 0;
-        int fourthByte = 0;
+        byte firstByte = 0;
+        byte secondByte = 0;
+        byte thirdByte = 0;
+        byte fourthByte = 0;
 
         do
         {
+            byte value = (byte)(length & 0x7F);
+
             switch (byteLength)
             {
                 case 0:
-                    firstByte = length & 0x7F;
+                    firstByte = value;
                     break;
                 case 1:
-                    secondByte = length & 0x7F;
+                    secondByte = value;
                     break;
                 case 2:
-                    thirdByte = length & 0x7F;
+                    thirdByte = value;
                     break;
                 case 3:
-                    fourthByte = length & 0x7F;
+                    fourthByte = value;
                     break;
             }
 
@@ -75,7 +77,7 @@ internal static class ProtobufSerializer
         slice[0] = (byte)(firstByte | 0x80);
         slice[1] = (byte)(secondByte | 0x80);
         slice[2] = (byte)(thirdByte | 0x80);
-        slice[3] = (byte)fourthByte;
+        slice[3] = fourthByte;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufSerializer.cs
@@ -43,10 +43,10 @@ internal static class ProtobufSerializer
     internal static void WriteReservedLength(byte[] buffer, int writePosition, int length)
     {
         int byteLength = 0;
-        int? firstByte = null;
-        int? secondByte = null;
-        int? thirdByte = null;
-        int? fourthByte = null;
+        int firstByte = 0;
+        int secondByte = 0;
+        int thirdByte = 0;
+        int fourthByte = 0;
 
         do
         {
@@ -72,10 +72,10 @@ internal static class ProtobufSerializer
         while (length > 0);
 
         var slice = buffer.AsSpan(writePosition, 4);
-        slice[0] = (byte)(firstByte.GetValueOrDefault() | 0x80);
-        slice[1] = (byte)(secondByte.GetValueOrDefault() | 0x80);
-        slice[2] = (byte)(thirdByte.GetValueOrDefault() | 0x80);
-        slice[3] = (byte)fourthByte.GetValueOrDefault();
+        slice[0] = (byte)(firstByte | 0x80);
+        slice[1] = (byte)(secondByte | 0x80);
+        slice[2] = (byte)(thirdByte | 0x80);
+        slice[3] = (byte)fourthByte;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufSerializer.cs
@@ -72,35 +72,10 @@ internal static class ProtobufSerializer
         while (length > 0);
 
         var slice = buffer.AsSpan(writePosition, 4);
-
-        if (fourthByte.HasValue)
-        {
-            slice[0] = (byte)(firstByte.GetValueOrDefault() | 0x80);
-            slice[1] = (byte)(secondByte.GetValueOrDefault() | 0x80);
-            slice[2] = (byte)(thirdByte.GetValueOrDefault() | 0x80);
-            slice[3] = (byte)fourthByte.GetValueOrDefault();
-        }
-        else if (thirdByte.HasValue)
-        {
-            slice[0] = (byte)(firstByte.GetValueOrDefault() | 0x80);
-            slice[1] = (byte)(secondByte.GetValueOrDefault() | 0x80);
-            slice[2] = (byte)(thirdByte.GetValueOrDefault() | 0x80);
-            slice[3] = 0;
-        }
-        else if (secondByte.HasValue)
-        {
-            slice[0] = (byte)(firstByte.GetValueOrDefault() | 0x80);
-            slice[1] = (byte)(secondByte.GetValueOrDefault() | 0x80);
-            slice[2] = 0x80;
-            slice[3] = 0;
-        }
-        else
-        {
-            slice[0] = (byte)(firstByte.GetValueOrDefault() | 0x80);
-            slice[1] = 0x80;
-            slice[2] = 0x80;
-            slice[3] = 0;
-        }
+        slice[0] = (byte)(firstByte.GetValueOrDefault() | 0x80);
+        slice[1] = (byte)(secondByte.GetValueOrDefault() | 0x80);
+        slice[2] = (byte)(thirdByte.GetValueOrDefault() | 0x80);
+        slice[3] = (byte)fourthByte.GetValueOrDefault();
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
## Changes

Refactor `ProtobufSerializer.WriteReservedLength()` to improve performance and reduce size.

I went through a number of iterations of improvement done manually, then finally I asked GitHub Copilot if it could improve it further, which is the final result. Check the commit history to see the progression.

I wrote my own set of benchmarks, which are in [this Gist](https://gist.github.com/martincostello/9b505d1e762b5877e607e2488f6774db) to verify the changes. The relative results are shown in full below.

The TL;DR is that changes reduces the duration for the values extracted from the unit tests to between 0.03 and 0.23 the duration of the baseline.

<details>

<summary>ProtobufSerializer Benchmarks</summary>

```

BenchmarkDotNet v0.15.2, Windows 11 (10.0.26100.4351/24H2/2024Update/HudsonValley)
13th Gen Intel Core i7-13700H 2.90GHz, 1 CPU, 20 logical and 14 physical cores
.NET SDK 9.0.301
  [Host]     : .NET 9.0.6 (9.0.625.26613), X64 RyuJIT AVX2
  DefaultJob : .NET 9.0.6 (9.0.625.26613), X64 RyuJIT AVX2


```
| Method                                         | length    | Mean      | Error     | StdDev    | Median    | Ratio | RatioSD | Allocated | Alloc Ratio |
|----------------------------------------------- |---------- |----------:|----------:|----------:|----------:|------:|--------:|----------:|------------:|
| **Baseline**                                       | **127**       | **1.2741 ns** | **0.0206 ns** | **0.0183 ns** | **1.2744 ns** |  **1.00** |    **0.02** |         **-** |          **NA** |
| GetValueOrDefault()                            | 127       | 1.3298 ns | 0.0098 ns | 0.0087 ns | 1.3281 ns |  1.04 |    0.02 |         - |          NA |
| Slice()                                        | 127       | 1.0252 ns | 0.0170 ns | 0.0159 ns | 1.0271 ns |  0.80 |    0.02 |         - |          NA |
| &#39;Slice() and GetValueOrDefault()&#39;              | 127       | 1.1376 ns | 0.0149 ns | 0.0132 ns | 1.1375 ns |  0.89 |    0.02 |         - |          NA |
| &#39;Slice() and GetValueOrDefault() + compaction&#39; | 127       | 1.0143 ns | 0.0282 ns | 0.0250 ns | 1.0061 ns |  0.80 |    0.02 |         - |          NA |
| &#39;Slice() and integers + compaction&#39;            | 127       | 1.0403 ns | 0.0363 ns | 0.0340 ns | 1.0450 ns |  0.82 |    0.03 |         - |          NA |
| &#39;Slice() and bytes + compaction&#39;               | 127       | 0.7778 ns | 0.0201 ns | 0.0168 ns | 0.7729 ns |  0.61 |    0.02 |         - |          NA |
| Copilot                                        | 127       | 0.2873 ns | 0.0108 ns | 0.0095 ns | 0.2844 ns |  0.23 |    0.01 |         - |          NA |
|                                                |           |           |           |           |           |       |         |           |             |
| **Baseline**                                       | **128**       | **3.0613 ns** | **0.0522 ns** | **0.0463 ns** | **3.0507 ns** |  **1.00** |    **0.02** |         **-** |          **NA** |
| GetValueOrDefault()                            | 128       | 2.8855 ns | 0.0354 ns | 0.0347 ns | 2.8845 ns |  0.94 |    0.02 |         - |          NA |
| Slice()                                        | 128       | 3.2969 ns | 0.0778 ns | 0.0690 ns | 3.2729 ns |  1.08 |    0.03 |         - |          NA |
| &#39;Slice() and GetValueOrDefault()&#39;              | 128       | 3.9021 ns | 0.0407 ns | 0.0381 ns | 3.9064 ns |  1.27 |    0.02 |         - |          NA |
| &#39;Slice() and GetValueOrDefault() + compaction&#39; | 128       | 2.3129 ns | 0.0380 ns | 0.0318 ns | 2.3078 ns |  0.76 |    0.01 |         - |          NA |
| &#39;Slice() and integers + compaction&#39;            | 128       | 2.5915 ns | 0.0855 ns | 0.0950 ns | 2.5896 ns |  0.85 |    0.03 |         - |          NA |
| &#39;Slice() and bytes + compaction&#39;               | 128       | 2.0225 ns | 0.0293 ns | 0.0274 ns | 2.0244 ns |  0.66 |    0.01 |         - |          NA |
| Copilot                                        | 128       | 0.2741 ns | 0.0111 ns | 0.0087 ns | 0.2765 ns |  0.09 |    0.00 |         - |          NA |
|                                                |           |           |           |           |           |       |         |           |             |
| **Baseline**                                       | **300**       | **3.0503 ns** | **0.0308 ns** | **0.0288 ns** | **3.0558 ns** |  **1.00** |    **0.01** |         **-** |          **NA** |
| GetValueOrDefault()                            | 300       | 2.8419 ns | 0.0286 ns | 0.0239 ns | 2.8416 ns |  0.93 |    0.01 |         - |          NA |
| Slice()                                        | 300       | 3.2978 ns | 0.0884 ns | 0.1086 ns | 3.2514 ns |  1.08 |    0.04 |         - |          NA |
| &#39;Slice() and GetValueOrDefault()&#39;              | 300       | 3.8534 ns | 0.0346 ns | 0.0324 ns | 3.8433 ns |  1.26 |    0.02 |         - |          NA |
| &#39;Slice() and GetValueOrDefault() + compaction&#39; | 300       | 2.3062 ns | 0.0221 ns | 0.0207 ns | 2.3080 ns |  0.76 |    0.01 |         - |          NA |
| &#39;Slice() and integers + compaction&#39;            | 300       | 2.6077 ns | 0.0860 ns | 0.1056 ns | 2.5961 ns |  0.85 |    0.03 |         - |          NA |
| &#39;Slice() and bytes + compaction&#39;               | 300       | 2.0294 ns | 0.0158 ns | 0.0132 ns | 2.0329 ns |  0.67 |    0.01 |         - |          NA |
| Copilot                                        | 300       | 0.2813 ns | 0.0130 ns | 0.0109 ns | 0.2829 ns |  0.09 |    0.00 |         - |          NA |
|                                                |           |           |           |           |           |       |         |           |             |
| **Baseline**                                       | **16383**     | **3.1183 ns** | **0.0951 ns** | **0.1095 ns** | **3.0611 ns** |  **1.00** |    **0.05** |         **-** |          **NA** |
| GetValueOrDefault()                            | 16383     | 2.8636 ns | 0.0433 ns | 0.0383 ns | 2.8557 ns |  0.92 |    0.03 |         - |          NA |
| Slice()                                        | 16383     | 3.2731 ns | 0.0547 ns | 0.0457 ns | 3.2735 ns |  1.05 |    0.04 |         - |          NA |
| &#39;Slice() and GetValueOrDefault()&#39;              | 16383     | 3.8603 ns | 0.0736 ns | 0.0575 ns | 3.8529 ns |  1.24 |    0.04 |         - |          NA |
| &#39;Slice() and GetValueOrDefault() + compaction&#39; | 16383     | 2.2777 ns | 0.0793 ns | 0.0944 ns | 2.3116 ns |  0.73 |    0.04 |         - |          NA |
| &#39;Slice() and integers + compaction&#39;            | 16383     | 2.5924 ns | 0.0836 ns | 0.0741 ns | 2.5891 ns |  0.83 |    0.04 |         - |          NA |
| &#39;Slice() and bytes + compaction&#39;               | 16383     | 2.0150 ns | 0.0097 ns | 0.0086 ns | 2.0104 ns |  0.65 |    0.02 |         - |          NA |
| Copilot                                        | 16383     | 0.2070 ns | 0.0390 ns | 0.0365 ns | 0.2115 ns |  0.07 |    0.01 |         - |          NA |
|                                                |           |           |           |           |           |       |         |           |             |
| **Baseline**                                       | **16384**     | **5.0503 ns** | **0.0745 ns** | **0.0661 ns** | **5.0640 ns** |  **1.00** |    **0.02** |         **-** |          **NA** |
| GetValueOrDefault()                            | 16384     | 4.6712 ns | 0.0382 ns | 0.0299 ns | 4.6765 ns |  0.93 |    0.01 |         - |          NA |
| Slice()                                        | 16384     | 5.1133 ns | 0.1235 ns | 0.1156 ns | 5.1489 ns |  1.01 |    0.03 |         - |          NA |
| &#39;Slice() and GetValueOrDefault()&#39;              | 16384     | 4.9267 ns | 0.0239 ns | 0.0223 ns | 4.9293 ns |  0.98 |    0.01 |         - |          NA |
| &#39;Slice() and GetValueOrDefault() + compaction&#39; | 16384     | 3.2103 ns | 0.0994 ns | 0.1426 ns | 3.3136 ns |  0.64 |    0.03 |         - |          NA |
| &#39;Slice() and integers + compaction&#39;            | 16384     | 3.6348 ns | 0.0073 ns | 0.0061 ns | 3.6366 ns |  0.72 |    0.01 |         - |          NA |
| &#39;Slice() and bytes + compaction&#39;               | 16384     | 1.9680 ns | 0.1113 ns | 0.2688 ns | 1.9647 ns |  0.39 |    0.05 |         - |          NA |
| Copilot                                        | 16384     | 0.2813 ns | 0.0402 ns | 0.0356 ns | 0.2782 ns |  0.06 |    0.01 |         - |          NA |
|                                                |           |           |           |           |           |       |         |           |             |
| **Baseline**                                       | **2097151**   | **4.8406 ns** | **0.0761 ns** | **0.0675 ns** | **4.8390 ns** |  **1.00** |    **0.02** |         **-** |          **NA** |
| GetValueOrDefault()                            | 2097151   | 4.8787 ns | 0.0720 ns | 0.0639 ns | 4.8744 ns |  1.01 |    0.02 |         - |          NA |
| Slice()                                        | 2097151   | 5.1796 ns | 0.0340 ns | 0.0318 ns | 5.1808 ns |  1.07 |    0.02 |         - |          NA |
| &#39;Slice() and GetValueOrDefault()&#39;              | 2097151   | 4.7039 ns | 0.1020 ns | 0.0954 ns | 4.7403 ns |  0.97 |    0.02 |         - |          NA |
| &#39;Slice() and GetValueOrDefault() + compaction&#39; | 2097151   | 3.6774 ns | 0.0125 ns | 0.0111 ns | 3.6783 ns |  0.76 |    0.01 |         - |          NA |
| &#39;Slice() and integers + compaction&#39;            | 2097151   | 3.5240 ns | 0.0614 ns | 0.0575 ns | 3.4791 ns |  0.73 |    0.02 |         - |          NA |
| &#39;Slice() and bytes + compaction&#39;               | 2097151   | 3.5420 ns | 0.0205 ns | 0.0182 ns | 3.5426 ns |  0.73 |    0.01 |         - |          NA |
| Copilot                                        | 2097151   | 0.2394 ns | 0.0020 ns | 0.0017 ns | 0.2391 ns |  0.05 |    0.00 |         - |          NA |
|                                                |           |           |           |           |           |       |         |           |             |
| **Baseline**                                       | **2097152**   | **5.6179 ns** | **0.1196 ns** | **0.1118 ns** | **5.5939 ns** |  **1.00** |    **0.03** |         **-** |          **NA** |
| GetValueOrDefault()                            | 2097152   | 5.3133 ns | 0.0675 ns | 0.0631 ns | 5.3303 ns |  0.95 |    0.02 |         - |          NA |
| Slice()                                        | 2097152   | 5.4426 ns | 0.0391 ns | 0.0347 ns | 5.4346 ns |  0.97 |    0.02 |         - |          NA |
| &#39;Slice() and GetValueOrDefault()&#39;              | 2097152   | 5.3498 ns | 0.0723 ns | 0.0677 ns | 5.3423 ns |  0.95 |    0.02 |         - |          NA |
| &#39;Slice() and GetValueOrDefault() + compaction&#39; | 2097152   | 5.0674 ns | 0.0611 ns | 0.0572 ns | 5.0755 ns |  0.90 |    0.02 |         - |          NA |
| &#39;Slice() and integers + compaction&#39;            | 2097152   | 5.1128 ns | 0.1351 ns | 0.2294 ns | 5.2209 ns |  0.91 |    0.04 |         - |          NA |
| &#39;Slice() and bytes + compaction&#39;               | 2097152   | 5.3165 ns | 0.0970 ns | 0.0907 ns | 5.2700 ns |  0.95 |    0.02 |         - |          NA |
| Copilot                                        | 2097152   | 0.2453 ns | 0.0045 ns | 0.0040 ns | 0.2437 ns |  0.04 |    0.00 |         - |          NA |
|                                                |           |           |           |           |           |       |         |           |             |
| **Baseline**                                       | **268435455** | **5.7418 ns** | **0.1013 ns** | **0.0898 ns** | **5.6959 ns** |  **1.00** |    **0.02** |         **-** |          **NA** |
| GetValueOrDefault()                            | 268435455 | 5.6566 ns | 0.0520 ns | 0.0486 ns | 5.6554 ns |  0.99 |    0.02 |         - |          NA |
| Slice()                                        | 268435455 | 5.7238 ns | 0.0576 ns | 0.0538 ns | 5.7366 ns |  1.00 |    0.02 |         - |          NA |
| &#39;Slice() and GetValueOrDefault()&#39;              | 268435455 | 5.2437 ns | 0.0557 ns | 0.0521 ns | 5.2673 ns |  0.91 |    0.02 |         - |          NA |
| &#39;Slice() and GetValueOrDefault() + compaction&#39; | 268435455 | 5.0273 ns | 0.0100 ns | 0.0088 ns | 5.0296 ns |  0.88 |    0.01 |         - |          NA |
| &#39;Slice() and integers + compaction&#39;            | 268435455 | 5.1438 ns | 0.0971 ns | 0.0909 ns | 5.1231 ns |  0.90 |    0.02 |         - |          NA |
| &#39;Slice() and bytes + compaction&#39;               | 268435455 | 5.5613 ns | 0.0900 ns | 0.0798 ns | 5.5541 ns |  0.97 |    0.02 |         - |          NA |
| Copilot                                        | 268435455 | 0.1799 ns | 0.0377 ns | 0.0449 ns | 0.1681 ns |  0.03 |    0.01 |         - |          NA |

</details>

I also ran the GRPC-related exporter benchmarks in the code base (but with the number of batches changed to just 1 and 5 so they'd finish in an reasonable time) and got the following results. These results are much more modest at a macro level compared to the above microbenchmarks.

### Benchmark Results

```
BenchmarkDotNet v0.15.2, Windows 11 (10.0.26100.4351/24H2/2024Update/HudsonValley)
13th Gen Intel Core i7-13700H 2.90GHz, 1 CPU, 20 logical and 14 physical cores
.NET SDK 9.0.301
  [Host]     : .NET 9.0.6 (9.0.625.26613), X64 RyuJIT AVX2
  DefaultJob : .NET 9.0.6 (9.0.625.26613), X64 RyuJIT AVX2
```

#### gRPC Logs and Traces

```text
dotnet run -c Release -f net9.0 -- -m -f *_Grpc*
```

##### main

| Method               | Mean     | Error    | StdDev   | Gen0   | Allocated |
|--------------------- |---------:|---------:|---------:|-------:|----------:|
| OtlpLogExporter_Grpc | 83.73 μs | 1.587 μs | 3.549 μs | 0.4883 |   6.38 KB |
| OtlpTraceExporter_Grpc | 81.69 μs | 0.746 μs | 1.070 μs | 0.4883 |   6.39 KB |


##### PR

| Method               | Mean     | Error    | StdDev   | Gen0   | Allocated |
|--------------------- |---------:|---------:|---------:|-------:|----------:|
| OtlpLogExporter_Grpc | 72.55 μs | 1.421 μs | 2.413 μs | 0.4883 |   6.38 KB |
| OtlpTraceExporter_Grpc | 81.29 μs | 1.597 μs | 1.775 μs | 0.4883 |   6.39 KB |

#### OtlpGrpcExporterBenchmarks

```text
dotnet run -c Release -f net9.0 -- -m -f *OtlpGrpcExporterBenchmarks*
```

##### main

| Method                | NumberOfBatches | NumberOfSpans | Mean     | Error    | StdDev   | Allocated |
|---------------------- |---------------- |-------------- |---------:|---------:|---------:|----------:|
| **OtlpExporter_Batching** | **1**               | **10000**         |  **4.091 s** | **0.0122 s** | **0.0108 s** |  **16.25 KB** |
| **OtlpExporter_Batching** | **5**               | **10000**         | **20.453 s** | **0.0325 s** | **0.0304 s** |   **74.8 KB** |

##### PR

| Method                | NumberOfBatches | NumberOfSpans | Mean     | Error    | StdDev   | Allocated |
|---------------------- |---------------- |-------------- |---------:|---------:|---------:|----------:|
| **OtlpExporter_Batching** | **1**               | **10000**         |  **4.092 s** | **0.0127 s** | **0.0119 s** |  **14.98 KB** |
| **OtlpExporter_Batching** | **5**               | **10000**         | **20.439 s** | **0.0281 s** | **0.0263 s** |   **74.8 KB** |

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
