### PR TITLE
Add FormatMessage option to self diagnostics

### DIFF
--- a/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsConfigParserTests.cs
+++ b/test/OpenTelemetry.Tests/Internal/SelfDiagnosticsConfigParserTests.cs
@@ -72,4 +72,17 @@ public class SelfDiagnosticsConfigParserTests
         Assert.True(SelfDiagnosticsConfigParser.TryParseLogLevel(configJson, out string? logLevelString));
         Assert.Equal("Error", logLevelString);
     }
+
+    [Fact]
+    public void SelfDiagnosticsConfigParser_TryParseFormatMessage()
+    {
+        string configJson = @"{
+                    ""LogDirectory"": ""Diagnostics"",
+                    ""FileSize"": 1024,
+                    ""LogLevel"": ""Error"",
+                    ""FormatMessage"": ""true""
+                    }";
+        Assert.True(SelfDiagnosticsConfigParser.TryParseFormatMessage(configJson, out bool formatMessage));
+        Assert.True(formatMessage);
+    }
 }


### PR DESCRIPTION
## Summary
- add `FormatMessage` to self diagnostics config parser
- respect `FormatMessage` in `SelfDiagnosticsConfigRefresher`
- allow `SelfDiagnosticsEventListener` to format messages
- test new configuration and logging behavior

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ed81223608324bc982bcbfb6e8cd7