### PR TITLE
[infra] Fix post release steps related to artifacts output

### DIFF
--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -490,8 +490,10 @@ function GetCoreDependenciesForProjects {
         $output = dotnet restore $project -p:RunningDotNetPack=true
 
         $projectDir = $project | Split-Path -Parent
+        $projectDirName = $projectDir | Split-Path -Leaf
+        $projectArtifactsDir = $projectDir | Split-Path -Parent | Split-Path -Parent | Join-Path -ChildPath "artifacts/obj/$projectDirName"
 
-        $content = (Get-Content "$projectDir/obj/project.assets.json" -Raw)
+        $content = (Get-Content "$projectArtifactsDir/project.assets.json" -Raw)
 
         $projectDependencies = @{}
 


### PR DESCRIPTION
Fixes issues related to #6301
Failing build: https://github.com/open-telemetry/opentelemetry-dotnet/actions/runs/18153830423/job/51669380274

## Changes

project.assets.json are located in different place
<img width="257" height="316" alt="image" src="https://github.com/user-attachments/assets/b79836bc-6eee-4bef-b6c2-4df4833bf052" />

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
