### PR TITLE
[Shared] Fix new code analysis warnings

### DIFF
--- a/src/Shared/AssemblyVersionExtensions.cs
+++ b/src/Shared/AssemblyVersionExtensions.cs
@@ -15,8 +15,6 @@ internal static class AssemblyVersionExtensions
 
         var informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
 
-        Debug.Assert(!string.IsNullOrEmpty(informationalVersion), "AssemblyInformationalVersionAttribute was not found in assembly");
-
         return ParsePackageVersion(informationalVersion!);
     }
 
@@ -32,7 +30,9 @@ internal static class AssemblyVersionExtensions
             return false;
         }
 
+#pragma warning disable IDE0370 // Suppression is unnecessary
         packageVersion = ParsePackageVersion(informationalVersion!);
+#pragma warning restore IDE0370 // Suppression is unnecessary
         return true;
     }
 

--- a/src/Shared/Configuration/OpenTelemetryConfigurationExtensions.cs
+++ b/src/Shared/Configuration/OpenTelemetryConfigurationExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
@@ -20,10 +19,7 @@ internal static class OpenTelemetryConfigurationExtensions
         [NotNullWhen(true)]
         out string? value)
     {
-        Debug.Assert(configuration != null, "configuration was null");
-
-        value = configuration![key];
-
+        value = configuration[key];
         return !string.IsNullOrWhiteSpace(value);
     }
 
@@ -34,8 +30,6 @@ internal static class OpenTelemetryConfigurationExtensions
         [NotNullWhen(true)]
         out Uri? value)
     {
-        Debug.Assert(logger != null, "logger was null");
-
         if (!configuration.TryGetStringValue(key, out var stringValue))
         {
             value = null;
@@ -44,7 +38,7 @@ internal static class OpenTelemetryConfigurationExtensions
 
         if (!Uri.TryCreate(stringValue, UriKind.Absolute, out value))
         {
-            logger!.LogInvalidConfigurationValue(key, stringValue);
+            logger.LogInvalidConfigurationValue(key, stringValue);
             return false;
         }
 
@@ -57,8 +51,6 @@ internal static class OpenTelemetryConfigurationExtensions
         string key,
         out int value)
     {
-        Debug.Assert(logger != null, "logger was null");
-
         if (!configuration.TryGetStringValue(key, out var stringValue))
         {
             value = default;
@@ -67,7 +59,7 @@ internal static class OpenTelemetryConfigurationExtensions
 
         if (!int.TryParse(stringValue, NumberStyles.None, CultureInfo.InvariantCulture, out value))
         {
-            logger!.LogInvalidConfigurationValue(key, stringValue);
+            logger.LogInvalidConfigurationValue(key, stringValue);
             return false;
         }
 
@@ -80,8 +72,6 @@ internal static class OpenTelemetryConfigurationExtensions
         string key,
         out bool value)
     {
-        Debug.Assert(logger != null, "logger was null");
-
         if (!configuration.TryGetStringValue(key, out var stringValue))
         {
             value = default;
@@ -90,7 +80,7 @@ internal static class OpenTelemetryConfigurationExtensions
 
         if (!bool.TryParse(stringValue, out value))
         {
-            logger!.LogInvalidConfigurationValue(key, stringValue);
+            logger.LogInvalidConfigurationValue(key, stringValue);
             return false;
         }
 
@@ -105,8 +95,6 @@ internal static class OpenTelemetryConfigurationExtensions
         [NotNullWhen(true)]
         out T? value)
     {
-        Debug.Assert(logger != null, "logger was null");
-
         if (!configuration.TryGetStringValue(key, out var stringValue))
         {
             value = default;
@@ -115,11 +103,10 @@ internal static class OpenTelemetryConfigurationExtensions
 
         if (!tryParseFunc(stringValue, out value))
         {
-            logger!.LogInvalidConfigurationValue(key, stringValue);
+            logger.LogInvalidConfigurationValue(key, stringValue);
             return false;
         }
 
         return true;
     }
 }
-

--- a/src/Shared/Guard.cs
+++ b/src/Shared/Guard.cs
@@ -121,9 +121,7 @@ namespace OpenTelemetry.Internal
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ThrowIfInvalidTimeout(int value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
-        {
-            ThrowIfOutOfRange(value, paramName, min: Timeout.Infinite, message: $"Must be non-negative or '{nameof(Timeout)}.{nameof(Timeout.Infinite)}'");
-        }
+            => ThrowIfOutOfRange(value, paramName, min: Timeout.Infinite, message: $"Must be non-negative or '{nameof(Timeout)}.{nameof(Timeout.Infinite)}'");
 
         /// <summary>
         /// Throw an exception if the value is not within the given range.
@@ -138,9 +136,7 @@ namespace OpenTelemetry.Internal
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ThrowIfOutOfRange(int value, [CallerArgumentExpression(nameof(value))] string? paramName = null, int min = int.MinValue, int max = int.MaxValue, string? minName = null, string? maxName = null, string? message = null)
-        {
-            Range(value, paramName, min, max, minName, maxName, message);
-        }
+            => Range(value, paramName, min, max, minName, maxName, message);
 
         /// <summary>
         /// Throw an exception if the value is not within the given range.
@@ -155,9 +151,7 @@ namespace OpenTelemetry.Internal
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ThrowIfOutOfRange(double value, [CallerArgumentExpression(nameof(value))] string? paramName = null, double min = double.MinValue, double max = double.MaxValue, string? minName = null, string? maxName = null, string? message = null)
-        {
-            Range(value, paramName, min, max, minName, maxName, message);
-        }
+            => Range(value, paramName, min, max, minName, maxName, message);
 
         /// <summary>
         /// Throw an exception if the value is not of the expected type.
@@ -169,14 +163,9 @@ namespace OpenTelemetry.Internal
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T ThrowIfNotOfType<T>([NotNull] object? value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
-        {
-            if (value is not T result)
-            {
-                throw new InvalidCastException($"Cannot cast '{paramName}' from '{value?.GetType().ToString() ?? "null"}' to '{typeof(T)}'");
-            }
-
-            return result;
-        }
+            => value is not T result
+               ? throw new InvalidCastException($"Cannot cast '{paramName}' from '{value?.GetType().ToString() ?? "null"}' to '{typeof(T)}'")
+               : result;
 
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Shared/Metrics/Base2ExponentialBucketHistogramHelper.cs
+++ b/src/Shared/Metrics/Base2ExponentialBucketHistogramHelper.cs
@@ -75,7 +75,7 @@ internal static class Base2ExponentialBucketHistogramHelper
         // the correct biased exponent. If n is greater than the maximum exponent (1023) or less than
         // the minimum exponent (-1022), adjust x and n to compute correct result.
 
-        double y = x;
+        var y = x;
         if (n > 1023)
         {
             y *= SCALEB_C1;
@@ -105,7 +105,7 @@ internal static class Base2ExponentialBucketHistogramHelper
             }
         }
 
-        double u = BitConverter.Int64BitsToDouble((long)(0x3ff + n) << 52);
+        var u = BitConverter.Int64BitsToDouble((long)(0x3ff + n) << 52);
         return y * u;
     }
 #pragma warning restore SA1119 // Statement should not use unnecessary parenthesis

--- a/src/Shared/Options/DelegatingOptionsFactoryServiceCollectionExtensions.cs
+++ b/src/Shared/Options/DelegatingOptionsFactoryServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Diagnostics;
 #if NET
 using System.Diagnostics.CodeAnalysis;
 #endif
@@ -22,20 +21,17 @@ internal static class DelegatingOptionsFactoryServiceCollectionExtensions
         Func<IConfiguration, T> optionsFactoryFunc)
         where T : class
     {
-        Debug.Assert(services != null, "services was null");
-        Debug.Assert(optionsFactoryFunc != null, "optionsFactoryFunc was null");
-
-        services!.TryAddSingleton<IOptionsFactory<T>>(sp =>
+        services.TryAddSingleton<IOptionsFactory<T>>(sp =>
         {
             return new DelegatingOptionsFactory<T>(
-                (c, n) => optionsFactoryFunc!(c),
+                (c, n) => optionsFactoryFunc(c),
                 sp.GetRequiredService<IConfiguration>(),
                 sp.GetServices<IConfigureOptions<T>>(),
                 sp.GetServices<IPostConfigureOptions<T>>(),
                 sp.GetServices<IValidateOptions<T>>());
         });
 
-        return services!;
+        return services;
     }
 
 #if NET
@@ -47,20 +43,17 @@ internal static class DelegatingOptionsFactoryServiceCollectionExtensions
         Func<IServiceProvider, IConfiguration, string, T> optionsFactoryFunc)
         where T : class
     {
-        Debug.Assert(services != null, "services was null");
-        Debug.Assert(optionsFactoryFunc != null, "optionsFactoryFunc was null");
-
-        services!.TryAddSingleton<IOptionsFactory<T>>(sp =>
+        services.TryAddSingleton<IOptionsFactory<T>>(sp =>
         {
             return new DelegatingOptionsFactory<T>(
-                (c, n) => optionsFactoryFunc!(sp, c, n),
+                (c, n) => optionsFactoryFunc(sp, c, n),
                 sp.GetRequiredService<IConfiguration>(),
                 sp.GetServices<IConfigureOptions<T>>(),
                 sp.GetServices<IPostConfigureOptions<T>>(),
                 sp.GetServices<IValidateOptions<T>>());
         });
 
-        return services!;
+        return services;
     }
 
 #if NET
@@ -71,11 +64,9 @@ internal static class DelegatingOptionsFactoryServiceCollectionExtensions
         this IServiceCollection services)
         where T : class
     {
-        Debug.Assert(services != null, "services was null");
+        services.TryAddSingleton<IOptionsMonitor<T>, SingletonOptionsManager<T>>();
+        services.TryAddScoped<IOptionsSnapshot<T>, SingletonOptionsManager<T>>();
 
-        services!.TryAddSingleton<IOptionsMonitor<T>, SingletonOptionsManager<T>>();
-        services!.TryAddScoped<IOptionsSnapshot<T>, SingletonOptionsManager<T>>();
-
-        return services!;
+        return services;
     }
 }

--- a/src/Shared/StatusHelper.cs
+++ b/src/Shared/StatusHelper.cs
@@ -49,7 +49,7 @@ internal static class StatusHelper
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryGetStatusCodeForTagValue(string? statusCodeTagValue, out StatusCode statusCode)
     {
-        StatusCode? tempStatusCode = GetStatusCodeForTagValue(statusCodeTagValue);
+        var tempStatusCode = GetStatusCodeForTagValue(statusCodeTagValue);
 
         statusCode = tempStatusCode ?? default;
 

--- a/src/Shared/TagWriter/TagWriter.cs
+++ b/src/Shared/TagWriter/TagWriter.cs
@@ -24,9 +24,7 @@ internal abstract class TagWriter<TTagState, TArrayState>
         ref TTagState state,
         KeyValuePair<string, object?> tag,
         int? tagValueMaxLength = null)
-    {
-        return this.TryWriteTag(ref state, tag.Key, tag.Value, tagValueMaxLength);
-    }
+        => this.TryWriteTag(ref state, tag.Key, tag.Value, tagValueMaxLength);
 
     public bool TryWriteTag(
         ref TTagState state,
@@ -76,7 +74,7 @@ internal abstract class TagWriter<TTagState, TArrayState>
                 {
                     this.WriteArrayTagInternal(ref state, key, array, tagValueMaxLength);
                 }
-                catch (Exception ex) when (ex is IndexOutOfRangeException || ex is ArgumentException)
+                catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentException)
                 {
                     throw;
                 }
@@ -141,11 +139,9 @@ internal abstract class TagWriter<TTagState, TArrayState>
         string tagValueTypeFullName);
 
     private static ReadOnlySpan<char> TruncateString(ReadOnlySpan<char> value, int? maxLength)
-    {
-        return maxLength.HasValue && value.Length > maxLength
-            ? value.Slice(0, maxLength.Value)
-            : value;
-    }
+        => maxLength.HasValue && value.Length > maxLength
+           ? value.Slice(0, maxLength.Value)
+           : value;
 
     private void WriteCharTag(ref TTagState state, string key, char value)
     {
@@ -187,7 +183,7 @@ internal abstract class TagWriter<TTagState, TArrayState>
 
             this.arrayWriter.EndWriteArray(ref arrayState);
         }
-        catch (Exception ex) when (ex is IndexOutOfRangeException || ex is ArgumentException)
+        catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentException)
         {
             // If the array writer cannot be resized, TryResize should log a message to the event source, return false.
             if (this.arrayWriter.TryResize())
@@ -366,7 +362,7 @@ internal abstract class TagWriter<TTagState, TArrayState>
     private void WriteStructToArray<TItem>(ref TArrayState arrayState, TItem[] array)
         where TItem : struct
     {
-        foreach (TItem item in array)
+        foreach (var item in array)
         {
             if (typeof(TItem) == typeof(char))
             {
@@ -440,9 +436,7 @@ internal abstract class TagWriter<TTagState, TArrayState>
 
     private bool LogUnsupportedTagTypeAndReturnFalse(string key, object value)
     {
-        Debug.Assert(value != null, "value was null");
-
-        this.OnUnsupportedTagDropped(key, value!.GetType().ToString());
+        this.OnUnsupportedTagDropped(key, value.GetType().ToString());
         return false;
     }
 }


### PR DESCRIPTION
## Changes

Cherry-pick fixes for new code analysis warnings identified by the .NET 11 preview 2 SDK in #6899.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
