### PR TITLE
[OTLP] Dispose exporter if setup fails

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporterHelperExtensions.cs
@@ -327,25 +327,33 @@ public static class OtlpLogExporterHelperExtensions
             experimentalOptions!);
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
-        if (configureExporterInstance != null)
+        try
         {
-            otlpExporter = configureExporterInstance(otlpExporter);
-        }
+            if (configureExporterInstance != null)
+            {
+                otlpExporter = configureExporterInstance(otlpExporter);
+            }
 
-        if (processorOptions!.ExportProcessorType == ExportProcessorType.Simple)
-        {
-            return new SimpleLogRecordExportProcessor(otlpExporter);
-        }
-        else
-        {
-            var batchOptions = processorOptions.BatchExportProcessorOptions;
+            if (processorOptions!.ExportProcessorType == ExportProcessorType.Simple)
+            {
+                return new SimpleLogRecordExportProcessor(otlpExporter);
+            }
+            else
+            {
+                var batchOptions = processorOptions.BatchExportProcessorOptions;
 
-            return new BatchLogRecordExportProcessor(
-                otlpExporter,
-                batchOptions.MaxQueueSize,
-                batchOptions.ScheduledDelayMilliseconds,
-                batchOptions.ExporterTimeoutMilliseconds,
-                batchOptions.MaxExportBatchSize);
+                return new BatchLogRecordExportProcessor(
+                    otlpExporter,
+                    batchOptions.MaxQueueSize,
+                    batchOptions.ScheduledDelayMilliseconds,
+                    batchOptions.ExporterTimeoutMilliseconds,
+                    batchOptions.MaxExportBatchSize);
+            }
+        }
+        catch (Exception)
+        {
+            otlpExporter.Dispose();
+            throw;
         }
     }
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporterHelperExtensions.cs
@@ -350,7 +350,7 @@ public static class OtlpLogExporterHelperExtensions
                     batchOptions.MaxExportBatchSize);
             }
         }
-        catch (Exception)
+        catch
         {
             otlpExporter.Dispose();
             throw;

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
@@ -172,7 +172,7 @@ public static class OtlpTraceExporterHelperExtensions
                     batchExportProcessorOptions.MaxExportBatchSize);
             }
         }
-        catch (Exception)
+        catch
         {
             otlpExporter.Dispose();
             throw;

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
@@ -151,23 +151,31 @@ public static class OtlpTraceExporterHelperExtensions
         BaseExporter<Activity> otlpExporter = new OtlpTraceExporter(exporterOptions!, sdkLimitOptions!, experimentalOptions!);
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
-        if (configureExporterInstance != null)
+        try
         {
-            otlpExporter = configureExporterInstance(otlpExporter);
-        }
+            if (configureExporterInstance != null)
+            {
+                otlpExporter = configureExporterInstance(otlpExporter);
+            }
 
-        if (exportProcessorType == ExportProcessorType.Simple)
-        {
-            return new SimpleActivityExportProcessor(otlpExporter);
+            if (exportProcessorType == ExportProcessorType.Simple)
+            {
+                return new SimpleActivityExportProcessor(otlpExporter);
+            }
+            else
+            {
+                return new BatchActivityExportProcessor(
+                    otlpExporter,
+                    batchExportProcessorOptions!.MaxQueueSize,
+                    batchExportProcessorOptions.ScheduledDelayMilliseconds,
+                    batchExportProcessorOptions.ExporterTimeoutMilliseconds,
+                    batchExportProcessorOptions.MaxExportBatchSize);
+            }
         }
-        else
+        catch (Exception)
         {
-            return new BatchActivityExportProcessor(
-                otlpExporter,
-                batchExportProcessorOptions!.MaxQueueSize,
-                batchExportProcessorOptions.ScheduledDelayMilliseconds,
-                batchExportProcessorOptions.ExporterTimeoutMilliseconds,
-                batchExportProcessorOptions.MaxExportBatchSize);
+            otlpExporter.Dispose();
+            throw;
         }
     }
 }


### PR DESCRIPTION
Relates to question in [#otel-dotnet Slack channel](https://cloud-native.slack.com/archives/C01N3BC2W7Q/p1752825125859589?thread_ts=1752739794.707009&cid=C01N3BC2W7Q).

## Changes

Dispose of the constructed exporter if an exception is thrown before the processor is initialized, such as if `configureExporterInstance` throws.

The suppression is retained as it's required as the analyzer doesn't understand that control of the object's lifetime is passed to the processor, which will dispose of the exporter.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
