### PR TITLE
[Infra] Bump Cosign to v2.5.3

### DIFF
--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Install Cosign
       uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
       with:
-        cosign-release: v2.4.0
+        cosign-release: v2.5.3
 
     - name: dotnet restore
       run: dotnet restore ./build/OpenTelemetry.proj -p:RunningDotNetPack=true


### PR DESCRIPTION
## Changes

Bump Cosign to the latest release, [v2.5.3](https://github.com/sigstore/cosign/releases/tag/v2.5.3).

I noticed it was several releases old while working on #6416.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
