### PR TITLE
Remove redundant test

### DIFF
--- a/test/OpenTelemetry.Tests/Trace/LinkTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/LinkTests.cs
@@ -73,18 +73,6 @@ public sealed class LinkTests : IDisposable
         Assert.True(link1.Equals(link3));
     }
 
-    [Fact(Skip = "ActivityLink.Equals is broken in DS7 preview: https://github.com/dotnet/runtime/issues/74026")]
-    public void Equality_WithAttributes()
-    {
-        var link1 = new Link(this.spanContext, this.tags);
-        var link2 = new Link(this.spanContext, this.tags);
-        object link3 = new Link(this.spanContext, this.tags);
-
-        Assert.Equal(link1, link2);
-        Assert.True(link1 == link2);
-        Assert.True(link1.Equals(link3));
-    }
-
     [Fact]
     public void NotEquality()
     {


### PR DESCRIPTION
## Changes

The linked issue is closed as "by design", so the test no longer appears to be valid.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
