### PR TITLE
[Test] Update OTLP proto files to 1.9.0

### DIFF
--- a/src/Shared/Proto/opentelemetry/proto/common/v1/common.proto
+++ b/src/Shared/Proto/opentelemetry/proto/common/v1/common.proto
@@ -54,8 +54,10 @@ message ArrayValue {
 message KeyValueList {
   // A collection of key/value pairs of key-value pairs. The list may be empty (may
   // contain 0 elements).
+  //
   // The keys MUST be unique (it is not allowed to have more than one
   // value with the same key).
+  // The behavior of software that receives duplicated keys can be unpredictable.
   repeated KeyValue values = 1;
 }
 
@@ -70,7 +72,7 @@ message KeyValue {
 }
 
 // InstrumentationScope is a message representing the instrumentation scope information
-// such as the fully qualified name and version.
+// such as the fully qualified name and version. 
 message InstrumentationScope {
   // A name denoting the Instrumentation scope.
   // An empty instrumentation scope name means the name is unknown.
@@ -83,6 +85,7 @@ message InstrumentationScope {
   // Additional attributes that describe the scope. [Optional].
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
+  // The behavior of software that receives duplicated keys can be unpredictable.
   repeated KeyValue attributes = 3;
 
   // The number of attributes that were discarded. Attributes

--- a/src/Shared/Proto/opentelemetry/proto/logs/v1/logs.proto
+++ b/src/Shared/Proto/opentelemetry/proto/logs/v1/logs.proto
@@ -78,7 +78,8 @@ message ScopeLogs {
   // is recorded in. Notably, the last part of the URL path is the version number of the
   // schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
   // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
-  // This schema_url applies to all logs in the "logs" field.
+  // This schema_url applies to the data in the "scope" field and all logs in the
+  // "log_records" field.
   string schema_url = 3;
 }
 
@@ -174,6 +175,7 @@ message LogRecord {
   // Additional attributes that describe the specific event occurrence. [Optional].
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
+  // The behavior of software that receives duplicated keys can be unpredictable.
   repeated opentelemetry.proto.common.v1.KeyValue attributes = 6;
   uint32 dropped_attributes_count = 7;
 

--- a/src/Shared/Proto/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/src/Shared/Proto/opentelemetry/proto/metrics/v1/metrics.proto
@@ -96,7 +96,8 @@ message ScopeMetrics {
   // is recorded in. Notably, the last part of the URL path is the version number of the
   // schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
   // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
-  // This schema_url applies to all metrics in the "metrics" field.
+  // This schema_url applies to the data in the "scope" field and all metrics in the
+  // "metrics" field.
   string schema_url = 3;
 }
 
@@ -215,6 +216,7 @@ message Metric {
   // for lossless roundtrip translation to / from another data model.
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
+  // The behavior of software that receives duplicated keys can be unpredictable.
   repeated opentelemetry.proto.common.v1.KeyValue metadata = 12;
 }
 
@@ -387,16 +389,7 @@ message NumberDataPoint {
   // where this point belongs. The list may be empty (may contain 0 elements).
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
-  //
-  // The attribute values SHOULD NOT contain empty values.
-  // The attribute values SHOULD NOT contain bytes values.
-  // The attribute values SHOULD NOT contain array values different than array of string values, bool values, int values,
-  // double values.
-  // The attribute values SHOULD NOT contain kvlist values.
-  // The behavior of software that receives attributes containing such values can be unpredictable.
-  // These restrictions can change in a minor release.
-  // The restrictions take origin from the OpenTelemetry specification:
-  // https://github.com/open-telemetry/opentelemetry-specification/blob/v1.47.0/specification/common/README.md#attribute.
+  // The behavior of software that receives duplicated keys can be unpredictable.
   repeated opentelemetry.proto.common.v1.KeyValue attributes = 7;
 
   // StartTimeUnixNano is optional but strongly encouraged, see the
@@ -445,16 +438,7 @@ message HistogramDataPoint {
   // where this point belongs. The list may be empty (may contain 0 elements).
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
-  //
-  // The attribute values SHOULD NOT contain empty values.
-  // The attribute values SHOULD NOT contain bytes values.
-  // The attribute values SHOULD NOT contain array values different than array of string values, bool values, int values,
-  // double values.
-  // The attribute values SHOULD NOT contain kvlist values.
-  // The behavior of software that receives attributes containing such values can be unpredictable.
-  // These restrictions can change in a minor release.
-  // The restrictions take origin from the OpenTelemetry specification:
-  // https://github.com/open-telemetry/opentelemetry-specification/blob/v1.47.0/specification/common/README.md#attribute.
+  // The behavior of software that receives duplicated keys can be unpredictable.
   repeated opentelemetry.proto.common.v1.KeyValue attributes = 9;
 
   // StartTimeUnixNano is optional but strongly encouraged, see the
@@ -539,16 +523,7 @@ message ExponentialHistogramDataPoint {
   // where this point belongs. The list may be empty (may contain 0 elements).
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
-  //
-  // The attribute values SHOULD NOT contain empty values.
-  // The attribute values SHOULD NOT contain bytes values.
-  // The attribute values SHOULD NOT contain array values different than array of string values, bool values, int values,
-  // double values.
-  // The attribute values SHOULD NOT contain kvlist values.
-  // The behavior of software that receives attributes containing such values can be unpredictable.
-  // These restrictions can change in a minor release.
-  // The restrictions take origin from the OpenTelemetry specification:
-  // https://github.com/open-telemetry/opentelemetry-specification/blob/v1.47.0/specification/common/README.md#attribute.
+  // The behavior of software that receives duplicated keys can be unpredictable.
   repeated opentelemetry.proto.common.v1.KeyValue attributes = 1;
 
   // StartTimeUnixNano is optional but strongly encouraged, see the
@@ -665,16 +640,7 @@ message SummaryDataPoint {
   // where this point belongs. The list may be empty (may contain 0 elements).
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
-  //
-  // The attribute values SHOULD NOT contain empty values.
-  // The attribute values SHOULD NOT contain bytes values.
-  // The attribute values SHOULD NOT contain array values different than array of string values, bool values, int values,
-  // double values.
-  // The attribute values SHOULD NOT contain kvlist values.
-  // The behavior of software that receives attributes containing such values can be unpredictable.
-  // These restrictions can change in a minor release.
-  // The restrictions take origin from the OpenTelemetry specification:
-  // https://github.com/open-telemetry/opentelemetry-specification/blob/v1.47.0/specification/common/README.md#attribute.
+  // The behavior of software that receives duplicated keys can be unpredictable.
   repeated opentelemetry.proto.common.v1.KeyValue attributes = 7;
 
   // StartTimeUnixNano is optional but strongly encouraged, see the

--- a/src/Shared/Proto/opentelemetry/proto/profiles/v1development/profiles.proto
+++ b/src/Shared/Proto/opentelemetry/proto/profiles/v1development/profiles.proto
@@ -97,12 +97,29 @@ option go_package = "go.opentelemetry.io/proto/otlp/profiles/v1development";
 //
 
 // ProfilesDictionary represents the profiles data shared across the
-// entire message being sent.
+// entire message being sent. The following applies to all fields in this
+// message:
 //
-// Note that all fields in this message MUST have a zero value encoded as the first element.
-// This allows for _index fields pointing into the dictionary to use a 0 pointer value
-// to indicate 'null' / 'not set'. Unless otherwise defined, a 'zero value' message value
-// is one with all default field values, so as to minimize wire encoded size.
+// - A dictionary is an array of dictionary items. Users of the dictionary
+//   compactly reference the items using the index within the array.
+//
+// - A dictionary MUST have a zero value encoded as the first element. This
+//   allows for _index fields pointing into the dictionary to use a 0 pointer
+//   value to indicate 'null' / 'not set'. Unless otherwise defined, a 'zero
+//   value' message value is one with all default field values, so as to
+//   minimize wire encoded size.
+//
+// - There SHOULD NOT be dupes in a dictionary. The identity of dictionary
+//   items is based on their value, recursively as needed. If a particular
+//   implementation does emit duplicated items, it MUST NOT attempt to give them
+//   meaning based on the index or order. A profile processor may remove
+//   duplicate items and this MUST NOT have any observable effects for
+//   consumers.
+//
+// - There SHOULD NOT be orphaned (unreferenced) items in a dictionary. A
+//   profile processor may remove ("garbage-collect") orphaned items and this
+//   MUST NOT have any observable effects for consumers.
+//
 message ProfilesDictionary {
   // Mappings from address ranges to the image/binary/library mapped
   // into that address range referenced by locations via Location.mapping_index.
@@ -148,16 +165,6 @@ message ProfilesDictionary {
   //     "/http/user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36"
   //     "abc.com/myattribute": true
   //     "allocation_size": 128 bytes
-  //
-  // The attribute values SHOULD NOT contain empty values.
-  // The attribute values SHOULD NOT contain bytes values.
-  // The attribute values SHOULD NOT contain array values different than array of string values, bool values, int values,
-  // double values.
-  // The attribute values SHOULD NOT contain kvlist values.
-  // The behavior of software that receives attributes containing such values can be unpredictable.
-  // These restrictions can change in a minor release.
-  // The restrictions take origin from the OpenTelemetry specification:
-  // https://github.com/open-telemetry/opentelemetry-specification/blob/v1.47.0/specification/common/README.md#attribute.
   //
   // attribute_table[0] must always be zero value (KeyValueAndUnit{}) and present.
   repeated KeyValueAndUnit attribute_table = 6;
@@ -229,7 +236,8 @@ message ScopeProfiles {
   // is recorded in. Notably, the last part of the URL path is the version number of the
   // schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
   // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
-  // This schema_url applies to all profiles in the "profiles" field.
+  // This schema_url applies to the data in the "scope" field and all profiles in the
+  // "profiles" field.
   string schema_url = 3;
 }
 
@@ -285,12 +293,6 @@ message Profile {
   ValueType period_type = 5;
   // The number of events between sampled occurrences.
   int64 period = 6;
-  // Free-form text associated with the profile. The text is displayed as is
-  // to the user by the tools that read profiles (e.g. by pprof). This field
-  // should not be used to store any machine-readable information, it is only
-  // for human-friendly content. The profile must stay functional if this field
-  // is cleaned.
-  repeated int32 comment_strindices = 7; // Indices into ProfilesDictionary.string_table.
 
   // A globally unique identifier for a profile. The ID is a 16-byte array. An ID with
   // all zeroes is considered invalid. It may be used for deduplication and signal
@@ -298,26 +300,39 @@ message Profile {
   // in this field as not equal, even if they represented the same object at an earlier
   // time.
   // This field is optional; an ID may be assigned to an ID-less profile in a later step.
-  bytes profile_id = 8;
+  bytes profile_id = 7;
 
   // The number of attributes that were discarded. Attributes
   // can be discarded because their keys are too long or because there are too many
   // attributes. If this value is 0, then no attributes were dropped.
-  uint32 dropped_attributes_count = 9;
+  uint32 dropped_attributes_count = 8;
 
-  // Specifies format of the original payload. Common values are defined in semantic conventions. [required if original_payload is present]
-  string original_payload_format = 10;
-
-  // Original payload can be stored in this field. This can be useful for users who want to get the original payload.
-  // Formats such as JFR are highly extensible and can contain more information than what is defined in this spec.
-  // Inclusion of original payload should be configurable by the user. Default behavior should be to not include the original payload.
-  // If the original payload is in pprof format, it SHOULD not be included in this field.
-  // The field is optional, however if it is present then equivalent converted data should be populated in other fields
-  // of this message as far as is practicable.
-  bytes original_payload = 11;
+  // The original payload format. See also original_payload. Optional, but the
+  // format and the bytes must be set or unset together.
+  //
+  // The allowed values for the format string are defined by the OpenTelemetry
+  // specification. Some examples are "jfr", "pprof", "linux_perf".
+  //
+  // The original payload may be optionally provided when the conversion to the
+  // OLTP format was done from a different format with some loss of the fidelity
+  // and the receiver may want to store the original payload to allow future
+  // lossless export or reinterpretation. Some examples of the original format
+  // are JFR (Java Flight Recorder), pprof, Linux perf.
+  //
+  // Even when the original payload is in a format that is semantically close to
+  // OTLP, such as pprof, a conversion may still be lossy in some cases (e.g. if
+  // the pprof file contains custom extensions or conventions).
+  //
+  // The original payload can be large in size, so including the original
+  // payload should be configurable by the profiler or collector options. The
+  // default behavior should be to not include the original payload.
+  string original_payload_format = 9;
+  // The original payload bytes. See also original_payload_format. Optional, but
+  // format and the bytes must be set or unset together.
+  bytes original_payload = 10;
 
   // References to attributes in attribute_table. [optional]
-  repeated int32 attribute_indices = 12;
+  repeated int32 attribute_indices = 11;
 }
 
 // A pointer from a profile Sample to a trace Span.

--- a/src/Shared/Proto/opentelemetry/proto/resource/v1/resource.proto
+++ b/src/Shared/Proto/opentelemetry/proto/resource/v1/resource.proto
@@ -29,16 +29,7 @@ message Resource {
   // Set of attributes that describe the resource.
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
-  //
-  // The attribute values SHOULD NOT contain empty values.
-  // The attribute values SHOULD NOT contain bytes values.
-  // The attribute values SHOULD NOT contain array values different than array of string values, bool values, int values,
-  // double values.
-  // The attribute values SHOULD NOT contain kvlist values.
-  // The behavior of software that receives attributes containing such values can be unpredictable.
-  // These restrictions can change in a minor release.
-  // The restrictions take origin from the OpenTelemetry specification:
-  // https://github.com/open-telemetry/opentelemetry-specification/blob/v1.47.0/specification/common/README.md#attribute.
+  // The behavior of software that receives duplicated keys can be unpredictable.
   repeated opentelemetry.proto.common.v1.KeyValue attributes = 1;
 
   // The number of dropped attributes. If the value is 0, then

--- a/src/Shared/Proto/opentelemetry/proto/trace/v1/trace.proto
+++ b/src/Shared/Proto/opentelemetry/proto/trace/v1/trace.proto
@@ -78,7 +78,8 @@ message ScopeSpans {
   // is recorded in. Notably, the last part of the URL path is the version number of the
   // schema: http[s]://server[:port]/path/<version>. To learn more about Schema URL see
   // https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
-  // This schema_url applies to all spans and span events in the "spans" field.
+  // This schema_url applies to the data in the "scope" field and all spans and span
+  // events in the "spans" field.
   string schema_url = 3;
 }
 
@@ -208,16 +209,7 @@ message Span {
   //
   // Attribute keys MUST be unique (it is not allowed to have more than one
   // attribute with the same key).
-  //
-  // The attribute values SHOULD NOT contain empty values.
-  // The attribute values SHOULD NOT contain bytes values.
-  // The attribute values SHOULD NOT contain array values different than array of string values, bool values, int values,
-  // double values.
-  // The attribute values SHOULD NOT contain kvlist values.
-  // The behavior of software that receives attributes containing such values can be unpredictable.
-  // These restrictions can change in a minor release.
-  // The restrictions take origin from the OpenTelemetry specification:
-  // https://github.com/open-telemetry/opentelemetry-specification/blob/v1.47.0/specification/common/README.md#attribute.
+  // The behavior of software that receives duplicated keys can be unpredictable.
   repeated opentelemetry.proto.common.v1.KeyValue attributes = 9;
 
   // The number of attributes that were discarded. Attributes
@@ -238,16 +230,7 @@ message Span {
     // A collection of attribute key/value pairs on the event.
     // Attribute keys MUST be unique (it is not allowed to have more than one
     // attribute with the same key).
-    //
-    // The attribute values SHOULD NOT contain empty values.
-    // The attribute values SHOULD NOT contain bytes values.
-    // The attribute values SHOULD NOT contain array values different than array of string values, bool values, int values,
-    // double values.
-    // The attribute values SHOULD NOT contain kvlist values.
-    // The behavior of software that receives attributes containing such values can be unpredictable.
-    // These restrictions can change in a minor release.
-    // The restrictions take origin from the OpenTelemetry specification:
-    // https://github.com/open-telemetry/opentelemetry-specification/blob/v1.47.0/specification/common/README.md#attribute.
+    // The behavior of software that receives duplicated keys can be unpredictable.
     repeated opentelemetry.proto.common.v1.KeyValue attributes = 3;
 
     // The number of dropped attributes. If the value is 0,
@@ -280,16 +263,7 @@ message Span {
     // A collection of attribute key/value pairs on the link.
     // Attribute keys MUST be unique (it is not allowed to have more than one
     // attribute with the same key).
-    //
-    // The attribute values SHOULD NOT contain empty values.
-    // The attribute values SHOULD NOT contain bytes values.
-    // The attribute values SHOULD NOT contain array values different than array of string values, bool values, int values,
-    // double values.
-    // The attribute values SHOULD NOT contain kvlist values.
-    // The behavior of software that receives attributes containing such values can be unpredictable.
-    // These restrictions can change in a minor release.
-    // The restrictions take origin from the OpenTelemetry specification:
-    // https://github.com/open-telemetry/opentelemetry-specification/blob/v1.47.0/specification/common/README.md#attribute.
+    // The behavior of software that receives duplicated keys can be unpredictable.
     repeated opentelemetry.proto.common.v1.KeyValue attributes = 4;
 
     // The number of dropped attributes. If the value is 0,
@@ -342,7 +316,7 @@ message Status {
   enum StatusCode {
     // The default status.
     STATUS_CODE_UNSET               = 0;
-    // The Span has been validated by an Application developer or Operator to
+    // The Span has been validated by an Application developer or Operator to 
     // have completed successfully.
     STATUS_CODE_OK                  = 1;
     // The Span contains an error.


### PR DESCRIPTION
Handles https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v1.9.0

## Changes

Bump OTLP proto files to 1.9.0 in tests.
This time, I do not see any changes should be made in this repository.
Changes are mostly related to the profiling.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
