### PR TITLE
[OTLP] Decoupling OTEL_EXPORTER_OTLP_CERTIFICATE from mTLS

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OpenTelemetryProtocolExporterEventSource.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OpenTelemetryProtocolExporterEventSource.cs
@@ -325,5 +325,28 @@ internal sealed class OpenTelemetryProtocolExporterEventSource : EventSource, IC
         Level = EventLevel.Error)]
     internal void MtlsHttpClientCreationFailed(string exception) =>
         this.WriteEvent(34, exception);
+
+    [Event(
+        35,
+        Message = "CA configured for server validation. Subject: '{0}'.",
+        Level = EventLevel.Informational)]
+    internal void CaCertificateConfigured(string subject) =>
+        this.WriteEvent(35, subject);
+
+    [NonEvent]
+    internal void SecureHttpClientCreationFailed(Exception ex)
+    {
+        if (Log.IsEnabled(EventLevel.Error, EventKeywords.All))
+        {
+            this.SecureHttpClientCreationFailed(ex.ToInvariantString());
+        }
+    }
+
+    [Event(
+        36,
+        Message = "Failed to create secure HttpClient. Exception: {0}",
+        Level = EventLevel.Error)]
+    internal void SecureHttpClientCreationFailed(string exception) =>
+        this.WriteEvent(36, exception);
 #endif
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpCertificateManager.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpCertificateManager.cs
@@ -10,11 +10,15 @@ using System.Security.Cryptography.X509Certificates;
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 
 /// <summary>
-/// Manages certificate loading, validation, and security checks for mTLS connections.
+/// Manages certificate loading, validation, and security checks for TLS connections.
 /// </summary>
+/// <remarks>
+/// This class provides functionality for both simple server certificate trust
+/// (for self-signed certificates) and mTLS client authentication scenarios.
+/// </remarks>
 internal static class OtlpCertificateManager
 {
-    internal const string CaCertificateType = "CA certificate";
+    internal const string CaCertificateType = "CA Certificate";
     internal const string ClientCertificateType = "Client certificate";
     internal const string ClientPrivateKeyType = "Client private key";
 
@@ -218,6 +222,10 @@ internal static class OtlpCertificateManager
     /// <param name="sslPolicyErrors">The SSL policy errors.</param>
     /// <param name="caCertificate">The CA certificate to validate against.</param>
     /// <returns>True if the certificate is valid; otherwise, false.</returns>
+    /// <remarks>
+    /// This method is used to validate server certificates against a CA.
+    /// Common use case: connecting to a server with a self-signed certificate.
+    /// </remarks>
     internal static bool ValidateServerCertificate(
         X509Certificate2 serverCert,
         X509Chain chain,

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpCertificateManager.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpCertificateManager.cs
@@ -12,7 +12,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 /// <summary>
 /// Manages certificate loading, validation, and security checks for mTLS connections.
 /// </summary>
-internal static class OtlpMtlsCertificateManager
+internal static class OtlpCertificateManager
 {
     internal const string CaCertificateType = "CA certificate";
     internal const string ClientCertificateType = "Client certificate";

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpSecureHttpClientFactory.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpSecureHttpClientFactory.cs
@@ -10,7 +10,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 /// <summary>
 /// Factory for creating HttpClient instances configured with mTLS settings.
 /// </summary>
-internal static class OtlpMtlsHttpClientFactory
+internal static class OtlpSecureHttpClientFactory
 {
     /// <summary>
     /// Creates an HttpClient configured with mTLS settings.
@@ -20,7 +20,7 @@ internal static class OtlpMtlsHttpClientFactory
     /// <returns>An HttpClient configured for mTLS.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="mtlsOptions"/> is null.</exception>
     /// <exception cref="InvalidOperationException">Thrown when mTLS is not enabled.</exception>
-    public static HttpClient CreateMtlsHttpClient(
+    public static HttpClient CreateSecureHttpClient(
         OtlpMtlsOptions mtlsOptions,
         Action<HttpClient>? configureClient = null)
     {
@@ -40,14 +40,14 @@ internal static class OtlpMtlsHttpClientFactory
             // Load certificates
             if (!string.IsNullOrEmpty(mtlsOptions.CaCertificatePath))
             {
-                caCertificate = OtlpMtlsCertificateManager.LoadCaCertificate(
+                caCertificate = OtlpCertificateManager.LoadCaCertificate(
                     mtlsOptions.CaCertificatePath);
 
                 if (mtlsOptions.EnableCertificateChainValidation)
                 {
-                    OtlpMtlsCertificateManager.ValidateCertificateChain(
+                    OtlpCertificateManager.ValidateCertificateChain(
                         caCertificate,
-                        OtlpMtlsCertificateManager.CaCertificateType);
+                        OtlpCertificateManager.CaCertificateType);
                 }
             }
 
@@ -56,22 +56,22 @@ internal static class OtlpMtlsHttpClientFactory
                 if (string.IsNullOrEmpty(mtlsOptions.ClientKeyPath))
                 {
                     // Load certificate without separate key file (e.g., PKCS#12 format)
-                    clientCertificate = OtlpMtlsCertificateManager.LoadClientCertificate(
+                    clientCertificate = OtlpCertificateManager.LoadClientCertificate(
                         mtlsOptions.ClientCertificatePath,
                         null);
                 }
                 else
                 {
-                    clientCertificate = OtlpMtlsCertificateManager.LoadClientCertificate(
+                    clientCertificate = OtlpCertificateManager.LoadClientCertificate(
                         mtlsOptions.ClientCertificatePath,
                         mtlsOptions.ClientKeyPath);
                 }
 
                 if (mtlsOptions.EnableCertificateChainValidation)
                 {
-                    OtlpMtlsCertificateManager.ValidateCertificateChain(
+                    OtlpCertificateManager.ValidateCertificateChain(
                         clientCertificate,
-                        OtlpMtlsCertificateManager.ClientCertificateType);
+                        OtlpCertificateManager.ClientCertificateType);
                 }
 
                 OpenTelemetryProtocolExporterEventSource.Log.MtlsConfigurationEnabled(
@@ -142,7 +142,7 @@ internal static class OtlpMtlsHttpClientFactory
                         return false;
                     }
 
-                    return OtlpMtlsCertificateManager.ValidateServerCertificate(
+                    return OtlpCertificateManager.ValidateServerCertificate(
                         cert,
                         chain,
                         sslPolicyErrors,

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -78,7 +78,7 @@ public class OtlpExporterOptions : IOtlpExporterOptions
             // If mTLS is configured, create an mTLS-enabled client
             if (this.MtlsOptions?.IsEnabled == true)
             {
-                return OtlpMtlsHttpClientFactory.CreateMtlsHttpClient(
+                return OtlpSecureHttpClientFactory.CreateSecureHttpClient(
                     this.MtlsOptions,
                     client => client.Timeout = timeout);
             }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -75,7 +75,7 @@ public class OtlpExporterOptions : IOtlpExporterOptions
             var timeout = TimeSpan.FromMilliseconds(this.TimeoutMilliseconds);
 
 #if NET
-            // If mTLS is configured, create an mTLS-enabled client
+            // If TLS configuration is enabled (mTLS or CA only), create a secure client
             if (this.MtlsOptions?.IsEnabled == true)
             {
                 return OtlpSecureHttpClientFactory.CreateSecureHttpClient(

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMtlsOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMtlsOptions.cs
@@ -5,32 +5,48 @@
 
 namespace OpenTelemetry.Exporter;
 
-internal sealed class OtlpMtlsOptions
+/// <summary>
+/// Represents mTLS (mutual TLS) configuration options for OTLP exporter.
+/// Extends <see cref="OtlpTlsOptions"/> with client certificate authentication.
+/// </summary>
+/// <remarks>
+/// mTLS is an authentication system in which both the client and server authenticate each other.
+/// This class provides client certificate configuration for scenarios requiring mutual authentication.
+/// For simple server certificate trust (e.g., self-signed certificates), use <see cref="OtlpTlsOptions"/> directly.
+/// </remarks>
+internal sealed class OtlpMtlsOptions : OtlpTlsOptions
 {
-    /// <summary>
-    /// Gets or sets the path to the CA certificate file in PEM format.
-    /// </summary>
-    public string? CaCertificatePath { get; set; }
-
     /// <summary>
     /// Gets or sets the path to the client certificate file in PEM format.
     /// </summary>
+    /// <remarks>
+    /// Corresponds to the OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE environment variable.
+    /// This is used for client authentication in mTLS scenarios.
+    /// </remarks>
     public string? ClientCertificatePath { get; set; }
 
     /// <summary>
     /// Gets or sets the path to the client private key file in PEM format.
     /// </summary>
+    /// <remarks>
+    /// Corresponds to the OTEL_EXPORTER_OTLP_CLIENT_KEY environment variable.
+    /// Required when the client certificate file does not include the private key.
+    /// </remarks>
     public string? ClientKeyPath { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether to enable certificate chain validation.
-    /// When enabled, the exporter will validate the certificate chain and reject invalid certificates.
+    /// Gets a value indicating whether mTLS (mutual TLS) is enabled.
     /// </summary>
-    public bool EnableCertificateChainValidation { get; set; } = true;
+    /// <remarks>
+    /// Returns true when client certificate is configured for mutual authentication.
+    /// Note: Having only <see cref="OtlpTlsOptions.CaCertificatePath"/> does not constitute mTLS.
+    /// </remarks>
+    public override bool IsMtlsEnabled =>
+        !string.IsNullOrWhiteSpace(this.ClientCertificatePath);
 
     /// <summary>
-    /// Gets a value indicating whether mTLS is enabled.
-    /// mTLS is considered enabled if at least the client certificate path or CA certificate path is provided.
+    /// Gets a value indicating whether any TLS configuration is enabled.
+    /// TLS is considered enabled if at least the client certificate path or CA path is provided.
     /// </summary>
     public bool IsEnabled =>
         !string.IsNullOrWhiteSpace(this.ClientCertificatePath)

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTlsOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTlsOptions.cs
@@ -1,0 +1,50 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if NET
+
+namespace OpenTelemetry.Exporter;
+
+/// <summary>
+/// Represents TLS configuration options for OTLP exporter.
+/// This class handles server certificate trust for scenarios such as self-signed certificates.
+/// </summary>
+/// <remarks>
+/// The <see cref="CaCertificatePath"/> option enables trust of server certificates
+/// that are not verified by a third-party certificate authority. This is commonly used
+/// when connecting to servers with self-signed certificates.
+/// </remarks>
+internal class OtlpTlsOptions
+{
+    /// <summary>
+    /// Gets or sets the path to the CA file in PEM format.
+    /// </summary>
+    /// <remarks>
+    /// This corresponds to the OTEL_EXPORTER_OTLP_CERTIFICATE environment variable.
+    /// Use this when the server has a self-signed certificate or uses a private CA.
+    /// </remarks>
+    public string? CaCertificatePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to enable certificate chain validation.
+    /// When enabled, the exporter will validate the certificate chain and reject invalid certificates.
+    /// </summary>
+    public bool EnableCertificateChainValidation { get; set; } = true;
+
+    /// <summary>
+    /// Gets a value indicating whether TLS certificate trust is configured.
+    /// </summary>
+    public virtual bool IsTlsEnabled =>
+        !string.IsNullOrWhiteSpace(this.CaCertificatePath);
+
+    /// <summary>
+    /// Gets a value indicating whether mTLS (mutual TLS) is configured.
+    /// </summary>
+    /// <remarks>
+    /// Returns true only when client certificates are configured for mutual authentication.
+    /// Server certificate trust alone (CaCertificatePath) does not constitute mTLS.
+    /// </remarks>
+    public virtual bool IsMtlsEnabled => false;
+}
+
+#endif

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpCertificateManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpCertificateManagerTests.cs
@@ -5,7 +5,7 @@
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests;
 
-public class OtlpMtlsCertificateManagerTests
+public class OtlpCertificateManagerTests
 {
     private const string TestCertPem =
         @"-----BEGIN CERTIFICATE-----
@@ -39,7 +39,7 @@ INVALID CERTIFICATE DATA
     public void LoadClientCertificate_ThrowsFileNotFoundException_WhenCertificateFileDoesNotExist()
     {
         var exception = Assert.Throws<FileNotFoundException>(() =>
-            OpenTelemetryProtocol.Implementation.OtlpMtlsCertificateManager.LoadClientCertificate(
+            OpenTelemetryProtocol.Implementation.OtlpCertificateManager.LoadClientCertificate(
                 "/nonexistent/client.crt",
                 "/nonexistent/client.key"));
 
@@ -56,7 +56,7 @@ INVALID CERTIFICATE DATA
         try
         {
             var exception = Assert.Throws<FileNotFoundException>(() =>
-                OpenTelemetryProtocol.Implementation.OtlpMtlsCertificateManager.LoadClientCertificate(
+                OpenTelemetryProtocol.Implementation.OtlpCertificateManager.LoadClientCertificate(
                     tempCertFile,
                     "/nonexistent/client.key"));
 
@@ -73,7 +73,7 @@ INVALID CERTIFICATE DATA
     public void LoadCaCertificate_ThrowsFileNotFoundException_WhenTrustStoreFileDoesNotExist()
     {
         var exception = Assert.Throws<FileNotFoundException>(() =>
-            OpenTelemetryProtocol.Implementation.OtlpMtlsCertificateManager.LoadCaCertificate("/nonexistent/ca.crt"));
+            OpenTelemetryProtocol.Implementation.OtlpCertificateManager.LoadCaCertificate("/nonexistent/ca.crt"));
 
         Assert.Contains("CA certificate file not found", exception.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("/nonexistent/ca.crt", exception.Message, StringComparison.OrdinalIgnoreCase);
@@ -90,7 +90,7 @@ INVALID CERTIFICATE DATA
         try
         {
             var exception = Assert.Throws<InvalidOperationException>(() =>
-                OpenTelemetryProtocol.Implementation.OtlpMtlsCertificateManager.LoadClientCertificate(tempCertFile, tempKeyFile));
+                OpenTelemetryProtocol.Implementation.OtlpCertificateManager.LoadClientCertificate(tempCertFile, tempKeyFile));
 
             Assert.Contains(
                 "Failed to load client certificate",
@@ -113,7 +113,7 @@ INVALID CERTIFICATE DATA
         try
         {
             var exception = Assert.Throws<InvalidOperationException>(() =>
-                OpenTelemetryProtocol.Implementation.OtlpMtlsCertificateManager.LoadCaCertificate(tempTrustStoreFile));
+                OpenTelemetryProtocol.Implementation.OtlpCertificateManager.LoadCaCertificate(tempTrustStoreFile));
 
             Assert.Contains(
                 "Failed to load CA certificate",
@@ -133,7 +133,7 @@ INVALID CERTIFICATE DATA
         using var cert = CreateSelfSignedCertificate();
 
         // Should not throw for self-signed certificate with proper validation
-        var result = OpenTelemetryProtocol.Implementation.OtlpMtlsCertificateManager.ValidateCertificateChain(cert, "test certificate");
+        var result = OpenTelemetryProtocol.Implementation.OtlpCertificateManager.ValidateCertificateChain(cert, "test certificate");
 
         // For self-signed certificates, validation may fail, but method should not throw
         Assert.True(result || !result); // Just check that it returns a boolean
@@ -146,7 +146,7 @@ INVALID CERTIFICATE DATA
         using var cert = CreateSelfSignedCertificate();
 
         // Should return a boolean result
-        var result = OpenTelemetryProtocol.Implementation.OtlpMtlsCertificateManager.ValidateCertificateChain(cert, "test certificate");
+        var result = OpenTelemetryProtocol.Implementation.OtlpCertificateManager.ValidateCertificateChain(cert, "test certificate");
 
         // The result can be true or false, but the method should not throw
         Assert.True(result || !result);
@@ -166,7 +166,7 @@ INVALID CERTIFICATE DATA
             // Note: We expect this to fail because we're using dummy cert/key content
             // but it should not fail due to the method signature
             var exception = Assert.Throws<InvalidOperationException>(() =>
-                OpenTelemetryProtocol.Implementation.OtlpMtlsCertificateManager.LoadClientCertificate(
+                OpenTelemetryProtocol.Implementation.OtlpCertificateManager.LoadClientCertificate(
                     tempCertFile,
                     tempKeyFile));
 

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpSecureHttpClientFactoryTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpSecureHttpClientFactoryTests.cs
@@ -10,7 +10,7 @@ using System.Text;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests;
 
-public class OtlpMtlsHttpClientFactoryTests
+public class OtlpSecureHttpClientFactoryTests
 {
     [Fact]
     public void CreateHttpClient_ThrowsInvalidOperationException_WhenMtlsIsDisabled()
@@ -18,7 +18,7 @@ public class OtlpMtlsHttpClientFactoryTests
         var options = new OtlpMtlsOptions(); // Disabled by default
 
         Assert.Throws<InvalidOperationException>(() =>
-            OpenTelemetryProtocol.Implementation.OtlpMtlsHttpClientFactory.CreateMtlsHttpClient(options));
+            OpenTelemetryProtocol.Implementation.OtlpSecureHttpClientFactory.CreateSecureHttpClient(options));
     }
 
     [Fact]
@@ -27,7 +27,7 @@ public class OtlpMtlsHttpClientFactoryTests
         var options = new OtlpMtlsOptions { ClientCertificatePath = "/nonexistent/client.crt" };
 
         var exception = Assert.Throws<FileNotFoundException>(() =>
-            OpenTelemetryProtocol.Implementation.OtlpMtlsHttpClientFactory.CreateMtlsHttpClient(options));
+            OpenTelemetryProtocol.Implementation.OtlpSecureHttpClientFactory.CreateSecureHttpClient(options));
 
         Assert.Contains("Certificate file not found", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
@@ -49,7 +49,7 @@ public class OtlpMtlsHttpClientFactoryTests
                 EnableCertificateChainValidation = false, // Ignore validation for test cert
             };
 
-            using var httpClient = OpenTelemetryProtocol.Implementation.OtlpMtlsHttpClientFactory.CreateMtlsHttpClient(options);
+            using var httpClient = OpenTelemetryProtocol.Implementation.OtlpSecureHttpClientFactory.CreateSecureHttpClient(options);
 
             Assert.NotNull(httpClient);
 
@@ -89,7 +89,7 @@ public class OtlpMtlsHttpClientFactoryTests
                     EnableCertificateChainValidation = false, // Avoid platform-specific chain build differences
                 };
 
-                using var httpClient = OpenTelemetryProtocol.Implementation.OtlpMtlsHttpClientFactory.CreateMtlsHttpClient(options);
+                using var httpClient = OpenTelemetryProtocol.Implementation.OtlpSecureHttpClientFactory.CreateSecureHttpClient(options);
 
                 Assert.NotNull(httpClient);
 
@@ -130,7 +130,7 @@ public class OtlpMtlsHttpClientFactoryTests
                     EnableCertificateChainValidation = false, // Avoid platform-specific chain build differences
                 };
 
-                using var httpClient = OpenTelemetryProtocol.Implementation.OtlpMtlsHttpClientFactory.CreateMtlsHttpClient(options);
+                using var httpClient = OpenTelemetryProtocol.Implementation.OtlpSecureHttpClientFactory.CreateSecureHttpClient(options);
 
                 var handlerField = typeof(HttpMessageInvoker).GetField(
                     "_handler",
@@ -171,7 +171,7 @@ public class OtlpMtlsHttpClientFactoryTests
                     EnableCertificateChainValidation = false,
                 };
 
-                using var httpClient = OpenTelemetryProtocol.Implementation.OtlpMtlsHttpClientFactory.CreateMtlsHttpClient(options);
+                using var httpClient = OpenTelemetryProtocol.Implementation.OtlpSecureHttpClientFactory.CreateSecureHttpClient(options);
 
                 var handlerField = typeof(HttpMessageInvoker).GetField(
                     "_handler",
@@ -212,7 +212,7 @@ public class OtlpMtlsHttpClientFactoryTests
         using var chain = new X509Chain();
         chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
 
-        var result = OpenTelemetryProtocol.Implementation.OtlpMtlsCertificateManager.ValidateServerCertificate(
+        var result = OpenTelemetryProtocol.Implementation.OtlpCertificateManager.ValidateServerCertificate(
             serverCertificate,
             chain,
             SslPolicyErrors.None,
@@ -229,7 +229,7 @@ public class OtlpMtlsHttpClientFactoryTests
         using var chain = new X509Chain();
         chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
 
-        var result = OpenTelemetryProtocol.Implementation.OtlpMtlsCertificateManager.ValidateServerCertificate(
+        var result = OpenTelemetryProtocol.Implementation.OtlpCertificateManager.ValidateServerCertificate(
             serverCertificate,
             chain,
             SslPolicyErrors.RemoteCertificateChainErrors,
@@ -248,7 +248,7 @@ public class OtlpMtlsHttpClientFactoryTests
         using var chain = new X509Chain();
         chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
 
-        var result = OpenTelemetryProtocol.Implementation.OtlpMtlsCertificateManager.ValidateServerCertificate(
+        var result = OpenTelemetryProtocol.Implementation.OtlpCertificateManager.ValidateServerCertificate(
             serverCertificate,
             chain,
             SslPolicyErrors.RemoteCertificateChainErrors,
@@ -262,18 +262,18 @@ public class OtlpMtlsHttpClientFactoryTests
     {
         using var expiredCertificate = CreateExpiredCertificate();
 
-        var result = OpenTelemetryProtocol.Implementation.OtlpMtlsCertificateManager.ValidateCertificateChain(
+        var result = OpenTelemetryProtocol.Implementation.OtlpCertificateManager.ValidateCertificateChain(
             expiredCertificate,
-            OpenTelemetryProtocol.Implementation.OtlpMtlsCertificateManager.ClientCertificateType);
+            OpenTelemetryProtocol.Implementation.OtlpCertificateManager.ClientCertificateType);
 
         Assert.False(result);
     }
 
     [Fact]
-    public void CreateMtlsHttpClient_ThrowsArgumentNullException_WhenOptionsIsNull()
+    public void CreateSecureHttpClient_ThrowsArgumentNullException_WhenOptionsIsNull()
     {
         var exception = Assert.Throws<ArgumentNullException>(() =>
-            OpenTelemetryProtocol.Implementation.OtlpMtlsHttpClientFactory.CreateMtlsHttpClient(null!));
+            OpenTelemetryProtocol.Implementation.OtlpSecureHttpClientFactory.CreateSecureHttpClient(null!));
 
         Assert.Equal("mtlsOptions", exception.ParamName);
     }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpSecureHttpClientFactoryTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpSecureHttpClientFactoryTests.cs
@@ -72,16 +72,16 @@ public class OtlpSecureHttpClientFactoryTests
     }
 
     [Fact]
-    public void CreateHttpClient_ConfiguresServerCertificateValidation_WhenTrustedRootCertificatesProvided()
+    public void CreateHttpClient_ConfiguresServerCertificateValidation_WhenCaCertificatesProvided()
     {
         RunWithCryptoSupportCheck(() =>
         {
             var tempTrustStoreFile = Path.GetTempFileName();
             try
             {
-                // Create a self-signed certificate for testing as trusted root
-                using var trustedCert = CreateSelfSignedCertificate();
-                File.WriteAllText(tempTrustStoreFile, ExportCertificateWithPrivateKey(trustedCert));
+                // Create a self-signed certificate for testing as CA root
+                using var caCert = CreateSelfSignedCertificate();
+                File.WriteAllText(tempTrustStoreFile, ExportCertificateWithPrivateKey(caCert));
 
                 var options = new OtlpMtlsOptions
                 {
@@ -275,7 +275,7 @@ public class OtlpSecureHttpClientFactoryTests
         var exception = Assert.Throws<ArgumentNullException>(() =>
             OpenTelemetryProtocol.Implementation.OtlpSecureHttpClientFactory.CreateSecureHttpClient(null!));
 
-        Assert.Equal("mtlsOptions", exception.ParamName);
+        Assert.Equal("tlsOptions", exception.ParamName);
     }
 
     private static X509Certificate2 CreateSelfSignedCertificate()

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTlsOptionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTlsOptionsTests.cs
@@ -1,0 +1,294 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#if NET
+
+using System.Net.Security;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests;
+
+/// <summary>
+/// Tests for TLS options and secure HTTP client configuration.
+/// </summary>
+public class OtlpTlsOptionsTests
+{
+    [Fact]
+    public void OtlpTlsOptions_IsTlsEnabled_ReturnsFalse_WhenNoCaCertificatePath()
+    {
+        var options = new OtlpTlsOptions();
+        Assert.False(options.IsTlsEnabled);
+    }
+
+    [Fact]
+    public void OtlpTlsOptions_IsTlsEnabled_ReturnsTrue_WhenCaCertificatePathProvided()
+    {
+        var options = new OtlpTlsOptions { CaCertificatePath = "/path/to/ca.crt" };
+        Assert.True(options.IsTlsEnabled);
+    }
+
+    [Fact]
+    public void OtlpTlsOptions_IsMtlsEnabled_ReturnsFalse_ByDefault()
+    {
+        var options = new OtlpTlsOptions { CaCertificatePath = "/path/to/ca.crt" };
+        Assert.False(options.IsMtlsEnabled);
+    }
+
+    [Fact]
+    public void OtlpMtlsOptions_IsMtlsEnabled_ReturnsTrue_WhenClientCertificateProvided()
+    {
+        var options = new OtlpMtlsOptions { ClientCertificatePath = "/path/to/client.crt" };
+        Assert.True(options.IsMtlsEnabled);
+    }
+
+    [Fact]
+    public void OtlpMtlsOptions_IsMtlsEnabled_ReturnsFalse_WhenOnlyCaCertificateProvided()
+    {
+        // This is the key distinction: CA alone does NOT constitute mTLS
+        var options = new OtlpMtlsOptions { CaCertificatePath = "/path/to/ca.crt" };
+        Assert.False(options.IsMtlsEnabled);
+        Assert.True(options.IsTlsEnabled); // But TLS is still enabled for server cert validation
+    }
+
+    [Fact]
+    public void OtlpSecureHttpClientFactory_CreatesClient_WithCaCertificateOnly()
+    {
+        RunWithCryptoSupportCheck(() =>
+        {
+            var tempCertFile = Path.GetTempFileName();
+            try
+            {
+                using var cert = CreateSelfSignedCertificate();
+                File.WriteAllText(tempCertFile, ExportCertificateWithPrivateKey(cert));
+
+                var options = new OtlpTlsOptions
+                {
+                    CaCertificatePath = tempCertFile,
+                    EnableCertificateChainValidation = false,
+                };
+
+                using var client = OpenTelemetryProtocol.Implementation.OtlpSecureHttpClientFactory.CreateSecureHttpClient(options);
+
+                Assert.NotNull(client);
+            }
+            finally
+            {
+                if (File.Exists(tempCertFile))
+                {
+                    File.Delete(tempCertFile);
+                }
+            }
+        });
+    }
+
+    [Fact]
+    public void OtlpSecureHttpClientFactory_CreatesClient_WithMtlsClientCertificate()
+    {
+        RunWithCryptoSupportCheck(() =>
+        {
+            var tempCertFile = Path.GetTempFileName();
+            try
+            {
+                using var cert = CreateSelfSignedCertificate();
+                var certBytes = cert.Export(X509ContentType.Pfx);
+                File.WriteAllBytes(tempCertFile, certBytes);
+
+                var options = new OtlpMtlsOptions
+                {
+                    ClientCertificatePath = tempCertFile,
+                    EnableCertificateChainValidation = false,
+                };
+
+                using var client = OpenTelemetryProtocol.Implementation.OtlpSecureHttpClientFactory.CreateSecureHttpClient(options);
+
+                Assert.NotNull(client);
+            }
+            finally
+            {
+                if (File.Exists(tempCertFile))
+                {
+                    File.Delete(tempCertFile);
+                }
+            }
+        });
+    }
+
+    [Fact]
+    public void OtlpSecureHttpClientFactory_ThrowsArgumentNullException_WhenOptionsIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            OpenTelemetryProtocol.Implementation.OtlpSecureHttpClientFactory.CreateSecureHttpClient(null!));
+    }
+
+    [Fact]
+    public void OtlpSecureHttpClientFactory_ThrowsInvalidOperationException_WhenTlsNotEnabled()
+    {
+        var options = new OtlpTlsOptions();
+        Assert.Throws<InvalidOperationException>(() =>
+            OpenTelemetryProtocol.Implementation.OtlpSecureHttpClientFactory.CreateSecureHttpClient(options));
+    }
+
+    [Fact]
+    public void OtlpCertificateManager_LoadCaCertificate_ThrowsFileNotFoundException()
+    {
+        Assert.Throws<FileNotFoundException>(() =>
+            OpenTelemetryProtocol.Implementation.OtlpCertificateManager.LoadCaCertificate("/nonexistent/cert.pem"));
+    }
+
+    [Fact]
+    public void OtlpCertificateManager_ValidateServerCertificate_ReturnsTrue_WhenNoSslPolicyErrors()
+    {
+        using var caCertificate = CreateCertificateAuthority();
+        using var serverCertificate = CreateServerCertificate(caCertificate);
+        using var chain = new X509Chain();
+        chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+
+        var result = OpenTelemetryProtocol.Implementation.OtlpCertificateManager.ValidateServerCertificate(
+            serverCertificate,
+            chain,
+            SslPolicyErrors.None,
+            caCertificate);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void OtlpCertificateManager_ValidateServerCertificate_ReturnsTrue_WithProvidedTrustedCert()
+    {
+        using var caCertificate = CreateCertificateAuthority();
+        using var serverCertificate = CreateServerCertificate(caCertificate);
+        using var chain = new X509Chain();
+        chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+
+        var result = OpenTelemetryProtocol.Implementation.OtlpCertificateManager.ValidateServerCertificate(
+            serverCertificate,
+            chain,
+            SslPolicyErrors.RemoteCertificateChainErrors,
+            caCertificate);
+
+        Assert.True(result);
+        Assert.Equal(caCertificate.Thumbprint, chain.ChainElements[^1].Certificate.Thumbprint);
+    }
+
+    private static X509Certificate2 CreateSelfSignedCertificate()
+    {
+        using var rsa = RSA.Create(2048);
+        var req = new CertificateRequest(
+            "CN=Test Certificate",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+
+        var cert = req.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddDays(-1),
+            DateTimeOffset.UtcNow.AddDays(30));
+#if NET9_0_OR_GREATER
+        return X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx), (string?)null, X509KeyStorageFlags.Exportable);
+#else
+#pragma warning disable SYSLIB0057
+        return new X509Certificate2(cert.Export(X509ContentType.Pfx), (string?)null, X509KeyStorageFlags.Exportable);
+#pragma warning restore SYSLIB0057
+#endif
+    }
+
+    private static X509Certificate2 CreateCertificateAuthority()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(
+            "CN=Test CA",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+
+        request.CertificateExtensions.Add(new X509BasicConstraintsExtension(true, false, 0, true));
+        request.CertificateExtensions.Add(new X509KeyUsageExtension(
+            X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign,
+            true));
+        request.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
+
+        var cert = request.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddDays(-1),
+            DateTimeOffset.UtcNow.AddYears(1));
+
+#if NET9_0_OR_GREATER
+        return X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx), (string?)null, X509KeyStorageFlags.Exportable);
+#else
+#pragma warning disable SYSLIB0057
+        return new X509Certificate2(cert.Export(X509ContentType.Pfx), (string?)null, X509KeyStorageFlags.Exportable);
+#pragma warning restore SYSLIB0057
+#endif
+    }
+
+    private static X509Certificate2 CreateServerCertificate(X509Certificate2 issuer)
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest(
+            "CN=localhost",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+
+        request.CertificateExtensions.Add(new X509BasicConstraintsExtension(false, false, 0, false));
+        request.CertificateExtensions.Add(new X509KeyUsageExtension(
+            X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment,
+            true));
+        request.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
+
+        var sanBuilder = new SubjectAlternativeNameBuilder();
+        sanBuilder.AddDnsName("localhost");
+        request.CertificateExtensions.Add(sanBuilder.Build());
+
+        var serialNumber = new byte[16];
+        RandomNumberGenerator.Fill(serialNumber);
+
+        var cert = request.Create(
+            issuer,
+            DateTimeOffset.UtcNow.AddDays(-1),
+            DateTimeOffset.UtcNow.AddDays(30),
+            serialNumber);
+
+#if NET9_0_OR_GREATER
+        return X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx), (string?)null, X509KeyStorageFlags.Exportable);
+#else
+#pragma warning disable SYSLIB0057
+        return new X509Certificate2(cert.Export(X509ContentType.Pfx), (string?)null, X509KeyStorageFlags.Exportable);
+#pragma warning restore SYSLIB0057
+#endif
+    }
+
+    private static string ExportCertificateWithPrivateKey(X509Certificate2 certificate)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine(certificate.ExportCertificatePem().Trim());
+
+        using RSA? privateKey = certificate.GetRSAPrivateKey();
+        if (privateKey != null)
+        {
+            var pkcs8Bytes = privateKey.ExportPkcs8PrivateKey();
+            var privateKeyPem = PemEncoding.Write("PRIVATE KEY", pkcs8Bytes);
+            builder.AppendLine(new string(privateKeyPem).Trim());
+        }
+
+        return builder.ToString();
+    }
+
+    private static void RunWithCryptoSupportCheck(Action testBody)
+    {
+        try
+        {
+            testBody();
+        }
+        catch (PlatformNotSupportedException ex)
+        {
+            Console.WriteLine($"Skipping TLS tests: {ex.Message}");
+        }
+        catch (CryptographicException ex) when (ex.Message.Contains("not supported", StringComparison.OrdinalIgnoreCase))
+        {
+            Console.WriteLine($"Skipping TLS tests: {ex.Message}");
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
Fixes #6764 
Design discussion issue #6764 

## Changes

Decouples `OTEL_EXPORTER_OTLP_CERTIFICATE` from mTLS-specific classes to support standalone TLS scenarios (e.g., trusting self-signed server certificates without client authentication).

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)