### PR TITLE
feat(exporter-otlp): Add max retry limit

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/OtlpExporterPersistentStorageTransmissionHandler.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/OtlpExporterPersistentStorageTransmissionHandler.cs
@@ -51,7 +51,7 @@ internal sealed class OtlpExporterPersistentStorageTransmissionHandler : OtlpExp
     protected override bool OnSubmitRequestFailure(byte[] request, int contentLength, ExportClientResponse response)
     {
         Debug.Assert(request != null, "request was null");
-        return RetryHelper.ShouldRetryRequest(response, OtlpRetry.InitialBackoffMilliseconds, out _) && this.persistentBlobProvider.TryCreateBlob(request!, out _);
+        return RetryHelper.ShouldRetryRequest(response, OtlpRetry.InitialBackoffMilliseconds, 0, out _) && this.persistentBlobProvider.TryCreateBlob(request!, out _);
     }
 
     protected override void OnShutdown(int timeoutMilliseconds)
@@ -127,7 +127,7 @@ internal sealed class OtlpExporterPersistentStorageTransmissionHandler : OtlpExp
                     if (blob.TryLease((int)this.TimeoutMilliseconds) && blob.TryRead(out var data))
                     {
                         var deadlineUtc = DateTime.UtcNow.AddMilliseconds(this.TimeoutMilliseconds);
-                        if (this.TryRetryRequest(data, data.Length, deadlineUtc, out var response) || !RetryHelper.ShouldRetryRequest(response, OtlpRetry.InitialBackoffMilliseconds, out var retryInfo))
+                        if (this.TryRetryRequest(data, data.Length, deadlineUtc, out var response) || !RetryHelper.ShouldRetryRequest(response, OtlpRetry.InitialBackoffMilliseconds, 0, out var retryInfo))
                         {
                             blob.TryDelete();
                         }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/OtlpExporterRetryTransmissionHandler.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/OtlpExporterRetryTransmissionHandler.cs
@@ -15,7 +15,8 @@ internal sealed class OtlpExporterRetryTransmissionHandler : OtlpExporterTransmi
     protected override bool OnSubmitRequestFailure(byte[] request, int contentLength, ExportClientResponse response)
     {
         var nextRetryDelayMilliseconds = OtlpRetry.InitialBackoffMilliseconds;
-        while (RetryHelper.ShouldRetryRequest(response, nextRetryDelayMilliseconds, out var retryResult))
+        int attempt = 0;
+        while (RetryHelper.ShouldRetryRequest(response, nextRetryDelayMilliseconds, attempt, out var retryResult))
         {
             // Note: This delay cannot exceed the configured timeout period for otlp exporter.
             // If the backend responds with `RetryAfter` duration that would result in exceeding the configured timeout period
@@ -28,6 +29,7 @@ internal sealed class OtlpExporterRetryTransmissionHandler : OtlpExporterTransmi
             }
 
             nextRetryDelayMilliseconds = retryResult.NextRetryDelayMilliseconds;
+            attempt++;
         }
 
         return false;

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/RetryHelper.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/RetryHelper.cs
@@ -7,18 +7,18 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Transmissi
 
 internal static class RetryHelper
 {
-    internal static bool ShouldRetryRequest(ExportClientResponse response, int retryDelayMilliseconds, out OtlpRetry.RetryResult retryResult)
+    internal static bool ShouldRetryRequest(ExportClientResponse response, int retryDelayMilliseconds, int attempt, out OtlpRetry.RetryResult retryResult)
     {
         if (response is ExportClientGrpcResponse grpcResponse)
         {
-            if (OtlpRetry.TryGetGrpcRetryResult(grpcResponse, retryDelayMilliseconds, out retryResult))
+            if (OtlpRetry.TryGetGrpcRetryResult(grpcResponse, retryDelayMilliseconds, attempt, out retryResult))
             {
                 return true;
             }
         }
         else if (response is ExportClientHttpResponse httpResponse)
         {
-            if (OtlpRetry.TryGetHttpRetryResult(httpResponse, retryDelayMilliseconds, out retryResult))
+            if (OtlpRetry.TryGetHttpRetryResult(httpResponse, retryDelayMilliseconds, attempt, out retryResult))
             {
                 return true;
             }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/GrpcRetryTestCase.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/GrpcRetryTestCase.cs
@@ -76,13 +76,26 @@ public class GrpcRetryTestCase
                     new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 2250),
                     new(StatusCode.Unavailable, throttleDelay: GetThrottleDelayString(Duration.FromTimeSpan(TimeSpan.FromMilliseconds(500))), expectedNextRetryDelayMilliseconds: 750),
                     new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 1125),
-                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 1688),
-                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 2532),
-                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 3798),
-                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 5000),
-                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 5000)
+                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 1688)
                 ],
-                expectedRetryAttempts: 9),
+                expectedRetryAttempts: 5),
+
+            // Verify max retry limit (5 attempts pass, 6th fails)
+            new(
+                "Max retries exceeded (fail on 6th attempt)",
+                [
+
+                    // Attempts 1-5 should pass with correct backoff values
+                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 1500),
+                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 2250),
+                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 3375),
+                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 5000),
+                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 5000),
+
+                    // Attempt 6 should fail, next delay is irrelevant
+                    new(StatusCode.Unavailable, expectedSuccess: false)
+                ],
+                expectedRetryAttempts: 6),
         ];
     }
 

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/HttpRetryTestCase.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/HttpRetryTestCase.cs
@@ -61,6 +61,23 @@ public class HttpRetryTestCase
                 [
                     new(statusCode: HttpStatusCode.ServiceUnavailable, isDeadlineExceeded: true, expectedSuccess: false)
                 ]),
+
+            // Verify max retry limit (5 attempts pass, 6th fails)
+            new(
+                "Max retries exceeded (fail on 6th attempt)",
+                [
+
+                    // Attempts 1-5 should pass with correct backoff values
+                    new(statusCode: HttpStatusCode.ServiceUnavailable, expectedNextRetryDelayMilliseconds: 1500),
+                    new(statusCode: HttpStatusCode.ServiceUnavailable, expectedNextRetryDelayMilliseconds: 2250),
+                    new(statusCode: HttpStatusCode.ServiceUnavailable, expectedNextRetryDelayMilliseconds: 3375),
+                    new(statusCode: HttpStatusCode.ServiceUnavailable, expectedNextRetryDelayMilliseconds: 5000),
+                    new(statusCode: HttpStatusCode.ServiceUnavailable, expectedNextRetryDelayMilliseconds: 5000),
+
+                    // Attempt 6 should fail, next delay is irrelevant
+                    new(statusCode: HttpStatusCode.ServiceUnavailable, expectedSuccess: false)
+                ],
+                expectedRetryAttempts: 6),
         ];
 
         // TODO: Add more cases.

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpRetryTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpRetryTests.cs
@@ -33,7 +33,7 @@ public class OtlpRetryTests
             var statusCode = retryAttempt.Response.Status.Value.StatusCode;
             var deadline = retryAttempt.Response.DeadlineUtc;
             var trailers = retryAttempt.Response.GrpcStatusDetailsHeader;
-            var success = OtlpRetry.TryGetGrpcRetryResult(retryAttempt.Response, nextRetryDelayMilliseconds, out var retryResult);
+            var success = OtlpRetry.TryGetGrpcRetryResult(retryAttempt.Response, nextRetryDelayMilliseconds, attempts - 1, out var retryResult);
 
             Assert.Equal(retryAttempt.ExpectedSuccess, success);
 
@@ -82,7 +82,7 @@ public class OtlpRetryTests
             var statusCode = retryAttempt.Response.StatusCode;
             var deadline = retryAttempt.Response.DeadlineUtc;
             var headers = retryAttempt.Response.Headers;
-            var success = OtlpRetry.TryGetHttpRetryResult(retryAttempt.Response, nextRetryDelayMilliseconds, out var retryResult);
+            var success = OtlpRetry.TryGetHttpRetryResult(retryAttempt.Response, nextRetryDelayMilliseconds, attempts - 1, out var retryResult);
 
             Assert.Equal(retryAttempt.ExpectedSuccess, success);
 


### PR DESCRIPTION
Closes #6282 

## Description

This pull request addresses the `// TODO` comment in the `OtlpRetry` helper and resolves the issue of potentially indefinite retries in the OTLP exporter. It introduces a hardcoded maximum limit of **5** retry attempts for failed exports.

## Changes Made

- **Implemented Max Retry Limit:** The core logic in `OtlpRetry.TryGetGrpcRetryResult` and `OtlpRetry.TryGetHttpRetryResult` has been updated to check the number of attempts. If `attempt >= 5`, the methods will now return `false`, effectively stopping the retry loop.

- **Updated Existing Tests:** The existing test case `Exponential backoff after throttling` in `GrpcRetryTestCase`, which previously simulated 9 retries, has been adjusted to respect the new limit of 5.

- **Added New Boundary Tests:** To ensure the limit is strictly enforced, new test cases named `"Max retries exceeded (fail on 6th attempt)"` have been added for both `GrpcRetryTestCase` and `HttpRetryTestCase`. These tests verify that:
  - The first 5 retry attempts are successful (`true`).
  - The 6th attempt correctly fails (`false`).

This change provides a safer default behavior for the exporter and serves as a foundational step for potentially making this limit configurable in the future.