### PR TITLE
[Infra] Use dotnet nuget to push packages

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -49,6 +49,9 @@ jobs:
         token: ${{ secrets[needs.automation.outputs.token-secret-name] }}
         ref: ${{ github.event.repository.default_branch }}
 
+    - name: Setup .NET
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+
     - name: Push packages and publish release
       shell: pwsh
       env:

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -87,12 +87,15 @@ jobs:
         if-no-files-found: error
 
     - name: Publish MyGet
+      working-directory: ./artifacts/package/release
       env:
         MYGET_TOKEN_EXISTS: ${{ secrets.MYGET_TOKEN != '' }}
+        API_KEY: ${{ secrets.MYGET_TOKEN }}
+        SOURCE: https://www.myget.org/F/opentelemetry/api/v2/package
       if: env.MYGET_TOKEN_EXISTS == 'true' # Skip MyGet publish if run on a fork without the secret
+      shell: pwsh
       run: |
-        nuget setApiKey ${{ secrets.MYGET_TOKEN }} -Source https://www.myget.org/F/opentelemetry/api/v2/package
-        nuget push ./artifacts/package/release/*.nupkg -Source https://www.myget.org/F/opentelemetry/api/v2/package
+        dotnet nuget push *.nupkg --api-key ${env:API_KEY} --skip-duplicate --source ${env:SOURCE}
 
   post-build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -133,7 +133,7 @@ jobs:
         CreateDraftRelease `
           -gitRepository '${{ github.repository }}' `
           -tag '${{ github.ref_name }}' `
-          -releaseFiles '${{ github.workspace }}/artifacts/${{ github.ref_name }}-packages.zip#Packages'
+          -releaseFiles '${{ github.workspace }}/artifacts/${{ github.ref_name }}-packages.zip'
 
     - name: Post notice when packages are ready
       shell: pwsh

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -236,7 +236,7 @@ function PushPackagesPublishReleaseUnlockAndPostNoticeOnPrepareReleasePullReques
     gh pr comment $pullRequestNumber `
       --body "I am uploading the packages for ``$tag`` to NuGet and then I will publish the release."
 
-    nuget push "$artifactDownloadPath/**/*.nupkg" -Source https://api.nuget.org/v3/index.json -ApiKey "$env:NUGET_TOKEN" -SymbolApiKey "$env:NUGET_TOKEN"
+    dotnet nuget push "$artifactDownloadPath/**/*.nupkg" --source https://api.nuget.org/v3/index.json --api-key "$env:NUGET_TOKEN" --symbol-api-key "$env:NUGET_TOKEN"
 
     if ($LASTEXITCODE -gt 0)
     {


### PR DESCRIPTION
Replaces #6462 as EasyCLA doesn't work on branches anymore. https://github.com/open-telemetry/opentelemetry-dotnet/pull/6462#issuecomment-3268857240

## Changes

- Use `dotnet nuget` instead of `nuget` so that the version is deterministic from the .NET SDK version, as well as consistent with opentelemetry-dotnet-contrib.
- Copy fix from https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3058.
- Copy fix from https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/3061.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
