### PR TITLE
[OpenTracing] Fix new code analysis warnings

### DIFF
--- a/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/ScopeManagerShim.cs
@@ -10,7 +10,9 @@ namespace OpenTelemetry.Shims.OpenTracing;
 
 internal sealed class ScopeManagerShim : IScopeManager
 {
+#pragma warning disable IDE0028 // Simplify collection initialization
     private static readonly ConditionalWeakTable<TelemetrySpan, IScope> SpanScopeTable = new();
+#pragma warning restore IDE0028 // Simplify collection initialization
 
 #if DEBUG
     private int spanScopeTableCount;
@@ -24,17 +26,12 @@ internal sealed class ScopeManagerShim : IScopeManager
         get
         {
             var currentSpan = Tracer.CurrentSpan;
-            if (currentSpan == null || !currentSpan.Context.IsValid)
-            {
-                return null;
-            }
-
-            if (SpanScopeTable.TryGetValue(currentSpan, out var openTracingScope))
-            {
-                return openTracingScope;
-            }
-
-            return new ScopeInstrumentation(currentSpan);
+            return
+                currentSpan == null || !currentSpan.Context.IsValid ?
+                null :
+                SpanScopeTable.TryGetValue(currentSpan, out var openTracingScope) ?
+                openTracingScope :
+                new ScopeInstrumentation(currentSpan);
         }
     }
 
@@ -56,7 +53,7 @@ internal sealed class ScopeManagerShim : IScopeManager
                     Interlocked.Decrement(ref this.spanScopeTableCount);
                 }
 #endif
-                scope!.Dispose();
+                scope?.Dispose();
             });
 
         SpanScopeTable.Add(shim.Span, instrumentation);
@@ -82,8 +79,6 @@ internal sealed class ScopeManagerShim : IScopeManager
 
         /// <inheritdoc/>
         public void Dispose()
-        {
-            this.disposeAction?.Invoke();
-        }
+            => this.disposeAction?.Invoke();
     }
 }

--- a/src/OpenTelemetry.Shims.OpenTracing/SpanShim.cs
+++ b/src/OpenTelemetry.Shims.OpenTracing/SpanShim.cs
@@ -43,15 +43,11 @@ internal sealed class SpanShim : ISpan
 
     /// <inheritdoc/>
     public void Finish()
-    {
-        this.Span.End();
-    }
+        => this.Span.End();
 
     /// <inheritdoc/>
     public void Finish(DateTimeOffset finishTimestamp)
-    {
-        this.Span.End(finishTimestamp);
-    }
+        => this.Span.End(finishTimestamp);
 
     /// <inheritdoc/>
     public string? GetBaggageItem(string key)
@@ -114,9 +110,7 @@ internal sealed class SpanShim : ISpan
 
     /// <inheritdoc/>
     public ISpan Log(IEnumerable<KeyValuePair<string, object>> fields)
-    {
-        return this.Log(DateTimeOffset.MinValue, fields);
-    }
+        => this.Log(DateTimeOffset.MinValue, fields);
 
     /// <inheritdoc/>
     public ISpan Log(string @event)
@@ -211,12 +205,9 @@ internal sealed class SpanShim : ISpan
     {
         Guard.ThrowIfNull(tag);
 
-        if (value != null && int.TryParse(value, out var result))
-        {
-            return this.SetTag(tag.Key, result);
-        }
-
-        return this.SetTag(tag.Key, value);
+        return value != null && int.TryParse(value, out var result) ?
+               this.SetTag(tag.Key, result) :
+               this.SetTag(tag.Key, value);
     }
 
     /// <inheritdoc/>
@@ -276,7 +267,11 @@ internal sealed class SpanShim : ISpan
             else
             {
                 // TODO should we completely ignore unsupported types?
+#if NET
                 attributes.Add(field.Key, field.Value.ToString()!);
+#else
+                attributes.Add(field.Key, field.Value.ToString());
+#endif
             }
         }
 

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/IntegrationTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/IntegrationTests.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using OpenTelemetry.Context.Propagation;
 using OpenTelemetry.Trace;
-using OpenTracing;
 using Xunit;
 
 namespace OpenTelemetry.Shims.OpenTracing.Tests;
@@ -68,12 +67,10 @@ public class IntegrationTests
 
         using (var parentActivity = parentActivitySource.StartActivity(ParentActivityName))
         {
-            using (IScope parentScope = otTracer.BuildSpan(ShimActivityName).StartActive())
-            {
-                parentScope.Span.SetTag("parent", true);
+            using var parentScope = otTracer.BuildSpan(ShimActivityName).StartActive();
+            parentScope.Span.SetTag("parent", true);
 
-                using var childActivity = childActivitySource.StartActivity(ChildActivityName);
-            }
+            using var childActivity = childActivitySource.StartActivity(ChildActivityName);
         }
 
         var expectedExportedSpans = new string?[]
@@ -85,7 +82,7 @@ public class IntegrationTests
             .Where(s => s is not null)
             .ToList();
 
-        for (int i = 0; i < expectedExportedSpans.Count; i++)
+        for (var i = 0; i < expectedExportedSpans.Count; i++)
         {
             Assert.Equal(expectedExportedSpans[i], exportedSpans[i].DisplayName);
         }
@@ -109,9 +106,7 @@ public class IntegrationTests
         }
 
         public override SamplingResult ShouldSample(in SamplingParameters samplingParameters)
-        {
-            return new SamplingResult(this.shouldSampleDelegate(samplingParameters));
-        }
+            => new(this.shouldSampleDelegate(samplingParameters));
     }
 }
 

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/ListenAndSampleAllActivitySourcesFixture.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/ListenAndSampleAllActivitySourcesFixture.cs
@@ -19,7 +19,7 @@ public sealed class ListenAndSampleAllActivitySourcesFixture : IDisposable
         this.listener = new ActivityListener
         {
             ShouldListenTo = _ => true,
-            Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded,
+            Sample = (ref options) => ActivitySamplingResult.AllDataAndRecorded,
         };
 
         ActivitySource.AddActivityListener(this.listener);

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/SpanShimTests.cs
@@ -16,9 +16,7 @@ public class SpanShimTests
 
     [Fact]
     public void CtorArgumentValidation()
-    {
-        Assert.Throws<ArgumentNullException>(() => new SpanShim(null!));
-    }
+        => Assert.Throws<ArgumentNullException>(() => new SpanShim(null!));
 
     [Fact]
     public void SpanContextIsNotNull()
@@ -124,16 +122,10 @@ public class SpanShimTests
 
         Assert.Throws<ArgumentNullException>(() => shim.Log((IEnumerable<KeyValuePair<string, object>>)null!));
 
-        shim.Log(new List<KeyValuePair<string, object>>
-        {
-            new("foo", "bar"),
-        });
+        shim.Log([new("foo", "bar")]);
 
         // "event" is a special event name
-        shim.Log(new List<KeyValuePair<string, object>>
-        {
-            new("event", "foo"),
-        });
+        shim.Log([new("event", "foo")]);
 
         Assert.NotNull(shim.Span.Activity);
 
@@ -158,16 +150,10 @@ public class SpanShimTests
         Assert.Throws<ArgumentNullException>(() => shim.Log((IEnumerable<KeyValuePair<string, object>>)null!));
         var now = DateTimeOffset.UtcNow;
 
-        shim.Log(now, new List<KeyValuePair<string, object>>
-        {
-            new("foo", "bar"),
-        });
+        shim.Log(now, [new("foo", "bar")]);
 
         // "event" is a special event name
-        shim.Log(now, new List<KeyValuePair<string, object>>
-        {
-            new("event", "foo"),
-        });
+        shim.Log(now, [new("event", "foo")]);
 
         Assert.NotNull(shim.Span.Activity);
         Assert.Equal(2, shim.Span.Activity.Events.Count());

--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/TracerShimTests.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/TracerShimTests.cs
@@ -146,7 +146,7 @@ public class TracerShimTests
     /// <seealso cref="OpenTracing.Propagation.ITextMap" />
     private sealed class TextMapCarrier : ITextMap
     {
-        private readonly Dictionary<string, string> map = new();
+        private readonly Dictionary<string, string> map = [];
 
         public IDictionary<string, string> Map => this.map;
 


### PR DESCRIPTION
## Changes

Cherry-pick fixes for new code analysis warnings identified by the .NET 11 preview 2 SDK in #6899.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
