### PR TITLE
[Docs] Fix new code analysis warnings

### DIFF
--- a/docs/logs/customizing-the-sdk/Program.cs
+++ b/docs/logs/customizing-the-sdk/Program.cs
@@ -21,10 +21,7 @@ var logger = loggerFactory.CreateLogger<Program>();
 
 logger.FoodPriceChanged("artichoke", 9.99);
 
-using (logger.BeginScope(new List<KeyValuePair<string, object>>
-{
-    new KeyValuePair<string, object>("store", "Seattle"),
-}))
+using (logger.BeginScope(new List<KeyValuePair<string, object>> { new("store", "Seattle") }))
 {
     logger.FoodPriceChanged("truffle", 999.99);
 }

--- a/docs/logs/extending-the-sdk/MyExporter.cs
+++ b/docs/logs/extending-the-sdk/MyExporter.cs
@@ -30,7 +30,7 @@ internal sealed class MyExporter : BaseExporter<LogRecord>
 
             sb.Append($"{record}(");
 
-            int scopeDepth = -1;
+            var scopeDepth = -1;
 
             record.ForEachScope(ProcessScope, sb);
 

--- a/docs/metrics/customizing-the-sdk/Program.cs
+++ b/docs/metrics/customizing-the-sdk/Program.cs
@@ -59,43 +59,43 @@ internal static class Program
         var random = new Random();
 
         var counter = Meter1.CreateCounter<long>("MyCounter");
-        for (int i = 0; i < 20000; i++)
+        for (var i = 0; i < 20000; i++)
         {
             counter.Add(1, new("tag1", "value1"), new("tag2", "value2"));
         }
 
         var histogram = Meter1.CreateHistogram<long>("MyHistogram");
-        for (int i = 0; i < 20000; i++)
+        for (var i = 0; i < 20000; i++)
         {
             histogram.Record(random.Next(1, 1000), new("tag1", "value1"), new("tag2", "value2"));
         }
 
         var exponentialBucketHistogram = Meter1.CreateHistogram<long>("MyExponentialBucketHistogram");
-        for (int i = 0; i < 20000; i++)
+        for (var i = 0; i < 20000; i++)
         {
             exponentialBucketHistogram.Record(random.Next(1, 1000), new("tag1", "value1"), new("tag2", "value2"));
         }
 
         var histogramWithMultipleAggregations = Meter1.CreateHistogram<long>("histogramWithMultipleAggregations");
-        for (int i = 0; i < 20000; i++)
+        for (var i = 0; i < 20000; i++)
         {
             histogramWithMultipleAggregations.Record(random.Next(1, 1000), new("tag1", "value1"), new("tag2", "value2"));
         }
 
         var counterCustomTags = Meter1.CreateCounter<long>("MyCounterCustomTags");
-        for (int i = 0; i < 20000; i++)
+        for (var i = 0; i < 20000; i++)
         {
             counterCustomTags.Add(1, new("tag1", "value1"), new("tag2", "value2"), new("tag3", "value4"));
         }
 
         var counterDrop = Meter1.CreateCounter<long>("MyCounterDrop");
-        for (int i = 0; i < 20000; i++)
+        for (var i = 0; i < 20000; i++)
         {
             counterDrop.Add(1, new("tag1", "value1"), new("tag2", "value2"));
         }
 
         var histogram2 = Meter2.CreateHistogram<long>("MyHistogram2");
-        for (int i = 0; i < 20000; i++)
+        for (var i = 0; i < 20000; i++)
         {
             histogram2.Record(random.Next(1, 1000), new("tag1", "value1"), new("tag2", "value2"));
         }

--- a/docs/metrics/learning-more-instruments/Program.cs
+++ b/docs/metrics/learning-more-instruments/Program.cs
@@ -30,7 +30,7 @@ internal static class Program
             .Build();
 
         var random = new Random();
-        for (int i = 0; i < 1000; i++)
+        for (var i = 0; i < 1000; i++)
         {
             MyHistogram.Record(random.Next(1, 1000));
         }

--- a/docs/trace/customizing-the-sdk/Program.cs
+++ b/docs/trace/customizing-the-sdk/Program.cs
@@ -33,11 +33,11 @@ internal static class Program
             // The following adds subscription to activities from all Activity Sources
             // whose name starts with "AbcCompany.XyzProduct.".
             .AddSource("AbcCompany.XyzProduct.*")
-            .ConfigureResource(resource => resource.AddAttributes(new List<KeyValuePair<string, object>>
-                {
+            .ConfigureResource(resource => resource.AddAttributes(
+                [
                     new KeyValuePair<string, object>("static-attribute1", "v1"),
                     new KeyValuePair<string, object>("static-attribute2", "v2"),
-                }))
+                ]))
             .ConfigureResource(resource => resource.AddService("MyServiceName"))
             .AddConsoleExporter()
             .Build();

--- a/docs/trace/links-based-sampler/Program.cs
+++ b/docs/trace/links-based-sampler/Program.cs
@@ -11,7 +11,7 @@ internal static class Program
 {
     private static readonly ActivitySource MyActivitySource = new("LinksAndParentBasedSampler.Example");
 
-    public static void Main(string[] args)
+    public static void Main()
     {
         using var tracerProvider = Sdk.CreateTracerProviderBuilder()
              .SetSampler(new LinksAndParentBasedSampler(new ParentBasedSampler(new TraceIdRatioBasedSampler(0.2))))
@@ -44,7 +44,7 @@ internal static class Program
 
         for (var i = 0; i < 5; i++)
         {
-            int randomValue = random.Next(10);
+            var randomValue = random.Next(10);
             var traceFlags = (randomValue == 0) ? ActivityTraceFlags.Recorded : ActivityTraceFlags.None;
             var context = new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), traceFlags);
             linkedActivitiesList.Add(new ActivityLink(context));

--- a/docs/trace/links-creation-with-new-activities/Program.cs
+++ b/docs/trace/links-creation-with-new-activities/Program.cs
@@ -11,23 +11,19 @@ internal static class Program
 {
     private static readonly ActivitySource MyActivitySource = new("LinksCreationWithNewRootActivities");
 
-    public static async Task Main(string[] args)
+    public static async Task Main()
     {
         using var tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddSource("LinksCreationWithNewRootActivities")
                 .AddConsoleExporter()
                 .Build();
 
-        using (var activity = MyActivitySource.StartActivity("OrchestratingActivity"))
-        {
-            activity?.SetTag("foo", 1);
-            await DoFanoutAsync().ConfigureAwait(false);
+        using var activity = MyActivitySource.StartActivity("OrchestratingActivity");
+        activity?.SetTag("foo", 1);
+        await DoFanoutAsync().ConfigureAwait(false);
 
-            using (var nestedActivity = MyActivitySource.StartActivity("WrapUp"))
-            {
-                nestedActivity?.SetTag("foo", 1);
-            }
-        }
+        using var nestedActivity = MyActivitySource.StartActivity("WrapUp");
+        nestedActivity?.SetTag("foo", 1);
     }
 
     public static async Task DoFanoutAsync()
@@ -38,7 +34,7 @@ internal static class Program
         var activityContext = Activity.Current!.Context;
         var links = new List<ActivityLink>
         {
-            new ActivityLink(activityContext),
+            new(activityContext),
         };
 
         var tasks = new List<Task>();
@@ -47,9 +43,9 @@ internal static class Program
         // We create a new root activity for each operation and
         // link it to an outer activity that happens to be the current
         // activity.
-        for (int i = 0; i < NumConcurrentOperations; i++)
+        for (var i = 0; i < NumConcurrentOperations; i++)
         {
-            int operationIndex = i;
+            var operationIndex = i;
 
             var task = Task.Run(() =>
             {

--- a/docs/trace/stratified-sampling-example/Program.cs
+++ b/docs/trace/stratified-sampling-example/Program.cs
@@ -11,7 +11,7 @@ internal sealed class Program
 {
     private static readonly ActivitySource MyActivitySource = new("StratifiedSampling.POC");
 
-    public static void Main(string[] args)
+    public static void Main()
     {
         // We wrap the stratified sampler within a parentbased sampler.
         // This is to enable downstream participants (i.e., the non-root spans) to have
@@ -47,10 +47,9 @@ internal sealed class Program
             using (var activity = MyActivitySource.StartActivity(ActivityKind.Internal, parentContext: default, tags: tagsList))
             {
                 activity?.SetTag("foo", "bar");
-                using (var activity2 = MyActivitySource.StartActivity(ActivityKind.Internal, parentContext: default, tags: tagsList))
-                {
-                    activity2?.SetTag("foo", "child");
-                }
+
+                using var activity2 = MyActivitySource.StartActivity(ActivityKind.Internal, parentContext: default, tags: tagsList);
+                activity2?.SetTag("foo", "child");
             }
 
             tagsList.Clear();

--- a/docs/trace/stratified-sampling-example/StratifiedSampler.cs
+++ b/docs/trace/stratified-sampling-example/StratifiedSampler.cs
@@ -15,8 +15,8 @@ internal sealed class StratifiedSampler : Sampler
     private const string QueryTypeUserInitiated = "userInitiated";
     private const string QueryTypeProgrammatic = "programmatic";
 
-    private readonly Dictionary<int, double> samplingRatios = new();
-    private readonly List<Sampler> samplers = new();
+    private readonly Dictionary<int, double> samplingRatios = [];
+    private readonly List<Sampler> samplers = [];
 
     public StratifiedSampler()
     {

--- a/docs/trace/tail-based-sampling-span-level/Program.cs
+++ b/docs/trace/tail-based-sampling-span-level/Program.cs
@@ -11,7 +11,7 @@ internal static class Program
 {
     private static readonly ActivitySource MyActivitySource = new("SDK.TailSampling.POC");
 
-    public static void Main(string[] args)
+    public static void Main()
     {
         using var tracerProvider = Sdk.CreateTracerProviderBuilder()
             .SetSampler(new ParentBasedElseAlwaysRecordSampler())
@@ -25,21 +25,19 @@ internal static class Program
         // Generate some spans
         for (var i = 0; i < 50; i++)
         {
-            using (var activity = MyActivitySource.StartActivity("SayHello"))
-            {
-                activity?.SetTag("foo", "bar");
+            using var activity = MyActivitySource.StartActivity("SayHello");
+            activity?.SetTag("foo", "bar");
 
-                // Simulate a mix of failed and successful spans
-                var randomValue = random.Next(5);
-                switch (randomValue)
-                {
-                    case 0:
-                        activity?.SetStatus(ActivityStatusCode.Error);
-                        break;
-                    default:
-                        activity?.SetStatus(ActivityStatusCode.Ok);
-                        break;
-                }
+            // Simulate a mix of failed and successful spans
+            var randomValue = random.Next(5);
+            switch (randomValue)
+            {
+                case 0:
+                    activity?.SetStatus(ActivityStatusCode.Error);
+                    break;
+                default:
+                    activity?.SetStatus(ActivityStatusCode.Ok);
+                    break;
             }
         }
     }

--- a/examples/AspNetCore/Controllers/WeatherForecastController.cs
+++ b/examples/AspNetCore/Controllers/WeatherForecastController.cs
@@ -1,13 +1,12 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-namespace Examples.AspNetCore.Controllers;
-
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Security.Cryptography;
-using Examples.AspNetCore;
 using Microsoft.AspNetCore.Mvc;
+
+namespace Examples.AspNetCore.Controllers;
 
 [ApiController]
 [Route("[controller]")]

--- a/examples/AspNetCore/InstrumentationSource.cs
+++ b/examples/AspNetCore/InstrumentationSource.cs
@@ -1,10 +1,10 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-namespace Examples.AspNetCore;
-
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+
+namespace Examples.AspNetCore;
 
 /// <summary>
 /// It is recommended to use a custom type to hold references for
@@ -19,7 +19,7 @@ public sealed class InstrumentationSource : IDisposable
 
     public InstrumentationSource()
     {
-        string? version = typeof(InstrumentationSource).Assembly.GetName().Version?.ToString();
+        var version = typeof(InstrumentationSource).Assembly.GetName().Version?.ToString();
         this.ActivitySource = new ActivitySource(ActivitySourceName, version);
         this.meter = new Meter(MeterName, version);
         this.FreezingDaysCounter = this.meter.CreateCounter<long>("weather.days.freezing", description: "The number of days where the temperature is below freezing");

--- a/examples/AspNetCore/Program.cs
+++ b/examples/AspNetCore/Program.cs
@@ -38,7 +38,7 @@ appBuilder.Logging.ClearProviders();
 appBuilder.Services.AddOpenTelemetry()
     .ConfigureResource(r => r
         .AddService(
-            serviceName: appBuilder.Configuration.GetValue("ServiceName", defaultValue: "otel-test")!,
+            serviceName: appBuilder.Configuration.GetValue("ServiceName", defaultValue: "otel-test"),
             serviceVersion: typeof(Program).Assembly.GetName().Version?.ToString() ?? "unknown",
             serviceInstanceId: Environment.MachineName))
     .WithTracing(builder =>
@@ -107,7 +107,7 @@ appBuilder.Services.AddOpenTelemetry()
                 builder.AddOtlpExporter(otlpOptions =>
                 {
                     // Use IConfiguration directly for Otlp exporter endpoint option.
-                    otlpOptions.Endpoint = new Uri(appBuilder.Configuration.GetValue("Otlp:Endpoint", defaultValue: "http://localhost:4317")!);
+                    otlpOptions.Endpoint = new Uri(appBuilder.Configuration.GetValue("Otlp:Endpoint", defaultValue: "http://localhost:4317"));
                 });
                 break;
             default:

--- a/examples/Console/InstrumentationWithActivitySource.cs
+++ b/examples/Console/InstrumentationWithActivitySource.cs
@@ -53,7 +53,7 @@ internal sealed class InstrumentationWithActivitySource : IDisposable
                         var headerKeys = context.Request.Headers.AllKeys;
                         foreach (var headerKey in headerKeys)
                         {
-                            string? headerValue = context.Request.Headers[headerKey];
+                            var headerValue = context.Request.Headers[headerKey];
                             activity?.SetTag($"http.header.{headerKey}", headerValue);
                         }
 

--- a/examples/Console/Program.cs
+++ b/examples/Console/Program.cs
@@ -28,8 +28,7 @@ internal static class Program
     /// (eg: C:\repos\opentelemetry-dotnet\examples\Console\).
     /// </summary>
     /// <param name="args">Arguments from command line.</param>
-    public static void Main(string[] args)
-    {
+    public static void Main(string[] args) =>
         Parser.Default.ParseArguments<PrometheusOptions, MetricsOptions, LogsOptions, GrpcNetClientOptions, HttpClientOptions, ConsoleOptions, OpenTelemetryShimOptions, OpenTracingShimOptions, OtlpOptions, InMemoryOptions>(args)
             .MapResult(
                 (PrometheusOptions options) => TestPrometheusExporter.Run(options),
@@ -37,13 +36,12 @@ internal static class Program
                 (LogsOptions options) => TestLogs.Run(options),
                 (GrpcNetClientOptions options) => TestGrpcNetClient.Run(options),
                 (HttpClientOptions options) => TestHttpClient.Run(options),
-                (ConsoleOptions options) => TestConsoleExporter.Run(options),
-                (OpenTelemetryShimOptions options) => TestOTelShimWithConsoleExporter.Run(options),
-                (OpenTracingShimOptions options) => TestOpenTracingShim.Run(options),
+                (ConsoleOptions options) => TestConsoleExporter.Run(),
+                (OpenTelemetryShimOptions options) => TestOTelShimWithConsoleExporter.Run(),
+                (OpenTracingShimOptions options) => TestOpenTracingShim.Run(),
                 (OtlpOptions options) => TestOtlpExporter.Run(options),
-                (InMemoryOptions options) => TestInMemoryExporter.Run(options),
-                errs => 1);
-    }
+                (InMemoryOptions options) => TestInMemoryExporter.Run(),
+                _ => 1);
 }
 
 #pragma warning disable SA1402 // File may only contain a single type
@@ -84,29 +82,19 @@ internal sealed class MetricsOptions
 }
 
 [Verb("grpc", HelpText = "Specify the options required to test Grpc.Net.Client")]
-internal sealed class GrpcNetClientOptions
-{
-}
+internal sealed class GrpcNetClientOptions;
 
 [Verb("httpclient", HelpText = "Specify the options required to test HttpClient")]
-internal sealed class HttpClientOptions
-{
-}
+internal sealed class HttpClientOptions;
 
 [Verb("console", HelpText = "Specify the options required to test console exporter")]
-internal sealed class ConsoleOptions
-{
-}
+internal sealed class ConsoleOptions;
 
 [Verb("otelshim", HelpText = "Specify the options required to test OpenTelemetry Shim with console exporter")]
-internal sealed class OpenTelemetryShimOptions
-{
-}
+internal sealed class OpenTelemetryShimOptions;
 
 [Verb("opentracing", HelpText = "Specify the options required to test OpenTracing Shim with console exporter")]
-internal sealed class OpenTracingShimOptions
-{
-}
+internal sealed class OpenTracingShimOptions;
 
 [Verb("otlp", HelpText = "Specify the options required to test OpenTelemetry Protocol (OTLP)")]
 internal sealed class OtlpOptions
@@ -138,8 +126,6 @@ internal sealed class LogsOptions
 }
 
 [Verb("inmemory", HelpText = "Specify the options required to test InMemory Exporter")]
-internal sealed class InMemoryOptions
-{
-}
+internal sealed class InMemoryOptions;
 
 #pragma warning restore SA1402 // File may only contain a single type

--- a/examples/Console/TestConsoleExporter.cs
+++ b/examples/Console/TestConsoleExporter.cs
@@ -15,12 +15,7 @@ internal sealed class TestConsoleExporter
     // (eg: C:\repos\opentelemetry-dotnet\examples\Console\)
     //
     // dotnet run console
-    internal static int Run(ConsoleOptions options)
-    {
-        return RunWithActivitySource();
-    }
-
-    private static int RunWithActivitySource()
+    public static int Run()
     {
         // Enable OpenTelemetry for the sources "Samples.SampleServer" and "Samples.SampleClient"
         // and use Console exporter.

--- a/examples/Console/TestInMemoryExporter.cs
+++ b/examples/Console/TestInMemoryExporter.cs
@@ -15,7 +15,7 @@ internal sealed class TestInMemoryExporter
     // (eg: C:\repos\opentelemetry-dotnet\examples\Console\)
     //
     // dotnet run inmemory
-    internal static int Run(InMemoryOptions options)
+    internal static int Run()
     {
         // List that will be populated with the traces by InMemoryExporter
         var exportedItems = new List<Activity>();

--- a/examples/Console/TestOTelShimWithConsoleExporter.cs
+++ b/examples/Console/TestOTelShimWithConsoleExporter.cs
@@ -9,7 +9,7 @@ namespace Examples.Console;
 
 internal sealed class TestOTelShimWithConsoleExporter
 {
-    internal static int Run(OpenTelemetryShimOptions options)
+    internal static int Run()
     {
         // Enable OpenTelemetry for the source "MyCompany.MyProduct.MyWebServer"
         // and use a single pipeline with a custom MyProcessor, and Console exporter.

--- a/examples/Console/TestOpenTracingShim.cs
+++ b/examples/Console/TestOpenTracingShim.cs
@@ -6,13 +6,12 @@ using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Shims.OpenTracing;
 using OpenTelemetry.Trace;
-using OpenTracing;
 
 namespace Examples.Console;
 
 internal sealed class TestOpenTracingShim
 {
-    internal static int Run(OpenTracingShimOptions options)
+    internal static int Run()
     {
         // Enable OpenTelemetry for the source "opentracing-shim"
         // and use Console exporter.
@@ -40,13 +39,13 @@ internal sealed class TestOpenTracingShim
 
         // The code below is meant to resemble application code that has been instrumented
         // with the OpenTracing API.
-        using (IScope parentScope = openTracingTracer.BuildSpan("Parent").StartActive(finishSpanOnDispose: true))
+        using (var parentScope = openTracingTracer.BuildSpan("Parent").StartActive(finishSpanOnDispose: true))
         {
             parentScope.Span.SetTag("my", "value");
             parentScope.Span.SetOperationName("parent span new name");
 
             // The child scope will automatically use parentScope as its parent.
-            using IScope childScope = openTracingTracer.BuildSpan("Child").StartActive(finishSpanOnDispose: true);
+            using var childScope = openTracingTracer.BuildSpan("Child").StartActive(finishSpanOnDispose: true);
             childScope.Span.SetTag("Child Tag", "Child Tag Value").SetTag("ch", "value").SetTag("more", "attributes");
         }
 


### PR DESCRIPTION
## Changes

Cherry-pick fixes for new code analysis warnings identified by the .NET 11 preview 2 SDK in #6899.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
