### PR TITLE
Use spans for serialization

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
@@ -62,13 +62,13 @@ internal static class ProtobufOtlpLogSerializer
 
             try
             {
-                writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpLogFieldNumberConstants.LogsData_Resource_Logs, ProtobufWireType.LEN);
+                writePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(writePosition), ProtobufOtlpLogFieldNumberConstants.LogsData_Resource_Logs, ProtobufWireType.LEN);
                 int logsDataLengthPosition = writePosition;
                 writePosition += ReserveSizeForLength;
 
                 writePosition = WriteResourceLogs(buffer, writePosition, sdkLimitOptions, experimentalOptions, resource, scopeLogs);
 
-                ProtobufSerializer.WriteReservedLength(buffer, logsDataLengthPosition, writePosition - (logsDataLengthPosition + ReserveSizeForLength));
+                ProtobufSerializer.WriteReservedLength(buffer.AsSpan(logsDataLengthPosition), writePosition - (logsDataLengthPosition + ReserveSizeForLength));
 
                 // Serialization succeeded, return the final write position
                 return writePosition;
@@ -129,12 +129,12 @@ internal static class ProtobufOtlpLogSerializer
         {
             foreach (KeyValuePair<string, List<LogRecord>> entry in scopeLogs)
             {
-                writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpLogFieldNumberConstants.ResourceLogs_Scope_Logs, ProtobufWireType.LEN);
+                writePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(writePosition), ProtobufOtlpLogFieldNumberConstants.ResourceLogs_Scope_Logs, ProtobufWireType.LEN);
                 int resourceLogsScopeLogsLengthPosition = writePosition;
                 writePosition += ReserveSizeForLength;
 
                 writePosition = WriteScopeLog(buffer, writePosition, sdkLimitOptions, experimentalOptions, entry.Value[0].Logger.Name, entry.Value);
-                ProtobufSerializer.WriteReservedLength(buffer, resourceLogsScopeLogsLengthPosition, writePosition - (resourceLogsScopeLogsLengthPosition + ReserveSizeForLength));
+                ProtobufSerializer.WriteReservedLength(buffer.AsSpan(resourceLogsScopeLogsLengthPosition), writePosition - (resourceLogsScopeLogsLengthPosition + ReserveSizeForLength));
             }
         }
 
@@ -148,8 +148,8 @@ internal static class ProtobufOtlpLogSerializer
         var serializedLengthSize = ProtobufSerializer.ComputeVarInt64Size((ulong)numberOfUtf8CharsInString);
 
         // numberOfUtf8CharsInString + tagSize + length field size.
-        writePosition = ProtobufSerializer.WriteTagAndLength(buffer, writePosition, numberOfUtf8CharsInString + 1 + serializedLengthSize, ProtobufOtlpLogFieldNumberConstants.ScopeLogs_Scope, ProtobufWireType.LEN);
-        writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Name, numberOfUtf8CharsInString, value);
+        writePosition += ProtobufSerializer.WriteTagAndLength(buffer.AsSpan(writePosition), numberOfUtf8CharsInString + 1 + serializedLengthSize, ProtobufOtlpLogFieldNumberConstants.ScopeLogs_Scope, ProtobufWireType.LEN);
+        writePosition += ProtobufSerializer.WriteStringWithTag(buffer.AsSpan(writePosition), ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Name, numberOfUtf8CharsInString, value);
 
         for (int i = 0; i < logRecords.Count; i++)
         {
@@ -175,23 +175,23 @@ internal static class ProtobufOtlpLogSerializer
 
         ref var otlpTagWriterState = ref state.TagWriterState;
 
-        otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpLogFieldNumberConstants.ScopeLogs_Log_Records, ProtobufWireType.LEN);
+        otlpTagWriterState.WritePosition += ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer.AsSpan(otlpTagWriterState.WritePosition), ProtobufOtlpLogFieldNumberConstants.ScopeLogs_Log_Records, ProtobufWireType.LEN);
         int logRecordLengthPosition = otlpTagWriterState.WritePosition;
         otlpTagWriterState.WritePosition += ReserveSizeForLength;
 
         var timestamp = (ulong)logRecord.Timestamp.ToUnixTimeNanoseconds();
-        otlpTagWriterState.WritePosition = ProtobufSerializer.WriteFixed64WithTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpLogFieldNumberConstants.LogRecord_Time_Unix_Nano, timestamp);
-        otlpTagWriterState.WritePosition = ProtobufSerializer.WriteFixed64WithTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpLogFieldNumberConstants.LogRecord_Observed_Time_Unix_Nano, timestamp);
+        otlpTagWriterState.WritePosition += ProtobufSerializer.WriteFixed64WithTag(otlpTagWriterState.Buffer.AsSpan(otlpTagWriterState.WritePosition), ProtobufOtlpLogFieldNumberConstants.LogRecord_Time_Unix_Nano, timestamp);
+        otlpTagWriterState.WritePosition += ProtobufSerializer.WriteFixed64WithTag(otlpTagWriterState.Buffer.AsSpan(otlpTagWriterState.WritePosition), ProtobufOtlpLogFieldNumberConstants.LogRecord_Observed_Time_Unix_Nano, timestamp);
 
-        otlpTagWriterState.WritePosition = ProtobufSerializer.WriteEnumWithTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpLogFieldNumberConstants.LogRecord_Severity_Number, logRecord.Severity.HasValue ? (int)logRecord.Severity : 0);
+        otlpTagWriterState.WritePosition += ProtobufSerializer.WriteEnumWithTag(otlpTagWriterState.Buffer.AsSpan(otlpTagWriterState.WritePosition), ProtobufOtlpLogFieldNumberConstants.LogRecord_Severity_Number, logRecord.Severity.HasValue ? (int)logRecord.Severity : 0);
 
         if (!string.IsNullOrWhiteSpace(logRecord.SeverityText))
         {
-            otlpTagWriterState.WritePosition = ProtobufSerializer.WriteStringWithTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpLogFieldNumberConstants.LogRecord_Severity_Text, logRecord.SeverityText!);
+            otlpTagWriterState.WritePosition += ProtobufSerializer.WriteStringWithTag(otlpTagWriterState.Buffer.AsSpan(otlpTagWriterState.WritePosition), ProtobufOtlpLogFieldNumberConstants.LogRecord_Severity_Text, logRecord.SeverityText!);
         }
         else if (logRecord.Severity.HasValue)
         {
-            otlpTagWriterState.WritePosition = ProtobufSerializer.WriteStringWithTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpLogFieldNumberConstants.LogRecord_Severity_Text, logRecord.Severity.Value.ToShortName());
+            otlpTagWriterState.WritePosition += ProtobufSerializer.WriteStringWithTag(otlpTagWriterState.Buffer.AsSpan(otlpTagWriterState.WritePosition), ProtobufOtlpLogFieldNumberConstants.LogRecord_Severity_Text, logRecord.Severity.Value.ToShortName());
         }
 
         if (experimentalOptions.EmitLogEventAttributes)
@@ -248,30 +248,29 @@ internal static class ProtobufOtlpLogSerializer
 
         if (logRecord.TraceId != default && logRecord.SpanId != default)
         {
-            otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTagAndLength(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, TraceIdSize, ProtobufOtlpLogFieldNumberConstants.LogRecord_Trace_Id, ProtobufWireType.LEN);
+            otlpTagWriterState.WritePosition += ProtobufSerializer.WriteTagAndLength(otlpTagWriterState.Buffer.AsSpan(otlpTagWriterState.WritePosition), TraceIdSize, ProtobufOtlpLogFieldNumberConstants.LogRecord_Trace_Id, ProtobufWireType.LEN);
             otlpTagWriterState.WritePosition = ProtobufOtlpTraceSerializer.WriteTraceId(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, logRecord.TraceId);
 
-            otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTagAndLength(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, SpanIdSize, ProtobufOtlpLogFieldNumberConstants.LogRecord_Span_Id, ProtobufWireType.LEN);
+            otlpTagWriterState.WritePosition += ProtobufSerializer.WriteTagAndLength(otlpTagWriterState.Buffer.AsSpan(otlpTagWriterState.WritePosition), SpanIdSize, ProtobufOtlpLogFieldNumberConstants.LogRecord_Span_Id, ProtobufWireType.LEN);
             otlpTagWriterState.WritePosition = ProtobufOtlpTraceSerializer.WriteSpanId(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, logRecord.SpanId);
 
-            otlpTagWriterState.WritePosition = ProtobufSerializer.WriteFixed32WithTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpLogFieldNumberConstants.LogRecord_Flags, (uint)logRecord.TraceFlags);
+            otlpTagWriterState.WritePosition += ProtobufSerializer.WriteFixed32WithTag(otlpTagWriterState.Buffer.AsSpan(otlpTagWriterState.WritePosition), ProtobufOtlpLogFieldNumberConstants.LogRecord_Flags, (uint)logRecord.TraceFlags);
         }
 
         if (logRecord.EventId.Name != null)
         {
-            otlpTagWriterState.WritePosition = ProtobufSerializer.WriteStringWithTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpLogFieldNumberConstants.LogRecord_Event_Name, logRecord.EventId.Name!);
+            otlpTagWriterState.WritePosition += ProtobufSerializer.WriteStringWithTag(otlpTagWriterState.Buffer.AsSpan(otlpTagWriterState.WritePosition), ProtobufOtlpLogFieldNumberConstants.LogRecord_Event_Name, logRecord.EventId.Name!);
         }
 
         logRecord.ForEachScope(ProcessScope, state);
 
         if (otlpTagWriterState.DroppedTagCount > 0)
         {
-            otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(buffer, otlpTagWriterState.WritePosition, ProtobufOtlpLogFieldNumberConstants.LogRecord_Dropped_Attributes_Count, ProtobufWireType.VARINT);
-            otlpTagWriterState.WritePosition = ProtobufSerializer.WriteVarInt32(buffer, otlpTagWriterState.WritePosition, (uint)otlpTagWriterState.DroppedTagCount);
+            otlpTagWriterState.WritePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(otlpTagWriterState.WritePosition), ProtobufOtlpLogFieldNumberConstants.LogRecord_Dropped_Attributes_Count, ProtobufWireType.VARINT);
+            otlpTagWriterState.WritePosition += ProtobufSerializer.WriteVarInt32(buffer.AsSpan(otlpTagWriterState.WritePosition), (uint)otlpTagWriterState.DroppedTagCount);
         }
 
-        ProtobufSerializer.WriteReservedLength(otlpTagWriterState.Buffer, logRecordLengthPosition, otlpTagWriterState.WritePosition - (logRecordLengthPosition + ReserveSizeForLength));
-
+        ProtobufSerializer.WriteReservedLength(otlpTagWriterState.Buffer.AsSpan(logRecordLengthPosition), otlpTagWriterState.WritePosition - (logRecordLengthPosition + ReserveSizeForLength));
         return otlpTagWriterState.WritePosition;
 
         static void ProcessScope(LogRecordScope scope, SerializationState state)
@@ -314,8 +313,9 @@ internal static class ProtobufOtlpLogSerializer
         var serializedLengthSize = ProtobufSerializer.ComputeVarInt64Size((ulong)numberOfUtf8CharsInString);
 
         // length = numberOfUtf8CharsInString + tagSize + length field size.
-        writePosition = ProtobufSerializer.WriteTagAndLength(buffer, writePosition, numberOfUtf8CharsInString + 1 + serializedLengthSize, ProtobufOtlpLogFieldNumberConstants.LogRecord_Body, ProtobufWireType.LEN);
-        writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpCommonFieldNumberConstants.AnyValue_String_Value, numberOfUtf8CharsInString, value);
+
+        writePosition += ProtobufSerializer.WriteTagAndLength(buffer.AsSpan(writePosition), numberOfUtf8CharsInString + 1 + serializedLengthSize, ProtobufOtlpLogFieldNumberConstants.LogRecord_Body, ProtobufWireType.LEN);
+        writePosition += ProtobufSerializer.WriteStringWithTag(buffer.AsSpan(writePosition), ProtobufOtlpCommonFieldNumberConstants.AnyValue_String_Value, numberOfUtf8CharsInString, value);
         return writePosition;
     }
 
@@ -332,14 +332,14 @@ internal static class ProtobufOtlpLogSerializer
         }
         else
         {
-            state.TagWriterState.WritePosition = ProtobufSerializer.WriteTag(state.TagWriterState.Buffer, state.TagWriterState.WritePosition, ProtobufOtlpLogFieldNumberConstants.LogRecord_Attributes, ProtobufWireType.LEN);
+            state.TagWriterState.WritePosition += ProtobufSerializer.WriteTag(state.TagWriterState.Buffer.AsSpan(state.TagWriterState.WritePosition), ProtobufOtlpLogFieldNumberConstants.LogRecord_Attributes, ProtobufWireType.LEN);
             int logAttributesLengthPosition = state.TagWriterState.WritePosition;
             state.TagWriterState.WritePosition += ReserveSizeForLength;
 
             ProtobufOtlpTagWriter.Instance.TryWriteTag(ref state.TagWriterState, key, value, state.AttributeValueLengthLimit);
 
             var logAttributesLength = state.TagWriterState.WritePosition - (logAttributesLengthPosition + ReserveSizeForLength);
-            ProtobufSerializer.WriteReservedLength(state.TagWriterState.Buffer, logAttributesLengthPosition, logAttributesLength);
+            ProtobufSerializer.WriteReservedLength(state.TagWriterState.Buffer.AsSpan(logAttributesLengthPosition), logAttributesLength);
             state.TagWriterState.TagCount++;
         }
     }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpMetricSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpMetricSerializer.cs
@@ -17,7 +17,7 @@ internal static class ProtobufOtlpMetricSerializer
     [ThreadStatic]
     private static Dictionary<string, List<Metric>>? scopeMetricsList;
 
-    private delegate int WriteExemplarFunc(byte[] buffer, int writePosition, in Exemplar exemplar);
+    private delegate int WriteExemplarFunc(Span<byte> buffer, in Exemplar exemplar);
 
     internal static int WriteMetricsData(ref byte[] buffer, int writePosition, Resources.Resource? resource, in Batch<Metric> batch)
     {
@@ -50,13 +50,13 @@ internal static class ProtobufOtlpMetricSerializer
 
             try
             {
-                writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.MetricsData_Resource_Metrics, ProtobufWireType.LEN);
+                writePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.MetricsData_Resource_Metrics, ProtobufWireType.LEN);
                 int mericsDataLengthPosition = writePosition;
                 writePosition += ReserveSizeForLength;
 
                 writePosition = WriteResourceMetrics(buffer, writePosition, resource, scopeMetrics);
 
-                ProtobufSerializer.WriteReservedLength(buffer, mericsDataLengthPosition, writePosition - (mericsDataLengthPosition + ReserveSizeForLength));
+                ProtobufSerializer.WriteReservedLength(buffer.AsSpan(mericsDataLengthPosition), writePosition - (mericsDataLengthPosition + ReserveSizeForLength));
 
                 // Serialization succeeded, return the final write position
                 return writePosition;
@@ -65,7 +65,6 @@ internal static class ProtobufOtlpMetricSerializer
             {
                 // Reset write position and attempt to increase the buffer size
                 writePosition = entryWritePosition;
-
                 if (!ProtobufSerializer.IncreaseBufferSize(ref buffer, OtlpSignalType.Metrics))
                 {
                     throw;
@@ -102,13 +101,13 @@ internal static class ProtobufOtlpMetricSerializer
         {
             foreach (KeyValuePair<string, List<Metric>> entry in scopeMetrics)
             {
-                writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ResourceMetrics_Scope_Metrics, ProtobufWireType.LEN);
+                writePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.ResourceMetrics_Scope_Metrics, ProtobufWireType.LEN);
                 int resourceMetricsScopeMetricsLengthPosition = writePosition;
                 writePosition += ReserveSizeForLength;
 
                 writePosition = WriteScopeMetric(buffer, writePosition, entry.Key, entry.Value);
 
-                ProtobufSerializer.WriteReservedLength(buffer, resourceMetricsScopeMetricsLengthPosition, writePosition - (resourceMetricsScopeMetricsLengthPosition + ReserveSizeForLength));
+                ProtobufSerializer.WriteReservedLength(buffer.AsSpan(resourceMetricsScopeMetricsLengthPosition), writePosition - (resourceMetricsScopeMetricsLengthPosition + ReserveSizeForLength));
             }
         }
 
@@ -117,7 +116,7 @@ internal static class ProtobufOtlpMetricSerializer
 
     private static int WriteScopeMetric(byte[] buffer, int writePosition, string meterName, List<Metric> metrics)
     {
-        writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ScopeMetrics_Scope, ProtobufWireType.LEN);
+        writePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.ScopeMetrics_Scope, ProtobufWireType.LEN);
         int instrumentationScopeLengthPosition = writePosition;
         writePosition += ReserveSizeForLength;
 
@@ -125,10 +124,10 @@ internal static class ProtobufOtlpMetricSerializer
         var meterVersion = metrics[0].MeterVersion;
         var meterTags = metrics[0].MeterTags;
 
-        writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Name, meterName);
+        writePosition += ProtobufSerializer.WriteStringWithTag(buffer.AsSpan(writePosition), ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Name, meterName);
         if (meterVersion != null)
         {
-            writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Version, meterVersion);
+            writePosition += ProtobufSerializer.WriteStringWithTag(buffer.AsSpan(writePosition), ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Version, meterVersion);
         }
 
         if (meterTags != null)
@@ -149,7 +148,7 @@ internal static class ProtobufOtlpMetricSerializer
             }
         }
 
-        ProtobufSerializer.WriteReservedLength(buffer, instrumentationScopeLengthPosition, writePosition - (instrumentationScopeLengthPosition + ReserveSizeForLength));
+        ProtobufSerializer.WriteReservedLength(buffer.AsSpan(instrumentationScopeLengthPosition), writePosition - (instrumentationScopeLengthPosition + ReserveSizeForLength));
 
         for (int i = 0; i < metrics.Count; i++)
         {
@@ -161,20 +160,20 @@ internal static class ProtobufOtlpMetricSerializer
 
     private static int WriteMetric(byte[] buffer, int writePosition, Metric metric)
     {
-        writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ScopeMetrics_Metrics, ProtobufWireType.LEN);
+        writePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.ScopeMetrics_Metrics, ProtobufWireType.LEN);
         int metricLengthPosition = writePosition;
         writePosition += ReserveSizeForLength;
 
-        writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Metric_Name, metric.Name);
+        writePosition += ProtobufSerializer.WriteStringWithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.Metric_Name, metric.Name);
 
         if (metric.Description != null)
         {
-            writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Metric_Description, metric.Description);
+            writePosition += ProtobufSerializer.WriteStringWithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.Metric_Description, metric.Description);
         }
 
         if (metric.Unit != null)
         {
-            writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Metric_Unit, metric.Unit);
+            writePosition += ProtobufSerializer.WriteStringWithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.Metric_Unit, metric.Unit);
         }
 
         var aggregationValue = metric.Temporality == AggregationTemporality.Cumulative
@@ -186,12 +185,12 @@ internal static class ProtobufOtlpMetricSerializer
             case MetricType.LongSum:
             case MetricType.LongSumNonMonotonic:
                 {
-                    writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Metric_Data_Sum, ProtobufWireType.LEN);
+                    writePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.Metric_Data_Sum, ProtobufWireType.LEN);
                     int metricTypeLengthPosition = writePosition;
                     writePosition += ReserveSizeForLength;
 
-                    writePosition = ProtobufSerializer.WriteBoolWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Sum_Is_Monotonic, metric.MetricType == MetricType.LongSum);
-                    writePosition = ProtobufSerializer.WriteEnumWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Sum_Aggregation_Temporality, aggregationValue);
+                    writePosition += ProtobufSerializer.WriteBoolWithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.Sum_Is_Monotonic, metric.MetricType == MetricType.LongSum);
+                    writePosition += ProtobufSerializer.WriteEnumWithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.Sum_Aggregation_Temporality, aggregationValue);
 
                     foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                     {
@@ -199,19 +198,19 @@ internal static class ProtobufOtlpMetricSerializer
                         writePosition = WriteNumberDataPoint(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Sum_Data_Points, in metricPoint, sum);
                     }
 
-                    ProtobufSerializer.WriteReservedLength(buffer, metricTypeLengthPosition, writePosition - (metricTypeLengthPosition + ReserveSizeForLength));
+                    ProtobufSerializer.WriteReservedLength(buffer.AsSpan(metricTypeLengthPosition), writePosition - (metricTypeLengthPosition + ReserveSizeForLength));
                     break;
                 }
 
             case MetricType.DoubleSum:
             case MetricType.DoubleSumNonMonotonic:
                 {
-                    writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Metric_Data_Sum, ProtobufWireType.LEN);
+                    writePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.Metric_Data_Sum, ProtobufWireType.LEN);
                     int metricTypeLengthPosition = writePosition;
                     writePosition += ReserveSizeForLength;
 
-                    writePosition = ProtobufSerializer.WriteBoolWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Sum_Is_Monotonic, metric.MetricType == MetricType.DoubleSum);
-                    writePosition = ProtobufSerializer.WriteEnumWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Sum_Aggregation_Temporality, aggregationValue);
+                    writePosition += ProtobufSerializer.WriteBoolWithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.Sum_Is_Monotonic, metric.MetricType == MetricType.DoubleSum);
+                    writePosition += ProtobufSerializer.WriteEnumWithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.Sum_Aggregation_Temporality, aggregationValue);
 
                     foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                     {
@@ -219,13 +218,13 @@ internal static class ProtobufOtlpMetricSerializer
                         writePosition = WriteNumberDataPoint(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Sum_Data_Points, in metricPoint, sum);
                     }
 
-                    ProtobufSerializer.WriteReservedLength(buffer, metricTypeLengthPosition, writePosition - (metricTypeLengthPosition + ReserveSizeForLength));
+                    ProtobufSerializer.WriteReservedLength(buffer.AsSpan(metricTypeLengthPosition), writePosition - (metricTypeLengthPosition + ReserveSizeForLength));
                     break;
                 }
 
             case MetricType.LongGauge:
                 {
-                    writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Metric_Data_Gauge, ProtobufWireType.LEN);
+                    writePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.Metric_Data_Gauge, ProtobufWireType.LEN);
                     int metricTypeLengthPosition = writePosition;
                     writePosition += ReserveSizeForLength;
 
@@ -235,13 +234,13 @@ internal static class ProtobufOtlpMetricSerializer
                         writePosition = WriteNumberDataPoint(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Gauge_Data_Points, in metricPoint, lastValue);
                     }
 
-                    ProtobufSerializer.WriteReservedLength(buffer, metricTypeLengthPosition, writePosition - (metricTypeLengthPosition + ReserveSizeForLength));
+                    ProtobufSerializer.WriteReservedLength(buffer.AsSpan(metricTypeLengthPosition), writePosition - (metricTypeLengthPosition + ReserveSizeForLength));
                     break;
                 }
 
             case MetricType.DoubleGauge:
                 {
-                    writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Metric_Data_Gauge, ProtobufWireType.LEN);
+                    writePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.Metric_Data_Gauge, ProtobufWireType.LEN);
                     int metricTypeLengthPosition = writePosition;
                     writePosition += ReserveSizeForLength;
 
@@ -251,29 +250,29 @@ internal static class ProtobufOtlpMetricSerializer
                         writePosition = WriteNumberDataPoint(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Gauge_Data_Points, in metricPoint, lastValue);
                     }
 
-                    ProtobufSerializer.WriteReservedLength(buffer, metricTypeLengthPosition, writePosition - (metricTypeLengthPosition + ReserveSizeForLength));
+                    ProtobufSerializer.WriteReservedLength(buffer.AsSpan(metricTypeLengthPosition), writePosition - (metricTypeLengthPosition + ReserveSizeForLength));
                     break;
                 }
 
             case MetricType.Histogram:
                 {
-                    writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Metric_Data_Histogram, ProtobufWireType.LEN);
+                    writePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.Metric_Data_Histogram, ProtobufWireType.LEN);
                     int metricTypeLengthPosition = writePosition;
                     writePosition += ReserveSizeForLength;
 
-                    writePosition = ProtobufSerializer.WriteEnumWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Histogram_Aggregation_Temporality, aggregationValue);
+                    writePosition += ProtobufSerializer.WriteEnumWithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.Histogram_Aggregation_Temporality, aggregationValue);
 
                     foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                     {
-                        writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Histogram_Data_Points, ProtobufWireType.LEN);
+                        writePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.Histogram_Data_Points, ProtobufWireType.LEN);
                         int dataPointLengthPosition = writePosition;
                         writePosition += ReserveSizeForLength;
 
                         var startTime = (ulong)metricPoint.StartTime.ToUnixTimeNanoseconds();
-                        writePosition = ProtobufSerializer.WriteFixed64WithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.HistogramDataPoint_Start_Time_Unix_Nano, startTime);
+                        writePosition += ProtobufSerializer.WriteFixed64WithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.HistogramDataPoint_Start_Time_Unix_Nano, startTime);
 
                         var endTime = (ulong)metricPoint.EndTime.ToUnixTimeNanoseconds();
-                        writePosition = ProtobufSerializer.WriteFixed64WithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.HistogramDataPoint_Time_Unix_Nano, endTime);
+                        writePosition += ProtobufSerializer.WriteFixed64WithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.HistogramDataPoint_Time_Unix_Nano, endTime);
 
                         foreach (var tag in metricPoint.Tags)
                         {
@@ -281,47 +280,47 @@ internal static class ProtobufOtlpMetricSerializer
                         }
 
                         var count = (ulong)metricPoint.GetHistogramCount();
-                        writePosition = ProtobufSerializer.WriteFixed64WithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.HistogramDataPoint_Count, count);
+                        writePosition += ProtobufSerializer.WriteFixed64WithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.HistogramDataPoint_Count, count);
 
                         var sum = metricPoint.GetHistogramSum();
-                        writePosition = ProtobufSerializer.WriteDoubleWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.HistogramDataPoint_Sum, sum);
+                        writePosition += ProtobufSerializer.WriteDoubleWithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.HistogramDataPoint_Sum, sum);
 
                         if (metricPoint.TryGetHistogramMinMaxValues(out double min, out double max))
                         {
-                            writePosition = ProtobufSerializer.WriteDoubleWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.HistogramDataPoint_Min, min);
-                            writePosition = ProtobufSerializer.WriteDoubleWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.HistogramDataPoint_Max, max);
+                            writePosition += ProtobufSerializer.WriteDoubleWithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.HistogramDataPoint_Min, min);
+                            writePosition += ProtobufSerializer.WriteDoubleWithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.HistogramDataPoint_Max, max);
                         }
 
-                        writePosition = WriteHistogramBuckets(buffer, writePosition, metricPoint.GetHistogramBuckets());
+                        writePosition += WriteHistogramBuckets(buffer.AsSpan(writePosition), metricPoint.GetHistogramBuckets());
 
                         writePosition = WriteDoubleExemplars(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.HistogramDataPoint_Exemplars, in metricPoint);
 
-                        ProtobufSerializer.WriteReservedLength(buffer, dataPointLengthPosition, writePosition - (dataPointLengthPosition + ReserveSizeForLength));
+                        ProtobufSerializer.WriteReservedLength(buffer.AsSpan(dataPointLengthPosition), writePosition - (dataPointLengthPosition + ReserveSizeForLength));
                     }
 
-                    ProtobufSerializer.WriteReservedLength(buffer, metricTypeLengthPosition, writePosition - (metricTypeLengthPosition + ReserveSizeForLength));
+                    ProtobufSerializer.WriteReservedLength(buffer.AsSpan(metricTypeLengthPosition), writePosition - (metricTypeLengthPosition + ReserveSizeForLength));
                     break;
                 }
 
             case MetricType.ExponentialHistogram:
                 {
-                    writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Metric_Data_Exponential_Histogram, ProtobufWireType.LEN);
+                    writePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.Metric_Data_Exponential_Histogram, ProtobufWireType.LEN);
                     int metricTypeLengthPosition = writePosition;
                     writePosition += ReserveSizeForLength;
 
-                    writePosition = ProtobufSerializer.WriteEnumWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogram_Aggregation_Temporality, aggregationValue);
+                    writePosition += ProtobufSerializer.WriteEnumWithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogram_Aggregation_Temporality, aggregationValue);
 
                     foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                     {
-                        writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogram_Data_Points, ProtobufWireType.LEN);
+                        writePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogram_Data_Points, ProtobufWireType.LEN);
                         int dataPointLengthPosition = writePosition;
                         writePosition += ReserveSizeForLength;
 
                         var startTime = (ulong)metricPoint.StartTime.ToUnixTimeNanoseconds();
-                        writePosition = ProtobufSerializer.WriteFixed64WithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Start_Time_Unix_Nano, startTime);
+                        writePosition += ProtobufSerializer.WriteFixed64WithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Start_Time_Unix_Nano, startTime);
 
                         var endTime = (ulong)metricPoint.EndTime.ToUnixTimeNanoseconds();
-                        writePosition = ProtobufSerializer.WriteFixed64WithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Time_Unix_Nano, endTime);
+                        writePosition += ProtobufSerializer.WriteFixed64WithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Time_Unix_Nano, endTime);
 
                         foreach (var tag in metricPoint.Tags)
                         {
@@ -329,64 +328,64 @@ internal static class ProtobufOtlpMetricSerializer
                         }
 
                         var sum = metricPoint.GetHistogramSum();
-                        writePosition = ProtobufSerializer.WriteDoubleWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Sum, sum);
+                        writePosition += ProtobufSerializer.WriteDoubleWithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Sum, sum);
 
                         var count = (ulong)metricPoint.GetHistogramCount();
-                        writePosition = ProtobufSerializer.WriteFixed64WithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Count, count);
+                        writePosition += ProtobufSerializer.WriteFixed64WithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Count, count);
 
                         if (metricPoint.TryGetHistogramMinMaxValues(out double min, out double max))
                         {
-                            writePosition = ProtobufSerializer.WriteDoubleWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Min, min);
-                            writePosition = ProtobufSerializer.WriteDoubleWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Max, max);
+                            writePosition += ProtobufSerializer.WriteDoubleWithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Min, min);
+                            writePosition += ProtobufSerializer.WriteDoubleWithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Max, max);
                         }
 
                         var exponentialHistogramData = metricPoint.GetExponentialHistogramData();
 
-                        writePosition = ProtobufSerializer.WriteSInt32WithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Scale, exponentialHistogramData.Scale);
-                        writePosition = ProtobufSerializer.WriteFixed64WithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Zero_Count, (ulong)exponentialHistogramData.ZeroCount);
+                        writePosition += ProtobufSerializer.WriteSInt32WithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Scale, exponentialHistogramData.Scale);
+                        writePosition += ProtobufSerializer.WriteFixed64WithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Zero_Count, (ulong)exponentialHistogramData.ZeroCount);
 
-                        writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Positive, ProtobufWireType.LEN);
+                        writePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Positive, ProtobufWireType.LEN);
                         int positiveBucketsLengthPosition = writePosition;
                         writePosition += ReserveSizeForLength;
 
-                        writePosition = ProtobufSerializer.WriteSInt32WithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Buckets_Offset, exponentialHistogramData.PositiveBuckets.Offset);
+                        writePosition += ProtobufSerializer.WriteSInt32WithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Buckets_Offset, exponentialHistogramData.PositiveBuckets.Offset);
 
                         foreach (var bucketCount in exponentialHistogramData.PositiveBuckets)
                         {
-                            writePosition = ProtobufSerializer.WriteInt64WithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Buckets_Bucket_Counts, (ulong)bucketCount);
+                            writePosition += ProtobufSerializer.WriteInt64WithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Buckets_Bucket_Counts, (ulong)bucketCount);
                         }
 
-                        ProtobufSerializer.WriteReservedLength(buffer, positiveBucketsLengthPosition, writePosition - (positiveBucketsLengthPosition + ReserveSizeForLength));
+                        ProtobufSerializer.WriteReservedLength(buffer.AsSpan(positiveBucketsLengthPosition), writePosition - (positiveBucketsLengthPosition + ReserveSizeForLength));
 
                         writePosition = WriteDoubleExemplars(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Exemplars, in metricPoint);
 
-                        ProtobufSerializer.WriteReservedLength(buffer, dataPointLengthPosition, writePosition - (dataPointLengthPosition + ReserveSizeForLength));
+                        ProtobufSerializer.WriteReservedLength(buffer.AsSpan(dataPointLengthPosition), writePosition - (dataPointLengthPosition + ReserveSizeForLength));
                     }
 
-                    ProtobufSerializer.WriteReservedLength(buffer, metricTypeLengthPosition, writePosition - (metricTypeLengthPosition + ReserveSizeForLength));
+                    ProtobufSerializer.WriteReservedLength(buffer.AsSpan(metricTypeLengthPosition), writePosition - (metricTypeLengthPosition + ReserveSizeForLength));
                     break;
                 }
         }
 
-        ProtobufSerializer.WriteReservedLength(buffer, metricLengthPosition, writePosition - (metricLengthPosition + ReserveSizeForLength));
+        ProtobufSerializer.WriteReservedLength(buffer.AsSpan(metricLengthPosition), writePosition - (metricLengthPosition + ReserveSizeForLength));
         return writePosition;
     }
 
     private static int WriteNumberDataPoint(byte[] buffer, int writePosition, int fieldNumber, in MetricPoint metricPoint, long value)
     {
-        writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, fieldNumber, ProtobufWireType.LEN);
+        writePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(writePosition), fieldNumber, ProtobufWireType.LEN);
         int dataPointLengthPosition = writePosition;
         writePosition += ReserveSizeForLength;
 
         // Casting to ulong is ok here as the bit representation for long versus ulong will be the same
         // The difference would in the way the bit representation is interpreted on decoding side (signed versus unsigned)
-        writePosition = ProtobufSerializer.WriteFixed64WithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.NumberDataPoint_Value_As_Int, (ulong)value);
+        writePosition += ProtobufSerializer.WriteFixed64WithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.NumberDataPoint_Value_As_Int, (ulong)value);
 
         var startTime = (ulong)metricPoint.StartTime.ToUnixTimeNanoseconds();
-        writePosition = ProtobufSerializer.WriteFixed64WithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.NumberDataPoint_Start_Time_Unix_Nano, startTime);
+        writePosition += ProtobufSerializer.WriteFixed64WithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.NumberDataPoint_Start_Time_Unix_Nano, startTime);
 
         var endTime = (ulong)metricPoint.EndTime.ToUnixTimeNanoseconds();
-        writePosition = ProtobufSerializer.WriteFixed64WithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.NumberDataPoint_Time_Unix_Nano, endTime);
+        writePosition += ProtobufSerializer.WriteFixed64WithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.NumberDataPoint_Time_Unix_Nano, endTime);
 
         foreach (var tag in metricPoint.Tags)
         {
@@ -402,28 +401,28 @@ internal static class ProtobufOtlpMetricSerializer
                     writePosition,
                     in exemplar,
                     ProtobufOtlpMetricFieldNumberConstants.NumberDataPoint_Exemplars,
-                    static (byte[] buffer, int writePosition, in Exemplar exemplar) => ProtobufSerializer.WriteFixed64WithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Exemplar_Value_As_Int, (ulong)exemplar.LongValue));
+                    static (Span<byte> buffer, in Exemplar exemplar) => ProtobufSerializer.WriteFixed64WithTag(buffer, ProtobufOtlpMetricFieldNumberConstants.Exemplar_Value_As_Int, (ulong)exemplar.LongValue));
             }
         }
 
-        ProtobufSerializer.WriteReservedLength(buffer, dataPointLengthPosition, writePosition - (dataPointLengthPosition + ReserveSizeForLength));
+        ProtobufSerializer.WriteReservedLength(buffer.AsSpan(dataPointLengthPosition), writePosition - (dataPointLengthPosition + ReserveSizeForLength));
         return writePosition;
     }
 
     private static int WriteNumberDataPoint(byte[] buffer, int writePosition, int fieldNumber, in MetricPoint metricPoint, double value)
     {
-        writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, fieldNumber, ProtobufWireType.LEN);
+        writePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(writePosition), fieldNumber, ProtobufWireType.LEN);
         int dataPointLengthPosition = writePosition;
         writePosition += ReserveSizeForLength;
 
         // Using a func here to avoid boxing/unboxing.
-        writePosition = ProtobufSerializer.WriteDoubleWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.NumberDataPoint_Value_As_Double, value);
+        writePosition += ProtobufSerializer.WriteDoubleWithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.NumberDataPoint_Value_As_Double, value);
 
         var startTime = (ulong)metricPoint.StartTime.ToUnixTimeNanoseconds();
-        writePosition = ProtobufSerializer.WriteFixed64WithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.NumberDataPoint_Start_Time_Unix_Nano, startTime);
+        writePosition += ProtobufSerializer.WriteFixed64WithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.NumberDataPoint_Start_Time_Unix_Nano, startTime);
 
         var endTime = (ulong)metricPoint.EndTime.ToUnixTimeNanoseconds();
-        writePosition = ProtobufSerializer.WriteFixed64WithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.NumberDataPoint_Time_Unix_Nano, endTime);
+        writePosition += ProtobufSerializer.WriteFixed64WithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.NumberDataPoint_Time_Unix_Nano, endTime);
 
         foreach (var tag in metricPoint.Tags)
         {
@@ -432,7 +431,7 @@ internal static class ProtobufOtlpMetricSerializer
 
         writePosition = WriteDoubleExemplars(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.NumberDataPoint_Exemplars, in metricPoint);
 
-        ProtobufSerializer.WriteReservedLength(buffer, dataPointLengthPosition, writePosition - (dataPointLengthPosition + ReserveSizeForLength));
+        ProtobufSerializer.WriteReservedLength(buffer.AsSpan(dataPointLengthPosition), writePosition - (dataPointLengthPosition + ReserveSizeForLength));
         return writePosition;
     }
 
@@ -444,13 +443,13 @@ internal static class ProtobufOtlpMetricSerializer
             WritePosition = writePosition,
         };
 
-        otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(buffer, otlpTagWriterState.WritePosition, fieldNumber, ProtobufWireType.LEN);
+        otlpTagWriterState.WritePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(otlpTagWriterState.WritePosition), fieldNumber, ProtobufWireType.LEN);
         int fieldLengthPosition = otlpTagWriterState.WritePosition;
         otlpTagWriterState.WritePosition += ReserveSizeForLength;
 
         ProtobufOtlpTagWriter.Instance.TryWriteTag(ref otlpTagWriterState, tag.Key, tag.Value);
 
-        ProtobufSerializer.WriteReservedLength(buffer, fieldLengthPosition, otlpTagWriterState.WritePosition - (fieldLengthPosition + ReserveSizeForLength));
+        ProtobufSerializer.WriteReservedLength(buffer.AsSpan(fieldLengthPosition), otlpTagWriterState.WritePosition - (fieldLengthPosition + ReserveSizeForLength));
         return otlpTagWriterState.WritePosition;
     }
 
@@ -465,7 +464,7 @@ internal static class ProtobufOtlpMetricSerializer
                     writePosition,
                     in exemplar,
                     fieldNumber,
-                    static (byte[] buffer, int writePosition, in Exemplar exemplar) => ProtobufSerializer.WriteDoubleWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Exemplar_Value_As_Double, exemplar.DoubleValue));
+                    static (Span<byte> buffer, in Exemplar exemplar) => ProtobufSerializer.WriteDoubleWithTag(buffer, ProtobufOtlpMetricFieldNumberConstants.Exemplar_Value_As_Double, exemplar.DoubleValue));
             }
         }
 
@@ -474,7 +473,7 @@ internal static class ProtobufOtlpMetricSerializer
 
     private static int WriteExemplar(byte[] buffer, int writePosition, in Exemplar exemplar, int fieldNumber, WriteExemplarFunc writeValueFunc)
     {
-        writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, fieldNumber, ProtobufWireType.LEN);
+        writePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(writePosition), fieldNumber, ProtobufWireType.LEN);
         int exemplarLengthPosition = writePosition;
         writePosition += ReserveSizeForLength;
 
@@ -483,59 +482,59 @@ internal static class ProtobufOtlpMetricSerializer
             writePosition = WriteTag(buffer, writePosition, tag, ProtobufOtlpMetricFieldNumberConstants.Exemplar_Filtered_Attributes);
         }
 
-        writePosition = writeValueFunc(buffer, writePosition, in exemplar);
+        writePosition += writeValueFunc(buffer.AsSpan(writePosition), in exemplar);
 
         var time = (ulong)exemplar.Timestamp.ToUnixTimeNanoseconds();
-        writePosition = ProtobufSerializer.WriteFixed64WithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Exemplar_Time_Unix_Nano, time);
+        writePosition += ProtobufSerializer.WriteFixed64WithTag(buffer.AsSpan(writePosition), ProtobufOtlpMetricFieldNumberConstants.Exemplar_Time_Unix_Nano, time);
 
         if (exemplar.SpanId != default)
         {
-            writePosition = ProtobufSerializer.WriteTagAndLength(buffer, writePosition, SpanIdSize, ProtobufOtlpMetricFieldNumberConstants.Exemplar_Span_Id, ProtobufWireType.LEN);
+            writePosition += ProtobufSerializer.WriteTagAndLength(buffer.AsSpan(writePosition), SpanIdSize, ProtobufOtlpMetricFieldNumberConstants.Exemplar_Span_Id, ProtobufWireType.LEN);
             var spanIdBytes = new Span<byte>(buffer, writePosition, SpanIdSize);
             exemplar.SpanId.CopyTo(spanIdBytes);
             writePosition += SpanIdSize;
 
-            writePosition = ProtobufSerializer.WriteTagAndLength(buffer, writePosition, TraceIdSize, ProtobufOtlpMetricFieldNumberConstants.Exemplar_Trace_Id, ProtobufWireType.LEN);
+            writePosition += ProtobufSerializer.WriteTagAndLength(buffer.AsSpan(writePosition), TraceIdSize, ProtobufOtlpMetricFieldNumberConstants.Exemplar_Trace_Id, ProtobufWireType.LEN);
             var traceIdBytes = new Span<byte>(buffer, writePosition, TraceIdSize);
             exemplar.TraceId.CopyTo(traceIdBytes);
             writePosition += TraceIdSize;
         }
 
-        ProtobufSerializer.WriteReservedLength(buffer, exemplarLengthPosition, writePosition - (exemplarLengthPosition + ReserveSizeForLength));
+        ProtobufSerializer.WriteReservedLength(buffer.AsSpan(exemplarLengthPosition), writePosition - (exemplarLengthPosition + ReserveSizeForLength));
         return writePosition;
     }
 
-    private static int WriteHistogramBuckets(byte[] buffer, int writePosition, HistogramBuckets buckets)
+    private static int WriteHistogramBuckets(Span<byte> buffer, HistogramBuckets buckets)
     {
-        writePosition = WriteBucketCounts(buffer, writePosition, buckets.BucketCounts);
+        var bytesWritten = WriteBucketCounts(buffer, buckets.BucketCounts);
 
-        writePosition = WriteExplicitBounds(buffer, writePosition, buckets.ExplicitBounds!);
+        bytesWritten += WriteExplicitBounds(buffer.Slice(bytesWritten), buckets.ExplicitBounds!);
 
-        return writePosition;
+        return bytesWritten;
 
-        static int WriteBucketCounts(byte[] buffer, int writePosition, HistogramBuckets.HistogramBucketValues[] values)
+        static int WriteBucketCounts(Span<byte> buffer, HistogramBuckets.HistogramBucketValues[] values)
         {
             int length = values.Length;
 
-            writePosition = WritePackedLength(
+            var bytesWritten = WritePackedLength(
                 buffer,
-                writePosition,
                 length,
                 ProtobufOtlpMetricFieldNumberConstants.HistogramDataPoint_Bucket_Counts);
 
             for (int i = 0; i < length; i++)
             {
-                writePosition = ProtobufSerializer.WriteFixed64LittleEndianFormat(
-                    buffer,
-                    writePosition,
+                bytesWritten += ProtobufSerializer.WriteFixed64LittleEndianFormat(
+                    buffer.Slice(bytesWritten),
                     (ulong)values[i].SnapshotValue);
             }
 
-            return writePosition;
+            return bytesWritten;
         }
 
-        static int WriteExplicitBounds(byte[] buffer, int writePosition, double[] values)
+        static int WriteExplicitBounds(Span<byte> buffer, double[] values)
         {
+            var bytesWritten = 0;
+
             int length = 0;
 
             for (int i = 0; i < values.Length; i++)
@@ -548,9 +547,8 @@ internal static class ProtobufOtlpMetricSerializer
 
             if (length > 0)
             {
-                writePosition = WritePackedLength(
-                    buffer,
-                    writePosition,
+                bytesWritten += WritePackedLength(
+                    buffer.Slice(bytesWritten),
                     length,
                     ProtobufOtlpMetricFieldNumberConstants.HistogramDataPoint_Explicit_Bounds);
 
@@ -559,19 +557,18 @@ internal static class ProtobufOtlpMetricSerializer
                     var value = values[i];
                     if (value != double.PositiveInfinity)
                     {
-                        writePosition = ProtobufSerializer.WriteDouble(buffer, writePosition, value);
+                        bytesWritten += ProtobufSerializer.WriteDouble(buffer.Slice(bytesWritten), value);
                     }
                 }
             }
 
-            return writePosition;
+            return bytesWritten;
         }
 
-        static int WritePackedLength(byte[] buffer, int writePosition, int length, int fieldNumber)
+        static int WritePackedLength(Span<byte> buffer, int length, int fieldNumber)
         {
             return ProtobufSerializer.WriteTagAndLength(
                 buffer,
-                writePosition,
                 length * 8,
                 fieldNumber,
                 ProtobufWireType.LEN);

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpResourceSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpResourceSerializer.cs
@@ -17,7 +17,7 @@ internal static class ProtobufOtlpResourceSerializer
             WritePosition = writePosition,
         };
 
-        otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpTraceFieldNumberConstants.ResourceSpans_Resource, ProtobufWireType.LEN);
+        otlpTagWriterState.WritePosition += ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer.AsSpan(otlpTagWriterState.WritePosition), ProtobufOtlpTraceFieldNumberConstants.ResourceSpans_Resource, ProtobufWireType.LEN);
         int resourceLengthPosition = otlpTagWriterState.WritePosition;
         otlpTagWriterState.WritePosition += ReserveSizeForLength;
 
@@ -40,20 +40,20 @@ internal static class ProtobufOtlpResourceSerializer
         }
 
         var resourceLength = otlpTagWriterState.WritePosition - (resourceLengthPosition + ReserveSizeForLength);
-        ProtobufSerializer.WriteReservedLength(otlpTagWriterState.Buffer, resourceLengthPosition, resourceLength);
+        ProtobufSerializer.WriteReservedLength(otlpTagWriterState.Buffer.AsSpan(resourceLengthPosition), resourceLength);
 
         return otlpTagWriterState.WritePosition;
     }
 
     private static void ProcessResourceAttribute(ref ProtobufOtlpTagWriter.OtlpTagWriterState otlpTagWriterState, KeyValuePair<string, object> attribute)
     {
-        otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpTraceFieldNumberConstants.Resource_Attributes, ProtobufWireType.LEN);
+        otlpTagWriterState.WritePosition += ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer.AsSpan(otlpTagWriterState.WritePosition), ProtobufOtlpTraceFieldNumberConstants.Resource_Attributes, ProtobufWireType.LEN);
         int resourceAttributesLengthPosition = otlpTagWriterState.WritePosition;
         otlpTagWriterState.WritePosition += ReserveSizeForLength;
 
         ProtobufOtlpTagWriter.Instance.TryWriteTag(ref otlpTagWriterState, attribute.Key, attribute.Value);
 
         var resourceAttributesLength = otlpTagWriterState.WritePosition - (resourceAttributesLengthPosition + ReserveSizeForLength);
-        ProtobufSerializer.WriteReservedLength(otlpTagWriterState.Buffer, resourceAttributesLengthPosition, resourceAttributesLength);
+        ProtobufSerializer.WriteReservedLength(otlpTagWriterState.Buffer.AsSpan(resourceAttributesLengthPosition), resourceAttributesLength);
     }
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTagWriter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTagWriter.cs
@@ -18,59 +18,59 @@ internal sealed class ProtobufOtlpTagWriter : TagWriter<ProtobufOtlpTagWriter.Ot
     protected override void WriteIntegralTag(ref OtlpTagWriterState state, string key, long value)
     {
         // Write KeyValue tag
-        state.WritePosition = ProtobufSerializer.WriteStringWithTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Key, key);
+        state.WritePosition += ProtobufSerializer.WriteStringWithTag(state.Buffer.AsSpan(state.WritePosition), ProtobufOtlpCommonFieldNumberConstants.KeyValue_Key, key);
 
         // Write KeyValue.Value tag, length and value.
         var size = ProtobufSerializer.ComputeVarInt64Size((ulong)value) + 1; // ComputeVarint64Size(ulong) + TagSize
-        state.WritePosition = ProtobufSerializer.WriteTagAndLength(state.Buffer, state.WritePosition, size, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Value, ProtobufWireType.LEN);
-        state.WritePosition = ProtobufSerializer.WriteInt64WithTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.AnyValue_Int_Value, (ulong)value);
+        state.WritePosition += ProtobufSerializer.WriteTagAndLength(state.Buffer.AsSpan(state.WritePosition), size, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Value, ProtobufWireType.LEN);
+        state.WritePosition += ProtobufSerializer.WriteInt64WithTag(state.Buffer.AsSpan(state.WritePosition), ProtobufOtlpCommonFieldNumberConstants.AnyValue_Int_Value, (ulong)value);
     }
 
     protected override void WriteFloatingPointTag(ref OtlpTagWriterState state, string key, double value)
     {
         // Write KeyValue tag
-        state.WritePosition = ProtobufSerializer.WriteStringWithTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Key, key);
+        state.WritePosition += ProtobufSerializer.WriteStringWithTag(state.Buffer.AsSpan(state.WritePosition), ProtobufOtlpCommonFieldNumberConstants.KeyValue_Key, key);
 
         // Write KeyValue.Value tag, length and value.
-        state.WritePosition = ProtobufSerializer.WriteTagAndLength(state.Buffer, state.WritePosition, 9, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Value, ProtobufWireType.LEN); // 8 + TagSize
-        state.WritePosition = ProtobufSerializer.WriteDoubleWithTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.AnyValue_Double_Value, value);
+        state.WritePosition += ProtobufSerializer.WriteTagAndLength(state.Buffer.AsSpan(state.WritePosition), 9, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Value, ProtobufWireType.LEN); // 8 + TagSize
+        state.WritePosition += ProtobufSerializer.WriteDoubleWithTag(state.Buffer.AsSpan(state.WritePosition), ProtobufOtlpCommonFieldNumberConstants.AnyValue_Double_Value, value);
     }
 
     protected override void WriteBooleanTag(ref OtlpTagWriterState state, string key, bool value)
     {
         // Write KeyValue tag
-        state.WritePosition = ProtobufSerializer.WriteStringWithTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Key, key);
+        state.WritePosition += ProtobufSerializer.WriteStringWithTag(state.Buffer.AsSpan(state.WritePosition), ProtobufOtlpCommonFieldNumberConstants.KeyValue_Key, key);
 
         // Write KeyValue.Value tag, length and value.
-        state.WritePosition = ProtobufSerializer.WriteTagAndLength(state.Buffer, state.WritePosition, 2, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Value, ProtobufWireType.LEN); // 1 + TagSize
-        state.WritePosition = ProtobufSerializer.WriteBoolWithTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.AnyValue_Bool_Value, value);
+        state.WritePosition += ProtobufSerializer.WriteTagAndLength(state.Buffer.AsSpan(state.WritePosition), 2, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Value, ProtobufWireType.LEN); // 1 + TagSize
+        state.WritePosition += ProtobufSerializer.WriteBoolWithTag(state.Buffer.AsSpan(state.WritePosition), ProtobufOtlpCommonFieldNumberConstants.AnyValue_Bool_Value, value);
     }
 
     protected override void WriteStringTag(ref OtlpTagWriterState state, string key, ReadOnlySpan<char> value)
     {
         // Write KeyValue tag
-        state.WritePosition = ProtobufSerializer.WriteStringWithTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Key, key);
+        state.WritePosition += ProtobufSerializer.WriteStringWithTag(state.Buffer.AsSpan(state.WritePosition), ProtobufOtlpCommonFieldNumberConstants.KeyValue_Key, key);
 
         // Write KeyValue.Value tag, length and value.
         var numberOfUtf8CharsInString = ProtobufSerializer.GetNumberOfUtf8CharsInString(value);
         var serializedLengthSize = ProtobufSerializer.ComputeVarInt64Size((ulong)numberOfUtf8CharsInString);
 
         // length = numberOfUtf8CharsInString + tagSize + length field size.
-        state.WritePosition = ProtobufSerializer.WriteTagAndLength(state.Buffer, state.WritePosition, numberOfUtf8CharsInString + 1 + serializedLengthSize, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Value, ProtobufWireType.LEN);
-        state.WritePosition = ProtobufSerializer.WriteStringWithTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.AnyValue_String_Value, numberOfUtf8CharsInString, value);
+        state.WritePosition += ProtobufSerializer.WriteTagAndLength(state.Buffer.AsSpan(state.WritePosition), numberOfUtf8CharsInString + 1 + serializedLengthSize, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Value, ProtobufWireType.LEN);
+        state.WritePosition += ProtobufSerializer.WriteStringWithTag(state.Buffer.AsSpan(state.WritePosition), ProtobufOtlpCommonFieldNumberConstants.AnyValue_String_Value, numberOfUtf8CharsInString, value);
     }
 
     protected override void WriteArrayTag(ref OtlpTagWriterState state, string key, ref OtlpTagWriterArrayState value)
     {
         // Write KeyValue tag
-        state.WritePosition = ProtobufSerializer.WriteStringWithTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Key, key);
+        state.WritePosition += ProtobufSerializer.WriteStringWithTag(state.Buffer.AsSpan(state.WritePosition), ProtobufOtlpCommonFieldNumberConstants.KeyValue_Key, key);
 
         // Write KeyValue.Value tag and length
         var serializedLengthSize = ProtobufSerializer.ComputeVarInt64Size((ulong)value.WritePosition);
-        state.WritePosition = ProtobufSerializer.WriteTagAndLength(state.Buffer, state.WritePosition, value.WritePosition + 1 + serializedLengthSize, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Value, ProtobufWireType.LEN); // Array content length + Array tag size + length field size
+        state.WritePosition += ProtobufSerializer.WriteTagAndLength(state.Buffer.AsSpan(state.WritePosition), value.WritePosition + 1 + serializedLengthSize, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Value, ProtobufWireType.LEN); // Array content length + Array tag size + length field size
 
         // Write Array tag and length
-        state.WritePosition = ProtobufSerializer.WriteTagAndLength(state.Buffer, state.WritePosition, value.WritePosition, ProtobufOtlpCommonFieldNumberConstants.AnyValue_Array_Value, ProtobufWireType.LEN);
+        state.WritePosition += ProtobufSerializer.WriteTagAndLength(state.Buffer.AsSpan(state.WritePosition), value.WritePosition, ProtobufOtlpCommonFieldNumberConstants.AnyValue_Array_Value, ProtobufWireType.LEN);
         Buffer.BlockCopy(value.Buffer, 0, state.Buffer, state.WritePosition, value.WritePosition);
         state.WritePosition += value.WritePosition;
     }
@@ -83,21 +83,21 @@ internal sealed class ProtobufOtlpTagWriter : TagWriter<ProtobufOtlpTagWriter.Ot
 
     protected override bool TryWriteEmptyTag(ref OtlpTagWriterState state, string key, object? value)
     {
-        state.WritePosition = ProtobufSerializer.WriteStringWithTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Key, key);
-        state.WritePosition = ProtobufSerializer.WriteTagAndLength(state.Buffer, state.WritePosition, 0, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Value, ProtobufWireType.LEN);
+        state.WritePosition += ProtobufSerializer.WriteStringWithTag(state.Buffer.AsSpan(state.WritePosition), ProtobufOtlpCommonFieldNumberConstants.KeyValue_Key, key);
+        state.WritePosition += ProtobufSerializer.WriteTagAndLength(state.Buffer.AsSpan(state.WritePosition), 0, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Value, ProtobufWireType.LEN);
         return true;
     }
 
     protected override bool TryWriteByteArrayTag(ref OtlpTagWriterState state, string key, ReadOnlySpan<byte> value)
     {
         // Write KeyValue tag
-        state.WritePosition = ProtobufSerializer.WriteStringWithTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Key, key);
+        state.WritePosition = ProtobufSerializer.WriteStringWithTag(state.Buffer.AsSpan(state.WritePosition), ProtobufOtlpCommonFieldNumberConstants.KeyValue_Key, key);
 
         var serializedLengthSize = ProtobufSerializer.ComputeVarInt64Size((ulong)value.Length);
 
         // length = value.Length + tagSize + length field size.
-        state.WritePosition = ProtobufSerializer.WriteTagAndLength(state.Buffer, state.WritePosition, value.Length + 1 + serializedLengthSize, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Value, ProtobufWireType.LEN);
-        state.WritePosition = ProtobufSerializer.WriteByteArrayWithTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.AnyValue_Bytes_Value, value);
+        state.WritePosition += ProtobufSerializer.WriteTagAndLength(state.Buffer.AsSpan(state.WritePosition), value.Length + 1 + serializedLengthSize, ProtobufOtlpCommonFieldNumberConstants.KeyValue_Value, ProtobufWireType.LEN);
+        state.WritePosition += ProtobufSerializer.WriteByteArrayWithTag(state.Buffer.AsSpan(state.WritePosition), ProtobufOtlpCommonFieldNumberConstants.AnyValue_Bytes_Value, value);
 
         return true;
     }
@@ -135,26 +135,26 @@ internal sealed class ProtobufOtlpTagWriter : TagWriter<ProtobufOtlpTagWriter.Ot
 
         public override void WriteNullValue(ref OtlpTagWriterArrayState state)
         {
-            state.WritePosition = ProtobufSerializer.WriteTagAndLength(state.Buffer, state.WritePosition, 0, ProtobufOtlpCommonFieldNumberConstants.ArrayValue_Value, ProtobufWireType.LEN);
+            state.WritePosition += ProtobufSerializer.WriteTagAndLength(state.Buffer.AsSpan(state.WritePosition), 0, ProtobufOtlpCommonFieldNumberConstants.ArrayValue_Value, ProtobufWireType.LEN);
         }
 
         public override void WriteIntegralValue(ref OtlpTagWriterArrayState state, long value)
         {
             var size = ProtobufSerializer.ComputeVarInt64Size((ulong)value) + 1;
-            state.WritePosition = ProtobufSerializer.WriteTagAndLength(state.Buffer, state.WritePosition, size, ProtobufOtlpCommonFieldNumberConstants.ArrayValue_Value, ProtobufWireType.LEN);
-            state.WritePosition = ProtobufSerializer.WriteInt64WithTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.AnyValue_Int_Value, (ulong)value);
+            state.WritePosition += ProtobufSerializer.WriteTagAndLength(state.Buffer.AsSpan(state.WritePosition), size, ProtobufOtlpCommonFieldNumberConstants.ArrayValue_Value, ProtobufWireType.LEN);
+            state.WritePosition += ProtobufSerializer.WriteInt64WithTag(state.Buffer.AsSpan(state.WritePosition), ProtobufOtlpCommonFieldNumberConstants.AnyValue_Int_Value, (ulong)value);
         }
 
         public override void WriteFloatingPointValue(ref OtlpTagWriterArrayState state, double value)
         {
-            state.WritePosition = ProtobufSerializer.WriteTagAndLength(state.Buffer, state.WritePosition, 9, ProtobufOtlpCommonFieldNumberConstants.ArrayValue_Value, ProtobufWireType.LEN);
-            state.WritePosition = ProtobufSerializer.WriteDoubleWithTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.AnyValue_Double_Value, value);
+            state.WritePosition += ProtobufSerializer.WriteTagAndLength(state.Buffer.AsSpan(state.WritePosition), 9, ProtobufOtlpCommonFieldNumberConstants.ArrayValue_Value, ProtobufWireType.LEN);
+            state.WritePosition += ProtobufSerializer.WriteDoubleWithTag(state.Buffer.AsSpan(state.WritePosition), ProtobufOtlpCommonFieldNumberConstants.AnyValue_Double_Value, value);
         }
 
         public override void WriteBooleanValue(ref OtlpTagWriterArrayState state, bool value)
         {
-            state.WritePosition = ProtobufSerializer.WriteTagAndLength(state.Buffer, state.WritePosition, 2, ProtobufOtlpCommonFieldNumberConstants.ArrayValue_Value, ProtobufWireType.LEN);
-            state.WritePosition = ProtobufSerializer.WriteBoolWithTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.AnyValue_Bool_Value, value);
+            state.WritePosition += ProtobufSerializer.WriteTagAndLength(state.Buffer.AsSpan(state.WritePosition), 2, ProtobufOtlpCommonFieldNumberConstants.ArrayValue_Value, ProtobufWireType.LEN);
+            state.WritePosition += ProtobufSerializer.WriteBoolWithTag(state.Buffer.AsSpan(state.WritePosition), ProtobufOtlpCommonFieldNumberConstants.AnyValue_Bool_Value, value);
         }
 
         public override void WriteStringValue(ref OtlpTagWriterArrayState state, ReadOnlySpan<char> value)
@@ -164,8 +164,8 @@ internal sealed class ProtobufOtlpTagWriter : TagWriter<ProtobufOtlpTagWriter.Ot
             var serializedLengthSize = ProtobufSerializer.ComputeVarInt64Size((ulong)numberOfUtf8CharsInString);
 
             // length = numberOfUtf8CharsInString + tagSize + length field size.
-            state.WritePosition = ProtobufSerializer.WriteTagAndLength(state.Buffer, state.WritePosition, numberOfUtf8CharsInString + 1 + serializedLengthSize, ProtobufOtlpCommonFieldNumberConstants.ArrayValue_Value, ProtobufWireType.LEN);
-            state.WritePosition = ProtobufSerializer.WriteStringWithTag(state.Buffer, state.WritePosition, ProtobufOtlpCommonFieldNumberConstants.AnyValue_String_Value, numberOfUtf8CharsInString, value);
+            state.WritePosition += ProtobufSerializer.WriteTagAndLength(state.Buffer.AsSpan(state.WritePosition), numberOfUtf8CharsInString + 1 + serializedLengthSize, ProtobufOtlpCommonFieldNumberConstants.ArrayValue_Value, ProtobufWireType.LEN);
+            state.WritePosition += ProtobufSerializer.WriteStringWithTag(state.Buffer.AsSpan(state.WritePosition), ProtobufOtlpCommonFieldNumberConstants.AnyValue_String_Value, numberOfUtf8CharsInString, value);
         }
 
         public override void EndWriteArray(ref OtlpTagWriterArrayState state)

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTraceSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTraceSerializer.cs
@@ -51,13 +51,13 @@ internal static class ProtobufOtlpTraceSerializer
 
             try
             {
-                writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.TracesData_Resource_Spans, ProtobufWireType.LEN);
+                writePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(writePosition), ProtobufOtlpTraceFieldNumberConstants.TracesData_Resource_Spans, ProtobufWireType.LEN);
                 int resourceSpansScopeSpansLengthPosition = writePosition;
                 writePosition += ReserveSizeForLength;
 
                 writePosition = WriteResourceSpans(buffer, writePosition, sdkLimitOptions, resource);
 
-                ProtobufSerializer.WriteReservedLength(buffer, resourceSpansScopeSpansLengthPosition, writePosition - (resourceSpansScopeSpansLengthPosition + ReserveSizeForLength));
+                ProtobufSerializer.WriteReservedLength(buffer.AsSpan(resourceSpansScopeSpansLengthPosition), writePosition - (resourceSpansScopeSpansLengthPosition + ReserveSizeForLength));
 
                 // Serialization succeeded, return the final write position
                 return writePosition;
@@ -107,12 +107,12 @@ internal static class ProtobufOtlpTraceSerializer
         {
             foreach (KeyValuePair<string, List<Activity>> entry in scopeTracesList)
             {
-                writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.ResourceSpans_Scope_Spans, ProtobufWireType.LEN);
+                writePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(writePosition), ProtobufOtlpTraceFieldNumberConstants.ResourceSpans_Scope_Spans, ProtobufWireType.LEN);
                 int resourceSpansScopeSpansLengthPosition = writePosition;
                 writePosition += ReserveSizeForLength;
 
                 writePosition = WriteScopeSpan(buffer, writePosition, sdkLimitOptions, entry.Value[0].Source, entry.Value);
-                ProtobufSerializer.WriteReservedLength(buffer, resourceSpansScopeSpansLengthPosition, writePosition - (resourceSpansScopeSpansLengthPosition + ReserveSizeForLength));
+                ProtobufSerializer.WriteReservedLength(buffer.AsSpan(resourceSpansScopeSpansLengthPosition), writePosition - (resourceSpansScopeSpansLengthPosition + ReserveSizeForLength));
             }
         }
 
@@ -121,14 +121,14 @@ internal static class ProtobufOtlpTraceSerializer
 
     internal static int WriteScopeSpan(byte[] buffer, int writePosition, SdkLimitOptions sdkLimitOptions, ActivitySource activitySource, List<Activity> activities)
     {
-        writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.ScopeSpans_Scope, ProtobufWireType.LEN);
+        writePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(writePosition), ProtobufOtlpTraceFieldNumberConstants.ScopeSpans_Scope, ProtobufWireType.LEN);
         int instrumentationScopeLengthPosition = writePosition;
         writePosition += ReserveSizeForLength;
 
-        writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Name, activitySource.Name);
+        writePosition += ProtobufSerializer.WriteStringWithTag(buffer.AsSpan(writePosition), ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Name, activitySource.Name);
         if (activitySource.Version != null)
         {
-            writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Version, activitySource.Version);
+            writePosition += ProtobufSerializer.WriteStringWithTag(buffer.AsSpan(writePosition), ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Version, activitySource.Version);
         }
 
         if (activitySource.Tags != null)
@@ -149,14 +149,14 @@ internal static class ProtobufOtlpTraceSerializer
                 {
                     if (otlpTagWriterState.TagCount < maxAttributeCount)
                     {
-                        otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Attributes, ProtobufWireType.LEN);
+                        otlpTagWriterState.WritePosition += ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer.AsSpan(otlpTagWriterState.WritePosition), ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Attributes, ProtobufWireType.LEN);
                         int instrumentationScopeAttributesLengthPosition = otlpTagWriterState.WritePosition;
                         otlpTagWriterState.WritePosition += ReserveSizeForLength;
 
                         ProtobufOtlpTagWriter.Instance.TryWriteTag(ref otlpTagWriterState, activitySourceTagsList[i].Key, activitySourceTagsList[i].Value, maxAttributeValueLength);
 
                         var instrumentationScopeAttributesLength = otlpTagWriterState.WritePosition - (instrumentationScopeAttributesLengthPosition + ReserveSizeForLength);
-                        ProtobufSerializer.WriteReservedLength(otlpTagWriterState.Buffer, instrumentationScopeAttributesLengthPosition, instrumentationScopeAttributesLength);
+                        ProtobufSerializer.WriteReservedLength(otlpTagWriterState.Buffer.AsSpan(instrumentationScopeAttributesLengthPosition), instrumentationScopeAttributesLength);
                         otlpTagWriterState.TagCount++;
                     }
                     else
@@ -171,14 +171,14 @@ internal static class ProtobufOtlpTraceSerializer
                 {
                     if (otlpTagWriterState.TagCount < maxAttributeCount)
                     {
-                        otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Attributes, ProtobufWireType.LEN);
+                        otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer.AsSpan(otlpTagWriterState.WritePosition), ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Attributes, ProtobufWireType.LEN);
                         int instrumentationScopeAttributesLengthPosition = otlpTagWriterState.WritePosition;
                         otlpTagWriterState.WritePosition += ReserveSizeForLength;
 
                         ProtobufOtlpTagWriter.Instance.TryWriteTag(ref otlpTagWriterState, tag.Key, tag.Value, maxAttributeValueLength);
 
                         var instrumentationScopeAttributesLength = otlpTagWriterState.WritePosition - (instrumentationScopeAttributesLengthPosition + ReserveSizeForLength);
-                        ProtobufSerializer.WriteReservedLength(otlpTagWriterState.Buffer, instrumentationScopeAttributesLengthPosition, instrumentationScopeAttributesLength);
+                        ProtobufSerializer.WriteReservedLength(otlpTagWriterState.Buffer.AsSpan(instrumentationScopeAttributesLengthPosition), instrumentationScopeAttributesLength);
                         otlpTagWriterState.TagCount++;
                     }
                     else
@@ -190,14 +190,14 @@ internal static class ProtobufOtlpTraceSerializer
 
             if (otlpTagWriterState.DroppedTagCount > 0)
             {
-                otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(buffer, otlpTagWriterState.WritePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Dropped_Attributes_Count, ProtobufWireType.VARINT);
-                otlpTagWriterState.WritePosition = ProtobufSerializer.WriteVarInt32(buffer, otlpTagWriterState.WritePosition, (uint)otlpTagWriterState.DroppedTagCount);
+                otlpTagWriterState.WritePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(otlpTagWriterState.WritePosition), ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Dropped_Attributes_Count, ProtobufWireType.VARINT);
+                otlpTagWriterState.WritePosition += ProtobufSerializer.WriteVarInt32(buffer.AsSpan(otlpTagWriterState.WritePosition), (uint)otlpTagWriterState.DroppedTagCount);
             }
 
             writePosition = otlpTagWriterState.WritePosition;
         }
 
-        ProtobufSerializer.WriteReservedLength(buffer, instrumentationScopeLengthPosition, writePosition - (instrumentationScopeLengthPosition + ReserveSizeForLength));
+        ProtobufSerializer.WriteReservedLength(buffer.AsSpan(instrumentationScopeLengthPosition), writePosition - (instrumentationScopeLengthPosition + ReserveSizeForLength));
 
         for (int i = 0; i < activities.Count; i++)
         {
@@ -209,38 +209,38 @@ internal static class ProtobufOtlpTraceSerializer
 
     internal static int WriteSpan(byte[] buffer, int writePosition, SdkLimitOptions sdkLimitOptions, Activity activity)
     {
-        writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.ScopeSpans_Span, ProtobufWireType.LEN);
+        writePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(writePosition), ProtobufOtlpTraceFieldNumberConstants.ScopeSpans_Span, ProtobufWireType.LEN);
         int spanLengthPosition = writePosition;
         writePosition += ReserveSizeForLength;
 
-        writePosition = ProtobufSerializer.WriteTagAndLength(buffer, writePosition, TraceIdSize, ProtobufOtlpTraceFieldNumberConstants.Span_Trace_Id, ProtobufWireType.LEN);
+        writePosition += ProtobufSerializer.WriteTagAndLength(buffer.AsSpan(writePosition), TraceIdSize, ProtobufOtlpTraceFieldNumberConstants.Span_Trace_Id, ProtobufWireType.LEN);
         writePosition = WriteTraceId(buffer, writePosition, activity.TraceId);
 
-        writePosition = ProtobufSerializer.WriteTagAndLength(buffer, writePosition, SpanIdSize, ProtobufOtlpTraceFieldNumberConstants.Span_Span_Id, ProtobufWireType.LEN);
+        writePosition += ProtobufSerializer.WriteTagAndLength(buffer.AsSpan(writePosition), SpanIdSize, ProtobufOtlpTraceFieldNumberConstants.Span_Span_Id, ProtobufWireType.LEN);
         writePosition = WriteSpanId(buffer, writePosition, activity.SpanId);
 
         if (activity.TraceStateString != null)
         {
-            writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.Span_Trace_State, activity.TraceStateString);
+            writePosition += ProtobufSerializer.WriteStringWithTag(buffer.AsSpan(writePosition), ProtobufOtlpTraceFieldNumberConstants.Span_Trace_State, activity.TraceStateString);
         }
 
         if (activity.ParentSpanId != default)
         {
-            writePosition = ProtobufSerializer.WriteTagAndLength(buffer, writePosition, SpanIdSize, ProtobufOtlpTraceFieldNumberConstants.Span_Parent_Span_Id, ProtobufWireType.LEN);
+            writePosition += ProtobufSerializer.WriteTagAndLength(buffer.AsSpan(writePosition), SpanIdSize, ProtobufOtlpTraceFieldNumberConstants.Span_Parent_Span_Id, ProtobufWireType.LEN);
             writePosition = WriteSpanId(buffer, writePosition, activity.ParentSpanId);
         }
 
         writePosition = WriteTraceFlags(buffer, writePosition, activity.ActivityTraceFlags, activity.HasRemoteParent, ProtobufOtlpTraceFieldNumberConstants.Span_Flags);
-        writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.Span_Name, activity.DisplayName);
-        writePosition = ProtobufSerializer.WriteEnumWithTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.Span_Kind, (int)activity.Kind + 1);
-        writePosition = ProtobufSerializer.WriteFixed64WithTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.Span_Start_Time_Unix_Nano, (ulong)activity.StartTimeUtc.ToUnixTimeNanoseconds());
-        writePosition = ProtobufSerializer.WriteFixed64WithTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.Span_End_Time_Unix_Nano, (ulong)(activity.StartTimeUtc.ToUnixTimeNanoseconds() + activity.Duration.ToNanoseconds()));
+        writePosition += ProtobufSerializer.WriteStringWithTag(buffer.AsSpan(writePosition), ProtobufOtlpTraceFieldNumberConstants.Span_Name, activity.DisplayName);
+        writePosition += ProtobufSerializer.WriteEnumWithTag(buffer.AsSpan(writePosition), ProtobufOtlpTraceFieldNumberConstants.Span_Kind, (int)activity.Kind + 1);
+        writePosition += ProtobufSerializer.WriteFixed64WithTag(buffer.AsSpan(writePosition), ProtobufOtlpTraceFieldNumberConstants.Span_Start_Time_Unix_Nano, (ulong)activity.StartTimeUtc.ToUnixTimeNanoseconds());
+        writePosition += ProtobufSerializer.WriteFixed64WithTag(buffer.AsSpan(writePosition), ProtobufOtlpTraceFieldNumberConstants.Span_End_Time_Unix_Nano, (ulong)(activity.StartTimeUtc.ToUnixTimeNanoseconds() + activity.Duration.ToNanoseconds()));
 
         (writePosition, StatusCode? statusCode, string? statusMessage) = WriteActivityTags(buffer, writePosition, sdkLimitOptions, activity);
         writePosition = WriteSpanEvents(buffer, writePosition, sdkLimitOptions, activity);
         writePosition = WriteSpanLinks(buffer, writePosition, sdkLimitOptions, activity);
         writePosition = WriteSpanStatus(buffer, writePosition, activity, statusCode, statusMessage);
-        ProtobufSerializer.WriteReservedLength(buffer, spanLengthPosition, writePosition - (spanLengthPosition + ReserveSizeForLength));
+        ProtobufSerializer.WriteReservedLength(buffer.AsSpan(spanLengthPosition), writePosition - (spanLengthPosition + ReserveSizeForLength));
 
         return writePosition;
     }
@@ -269,7 +269,7 @@ internal static class ProtobufOtlpTraceSerializer
             spanFlags |= 0x00000200;
         }
 
-        position = ProtobufSerializer.WriteFixed32WithTag(buffer, position, fieldNumber, spanFlags);
+        position += ProtobufSerializer.WriteFixed32WithTag(buffer.AsSpan(position), fieldNumber, spanFlags);
 
         return position;
     }
@@ -314,13 +314,13 @@ internal static class ProtobufOtlpTraceSerializer
 
             if (otlpTagWriterState.TagCount < maxAttributeCount)
             {
-                otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpTraceFieldNumberConstants.Span_Attributes, ProtobufWireType.LEN);
+                otlpTagWriterState.WritePosition += ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer.AsSpan(otlpTagWriterState.WritePosition), ProtobufOtlpTraceFieldNumberConstants.Span_Attributes, ProtobufWireType.LEN);
                 int spanAttributesLengthPosition = otlpTagWriterState.WritePosition;
                 otlpTagWriterState.WritePosition += ReserveSizeForLength;
 
                 ProtobufOtlpTagWriter.Instance.TryWriteTag(ref otlpTagWriterState, tag.Key, tag.Value, maxAttributeValueLength);
 
-                ProtobufSerializer.WriteReservedLength(buffer, spanAttributesLengthPosition, otlpTagWriterState.WritePosition - (spanAttributesLengthPosition + 4));
+                ProtobufSerializer.WriteReservedLength(buffer.AsSpan(spanAttributesLengthPosition), otlpTagWriterState.WritePosition - (spanAttributesLengthPosition + 4));
                 otlpTagWriterState.TagCount++;
             }
             else
@@ -331,8 +331,8 @@ internal static class ProtobufOtlpTraceSerializer
 
         if (otlpTagWriterState.DroppedTagCount > 0)
         {
-            otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(buffer, otlpTagWriterState.WritePosition, ProtobufOtlpTraceFieldNumberConstants.Span_Dropped_Attributes_Count, ProtobufWireType.VARINT);
-            otlpTagWriterState.WritePosition = ProtobufSerializer.WriteVarInt32(buffer, otlpTagWriterState.WritePosition, (uint)otlpTagWriterState.DroppedTagCount);
+            otlpTagWriterState.WritePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(otlpTagWriterState.WritePosition), ProtobufOtlpTraceFieldNumberConstants.Span_Dropped_Attributes_Count, ProtobufWireType.VARINT);
+            otlpTagWriterState.WritePosition += ProtobufSerializer.WriteVarInt32(buffer.AsSpan(otlpTagWriterState.WritePosition), (uint)otlpTagWriterState.DroppedTagCount);
         }
 
         return (otlpTagWriterState.WritePosition, statusCode, statusMessage);
@@ -347,15 +347,15 @@ internal static class ProtobufOtlpTraceSerializer
         {
             if (eventCount < maxEventCountLimit)
             {
-                writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.Span_Events, ProtobufWireType.LEN);
+                writePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(writePosition), ProtobufOtlpTraceFieldNumberConstants.Span_Events, ProtobufWireType.LEN);
                 int spanEventsLengthPosition = writePosition;
                 writePosition += ReserveSizeForLength; // Reserve 4 bytes for length
 
-                writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.Event_Name, evnt.Name);
-                writePosition = ProtobufSerializer.WriteFixed64WithTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.Event_Time_Unix_Nano, (ulong)evnt.Timestamp.ToUnixTimeNanoseconds());
+                writePosition += ProtobufSerializer.WriteStringWithTag(buffer.AsSpan(writePosition), ProtobufOtlpTraceFieldNumberConstants.Event_Name, evnt.Name);
+                writePosition += ProtobufSerializer.WriteFixed64WithTag(buffer.AsSpan(writePosition), ProtobufOtlpTraceFieldNumberConstants.Event_Time_Unix_Nano, (ulong)evnt.Timestamp.ToUnixTimeNanoseconds());
                 writePosition = WriteEventAttributes(ref buffer, writePosition, sdkLimitOptions, evnt);
 
-                ProtobufSerializer.WriteReservedLength(buffer, spanEventsLengthPosition, writePosition - (spanEventsLengthPosition + ReserveSizeForLength));
+                ProtobufSerializer.WriteReservedLength(buffer.AsSpan(spanEventsLengthPosition), writePosition - (spanEventsLengthPosition + ReserveSizeForLength));
                 eventCount++;
             }
             else
@@ -366,8 +366,8 @@ internal static class ProtobufOtlpTraceSerializer
 
         if (droppedEventCount > 0)
         {
-            writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.Span_Dropped_Events_Count, ProtobufWireType.VARINT);
-            writePosition = ProtobufSerializer.WriteVarInt32(buffer, writePosition, (uint)droppedEventCount);
+            writePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(writePosition), ProtobufOtlpTraceFieldNumberConstants.Span_Dropped_Events_Count, ProtobufWireType.VARINT);
+            writePosition += ProtobufSerializer.WriteVarInt32(buffer.AsSpan(writePosition), (uint)droppedEventCount);
         }
 
         return writePosition;
@@ -390,11 +390,11 @@ internal static class ProtobufOtlpTraceSerializer
         {
             if (otlpTagWriterState.TagCount < maxAttributeCount)
             {
-                otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpTraceFieldNumberConstants.Event_Attributes, ProtobufWireType.LEN);
+                otlpTagWriterState.WritePosition += ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer.AsSpan(otlpTagWriterState.WritePosition), ProtobufOtlpTraceFieldNumberConstants.Event_Attributes, ProtobufWireType.LEN);
                 int eventAttributesLengthPosition = otlpTagWriterState.WritePosition;
                 otlpTagWriterState.WritePosition += ReserveSizeForLength;
                 ProtobufOtlpTagWriter.Instance.TryWriteTag(ref otlpTagWriterState, tag.Key, tag.Value, maxAttributeValueLength);
-                ProtobufSerializer.WriteReservedLength(buffer, eventAttributesLengthPosition, otlpTagWriterState.WritePosition - (eventAttributesLengthPosition + ReserveSizeForLength));
+                ProtobufSerializer.WriteReservedLength(buffer.AsSpan(eventAttributesLengthPosition), otlpTagWriterState.WritePosition - (eventAttributesLengthPosition + ReserveSizeForLength));
                 otlpTagWriterState.TagCount++;
             }
             else
@@ -405,8 +405,8 @@ internal static class ProtobufOtlpTraceSerializer
 
         if (otlpTagWriterState.DroppedTagCount > 0)
         {
-            otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(buffer, otlpTagWriterState.WritePosition, ProtobufOtlpTraceFieldNumberConstants.Event_Dropped_Attributes_Count, ProtobufWireType.VARINT);
-            otlpTagWriterState.WritePosition = ProtobufSerializer.WriteVarInt32(buffer, otlpTagWriterState.WritePosition, (uint)otlpTagWriterState.DroppedTagCount);
+            otlpTagWriterState.WritePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(otlpTagWriterState.WritePosition), ProtobufOtlpTraceFieldNumberConstants.Event_Dropped_Attributes_Count, ProtobufWireType.VARINT);
+            otlpTagWriterState.WritePosition += ProtobufSerializer.WriteVarInt32(buffer.AsSpan(otlpTagWriterState.WritePosition), (uint)otlpTagWriterState.DroppedTagCount);
         }
 
         return otlpTagWriterState.WritePosition;
@@ -422,23 +422,23 @@ internal static class ProtobufOtlpTraceSerializer
         {
             if (linkCount < maxLinksCount)
             {
-                writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.Span_Links, ProtobufWireType.LEN);
+                writePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(writePosition), ProtobufOtlpTraceFieldNumberConstants.Span_Links, ProtobufWireType.LEN);
                 int spanLinksLengthPosition = writePosition;
                 writePosition += ReserveSizeForLength; // Reserve 4 bytes for length
 
-                writePosition = ProtobufSerializer.WriteTagAndLength(buffer, writePosition, TraceIdSize, ProtobufOtlpTraceFieldNumberConstants.Link_Trace_Id, ProtobufWireType.LEN);
+                writePosition += ProtobufSerializer.WriteTagAndLength(buffer.AsSpan(writePosition), TraceIdSize, ProtobufOtlpTraceFieldNumberConstants.Link_Trace_Id, ProtobufWireType.LEN);
                 writePosition = WriteTraceId(buffer, writePosition, link.Context.TraceId);
-                writePosition = ProtobufSerializer.WriteTagAndLength(buffer, writePosition, SpanIdSize, ProtobufOtlpTraceFieldNumberConstants.Link_Span_Id, ProtobufWireType.LEN);
+                writePosition += ProtobufSerializer.WriteTagAndLength(buffer.AsSpan(writePosition), SpanIdSize, ProtobufOtlpTraceFieldNumberConstants.Link_Span_Id, ProtobufWireType.LEN);
                 writePosition = WriteSpanId(buffer, writePosition, link.Context.SpanId);
                 if (link.Context.TraceState != null)
                 {
-                    writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.Span_Trace_State, link.Context.TraceState);
+                    writePosition += ProtobufSerializer.WriteStringWithTag(buffer.AsSpan(writePosition), ProtobufOtlpTraceFieldNumberConstants.Span_Trace_State, link.Context.TraceState);
                 }
 
                 writePosition = WriteLinkAttributes(buffer, writePosition, sdkLimitOptions, link);
                 writePosition = WriteTraceFlags(buffer, writePosition, link.Context.TraceFlags, link.Context.IsRemote, ProtobufOtlpTraceFieldNumberConstants.Link_Flags);
 
-                ProtobufSerializer.WriteReservedLength(buffer, spanLinksLengthPosition, writePosition - (spanLinksLengthPosition + ReserveSizeForLength));
+                ProtobufSerializer.WriteReservedLength(buffer.AsSpan(spanLinksLengthPosition), writePosition - (spanLinksLengthPosition + ReserveSizeForLength));
                 linkCount++;
             }
             else
@@ -449,8 +449,8 @@ internal static class ProtobufOtlpTraceSerializer
 
         if (droppedLinkCount > 0)
         {
-            writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.Span_Dropped_Links_Count, ProtobufWireType.VARINT);
-            writePosition = ProtobufSerializer.WriteVarInt32(buffer, writePosition, (uint)droppedLinkCount);
+            writePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(writePosition), ProtobufOtlpTraceFieldNumberConstants.Span_Dropped_Links_Count, ProtobufWireType.VARINT);
+            writePosition += ProtobufSerializer.WriteVarInt32(buffer.AsSpan(writePosition), (uint)droppedLinkCount);
         }
 
         return writePosition;
@@ -472,11 +472,11 @@ internal static class ProtobufOtlpTraceSerializer
         {
             if (otlpTagWriterState.TagCount < maxAttributeCount)
             {
-                otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpTraceFieldNumberConstants.Link_Attributes, ProtobufWireType.LEN);
+                otlpTagWriterState.WritePosition += ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer.AsSpan(otlpTagWriterState.WritePosition), ProtobufOtlpTraceFieldNumberConstants.Link_Attributes, ProtobufWireType.LEN);
                 int linkAttributesLengthPosition = otlpTagWriterState.WritePosition;
                 otlpTagWriterState.WritePosition += ReserveSizeForLength;
                 ProtobufOtlpTagWriter.Instance.TryWriteTag(ref otlpTagWriterState, tag.Key, tag.Value, maxAttributeValueLength);
-                ProtobufSerializer.WriteReservedLength(buffer, linkAttributesLengthPosition, otlpTagWriterState.WritePosition - (linkAttributesLengthPosition + ReserveSizeForLength));
+                ProtobufSerializer.WriteReservedLength(buffer.AsSpan(linkAttributesLengthPosition), otlpTagWriterState.WritePosition - (linkAttributesLengthPosition + ReserveSizeForLength));
                 otlpTagWriterState.TagCount++;
             }
             else
@@ -487,8 +487,8 @@ internal static class ProtobufOtlpTraceSerializer
 
         if (otlpTagWriterState.DroppedTagCount > 0)
         {
-            otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(buffer, otlpTagWriterState.WritePosition, ProtobufOtlpTraceFieldNumberConstants.Link_Dropped_Attributes_Count, ProtobufWireType.VARINT);
-            otlpTagWriterState.WritePosition = ProtobufSerializer.WriteVarInt32(buffer, otlpTagWriterState.WritePosition, (uint)otlpTagWriterState.DroppedTagCount);
+            otlpTagWriterState.WritePosition += ProtobufSerializer.WriteTag(buffer.AsSpan(otlpTagWriterState.WritePosition), ProtobufOtlpTraceFieldNumberConstants.Link_Dropped_Attributes_Count, ProtobufWireType.VARINT);
+            otlpTagWriterState.WritePosition += ProtobufSerializer.WriteVarInt32(buffer.AsSpan(otlpTagWriterState.WritePosition), (uint)otlpTagWriterState.DroppedTagCount);
         }
 
         return otlpTagWriterState.WritePosition;
@@ -512,16 +512,16 @@ internal static class ProtobufOtlpTraceSerializer
             var serializedLengthSize = ProtobufSerializer.ComputeVarInt64Size((ulong)numberOfUtf8CharsInString);
 
             // length = numberOfUtf8CharsInString + Status_Message tag size + serializedLengthSize field size + Span_Status tag size + Span_Status length size.
-            position = ProtobufSerializer.WriteTagAndLength(buffer, position, numberOfUtf8CharsInString + 1 + serializedLengthSize + 2, ProtobufOtlpTraceFieldNumberConstants.Span_Status, ProtobufWireType.LEN);
-            position = ProtobufSerializer.WriteStringWithTag(buffer, position, ProtobufOtlpTraceFieldNumberConstants.Status_Message, numberOfUtf8CharsInString, descriptionSpan);
+            position += ProtobufSerializer.WriteTagAndLength(buffer.AsSpan(position), numberOfUtf8CharsInString + 1 + serializedLengthSize + 2, ProtobufOtlpTraceFieldNumberConstants.Span_Status, ProtobufWireType.LEN);
+            position += ProtobufSerializer.WriteStringWithTag(buffer.AsSpan(position), ProtobufOtlpTraceFieldNumberConstants.Status_Message, numberOfUtf8CharsInString, descriptionSpan);
         }
         else
         {
-            position = ProtobufSerializer.WriteTagAndLength(buffer, position, 2, ProtobufOtlpTraceFieldNumberConstants.Span_Status, ProtobufWireType.LEN);
+            position += ProtobufSerializer.WriteTagAndLength(buffer.AsSpan(position), 2, ProtobufOtlpTraceFieldNumberConstants.Span_Status, ProtobufWireType.LEN);
         }
 
         var finalStatusCode = useActivity ? (int)activity.Status : (statusCode != null && statusCode != StatusCode.Unset) ? (int)statusCode! : (int)StatusCode.Unset;
-        position = ProtobufSerializer.WriteEnumWithTag(buffer, position, ProtobufOtlpTraceFieldNumberConstants.Status_Code, finalStatusCode);
+        position += ProtobufSerializer.WriteEnumWithTag(buffer.AsSpan(position), ProtobufOtlpTraceFieldNumberConstants.Status_Code, finalStatusCode);
 
         return position;
     }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/Serializer/ProtobufSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/Serializer/ProtobufSerializerTests.cs
@@ -20,7 +20,7 @@ public class ProtobufSerializerTests
     public void WriteTag_WritesCorrectly()
     {
         byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteTag(buffer, 0, 1, ProtobufWireType.VARINT);
+        int position = ProtobufSerializer.WriteTag(buffer.AsSpan(0), 1, ProtobufWireType.VARINT);
         Assert.Equal(1, position);
         Assert.Equal(8, buffer[0]);
     }
@@ -29,7 +29,7 @@ public class ProtobufSerializerTests
     public void WriteLength_WritesCorrectly()
     {
         byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteLength(buffer, 0, 300);
+        int position = ProtobufSerializer.WriteLength(buffer.AsSpan(0), 300);
         Assert.Equal(2, position);
         Assert.Equal(0xAC, buffer[0]);
         Assert.Equal(0x02, buffer[1]);
@@ -39,7 +39,7 @@ public class ProtobufSerializerTests
     public void WriteBoolWithTag_WritesCorrectly()
     {
         byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteBoolWithTag(buffer, 0, 1, true);
+        int position = ProtobufSerializer.WriteBoolWithTag(buffer.AsSpan(0), 1, true);
         Assert.Equal(2, position);
         Assert.Equal(8, buffer[0]);
         Assert.Equal(1, buffer[1]);
@@ -49,7 +49,7 @@ public class ProtobufSerializerTests
     public void WriteFixed32WithTag_WritesCorrectly()
     {
         byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteFixed32WithTag(buffer, 0, 1, 0x12345678);
+        int position = ProtobufSerializer.WriteFixed32WithTag(buffer.AsSpan(0), 1, 0x12345678);
         Assert.Equal(5, position);
         Assert.Equal(13, buffer[0]);
         Assert.Equal(0x78, buffer[1]);
@@ -62,7 +62,7 @@ public class ProtobufSerializerTests
     public void WriteFixed64WithTag_WritesCorrectly()
     {
         byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteFixed64WithTag(buffer, 0, 1, 0x123456789ABCDEF0);
+        int position = ProtobufSerializer.WriteFixed64WithTag(buffer.AsSpan(0), 1, 0x123456789ABCDEF0);
         Assert.Equal(9, position);
         Assert.Equal(9, buffer[0]); // Tag
         Assert.Equal(0xF0, buffer[1]);
@@ -79,7 +79,7 @@ public class ProtobufSerializerTests
     public void WriteStringWithTag_WritesCorrectly()
     {
         byte[] buffer = new byte[20];
-        int position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, "Hello");
+        int position = ProtobufSerializer.WriteStringWithTag(buffer.AsSpan(0), 1, "Hello");
         Assert.Equal(7, position);
         Assert.Equal(10, buffer[0]);
         Assert.Equal(5, buffer[1]);
@@ -110,7 +110,7 @@ public class ProtobufSerializerTests
         }
 #endif
         byte[] buffer = new byte[10];
-        ProtobufSerializer.WriteReservedLength(buffer, 0, length);
+        ProtobufSerializer.WriteReservedLength(buffer.AsSpan(), length);
 
         for (int i = 0; i < expectedBytes.Length; i++)
         {
@@ -122,7 +122,7 @@ public class ProtobufSerializerTests
     public void WriteTagAndLength_WritesCorrectly()
     {
         byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteTagAndLength(buffer, 0, 300, 1, ProtobufWireType.LEN);
+        int position = ProtobufSerializer.WriteTagAndLength(buffer.AsSpan(0), 300, 1, ProtobufWireType.LEN);
         Assert.Equal(3, position);
         Assert.Equal(10, buffer[0]); // Tag
         Assert.Equal(0xAC, buffer[1]); // Length (300 in varint encoding)
@@ -133,7 +133,7 @@ public class ProtobufSerializerTests
     public void WriteEnumWithTag_WritesCorrectly()
     {
         byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteEnumWithTag(buffer, 0, 1, 5);
+        int position = ProtobufSerializer.WriteEnumWithTag(buffer.AsSpan(0), 1, 5);
         Assert.Equal(2, position);
         Assert.Equal(8, buffer[0]); // Tag
         Assert.Equal(5, buffer[1]); // Enum value
@@ -143,7 +143,7 @@ public class ProtobufSerializerTests
     public void WriteVarInt64_WritesCorrectly()
     {
         byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteVarInt64(buffer, 0, 300);
+        int position = ProtobufSerializer.WriteVarInt64(buffer.AsSpan(0), 300);
         Assert.Equal(2, position);
         Assert.Equal(0xAC, buffer[0]);
         Assert.Equal(0x02, buffer[1]);
@@ -153,7 +153,7 @@ public class ProtobufSerializerTests
     public void WriteInt64WithTag_WritesCorrectly()
     {
         byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteInt64WithTag(buffer, 0, 1, 300);
+        int position = ProtobufSerializer.WriteInt64WithTag(buffer.AsSpan(0), 1, 300);
         Assert.Equal(3, position);
         Assert.Equal(8, buffer[0]); // Tag
         Assert.Equal(0xAC, buffer[1]);
@@ -164,7 +164,7 @@ public class ProtobufSerializerTests
     public void WriteDoubleWithTag_WritesCorrectly()
     {
         byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteDoubleWithTag(buffer, 0, 1, 123.456);
+        int position = ProtobufSerializer.WriteDoubleWithTag(buffer.AsSpan(0), 1, 123.456);
         Assert.Equal(9, position);
         Assert.Equal(9, buffer[0]); // Tag
 
@@ -183,14 +183,14 @@ public class ProtobufSerializerTests
     public void WriteSignedInt32_WritesCorrectly()
     {
         byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteSInt32WithTag(buffer, 0, 1, 300);
+        int position = ProtobufSerializer.WriteSInt32WithTag(buffer.AsSpan(0), 1, 300);
         Assert.Equal(3, position);
         Assert.Equal(8, buffer[0]); // Tag
         Assert.Equal(0xD8, buffer[1]);
         Assert.Equal(0x04, buffer[2]);
 
         buffer = new byte[10];
-        position = ProtobufSerializer.WriteSInt32WithTag(buffer, 0, 1, -300);
+        position = ProtobufSerializer.WriteSInt32WithTag(buffer.AsSpan(0), 1, -300);
         Assert.Equal(3, position);
         Assert.Equal(8, buffer[0]); // Tag
         Assert.Equal(0xD7, buffer[1]);
@@ -201,7 +201,7 @@ public class ProtobufSerializerTests
     public void WriteVarInt32_WritesCorrectly()
     {
         byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteVarInt32(buffer, 0, 300);
+        int position = ProtobufSerializer.WriteVarInt32(buffer.AsSpan(0), 300);
         Assert.Equal(2, position);
         Assert.Equal(0xAC, buffer[0]);
         Assert.Equal(0x02, buffer[1]);
@@ -211,7 +211,7 @@ public class ProtobufSerializerTests
     public void WriteVarInt32_MaxValue_WritesCorrectly()
     {
         byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteVarInt32(buffer, 0, uint.MaxValue);
+        int position = ProtobufSerializer.WriteVarInt32(buffer.AsSpan(0), uint.MaxValue);
         Assert.Equal(5, position);
         Assert.Equal(0xFF, buffer[0]);
         Assert.Equal(0xFF, buffer[1]);
@@ -224,7 +224,7 @@ public class ProtobufSerializerTests
     public void WriteVarInt64_MaxValue_WritesCorrectly()
     {
         byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteVarInt64(buffer, 0, ulong.MaxValue);
+        int position = ProtobufSerializer.WriteVarInt64(buffer.AsSpan(0), ulong.MaxValue);
         Assert.Equal(10, position);
         for (int i = 0; i < 9; i++)
         {
@@ -238,7 +238,7 @@ public class ProtobufSerializerTests
     public void WriteStringWithTag_EmptyString_WritesCorrectly()
     {
         byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, string.Empty);
+        int position = ProtobufSerializer.WriteStringWithTag(buffer.AsSpan(0), 1, string.Empty);
         Assert.Equal(2, position);
         Assert.Equal(10, buffer[0]); // Tag
         Assert.Equal(0, buffer[1]); // Length
@@ -248,7 +248,7 @@ public class ProtobufSerializerTests
     public void WriteStringWithTag_ASCIIString_WritesCorrectly()
     {
         byte[] buffer = new byte[20];
-        int position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, "Hello");
+        int position = ProtobufSerializer.WriteStringWithTag(buffer.AsSpan(0), 1, "Hello");
         Assert.Equal(7, position);
         Assert.Equal(10, buffer[0]); // Tag
         Assert.Equal(5, buffer[1]); // Length
@@ -264,7 +264,7 @@ public class ProtobufSerializerTests
     {
         byte[] buffer = new byte[20];
         string unicodeString = "\u3053\u3093\u306b\u3061\u306f"; // "Hello" in Japanese
-        int position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, unicodeString);
+        int position = ProtobufSerializer.WriteStringWithTag(buffer.AsSpan(0), 1, unicodeString);
         Assert.Equal(17, position);
         Assert.Equal(10, buffer[0]); // Tag
         Assert.Equal(15, buffer[1]); // Length (3 bytes per character in UTF-8)
@@ -280,7 +280,7 @@ public class ProtobufSerializerTests
     {
         string longString = new string('a', 1000);
         byte[] buffer = new byte[1100];
-        int position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, longString);
+        int position = ProtobufSerializer.WriteStringWithTag(buffer.AsSpan(0), 1, longString);
         Assert.Equal(1003, position);
         Assert.Equal(10, buffer[0]); // Tag
         Assert.Equal(0xE8, buffer[1]); // Length (1000 in varint encoding)
@@ -297,7 +297,7 @@ public class ProtobufSerializerTests
     {
         byte[] buffer = new byte[30];
         string mixedString = "Hello\u4e16\u754c"; // "Hello World" with "World" in Chinese
-        int position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, mixedString);
+        int position = ProtobufSerializer.WriteStringWithTag(buffer.AsSpan(0), 1, mixedString);
         Assert.Equal(13, position);
         Assert.Equal(10, buffer[0]); // Tag
         Assert.Equal(11, buffer[1]); // Length (5 for "Hello" + 6 for Chinese "World" in UTF-8)
@@ -313,7 +313,7 @@ public class ProtobufSerializerTests
     {
         byte[] buffer = new byte[30];
         string specialString = "Hello\n\t\"World\"";
-        int position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, specialString);
+        int position = ProtobufSerializer.WriteStringWithTag(buffer.AsSpan(0), 1, specialString);
         Assert.Equal(16, position);
         Assert.Equal(10, buffer[0]); // Tag
         Assert.Equal(14, buffer[1]); // Length
@@ -329,7 +329,7 @@ public class ProtobufSerializerTests
     {
         byte[] buffer = new byte[20];
         string stringWithNull = "Hello\0World";
-        int position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, stringWithNull);
+        int position = ProtobufSerializer.WriteStringWithTag(buffer.AsSpan(0), 1, stringWithNull);
         Assert.Equal(13, position);
         Assert.Equal(10, buffer[0]); // Tag
         Assert.Equal(11, buffer[1]); // Length
@@ -345,7 +345,7 @@ public class ProtobufSerializerTests
     {
         byte[] buffer = new byte[20];
         string surrogatePairString = "\uD83D\uDCD6"; // Books emoji
-        int position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, surrogatePairString);
+        int position = ProtobufSerializer.WriteStringWithTag(buffer.AsSpan(0), 1, surrogatePairString);
         Assert.Equal(6, position);
         Assert.Equal(10, buffer[0]); // Tag
         Assert.Equal(4, buffer[1]); // Length (4 bytes for the surrogate pair in UTF-8)


### PR DESCRIPTION
Addresses #6543

## Changes

Refactored serialization logic to use `Span<byte>` for buffer manipulation, improving performance, memory efficiency, and code readability. Updated method signatures to eliminate explicit `writePosition` management, replaced incremental write logic with consistent `+=` operations, and streamlined encoding methods. Enhanced test coverage to validate edge cases and updated all test cases to align with the new implementation. Applied changes consistently across all serializers, ensuring backward compatibility and laying the groundwork for future optimizations. Improved error handling, debugging, and documentation for better maintainability and robustness.

## Merge requirement checklist

* [X] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [X] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
