### PR TITLE
[Infra/OpenTelemetry] Wait longer before assertion to avoid flaky test

### DIFF
--- a/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorTests.cs
@@ -92,7 +92,7 @@ public class BatchExportActivityProcessorTests
         Assert.Equal(0, processor.ProcessedCount);
 
         // waiting to see if time is triggering the exporter
-        await Task.Delay(TimeSpan.FromSeconds(1));
+        await Task.Delay(TimeSpan.FromSeconds(2));
         Assert.Empty(exportedItems);
 
         // forcing flush


### PR DESCRIPTION
## Changes

Wait longer before flushing to give the batch export thread more time to start and process the buffer to avoid [flaky test](https://github.com/open-telemetry/opentelemetry-dotnet/actions/runs/18781816676/job/53589704509?pr=6646#step:7:1893).

```text
  Failed OpenTelemetry.Trace.Tests.BatchExportActivityProcessorTests.CheckForceFlushExport(timeout: 1) [1 s]
  Error Message:
   Assert.Equal() Failure: Values differ
Expected: True
Actual:   False
  Stack Trace:
     at OpenTelemetry.Trace.Tests.BatchExportActivityProcessorTests.CheckForceFlushExport(Int32 timeout) in /home/runner/work/opentelemetry-dotnet/opentelemetry-dotnet/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorTests.cs:line 101
--- End of stack trace from previous location ---
```

Previously there was a 1 second wait competing with a 1 second polling frequency:

https://github.com/open-telemetry/opentelemetry-dotnet/blob/59ae884507bde8f064782d2978b01decf4abc699/src/OpenTelemetry/BatchExportProcessor.cs#L147-L149

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
