### PR TITLE
[Infra] Update renovate configuration to include tests and examples

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,16 @@
     ":gitSignOff",
     ":ignoreUnstable"
   ],
+  "ignorePresets": [
+    ":ignoreModulesAndTests"
+  ],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/__tests__/**",
+    "**/__fixtures__/**"
+  ],
   "labels": ["dependencies", "infra"],
   "packageRules": [
     {


### PR DESCRIPTION
## Changes

Disable the built-in `ignoreModulesAndTests` preset, then manually specify the equivalent settings except without the exclusion for examples and test(s).

Approach based on [renovatebot/renovate/discussions/25354](https://github.com/renovatebot/renovate/discussions/25354#discussioncomment-8399068).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
