### PR TITLE
[infra] Fix role check during release process

### DIFF
--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -202,7 +202,7 @@ function PushPackagesPublishReleaseUnlockAndPostNoticeOnPrepareReleasePullReques
   $tag = $match.Groups[1].Value
 
   $commentUserPermission = gh api "repos/$gitRepository/collaborators/$commentUserName/permission" | ConvertFrom-Json
-  if ($commentUserPermission.permission -ne 'admin')
+  if ($commentUserPermission.permission -ne 'maintain')
   {
     gh pr comment $pullRequestNumber `
       --body "I'm sorry @$commentUserName but you don't have permission to push packages. Only maintainers can push to NuGet."


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-dotnet/pull/6546#issuecomment-3354888036

## Changes

Roel require to push should be `maintain` instead of `admin`.

Checked based on my (maintainer) and @martincostello (approver) account. Requests to `gh api "repos/$gitRepository/collaborators/$commentUserName/permission"`

returns

```json
Kielek
    "permissions": {
      "admin": false,
      "maintain": true,
      "push": true,
      "triage": true,
      "pull": true
    },

marticostello
    "permissions": {
      "admin": false,
      "maintain": false,
      "push": true,
      "triage": true,
      "pull": true
    },
```

Change required to last converting maintainers to lower privileges.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
