### PR TITLE
[OTLP] Set TE header for gRPC calls

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -19,6 +19,10 @@ Notes](../../RELEASENOTES.md).
   Note that exporting `logrecord.event.id` is still behind that same feature
   flag. ([#6306](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6306))
 
+* gRPC calls to export traces, logs, and metrics using `OtlpExportProtocol.Grpc`
+  now set the `TE=trailers` HTTP request header to improve interoperability.
+  ([#6449](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6449))
+
 ## 1.12.0
 
 Released 2025-Apr-29

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcExportClient.cs
@@ -39,6 +39,11 @@ internal sealed class OtlpGrpcExportClient : OtlpExportClient
         try
         {
             using var httpRequest = this.CreateHttpRequest(buffer, contentLength);
+
+            // TE is required by some servers, e.g. C Core.
+            // A missing TE header results in servers aborting the gRPC call.
+            httpRequest.Headers.TryAddWithoutValidation("TE", "trailers");
+
             using var httpResponse = this.SendHttpRequest(httpRequest, cancellationToken);
 
             httpResponse.EnsureSuccessStatusCode();


### PR DESCRIPTION
Potentially resolves #6296.

## Changes

Set `TE=trailers` header for gRPC calls.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
