### PR TITLE
[Benchmarks] Reduce total runtime

### DIFF
--- a/test/Benchmarks/Exporter/OtlpGrpcExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/OtlpGrpcExporterBenchmarks.cs
@@ -23,7 +23,7 @@ public class OtlpGrpcExporterBenchmarks
     private Activity? activity;
     private CircularBuffer<Activity>? activityBatch;
 
-    [Params(1, 10, 100)]
+    [Params(1, 10, 20)]
     public int NumberOfBatches { get; set; }
 
     [Params(10000)]

--- a/test/Benchmarks/Exporter/OtlpHttpExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/OtlpHttpExporterBenchmarks.cs
@@ -28,7 +28,7 @@ public class OtlpHttpExporterBenchmarks
     private Activity? activity;
     private CircularBuffer<Activity>? activityBatch;
 
-    [Params(1, 10, 100)]
+    [Params(1, 10, 20)]
     public int NumberOfBatches { get; set; }
 
     [Params(10000)]

--- a/test/Benchmarks/Exporter/ZipkinExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/ZipkinExporterBenchmarks.cs
@@ -25,7 +25,7 @@ public class ZipkinExporterBenchmarks
     private string? serverHost;
     private int serverPort;
 
-    [Params(1, 10, 100)]
+    [Params(1, 10, 20)]
     public int NumberOfBatches { get; set; }
 
     [Params(10000)]


### PR DESCRIPTION
Relates to #6567.

## Changes

Reduce exporter benchmarks' total runtime by reducing the maximum `NumberOfBatches` value from `100` to `20`.

While running the benchmarks for #6567, I noticed that it took 75 minutes _just_ to get to the warm-up phase of running the OTLP exporter benchmarks for gRPC.

Reducing the value to `20` completes the the three benchmarks in ~50 minutes, so ~100 minutes to do a before and after comparison on the same machine.

The results in #6567 show that the time and memory increases linearly with the number of batches, so I don't think there's any need to run 100 batches as that implies a runtime of 400s per iteration for no real benefit of improving accuracy of the benchmarks.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
