### PR TITLE
[bug] Flaky test: BatchExportActivityProcessorTests.CheckForceFlushExport 

### DIFF
--- a/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorTests.cs
@@ -65,7 +65,7 @@ public class BatchExportActivityProcessorTests
     [Theory]
     [InlineData(Timeout.Infinite)]
     [InlineData(0)]
-    [InlineData(10)]
+    [InlineData(1)]
     public async Task CheckForceFlushExport(int timeout)
     {
         var exportedItems = new List<Activity>();


### PR DESCRIPTION
Fixes #6657 

## Changes

Changed the wait timing from 2 to 1.5 in ```BatchExportActivityProcessorTests.cs``` and would further monitor with github tests

