### PR TITLE
[OpenTelemetry] Add OnEnding span processor functionality

### DIFF
--- a/OpenTelemetry.sln
+++ b/OpenTelemetry.sln
@@ -308,6 +308,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "experimental-apis", "experi
 		docs\diagnostics\experimental-apis\OTEL1000.md = docs\diagnostics\experimental-apis\OTEL1000.md
 		docs\diagnostics\experimental-apis\OTEL1001.md = docs\diagnostics\experimental-apis\OTEL1001.md
 		docs\diagnostics\experimental-apis\OTEL1004.md = docs\diagnostics\experimental-apis\OTEL1004.md
+		docs\diagnostics\experimental-apis\OTEL1005.md = docs\diagnostics\experimental-apis\OTEL1005.md
 		docs\diagnostics\experimental-apis\README.md = docs\diagnostics\experimental-apis\README.md
 	EndProjectSection
 EndProject

--- a/build/Common.props
+++ b/build/Common.props
@@ -12,7 +12,7 @@
     <NuGetAuditMode>all</NuGetAuditMode>
     <NuGetAuditLevel>low</NuGetAuditLevel>
     <!-- Suppress warnings for repo code using experimental features -->
-    <NoWarn>$(NoWarn);OTEL1000;OTEL1001;OTEL1002;OTEL1004</NoWarn>
+    <NoWarn>$(NoWarn);OTEL1000;OTEL1001;OTEL1002;OTEL1004;OTEL1005</NoWarn>
     <AnalysisLevel>latest-All</AnalysisLevel>
   </PropertyGroup>
 

--- a/docs/diagnostics/experimental-apis/OTEL1005.md
+++ b/docs/diagnostics/experimental-apis/OTEL1005.md
@@ -1,0 +1,31 @@
+# OpenTelemetry .NET Diagnostic: OTEL1004
+
+## Overview
+
+This is an experimental API for modifying spans before they end/close
+
+### Details
+
+#### ExtendedBaseProcessor
+
+The abstract class `ExtendedBaseProcessor` provides an extension of the
+`BaseProcessor` that allows spans to be modified before they end as per the
+OpenTelemetry specification. It provides the `OnEnding` function that is called
+during the span `End()` operation. The end timestamp MUST have been computed
+(the `OnEnding` method duration is not included in the span duration). The Span
+object MUST still be mutable (i.e., `SetAttribute`, `AddLink`, `AddEvent` can be
+called) while `OnEnding` is called. This method MUST be called synchronously
+within the [`Span.End()` API](api.md#end), therefore it should not block or
+throw an exception. If multiple `SpanProcessors` are registered, their
+`OnEnding` callbacks are invoked in the order they have been registered. The
+SDK MUST guarantee that the span can no longer be modified by any other thread
+before invoking `OnEnding` of the first `SpanProcessor`. From that point on,
+modifications are only allowed synchronously from within the invoked `OnEnding`
+callbacks. All registered SpanProcessor `OnEnding` callbacks are executed before
+any SpanProcessor's `OnEnd` callback is invoked.
+
+**Parameters:**
+
+* `span` - a read/write span object for the span which is about to be ended.
+
+**Returns:** `Void`

--- a/docs/diagnostics/experimental-apis/README.md
+++ b/docs/diagnostics/experimental-apis/README.md
@@ -33,6 +33,12 @@ Description: ExemplarReservoir Support
 
 Details: [OTEL1004](./OTEL1004.md)
 
+### OTEL1005
+
+Description: OnEnding Implementation
+
+Details: [OTEL1005](./OTEL1005.md)
+
 ## Inactive
 
 Experimental APIs which have been released stable or removed:

--- a/src/OpenTelemetry/.publicApi/Experimental/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/Experimental/PublicAPI.Unshipped.txt
@@ -25,3 +25,7 @@ OpenTelemetry.Metrics.MetricStreamConfiguration.ExemplarReservoirFactory.set -> 
 [OTEL1000]static Microsoft.Extensions.Logging.OpenTelemetryLoggingExtensions.UseOpenTelemetry(this Microsoft.Extensions.Logging.ILoggingBuilder! builder, System.Action<OpenTelemetry.Logs.LoggerProviderBuilder!>? configureBuilder, System.Action<OpenTelemetry.Logs.OpenTelemetryLoggerOptions!>? configureOptions) -> Microsoft.Extensions.Logging.ILoggingBuilder!
 [OTEL1001]static OpenTelemetry.Sdk.CreateLoggerProviderBuilder() -> OpenTelemetry.Logs.LoggerProviderBuilder!
 [OTEL1004]virtual OpenTelemetry.Metrics.FixedSizeExemplarReservoir.OnCollected() -> void
+[OTEL1005]OpenTelemetry.ExtendedBaseProcessor<T>
+[OTEL1005]OpenTelemetry.ExtendedBaseProcessor<T>.ExtendedBaseProcessor() -> void
+[OTEL1005]virtual OpenTelemetry.ExtendedBaseProcessor<T>.OnEnding(T data) -> void
+[OTEL1005]override OpenTelemetry.CompositeProcessor<T>.OnEnding(T data) -> void

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -37,6 +37,9 @@ Released 2025-Oct-21
 * Add support for .NET 10.0.
   ([#6307](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6307))
 
+* feat: add on ending span processor functionality
+  ([#6617](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6617))
+
 ## 1.13.1
 
 Released 2025-Oct-09

--- a/src/OpenTelemetry/ExtendedBaseProcessor.cs
+++ b/src/OpenTelemetry/ExtendedBaseProcessor.cs
@@ -1,0 +1,34 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if EXPOSE_EXPERIMENTAL_FEATURES
+using System.Diagnostics.CodeAnalysis;
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry;
+
+/// <summary>
+/// Extended base processor base class.
+/// </summary>
+/// <typeparam name="T">The type of object to be processed.</typeparam>
+[Experimental(DiagnosticDefinitions.ExtendedBaseProcessorExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
+#pragma warning disable CA1012 // Abstract types should not have public constructors
+public abstract class ExtendedBaseProcessor<T> : BaseProcessor<T>
+#pragma warning restore CA1012 // Abstract types should not have public constructors
+{
+    /// <summary>
+    /// Called synchronously before a telemetry object ends.
+    /// </summary>
+    /// <param name="data">
+    /// The started telemetry object.
+    /// </param>
+    /// <remarks>
+    /// This function is called synchronously on the thread which ended
+    /// the telemetry object. This function should be thread-safe, and
+    /// should not block indefinitely or throw exceptions.
+    /// </remarks>
+    public virtual void OnEnding(T data)
+    {
+    }
+}
+#endif

--- a/src/OpenTelemetry/Trace/TracerProviderSdk.cs
+++ b/src/OpenTelemetry/Trace/TracerProviderSdk.cs
@@ -189,6 +189,12 @@ internal sealed class TracerProviderSdk : TracerProvider
 
                 if (SuppressInstrumentationScope.DecrementIfTriggered() == 0)
                 {
+#if EXPOSE_EXPERIMENTAL_FEATURES
+                    if (typeof(ExtendedBaseProcessor<Activity>).IsAssignableFrom(this.processor?.GetType()))
+                    {
+                        (this.processor as ExtendedBaseProcessor<Activity>)?.OnEnding(activity);
+                    }
+#endif
                     this.processor?.OnEnd(activity);
                 }
             };
@@ -224,6 +230,13 @@ internal sealed class TracerProviderSdk : TracerProvider
 
                 if (SuppressInstrumentationScope.DecrementIfTriggered() == 0)
                 {
+#if EXPOSE_EXPERIMENTAL_FEATURES
+                    if (typeof(ExtendedBaseProcessor<Activity>).IsAssignableFrom(this.processor?.GetType()))
+                    {
+                        (this.processor as ExtendedBaseProcessor<Activity>)?.OnEnding(activity);
+                    }
+#endif
+
                     this.processor?.OnEnd(activity);
                 }
             };

--- a/src/Shared/DiagnosticDefinitions.cs
+++ b/src/Shared/DiagnosticDefinitions.cs
@@ -10,6 +10,7 @@ internal static class DiagnosticDefinitions
     public const string LoggerProviderExperimentalApi = "OTEL1000";
     public const string LogsBridgeExperimentalApi = "OTEL1001";
     public const string ExemplarReservoirExperimentalApi = "OTEL1004";
+    public const string ExtendedBaseProcessorExperimentalApi = "OTEL1005";
 
     /* Definitions which have been released stable:
     public const string ExemplarExperimentalApi = "OTEL1002";

--- a/test/OpenTelemetry.Tests/Shared/TestActivityProcessor.cs
+++ b/test/OpenTelemetry.Tests/Shared/TestActivityProcessor.cs
@@ -5,9 +5,10 @@ using System.Diagnostics;
 
 namespace OpenTelemetry.Tests;
 
-internal sealed class TestActivityProcessor : BaseProcessor<Activity>
+internal sealed class TestActivityProcessor : ExtendedBaseProcessor<Activity>
 {
     public Action<Activity>? StartAction;
+    public Action<Activity>? EndingAction;
     public Action<Activity>? EndAction;
 
     public TestActivityProcessor()
@@ -20,6 +21,13 @@ internal sealed class TestActivityProcessor : BaseProcessor<Activity>
         this.EndAction = onEnd;
     }
 
+    public TestActivityProcessor(Action<Activity>? onStart, Action<Activity>? onEnding, Action<Activity>? onEnd)
+    {
+        this.StartAction = onStart;
+        this.EndingAction = onEnding;
+        this.EndAction = onEnd;
+    }
+
     public bool ShutdownCalled { get; private set; }
 
     public bool ForceFlushCalled { get; private set; }
@@ -29,6 +37,11 @@ internal sealed class TestActivityProcessor : BaseProcessor<Activity>
     public override void OnStart(Activity span)
     {
         this.StartAction?.Invoke(span);
+    }
+
+    public override void OnEnding(Activity span)
+    {
+        this.EndingAction?.Invoke(span);
     }
 
     public override void OnEnd(Activity span)


### PR DESCRIPTION
Fixes: N/A
Design discussion issue: https://github.com/open-telemetry/opentelemetry-specification/pull/4024

## Changes

Changes based loosely on the same changes made to opentelemetry-java: https://github.com/open-telemetry/opentelemetry-java/pull/6367

This change creates a new ExtendedBaseProcessor that allows users to implement onEnding functionality to their processor, as per the spec: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#onending

Specific changes:
- Changed `CompositeProcessor` to be extended from the new `ExtendedBaseProcessor` to support processors that have OnEnding
- Created new `ExtendedBaseProcessor` as the place where this functionality is added, so as to not break any current experience of extending the normal `BaseProcessor`
- Updated TestActivityProcessor to extend the new OnEnding method while being agnostic to it for tests that don't need it
- Updated unit tests to verify the running order of the span lifecycle is correct and includes the OnEnding invocation

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
