### PR TITLE
[Infra] Fix merged PR survey workflow

### DIFF
--- a/.github/workflows/survey-on-merged-pr.yml
+++ b/.github/workflows/survey-on-merged-pr.yml
@@ -13,8 +13,11 @@ jobs:
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
-    # Only run for merged pull requests by non-members
-    if: github.event.pull_request.merged && contains(fromJson('["CONTRIBUTOR", "FIRST_TIME_CONTRIBUTOR", "FIRST_TIMER"]'), github.event.pull_request.author_association)
+    # Only run for merged pull requests by non-members users (i.e. not bots)
+    if: |
+      github.event.pull_request.merged &&
+      github.event.pull_request.user.type == 'User' &&
+      contains(fromJson('["CONTRIBUTOR", "FIRST_TIME_CONTRIBUTOR", "FIRST_TIMER"]'), github.event.pull_request.author_association)
     steps:
       - name: Add comment
         run: |


### PR DESCRIPTION
## Changes

While pull requests _are_ issues, closing them doesn't trigger the `issue:closed` event. This was a misunderstanding on my part when I suggested the changes to #6469.

Instead switch to `pull_request_target`, but with minimal permissions and repository access to ensure access is secure.

Concept tested here: [martincostello/workflow-testing](https://github.com/martincostello/workflow-testing)

/cc @maryliag

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
