### PR TITLE
[infra] use env. var. to read github body comment

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -198,6 +198,8 @@ jobs:
         token: ${{ secrets[needs.automation.outputs.token-secret-name] }}
 
     - name: Update release notes
+      env:
+        COMMENT_BODY: ${{ github.event.comment.body }}
       shell: pwsh
       run: |
         Import-Module .\build\scripts\prepare-release.psm1
@@ -207,6 +209,6 @@ jobs:
           -pullRequestNumber '${{ github.event.issue.number }}' `
           -botUserName '${{ needs.automation.outputs.username }}' `
           -commentUserName '${{ github.event.comment.user.login }}' `
-          -commentBody '${{ github.event.comment.body }}' `
+          -commentBody $Env:COMMENT_BODY `
           -gitUserName '${{ needs.automation.outputs.username }}' `
           -gitUserEmail '${{ needs.automation.outputs.email }}'


### PR DESCRIPTION
Handles Dangerous-Workflow issue found by [OpenSSF Scorecard report](https://scorecard.dev/viewer/?uri=github.com/open-telemetry/opentelemetry-dotnet)

## Changes

Use env. var. to pass body comment from GH to the PowerShell script to avoid injecting malicious code to our pipeline

Tested on my fork, screen from the results (please ignore issue related to the long line and the fact that it was using my account, it is the way how I configured bot):
<img width="3727" height="1267" alt="image" src="https://github.com/user-attachments/assets/5273b3d0-2044-4927-92b5-23dd74cc4541" />


## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
