### PR TITLE
[Infra] Set workflow job timeout to 30m

### DIFF
--- a/.github/workflows/Component.BuildTest.yml
+++ b/.github/workflows/Component.BuildTest.yml
@@ -50,6 +50,7 @@ jobs:
           version: net8.0
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:


### PR DESCRIPTION
## Changes

The default is 6 hours, but no job should take longer than 30 minutes (most are much less anyway, ~10 minutes).

For example, [this job](https://github.com/open-telemetry/opentelemetry-dotnet/actions/runs/17608601770/job/50025072698?pr=6307) hung and got cancelled after 6 hours.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
