### PR TITLE
[Infra] Remove SDK issue workaround

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,8 +3,4 @@
     <ArtifactsPath>$([System.IO.Path]::Combine('$(MSBuildThisFileDirectory)', 'artifacts'))</ArtifactsPath>
     <UseArtifactsOutput>true</UseArtifactsOutput>
   </PropertyGroup>
-  <!-- HACK Workaround for https://github.com/dotnet/sdk/issues/51265 -->
-  <PropertyGroup>
-    <RestoreEnablePackagePruning>false</RestoreEnablePackagePruning>
-  </PropertyGroup>
 </Project>

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -5,11 +5,18 @@
   <ItemGroup Condition="'$(ReferenceCoyotePackages)' == 'true'">
     <PackageReference Include="Microsoft.Coyote" />
 
-    <!-- System.Text.Json is an indirect reference through Coyote. This
-    reference is needed to mitigate:
-    https://github.com/advisories/GHSA-hh2w-p6rv-4g7w. Remove this if Coyote
-    publishes a fixed version. -->
-    <PackageReference Include="System.Text.Json" VersionOverride="8.0.6" />
+    <!--
+      System.Text.Json is an indirect reference through Coyote which flags
+      the GitHub Security Advisories listed below. However, if we reference
+      System.Text.Json directly, the .NET 10 SDK will generate a NU1510
+      warning that the package reference is redundant and will be pruned,
+      so instead just suppress the advisories as the in-box version will
+      be selected and will be a patched version with no vulnerability.
+
+      Remove this if Coyote publishes a fixed version.
+    -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-8g4q-xg66-9fp4" />
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-hh2w-p6rv-4g7w" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Changes

Remove workaround for https://github.com/dotnet/sdk/issues/51265 that should be fixed in the stable .NET 10 SDK that was missed from #6667.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
