### PR TITLE
Add Martin Costello as a maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ you're more than welcome to participate!
 ### Maintainers
 
 * [Alan West](https://github.com/alanwest), New Relic
+* [Martin Costello](https://github.com/martincostello), Grafana Labs
 * [Piotr Kie&#x142;kowicz](https://github.com/Kielek), Splunk
 * [Rajkumar Rangaraj](https://github.com/rajkumar-rangaraj), Microsoft
 
@@ -283,7 +284,6 @@ For more information about the maintainer role, see the [community repository](h
 ### Approvers
 
 * [Cijo Thomas](https://github.com/cijothomas), Microsoft
-* [Martin Costello](https://github.com/martincostello), Grafana Labs
 * [Mikel Blanchard](https://github.com/CodeBlanch), Microsoft
 
 For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).


### PR DESCRIPTION
@martincostello, we call upon you to join us as a maintainer for OpenTelemetry .NET!

Over the past year you have countless contributions that have improved the quality of this project. This has included numerous improvements to our CI and build infrastructure, improving tests by fixing bad ones and adding additional coverage, and ensuring compatibility with upcoming versions of .NET. Most importantly, in your roll as an approver (and even prior to that), you have been highly responsive with your feedback in both issues and PRs.

We're looking forward to our continued work with you. We'd be pleased if you would accept our offer!