### PR TITLE
[Propagators] Fix new code analysis warnings

### DIFF
--- a/src/OpenTelemetry.Extensions.Propagators/B3Propagator.cs
+++ b/src/OpenTelemetry.Extensions.Propagators/B3Propagator.cs
@@ -201,7 +201,7 @@ public sealed class B3Propagator : TextMapPropagator
             }
 
             var parts = header.Split(XB3CombinedDelimiter);
-            if (parts.Length < 2 || parts.Length > 4)
+            if (parts.Length is < 2 or > 4)
             {
                 return context;
             }


### PR DESCRIPTION
## Changes

Cherry-pick fixes for new code analysis warnings identified by the .NET 11 preview 2 SDK in #6899.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
