### PR TITLE
[OTLP] Avoid redundant allocations and log HTTP export success

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -7,6 +7,12 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Avoid allocating strings when logging gRPC export events unless required.
+  ([#6562](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6562))
+
+* Log export success when exporting telemetry using `http/protobuf`.
+  ([#6562](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6562))
+
 ## 1.13.0
 
 Released 2025-Oct-01

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -7,9 +7,6 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* Log export success when exporting telemetry using `http/protobuf`.
-  ([#6562](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6562))
-
 ## 1.13.0
 
 Released 2025-Oct-01

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -7,9 +7,6 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
-* Avoid allocating strings when logging gRPC export events unless required.
-  ([#6562](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6562))
-
 * Log export success when exporting telemetry using `http/protobuf`.
   ([#6562](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6562))
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcExportClient.cs
@@ -67,7 +67,7 @@ internal sealed class OtlpGrpcExportClient : OtlpExportClient
                         status = new Status(StatusCode.Internal, "Failed to deserialize response message.");
                     }
 
-                    OpenTelemetryProtocolExporterEventSource.Log.ResponseDeserializationFailed(this.Endpoint.ToString());
+                    OpenTelemetryProtocolExporterEventSource.Log.ResponseDeserializationFailed(this.Endpoint);
 
                     return new ExportClientGrpcResponse(
                         success: false,
@@ -88,7 +88,7 @@ internal sealed class OtlpGrpcExportClient : OtlpExportClient
 
             if (status.StatusCode == StatusCode.OK)
             {
-                OpenTelemetryProtocolExporterEventSource.Log.ExportSuccess(this.Endpoint.ToString(), "Export completed successfully.");
+                OpenTelemetryProtocolExporterEventSource.Log.ExportSuccess(this.Endpoint, "Export completed successfully.");
                 return SuccessExportResponse;
             }
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpHttpExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpHttpExportClient.cs
@@ -39,6 +39,7 @@ internal sealed class OtlpHttpExportClient : OtlpExportClient
                 return new ExportClientHttpResponse(success: false, deadlineUtc: deadlineUtc, response: httpResponse, ex);
             }
 
+            OpenTelemetryProtocolExporterEventSource.Log.ExportSuccess(this.Endpoint, "Export completed successfully.");
             return SuccessExportResponse;
         }
         catch (HttpRequestException ex)

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OpenTelemetryProtocolExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OpenTelemetryProtocolExporterEventSource.cs
@@ -104,6 +104,24 @@ internal sealed class OpenTelemetryProtocolExporterEventSource : EventSource, IC
         }
     }
 
+    [NonEvent]
+    public void ExportSuccess(Uri endpoint, string message)
+    {
+        if (Log.IsEnabled(EventLevel.Informational, EventKeywords.All))
+        {
+            this.ExportSuccess(endpoint.ToString(), message);
+        }
+    }
+
+    [NonEvent]
+    public void ResponseDeserializationFailed(Uri endpoint)
+    {
+        if (Log.IsEnabled(EventLevel.Error, EventKeywords.All))
+        {
+            this.ResponseDeserializationFailed(endpoint.ToString());
+        }
+    }
+
     [Event(2, Message = "Exporter failed send data to collector to {0} endpoint. Data will not be sent. Exception: {1}", Level = EventLevel.Error)]
     public void FailedToReachCollector(string rawCollectorUri, string ex)
     {


### PR DESCRIPTION
## Changes

Found while working on #6463.

- Avoid `Uri.ToString()` allocations when logging in OTLP export clients if the event source is not enabled at the relevant logging levels.
- Log successful HTTP export for parity with gRPC.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
