### PR TITLE
[repo] Add Piotr Kiełkowicz as a maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ you're more than welcome to participate!
 ### Maintainers
 
 * [Alan West](https://github.com/alanwest), New Relic
+* [Piotr Kie&#x142;kowicz](https://github.com/Kielek), Splunk
 * [Rajkumar Rangaraj](https://github.com/rajkumar-rangaraj), Microsoft
 
 For more information about the maintainer role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).
@@ -248,7 +249,6 @@ For more information about the maintainer role, see the [community repository](h
 * [Cijo Thomas](https://github.com/cijothomas), Microsoft
 * [Martin Costello](https://github.com/martincostello), Grafana Labs
 * [Mikel Blanchard](https://github.com/CodeBlanch), Microsoft
-* [Piotr Kie&#x142;kowicz](https://github.com/Kielek), Splunk
 
 For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).
 


### PR DESCRIPTION
I’m very happy to welcome Piotr as a maintainer for the OpenTelemetry .NET SDK repo. 🎉

Piotr is already a maintainer in the .NET Instrumentation and .NET Contrib repositories, and he has made several valuable contributions to the SDK repo that have helped ensure its quality and reliability. He is also one of the top contributors in the broader OpenTelemetry community, with a strong understanding of the specification.

We’re excited to have him officially join the maintainer team for the SDK repo and look forward to continuing the great collaboration ahead!
