### PR TITLE
[Infra] Update to .NET 10 GA

### DIFF
--- a/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
+++ b/src/OpenTelemetry.Api.ProviderBuilderExtensions/CHANGELOG.md
@@ -17,6 +17,10 @@ Notes](../../RELEASENOTES.md).
 * Update to stable versions for .NET 10.0 NuGet packages.
   ([#6667](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6667))
 
+* Update `Microsoft.Extensions.*` dependencies to `10.0.0` for .NET Framework
+  and .NET Standard.
+  ([#6667](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6667))
+
 ## 1.14.0-rc.1
 
 Released 2025-Oct-21

--- a/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Console/CHANGELOG.md
@@ -13,9 +13,6 @@ Notes](../../RELEASENOTES.md).
   section](../../README.md#digital-signing) for updated verification instructions.
   ([#6623](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6623))
 
-* Update to stable versions for .NET 10.0 NuGet packages.
-  ([#6667](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6667))
-
 ## 1.14.0-rc.1
 
 Released 2025-Oct-21

--- a/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.InMemory/CHANGELOG.md
@@ -13,9 +13,6 @@ Notes](../../RELEASENOTES.md).
   section](../../README.md#digital-signing) for updated verification instructions.
   ([#6623](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6623))
 
-* Update to stable versions for .NET 10.0 NuGet packages.
-  ([#6667](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6667))
-
 ## 1.14.0-rc.1
 
 Released 2025-Oct-21

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/CHANGELOG.md
@@ -14,9 +14,6 @@ Notes](../../RELEASENOTES.md).
   section](../../README.md#digital-signing) for updated verification instructions.
   ([#6623](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6623))
 
-* Update to stable versions for .NET 10.0 NuGet packages.
-  ([#6667](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6667))
-
 ## 1.14.0-rc.1
 
 Released 2025-Oct-21

--- a/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.AspNetCore/CHANGELOG.md
@@ -26,9 +26,6 @@ Notes](../../RELEASENOTES.md).
   section](../../README.md#digital-signing) for updated verification instructions.
   ([#6623](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6623))
 
-* Update to stable versions for .NET 10.0 NuGet packages.
-  ([#6667](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6667))
-
 ## 1.13.1-beta.1
 
 Released 2025-Oct-10

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/CHANGELOG.md
@@ -26,9 +26,6 @@ Notes](../../RELEASENOTES.md).
   section](../../README.md#digital-signing) for updated verification instructions.
   ([#6623](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6623))
 
-* Update to stable versions for .NET 10.0 NuGet packages.
-  ([#6667](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6667))
-
 ## 1.13.1-beta.1
 
 Released 2025-Oct-10

--- a/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
+++ b/src/OpenTelemetry.Exporter.Zipkin/CHANGELOG.md
@@ -13,9 +13,6 @@ Notes](../../RELEASENOTES.md).
   section](../../README.md#digital-signing) for updated verification instructions.
   ([#6623](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6623))
 
-* Update to stable versions for .NET 10.0 NuGet packages.
-  ([#6667](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6667))
-
 ## 1.14.0-rc.1
 
 Released 2025-Oct-21

--- a/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Hosting/CHANGELOG.md
@@ -16,6 +16,10 @@ Notes](../../RELEASENOTES.md).
 * Update to stable versions for .NET 10.0 NuGet packages.
   ([#6667](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6667))
 
+* Update `Microsoft.Extensions.*` dependencies to `10.0.0` for .NET Framework
+  and .NET Standard.
+  ([#6667](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6667))
+
 ## 1.14.0-rc.1
 
 Released 2025-Oct-21

--- a/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
+++ b/src/OpenTelemetry.Extensions.Propagators/CHANGELOG.md
@@ -13,9 +13,6 @@ covering all components see: [Release Notes](../../RELEASENOTES.md).
   section](../../README.md#digital-signing) for updated verification instructions.
   ([#6623](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6623))
 
-* Update to stable versions for .NET 10.0 NuGet packages.
-  ([#6667](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6667))
-
 ## 1.14.0-rc.1
 
 Released 2025-Oct-21

--- a/src/OpenTelemetry.Shims.OpenTracing/CHANGELOG.md
+++ b/src/OpenTelemetry.Shims.OpenTracing/CHANGELOG.md
@@ -16,9 +16,6 @@ Notes](../../RELEASENOTES.md).
   section](../../README.md#digital-signing) for updated verification instructions.
   ([#6623](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6623))
 
-* Update to stable versions for .NET 10.0 NuGet packages.
-  ([#6667](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6667))
-
 ## 1.13.1-beta.1
 
 Released 2025-Oct-10

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -16,6 +16,10 @@ Notes](../../RELEASENOTES.md).
 * Update to stable versions for .NET 10.0 NuGet packages.
   ([#6667](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6667))
 
+* Update `Microsoft.Extensions.*` dependencies to `10.0.0` for .NET Framework
+  and .NET Standard.
+  ([#6667](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6667))
+
 ## 1.14.0-rc.1
 
 Released 2025-Oct-21


### PR DESCRIPTION
## Changes

Update to stable release of .NET 10.

Opening now to be ready, but the CI will fail until .NET 10 GA is actually published and the Docker container digests are known.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] ~~Changes in public API reviewed (if applicable)~~
