### PR TITLE
[OTLP] refactor: rename mTLS helpers

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpCertificateManager.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpCertificateManager.cs
@@ -12,7 +12,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 /// <summary>
 /// Manages certificate loading, validation, and security checks for mTLS connections.
 /// </summary>
-internal static class OtlpMtlsCertificateManager
+internal static class OtlpCertificateManager
 {
     internal const string CaCertificateType = "CA certificate";
     internal const string ClientCertificateType = "Client certificate";

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpSecureHttpClientFactory.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpSecureHttpClientFactory.cs
@@ -10,7 +10,7 @@ namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 /// <summary>
 /// Factory for creating HttpClient instances configured with mTLS settings.
 /// </summary>
-internal static class OtlpMtlsHttpClientFactory
+internal static class OtlpSecureHttpClientFactory
 {
     /// <summary>
     /// Creates an HttpClient configured with mTLS settings.
@@ -20,7 +20,7 @@ internal static class OtlpMtlsHttpClientFactory
     /// <returns>An HttpClient configured for mTLS.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="mtlsOptions"/> is null.</exception>
     /// <exception cref="InvalidOperationException">Thrown when mTLS is not enabled.</exception>
-    public static HttpClient CreateMtlsHttpClient(
+    public static HttpClient CreateSecureHttpClient(
         OtlpMtlsOptions mtlsOptions,
         Action<HttpClient>? configureClient = null)
     {
@@ -40,14 +40,14 @@ internal static class OtlpMtlsHttpClientFactory
             // Load certificates
             if (!string.IsNullOrEmpty(mtlsOptions.CaCertificatePath))
             {
-                caCertificate = OtlpMtlsCertificateManager.LoadCaCertificate(
+                caCertificate = OtlpCertificateManager.LoadCaCertificate(
                     mtlsOptions.CaCertificatePath);
 
                 if (mtlsOptions.EnableCertificateChainValidation)
                 {
-                    OtlpMtlsCertificateManager.ValidateCertificateChain(
+                    OtlpCertificateManager.ValidateCertificateChain(
                         caCertificate,
-                        OtlpMtlsCertificateManager.CaCertificateType);
+                        OtlpCertificateManager.CaCertificateType);
                 }
             }
 
@@ -56,22 +56,22 @@ internal static class OtlpMtlsHttpClientFactory
                 if (string.IsNullOrEmpty(mtlsOptions.ClientKeyPath))
                 {
                     // Load certificate without separate key file (e.g., PKCS#12 format)
-                    clientCertificate = OtlpMtlsCertificateManager.LoadClientCertificate(
+                    clientCertificate = OtlpCertificateManager.LoadClientCertificate(
                         mtlsOptions.ClientCertificatePath,
                         null);
                 }
                 else
                 {
-                    clientCertificate = OtlpMtlsCertificateManager.LoadClientCertificate(
+                    clientCertificate = OtlpCertificateManager.LoadClientCertificate(
                         mtlsOptions.ClientCertificatePath,
                         mtlsOptions.ClientKeyPath);
                 }
 
                 if (mtlsOptions.EnableCertificateChainValidation)
                 {
-                    OtlpMtlsCertificateManager.ValidateCertificateChain(
+                    OtlpCertificateManager.ValidateCertificateChain(
                         clientCertificate,
-                        OtlpMtlsCertificateManager.ClientCertificateType);
+                        OtlpCertificateManager.ClientCertificateType);
                 }
 
                 OpenTelemetryProtocolExporterEventSource.Log.MtlsConfigurationEnabled(
@@ -142,7 +142,7 @@ internal static class OtlpMtlsHttpClientFactory
                         return false;
                     }
 
-                    return OtlpMtlsCertificateManager.ValidateServerCertificate(
+                    return OtlpCertificateManager.ValidateServerCertificate(
                         cert,
                         chain,
                         sslPolicyErrors,

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -78,7 +78,7 @@ public class OtlpExporterOptions : IOtlpExporterOptions
             // If mTLS is configured, create an mTLS-enabled client
             if (this.MtlsOptions?.IsEnabled == true)
             {
-                return OtlpMtlsHttpClientFactory.CreateMtlsHttpClient(
+                return OtlpSecureHttpClientFactory.CreateSecureHttpClient(
                     this.MtlsOptions,
                     client => client.Timeout = timeout);
             }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpCertificateManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpCertificateManagerTests.cs
@@ -5,7 +5,7 @@
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests;
 
-public class OtlpMtlsCertificateManagerTests
+public class OtlpCertificateManagerTests
 {
     private const string TestCertPem =
         @"-----BEGIN CERTIFICATE-----
@@ -39,7 +39,7 @@ INVALID CERTIFICATE DATA
     public void LoadClientCertificate_ThrowsFileNotFoundException_WhenCertificateFileDoesNotExist()
     {
         var exception = Assert.Throws<FileNotFoundException>(() =>
-            OpenTelemetryProtocol.Implementation.OtlpMtlsCertificateManager.LoadClientCertificate(
+            OpenTelemetryProtocol.Implementation.OtlpCertificateManager.LoadClientCertificate(
                 "/nonexistent/client.crt",
                 "/nonexistent/client.key"));
 
@@ -56,7 +56,7 @@ INVALID CERTIFICATE DATA
         try
         {
             var exception = Assert.Throws<FileNotFoundException>(() =>
-                OpenTelemetryProtocol.Implementation.OtlpMtlsCertificateManager.LoadClientCertificate(
+                OpenTelemetryProtocol.Implementation.OtlpCertificateManager.LoadClientCertificate(
                     tempCertFile,
                     "/nonexistent/client.key"));
 
@@ -73,7 +73,7 @@ INVALID CERTIFICATE DATA
     public void LoadCaCertificate_ThrowsFileNotFoundException_WhenTrustStoreFileDoesNotExist()
     {
         var exception = Assert.Throws<FileNotFoundException>(() =>
-            OpenTelemetryProtocol.Implementation.OtlpMtlsCertificateManager.LoadCaCertificate("/nonexistent/ca.crt"));
+            OpenTelemetryProtocol.Implementation.OtlpCertificateManager.LoadCaCertificate("/nonexistent/ca.crt"));
 
         Assert.Contains("CA certificate file not found", exception.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("/nonexistent/ca.crt", exception.Message, StringComparison.OrdinalIgnoreCase);
@@ -90,7 +90,7 @@ INVALID CERTIFICATE DATA
         try
         {
             var exception = Assert.Throws<InvalidOperationException>(() =>
-                OpenTelemetryProtocol.Implementation.OtlpMtlsCertificateManager.LoadClientCertificate(tempCertFile, tempKeyFile));
+                OpenTelemetryProtocol.Implementation.OtlpCertificateManager.LoadClientCertificate(tempCertFile, tempKeyFile));
 
             Assert.Contains(
                 "Failed to load client certificate",
@@ -113,7 +113,7 @@ INVALID CERTIFICATE DATA
         try
         {
             var exception = Assert.Throws<InvalidOperationException>(() =>
-                OpenTelemetryProtocol.Implementation.OtlpMtlsCertificateManager.LoadCaCertificate(tempTrustStoreFile));
+                OpenTelemetryProtocol.Implementation.OtlpCertificateManager.LoadCaCertificate(tempTrustStoreFile));
 
             Assert.Contains(
                 "Failed to load CA certificate",
@@ -133,7 +133,7 @@ INVALID CERTIFICATE DATA
         using var cert = CreateSelfSignedCertificate();
 
         // Should not throw for self-signed certificate with proper validation
-        var result = OpenTelemetryProtocol.Implementation.OtlpMtlsCertificateManager.ValidateCertificateChain(cert, "test certificate");
+        var result = OpenTelemetryProtocol.Implementation.OtlpCertificateManager.ValidateCertificateChain(cert, "test certificate");
 
         // For self-signed certificates, validation may fail, but method should not throw
         Assert.True(result || !result); // Just check that it returns a boolean
@@ -146,7 +146,7 @@ INVALID CERTIFICATE DATA
         using var cert = CreateSelfSignedCertificate();
 
         // Should return a boolean result
-        var result = OpenTelemetryProtocol.Implementation.OtlpMtlsCertificateManager.ValidateCertificateChain(cert, "test certificate");
+        var result = OpenTelemetryProtocol.Implementation.OtlpCertificateManager.ValidateCertificateChain(cert, "test certificate");
 
         // The result can be true or false, but the method should not throw
         Assert.True(result || !result);
@@ -166,7 +166,7 @@ INVALID CERTIFICATE DATA
             // Note: We expect this to fail because we're using dummy cert/key content
             // but it should not fail due to the method signature
             var exception = Assert.Throws<InvalidOperationException>(() =>
-                OpenTelemetryProtocol.Implementation.OtlpMtlsCertificateManager.LoadClientCertificate(
+                OpenTelemetryProtocol.Implementation.OtlpCertificateManager.LoadClientCertificate(
                     tempCertFile,
                     tempKeyFile));
 

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpSecureHttpClientFactoryTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpSecureHttpClientFactoryTests.cs
@@ -10,7 +10,7 @@ using System.Text;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests;
 
-public class OtlpMtlsHttpClientFactoryTests
+public class OtlpSecureHttpClientFactoryTests
 {
     [Fact]
     public void CreateHttpClient_ThrowsInvalidOperationException_WhenMtlsIsDisabled()
@@ -18,7 +18,7 @@ public class OtlpMtlsHttpClientFactoryTests
         var options = new OtlpMtlsOptions(); // Disabled by default
 
         Assert.Throws<InvalidOperationException>(() =>
-            OpenTelemetryProtocol.Implementation.OtlpMtlsHttpClientFactory.CreateMtlsHttpClient(options));
+            OpenTelemetryProtocol.Implementation.OtlpSecureHttpClientFactory.CreateSecureHttpClient(options));
     }
 
     [Fact]
@@ -27,7 +27,7 @@ public class OtlpMtlsHttpClientFactoryTests
         var options = new OtlpMtlsOptions { ClientCertificatePath = "/nonexistent/client.crt" };
 
         var exception = Assert.Throws<FileNotFoundException>(() =>
-            OpenTelemetryProtocol.Implementation.OtlpMtlsHttpClientFactory.CreateMtlsHttpClient(options));
+            OpenTelemetryProtocol.Implementation.OtlpSecureHttpClientFactory.CreateSecureHttpClient(options));
 
         Assert.Contains("Certificate file not found", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
@@ -49,7 +49,7 @@ public class OtlpMtlsHttpClientFactoryTests
                 EnableCertificateChainValidation = false, // Ignore validation for test cert
             };
 
-            using var httpClient = OpenTelemetryProtocol.Implementation.OtlpMtlsHttpClientFactory.CreateMtlsHttpClient(options);
+            using var httpClient = OpenTelemetryProtocol.Implementation.OtlpSecureHttpClientFactory.CreateSecureHttpClient(options);
 
             Assert.NotNull(httpClient);
 
@@ -89,7 +89,7 @@ public class OtlpMtlsHttpClientFactoryTests
                     EnableCertificateChainValidation = false, // Avoid platform-specific chain build differences
                 };
 
-                using var httpClient = OpenTelemetryProtocol.Implementation.OtlpMtlsHttpClientFactory.CreateMtlsHttpClient(options);
+                using var httpClient = OpenTelemetryProtocol.Implementation.OtlpSecureHttpClientFactory.CreateSecureHttpClient(options);
 
                 Assert.NotNull(httpClient);
 
@@ -130,7 +130,7 @@ public class OtlpMtlsHttpClientFactoryTests
                     EnableCertificateChainValidation = false, // Avoid platform-specific chain build differences
                 };
 
-                using var httpClient = OpenTelemetryProtocol.Implementation.OtlpMtlsHttpClientFactory.CreateMtlsHttpClient(options);
+                using var httpClient = OpenTelemetryProtocol.Implementation.OtlpSecureHttpClientFactory.CreateSecureHttpClient(options);
 
                 var handlerField = typeof(HttpMessageInvoker).GetField(
                     "_handler",
@@ -171,7 +171,7 @@ public class OtlpMtlsHttpClientFactoryTests
                     EnableCertificateChainValidation = false,
                 };
 
-                using var httpClient = OpenTelemetryProtocol.Implementation.OtlpMtlsHttpClientFactory.CreateMtlsHttpClient(options);
+                using var httpClient = OpenTelemetryProtocol.Implementation.OtlpSecureHttpClientFactory.CreateSecureHttpClient(options);
 
                 var handlerField = typeof(HttpMessageInvoker).GetField(
                     "_handler",
@@ -212,7 +212,7 @@ public class OtlpMtlsHttpClientFactoryTests
         using var chain = new X509Chain();
         chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
 
-        var result = OpenTelemetryProtocol.Implementation.OtlpMtlsCertificateManager.ValidateServerCertificate(
+        var result = OpenTelemetryProtocol.Implementation.OtlpCertificateManager.ValidateServerCertificate(
             serverCertificate,
             chain,
             SslPolicyErrors.None,
@@ -229,7 +229,7 @@ public class OtlpMtlsHttpClientFactoryTests
         using var chain = new X509Chain();
         chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
 
-        var result = OpenTelemetryProtocol.Implementation.OtlpMtlsCertificateManager.ValidateServerCertificate(
+        var result = OpenTelemetryProtocol.Implementation.OtlpCertificateManager.ValidateServerCertificate(
             serverCertificate,
             chain,
             SslPolicyErrors.RemoteCertificateChainErrors,
@@ -248,7 +248,7 @@ public class OtlpMtlsHttpClientFactoryTests
         using var chain = new X509Chain();
         chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
 
-        var result = OpenTelemetryProtocol.Implementation.OtlpMtlsCertificateManager.ValidateServerCertificate(
+        var result = OpenTelemetryProtocol.Implementation.OtlpCertificateManager.ValidateServerCertificate(
             serverCertificate,
             chain,
             SslPolicyErrors.RemoteCertificateChainErrors,
@@ -262,18 +262,18 @@ public class OtlpMtlsHttpClientFactoryTests
     {
         using var expiredCertificate = CreateExpiredCertificate();
 
-        var result = OpenTelemetryProtocol.Implementation.OtlpMtlsCertificateManager.ValidateCertificateChain(
+        var result = OpenTelemetryProtocol.Implementation.OtlpCertificateManager.ValidateCertificateChain(
             expiredCertificate,
-            OpenTelemetryProtocol.Implementation.OtlpMtlsCertificateManager.ClientCertificateType);
+            OpenTelemetryProtocol.Implementation.OtlpCertificateManager.ClientCertificateType);
 
         Assert.False(result);
     }
 
     [Fact]
-    public void CreateMtlsHttpClient_ThrowsArgumentNullException_WhenOptionsIsNull()
+    public void CreateSecureHttpClient_ThrowsArgumentNullException_WhenOptionsIsNull()
     {
         var exception = Assert.Throws<ArgumentNullException>(() =>
-            OpenTelemetryProtocol.Implementation.OtlpMtlsHttpClientFactory.CreateMtlsHttpClient(null!));
+            OpenTelemetryProtocol.Implementation.OtlpSecureHttpClientFactory.CreateSecureHttpClient(null!));
 
         Assert.Equal("mtlsOptions", exception.ParamName);
     }


### PR DESCRIPTION
Fixes #6777
Design discussion issue #6777

## Changes
- Renamed the mTLS certificate manager and HTTP client factory to more general TLS naming and updated test/file names accordingly; no behavior changes intended.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [x] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
