### PR TITLE
Slight improvement to readability to Metric ConsoleExporter

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -227,7 +227,11 @@ public class ConsoleMetricExporter : ConsoleExporter<Metric>
                 }
 
                 msg.AppendLine();
+#if NET
                 msg.AppendLine(CultureInfo.InvariantCulture, $"Metric Type: {metric.MetricType}");
+#else
+                msg.Append($"Metric Type: {metric.MetricType}");
+#endif
                 msg.AppendLine();
 #if NET
                 msg.Append(CultureInfo.InvariantCulture, $"Value: {valueDisplay}");

--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -226,7 +226,8 @@ public class ConsoleMetricExporter : ConsoleExporter<Metric>
                     msg.Append(' ');
                 }
 
-                msg.Append(metric.MetricType);
+                msg.AppendLine();
+                msg.AppendLine(CultureInfo.InvariantCulture, $"Metric Type: {metric.MetricType}");
                 msg.AppendLine();
 #if NET
                 msg.Append(CultureInfo.InvariantCulture, $"Value: {valueDisplay}");


### PR DESCRIPTION
MetricType was printed on same line as Tags/Attributes which was making it hard to read. This just moves it to newline.

Before:

```txt
Metric Name: MyHistogram, Description: , Unit: 
(2025-07-17T15:26:39.2086010Z, 2025-07-17T15:26:39.2137620Z] tag1: value1 tag2: value2Histogram
```

After:

```txt
Metric Name: MyHistogram, Description: , Unit: 
(2025-07-17T15:30:20.9946740Z, 2025-07-17T15:30:21.0003940Z] tag1: value1 tag2: value2
Metric Type: Histogram
```