### PR TITLE
[Tests] Fix flaky tests

### DIFF
--- a/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTests.cs
@@ -17,8 +17,8 @@ public class MetricPointReclaimTests
         using var meter = new Meter(Utils.GetCurrentMethodName());
         var counter = meter.CreateCounter<long>("MyFruitCounter");
 
-        int numberOfUpdateThreads = 25;
-        int maxNumberOfDistinctMetricPoints = 4000; // Default max MetricPoints * 2
+        const int NumberOfUpdateThreads = 25;
+        const int MaxNumberOfDistinctMetricPoints = 4000; // Default max MetricPoints * 2
 
         using var exporter = new CustomExporter(assertNoDroppedMeasurements: true);
         using var metricReader = new PeriodicExportingMetricReader(exporter, exportIntervalMilliseconds: 10)
@@ -26,67 +26,69 @@ public class MetricPointReclaimTests
             TemporalityPreference = MetricReaderTemporalityPreference.Delta,
         };
 
-        using var meterProvider = Sdk.CreateMeterProviderBuilder()
-            .AddMeter(Utils.GetCurrentMethodName())
-            .AddReader(metricReader)
-            .Build();
+        var builder = Sdk.CreateMeterProviderBuilder()
+                         .AddMeter(Utils.GetCurrentMethodName())
+                         .AddReader(metricReader);
 
-        void EmitMetric(object obj)
+        using (var meterProvider = builder.Build())
         {
-            var threadArguments = obj as ThreadArguments;
-            var random = new Random();
-            while (true)
+            void EmitMetric(object? obj)
             {
-                int i = Interlocked.Increment(ref threadArguments!.Counter);
-                if (i <= maxNumberOfDistinctMetricPoints)
+                var threadArguments = obj as ThreadArguments;
+                var random = new Random();
+                while (true)
                 {
-                    // Check for cases where a metric with no dimension is also emitted
-                    if (emitMetricWithNoDimensions)
+                    int i = Interlocked.Increment(ref threadArguments!.Counter);
+                    if (i <= MaxNumberOfDistinctMetricPoints)
                     {
-                        counter.Add(25);
-                    }
+                        // Check for cases where a metric with no dimension is also emitted
+                        if (emitMetricWithNoDimensions)
+                        {
+                            counter.Add(25);
+                        }
 
-                    // There are separate code paths for single dimension vs multiple dimensions
+                        // There are separate code paths for single dimension vs multiple dimensions
 #pragma warning disable CA5394 // Do not use insecure randomness
-                    if (random.Next(2) == 0)
+                        if (random.Next(2) == 0)
 #pragma warning restore CA5394 // Do not use insecure randomness
-                    {
-                        counter.Add(100, new KeyValuePair<string, object?>("key", $"value{i}"));
+                        {
+                            counter.Add(100, new KeyValuePair<string, object?>("key", $"value{i}"));
+                        }
+                        else
+                        {
+                            counter.Add(100, new KeyValuePair<string, object?>("key", $"value{i}"), new KeyValuePair<string, object?>("dimensionKey", "dimensionValue"));
+                        }
+
+                        Thread.Sleep(25);
                     }
                     else
                     {
-                        counter.Add(100, new KeyValuePair<string, object?>("key", $"value{i}"), new KeyValuePair<string, object?>("dimensionKey", "dimensionValue"));
+                        break;
                     }
-
-                    Thread.Sleep(25);
-                }
-                else
-                {
-                    break;
                 }
             }
+
+            var threads = new Thread[NumberOfUpdateThreads];
+            var threadArgs = new ThreadArguments();
+
+            for (int i = 0; i < threads.Length; i++)
+            {
+                threads[i] = new Thread(EmitMetric);
+                threads[i].Start(threadArgs);
+            }
+
+            for (int i = 0; i < threads.Length; i++)
+            {
+                threads[i].Join();
+            }
+
+            Assert.True(meterProvider.ForceFlush());
         }
-
-        var threads = new Thread[numberOfUpdateThreads];
-        var threadArgs = new ThreadArguments();
-
-        for (int i = 0; i < threads.Length; i++)
-        {
-            threads[i] = new Thread(EmitMetric!);
-            threads[i].Start(threadArgs);
-        }
-
-        for (int i = 0; i < threads.Length; i++)
-        {
-            threads[i].Join();
-        }
-
-        Assert.True(meterProvider.ForceFlush());
 
         long expectedSum =
             emitMetricWithNoDimensions ?
-            maxNumberOfDistinctMetricPoints * (100 + 25) :
-            maxNumberOfDistinctMetricPoints * 100;
+            MaxNumberOfDistinctMetricPoints * (100 + 25) :
+            MaxNumberOfDistinctMetricPoints * 100;
 
         Assert.Equal(expectedSum, exporter.Sum);
     }
@@ -102,8 +104,8 @@ public class MetricPointReclaimTests
         long sum = 0;
         long[] measurementValues = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
 
-        int numberOfUpdateThreads = 4;
-        int numberOfMeasurementsPerThread = 10;
+        const int NumberOfUpdateThreads = 4;
+        const int NumberOfMeasurementsPerThread = 10;
 
         using var exporter = new CustomExporter(assertNoDroppedMeasurements: false);
         using var metricReader = new PeriodicExportingMetricReader(exporter, exportIntervalMilliseconds: 10)
@@ -111,66 +113,71 @@ public class MetricPointReclaimTests
             TemporalityPreference = MetricReaderTemporalityPreference.Delta,
         };
 
-        using var meterProvider = Sdk.CreateMeterProviderBuilder()
-            .AddMeter(Utils.GetCurrentMethodName())
-            .SetMaxMetricPointsPerMetricStream(10) // Set max MetricPoints limit to 10
-            .AddReader(metricReader)
-            .Build();
+        const int MaxMetricPointsPerMetricStream = 10;
 
-        // Add 10 distinct combinations of dimensions to surpass the max metric points limit of 10.
-        // Note that one MetricPoint is reserved for zero tags and one MetricPoint is reserved for the overflow tag.
-        // This would lead to dropping a few measurements. We want to make sure that they can still be
-        // aggregated later on when there are free MetricPoints available.
-        for (int i = 0; i < 10; i++)
+        var builder = Sdk.CreateMeterProviderBuilder()
+                         .AddMeter(Utils.GetCurrentMethodName())
+                         .SetMaxMetricPointsPerMetricStream(MaxMetricPointsPerMetricStream)
+                         .AddReader(metricReader);
+
+        using (var meterProvider = builder.Build())
         {
-            counter.Add(100, new KeyValuePair<string, object?>("key", $"value{i}"));
-        }
-
-        Assert.True(meterProvider.ForceFlush());
-        Assert.True(meterProvider.ForceFlush());
-
-        exporter.Sum = 0;
-
-        void EmitMetric()
-        {
-            int numberOfMeasurements = 0;
-            var random = new Random();
-            while (numberOfMeasurements < numberOfMeasurementsPerThread)
+            // Add distinct combinations of dimensions to surpass the max metric points limit of 10.
+            // Note that one MetricPoint is reserved for zero tags and one MetricPoint is reserved for the overflow tag.
+            // This would lead to dropping a few measurements. We want to make sure that they can still be
+            // aggregated later on when there are free MetricPoints available.
+            for (int i = 0; i < MaxMetricPointsPerMetricStream; i++)
             {
-                // Check for cases where a metric with no dimension is also emitted
-                if (emitMetricWithNoDimension)
+                counter.Add(100, new KeyValuePair<string, object?>("key", $"value{i}"));
+            }
+
+            Assert.True(meterProvider.ForceFlush());
+            Assert.True(meterProvider.ForceFlush());
+
+            exporter.Sum = 0;
+
+            void EmitMetric()
+            {
+                int numberOfMeasurements = 0;
+                var random = new Random();
+                while (numberOfMeasurements < NumberOfMeasurementsPerThread)
                 {
-                    counter.Add(25);
-                    Interlocked.Add(ref sum, 25);
-                }
+                    // Check for cases where a metric with no dimension is also emitted
+                    if (emitMetricWithNoDimension)
+                    {
+                        counter.Add(25);
+                        Interlocked.Add(ref sum, 25);
+                    }
 
 #pragma warning disable CA5394 // Do not use insecure randomness
-                var index = random.Next(measurementValues.Length);
+                    var index = random.Next(measurementValues.Length);
 #pragma warning restore CA5394 // Do not use insecure randomness
-                var measurement = measurementValues[index];
-                counter.Add(measurement, new KeyValuePair<string, object?>("key", $"value{index}"));
-                Interlocked.Add(ref sum, measurement);
+                    var measurement = measurementValues[index];
+                    counter.Add(measurement, new KeyValuePair<string, object?>("key", $"value{index}"));
+                    Interlocked.Add(ref sum, measurement);
 
-                numberOfMeasurements++;
+                    numberOfMeasurements++;
 
-                Thread.Sleep(25);
+                    Thread.Sleep(25);
+                }
             }
+
+            var threads = new Thread[NumberOfUpdateThreads];
+
+            for (int i = 0; i < threads.Length; i++)
+            {
+                threads[i] = new Thread(EmitMetric);
+                threads[i].Start();
+            }
+
+            for (int i = 0; i < threads.Length; i++)
+            {
+                threads[i].Join();
+            }
+
+            Assert.True(meterProvider.ForceFlush());
         }
 
-        var threads = new Thread[numberOfUpdateThreads];
-
-        for (int i = 0; i < threads.Length; i++)
-        {
-            threads[i] = new Thread(EmitMetric);
-            threads[i].Start();
-        }
-
-        for (int i = 0; i < threads.Length; i++)
-        {
-            threads[i].Join();
-        }
-
-        Assert.True(meterProvider.ForceFlush());
         Assert.Equal(sum, exporter.Sum);
     }
 


### PR DESCRIPTION
## Changes

Refactor two different test classes to try and avoid flakiness in CI.

Also fixes the IDE suggestions from Visual Studio while I was touching the files.

First:

```text
[xUnit.net 00:00:04.36]     OpenTelemetry.Metrics.Tests.MetricExemplarTests.TestExemplarsExponentialHistogram(temporality: Cumulative) [FAIL]
[xUnit.net 00:00:04.36]       Assert.NotEqual() Failure: Values are equal
[xUnit.net 00:00:04.36]       Expected: Not 00000000000000000000000000000000
[xUnit.net 00:00:04.36]       Actual:       00000000000000000000000000000000
[xUnit.net 00:00:04.36]       Stack Trace:
[xUnit.net 00:00:04.36]         /home/runner/work/opentelemetry-dotnet/opentelemetry-dotnet/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs(844,0): at OpenTelemetry.Metrics.Tests.MetricExemplarTests.ValidateExemplars(IReadOnlyList`1 exemplars, DateTimeOffset startTime, DateTimeOffset endTime, IEnumerable`1 measurementValues, Func`2 getExemplarValueFunc)
[xUnit.net 00:00:04.36]         /home/runner/work/opentelemetry-dotnet/opentelemetry-dotnet/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs(670,0): at OpenTelemetry.Metrics.Tests.MetricExemplarTests.<TestExemplarsExponentialHistogram>g__ValidateSecondPhase|6_2(String instrumentName, MetricReaderTemporalityPreference temporality, DateTime testStartTime, List`1 exportedItems, ValueTuple`2[] firstMeasurementValues, ValueTuple`2[] secondMeasurementValues)
[xUnit.net 00:00:04.36]         /home/runner/work/opentelemetry-dotnet/opentelemetry-dotnet/test/OpenTelemetry.Tests/Metrics/MetricExemplarTests.cs(624,0): at OpenTelemetry.Metrics.Tests.MetricExemplarTests.TestExemplarsExponentialHistogram(MetricReaderTemporalityPreference temporality)
[xUnit.net 00:00:04.36]            at InvokeStub_MetricExemplarTests.TestExemplarsExponentialHistogram(Object, Span`1)
[xUnit.net 00:00:04.36]            at System.Reflection.MethodBaseInvoker.InvokeWithOneArg(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
```

Second:

```text
[xUnit.net 00:00:02.95]     OpenTelemetry.Metrics.Tests.MetricPointReclaimTests.MeasurementsAreAggregatedEvenAfterTheyAreDropped(emitMetricWithNoDimension: True) [FAIL]
[xUnit.net 00:00:02.95]       Assert.Equal() Failure: Values differ
[xUnit.net 00:00:02.95]       Expected: 3680
[xUnit.net 00:00:02.95]       Actual:   3670
[xUnit.net 00:00:02.96]       Stack Trace:
[xUnit.net 00:00:02.96]         Metrics\MetricPointReclaimTests.cs(174,0): at OpenTelemetry.Metrics.Tests.MetricPointReclaimTests.MeasurementsAreAggregatedEvenAfterTheyAreDropped(Boolean emitMetricWithNoDimension)
```

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
