### PR TITLE
[bug] Flaky test: BatchExportActivityProcessorTests.CheckForceFlushExport

### DIFF
--- a/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/BatchExportActivityProcessorTests.cs
@@ -65,7 +65,7 @@ public class BatchExportActivityProcessorTests
     [Theory]
     [InlineData(Timeout.Infinite)]
     [InlineData(0)]
-    [InlineData(1)]
+    [InlineData(10)]
     public async Task CheckForceFlushExport(int timeout)
     {
         var exportedItems = new List<Activity>();
@@ -92,7 +92,7 @@ public class BatchExportActivityProcessorTests
         Assert.Equal(0, processor.ProcessedCount);
 
         // waiting to see if time is triggering the exporter
-        await Task.Delay(TimeSpan.FromSeconds(1.5);
+        await Task.Delay(TimeSpan.FromSeconds(2));
         Assert.Empty(exportedItems);
 
         // forcing flush


### PR DESCRIPTION
Fixes #6657 

## Changes

Previously, the test used [InlineData(1)], where 1 ms was passed as the timeout.
Upon reviewing the OnForceFlush implementation (which ForceFlush wraps), it became clear that 1 ms is unrealistically short for the processor’s asynchronous flush operation.As in realistic cases, the timeout variable (in OnForceFlush function) would yield false value 

File reference:
```/home/tushar/opentelemetry-dotnet/src/OpenTelemetry/CompositeProcessor.cs```

```C# 
var timeout = timeoutMilliseconds - sw.ElapsedMilliseconds;
```
timeoutMilliseconds is 1ms and sw.ElapsedMilliseconds would be >=1ms (in slow CLI runners) the resulting timeout becomes 0 or negative, causing the test to fail.

By increasing the timeout to 10 ms, we ensure that slower CLI runners have sufficient time to complete the operation, allowing the test cases to pass reliably.