### PR TITLE
Decode the OTEL_RESOURCE_ATTRIBUTES environment variable according to the spec

### DIFF
--- a/src/OpenTelemetry/Resources/OtelEnvResourceDetector.cs
+++ b/src/OpenTelemetry/Resources/OtelEnvResourceDetector.cs
@@ -78,13 +78,13 @@ internal sealed class OtelEnvResourceDetector : IResourceDetector
             }
             else if (baggageEncoded[i] == '%')
             {
-                return baggageEncoded;
+                return baggageEncoded; // Bad percent triplet -> return original value
             }
             else
             {
                 if (!IsBaggageOctet(baggageEncoded[i]))
                 {
-                    return baggageEncoded;
+                    return baggageEncoded; // non-encoded character not baggage octet encoded -> return original value
                 }
 
                 bytes.Add((byte)baggageEncoded[i]);

--- a/test/OpenTelemetry.Tests/Resources/OtelEnvResourceDetectorTests.cs
+++ b/test/OpenTelemetry.Tests/Resources/OtelEnvResourceDetectorTests.cs
@@ -88,7 +88,7 @@ public sealed class OtelEnvResourceDetectorTests : IDisposable
     }
 
     [Fact]
-    public void OtelEnvResource_InvalidValueEncoding()
+    public void OtelEnvResource_InvalidValueEncoding_InEnvVar()
     {
         // Arrange
         var envVarValue = "key=invalid%encoding";
@@ -104,7 +104,7 @@ public sealed class OtelEnvResourceDetectorTests : IDisposable
     }
 
     [Fact]
-    public void OtelEnvResource_InvalidKeyEncoding()
+    public void OtelEnvResource_InvalidKeyEncoding_InEnvVar()
     {
         // Arrange
         var envVarValue = "Amélie=value";
@@ -119,7 +119,7 @@ public sealed class OtelEnvResourceDetectorTests : IDisposable
     }
 
     [Fact]
-    public void OtelEnvResource_ValidPercentEncodedValue()
+    public void OtelEnvResource_ValidPercentEncodedValue_InEnvVar()
     {
         // Arrange
         var envVarValue = "key=Am%C3%A9lie"; // "Amélie" with é encoded
@@ -135,7 +135,7 @@ public sealed class OtelEnvResourceDetectorTests : IDisposable
     }
 
     [Fact]
-    public void OtelEnvResource_ValidValueEncodingWithEqualSign()
+    public void OtelEnvResource_ValidValueEncodingWithEqualSign_InEnvVar()
     {
         // Arrange
         var envVarValue = "key1=value1,key2=value2==3";
@@ -151,7 +151,7 @@ public sealed class OtelEnvResourceDetectorTests : IDisposable
     }
 
     [Fact]
-    public void OtelEnvResource_EmptyValue()
+    public void OtelEnvResource_EmptyValue_InEnvVar()
     {
         // Arrange
         var envVarValue = "key1=,key2=val2";
@@ -167,7 +167,7 @@ public sealed class OtelEnvResourceDetectorTests : IDisposable
     }
 
     [Fact]
-    public void OtelEnvResource_EmptyKey()
+    public void OtelEnvResource_EmptyKey_InEnvVar()
     {
         // Arrange
         var envVarValue = "=val1,key2=val2";


### PR DESCRIPTION
Fixes #3395 

## Changes

Added percent-decoding of the `OTEL_RESOURCE_ATTRIBUTES` variable according to the spec, adhering to the [W3C Baggage](https://github.com/w3c/baggage/blob/main/baggage/HTTP_HEADER_FORMAT.md) format. As in the [Go implementation](https://github.com/open-telemetry/opentelemetry-go/pull/2963), I retained the original value in case decoding fails.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
