### PR TITLE
[Extensions.Propagators] Remove --prereleae flag from installation instruction

### DIFF
--- a/src/OpenTelemetry.Extensions.Propagators/README.md
+++ b/src/OpenTelemetry.Extensions.Propagators/README.md
@@ -26,7 +26,7 @@ Use `B3 OpenZipkin` context only:
 using OpenTelemetry;
 using OpenTelemetry.Extensions.Propagators;
 
-Sdk.SetDefaultTextMapPropagator(new B3Propagator())
+Sdk.SetDefaultTextMapPropagator(new B3Propagator());
 ```
 
 Use `B3 OpenZipkin` and `W3C Baggage` propagators at the same time:


### PR DESCRIPTION
## Changes

[Extensions.Propagators] Remove --prereleae flag from installation instruction

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
