### PR TITLE
Improve instrument name validation and log messages

### DIFF
--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -21,6 +21,10 @@ Notes](../../RELEASENOTES.md).
   }
   ```
 
+* Moved the `InstrumentNameRegex` from `MeterProviderBuilderSdk` to `Guard`.
+  This regex is used to validate the view and instrument name. If you overwrite
+  the validation regex using reflection you have to update the code.
+
 ## 1.12.0
 
 Released 2025-Apr-29

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderExtensions.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderExtensions.cs
@@ -105,10 +105,7 @@ public static class MeterProviderBuilderExtensions
     {
         Guard.ThrowIfNull(instrumentName);
 
-        if (!MeterProviderBuilderSdk.IsValidInstrumentName(name))
-        {
-            throw new ArgumentException($"Custom view name {name} is invalid.", nameof(name));
-        }
+        Guard.ThrowIfInvalidCustomViewName(name);
 
 #pragma warning disable CA1062 // Validate arguments of public methods - needed for netstandard2.1
 #if NET || NETSTANDARD2_1_OR_GREATER

--- a/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderSdk.cs
+++ b/src/OpenTelemetry/Metrics/Builder/MeterProviderBuilderSdk.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
-using System.Text.RegularExpressions;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Resources;
@@ -27,14 +26,6 @@ internal sealed class MeterProviderBuilderSdk : MeterProviderBuilder, IMeterProv
         this.serviceProvider = serviceProvider;
     }
 
-    // Note: We don't use static readonly here because some customers
-    // replace this using reflection which is not allowed on initonly static
-    // fields. See: https://github.com/dotnet/runtime/issues/11571.
-    // Customers: This is not guaranteed to work forever. We may change this
-    // mechanism in the future do this at your own risk.
-    public static Regex InstrumentNameRegex { get; set; } = new(
-        @"^[a-z][a-z0-9-._/]{0,254}$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
     public List<InstrumentationRegistration> Instrumentation { get; } = new();
 
     public ResourceBuilder? ResourceBuilder { get; private set; }
@@ -52,39 +43,6 @@ internal sealed class MeterProviderBuilderSdk : MeterProviderBuilder, IMeterProv
     public int MetricLimit { get; private set; } = DefaultMetricLimit;
 
     public int CardinalityLimit { get; private set; } = DefaultCardinalityLimit;
-
-    /// <summary>
-    /// Returns whether the given instrument name is valid according to the specification.
-    /// </summary>
-    /// <remarks>See specification: <see href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument"/>.</remarks>
-    /// <param name="instrumentName">The instrument name.</param>
-    /// <returns>Boolean indicating if the instrument is valid.</returns>
-    public static bool IsValidInstrumentName(string instrumentName)
-    {
-        if (string.IsNullOrWhiteSpace(instrumentName))
-        {
-            return false;
-        }
-
-        return InstrumentNameRegex.IsMatch(instrumentName);
-    }
-
-    /// <summary>
-    /// Returns whether the given custom view name is valid according to the specification.
-    /// </summary>
-    /// <remarks>See specification: <see href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument"/>.</remarks>
-    /// <param name="customViewName">The view name.</param>
-    /// <returns>Boolean indicating if the instrument is valid.</returns>
-    public static bool IsValidViewName(string customViewName)
-    {
-        // Only validate the view name in case it's not null. In case it's null, the view name will be the instrument name as per the spec.
-        if (customViewName == null)
-        {
-            return true;
-        }
-
-        return InstrumentNameRegex.IsMatch(customViewName);
-    }
 
     public void RegisterProvider(MeterProviderSdk meterProvider)
     {

--- a/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
+++ b/src/OpenTelemetry/Metrics/MeterProviderSdk.cs
@@ -260,7 +260,7 @@ internal sealed class MeterProviderSdk : MeterProvider
 
             if (viewConfigCount <= 0)
             {
-                if (!MeterProviderBuilderSdk.IsValidInstrumentName(instrument.Name))
+                if (!Guard.IsValidInstrumentName(instrument.Name))
                 {
                     OpenTelemetrySdkEventSource.Log.MetricInstrumentIgnored(
                         instrument.Name,

--- a/src/OpenTelemetry/Metrics/Reader/MetricReaderExt.cs
+++ b/src/OpenTelemetry/Metrics/Reader/MetricReaderExt.cs
@@ -126,13 +126,24 @@ public abstract partial class MetricReader
                     ? this.exemplarFilterForHistograms ?? this.exemplarFilter
                     : this.exemplarFilter;
 
-                if (!MeterProviderBuilderSdk.IsValidInstrumentName(metricStreamIdentity.InstrumentName))
+                if (!Guard.IsValidInstrumentName(metricStreamIdentity.InstrumentName))
                 {
-                    OpenTelemetrySdkEventSource.Log.MetricInstrumentIgnored(
+                    if (metricStreamConfig?.Name == null)
+                    {
+                        OpenTelemetrySdkEventSource.Log.MetricInstrumentIgnored(
                         metricStreamIdentity.InstrumentName,
                         metricStreamIdentity.MeterName,
-                        "Metric name is invalid.",
+                        "Instrument name is invalid.",
                         "The name must comply with the OpenTelemetry specification.");
+                    }
+                    else
+                    {
+                        OpenTelemetrySdkEventSource.Log.MetricInstrumentIgnored(
+                        metricStreamIdentity.InstrumentName,
+                        metricStreamIdentity.MeterName,
+                        "View name is invalid.",
+                        "The name must comply with the OpenTelemetry specification.");
+                    }
 
                     continue;
                 }

--- a/src/OpenTelemetry/Metrics/View/MetricStreamConfiguration.cs
+++ b/src/OpenTelemetry/Metrics/View/MetricStreamConfiguration.cs
@@ -37,10 +37,7 @@ public class MetricStreamConfiguration
         get => this.name;
         set
         {
-            if (value != null && !MeterProviderBuilderSdk.IsValidViewName(value))
-            {
-                throw new ArgumentException($"Custom view name {value} is invalid.", nameof(value));
-            }
+            Guard.ThrowIfInvalidViewName(value);
 
             this.name = value;
         }

--- a/src/Shared/Guard.cs
+++ b/src/Shared/Guard.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 
 #pragma warning disable SA1402 // File may only contain a single type
 #pragma warning disable SA1403 // File may only contain a single namespace
@@ -48,6 +49,14 @@ namespace OpenTelemetry.Internal
     /// </summary>
     internal static class Guard
     {
+        // Note: We don't use static readonly here because some customers
+        // replace this using reflection which is not allowed on initonly static
+        // fields. See: https://github.com/dotnet/runtime/issues/11571.
+        // Customers: This is not guaranteed to work forever. We may change this
+        // mechanism in the future do this at your own risk.
+        public static Regex InstrumentNameRegex { get; set; } = new(
+            @"^[a-z][a-z0-9-._/]{0,254}$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
         /// <summary>
         /// Throw an exception if the value is null.
         /// </summary>
@@ -176,6 +185,74 @@ namespace OpenTelemetry.Internal
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Throws an exception if the given view name is invalid according to the specification.
+        /// Null is valid because the instrument name will be used as the view name.
+        /// </summary>
+        /// <remarks>See specification: <see href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument"/>.</remarks>
+        /// <param name="viewName">The view name.</param>
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfInvalidViewName(string? viewName)
+        {
+            if (!IsValidViewName(viewName))
+            {
+                throw new ArgumentException($"View name {viewName} is invalid.", nameof(viewName));
+            }
+        }
+
+        /// <summary>
+        /// Throws an exception if the given custom view name is invalid according to the specification.
+        /// </summary>
+        /// <remarks>See specification: <see href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument"/>.</remarks>
+        /// <param name="viewName">The view name.</param>
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ThrowIfInvalidCustomViewName(string viewName)
+        {
+            if (!IsValidInstrumentName(viewName))
+            {
+                throw new ArgumentException($"Custom view name {viewName} is invalid.", nameof(viewName));
+            }
+        }
+
+        /// <summary>
+        /// Returns whether the given instrument name is valid according to the specification.
+        /// </summary>
+        /// <remarks>See specification: <see href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument"/>.</remarks>
+        /// <param name="instrumentName">The instrument name.</param>
+        /// <returns>Boolean indicating if the instrument is valid.</returns>
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsValidInstrumentName(string instrumentName)
+        {
+            if (string.IsNullOrWhiteSpace(instrumentName))
+            {
+                return false;
+            }
+
+            return InstrumentNameRegex.IsMatch(instrumentName);
+        }
+
+        /// <summary>
+        /// Returns whether the given custom view name is valid according to the specification.
+        /// </summary>
+        /// <remarks>See specification: <see href="https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument"/>.</remarks>
+        /// <param name="customViewName">The view name.</param>
+        /// <returns>Boolean indicating if the instrument is valid.</returns>
+        [DebuggerHidden]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsValidViewName(string? customViewName)
+        {
+            // Only validate the view name in case it's not null. In case it's null, the view name will be the instrument name as per the spec.
+            if (customViewName == null)
+            {
+                return true;
+            }
+
+            return InstrumentNameRegex.IsMatch(customViewName);
         }
 
         [DebuggerHidden]


### PR DESCRIPTION
Fixes #2532

## Changes

I moved the validation of view name and instrument name into Guard helpers. I improved the log message, specifying the incorrect metric name, as suggested in the issue.

The code has changed quite a bit since this issue was opened, so I'm not entirely sure whether my approach matches the original intent. 

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
