### PR TITLE
[Hosting] Fix new code analysis warnings

### DIFF
--- a/src/OpenTelemetry.Extensions.Hosting/Implementation/TelemetryHostedService.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/Implementation/TelemetryHostedService.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using OpenTelemetry.Logs;
@@ -33,27 +32,23 @@ internal sealed class TelemetryHostedService : IHostedService
     }
 
     public Task StopAsync(CancellationToken cancellationToken)
-    {
-        return Task.CompletedTask;
-    }
+        => Task.CompletedTask;
 
     internal static void Initialize(IServiceProvider serviceProvider)
     {
-        Debug.Assert(serviceProvider != null, "serviceProvider was null");
-
-        var meterProvider = serviceProvider!.GetService<MeterProvider>();
+        var meterProvider = serviceProvider.GetService<MeterProvider>();
         if (meterProvider == null)
         {
             HostingExtensionsEventSource.Log.MeterProviderNotRegistered();
         }
 
-        var tracerProvider = serviceProvider!.GetService<TracerProvider>();
+        var tracerProvider = serviceProvider.GetService<TracerProvider>();
         if (tracerProvider == null)
         {
             HostingExtensionsEventSource.Log.TracerProviderNotRegistered();
         }
 
-        var loggerProvider = serviceProvider!.GetService<LoggerProvider>();
+        var loggerProvider = serviceProvider.GetService<LoggerProvider>();
         if (loggerProvider == null)
         {
             HostingExtensionsEventSource.Log.LoggerProviderNotRegistered();

--- a/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryServicesExtensions.cs
+++ b/src/OpenTelemetry.Extensions.Hosting/OpenTelemetryServicesExtensions.cs
@@ -40,7 +40,7 @@ public static class OpenTelemetryServicesExtensions
     {
         Guard.ThrowIfNull(services);
 
-        if (!services.Any((ServiceDescriptor d) => d.ServiceType == typeof(IHostedService) && d.ImplementationType == typeof(TelemetryHostedService)))
+        if (!services.Any(d => d.ServiceType == typeof(IHostedService) && d.ImplementationType == typeof(TelemetryHostedService)))
         {
             services.Insert(0, ServiceDescriptor.Singleton<IHostedService, TelemetryHostedService>());
         }

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryMetricsBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryMetricsBuilderExtensionsTests.cs
@@ -327,7 +327,7 @@ public class OpenTelemetryMetricsBuilderExtensionsTests
     public void WhenOpenTelemetrySdkIsDisabledExceptionNotThrown()
     {
         // Arrange
-        string meterName = "TestMeter";
+        var meterName = "TestMeter";
 
         using (new EnvironmentVariableScope("OTEL_SDK_DISABLED", "true"))
         {

--- a/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryServicesExtensionsTests.cs
+++ b/test/OpenTelemetry.Extensions.Hosting.Tests/OpenTelemetryServicesExtensionsTests.cs
@@ -32,7 +32,7 @@ public class OpenTelemetryServicesExtensionsTests
     [Fact]
     public async Task AddOpenTelemetry_StartWithExceptionsThrows()
     {
-        bool expectedInnerExceptionThrown = false;
+        var expectedInnerExceptionThrown = false;
 
         var builder = new HostBuilder().ConfigureServices(services =>
         {
@@ -92,7 +92,7 @@ public class OpenTelemetryServicesExtensionsTests
     {
         var services = new ServiceCollection();
 
-        bool testRun = false;
+        var testRun = false;
 
         services.AddOpenTelemetry().WithTracing(builder =>
         {
@@ -124,7 +124,7 @@ public class OpenTelemetryServicesExtensionsTests
     [Fact]
     public async Task AddOpenTelemetry_WithTracing_HostConfigurationHonoredTest()
     {
-        bool configureBuilderCalled = false;
+        var configureBuilderCalled = false;
 
         var builder = new HostBuilder()
             .ConfigureAppConfiguration(builder =>
@@ -171,7 +171,7 @@ public class OpenTelemetryServicesExtensionsTests
     [Fact]
     public void AddOpenTelemetry_WithTracing_NestedResolutionUsingConfigureTest()
     {
-        bool innerTestExecuted = false;
+        var innerTestExecuted = false;
 
         var services = new ServiceCollection();
 
@@ -215,7 +215,7 @@ public class OpenTelemetryServicesExtensionsTests
     {
         var services = new ServiceCollection();
 
-        bool testRun = false;
+        var testRun = false;
 
         services.AddOpenTelemetry().WithMetrics(builder =>
         {
@@ -247,7 +247,7 @@ public class OpenTelemetryServicesExtensionsTests
     [Fact]
     public async Task AddOpenTelemetry_WithMetrics_HostConfigurationHonoredTest()
     {
-        bool configureBuilderCalled = false;
+        var configureBuilderCalled = false;
 
         var builder = new HostBuilder()
             .ConfigureAppConfiguration(builder =>
@@ -294,7 +294,7 @@ public class OpenTelemetryServicesExtensionsTests
     [Fact]
     public void AddOpenTelemetry_WithMetrics_NestedResolutionUsingConfigureTest()
     {
-        bool innerTestExecuted = false;
+        var innerTestExecuted = false;
 
         var services = new ServiceCollection();
 
@@ -338,7 +338,7 @@ public class OpenTelemetryServicesExtensionsTests
     {
         var services = new ServiceCollection();
 
-        bool testRun = false;
+        var testRun = false;
 
         services.AddOpenTelemetry().WithLogging(builder =>
         {
@@ -370,7 +370,7 @@ public class OpenTelemetryServicesExtensionsTests
     [Fact]
     public void AddOpenTelemetry_WithLogging_HostConfigurationHonoredTest()
     {
-        bool configureBuilderCalled = false;
+        var configureBuilderCalled = false;
 
         var builder = new HostBuilder()
             .ConfigureAppConfiguration(builder =>
@@ -411,7 +411,7 @@ public class OpenTelemetryServicesExtensionsTests
     [Fact]
     public void AddOpenTelemetry_WithLogging_NestedResolutionUsingConfigureTest()
     {
-        bool innerTestExecuted = false;
+        var innerTestExecuted = false;
 
         var services = new ServiceCollection();
 
@@ -460,7 +460,7 @@ public class OpenTelemetryServicesExtensionsTests
             .Single();
 
         // Give the background service some time to run.
-        await Task.WhenAny(service.ExecuteTask!, Task.Delay(TimeSpan.FromSeconds(5)));
+        await Task.WhenAny(service.ExecuteTask!, Task.Delay(TimeSpan.FromSeconds(5), CancellationToken.None));
 
         await host.StopAsync();
 


### PR DESCRIPTION
## Changes

Cherry-pick fixes for new code analysis warnings identified by the .NET 11 preview 2 SDK in #6899.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
