### PR TITLE
[Zipkin] Fix new code analysis warnings

### DIFF
--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/PooledList.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/PooledList.cs
@@ -27,15 +27,10 @@ internal readonly struct PooledList<T> : IEnumerable<T>, ICollection
 
     object ICollection.SyncRoot => this;
 
-    public ref T this[int index]
-    {
-        get => ref this.buffer[index];
-    }
+    public ref T this[int index] => ref this.buffer[index];
 
     public static PooledList<T> Create()
-    {
-        return new PooledList<T>(ArrayPool<T>.Shared.Rent(LastAllocatedSize), 0);
-    }
+        => new(ArrayPool<T>.Shared.Rent(LastAllocatedSize), 0);
 
     public static void Add(ref PooledList<T> list, T item)
     {
@@ -60,9 +55,7 @@ internal readonly struct PooledList<T> : IEnumerable<T>, ICollection
     }
 
     public static void Clear(ref PooledList<T> list)
-    {
-        list = new PooledList<T>(list.buffer, 0);
-    }
+        => list = new PooledList<T>(list.buffer, 0);
 
     public void Return()
     {
@@ -74,24 +67,16 @@ internal readonly struct PooledList<T> : IEnumerable<T>, ICollection
     }
 
     void ICollection.CopyTo(Array array, int index)
-    {
-        Array.Copy(this.buffer, 0, array, index, this.Count);
-    }
+        => Array.Copy(this.buffer, 0, array, index, this.Count);
 
     public Enumerator GetEnumerator()
-    {
-        return new Enumerator(in this);
-    }
+        => new(in this);
 
     IEnumerator<T> IEnumerable<T>.GetEnumerator()
-    {
-        return new Enumerator(in this);
-    }
+        => new Enumerator(in this);
 
     IEnumerator IEnumerable.GetEnumerator()
-    {
-        return new Enumerator(in this);
-    }
+        => new Enumerator(in this);
 
     public struct Enumerator : IEnumerator<T>, IEnumerator
     {
@@ -109,11 +94,11 @@ internal readonly struct PooledList<T> : IEnumerable<T>, ICollection
             this.current = default;
         }
 
-        public T Current => this.current;
+        public readonly T Current => this.current;
 
-        object? IEnumerator.Current => this.Current;
+        readonly object? IEnumerator.Current => this.Current;
 
-        public void Dispose()
+        public readonly void Dispose()
         {
         }
 

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinActivityConversionExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinActivityConversionExtensions.cs
@@ -20,14 +20,14 @@ internal static class ZipkinActivityConversionExtensions
     internal static ZipkinSpan ToZipkinSpan(this Activity activity, ZipkinEndpoint localEndpoint, bool useShortTraceIds = false)
     {
         var context = activity.Context;
-        string? parentId = activity.ParentSpanId == default ? null : EncodeSpanId(activity.ParentSpanId);
+        var parentId = activity.ParentSpanId == default ? null : EncodeSpanId(activity.ParentSpanId);
 
         var tags = PooledList<KeyValuePair<string, object?>>.Create();
         ExtractActivityTags(activity, ref tags);
         ExtractActivityStatus(activity, ref tags);
         ExtractActivitySource(activity, ref tags);
 
-        ZipkinEndpoint? remoteEndpoint = ExtractRemoteEndpoint(activity);
+        var remoteEndpoint = ExtractRemoteEndpoint(activity);
         var annotations = ExtractActivityEvents(activity);
 
         return new ZipkinSpan(
@@ -47,28 +47,24 @@ internal static class ZipkinActivityConversionExtensions
     }
 
     internal static string EncodeSpanId(ActivitySpanId spanId)
-    {
-        return spanId.ToHexString();
-    }
+        => spanId.ToHexString();
 
     internal static long ToEpochMicroseconds(this DateTimeOffset dateTimeOffset)
     {
         // Truncate sub-microsecond precision before offsetting by the Unix Epoch to avoid
         // the last digit being off by one for dates that result in negative Unix times
-        long microseconds = dateTimeOffset.Ticks / TicksPerMicrosecond;
+        var microseconds = dateTimeOffset.Ticks / TicksPerMicrosecond;
         return microseconds - UnixEpochMicroseconds;
     }
 
     internal static long ToEpochMicroseconds(this TimeSpan timeSpan)
-    {
-        return timeSpan.Ticks / TicksPerMicrosecond;
-    }
+        => timeSpan.Ticks / TicksPerMicrosecond;
 
     internal static long ToEpochMicroseconds(this DateTime utcDateTime)
     {
         // Truncate sub-microsecond precision before offsetting by the Unix Epoch to avoid
         // the last digit being off by one for dates that result in negative Unix times
-        long microseconds = utcDateTime.Ticks / TicksPerMicrosecond;
+        var microseconds = utcDateTime.Ticks / TicksPerMicrosecond;
         return microseconds - UnixEpochMicroseconds;
     }
 
@@ -84,31 +80,26 @@ internal static class ZipkinActivityConversionExtensions
         return id;
     }
 
-    private static string? ToActivityKind(Activity activity)
+    private static string? ToActivityKind(Activity activity) => activity.Kind switch
     {
-        return activity.Kind switch
-        {
-            ActivityKind.Server => "SERVER",
-            ActivityKind.Producer => "PRODUCER",
-            ActivityKind.Consumer => "CONSUMER",
-            ActivityKind.Client => "CLIENT",
-            _ => null,
-        };
-    }
+        ActivityKind.Server => "SERVER",
+        ActivityKind.Producer => "PRODUCER",
+        ActivityKind.Consumer => "CONSUMER",
+        ActivityKind.Client => "CLIENT",
+        ActivityKind.Internal or _ => null,
+    };
 
     private static string ExtractStatusDescription(Activity activity)
-    {
-        return activity.StatusDescription
-               ?? activity.GetTagItem(SpanAttributeConstants.StatusDescriptionKey) as string
-               ?? activity.GetTagItem(ZipkinErrorFlagTagName) as string
-               ?? string.Empty;
-    }
+        => activity.StatusDescription
+           ?? activity.GetTagItem(SpanAttributeConstants.StatusDescriptionKey) as string
+           ?? activity.GetTagItem(ZipkinErrorFlagTagName) as string
+           ?? string.Empty;
 
     private static void ExtractActivityTags(Activity activity, ref PooledList<KeyValuePair<string, object?>> tags)
     {
         foreach (ref readonly var tag in activity.EnumerateTagObjects())
         {
-            if (tag.Key != ZipkinErrorFlagTagName && tag.Key != SpanAttributeConstants.StatusCodeKey)
+            if (tag.Key is not ZipkinErrorFlagTagName and not SpanAttributeConstants.StatusCodeKey)
             {
                 PooledList<KeyValuePair<string, object?>>.Add(ref tags, tag);
             }
@@ -133,7 +124,7 @@ internal static class ZipkinActivityConversionExtensions
             // activity.Status is Error
             else
             {
-                string statusDescription = ExtractStatusDescription(activity);
+                var statusDescription = ExtractStatusDescription(activity);
                 PooledList<KeyValuePair<string, object?>>.Add(
                     ref tags,
                     new KeyValuePair<string, object?>(
@@ -164,7 +155,7 @@ internal static class ZipkinActivityConversionExtensions
                 }
                 else if (status == "ERROR")
                 {
-                    string statusDescription = ExtractStatusDescription(activity);
+                    var statusDescription = ExtractStatusDescription(activity);
 
                     activity.SetStatus(ActivityStatusCode.Error);
 
@@ -206,7 +197,7 @@ internal static class ZipkinActivityConversionExtensions
 
     private static ZipkinEndpoint? ExtractRemoteEndpoint(Activity activity)
     {
-        if (activity.Kind != ActivityKind.Client && activity.Kind != ActivityKind.Producer)
+        if (activity.Kind is not ActivityKind.Client and not ActivityKind.Producer)
         {
             return null;
         }
@@ -222,7 +213,7 @@ internal static class ZipkinActivityConversionExtensions
             return null;
         }
 
-        string? remoteEndpoint = activity.GetTagItem(SemanticConventions.AttributePeerService) as string;
+        var remoteEndpoint = activity.GetTagItem(SemanticConventions.AttributePeerService) as string;
         var endpoint = TryCreateEndpoint(remoteEndpoint);
         if (endpoint != null)
         {
@@ -244,8 +235,7 @@ internal static class ZipkinActivityConversionExtensions
         }
 
         var peerAddress = activity.GetTagItem(SemanticConventions.AttributeNetworkPeerAddress) as string;
-        var peerPort = activity.GetTagItem(SemanticConventions.AttributeNetworkPeerPort) as string;
-        remoteEndpoint = peerPort != null ? $"{peerAddress}:{peerPort}" : peerAddress;
+        remoteEndpoint = activity.GetTagItem(SemanticConventions.AttributeNetworkPeerPort) is string peerPort ? $"{peerAddress}:{peerPort}" : peerAddress;
         endpoint = TryCreateEndpoint(remoteEndpoint);
         if (endpoint != null)
         {
@@ -260,8 +250,7 @@ internal static class ZipkinActivityConversionExtensions
         }
 
         var serverAddress = activity.GetTagItem(SemanticConventions.AttributeServerSocketAddress) as string;
-        var serverPort = activity.GetTagItem(SemanticConventions.AttributeServerSocketPort) as string;
-        remoteEndpoint = serverPort != null ? $"{serverAddress}:{serverPort}" : serverAddress;
+        remoteEndpoint = activity.GetTagItem(SemanticConventions.AttributeServerSocketPort) is string serverPort ? $"{serverAddress}:{serverPort}" : serverAddress;
         endpoint = TryCreateEndpoint(remoteEndpoint);
         if (endpoint != null)
         {
@@ -276,8 +265,7 @@ internal static class ZipkinActivityConversionExtensions
         }
 
         var socketAddress = activity.GetTagItem(SemanticConventions.AttributeNetSockPeerAddr) as string;
-        var socketPort = activity.GetTagItem(SemanticConventions.AttributeNetSockPeerPort) as string;
-        remoteEndpoint = socketPort != null ? $"{socketAddress}:{socketPort}" : socketAddress;
+        remoteEndpoint = activity.GetTagItem(SemanticConventions.AttributeNetSockPeerPort) is string socketPort ? $"{socketAddress}:{socketPort}" : socketAddress;
         endpoint = TryCreateEndpoint(remoteEndpoint);
         if (endpoint != null)
         {
@@ -300,12 +288,7 @@ internal static class ZipkinActivityConversionExtensions
 
         remoteEndpoint = activity.GetTagItem(SemanticConventions.AttributeDbName) as string;
         endpoint = TryCreateEndpoint(remoteEndpoint);
-        if (endpoint != null)
-        {
-            return endpoint;
-        }
-
-        return null;
+        return endpoint ?? null;
     }
 
     private static PooledList<ZipkinAnnotation> ExtractActivityEvents(Activity activity)

--- a/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinTagWriter.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/Implementation/ZipkinTagWriter.cs
@@ -21,7 +21,7 @@ internal sealed class ZipkinTagWriter : JsonStringArrayTagWriter<Utf8JsonWriter>
     protected override void WriteIntegralTag(ref Utf8JsonWriter writer, string key, long value)
     {
         Span<byte> destination = stackalloc byte[StackallocByteThreshold];
-        if (Utf8Formatter.TryFormat(value, destination, out int bytesWritten))
+        if (Utf8Formatter.TryFormat(value, destination, out var bytesWritten))
         {
             writer.WriteString(key, destination.Slice(0, bytesWritten));
         }
@@ -34,7 +34,7 @@ internal sealed class ZipkinTagWriter : JsonStringArrayTagWriter<Utf8JsonWriter>
     protected override void WriteFloatingPointTag(ref Utf8JsonWriter writer, string key, double value)
     {
         Span<byte> destination = stackalloc byte[StackallocByteThreshold];
-        if (Utf8Formatter.TryFormat(value, destination, out int bytesWritten))
+        if (Utf8Formatter.TryFormat(value, destination, out var bytesWritten))
         {
             writer.WriteString(key, destination.Slice(0, bytesWritten));
         }

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporter.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporter.cs
@@ -108,8 +108,10 @@ public class ZipkinExporter : BaseExporter<Activity>
         string? ipv6 = null;
         if (!string.IsNullOrEmpty(hostName))
         {
+#pragma warning disable IDE0370 // Remove unnecessary suppression
             ipv4 = ResolveHostAddress(hostName!, AddressFamily.InterNetwork);
             ipv6 = ResolveHostAddress(hostName!, AddressFamily.InterNetworkV6);
+#pragma warning restore IDE0370 // Remove unnecessary suppression
         }
 
         string? serviceName = null;
@@ -124,8 +126,8 @@ public class ZipkinExporter : BaseExporter<Activity>
 
         if (string.IsNullOrEmpty(serviceName))
         {
-            serviceName = (string)this.ParentProvider.GetDefaultResource().Attributes.Where(
-                pair => pair.Key == ResourceSemanticConventions.AttributeServiceName).FirstOrDefault().Value;
+            serviceName = (string)this.ParentProvider.GetDefaultResource().Attributes.FirstOrDefault(
+                pair => pair.Key == ResourceSemanticConventions.AttributeServiceName).Value;
         }
 
         this.LocalEndpoint = new ZipkinEndpoint(

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporterHelperExtensions.cs
@@ -83,13 +83,13 @@ public static class ZipkinExporterHelperExtensions
         {
             options.HttpClientFactory = () =>
             {
-                Type? httpClientFactoryType = Type.GetType("System.Net.Http.IHttpClientFactory, Microsoft.Extensions.Http", throwOnError: false);
+                var httpClientFactoryType = Type.GetType("System.Net.Http.IHttpClientFactory, Microsoft.Extensions.Http", throwOnError: false);
                 if (httpClientFactoryType != null)
                 {
-                    object? httpClientFactory = serviceProvider.GetService(httpClientFactoryType);
+                    var httpClientFactory = serviceProvider.GetService(httpClientFactoryType);
                     if (httpClientFactory != null)
                     {
-                        MethodInfo? createClientMethod = httpClientFactoryType.GetMethod(
+                        var createClientMethod = httpClientFactoryType.GetMethod(
                             "CreateClient",
                             BindingFlags.Public | BindingFlags.Instance,
                             binder: null,

--- a/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.Zipkin/ZipkinExporterOptions.cs
@@ -38,22 +38,19 @@ public sealed class ZipkinExporterOptions
         IConfiguration configuration,
         BatchExportActivityProcessorOptions defaultBatchOptions)
     {
-        Debug.Assert(configuration != null, "configuration was null");
-        Debug.Assert(defaultBatchOptions != null, "defaultBatchOptions was null");
-
-        if (configuration!.TryGetUriValue(ZipkinExporterEventSource.Log, ZipkinEndpointEnvVar, out var endpoint))
+        if (configuration.TryGetUriValue(ZipkinExporterEventSource.Log, ZipkinEndpointEnvVar, out var endpoint))
         {
             this.Endpoint = endpoint;
         }
 
-        this.BatchExportProcessorOptions = defaultBatchOptions!;
+        this.BatchExportProcessorOptions = defaultBatchOptions;
     }
 
     /// <summary>
     /// Gets or sets Zipkin endpoint address. See https://zipkin.io/zipkin-api/#/default/post_spans.
     /// Typically https://zipkin-server-name:9411/api/v2/spans.
     /// </summary>
-    public Uri Endpoint { get; set; } = new Uri(DefaultZipkinEndpoint);
+    public Uri Endpoint { get; set; } = new(DefaultZipkinEndpoint);
 
     /// <summary>
     /// Gets or sets a value indicating whether short trace id should be used.

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/Implementation/ZipkinActivityConversionTests.cs
@@ -31,7 +31,7 @@ public class ZipkinActivityConversionTests
         Assert.Equal(activity.StartTimeUtc.ToEpochMicroseconds(), zipkinSpan.Timestamp);
         Assert.Equal((long)(activity.Duration.TotalMilliseconds * 1000), zipkinSpan.Duration);
 
-        int counter = 0;
+        var counter = 0;
         var tagsArray = zipkinSpan.Tags.ToArray();
 
         foreach (var tags in activity.TagObjects)
@@ -61,7 +61,7 @@ public class ZipkinActivityConversionTests
         Assert.Equal(activity.TraceId.ToHexString(), zipkinSpan.TraceId);
         Assert.Equal(activity.SpanId.ToHexString(), zipkinSpan.Id);
 
-        int counter = 0;
+        var counter = 0;
         var tagsArray = zipkinSpan.Tags.ToArray();
 
         foreach (var tags in activity.TagObjects)

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/PooledListTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/PooledListTests.cs
@@ -51,7 +51,7 @@ public class PooledListTests
         // The Add() method has a condition to double the size of the buffer
         // when the Count exceeds the buffer size.
         // This for loop is meant to trigger that condition.
-        for (int i = 0; i <= size; i++)
+        for (var i = 0; i <= size; i++)
         {
             PooledList<int>.Add(ref pooledList, i);
         }

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinActivitySource.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinActivitySource.cs
@@ -26,7 +26,7 @@ internal static class ZipkinActivitySource
         using var activityListener = new ActivityListener
         {
             ShouldListenTo = _ => true,
-            Sample = (ref ActivityCreationOptions<ActivityContext> options) => options.Parent.TraceFlags.HasFlag(ActivityTraceFlags.Recorded)
+            Sample = (ref options) => options.Parent.TraceFlags.HasFlag(ActivityTraceFlags.Recorded)
                 ? ActivitySamplingResult.AllDataAndRecorded
                 : ActivitySamplingResult.AllData,
         };
@@ -72,17 +72,11 @@ internal static class ZipkinActivitySource
             new(
                 "Event1",
                 eventTimestamp,
-                new(new Dictionary<string, object?>
-                {
-                    { "key", "value" },
-                })),
+                [new KeyValuePair<string, object?>("key", "value")]),
             new(
                 "Event2",
                 eventTimestamp,
-                new(new Dictionary<string, object?>
-                {
-                    { "key", "value" },
-                })),
+                [new KeyValuePair<string, object?>("key", "value")]),
         };
 
         var linkedSpanId = ActivitySpanId.CreateFromString("888915b6286b9c41".AsSpan());
@@ -106,7 +100,7 @@ internal static class ZipkinActivitySource
             parentContext: new(traceId, parentSpanId, ActivityTraceFlags.Recorded),
             tags,
             links,
-            startTime: startTimestamp)!;
+            startTime: startTimestamp);
 
         Assert.NotNull(activity);
 

--- a/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.Zipkin.Tests/ZipkinExporterTests.cs
@@ -37,7 +37,7 @@ public sealed class ZipkinExporterTests : IDisposable
     public ZipkinExporterTests()
     {
         this.testServer = TestHttpServer.RunServer(
-            ctx => ProcessServerRequest(ctx),
+            ProcessServerRequest,
             out this.testServerHost,
             out this.testServerPort);
 
@@ -47,7 +47,7 @@ public sealed class ZipkinExporterTests : IDisposable
 
             using StreamReader readStream = new(context.Request.InputStream);
 
-            string requestContent = readStream.ReadToEnd();
+            var requestContent = readStream.ReadToEnd();
 
             Responses.TryAdd(
                 Guid.Parse(context.Request.QueryString["requestId"]!),
@@ -58,15 +58,13 @@ public sealed class ZipkinExporterTests : IDisposable
     }
 
     public void Dispose()
-    {
-        this.testServer.Dispose();
-    }
+        => this.testServer.Dispose();
 
     [Fact]
     public void AddAddZipkinExporterNamedOptionsSupported()
     {
-        int defaultExporterOptionsConfigureOptionsInvocations = 0;
-        int namedExporterOptionsConfigureOptionsInvocations = 0;
+        var defaultExporterOptionsConfigureOptionsInvocations = 0;
+        var namedExporterOptionsConfigureOptionsInvocations = 0;
 
         using var tracerProvider = Sdk.CreateTracerProviderBuilder()
             .ConfigureServices(services =>
@@ -94,12 +92,12 @@ public sealed class ZipkinExporterTests : IDisposable
     public void SuppressesInstrumentation()
     {
         const string activitySourceName = "zipkin.test";
-        Guid requestId = Guid.NewGuid();
+        var requestId = Guid.NewGuid();
 #pragma warning disable CA2000 // Dispose objects before losing scope
         TestActivityProcessor testActivityProcessor = new();
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
-        int endCalledCount = 0;
+        var endCalledCount = 0;
 
         testActivityProcessor.EndAction =
             (a) =>
@@ -213,7 +211,7 @@ public sealed class ZipkinExporterTests : IDisposable
 
         var defaultFactory = options.HttpClientFactory;
 
-        int invocations = 0;
+        var invocations = 0;
         options.HttpClientFactory = () =>
         {
             invocations++;
@@ -260,7 +258,7 @@ public sealed class ZipkinExporterTests : IDisposable
 
         services.AddHttpClient();
 
-        int invocations = 0;
+        var invocations = 0;
 
         services.AddHttpClient("ZipkinExporter", configureClient: (client) => invocations++);
 
@@ -329,7 +327,7 @@ public sealed class ZipkinExporterTests : IDisposable
         string? statusDescription = null,
         bool addErrorTag = false)
     {
-        Guid requestId = Guid.NewGuid();
+        var requestId = Guid.NewGuid();
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
         ZipkinExporter exporter = new(
@@ -399,7 +397,7 @@ public sealed class ZipkinExporterTests : IDisposable
         var traceId = useShortTraceIds ? TraceId.Substring(TraceId.Length - 16, 16) : TraceId;
 
         string statusTag;
-        string errorTag = string.Empty;
+        var errorTag = string.Empty;
         switch (statusCode)
         {
             case ActivityStatusCode.Ok:


### PR DESCRIPTION
## Changes

Cherry-pick fixes for new code analysis warnings identified by the .NET 11 preview 2 SDK in #6899.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~

