### PR TITLE
Fix and tests for multiple metric readers

### DIFF
--- a/src/OpenTelemetry/Metrics/Reader/MetricReader.cs
+++ b/src/OpenTelemetry/Metrics/Reader/MetricReader.cs
@@ -218,6 +218,11 @@ public abstract partial class MetricReader : IDisposable
 
     internal virtual void SetParentProvider(BaseProvider parentProvider)
     {
+        if (this.parentProvider != null && this.parentProvider != parentProvider)
+        {
+            throw new NotSupportedException("A MetricReader must not be registered with multiple MeterProviders.");
+        }
+
         this.parentProvider = parentProvider;
     }
 


### PR DESCRIPTION
Fixes #2938 

## Changes

- Added tests as suggested in the issue
- Fix: the spec states ["The SDK MUST NOT allow a MetricReader instance to be registered on more than one MeterProvider instance"](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#metricreader). Added a test for this and noticed that the test failed, so I added a verification in the MetricReader.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [x] Changes in public API reviewed (if applicable)
