### PR TITLE
[Repo] Skip label workflow on forks

### DIFF
--- a/.github/workflows/add-labels.yml
+++ b/.github/workflows/add-labels.yml
@@ -13,7 +13,7 @@ jobs:
   add-labels-on-issues:
     permissions:
       issues: write
-    if: github.event_name == 'issues' && !github.event.issue.pull_request
+    if: github.event.repository.fork == false && github.event_name == 'issues' && !github.event.issue.pull_request
 
     runs-on: ubuntu-24.04
 
@@ -36,7 +36,7 @@ jobs:
   add-labels-on-pull-requests:
     permissions:
       pull-requests: write
-    if: github.event_name == 'pull_request_target'
+    if: github.event.repository.fork == false && github.event_name == 'pull_request_target'
 
     runs-on: ubuntu-24.04
 


### PR DESCRIPTION
## Changes

Skip labelling on forks.

I accidentally opened a PR in my fork, then noticed that the labelling job failed because my fork doesn't contain this repo's labels.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
