### PR TITLE
[infra] Fix release pipeline

### DIFF
--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -11,6 +11,8 @@ on:
         value: ${{ vars.AUTOMATION_EMAIL }}
       application-name:
         value: ${{ vars.AUTOMATION_APPLICATION_NAME }}
+      application-login:
+        value: ${{ vars.AUTOMATION_APPLICATION_LOGIN }}
       application-username:
         value: ${{ vars.AUTOMATION_APPLICATION_USERNAME }}
     secrets:

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -70,6 +70,7 @@ jobs:
       env:
         GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         EXPECTED_PR_AUTHOR_USER_NAME: ${{ needs.automation.outputs.application-name }}
+        EXPECTED_COMMENT_AUTHOR_USER_NAME: ${{ needs.automation.outputs.application-login }}
         COMMENT_USER_NAME: ${{ github.event.comment.user.login }}
         ISSUE_NUMBER: ${{ github.event.issue.number }}
         NUGET_TOKEN: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
@@ -81,6 +82,7 @@ jobs:
           -gitRepository ${env:GITHUB_REPOSITORY} `
           -pullRequestNumber ${env:ISSUE_NUMBER} `
           -expectedPrAuthorUserName ${env:EXPECTED_PR_AUTHOR_USER_NAME} `
+          -expectedCommentAuthorUserName ${env:EXPECTED_COMMENT_AUTHOR_USER_NAME} `
           -commentUserName ${env:COMMENT_USER_NAME} `
           -artifactDownloadPath "${env:GITHUB_WORKSPACE}/artifacts" `
           -pushToNuget $HasToken
@@ -153,6 +155,7 @@ jobs:
       env:
         GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         EXPECTED_PR_AUTHOR_USER_NAME: ${{ needs.automation.outputs.application-name }}
+        EXPECTED_COMMENT_AUTHOR_USER_NAME: ${{ needs.automation.outputs.application-login }}
         TAG: ${{ inputs.tag || github.ref_name }}
       run: |
         Import-Module .\build\scripts\post-release.psm1
@@ -160,4 +163,5 @@ jobs:
         TryPostReleasePublishedNoticeOnPrepareReleasePullRequest `
           -gitRepository ${env:GITHUB_REPOSITORY} `
           -expectedPrAuthorUserName ${env:EXPECTED_PR_AUTHOR_USER_NAME} `
+          -expectedCommentAuthorUserName ${env:EXPECTED_COMMENT_AUTHOR_USER_NAME} `
           -tag ${env:TAG}

--- a/.github/workflows/publish-packages-1.0.yml
+++ b/.github/workflows/publish-packages-1.0.yml
@@ -227,6 +227,7 @@ jobs:
       env:
         GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
         EXPECTED_PR_AUTHOR_USER_NAME: ${{ needs.automation.outputs.application-name }}
+        EXPECTED_COMMENT_AUTHOR_USER_NAME: ${{ needs.automation.outputs.application-login }}
         PACKAGES_URL: ${{ needs.build-pack-publish.outputs.artifact-url }}
       run: |
         Import-Module .\build\scripts\post-release.psm1
@@ -236,4 +237,5 @@ jobs:
           -tag ${env:GITHUB_REF_NAME} `
           -tagSha ${env:GITHUB_SHA} `
           -packagesUrl ${env:PACKAGES_URL} `
-          -expectedPrAuthorUserName ${env:EXPECTED_PR_AUTHOR_USER_NAME}
+          -expectedPrAuthorUserName ${env:EXPECTED_PR_AUTHOR_USER_NAME} `
+          -expectedCommentAuthorUserName ${env:EXPECTED_COMMENT_AUTHOR_USER_NAME}

--- a/build/scripts/post-release.psm1
+++ b/build/scripts/post-release.psm1
@@ -125,7 +125,8 @@ function TryPostPackagesReadyNoticeOnPrepareReleasePullRequest {
     [Parameter(Mandatory=$true)][string]$tag,
     [Parameter(Mandatory=$true)][string]$tagSha,
     [Parameter(Mandatory=$true)][string]$packagesUrl,
-    [Parameter(Mandatory=$true)][string]$expectedPrAuthorUserName
+    [Parameter(Mandatory=$true)][string]$expectedPrAuthorUserName,
+    [Parameter(Mandatory=$true)][string]$expectedCommentAuthorUserName
   )
 
   $prListResponse = gh pr list --search $tagSha --state merged --json number,author,title,comments | ConvertFrom-Json
@@ -146,7 +147,7 @@ function TryPostPackagesReadyNoticeOnPrepareReleasePullRequest {
     $foundComment = $false
     foreach ($comment in $pr.comments)
     {
-      if ($comment.author.login -eq $expectedPrAuthorUserName -and $comment.body.StartsWith("I just pushed the [$tag]"))
+      if ($comment.author.login -eq $expectedCommentAuthorUserName -and $comment.body.StartsWith("I just pushed the [$tag]"))
       {
         $foundComment = $true
         break
@@ -181,6 +182,7 @@ function PushPackagesPublishReleaseUnlockAndPostNoticeOnPrepareReleasePullReques
     [Parameter(Mandatory=$true)][string]$gitRepository,
     [Parameter(Mandatory=$true)][string]$pullRequestNumber,
     [Parameter(Mandatory=$true)][string]$expectedPrAuthorUserName,
+    [Parameter(Mandatory=$true)][string]$expectedCommentAuthorUserName,
     [Parameter(Mandatory=$true)][string]$commentUserName,
     [Parameter(Mandatory=$true)][string]$artifactDownloadPath,
     [Parameter(Mandatory=$true)][bool]$pushToNuget
@@ -215,7 +217,7 @@ function PushPackagesPublishReleaseUnlockAndPostNoticeOnPrepareReleasePullReques
   $packagesUrl = ''
   foreach ($comment in $prViewResponse.comments)
   {
-    if ($comment.author.login -eq $expectedPrAuthorUserName -and $comment.body.StartsWith("The packages for [$tag](https://github.com/$gitRepository/releases/tag/$tag) are now available:"))
+    if ($comment.author.login -eq $expectedCommentAuthorUserName -and $comment.body.StartsWith("The packages for [$tag](https://github.com/$gitRepository/releases/tag/$tag) are now available:"))
     {
       $foundComment = $true
       break
@@ -550,6 +552,7 @@ function TryPostReleasePublishedNoticeOnPrepareReleasePullRequest {
   param(
     [Parameter(Mandatory=$true)][string]$gitRepository,
     [Parameter(Mandatory=$true)][string]$expectedPrAuthorUserName,
+    [Parameter(Mandatory=$true)][string]$expectedCommentAuthorUserName,
     [Parameter(Mandatory=$true)][string]$tag
   )
 
@@ -577,7 +580,7 @@ function TryPostReleasePublishedNoticeOnPrepareReleasePullRequest {
     $foundComment = $false
     foreach ($comment in $pr.comments)
     {
-      if ($comment.author.login -eq $expectedPrAuthorUserName -and $comment.body.StartsWith("The packages for [$tag](https://github.com/$gitRepository/releases/tag/$tag) are now available:"))
+      if ($comment.author.login -eq $expectedCommentAuthorUserName -and $comment.body.StartsWith("The packages for [$tag](https://github.com/$gitRepository/releases/tag/$tag) are now available:"))
       {
         $foundComment = $true
         break


### PR DESCRIPTION
Fixes #6840
The comments.login is otelbot-dotnet instead of app/otelbot-dotnet

## Changes

## Problem

The release automation was failing with the error `Could not find package push comment on pr` when running the `/PushPackages` command on PR #6839.

**Root cause:** The GitHub API returns different `author.login` values for GitHub Apps depending on context:
- **PR author**: `app/otelbot-dotnet` (includes `app/` prefix)
- **Comment author**: `otelbot-dotnet` (no prefix)

The scripts were using the same variable (`expectedPrAuthorUserName`) to match both PR authors and comment authors, causing the comment author check to fail.

## Solution

Introduced a separate parameter `expectedCommentAuthorUserName` to correctly match comment authors.

## Changes

**New GitHub variable required:**
- `AUTOMATION_APPLICATION_LOGIN` = `otelbot-dotnet`

**Files modified:**

| File | Change |
|------|--------|
| `.github/workflows/automation.yml` | Added `application-login` output |
| `.github/workflows/publish-packages-1.0.yml` | Pass `expectedCommentAuthorUserName` to `TryPostPackagesReadyNoticeOnPrepareReleasePullRequest` |
| `.github/workflows/post-release.yml` | Pass `expectedCommentAuthorUserName` to both `PushPackagesPublishReleaseUnlockAndPostNoticeOnPrepareReleasePullRequest` and `TryPostReleasePublishedNoticeOnPrepareReleasePullRequest` |
| `build/scripts/post-release.psm1` | Added `expectedCommentAuthorUserName` parameter to 3 functions and use it for comment author matching |


## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* ~~[ ] Unit tests added/updated~~
* ~~[ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* ~~[ ] Changes in public API reviewed (if applicable)~~
