### PR TITLE
[Infra] Exclude keep-open label from stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,4 +28,5 @@ jobs:
           days-before-pr-close: 7
           days-before-issue-close: 7
           exempt-all-issue-milestones: true
-          exempt-issue-labels: needs-triage
+          exempt-issue-labels: 'keep-open,needs-triage'
+          exempt-pr-labels: 'keep-open'


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/2923#pullrequestreview-3054330365.

## Changes

Exclude issues and pull requests labelled with `keep-open` from the stale automation.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
