### PR TITLE
Added AlwaysRecordSampler

### DIFF
--- a/OpenTelemetry.slnx
+++ b/OpenTelemetry.slnx
@@ -87,6 +87,7 @@
     <File Path="docs/diagnostics/experimental-apis/OTEL1000.md" />
     <File Path="docs/diagnostics/experimental-apis/OTEL1001.md" />
     <File Path="docs/diagnostics/experimental-apis/OTEL1004.md" />
+    <File Path="docs/diagnostics/experimental-apis/OTEL1005.md" />
     <File Path="docs/diagnostics/experimental-apis/README.md" />
   </Folder>
   <Folder Name="/docs/logs/">

--- a/build/Common.props
+++ b/build/Common.props
@@ -12,7 +12,7 @@
     <NuGetAuditMode>all</NuGetAuditMode>
     <NuGetAuditLevel>low</NuGetAuditLevel>
     <!-- Suppress warnings for repo code using experimental features -->
-    <NoWarn>$(NoWarn);OTEL1000;OTEL1001;OTEL1002;OTEL1004</NoWarn>
+    <NoWarn>$(NoWarn);OTEL1000;OTEL1001;OTEL1002;OTEL1004;OTEL1005</NoWarn>
     <AnalysisLevel>latest-All</AnalysisLevel>
   </PropertyGroup>
 

--- a/docs/diagnostics/experimental-apis/OTEL1005.md
+++ b/docs/diagnostics/experimental-apis/OTEL1005.md
@@ -1,0 +1,18 @@
+# OpenTelemetry .NET Diagnostic: OTEL1005
+
+## Overview
+
+This is an experimental API for allowing spans to always be recorded.
+
+### Details
+
+#### AlwaysRecordSampler
+
+TODO: Explanation.
+
+**Parameters:**
+
+* TODO: Details
+* `span` - a read/write span object for the span which is about to be ended.
+
+**Returns:** `TODO`

--- a/docs/diagnostics/experimental-apis/README.md
+++ b/docs/diagnostics/experimental-apis/README.md
@@ -33,6 +33,12 @@ Description: ExemplarReservoir Support
 
 Details: [OTEL1004](./OTEL1004.md)
 
+### OTEL1005
+
+Description: AlwaysRecordSampler implementation for recording all spans
+
+Details: [OTEL1005](./OTEL1005.md)
+
 ## Inactive
 
 Experimental APIs which have been released stable or removed:

--- a/src/OpenTelemetry/.publicApi/Experimental/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry/.publicApi/Experimental/PublicAPI.Unshipped.txt
@@ -25,3 +25,6 @@ OpenTelemetry.Metrics.MetricStreamConfiguration.ExemplarReservoirFactory.set -> 
 [OTEL1000]static Microsoft.Extensions.Logging.OpenTelemetryLoggingExtensions.UseOpenTelemetry(this Microsoft.Extensions.Logging.ILoggingBuilder! builder, System.Action<OpenTelemetry.Logs.LoggerProviderBuilder!>? configureBuilder, System.Action<OpenTelemetry.Logs.OpenTelemetryLoggerOptions!>? configureOptions) -> Microsoft.Extensions.Logging.ILoggingBuilder!
 [OTEL1001]static OpenTelemetry.Sdk.CreateLoggerProviderBuilder() -> OpenTelemetry.Logs.LoggerProviderBuilder!
 [OTEL1004]virtual OpenTelemetry.Metrics.FixedSizeExemplarReservoir.OnCollected() -> void
+[OTEL1005]OpenTelemetry.Trace.AlwaysRecordSampler
+[OTEL1005]static OpenTelemetry.Trace.AlwaysRecordSampler.Create(OpenTelemetry.Trace.Sampler! rootSampler) -> OpenTelemetry.Trace.AlwaysRecordSampler!
+[OTEL1005]override OpenTelemetry.Trace.AlwaysRecordSampler.ShouldSample(in OpenTelemetry.Trace.SamplingParameters samplingParameters) -> OpenTelemetry.Trace.SamplingResult

--- a/src/OpenTelemetry/CHANGELOG.md
+++ b/src/OpenTelemetry/CHANGELOG.md
@@ -12,6 +12,9 @@ Notes](../../RELEASENOTES.md).
 * Added support for `Meter.TelemetrySchemaUrl` property.
   ([#6714](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6714))
 
+* Added `AlwaysRecordSampler`.
+  ([#6732](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6732))
+
 ## 1.14.0
 
 Released 2025-Nov-12

--- a/src/OpenTelemetry/Trace/Sampler/AlwaysRecordSampler.cs
+++ b/src/OpenTelemetry/Trace/Sampler/AlwaysRecordSampler.cs
@@ -1,0 +1,70 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Includes work from:
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#if EXPOSE_EXPERIMENTAL_FEATURES
+using System.Diagnostics.CodeAnalysis;
+#endif
+using OpenTelemetry.Internal;
+
+namespace OpenTelemetry.Trace;
+
+#if EXPOSE_EXPERIMENTAL_FEATURES
+/// <summary>
+/// This sampler will return the sampling result of the provided rootSampler, unless the
+/// sampling result contains the sampling decision <see cref="SamplingDecision.Drop"/>, in which case, a
+/// new sampling result will be returned that is functionally equivalent to the original, except that
+/// it contains the sampling decision  <see cref="SamplingDecision.RecordOnly"/>. This ensures that all
+/// spans are recorded, with no change to sampling.
+///
+/// The intended use case of this sampler is to provide a means of sending all spans to a
+/// processor without having an impact on the sampling rate. This may be desirable if a user wishes
+/// to count or otherwise measure all spans produced in a service, without incurring the cost of 100%
+/// sampling.
+/// </summary>
+[Experimental(DiagnosticDefinitions.AlwaysRecordSamplerExperimentalApi, UrlFormat = DiagnosticDefinitions.ExperimentalApiUrlFormat)]
+public
+#else
+internal
+#endif
+    sealed class AlwaysRecordSampler : Sampler
+{
+    private readonly Sampler rootSampler;
+
+    private AlwaysRecordSampler(Sampler rootSampler)
+    {
+        this.rootSampler = rootSampler;
+        this.Description = "AlwaysRecordSampler{" + rootSampler.Description + "}";
+    }
+
+    /// <summary>
+    /// Method to create an AlwaysRecordSampler.
+    /// </summary>
+    /// <param name="rootSampler"><see cref="Sampler"/>rootSampler to create AlwaysRecordSampler from.</param>
+    /// <returns>Created AlwaysRecordSampler.</returns>
+    public static AlwaysRecordSampler Create(Sampler rootSampler)
+    {
+        Guard.ThrowIfNull(rootSampler);
+        return new AlwaysRecordSampler(rootSampler);
+    }
+
+    /// <inheritdoc/>
+    public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
+    {
+        SamplingResult result = this.rootSampler.ShouldSample(samplingParameters);
+        if (result.Decision == SamplingDecision.Drop)
+        {
+            result = WrapResultWithRecordOnlyResult(result);
+        }
+
+        return result;
+    }
+
+    private static SamplingResult WrapResultWithRecordOnlyResult(SamplingResult result)
+    {
+        return new SamplingResult(SamplingDecision.RecordOnly, result.Attributes, result.TraceStateString);
+    }
+}

--- a/src/Shared/DiagnosticDefinitions.cs
+++ b/src/Shared/DiagnosticDefinitions.cs
@@ -10,6 +10,7 @@ internal static class DiagnosticDefinitions
     public const string LoggerProviderExperimentalApi = "OTEL1000";
     public const string LogsBridgeExperimentalApi = "OTEL1001";
     public const string ExemplarReservoirExperimentalApi = "OTEL1004";
+    public const string AlwaysRecordSamplerExperimentalApi = "OTEL1005";
 
     /* Definitions which have been released stable:
     public const string ExemplarExperimentalApi = "OTEL1002";

--- a/test/OpenTelemetry.Tests/Trace/AlwaysRecordSamplerTests.cs
+++ b/test/OpenTelemetry.Tests/Trace/AlwaysRecordSamplerTests.cs
@@ -1,0 +1,95 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Includes work from:
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using System.Diagnostics;
+using OpenTelemetry.Tests;
+using Xunit;
+
+namespace OpenTelemetry.Trace.Tests;
+
+/// <summary>
+/// AlwaysRecordSamplerTest test class.
+/// </summary>
+public class AlwaysRecordSamplerTests
+{
+    /// <summary>
+    /// Tests Description is set properly with AlwaysRecordSampler keyword.
+    /// </summary>
+    [Fact]
+    public void TestGetDescription()
+    {
+        var testSampler = new TestSampler();
+        var sampler = AlwaysRecordSampler.Create(testSampler);
+        Assert.Equal("AlwaysRecordSampler{TestSampler}", sampler.Description);
+    }
+
+    /// <summary>
+    /// Test RECORD_AND_SAMPLE sampling decision.
+    /// </summary>
+    [Fact]
+    public void TestRecordAndSampleSamplingDecision()
+    {
+        ValidateShouldSample(SamplingDecision.RecordAndSample, SamplingDecision.RecordAndSample);
+    }
+
+    /// <summary>
+    /// Test RECORD_ONLY sampling decision.
+    /// </summary>
+    [Fact]
+    public void TestRecordOnlySamplingDecision()
+    {
+        ValidateShouldSample(SamplingDecision.RecordOnly, SamplingDecision.RecordOnly);
+    }
+
+    /// <summary>
+    /// Test DROP sampling decision.
+    /// </summary>
+    [Fact]
+    public void TestDropSamplingDecision()
+    {
+        ValidateShouldSample(SamplingDecision.Drop, SamplingDecision.RecordOnly);
+    }
+
+    private static SamplingResult BuildRootSamplingResult(SamplingDecision samplingDecision)
+    {
+        ActivityTagsCollection? attributes = new ActivityTagsCollection
+        {
+            { "key", samplingDecision.GetType().Name },
+        };
+        string traceState = samplingDecision.GetType().Name;
+#pragma warning disable CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
+        return new SamplingResult(samplingDecision, attributes, traceState);
+#pragma warning restore CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
+    }
+
+    private static void ValidateShouldSample(
+        SamplingDecision rootDecision, SamplingDecision expectedDecision)
+    {
+        SamplingResult rootResult = BuildRootSamplingResult(rootDecision);
+        var testSampler = new TestSampler { SamplingAction = _ => rootResult };
+        var sampler = AlwaysRecordSampler.Create(testSampler);
+
+        SamplingParameters samplingParameters = new SamplingParameters(
+            default, default, "name", ActivityKind.Client, new ActivityTagsCollection(), new List<ActivityLink>());
+
+        SamplingResult actualResult = sampler.ShouldSample(samplingParameters);
+
+        if (rootDecision.Equals(expectedDecision))
+        {
+            Assert.True(actualResult.Equals(rootResult));
+            Assert.True(actualResult.Decision.Equals(rootDecision));
+        }
+        else
+        {
+            Assert.False(actualResult.Equals(rootResult));
+            Assert.True(actualResult.Decision.Equals(expectedDecision));
+        }
+
+        Assert.Equal(rootResult.Attributes, actualResult.Attributes);
+        Assert.Equal(rootDecision.GetType().Name, actualResult.TraceStateString);
+    }
+}


### PR DESCRIPTION
## Background

Spec PR: https://github.com/open-telemetry/opentelemetry-specification/pull/4699

Design discussion issue https://github.com/open-telemetry/opentelemetry-specification/issues/4698

## Changes

- Add AlwaysRecordSampler that replaces any Drop sampling decision provided by a delegate sampler with RecordOnly
- Added appropriate unit tests using the TestSampler as a delegate

Changes copied from the following with some modifications: [aws-otel-dotnet-instrumentation](https://github.com/aws-observability/aws-otel-dotnet-instrumentation/blob/main/src/AWS.Distro.OpenTelemetry.AutoInstrumentation/AlwaysRecordSampler.cs)

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
