### PR TITLE
[Benchmarks] Fix new code analysis warnings

### DIFF
--- a/test/Benchmarks/Context/Propagation/TraceContextPropagatorBenchmarks.cs
+++ b/test/Benchmarks/Context/Propagation/TraceContextPropagatorBenchmarks.cs
@@ -43,7 +43,7 @@ public class TraceContextPropagatorBenchmarks
 
         Span<char> keyBuffer = stackalloc char[length - 2];
 
-        string traceState = string.Empty;
+        var traceState = string.Empty;
         for (var i = 0; i < this.MembersCount; i++)
         {
             // We want a unique key for each member

--- a/test/Benchmarks/Exporter/OtlpGrpcExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/OtlpGrpcExporterBenchmarks.cs
@@ -56,9 +56,9 @@ public class OtlpGrpcExporterBenchmarks
     [Benchmark]
     public void OtlpExporter_Batching()
     {
-        for (int i = 0; i < this.NumberOfBatches; i++)
+        for (var i = 0; i < this.NumberOfBatches; i++)
         {
-            for (int c = 0; c < this.NumberOfSpans; c++)
+            for (var c = 0; c < this.NumberOfSpans; c++)
             {
                 this.activityBatch!.Add(this.activity!);
             }

--- a/test/Benchmarks/Exporter/OtlpHttpExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/OtlpHttpExporterBenchmarks.cs
@@ -40,7 +40,7 @@ public class OtlpHttpExporterBenchmarks
         this.server = TestHttpServer.RunServer(
             (ctx) =>
             {
-                using (Stream receiveStream = ctx.Request.InputStream)
+                using (var receiveStream = ctx.Request.InputStream)
                 {
                     while (true)
                     {
@@ -85,9 +85,9 @@ public class OtlpHttpExporterBenchmarks
     [Benchmark]
     public void OtlpExporter_Batching()
     {
-        for (int i = 0; i < this.NumberOfBatches; i++)
+        for (var i = 0; i < this.NumberOfBatches; i++)
         {
-            for (int c = 0; c < this.NumberOfSpans; c++)
+            for (var c = 0; c < this.NumberOfSpans; c++)
             {
                 this.activityBatch!.Add(this.activity!);
             }

--- a/test/Benchmarks/Exporter/PrometheusSerializerBenchmarks.cs
+++ b/test/Benchmarks/Exporter/PrometheusSerializerBenchmarks.cs
@@ -54,9 +54,9 @@ public class PrometheusSerializerBenchmarks
     [Benchmark]
     public void WriteMetric()
     {
-        for (int i = 0; i < this.NumberOfSerializeCalls; i++)
+        for (var i = 0; i < this.NumberOfSerializeCalls; i++)
         {
-            int cursor = 0;
+            var cursor = 0;
             foreach (var metric in this.metrics)
             {
                 cursor = PrometheusSerializer.WriteMetric(this.buffer, cursor, metric, this.GetPrometheusMetric(metric), openMetricsRequested: false, disableTimestamp: false);

--- a/test/Benchmarks/Exporter/ZipkinExporterBenchmarks.cs
+++ b/test/Benchmarks/Exporter/ZipkinExporterBenchmarks.cs
@@ -39,7 +39,7 @@ public class ZipkinExporterBenchmarks
         this.server = TestHttpServer.RunServer(
             (ctx) =>
             {
-                using (Stream receiveStream = ctx.Request.InputStream)
+                using (var receiveStream = ctx.Request.InputStream)
                 {
                     while (true)
                     {
@@ -74,9 +74,9 @@ public class ZipkinExporterBenchmarks
                 Endpoint = new Uri($"http://{this.serverHost}:{this.serverPort}"),
             });
 
-        for (int i = 0; i < this.NumberOfBatches; i++)
+        for (var i = 0; i < this.NumberOfBatches; i++)
         {
-            for (int c = 0; c < this.NumberOfSpans; c++)
+            for (var c = 0; c < this.NumberOfSpans; c++)
             {
                 this.activityBatch!.Add(this.activity!);
             }

--- a/test/Benchmarks/Helper/ActivityHelper.cs
+++ b/test/Benchmarks/Helper/ActivityHelper.cs
@@ -14,7 +14,7 @@ internal static class ActivityHelper
         var eventTimestamp = DateTime.UtcNow;
 
         var traceId = ActivityTraceId.CreateFromString("e8ea7e9ac72de94e91fabc613f9686b2".AsSpan());
-        var parentSpanId = ActivitySpanId.CreateFromBytes(new byte[] { 12, 23, 34, 45, 56, 67, 78, 89 });
+        var parentSpanId = ActivitySpanId.CreateFromBytes([12, 23, 34, 45, 56, 67, 78, 89]);
 
         var attributes = new Dictionary<string, object>
         {
@@ -28,20 +28,14 @@ internal static class ActivityHelper
 
         var events = new List<ActivityEvent>
         {
-            new ActivityEvent(
+            new(
                 "Event1",
                 eventTimestamp,
-                new ActivityTagsCollection(new Dictionary<string, object?>
-                {
-                    { "key", "value" },
-                })),
-            new ActivityEvent(
+                [new KeyValuePair<string, object?>("key", "value")]),
+            new(
                 "Event2",
                 eventTimestamp,
-                new ActivityTagsCollection(new Dictionary<string, object?>
-                {
-                    { "key", "value" },
-                })),
+                [new KeyValuePair<string, object?>("key", "value")]),
         };
 
         var linkedSpanId = ActivitySpanId.CreateFromString("888915b6286b9c41".AsSpan());
@@ -60,7 +54,7 @@ internal static class ActivityHelper
         using var listener = new ActivityListener()
         {
             ShouldListenTo = a => a.Name == nameof(CreateTestActivity),
-            Sample = (ref ActivityCreationOptions<ActivityContext> a) => ActivitySamplingResult.AllDataAndRecorded,
+            Sample = (ref a) => ActivitySamplingResult.AllDataAndRecorded,
         };
 
         ActivitySource.AddActivityListener(listener);

--- a/test/Benchmarks/Logs/LogScopeBenchmarks.cs
+++ b/test/Benchmarks/Logs/LogScopeBenchmarks.cs
@@ -25,7 +25,7 @@ public class LogScopeBenchmarks
 {
     private readonly LoggerExternalScopeProvider scopeProvider = new();
 
-    private readonly Action<LogRecordScope, object> callback = (LogRecordScope scope, object state) =>
+    private readonly Action<LogRecordScope, object> callback = (scope, state) =>
     {
         foreach (var scopeItem in scope)
         {

--- a/test/Benchmarks/Metrics/HistogramBenchmarks.cs
+++ b/test/Benchmarks/Metrics/HistogramBenchmarks.cs
@@ -66,7 +66,7 @@ public class HistogramBenchmarks
 
         // Evenly distribute the bound values over the range [0, MaxValue)
         this.bounds = new double[this.BoundCount];
-        for (int i = 0; i < this.bounds.Length; i++)
+        for (var i = 0; i < this.bounds.Length; i++)
         {
             this.bounds[i] = i * MaxValue / this.bounds.Length;
         }

--- a/test/Benchmarks/Trace/TraceBenchmarks.cs
+++ b/test/Benchmarks/Trace/TraceBenchmarks.cs
@@ -77,7 +77,7 @@ public class TraceBenchmarks
             ActivityStarted = null,
             ActivityStopped = null,
             ShouldListenTo = (activitySource) => activitySource.Name == this.sourceWithPropagationDataListner.Name,
-            Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.PropagationData,
+            Sample = (ref options) => ActivitySamplingResult.PropagationData,
         };
 
         ActivitySource.AddActivityListener(this.activityListenerPropagationData);
@@ -87,7 +87,7 @@ public class TraceBenchmarks
             ActivityStarted = null,
             ActivityStopped = null,
             ShouldListenTo = (activitySource) => activitySource.Name == this.sourceWithAllDataListner.Name,
-            Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData,
+            Sample = (ref options) => ActivitySamplingResult.AllData,
         };
 
         ActivitySource.AddActivityListener(this.activityListenerAllData);
@@ -97,7 +97,7 @@ public class TraceBenchmarks
             ActivityStarted = null,
             ActivityStopped = null,
             ShouldListenTo = (activitySource) => activitySource.Name == this.sourceWithAllDataAndRecordedListner.Name,
-            Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded,
+            Sample = (ref options) => ActivitySamplingResult.AllDataAndRecorded,
         };
 
         ActivitySource.AddActivityListener(this.activityListenerAllDataAndRecordedData);


### PR DESCRIPTION
## Changes

Cherry-pick fixes for new code analysis warnings identified by the .NET 11 preview 2 SDK in #6899.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
