### PR TITLE
docs: clarify MetricReaderOptions for metrics exporters

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/README.md
+++ b/src/OpenTelemetry.Exporter.Console/README.md
@@ -40,11 +40,33 @@ You can configure the `ConsoleExporter` through `Options` types properties
 and environment variables.
 The `Options` type setters take precedence over the environment variables.
 
+### MetricReaderOptions (metrics)
+
+For metrics, `AddConsoleExporter()` pairs the exporter with a
+`PeriodicExportingMetricReader`. Use `MetricReaderOptions` to configure
+temporality and export interval/timeout:
+
+```csharp
+var meterProvider = Sdk.CreateMeterProviderBuilder()
+    // rest of config not shown here.
+    .AddConsoleExporter((_, metricReaderOptions) =>
+    {
+        metricReaderOptions.TemporalityPreference = MetricReaderTemporalityPreference.Delta;
+
+        metricReaderOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = 10_000;
+        metricReaderOptions.PeriodicExportingMetricReaderOptions.ExportTimeoutMilliseconds = 5_000;
+    })
+    .Build();
+```
+
+See [`TestMetrics.cs`](../../examples/Console/TestMetrics.cs) for a runnable
+example.
+
 ## Environment Variables
 
 The following environment variables can be used to override the default
 values of the `PeriodicExportingMetricReaderOptions`
-(following the [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.12.0/specification/sdk-environment-variables.md#periodic-exporting-metricreader).
+(following the [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#periodic-exporting-metricreader)).
 
 | Environment variable          | `PeriodicExportingMetricReaderOptions` property |
 | ------------------------------| ------------------------------------------------|

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md
@@ -394,20 +394,24 @@ appBuilder.Services.Configure<LogRecordExportProcessorOptions>(
 ### MetricReaderOptions
 
 The `MetricReaderOptions` class may be used to configure reader settings for
-metrics:
+metrics (e.g. `TemporalityPreference` and `PeriodicExportingMetricReaderOptions`):
 
 ```csharp
 // Set via delegate using code:
 appBuilder.Services.AddOpenTelemetry()
     .WithMetrics(builder => builder.AddOtlpExporter((exporterOptions, readerOptions) =>
     {
+        readerOptions.TemporalityPreference = MetricReaderTemporalityPreference.Delta;
         readerOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = 10_000;
+        readerOptions.PeriodicExportingMetricReaderOptions.ExportTimeoutMilliseconds = 5_000;
     }));
 
 // Set via Options API using code:
 appBuilder.Services.Configure<MetricReaderOptions>(o =>
 {
+    o.TemporalityPreference = MetricReaderTemporalityPreference.Delta;
     o.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = 10_000;
+    o.PeriodicExportingMetricReaderOptions.ExportTimeoutMilliseconds = 5_000;
 });
 
 // Set via Options API using configuration:


### PR DESCRIPTION
Fixes #4417

Updates metrics configuration docs for:
- Console exporter: add a `MetricReaderOptions` section showing `TemporalityPreference` and `PeriodicExportingMetricReaderOptions` (export interval/timeout).
- OTLP exporter: expand the `MetricReaderOptions` examples to include temporality and export timeout configuration.

Tests:
- `markdownlint src/OpenTelemetry.Exporter.Console/README.md src/OpenTelemetry.Exporter.OpenTelemetryProtocol/README.md`
- `dotnet test test/OpenTelemetry.Exporter.Console.Tests/OpenTelemetry.Exporter.Console.Tests.csproj -c Release`
- `dotnet test test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests.csproj -c Release`
