### PR TITLE
[Repo] Fix SECURITY-INSIGHTS.yml

### DIFF
--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -1,85 +1,126 @@
 header:
-  schema-version: 2.0.0
-  last-updated: '2026-02-06'
-  last-reviewed: '2026-02-06'
-  url: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/SECURITY-INSIGHTS.yml
-  comment: |
-    This file contains the minimum information for https://github.com/open-telemetry/opentelemetry-dotnet.
+  schema-version: '1.0.0'
+  expiration-date: '2027-02-14T00:00:00.000Z'
+  last-updated: '2026-02-14'
+  last-reviewed: '2026-02-14'
+  project-url: https://github.com/open-telemetry/opentelemetry-dotnet
+  changelog: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/RELEASENOTES.md
+  license: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/LICENSE.TXT
 
-project:
-  name: OpenTelemetry .NET
-  homepage: https://opentelemetry.io/docs/languages/dotnet/
-  administrators:
-    - name: Alan West
-      affiliation: New Relic
-      social: https://github.com/alanwest
-      primary: true
-    - name: Piotr Kie\u0142kowicz
-      affiliation: Splunk
-      social: https://github.com/Kielek
-    - name: Rajkumar Rangaraj
-      affiliation: Microsoft
-      social: https://github.com/rajkumar-rangaraj
-  documentation:
-    code-of-conduct: https://github.com/open-telemetry/.github/blob/main/CODE_OF_CONDUCT.md
-    quickstart-guide: https://opentelemetry.io/docs/languages/dotnet/getting-started/
-  repositories:
-    - name: opentelemetry-dotnet
-      url: https://github.com/open-telemetry/opentelemetry-dotnet
-      comment: |
-        The OpenTelemetry .NET Client repository.
-  vulnerability-reporting:
-    bug-bounty-available: false
-    reports-accepted: true
-    policy: https://opentelemetry.io/docs/security/security-response/
-    contact:
-      name: The OpenTelemetry security team
-      email: security@opentelemetry.io
-      primary: true
-    comment: |
-      Report security vulnerabilities via https://github.com/open-telemetry/opentelemetry-dotnet/security.
-
-repository:
-  url: https://github.com/open-telemetry/opentelemetry-dotnet
+project-lifecycle:
   status: active
-  accepts-automated-change-request: true
-  accepts-change-request: true
   bug-fixes-only: false
-  no-third-party-packages: false
-  core-team:
-    - name: Alan West
-      affiliation: New Relic
-      social: https://github.com/alanwest
-      primary: true
-    - name: Cijo Thomas
-      affiliation: Microsoft
-      social: https://github.com/cijothomas
-    - name: Martin Costello
-      affiliation: Grafana Labs
-      social: https://github.com/martincostello
-    - name: Mikel Blanchard
-      affiliation: Microsoft
-      social: https://github.com/CodeBlanch
-    - name: Piotr Kie\u0142kowicz
-      affiliation: Splunk
-      social: https://github.com/Kielek
-    - name: Rajkumar Rangaraj
-      affiliation: Microsoft
-      social: https://github.com/rajkumar-rangaraj
-  documentation:
-    contributing-guide: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md
-    dependency-management-policy: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/.github/renovate.json
-  license:
-    url: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/LICENSE.TXT
-    expression: Apache-2.0
-  release:
-    automated-pipeline: true
-    distribution-points:
-      - uri: https://www.nuget.org/profiles/OpenTelemetry
-        comment: |
-          NuGet.org is the primary distribution point for OpenTelemetry .NET packages.
-  security:
-    assessments:
-      self:
-        evidence: https://github.com/open-telemetry/opentelemetry-dotnet/pull/6878
-        date: '2026-02-06'
+  core-maintainers:
+    - https://github.com/alanwest
+    - https://github.com/cijothomas
+    - https://github.com/CodeBlanch
+    - https://github.com/Kielek
+    - https://github.com/martincostello
+    - https://github.com/rajkumar-rangaraj
+
+contribution-policy:
+  accepts-pull-requests: true
+  accepts-automated-pull-requests: true
+  contributing-policy: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md
+  code-of-conduct: https://github.com/open-telemetry/.github/blob/main/CODE_OF_CONDUCT.md
+  automated-tools-list:
+    - automated-tool: renovatebot
+      action: allowed
+      comment: Automated dependency updates are accepted.
+
+documentation:
+  - https://opentelemetry.io/docs/languages/dotnet/
+
+distribution-points:
+  - pkg:nuget/OpenTelemetry
+  - pkg:nuget/OpenTelemetry.Api
+  - pkg:nuget/OpenTelemetry.Api.ProviderBuilderExtensions
+  - pkg:nuget/OpenTelemetry.Exporter.Console
+  - pkg:nuget/OpenTelemetry.Exporter.InMemory
+  - pkg:nuget/OpenTelemetry.Exporter.OpenTelemetryProtocol
+  - pkg:nuget/OpenTelemetry.Exporter.Prometheus.AspNetCore
+  - pkg:nuget/OpenTelemetry.Exporter.Prometheus.HttpListener
+  - pkg:nuget/OpenTelemetry.Exporter.Zipkin
+  - pkg:nuget/OpenTelemetry.Extensions.Hosting
+  - pkg:nuget/OpenTelemetry.Extensions.Propagators
+  - pkg:nuget/OpenTelemetry.Shims.OpenTracing
+
+security-artifacts:
+  threat-model:
+    threat-model-created: false
+    comment: |
+      No formal threat model created yet.
+  self-assessment:
+    self-assessment-created: false
+    comment: |
+      No formal self-assessment yet.
+
+security-contacts:
+  - type: website
+    value: https://github.com/open-telemetry/opentelemetry-dotnet/security
+    primary: true
+  - type: email
+    value: security@opentelemetry.io
+    primary: false
+  - type: email
+    value: cncf-opentelemetry-security@lists.cncf.io
+    primary: false
+
+security-testing:
+  - tool-type: sca
+    tool-name: Renovate
+    tool-version: latest
+    tool-url: https://docs.renovatebot.com/
+    tool-rulesets:
+      - built-in
+    integration:
+      ad-hoc: false
+      ci: true
+      before-release: true
+    comment: |
+      Automated dependency updates.
+  - tool-type: fuzzing
+    tool-name: FsCheck
+    tool-version: latest
+    tool-url: https://fscheck.github.io/FsCheck/
+    tool-rulesets:
+      - default
+    integration:
+      ad-hoc: false
+      ci: true
+      before-release: false
+    comment: |
+      FsCheck is used for fuzz testing as part of CI.
+  - tool-type: sast
+    tool-name: CodeQL
+    tool-version: latest
+    tool-url: https://github.com/github/codeql
+    tool-rulesets:
+      - default
+    integration:
+      ad-hoc: false
+      ci: true
+      before-release: true
+    comment: |
+      CodeQL static analysis is run in CI for all commits and pull requests to detect security vulnerabilities.
+
+vulnerability-reporting:
+  accepts-vulnerability-reports: true
+  email-contact: security@opentelemetry.io
+  security-policy: https://opentelemetry.io/docs/security/security-response/
+  bug-bounty-available: false
+  comment: |
+    Report security vulnerabilities via https://github.com/open-telemetry/opentelemetry-dotnet/security.
+
+dependencies:
+  third-party-packages: true
+  dependencies-lists:
+    - https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/Directory.Packages.props
+  dependencies-lifecycle:
+    policy-url: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/.github/renovate.json
+    comment: |
+      Dependencies are kept up to date by Renovate.
+  env-dependencies-policy:
+    policy-url: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/.github/renovate.json
+    comment: |
+      Dependencies are kept up to date by Renovate.


### PR DESCRIPTION
## Changes

Fix incorrect schema version being used - CLO Monitor needs v1 not v2.

<img width="797" height="350" alt="image" src="https://github.com/user-attachments/assets/ffe9c9cf-6c7d-43ea-9895-d9ab75233231" />

Refactored to the new schema and compared to [opentelemetry-go](https://github.com/open-telemetry/opentelemetry-go/blob/main/SECURITY-INSIGHTS.yml)'s version of the manifest.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
