### PR TITLE
[Api] Fix new code analysis warnings

### DIFF
--- a/src/OpenTelemetry.Api/Baggage.cs
+++ b/src/OpenTelemetry.Api/Baggage.cs
@@ -94,8 +94,8 @@ public readonly struct Baggage : IEquatable<Baggage>
             return default;
         }
 
-        Dictionary<string, string> baggageCopy = new Dictionary<string, string>(baggageItems.Count, StringComparer.Ordinal);
-        foreach (KeyValuePair<string, string> baggageItem in baggageItems)
+        var baggageCopy = new Dictionary<string, string>(baggageItems.Count, StringComparer.Ordinal);
+        foreach (var baggageItem in baggageItems)
         {
             if (string.IsNullOrEmpty(baggageItem.Value))
             {
@@ -226,7 +226,7 @@ public readonly struct Baggage : IEquatable<Baggage>
     {
         Guard.ThrowIfNullOrEmpty(name);
 
-        return this.baggage != null && this.baggage.TryGetValue(name, out string? value)
+        return this.baggage != null && this.baggage.TryGetValue(name, out var value)
             ? value
             : null;
     }
@@ -252,7 +252,11 @@ public readonly struct Baggage : IEquatable<Baggage>
         return new Baggage(
             new Dictionary<string, string>(this.baggage ?? EmptyBaggage, StringComparer.Ordinal)
             {
+#if NET
+                [name] = value,
+#else
                 [name] = value!,
+#endif
             });
     }
 
@@ -290,7 +294,11 @@ public readonly struct Baggage : IEquatable<Baggage>
             }
             else
             {
+#if NET
+                newBaggage[item.Key] = item.Value;
+#else
                 newBaggage[item.Key] = item.Value!;
+#endif
             }
         }
 
@@ -329,14 +337,15 @@ public readonly struct Baggage : IEquatable<Baggage>
     /// <inheritdoc/>
     public bool Equals(Baggage other)
     {
-        bool baggageIsNullOrEmpty = this.baggage == null || this.baggage.Count <= 0;
+        var baggageIsNullOrEmpty = this.baggage == null || this.baggage.Count <= 0;
 
-        if (baggageIsNullOrEmpty != (other.baggage == null || other.baggage.Count <= 0))
-        {
-            return false;
-        }
-
-        return baggageIsNullOrEmpty || this.baggage!.SequenceEqual(other.baggage!);
+        return
+            baggageIsNullOrEmpty == (other.baggage == null || other.baggage.Count <= 0) &&
+#if NET
+            (baggageIsNullOrEmpty || this.baggage!.SequenceEqual(other.baggage!));
+#else
+            (baggageIsNullOrEmpty || this.baggage.SequenceEqual(other.baggage));
+#endif
     }
 
     /// <inheritdoc/>

--- a/src/OpenTelemetry.Api/Context/Propagation/B3Propagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/B3Propagator.cs
@@ -88,14 +88,7 @@ public sealed class B3Propagator : TextMapPropagator
             return context;
         }
 
-        if (this.singleHeader)
-        {
-            return ExtractFromSingleHeader(context, carrier, getter);
-        }
-        else
-        {
-            return ExtractFromMultipleHeaders(context, carrier, getter);
-        }
+        return this.singleHeader ? ExtractFromSingleHeader(context, carrier, getter) : ExtractFromMultipleHeaders(context, carrier, getter);
     }
 
     /// <inheritdoc/>
@@ -208,8 +201,14 @@ public sealed class B3Propagator : TextMapPropagator
                 return context;
             }
 
-            var parts = header!.Split(XB3CombinedDelimiter);
-            if (parts.Length < 2 || parts.Length > 4)
+            var parts =
+#if NET
+                header.Split(XB3CombinedDelimiter);
+#else
+                header!.Split(XB3CombinedDelimiter);
+#endif
+
+            if (parts.Length is < 2 or > 4)
             {
                 return context;
             }

--- a/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/BaggagePropagator.cs
@@ -52,9 +52,16 @@ public class BaggagePropagator : TextMapPropagator
             var baggageCollection = getter(carrier, BaggageHeaderName);
             if (baggageCollection?.Any() ?? false)
             {
-                if (TryExtractBaggage([.. baggageCollection], out var baggage))
+                if (TryExtractBaggage([.. baggageCollection], out var baggageItems))
                 {
-                    return new PropagationContext(context.ActivityContext, new Baggage(baggage!));
+                    Baggage baggage =
+#if NET
+                        new(baggageItems);
+#else
+                        new(baggageItems!);
+#endif
+
+                    return new PropagationContext(context.ActivityContext, baggage);
                 }
             }
 
@@ -85,13 +92,13 @@ public class BaggagePropagator : TextMapPropagator
 
         using var e = context.Baggage.GetEnumerator();
 
-        if (e.MoveNext() == true)
+        if (e.MoveNext())
         {
-            int itemCount = 0;
-            StringBuilder baggage = new StringBuilder();
+            var itemCount = 0;
+            var baggage = new StringBuilder();
             do
             {
-                KeyValuePair<string, string> item = e.Current;
+                var item = e.Current;
                 if (string.IsNullOrEmpty(item.Value))
                 {
                     continue;
@@ -112,8 +119,8 @@ public class BaggagePropagator : TextMapPropagator
 #endif
         out Dictionary<string, string>? baggage)
     {
-        int baggageLength = -1;
-        bool done = false;
+        var baggageLength = -1;
+        var done = false;
         Dictionary<string, string>? baggageDictionary = null;
 
         foreach (var item in baggageCollection)

--- a/src/OpenTelemetry.Api/Context/Propagation/CompositeTextMapPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/CompositeTextMapPropagator.cs
@@ -43,13 +43,13 @@ public class CompositeTextMapPropagator : TextMapPropagator
         }
         else
         {
-            ISet<string>? fields = this.propagators[0].Fields;
+            var fields = this.propagators[0].Fields;
 
             var output = fields is not null
                 ? new HashSet<string>(fields)
                 : [];
 
-            for (int i = 1; i < this.propagators.Count; i++)
+            for (var i = 1; i < this.propagators.Count; i++)
             {
                 fields = this.propagators[i].Fields;
                 if (fields is not null)
@@ -68,7 +68,7 @@ public class CompositeTextMapPropagator : TextMapPropagator
     /// <inheritdoc/>
     public override PropagationContext Extract<T>(PropagationContext context, T carrier, Func<T, string, IEnumerable<string>?> getter)
     {
-        for (int i = 0; i < this.propagators.Count; i++)
+        for (var i = 0; i < this.propagators.Count; i++)
         {
             context = this.propagators[i].Extract(context, carrier, getter);
         }
@@ -79,7 +79,7 @@ public class CompositeTextMapPropagator : TextMapPropagator
     /// <inheritdoc/>
     public override void Inject<T>(PropagationContext context, T carrier, Action<T, string, string> setter)
     {
-        for (int i = 0; i < this.propagators.Count; i++)
+        for (var i = 0; i < this.propagators.Count; i++)
         {
             this.propagators[i].Inject(context, carrier, setter);
         }

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceContextPropagator.cs
@@ -122,7 +122,7 @@ public class TraceContextPropagator : TextMapPropagator
 
         setter(carrier, TraceParent, traceparent);
 
-        string? tracestateStr = context.ActivityContext.TraceState;
+        var tracestateStr = context.ActivityContext.TraceState;
         if (tracestateStr?.Length > 0)
         {
             setter(carrier, TraceState, tracestateStr);
@@ -228,13 +228,13 @@ public class TraceContextPropagator : TextMapPropagator
         {
             var keySet = new HashSet<string>();
             var result = new StringBuilder();
-            for (int i = 0; i < tracestateCollection.Length; ++i)
+            for (var i = 0; i < tracestateCollection.Length; ++i)
             {
                 var tracestate = tracestateCollection[i].AsSpan();
-                int begin = 0;
+                var begin = 0;
                 while (begin < tracestate.Length)
                 {
-                    int length = tracestate.Slice(begin).IndexOf(',');
+                    var length = tracestate.Slice(begin).IndexOf(',');
                     ReadOnlySpan<char> listMember;
                     if (length != -1)
                     {
@@ -262,7 +262,7 @@ public class TraceContextPropagator : TextMapPropagator
                         return false;
                     }
 
-                    int keyLength = listMember.IndexOf('=');
+                    var keyLength = listMember.IndexOf('=');
                     if (keyLength == listMember.Length || keyLength == -1)
                     {
                         // Missing key or value in tracestate
@@ -312,19 +312,11 @@ public class TraceContextPropagator : TextMapPropagator
     }
 
     private static byte HexCharToByte(char c)
-    {
-        if ((c >= '0') && (c <= '9'))
-        {
-            return (byte)(c - '0');
-        }
-
-        if ((c >= 'a') && (c <= 'f'))
-        {
-            return (byte)(c - 'a' + 10);
-        }
-
-        throw new ArgumentOutOfRangeException(nameof(c), c, "Must be within: [0-9] or [a-f]");
-    }
+        => c is >= '0' and <= '9'
+           ? (byte)(c - '0')
+           : c is >= 'a' and <= 'f'
+           ? (byte)(c - 'a' + 10)
+           : throw new ArgumentOutOfRangeException(nameof(c), c, "Must be within: [0-9] or [a-f]");
 
     private static bool ValidateKey(ReadOnlySpan<char> key)
     {
@@ -333,7 +325,7 @@ public class TraceContextPropagator : TextMapPropagator
         // It will be slightly differently from the next version of specification in GitHub repository.
 
         // There are two format for the key. The length rule applies to both.
-        if (key.Length <= 0 || key.Length > TraceStateKeyMaxLength)
+        if (key.Length is <= 0 or > TraceStateKeyMaxLength)
         {
             return false;
         }
@@ -349,10 +341,10 @@ public class TraceContextPropagator : TextMapPropagator
             return false;
         }
 
-        int tenantLength = -1;
-        for (int i = 1; i < key.Length; ++i)
+        var tenantLength = -1;
+        for (var i = 1; i < key.Length; ++i)
         {
-            char ch = key[i];
+            var ch = key[i];
             if (ch == '@')
             {
                 tenantLength = i;
@@ -377,20 +369,20 @@ public class TraceContextPropagator : TextMapPropagator
 
         // The second format:
         // key = (lcalpha / DIGIT) 0 * 240(lcalpha / DIGIT / "_" / "-" / "*" / "/") "@" lcalpha 0 * 13(lcalpha / DIGIT / "_" / "-" / "*" / "/")
-        if (tenantLength == 0 || tenantLength > TraceStateKeyTenantMaxLength)
+        if (tenantLength is 0 or > TraceStateKeyTenantMaxLength)
         {
             return false;
         }
 
-        int vendorLength = key.Length - tenantLength - 1;
-        if (vendorLength == 0 || vendorLength > TraceStateKeyVendorMaxLength)
+        var vendorLength = key.Length - tenantLength - 1;
+        if (vendorLength is 0 or > TraceStateKeyVendorMaxLength)
         {
             return false;
         }
 
-        for (int i = tenantLength + 1; i < key.Length; ++i)
+        for (var i = tenantLength + 1; i < key.Length; ++i)
         {
-            char ch = key[i];
+            var ch = key[i];
             if (!(IsLowerAlphaDigit(ch)
                 || ch == '_'
                 || ch == '-'
@@ -410,29 +402,27 @@ public class TraceContextPropagator : TextMapPropagator
         // value      = 0*255(chr) nblk-chr
         // nblk - chr = % x21 - 2B / % x2D - 3C / % x3E - 7E
         // chr        = % x20 / nblk - chr
-        if (value.Length <= 0 || value.Length > TraceStateValueMaxLength)
+        if (value.Length is <= 0 or > TraceStateValueMaxLength)
         {
             return false;
         }
 
-        for (int i = 0; i < value.Length - 1; ++i)
+        for (var i = 0; i < value.Length - 1; ++i)
         {
-            char c = value[i];
-            if (!(c >= 0x20 && c <= 0x7E && c != 0x2C && c != 0x3D))
+            var c = value[i];
+            if (c is not (>= (char)0x20 and <= (char)0x7E and not (char)0x2C and not (char)0x3D))
             {
                 return false;
             }
         }
 
-        char last = value[value.Length - 1];
-        return last >= 0x21 && last <= 0x7E && last != 0x2C && last != 0x3D;
+        var last = value[value.Length - 1];
+        return last is >= (char)0x21 and <= (char)0x7E and not (char)0x2C and not (char)0x3D;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsLowerAlphaDigit(char c)
-    {
-        return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z');
-    }
+        => c is (>= '0' and <= '9') or (>= 'a' and <= 'z');
 
 #if NET
     private static void WriteTraceParentIntoSpan(Span<char> destination, ActivityContext context)

--- a/src/OpenTelemetry.Api/Context/Propagation/TraceStateUtils.cs
+++ b/src/OpenTelemetry.Api/Context/Propagation/TraceStateUtils.cs
@@ -31,7 +31,7 @@ internal static class TraceStateUtils
             return false;
         }
 
-        bool isValid = true;
+        var isValid = true;
         try
         {
             var names = new HashSet<string>();
@@ -41,7 +41,7 @@ internal static class TraceStateUtils
             {
                 // tracestate: rojo=00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01,congo=BleGNlZWRzIHRohbCBwbGVhc3VyZS4
 
-                int pairEnd = traceStateSpan.IndexOf(',');
+                var pairEnd = traceStateSpan.IndexOf(',');
                 if (pairEnd < 0)
                 {
                     pairEnd = traceStateSpan.Length;
@@ -56,7 +56,11 @@ internal static class TraceStateUtils
                 var keyStr = key.ToString();
                 if (names.Add(keyStr))
                 {
+#if NET
+                    tracestate.Add(new KeyValuePair<string, string>(keyStr, value.ToString()));
+#else
                     tracestate!.Add(new KeyValuePair<string, string>(keyStr, value.ToString()));
+#endif
                 }
                 else
                 {
@@ -82,7 +86,11 @@ internal static class TraceStateUtils
 
             if (!isValid)
             {
+#if NET
+                tracestate.Clear();
+#else
                 tracestate!.Clear();
+#endif
                 return false;
             }
 
@@ -114,7 +122,7 @@ internal static class TraceStateUtils
 
         var sb = new StringBuilder();
 
-        int ind = 0;
+        var ind = 0;
         foreach (var entry in traceState)
         {
             if (ind++ < MaxKeyValuePairsCount)
@@ -191,12 +199,10 @@ internal static class TraceStateUtils
                 break;
             }
 
-            if (!(c >= 'a' && c <= 'z')
-                && !(c >= '0' && c <= '9')
-                && c != '_'
-                && c != '-'
-                && c != '*'
-                && c != '/')
+            if (c is not (>= 'a' and <= 'z') and not (>= '0' and <= '9') and not '_'
+                and not '-'
+                and not '*'
+                and not '/')
             {
                 return false;
             }
@@ -205,34 +211,32 @@ internal static class TraceStateUtils
         i++; // skip @ or increment further than key.Length
 
         var vendorLength = key.Length - i;
-        if (vendorLength == 0 || vendorLength > 14)
+        if (vendorLength is not 0 and <= 14)
         {
-            // vendor name should be at least 1 to 14 character long
-            return false;
-        }
-
-        if (vendorLength > 0 && i > 242)
-        {
-            // tenant section should be less than 241 characters long
-            return false;
-        }
-
-        for (; i < key.Length; i++)
-        {
-            var c = key[i];
-
-            if (!(c >= 'a' && c <= 'z')
-                && !(c >= '0' && c <= '9')
-                && c != '_'
-                && c != '-'
-                && c != '*'
-                && c != '/')
+            if (vendorLength > 0 && i > 242)
             {
+                // tenant section should be less than 241 characters long
                 return false;
             }
+
+            for (; i < key.Length; i++)
+            {
+                var c = key[i];
+
+                if (c is not (>= 'a' and <= 'z') and not (>= '0' and <= '9') and not '_'
+                    and not '-'
+                    and not '*'
+                    and not '/')
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
-        return true;
+        // vendor name should be at least 1 to 14 character long
+        return false;
     }
 
     private static bool ValidateValue(ReadOnlySpan<char> value)
@@ -247,7 +251,7 @@ internal static class TraceStateUtils
 
         foreach (var c in value)
         {
-            if (c == ',' || c == '=' || c < ' ' /* '\u0020' */ || c > '~' /* '\u007E' */)
+            if (c is ',' or '=' or < ' ' /* '\u0020' */ or > '~' /* '\u007E' */)
             {
                 return false;
             }

--- a/src/OpenTelemetry.Api/Logs/LogRecordAttributeList.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordAttributeList.cs
@@ -41,10 +41,9 @@ internal
     private KeyValuePair<string, object?> attribute6;
     private KeyValuePair<string, object?> attribute7;
     private KeyValuePair<string, object?> attribute8;
-    private int count;
 
     /// <inheritdoc/>
-    public readonly int Count => this.count;
+    public int Count { get; private set; }
 
     /// <inheritdoc/>
     public KeyValuePair<string, object?> this[int index]
@@ -57,23 +56,20 @@ internal
                 return this.OverflowAttributes[index];
             }
 
-            if ((uint)index >= (uint)this.count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index));
-            }
-
-            return index switch
-            {
-                0 => this.attribute1,
-                1 => this.attribute2,
-                2 => this.attribute3,
-                3 => this.attribute4,
-                4 => this.attribute5,
-                5 => this.attribute6,
-                6 => this.attribute7,
-                7 => this.attribute8,
-                _ => default, // we shouldn't come here anyway.
-            };
+            return (uint)index >= (uint)this.Count
+                ? throw new ArgumentOutOfRangeException(nameof(index))
+                : index switch
+                {
+                    0 => this.attribute1,
+                    1 => this.attribute2,
+                    2 => this.attribute3,
+                    3 => this.attribute4,
+                    4 => this.attribute5,
+                    5 => this.attribute6,
+                    6 => this.attribute7,
+                    7 => this.attribute8,
+                    _ => default, // we shouldn't come here anyway.
+                };
         }
 
         set
@@ -85,7 +81,7 @@ internal
                 return;
             }
 
-            if ((uint)index >= (uint)this.count)
+            if ((uint)index >= (uint)this.Count)
             {
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
@@ -133,7 +129,7 @@ internal
 
         LogRecordAttributeList logRecordAttributes = default;
         logRecordAttributes.OverflowAttributes = [.. attributes];
-        logRecordAttributes.count = logRecordAttributes.OverflowAttributes.Count;
+        logRecordAttributes.Count = logRecordAttributes.OverflowAttributes.Count;
         return logRecordAttributes;
     }
 
@@ -151,7 +147,7 @@ internal
     /// <param name="attribute">Attribute.</param>
     public void Add(KeyValuePair<string, object?> attribute)
     {
-        var count = this.count++;
+        var count = this.Count++;
 
         if (count <= OverflowMaxCount)
         {
@@ -168,11 +164,18 @@ internal
                 case 8:
                     this.MoveAttributesToTheOverflowList();
                     break;
+                default:
+                    break;
             }
         }
 
         Debug.Assert(this.OverflowAttributes is not null, "Overflow attributes creation failure.");
+
+#if NET
+        this.OverflowAttributes.Add(attribute);
+#else
         this.OverflowAttributes!.Add(attribute);
+#endif
     }
 
     /// <summary>
@@ -180,7 +183,7 @@ internal
     /// </summary>
     public void Clear()
     {
-        this.count = 0;
+        this.Count = 0;
         this.OverflowAttributes?.Clear();
     }
 
@@ -212,7 +215,7 @@ internal
 
     internal readonly IReadOnlyList<KeyValuePair<string, object?>> Export(ref List<KeyValuePair<string, object?>>? attributeStorage)
     {
-        int readonlyCount = this.count;
+        var readonlyCount = this.Count;
         if (readonlyCount <= 0)
         {
             return Empty;
@@ -279,7 +282,7 @@ internal
 
     private void MoveAttributesToTheOverflowList()
     {
-        Debug.Assert(this.count - 1 == OverflowMaxCount, "count did not match OverflowMaxCount");
+        Debug.Assert(this.Count - 1 == OverflowMaxCount, "count did not match OverflowMaxCount");
 
         var attributes = this.OverflowAttributes ??= new(OverflowAdditionalCapacity);
 

--- a/src/OpenTelemetry.Api/Logs/LogRecordData.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordData.cs
@@ -89,7 +89,7 @@ internal
     public DateTime Timestamp
     {
         readonly get => this.TimestampBacking;
-        set { this.TimestampBacking = value.Kind == DateTimeKind.Local ? value.ToUniversalTime() : value; }
+        set => this.TimestampBacking = value.Kind == DateTimeKind.Local ? value.ToUniversalTime() : value;
     }
 
     /// <summary>

--- a/src/OpenTelemetry.Api/Logs/LogRecordSeverityExtensions.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordSeverityExtensions.cs
@@ -103,9 +103,9 @@ internal
     /// cref="LogRecordSeverity"/>.</returns>
     public static string ToShortName(this LogRecordSeverity logRecordSeverity)
     {
-        int severityLevel = (int)logRecordSeverity;
+        var severityLevel = (int)logRecordSeverity;
 
-        if (severityLevel < 0 || severityLevel > 24)
+        if (severityLevel is < 0 or > 24)
         {
             severityLevel = 0;
         }

--- a/src/OpenTelemetry.Api/Logs/Logger.cs
+++ b/src/OpenTelemetry.Api/Logs/Logger.cs
@@ -31,7 +31,11 @@ abstract class Logger
     {
         this.Name = string.IsNullOrWhiteSpace(name)
             ? string.Empty
+#if NET10_0_OR_GREATER
+            : name;
+#else
             : name!;
+#endif
     }
 
     /// <summary>
@@ -60,9 +64,5 @@ abstract class Logger
         in LogRecordData data,
         in LogRecordAttributeList attributes);
 
-    internal void SetInstrumentationScope(
-        string? version)
-    {
-        this.Version = version;
-    }
+    internal void SetInstrumentationScope(string? version) => this.Version = version;
 }

--- a/src/OpenTelemetry.Api/Logs/LoggerProvider.cs
+++ b/src/OpenTelemetry.Api/Logs/LoggerProvider.cs
@@ -73,7 +73,11 @@ public class LoggerProvider : BaseProvider
             return NoopLogger;
         }
 
+#if NET
+        logger.SetInstrumentationScope(version);
+#else
         logger!.SetInstrumentationScope(version);
+#endif
 
         return logger;
     }

--- a/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
+++ b/src/OpenTelemetry.Api/Trace/ActivityExtensions.cs
@@ -45,6 +45,8 @@ public static class ActivityExtensions
                 case StatusCode.Error:
                     activity.SetStatus(ActivityStatusCode.Error, status.Description);
                     break;
+                default:
+                    break;
             }
 
             activity.SetTag(SpanAttributeConstants.StatusCodeKey, StatusHelper.GetTagValueForStatusCode(status.StatusCode));
@@ -70,12 +72,13 @@ public static class ActivityExtensions
     {
         if (activity != null)
         {
-            switch (activity.Status)
+            if (activity.Status is ActivityStatusCode.Ok)
             {
-                case ActivityStatusCode.Ok:
-                    return Status.Ok;
-                case ActivityStatusCode.Error:
-                    return new Status(StatusCode.Error, activity.StatusDescription);
+                return Status.Ok;
+            }
+            else if (activity.Status is ActivityStatusCode.Error)
+            {
+                return new Status(StatusCode.Error, activity.StatusDescription);
             }
 
             if (activity.TryGetStatus(out var statusCode, out var statusDescription))

--- a/src/OpenTelemetry.Api/Trace/SpanAttributes.cs
+++ b/src/OpenTelemetry.Api/Trace/SpanAttributes.cs
@@ -17,7 +17,7 @@ public class SpanAttributes
     /// </summary>
     public SpanAttributes()
     {
-        this.Attributes = new ActivityTagsCollection();
+        this.Attributes = [];
     }
 
     /// <summary>
@@ -29,7 +29,7 @@ public class SpanAttributes
     {
         Guard.ThrowIfNull(attributes);
 
-        foreach (KeyValuePair<string, object?> kvp in attributes)
+        foreach (var kvp in attributes)
         {
             this.AddInternal(kvp.Key, kvp.Value);
         }
@@ -43,9 +43,7 @@ public class SpanAttributes
     /// <param name="key">Entry key.</param>
     /// <param name="value">Entry value.</param>
     public void Add(string key, long value)
-    {
-        this.AddInternal(key, value);
-    }
+        => this.AddInternal(key, value);
 
     /// <summary>
     /// Add entry to the attributes.
@@ -53,9 +51,7 @@ public class SpanAttributes
     /// <param name="key">Entry key.</param>
     /// <param name="value">Entry value.</param>
     public void Add(string key, string? value)
-    {
-        this.AddInternal(key, value);
-    }
+        => this.AddInternal(key, value);
 
     /// <summary>
     /// Add entry to the attributes.
@@ -63,9 +59,7 @@ public class SpanAttributes
     /// <param name="key">Entry key.</param>
     /// <param name="value">Entry value.</param>
     public void Add(string key, bool value)
-    {
-        this.AddInternal(key, value);
-    }
+        => this.AddInternal(key, value);
 
     /// <summary>
     /// Add entry to the attributes.
@@ -73,9 +67,7 @@ public class SpanAttributes
     /// <param name="key">Entry key.</param>
     /// <param name="value">Entry value.</param>
     public void Add(string key, double value)
-    {
-        this.AddInternal(key, value);
-    }
+        => this.AddInternal(key, value);
 
     /// <summary>
     /// Add entry to the attributes.
@@ -83,9 +75,7 @@ public class SpanAttributes
     /// <param name="key">Entry key.</param>
     /// <param name="values">Entry value.</param>
     public void Add(string key, long[]? values)
-    {
-        this.AddInternal(key, values);
-    }
+        => this.AddInternal(key, values);
 
     /// <summary>
     /// Add entry to the attributes.
@@ -93,9 +83,7 @@ public class SpanAttributes
     /// <param name="key">Entry key.</param>
     /// <param name="values">Entry value.</param>
     public void Add(string key, string?[]? values)
-    {
-        this.AddInternal(key, values);
-    }
+        => this.AddInternal(key, values);
 
     /// <summary>
     /// Add entry to the attributes.
@@ -103,9 +91,7 @@ public class SpanAttributes
     /// <param name="key">Entry key.</param>
     /// <param name="values">Entry value.</param>
     public void Add(string key, bool[]? values)
-    {
-        this.AddInternal(key, values);
-    }
+        => this.AddInternal(key, values);
 
     /// <summary>
     /// Add entry to the attributes.
@@ -113,9 +99,7 @@ public class SpanAttributes
     /// <param name="key">Entry key.</param>
     /// <param name="values">Entry value.</param>
     public void Add(string key, double[]? values)
-    {
-        this.AddInternal(key, values);
-    }
+        => this.AddInternal(key, values);
 
     private void AddInternal(string key, object? value)
     {

--- a/src/OpenTelemetry.Api/Trace/SpanContext.cs
+++ b/src/OpenTelemetry.Api/Trace/SpanContext.cs
@@ -90,7 +90,13 @@ public readonly struct SpanContext : IEquatable<SpanContext>
             }
 
             var traceStateResult = new List<KeyValuePair<string, string>>();
+
+#if NET
+            TraceStateUtils.AppendTraceState(traceState, traceStateResult);
+#else
             TraceStateUtils.AppendTraceState(traceState!, traceStateResult);
+#endif
+
             return traceStateResult;
         }
     }

--- a/src/OpenTelemetry.Api/Trace/TelemetrySpan.cs
+++ b/src/OpenTelemetry.Api/Trace/TelemetrySpan.cs
@@ -300,7 +300,7 @@ public class TelemetrySpan : IDisposable
     /// <returns>The <see cref="TelemetrySpan"/> instance for chaining.</returns>
     public TelemetrySpan RecordException(string? type, string? message, string? stacktrace)
     {
-        SpanAttributes attributes = new SpanAttributes();
+        var attributes = new SpanAttributes();
 
         if (!string.IsNullOrWhiteSpace(type))
         {

--- a/src/OpenTelemetry.Api/Trace/TracerProvider.cs
+++ b/src/OpenTelemetry.Api/Trace/TracerProvider.cs
@@ -57,9 +57,7 @@ public class TracerProvider : BaseProvider
         string name,
         string? version,
         IEnumerable<KeyValuePair<string, object?>>? tags)
-    {
-        return this.GetTracer(name, version, null, tags);
-    }
+        => this.GetTracer(name, version, null, tags);
 
     /// <summary>
     /// Gets a tracer with given name, version and tags.
@@ -108,7 +106,7 @@ public class TracerProvider : BaseProvider
                 };
 
                 tracer = new(new(activitySourceOptions));
-                bool result = tracers.TryAdd(key, tracer);
+                var result = tracers.TryAdd(key, tracer);
 #if DEBUG
                 System.Diagnostics.Debug.Assert(result, "Write into tracers cache failed");
 #endif
@@ -160,16 +158,9 @@ public class TracerProvider : BaseProvider
         }
 
         public bool Equals(TracerKey other)
-        {
-            if (!string.Equals(this.Name, other.Name, StringComparison.Ordinal) ||
-                !string.Equals(this.Version, other.Version, StringComparison.Ordinal) ||
-                !string.Equals(this.SchemaUrl, other.SchemaUrl, StringComparison.Ordinal))
-            {
-                return false;
-            }
-
-            return AreTagsEqual(this.Tags, other.Tags);
-        }
+            => string.Equals(this.Name, other.Name, StringComparison.Ordinal) &&
+               string.Equals(this.Version, other.Version, StringComparison.Ordinal) &&
+               string.Equals(this.SchemaUrl, other.SchemaUrl, StringComparison.Ordinal) && AreTagsEqual(this.Tags, other.Tags);
 
         public override int GetHashCode()
         {
@@ -205,7 +196,7 @@ public class TracerProvider : BaseProvider
                 return false;
             }
 
-            for (int i = 0; i < tags1.Length; i++)
+            for (var i = 0; i < tags1.Length; i++)
             {
                 var kvp1 = tags1[i];
                 var kvp2 = tags2[i];
@@ -255,7 +246,7 @@ public class TracerProvider : BaseProvider
 #endif
                     if (kvp.Value != null)
                     {
-                        hash = (hash * 31) + kvp.Value.GetHashCode()!;
+                        hash = (hash * 31) + kvp.Value.GetHashCode();
                     }
                 }
             }
@@ -275,7 +266,7 @@ public class TracerProvider : BaseProvider
             orderedTagList.Sort((left, right) =>
             {
                 // First compare by key
-                int keyComparison = string.Compare(left.Key, right.Key, StringComparison.Ordinal);
+                var keyComparison = string.Compare(left.Key, right.Key, StringComparison.Ordinal);
                 if (keyComparison != 0)
                 {
                     return keyComparison;

--- a/src/Shared/ActivityHelperExtensions.cs
+++ b/src/Shared/ActivityHelperExtensions.cs
@@ -25,13 +25,11 @@ internal static class ActivityHelperExtensions
     [Obsolete]
     public static bool TryGetStatus(this Activity activity, out StatusCode statusCode, out string? statusDescription)
     {
-        Debug.Assert(activity != null, "Activity should not be null");
-
-        bool foundStatusCode = false;
+        var foundStatusCode = false;
         statusCode = default;
         statusDescription = null;
 
-        foreach (ref readonly var tag in activity!.EnumerateTagObjects())
+        foreach (ref readonly var tag in activity.EnumerateTagObjects())
         {
             switch (tag.Key)
             {
@@ -70,9 +68,7 @@ internal static class ActivityHelperExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static object? GetTagValue(this Activity activity, string? tagName)
     {
-        Debug.Assert(activity != null, "Activity should not be null");
-
-        foreach (ref readonly var tag in activity!.EnumerateTagObjects())
+        foreach (ref readonly var tag in activity.EnumerateTagObjects())
         {
             if (tag.Key == tagName)
             {
@@ -93,9 +89,7 @@ internal static class ActivityHelperExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryCheckFirstTag(this Activity activity, string tagName, out object? tagValue)
     {
-        Debug.Assert(activity != null, "Activity should not be null");
-
-        var enumerator = activity!.EnumerateTagObjects();
+        var enumerator = activity.EnumerateTagObjects();
 
         if (enumerator.MoveNext())
         {

--- a/test/OpenTelemetry.Api.ProviderBuilderExtensions.Tests/Logs/TestLoggerProviderBuilder.cs
+++ b/test/OpenTelemetry.Api.ProviderBuilderExtensions.Tests/Logs/TestLoggerProviderBuilder.cs
@@ -17,7 +17,7 @@ internal sealed class TestLoggerProviderBuilder : LoggerProviderBuilder, ILogger
 
     public ServiceProvider? ServiceProvider { get; private set; }
 
-    public List<object> Instrumentation { get; } = new();
+    public List<object> Instrumentation { get; } = [];
 
     public LoggerProvider? Provider { get; private set; }
 

--- a/test/OpenTelemetry.Api.ProviderBuilderExtensions.Tests/Metrics/TestMeterProviderBuilder.cs
+++ b/test/OpenTelemetry.Api.ProviderBuilderExtensions.Tests/Metrics/TestMeterProviderBuilder.cs
@@ -49,7 +49,7 @@ internal sealed class TestMeterProviderBuilder : MeterProviderBuilder, IMeterPro
         }
         else
         {
-            foreach (string name in names)
+            foreach (var name in names)
             {
                 this.Meters.Add(name);
             }

--- a/test/OpenTelemetry.Api.ProviderBuilderExtensions.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/OpenTelemetry.Api.ProviderBuilderExtensions.Tests/ServiceCollectionExtensionsTests.cs
@@ -22,7 +22,7 @@ public class ServiceCollectionExtensionsTests
 
         var services = new ServiceCollection();
 
-        for (int i = 0; i < numberOfCalls; i++)
+        for (var i = 0; i < numberOfCalls; i++)
         {
             services.ConfigureOpenTelemetryTracerProvider(builder => beforeServiceProviderInvocations++);
             services.ConfigureOpenTelemetryTracerProvider((sp, builder) => afterServiceProviderInvocations++);
@@ -57,7 +57,7 @@ public class ServiceCollectionExtensionsTests
 
         var services = new ServiceCollection();
 
-        for (int i = 0; i < numberOfCalls; i++)
+        for (var i = 0; i < numberOfCalls; i++)
         {
             services.ConfigureOpenTelemetryMeterProvider(builder => beforeServiceProviderInvocations++);
             services.ConfigureOpenTelemetryMeterProvider((sp, builder) => afterServiceProviderInvocations++);
@@ -92,7 +92,7 @@ public class ServiceCollectionExtensionsTests
 
         var services = new ServiceCollection();
 
-        for (int i = 0; i < numberOfCalls; i++)
+        for (var i = 0; i < numberOfCalls; i++)
         {
             services.ConfigureOpenTelemetryLoggerProvider(builder => beforeServiceProviderInvocations++);
             services.ConfigureOpenTelemetryLoggerProvider((sp, builder) => afterServiceProviderInvocations++);

--- a/test/OpenTelemetry.Api.ProviderBuilderExtensions.Tests/Trace/TestTracerProviderBuilder.cs
+++ b/test/OpenTelemetry.Api.ProviderBuilderExtensions.Tests/Trace/TestTracerProviderBuilder.cs
@@ -65,7 +65,7 @@ internal sealed class TestTracerProviderBuilder : TracerProviderBuilder, ITracer
         }
         else
         {
-            foreach (string name in names)
+            foreach (var name in names)
             {
                 this.Sources.Add(name);
             }

--- a/test/OpenTelemetry.Api.Tests/Context/Propagation/BaggagePropagatorTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Context/Propagation/BaggagePropagatorTests.cs
@@ -336,7 +336,7 @@ public class BaggagePropagatorTests
     public void ValidateInjectionOfSixtyFourEntries()
     {
         var baggageDict = new Dictionary<string, string>();
-        for (int i = 0; i < 64; i++)
+        for (var i = 0; i < 64; i++)
         {
             baggageDict[$"key{i}"] = "value";
         }
@@ -383,7 +383,7 @@ public class BaggagePropagatorTests
     {
         var baggageDict = new Dictionary<string, string>();
 
-        for (int i = 0; i < 512; i++)
+        for (var i = 0; i < 512; i++)
         {
             baggageDict[$"{i:D3}"] = "0123456789a";
         }

--- a/test/OpenTelemetry.Api.Tests/Context/Propagation/TestPropagator.cs
+++ b/test/OpenTelemetry.Api.Tests/Context/Propagation/TestPropagator.cs
@@ -52,7 +52,7 @@ internal sealed class TestPropagator : TextMapPropagator
         var tracestateCollection = getter(carrier, this.stateHeaderName);
         if (tracestateCollection?.Any() ?? false)
         {
-            TraceContextPropagator.TryExtractTracestate(tracestateCollection.ToArray(), out tracestate);
+            TraceContextPropagator.TryExtractTracestate([.. tracestateCollection], out tracestate);
         }
 
         return new PropagationContext(

--- a/test/OpenTelemetry.Api.Tests/Internal/GuardTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Internal/GuardTests.cs
@@ -186,6 +186,8 @@ public class CallerArgumentExpressionAttributeTests
         Assert.Equal("new object()", GetValue(new object()));
     }
 
+#pragma warning disable IDE0060 // Remove unused parameter
     private static string? GetValue(object? argument, [CallerArgumentExpression(nameof(argument))] string? expr = null) => expr;
+#pragma warning restore IDE0060 // Remove unused parameter
 }
 #endif

--- a/test/OpenTelemetry.Api.Tests/Logs/LogRecordAttributeListTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Logs/LogRecordAttributeListTests.cs
@@ -17,14 +17,14 @@ public sealed class LogRecordAttributeListTests
     {
         LogRecordAttributeList attributes = default;
 
-        for (int i = 0; i < numberOfItems; i++)
+        for (var i = 0; i < numberOfItems; i++)
         {
             attributes.Add($"key{i}", i);
         }
 
         Assert.Equal(numberOfItems, attributes.Count);
 
-        for (int i = 0; i < numberOfItems; i++)
+        for (var i = 0; i < numberOfItems; i++)
         {
             var item = attributes[i];
 
@@ -33,8 +33,8 @@ public sealed class LogRecordAttributeListTests
             Assert.Equal(i, (int)item.Value);
         }
 
-        int index = 0;
-        foreach (KeyValuePair<string, object?> item in attributes)
+        var index = 0;
+        foreach (var item in attributes)
         {
             Assert.Equal($"key{index}", item.Key);
             Assert.NotNull(item.Value);
@@ -62,16 +62,16 @@ public sealed class LogRecordAttributeListTests
     {
         LogRecordAttributeList attributes = default;
 
-        for (int c = 0; c <= 1; c++)
+        for (var c = 0; c <= 1; c++)
         {
-            for (int i = 0; i < numberOfItems; i++)
+            for (var i = 0; i < numberOfItems; i++)
             {
                 attributes.Add($"key{i}", i);
             }
 
             Assert.Equal(numberOfItems, attributes.Count);
 
-            for (int i = 0; i < numberOfItems; i++)
+            for (var i = 0; i < numberOfItems; i++)
             {
                 var item = attributes[i];
 
@@ -96,7 +96,7 @@ public sealed class LogRecordAttributeListTests
     {
         LogRecordAttributeList attributes = default;
 
-        for (int i = 0; i < numberOfItems; i++)
+        for (var i = 0; i < numberOfItems; i++)
         {
             attributes.Add($"key{i}", i);
         }
@@ -124,8 +124,8 @@ public sealed class LogRecordAttributeListTests
             Assert.Null(storage);
         }
 
-        int index = 0;
-        foreach (KeyValuePair<string, object?> item in exportedAttributes)
+        var index = 0;
+        foreach (var item in exportedAttributes)
         {
             Assert.Equal($"key{index}", item.Key);
             Assert.NotNull(item.Value);
@@ -137,7 +137,7 @@ public sealed class LogRecordAttributeListTests
     [Fact]
     public void InitializerAddSyntaxTest()
     {
-        LogRecordAttributeList list = new LogRecordAttributeList
+        var list = new LogRecordAttributeList
         {
             { "key1", new object() },
             { "key2", 2 },
@@ -149,7 +149,7 @@ public sealed class LogRecordAttributeListTests
     [Fact]
     public void InitializerIndexesSyntaxTest()
     {
-        LogRecordAttributeList list = new LogRecordAttributeList
+        var list = new LogRecordAttributeList
         {
             ["key1"] = new object(),
             ["key2"] = 2,

--- a/test/OpenTelemetry.Api.Tests/Trace/SpanAttributesTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Trace/SpanAttributesTests.cs
@@ -53,17 +53,14 @@ public class SpanAttributesTests
     public void ValidateConstructorWithList()
     {
         var spanAttributes = new SpanAttributes(
-            new List<KeyValuePair<string, object?>>
-            {
-            new("Span attribute int", 1),
-            new("Span attribute string", "str"),
-            });
+            [
+                new("Span attribute int", 1),
+                new("Span attribute string", "str"),
+            ]);
         Assert.Equal(2, spanAttributes.Attributes.Count);
     }
 
     [Fact]
     public void ValidateConstructorWithNullList()
-    {
-        Assert.Throws<ArgumentNullException>(() => new SpanAttributes(null!));
-    }
+        => Assert.Throws<ArgumentNullException>(() => new SpanAttributes(null!));
 }

--- a/test/OpenTelemetry.Api.Tests/Trace/TelemetrySpanTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Trace/TelemetrySpanTests.cs
@@ -11,28 +11,28 @@ public class TelemetrySpanTests
     [Fact]
     public void CheckRecordExceptionData()
     {
-        string message = "message";
+        var message = "message";
 
-        using Activity activity = new Activity("exception-test");
-        using TelemetrySpan telemetrySpan = new TelemetrySpan(activity);
+        using var activity = new Activity("exception-test");
+        using var telemetrySpan = new TelemetrySpan(activity);
         telemetrySpan.RecordException(new ArgumentNullException(message, new InvalidOperationException("new-exception")));
         Assert.Single(activity.Events);
 
         Assert.NotNull(telemetrySpan.Activity);
         var @event = telemetrySpan.Activity.Events.FirstOrDefault(q => q.Name == SemanticConventions.AttributeExceptionEventName);
         Assert.Equal(message, @event.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeExceptionMessage).Value);
-        Assert.Equal(typeof(ArgumentNullException).Name, @event.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeExceptionType).Value);
+        Assert.Equal(nameof(ArgumentNullException), @event.Tags.FirstOrDefault(t => t.Key == SemanticConventions.AttributeExceptionType).Value);
     }
 
     [Fact]
     public void CheckRecordExceptionData2()
     {
-        string type = "ArgumentNullException";
-        string message = "message";
-        string stack = "stack";
+        var type = "ArgumentNullException";
+        var message = "message";
+        var stack = "stack";
 
-        using Activity activity = new Activity("exception-test");
-        using TelemetrySpan telemetrySpan = new TelemetrySpan(activity);
+        using var activity = new Activity("exception-test");
+        using var telemetrySpan = new TelemetrySpan(activity);
         telemetrySpan.RecordException(type, message, stack);
         Assert.Single(activity.Events);
 
@@ -46,8 +46,8 @@ public class TelemetrySpanTests
     [Fact]
     public void CheckRecordExceptionEmpty()
     {
-        using Activity activity = new Activity("exception-test");
-        using TelemetrySpan telemetrySpan = new TelemetrySpan(activity);
+        using var activity = new Activity("exception-test");
+        using var telemetrySpan = new TelemetrySpan(activity);
         telemetrySpan.RecordException(string.Empty, string.Empty, string.Empty);
         Assert.Empty(activity.Events);
 

--- a/test/OpenTelemetry.Api.Tests/Trace/TracerTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Trace/TracerTests.cs
@@ -338,7 +338,7 @@ public sealed class TracerTests : IDisposable
         this.output.WriteLine($"Bugs, if any: {string.Join("\n", test.TestReport.BugReports)}");
 
         var dir = Directory.GetCurrentDirectory();
-        if (test.TryEmitReports(dir, $"{nameof(this.TracerConcurrencyTest)}_CoyoteOutput", out IEnumerable<string> reportPaths))
+        if (test.TryEmitReports(dir, $"{nameof(this.TracerConcurrencyTest)}_CoyoteOutput", out var reportPaths))
         {
             foreach (var reportPath in reportPaths)
             {
@@ -367,8 +367,8 @@ public sealed class TracerTests : IDisposable
 
             Assert.NotNull(tracers);
 
-            Thread[] getTracerThreads = new Thread[testTracerProvider.ExpectedNumberOfThreads];
-            for (int i = 0; i < testTracerProvider.ExpectedNumberOfThreads; i++)
+            var getTracerThreads = new Thread[testTracerProvider.ExpectedNumberOfThreads];
+            for (var i = 0; i < testTracerProvider.ExpectedNumberOfThreads; i++)
             {
                 getTracerThreads[i] = new Thread(state =>
                 {


### PR DESCRIPTION
## Changes

Cherry-pick fixes for new code analysis warnings identified by the .NET 11 preview 2 SDK in #6899.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
