### PR TITLE
[OTLP] refactor: trust custom CA only

### DIFF
--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpSecureHttpClientFactoryTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpSecureHttpClientFactoryTests.cs
@@ -258,6 +258,24 @@ public class OtlpSecureHttpClientFactoryTests
     }
 
     [Fact]
+    public void ValidateServerCertificate_ReturnsFalse_WhenCaDoesNotMatch_EvenIfSslPolicyErrorsNone()
+    {
+        using var caCertificate = CreateCertificateAuthority();
+        using var otherCaCertificate = CreateCertificateAuthority();
+        using var serverCertificate = CreateServerCertificate(caCertificate);
+        using var chain = new X509Chain();
+        chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+
+        var result = OpenTelemetryProtocol.Implementation.OtlpCertificateManager.ValidateServerCertificate(
+            serverCertificate,
+            chain,
+            SslPolicyErrors.None,
+            otherCaCertificate);
+
+        Assert.False(result);
+    }
+
+    [Fact]
     public void ValidateCertificateChain_ReturnsFalseForExpiredCertificate()
     {
         using var expiredCertificate = CreateExpiredCertificate();


### PR DESCRIPTION
Fixes #6800
Design discussion issue #6800

## Changes

- Enforce custom CA pinning even when system trust succeeds by always building the chain against the provided CA.
- Add a regression test that ensures a mismatched CA is rejected even if `SslPolicyErrors.None`.


## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
