### PR TITLE
[Infra/Extensions.Hosting] Fix flaky test 

### DIFF
--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryServicesExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryServicesExtensionsTests.cs
@@ -454,8 +454,13 @@ public class OpenTelemetryServicesExtensionsTests
         using var host = builder.Build();
         await host.StartAsync();
 
+        var service = host.Services
+            .GetServices<IHostedService>()
+            .OfType<TestHostedService>()
+            .Single();
+
         // Give the background service some time to run.
-        await Task.Delay(TimeSpan.FromSeconds(1));
+        await Task.WhenAny(service.ExecuteTask!, Task.Delay(TimeSpan.FromSeconds(5)));
 
         await host.StopAsync();
 


### PR DESCRIPTION
Fixes #6619

## Changes

Fix flaky `AddOpenTelemetry_HostedServiceOrder_DoesNotMatter` test by giving the background service enough time to run to generate the activity.

Will run a few times in draft to check there's no failures before marking as ready for review in case it doesn't resolve in CI (it works fine locally).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
