### PR TITLE
[Infra] Use NuGet Trusted Publishing

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -30,6 +30,9 @@ jobs:
 
     needs: automation
 
+    permissions:
+      id-token: write
+
     if: |
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
@@ -56,6 +59,12 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
 
+    - name: NuGet log in
+      uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # v1.1.0
+      id: nuget-login
+      with:
+        user: ${{ secrets.NUGET_USER }}
+
     - name: Push packages and publish release
       shell: pwsh
       env:
@@ -63,7 +72,7 @@ jobs:
         EXPECTED_PR_AUTHOR_USER_NAME: ${{ needs.automation.outputs.application-name }}
         COMMENT_USER_NAME: ${{ github.event.comment.user.login }}
         ISSUE_NUMBER: ${{ github.event.issue.number }}
-        NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}
+        NUGET_TOKEN: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
       run: |
         Import-Module .\build\scripts\post-release.psm1
 


### PR DESCRIPTION
Fixes #6490

## Changes

Switch to using GitHub OIDC for pushing packages to NuGet.org with [Trusted Publishing](https://devblogs.microsoft.com/dotnet/enhanced-security-is-here-with-the-new-trust-publishing-on-nuget-org/).

Requires a Trusted Publishing policy to be created in NuGet.org and then the `NUGET_USER` to be added to the repository secrets with the appropriate value for the person who set up the policy.

Required values for the policy:

- `open-telemetry`
- `opentelemetry-dotnet`
- `post-release.yml`

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
