### PR TITLE
[Prometheus] Fix new code analysis warnings

### DIFF
--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusCollectionManager.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusCollectionManager.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using OpenTelemetry.Metrics;
 
@@ -132,12 +131,8 @@ internal sealed class PrometheusCollectionManager
         try
         {
             this.collectionRunning = false;
-
-            if (this.collectionTcs != null)
-            {
-                this.collectionTcs.SetResult(response);
-                this.collectionTcs = null;
-            }
+            this.collectionTcs?.SetResult(response);
+            this.collectionTcs = null;
         }
         finally
         {
@@ -153,9 +148,7 @@ internal sealed class PrometheusCollectionManager
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void ExitCollect()
-    {
-        Interlocked.Decrement(ref this.readerCount);
-    }
+        => Interlocked.Decrement(ref this.readerCount);
 
     private static bool IncreaseBufferSize(ref byte[] buffer)
     {
@@ -191,9 +184,7 @@ internal sealed class PrometheusCollectionManager
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void ExitGlobalLock()
-    {
-        Interlocked.Exchange(ref this.globalLockState, 0);
-    }
+        => Interlocked.Exchange(ref this.globalLockState, 0);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void WaitForReadersToComplete()
@@ -214,8 +205,6 @@ internal sealed class PrometheusCollectionManager
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool ExecuteCollect(bool openMetricsRequested)
     {
-        Debug.Assert(this.exporter.Collect != null, "this.exporter.Collect was null");
-
         this.exporter.OnExport = this.onCollectRef;
         this.exporter.OpenMetricsRequested = openMetricsRequested;
         var result = this.exporter.Collect!(Timeout.Infinite);
@@ -226,7 +215,7 @@ internal sealed class PrometheusCollectionManager
     private ExportResult OnCollect(in Batch<Metric> metrics)
     {
         var cursor = 0;
-        ref byte[] buffer = ref (this.exporter.OpenMetricsRequested ? ref this.openMetricsBuffer : ref this.plainTextBuffer);
+        ref var buffer = ref (this.exporter.OpenMetricsRequested ? ref this.openMetricsBuffer : ref this.plainTextBuffer);
 
         try
         {

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusExporter.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusExporter.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Diagnostics;
 using OpenTelemetry.Internal;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
@@ -14,7 +13,6 @@ namespace OpenTelemetry.Exporter.Prometheus;
 [ExportModes(ExportModes.Pull)]
 internal sealed class PrometheusExporter : BaseExporter<Metric>, IPullMetricExporter
 {
-    private Resource? resource;
     private bool disposed;
 
     /// <summary>
@@ -53,15 +51,15 @@ internal sealed class PrometheusExporter : BaseExporter<Metric>, IPullMetricExpo
 
     internal bool DisableTimestamp { get; set; }
 
-    internal Resource Resource => this.resource ??= this.ParentProvider.GetResource();
+    internal Resource Resource
+    {
+        get => field ??= this.ParentProvider.GetResource();
+        private set;
+    }
 
     /// <inheritdoc/>
     public override ExportResult Export(in Batch<Metric> metrics)
-    {
-        Debug.Assert(this.OnExport != null, "this.OnExport was null");
-
-        return this.OnExport!(in metrics);
-    }
+        => this.OnExport!(in metrics);
 
     /// <inheritdoc/>
     protected override void Dispose(bool disposing)

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusMetric.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusMetric.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using OpenTelemetry.Metrics;
@@ -114,7 +113,10 @@ internal sealed class PrometheusMetric
 
         return sb?.ToString() ?? metricName;
 
-        static StringBuilder CreateStringBuilder(string name) => new(name.Length);
+        static StringBuilder CreateStringBuilder(string name)
+        {
+            return new(name.Length);
+        }
     }
 
     internal static string RemoveAnnotations(string unit)
@@ -157,8 +159,6 @@ internal sealed class PrometheusMetric
             return unit;
         }
 
-        Debug.Assert(sb != null, "sb was null");
-
         sb!.Append(unit, lastWriteIndex, unit.Length - lastWriteIndex);
 
         return sb.ToString();
@@ -166,7 +166,7 @@ internal sealed class PrometheusMetric
 
     internal static PrometheusType GetPrometheusType(MetricType openTelemetryMetricType)
     {
-        int metricType = (int)openTelemetryMetricType >> 4;
+        var metricType = (int)openTelemetryMetricType >> 4;
 
         /* Counter becomes counter
            Gauge becomes gauge
@@ -215,7 +215,7 @@ internal sealed class PrometheusMetric
     {
         updatedPerUnit = null;
 
-        for (int i = 0; i < updatedUnit.Length; i++)
+        for (var i = 0; i < updatedUnit.Length; i++)
         {
             if (updatedUnit[i] == '/')
             {

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializer.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/PrometheusSerializer.cs
@@ -32,7 +32,7 @@ internal static partial class PrometheusSerializer
             var result = value.TryFormat(span, out var cchWritten, "G", CultureInfo.InvariantCulture);
             Debug.Assert(result, $"{nameof(result)} should be true.");
 
-            for (int i = 0; i < cchWritten; i++)
+            for (var i = 0; i < cchWritten; i++)
             {
                 buffer[cursor++] = unchecked((byte)span[i]);
             }
@@ -66,7 +66,7 @@ internal static partial class PrometheusSerializer
         var result = value.TryFormat(span, out var cchWritten, "G", CultureInfo.InvariantCulture);
         Debug.Assert(result, $"{nameof(result)} should be true.");
 
-        for (int i = 0; i < cchWritten; i++)
+        for (var i = 0; i < cchWritten; i++)
         {
             buffer[cursor++] = unchecked((byte)span[i]);
         }
@@ -80,7 +80,7 @@ internal static partial class PrometheusSerializer
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int WriteAsciiStringNoEscape(byte[] buffer, int cursor, string value)
     {
-        for (int i = 0; i < value.Length; i++)
+        for (var i = 0; i < value.Length; i++)
         {
             buffer[cursor++] = unchecked((byte)value[i]);
         }
@@ -114,7 +114,7 @@ internal static partial class PrometheusSerializer
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int WriteUnicodeString(byte[] buffer, int cursor, string value)
     {
-        for (int i = 0; i < value.Length; i++)
+        for (var i = 0; i < value.Length; i++)
         {
             var ordinal = (ushort)value[i];
             switch (ordinal)
@@ -143,25 +143,21 @@ internal static partial class PrometheusSerializer
 
         var ordinal = (ushort)value[0];
 
-        if (ordinal >= (ushort)'0' && ordinal <= (ushort)'9')
+        if (ordinal is >= '0' and <= '9')
         {
             buffer[cursor++] = unchecked((byte)'_');
         }
 
-        for (int i = 0; i < value.Length; i++)
+        for (var i = 0; i < value.Length; i++)
         {
-            ordinal = (ushort)value[i];
+            ordinal = value[i];
 
-            if ((ordinal >= (ushort)'A' && ordinal <= (ushort)'Z') ||
-                (ordinal >= (ushort)'a' && ordinal <= (ushort)'z') ||
-                (ordinal >= (ushort)'0' && ordinal <= (ushort)'9'))
-            {
-                buffer[cursor++] = unchecked((byte)ordinal);
-            }
-            else
-            {
-                buffer[cursor++] = unchecked((byte)'_');
-            }
+            buffer[cursor++] =
+                ordinal is (>= 'A' and <= 'Z') or
+                (>= 'a' and <= 'z') or
+                (>= '0' and <= '9')
+                ? (byte)ordinal
+                : (byte)'_';
         }
 
         return cursor;
@@ -170,9 +166,7 @@ internal static partial class PrometheusSerializer
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int WriteLabelValue(byte[] buffer, int cursor, string value)
     {
-        Debug.Assert(value != null, $"{nameof(value)} should not be null.");
-
-        for (int i = 0; i < value!.Length; i++)
+        for (var i = 0; i < value.Length; i++)
         {
             var ordinal = (ushort)value[i];
             switch (ordinal)
@@ -215,12 +209,7 @@ internal static partial class PrometheusSerializer
         {
             // TODO: Attribute values should be written as their JSON representation. Extra logic may need to be added here to correctly convert other .NET types.
             // More detail: https://github.com/open-telemetry/opentelemetry-dotnet/issues/4822#issuecomment-1707328495
-            if (labelValue is bool b)
-            {
-                return b ? "true" : "false";
-            }
-
-            return labelValue?.ToString() ?? string.Empty;
+            return labelValue is bool b ? b ? "true" : "false" : labelValue?.ToString() ?? string.Empty;
         }
     }
 
@@ -232,7 +221,7 @@ internal static partial class PrometheusSerializer
 
         Debug.Assert(!string.IsNullOrWhiteSpace(name), "name was null or whitespace");
 
-        for (int i = 0; i < name.Length; i++)
+        for (var i = 0; i < name.Length; i++)
         {
             var ordinal = (ushort)name[i];
             buffer[cursor++] = unchecked((byte)ordinal);
@@ -249,7 +238,7 @@ internal static partial class PrometheusSerializer
 
         Debug.Assert(!string.IsNullOrWhiteSpace(name), "name was null or whitespace");
 
-        for (int i = 0; i < name.Length; i++)
+        for (var i = 0; i < name.Length; i++)
         {
             var ordinal = (ushort)name[i];
             buffer[cursor++] = unchecked((byte)ordinal);
@@ -320,7 +309,9 @@ internal static partial class PrometheusSerializer
         buffer[cursor++] = unchecked((byte)' ');
 
         // Unit name has already been escaped.
-        for (int i = 0; i < metric.Unit!.Length; i++)
+#pragma warning disable IDE0370 // Remove unnecessary suppression
+        for (var i = 0; i < metric.Unit!.Length; i++)
+#pragma warning restore IDE0370 // Remove unnecessary suppression
         {
             var ordinal = (ushort)metric.Unit[i];
             buffer[cursor++] = unchecked((byte)ordinal);
@@ -364,7 +355,7 @@ internal static partial class PrometheusSerializer
             cursor = WriteLong(buffer, cursor, value / 1000);
             buffer[cursor++] = unchecked((byte)'.');
 
-            long millis = value % 1000;
+            var millis = value % 1000;
 
             if (millis < 100)
             {
@@ -456,15 +447,12 @@ internal static partial class PrometheusSerializer
         return cursor;
     }
 
-    private static string MapPrometheusType(PrometheusType type)
+    private static string MapPrometheusType(PrometheusType type) => type switch
     {
-        return type switch
-        {
-            PrometheusType.Gauge => "gauge",
-            PrometheusType.Counter => "counter",
-            PrometheusType.Summary => "summary",
-            PrometheusType.Histogram => "histogram",
-            _ => "untyped",
-        };
-    }
+        PrometheusType.Gauge => "gauge",
+        PrometheusType.Counter => "counter",
+        PrometheusType.Summary => "summary",
+        PrometheusType.Histogram => "histogram",
+        PrometheusType.Untyped or _ => "untyped",
+    };
 }

--- a/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
+++ b/src/OpenTelemetry.Exporter.Prometheus.HttpListener/PrometheusHttpListener.cs
@@ -28,7 +28,7 @@ internal sealed class PrometheusHttpListener : IDisposable
 
         this.exporter = exporter;
 
-        string path = options.ScrapeEndpointPath ?? PrometheusHttpListenerOptions.DefaultScrapeEndpointPath;
+        var path = options.ScrapeEndpointPath ?? PrometheusHttpListenerOptions.DefaultScrapeEndpointPath;
 
 #if NET
         if (!path.StartsWith('/'))
@@ -48,7 +48,7 @@ internal sealed class PrometheusHttpListener : IDisposable
             path = $"{path}/";
         }
 
-        foreach (string uriPrefix in options.UriPrefixes)
+        foreach (var uriPrefix in options.UriPrefixes)
         {
             this.httpListener.Prefixes.Add($"{uriPrefix.TrimEnd('/')}{path}");
         }

--- a/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMeterProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMeterProviderBuilderExtensionsTests.cs
@@ -12,8 +12,8 @@ public sealed class PrometheusExporterMeterProviderBuilderExtensionsTests
     [Fact]
     public void TestAddPrometheusExporter_NamedOptions()
     {
-        int defaultExporterOptionsConfigureOptionsInvocations = 0;
-        int namedExporterOptionsConfigureOptionsInvocations = 0;
+        var defaultExporterOptionsConfigureOptionsInvocations = 0;
+        var namedExporterOptionsConfigureOptionsInvocations = 0;
 
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
             .ConfigureServices(services =>

--- a/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMiddlewareTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.AspNetCore.Tests/PrometheusExporterMiddlewareTests.cs
@@ -117,7 +117,7 @@ public sealed class PrometheusExporterMiddlewareTests
             services => services.Configure<PrometheusAspNetCoreOptions>(o => o.ScrapeEndpointPath = "/metrics_options"),
             validateResponse: rsp =>
             {
-                if (!rsp.Headers.TryGetValues("X-MiddlewareExecuted", out IEnumerable<string>? headers))
+                if (!rsp.Headers.TryGetValues("X-MiddlewareExecuted", out var headers))
                 {
                     headers = [];
                 }
@@ -144,7 +144,7 @@ public sealed class PrometheusExporterMiddlewareTests
             services => services.Configure<PrometheusAspNetCoreOptions>(o => o.ScrapeEndpointPath = "/metrics_options"),
             validateResponse: rsp =>
             {
-                if (!rsp.Headers.TryGetValues("X-MiddlewareExecuted", out IEnumerable<string>? headers))
+                if (!rsp.Headers.TryGetValues("X-MiddlewareExecuted", out var headers))
                 {
                     headers = [];
                 }
@@ -156,7 +156,7 @@ public sealed class PrometheusExporterMiddlewareTests
     [Fact]
     public async Task PrometheusExporterMiddlewareIntegration_MeterProvider()
     {
-        using MeterProvider meterProvider = Sdk.CreateMeterProviderBuilder()
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
             .AddMeter(MeterName)
             .ConfigureResource(x => x.Clear().AddService("my_service", serviceInstanceId: "id1"))
             .AddPrometheusExporter()
@@ -220,7 +220,7 @@ public sealed class PrometheusExporterMiddlewareTests
     [Fact]
     public async Task PrometheusExporterMiddlewareIntegration_MapEndpoint_WithMeterProvider()
     {
-        using MeterProvider meterProvider = Sdk.CreateMeterProviderBuilder()
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
             .AddMeter(MeterName)
             .ConfigureResource(x => x.Clear().AddService("my_service", serviceInstanceId: "id1"))
             .AddPrometheusExporter()
@@ -445,11 +445,11 @@ public sealed class PrometheusExporterMiddlewareTests
             ? $"{string.Join(",", meterTags.Select(x => $"{x.Key}=\"{x.Value}\""))},"
             : string.Empty;
 
-        string content = (await response.Content.ReadAsStringAsync()).ReplaceLineEndings();
+        var content = (await response.Content.ReadAsStringAsync()).ReplaceLineEndings();
 
         var timestampPart = disableTimestamp ? string.Empty : " (\\d+)";
         var timestampPartOpenMetrics = disableTimestamp ? string.Empty : " (\\d+\\.\\d{3})";
-        string expected = requestOpenMetrics
+        var expected = requestOpenMetrics
             ? $$"""
                     # TYPE target info
                     # HELP target Target metadata

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusCollectionManagerTests.cs
@@ -22,7 +22,7 @@ public sealed class PrometheusCollectionManagerTests
         var testTimeout = TimeSpan.FromMinutes(1);
         using var cts = new CancellationTokenSource(testTimeout);
 
-        bool cacheEnabled = scrapeResponseCacheDurationMilliseconds != 0;
+        var cacheEnabled = scrapeResponseCacheDurationMilliseconds != 0;
         using var meter = new Meter(Utils.GetCurrentMethodName());
 
         using (var provider = Sdk.CreateMeterProviderBuilder()
@@ -41,11 +41,11 @@ public sealed class PrometheusCollectionManagerTests
                 throw new InvalidOperationException("PrometheusExporter could not be found on MeterProvider.");
             }
 
-            int runningCollectCount = 0;
+            var runningCollectCount = 0;
             var collectFunc = exporter.Collect;
             exporter.Collect = (timeout) =>
             {
-                bool result = collectFunc!(timeout);
+                var result = collectFunc!(timeout);
                 runningCollectCount++;
 
                 cts.Token.ThrowIfCancellationRequested();
@@ -114,9 +114,9 @@ public sealed class PrometheusCollectionManagerTests
                 return [.. bag.Select((r) => Task.FromResult(r))];
 #else
 
-                Task<Response>[] tasks = new Task<Response>[parallelism];
+                var tasks = new Task<Response>[parallelism];
 
-                for (int i = 0; i < tasks.Length; i++)
+                for (var i = 0; i < tasks.Length; i++)
                 {
                     tasks[i] = Task.Run(() => CollectAsync(advanceClock), cts.Token);
                 }
@@ -140,7 +140,7 @@ public sealed class PrometheusCollectionManagerTests
 
             Assert.False(firstResponse.CollectionResponse.FromCache, "Response was served from the cache.");
 
-            for (int i = 1; i < collectTasks.Length; i++)
+            for (var i = 1; i < collectTasks.Length; i++)
             {
                 var response = await collectTasks[i];
 
@@ -195,7 +195,7 @@ public sealed class PrometheusCollectionManagerTests
 
             Assert.False(firstResponse.CollectionResponse.FromCache, "Response was served from the cache.");
 
-            for (int i = 1; i < collectTasks.Length; i++)
+            for (var i = 1; i < collectTasks.Length; i++)
             {
                 var response = await collectTasks[i];
 

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerMeterProviderBuilderExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerMeterProviderBuilderExtensionsTests.cs
@@ -12,8 +12,8 @@ public sealed class PrometheusHttpListenerMeterProviderBuilderExtensionsTests
     [Fact]
     public void TestAddPrometheusHttpListener_NamedOptions()
     {
-        int defaultExporterOptionsConfigureOptionsInvocations = 0;
-        int namedExporterOptionsConfigureOptionsInvocations = 0;
+        var defaultExporterOptionsConfigureOptionsInvocations = 0;
+        var namedExporterOptionsConfigureOptionsInvocations = 0;
 
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
             .ConfigureServices(services =>

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusHttpListenerTests.cs
@@ -30,64 +30,48 @@ public class PrometheusHttpListenerTests
     [InlineData("http://example.com", "https://example.com", "http://127.0.0.1")]
     [InlineData("http://example.com")]
     public void UriPrefixesPositiveTest(params string[] uriPrefixes)
-    {
-        TestPrometheusHttpListenerUriPrefixOptions(uriPrefixes);
-    }
+        => TestPrometheusHttpListenerUriPrefixOptions(uriPrefixes);
 
     [Fact]
-    public void UriPrefixesNull()
-    {
+    public void UriPrefixesNull() =>
         Assert.Throws<ArgumentNullException>(() =>
         {
             TestPrometheusHttpListenerUriPrefixOptions(null!);
         });
-    }
 
     [Fact]
-    public void UriPrefixesEmptyList()
-    {
+    public void UriPrefixesEmptyList() =>
         Assert.Throws<ArgumentException>(() =>
         {
             TestPrometheusHttpListenerUriPrefixOptions([]);
         });
-    }
 
     [Fact]
-    public void UriPrefixesInvalid()
-    {
+    public void UriPrefixesInvalid() =>
         Assert.Throws<ArgumentException>(() =>
         {
             TestPrometheusHttpListenerUriPrefixOptions(["ftp://example.com"]);
         });
-    }
 
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
     public async Task PrometheusExporterHttpServerIntegration(bool disableTimestamp)
-    {
-        await RunPrometheusExporterHttpServerIntegrationTest(disableTimestamp: disableTimestamp);
-    }
+        => await RunPrometheusExporterHttpServerIntegrationTest(disableTimestamp: disableTimestamp);
 
     [Fact]
     public async Task PrometheusExporterHttpServerIntegration_NoMetrics()
-    {
-        await RunPrometheusExporterHttpServerIntegrationTest(skipMetrics: true);
-    }
+        => await RunPrometheusExporterHttpServerIntegrationTest(skipMetrics: true);
 
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
     public async Task PrometheusExporterHttpServerIntegration_NoOpenMetrics(bool disableTimestamp)
-    {
-        await RunPrometheusExporterHttpServerIntegrationTest(acceptHeader: string.Empty, disableTimestamp: disableTimestamp);
-    }
+        => await RunPrometheusExporterHttpServerIntegrationTest(acceptHeader: string.Empty, disableTimestamp: disableTimestamp);
 
     [Fact]
     public async Task PrometheusExporterHttpServerIntegration_UseOpenMetricsVersionHeader()
-    {
-        await RunPrometheusExporterHttpServerIntegrationTest(acceptHeader: "application/openmetrics-text; version=1.0.0");
-    }
+        => await RunPrometheusExporterHttpServerIntegrationTest(acceptHeader: "application/openmetrics-text; version=1.0.0");
 
     [Fact]
     public async Task PrometheusExporterHttpServerIntegration_NoOpenMetrics_WithMeterTags()
@@ -116,8 +100,8 @@ public class PrometheusHttpListenerTests
     [Fact]
     public void PrometheusHttpListenerThrowsOnStart()
     {
-        Random random = new Random();
-        int retryAttempts = 5;
+        var random = new Random();
+        var retryAttempts = 5;
         string? address = null;
 
         PrometheusExporter? exporter = null;
@@ -127,7 +111,7 @@ public class PrometheusHttpListenerTests
         while (retryAttempts-- != 0)
         {
 #pragma warning disable CA5394 // Do not use insecure randomness
-            int port = random.Next(2000, 5000);
+            var port = random.Next(2000, 5000);
 #pragma warning restore CA5394 // Do not use insecure randomness
             address = $"http://localhost:{port}/";
 
@@ -196,7 +180,7 @@ public class PrometheusHttpListenerTests
             counter.Add(1);
         }
 
-        using HttpClient client = new HttpClient();
+        using var client = new HttpClient();
 
         if (!string.IsNullOrEmpty(acceptHeader))
         {
@@ -226,15 +210,15 @@ public class PrometheusHttpListenerTests
 
     private static MeterProvider BuildMeterProvider(Meter meter, IEnumerable<KeyValuePair<string, object>> attributes, out string address, bool disableTimestamp = false)
     {
-        Random random = new Random();
-        int retryAttempts = 5;
+        var random = new Random();
+        var retryAttempts = 5;
         string? generatedAddress = null;
         MeterProvider? provider = null;
 
         while (retryAttempts-- != 0)
         {
 #pragma warning disable CA5394 // Do not use insecure randomness
-            int port = random.Next(2000, 5000);
+            var port = random.Next(2000, 5000);
 #pragma warning restore CA5394 // Do not use insecure randomness
             generatedAddress = $"http://localhost:{port}/";
 
@@ -284,7 +268,7 @@ public class PrometheusHttpListenerTests
             counter.Add(0.99D, counterTags);
         }
 
-        using HttpClient client = new HttpClient();
+        using var client = new HttpClient();
 
         if (!string.IsNullOrEmpty(acceptHeader))
         {
@@ -300,11 +284,11 @@ public class PrometheusHttpListenerTests
 
             if (requestOpenMetrics)
             {
-                Assert.Equal("application/openmetrics-text; version=1.0.0; charset=utf-8", response.Content.Headers.ContentType!.ToString());
+                Assert.Equal("application/openmetrics-text; version=1.0.0; charset=utf-8", response.Content.Headers.ContentType?.ToString());
             }
             else
             {
-                Assert.Equal("text/plain; charset=utf-8; version=0.0.4", response.Content.Headers.ContentType!.ToString());
+                Assert.Equal("text/plain; charset=utf-8; version=0.0.4", response.Content.Headers.ContentType?.ToString());
             }
 
             var additionalTags = meterTags is { Length: > 0 }

--- a/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusMetricTests.cs
+++ b/test/OpenTelemetry.Exporter.Prometheus.HttpListener.Tests/PrometheusMetricTests.cs
@@ -26,243 +26,162 @@ public sealed class PrometheusMetricTests
 
     [Fact]
     public void SanitizeMetricName_Valid()
-    {
-        AssertSanitizeMetricName("active_directory_ds_replication_network_io", "active_directory_ds_replication_network_io");
-    }
+        => AssertSanitizeMetricName("active_directory_ds_replication_network_io", "active_directory_ds_replication_network_io");
 
     [Fact]
     public void SanitizeMetricName_RemoveConsecutiveUnderscores()
-    {
-        AssertSanitizeMetricName("cpu_sp__d_hertz", "cpu_sp_d_hertz");
-    }
+        => AssertSanitizeMetricName("cpu_sp__d_hertz", "cpu_sp_d_hertz");
 
     [Fact]
     public void SanitizeMetricName_SupportLeadingAndTrailingUnderscores()
-    {
-        AssertSanitizeMetricName("_cpu_speed_hertz_", "_cpu_speed_hertz_");
-    }
+        => AssertSanitizeMetricName("_cpu_speed_hertz_", "_cpu_speed_hertz_");
 
     [Fact]
     public void SanitizeMetricName_RemoveUnsupportedCharacters()
-    {
-        AssertSanitizeMetricName("metric_unit_$1000", "metric_unit_1000");
-    }
+        => AssertSanitizeMetricName("metric_unit_$1000", "metric_unit_1000");
 
     [Fact]
     public void SanitizeMetricName_RemoveWhitespace()
-    {
-        AssertSanitizeMetricName("unit include", "unit_include");
-    }
+        => AssertSanitizeMetricName("unit include", "unit_include");
 
     [Fact]
-    public void SanitizeMetricName_RemoveMultipleUnsupportedChracters()
-    {
-        AssertSanitizeMetricName("sample_me%%$$$_count_ !!@unit include", "sample_me_count_unit_include");
-    }
+    public void SanitizeMetricName_RemoveMultipleUnsupportedCharacters()
+        => AssertSanitizeMetricName("sample_me%%$$$_count_ !!@unit include", "sample_me_count_unit_include");
 
     [Fact]
     public void SanitizeMetricName_RemoveStartingNumber()
-    {
-        AssertSanitizeMetricName("1_some_metric_name", "_some_metric_name");
-    }
+        => AssertSanitizeMetricName("1_some_metric_name", "_some_metric_name");
 
     [Fact]
     public void SanitizeMetricName_SupportColon()
-    {
-        AssertSanitizeMetricName("sample_metric_name__:_per_meter", "sample_metric_name_:_per_meter");
-    }
+        => AssertSanitizeMetricName("sample_metric_name__:_per_meter", "sample_metric_name_:_per_meter");
 
     [Fact]
     public void Unit_Annotation_None()
-    {
-        Assert.Equal("Test", PrometheusMetric.RemoveAnnotations("Test"));
-    }
+        => Assert.Equal("Test", PrometheusMetric.RemoveAnnotations("Test"));
 
     [Fact]
     public void Unit_Annotation_RemoveLeading()
-    {
-        Assert.Equal("%", PrometheusMetric.RemoveAnnotations("%{percentage}"));
-    }
+        => Assert.Equal("%", PrometheusMetric.RemoveAnnotations("%{percentage}"));
 
     [Fact]
     public void Unit_Annotation_RemoveTrailing()
-    {
-        Assert.Equal("%", PrometheusMetric.RemoveAnnotations("{percentage}%"));
-    }
+        => Assert.Equal("%", PrometheusMetric.RemoveAnnotations("{percentage}%"));
 
     [Fact]
     public void Unit_Annotation_RemoveLeadingAndTrailing()
-    {
-        Assert.Equal("%", PrometheusMetric.RemoveAnnotations("{percentage}%{percentage}"));
-    }
+        => Assert.Equal("%", PrometheusMetric.RemoveAnnotations("{percentage}%{percentage}"));
 
     [Fact]
     public void Unit_Annotation_RemoveMiddle()
-    {
-        Assert.Equal("startend", PrometheusMetric.RemoveAnnotations("start{percentage}end"));
-    }
+        => Assert.Equal("startend", PrometheusMetric.RemoveAnnotations("start{percentage}end"));
 
     [Fact]
     public void Unit_Annotation_RemoveEverything()
-    {
-        Assert.Equal(string.Empty, PrometheusMetric.RemoveAnnotations("{percentage}"));
-    }
+        => Assert.Equal(string.Empty, PrometheusMetric.RemoveAnnotations("{percentage}"));
 
     [Fact]
     public void Unit_Annotation_Multiple_RemoveEverything()
-    {
-        Assert.Equal(string.Empty, PrometheusMetric.RemoveAnnotations("{one}{two}"));
-    }
+        => Assert.Equal(string.Empty, PrometheusMetric.RemoveAnnotations("{one}{two}"));
 
     [Fact]
     public void Unit_Annotation_NoClose()
-    {
-        Assert.Equal("{one", PrometheusMetric.RemoveAnnotations("{one"));
-    }
+        => Assert.Equal("{one", PrometheusMetric.RemoveAnnotations("{one"));
 
     [Fact]
     public void Unit_AnnotationMismatch_NoClose()
-    {
-        Assert.Equal("}", PrometheusMetric.RemoveAnnotations("{{one}}"));
-    }
+        => Assert.Equal("}", PrometheusMetric.RemoveAnnotations("{{one}}"));
 
     [Fact]
     public void Unit_AnnotationMismatch_Close()
-    {
-        Assert.Equal(string.Empty, PrometheusMetric.RemoveAnnotations("{{one}"));
-    }
+        => Assert.Equal(string.Empty, PrometheusMetric.RemoveAnnotations("{{one}"));
 
     [Fact]
     public void Name_GaugeWithUnit_NoAppendRatio()
-    {
-        AssertName("sample", "unit", PrometheusType.Gauge, false, "sample_unit");
-    }
+        => AssertName("sample", "unit", PrometheusType.Gauge, false, "sample_unit");
 
     [Fact]
     public void Name_SpecialCaseCounter_AppendTotal()
-    {
-        AssertName("sample", "unit", PrometheusType.Counter, false, "sample_unit_total");
-    }
+        => AssertName("sample", "unit", PrometheusType.Counter, false, "sample_unit_total");
 
     [Fact]
     public void Name_SpecialCaseCounterWithoutUnit_DropUnitAppendTotal()
-    {
-        AssertName("sample", "1", PrometheusType.Counter, false, "sample_total");
-    }
+        => AssertName("sample", "1", PrometheusType.Counter, false, "sample_total");
 
     [Fact]
     public void Name_DisableTotalSuffixAddition_TotalNotAppended()
-    {
-        AssertName("sample", "1", PrometheusType.Counter, true, "sample");
-    }
+        => AssertName("sample", "1", PrometheusType.Counter, true, "sample");
 
     [Fact]
     public void Name_TotalSuffixAlreadyPresent_DisableTotalSuffixAddition_TotalNotRemoved()
-    {
-        AssertName("sample_total", "1", PrometheusType.Counter, true, "sample_total");
-    }
+        => AssertName("sample_total", "1", PrometheusType.Counter, true, "sample_total");
 
     [Fact]
     public void Name_SpecialCaseCounterWithNumber_AppendTotal()
-    {
-        AssertName("sample", "2", PrometheusType.Counter, false, "sample_2_total");
-    }
+        => AssertName("sample", "2", PrometheusType.Counter, false, "sample_2_total");
 
     [Fact]
     public void Name_UnsupportedMetricNameChars_Drop()
-    {
-        AssertName("s%%ple", "%/m", PrometheusType.Summary, false, "s_ple_percent_per_minute");
-    }
+        => AssertName("s%%ple", "%/m", PrometheusType.Summary, false, "s_ple_percent_per_minute");
 
     [Fact]
     public void Name_UnitOtherThanOne_Normal()
-    {
-        AssertName("metric_name", "2", PrometheusType.Summary, false, "metric_name_2");
-    }
+        => AssertName("metric_name", "2", PrometheusType.Summary, false, "metric_name_2");
 
     [Fact]
     public void Name_UnitAlreadyPresentInName_NotAppended()
-    {
-        AssertName("metric_name_total", "total", PrometheusType.Counter, false, "metric_name_total");
-    }
+        => AssertName("metric_name_total", "total", PrometheusType.Counter, false, "metric_name_total");
 
     [Fact]
     public void Name_UnitAlreadyPresentInName_TotalNonCounterType_NotAppended()
-    {
-        AssertName("metric_name_total", "total", PrometheusType.Summary, false, "metric_name_total");
-    }
+        => AssertName("metric_name_total", "total", PrometheusType.Summary, false, "metric_name_total");
 
     [Fact]
     public void Name_UnitAlreadyPresentInName_CustomGauge_NotAppended()
-    {
-        AssertName("metric_hertz", "hertz", PrometheusType.Gauge, false, "metric_hertz");
-    }
+        => AssertName("metric_hertz", "hertz", PrometheusType.Gauge, false, "metric_hertz");
 
     [Fact]
     public void Name_UnitAlreadyPresentInName_CustomCounter_NotAppended()
-    {
-        AssertName("metric_hertz_total", "hertz_total", PrometheusType.Counter, false, "metric_hertz_total");
-    }
+        => AssertName("metric_hertz_total", "hertz_total", PrometheusType.Counter, false, "metric_hertz_total");
 
     [Fact]
     public void Name_UnitAlreadyPresentInName_OrderMatters_Appended()
-    {
-        AssertName("metric_total_hertz", "hertz_total", PrometheusType.Counter, false, "metric_total_hertz_hertz_total");
-    }
+        => AssertName("metric_total_hertz", "hertz_total", PrometheusType.Counter, false, "metric_total_hertz_hertz_total");
 
     [Fact]
     public void Name_StartWithNumber_UnderscoreStart()
-    {
-        AssertName("2_metric_name", "By", PrometheusType.Summary, false, "_metric_name_bytes");
-    }
+        => AssertName("2_metric_name", "By", PrometheusType.Summary, false, "_metric_name_bytes");
 
     [Fact]
     public void OpenMetricsName_UnitAlreadyPresentInName_Appended()
-    {
-        AssertOpenMetricsName("db_bytes_written", "By", PrometheusType.Gauge, false, "db_bytes_written_bytes");
-    }
+        => AssertOpenMetricsName("db_bytes_written", "By", PrometheusType.Gauge, false, "db_bytes_written_bytes");
 
     [Fact]
     public void OpenMetricsName_SuffixedWithUnit_NotAppended()
-    {
-        AssertOpenMetricsName("db_written_bytes", "By", PrometheusType.Gauge, false, "db_written_bytes");
-    }
+        => AssertOpenMetricsName("db_written_bytes", "By", PrometheusType.Gauge, false, "db_written_bytes");
 
     [Fact]
     public void OpenMetricsName_Counter_AppendTotal()
-    {
-        AssertOpenMetricsName("db_bytes_written", "By", PrometheusType.Counter, false, "db_bytes_written_bytes_total");
-    }
+        => AssertOpenMetricsName("db_bytes_written", "By", PrometheusType.Counter, false, "db_bytes_written_bytes_total");
 
     [Fact]
     public void OpenMetricsName_Counter_DisableSuffixTotal_AppendTotal()
-    {
-        AssertOpenMetricsName("db_bytes_written", "By", PrometheusType.Counter, true, "db_bytes_written_bytes_total");
-    }
+        => AssertOpenMetricsName("db_bytes_written", "By", PrometheusType.Counter, true, "db_bytes_written_bytes_total");
 
     [Fact]
     public void OpenMetricsName_CounterSuffixedWithTotal_AppendUnitAndTotal()
-    {
-        AssertOpenMetricsName("db_bytes_written_total", "By", PrometheusType.Counter, false, "db_bytes_written_bytes_total");
-    }
+        => AssertOpenMetricsName("db_bytes_written_total", "By", PrometheusType.Counter, false, "db_bytes_written_bytes_total");
 
     [Fact]
     public void OpenMetricsName_CounterSuffixedWithTotal_DisableSuffixTotal_AppendTotal()
-    {
-        AssertOpenMetricsName("db_bytes_written_total", "By", PrometheusType.Counter, false, "db_bytes_written_bytes_total");
-    }
+        => AssertOpenMetricsName("db_bytes_written_total", "By", PrometheusType.Counter, false, "db_bytes_written_bytes_total");
 
     [Fact]
-    public void OpenMetricsMetadataName_Counter_NotAppendTotal()
-    {
-        AssertOpenMetricsMetadataName("db_bytes_written", "By", PrometheusType.Counter, false, "db_bytes_written_bytes");
-    }
+    public void OpenMetricsMetadataName_Counter_NotAppendTotal() => AssertOpenMetricsMetadataName("db_bytes_written", "By", PrometheusType.Counter, false, "db_bytes_written_bytes");
 
     [Fact]
     public void OpenMetricsMetadataName_Counter_DisableSuffixTotal_NotAppendTotal()
-    {
-        AssertOpenMetricsMetadataName("db_bytes_written", "By", PrometheusType.Counter, true, "db_bytes_written_bytes");
-    }
+        => AssertOpenMetricsMetadataName("db_bytes_written", "By", PrometheusType.Counter, true, "db_bytes_written_bytes");
 
     [Theory]
     [MemberData(nameof(GetPrometheusType_Data))]
@@ -280,10 +199,7 @@ public sealed class PrometheusMetricTests
     [InlineData("ms", "milliseconds")]
     [InlineData("us", "microseconds")]
     [InlineData("ns", "nanoseconds")]
-    public void Name_TimeUnits_MappedCorrectly(string unit, string expectedUnit)
-    {
-        AssertName("metric", unit, PrometheusType.Gauge, false, $"metric_{expectedUnit}");
-    }
+    public void Name_TimeUnits_MappedCorrectly(string unit, string expectedUnit) => AssertName("metric", unit, PrometheusType.Gauge, false, $"metric_{expectedUnit}");
 
     [Theory]
     [InlineData("By", "bytes")]
@@ -300,10 +216,7 @@ public sealed class PrometheusMetricTests
     [InlineData("MB", "megabytes")]
     [InlineData("GB", "gigabytes")]
     [InlineData("TB", "terabytes")]
-    public void Name_ByteUnits_MappedCorrectly(string unit, string expectedUnit)
-    {
-        AssertName("metric", unit, PrometheusType.Gauge, false, $"metric_{expectedUnit}");
-    }
+    public void Name_ByteUnits_MappedCorrectly(string unit, string expectedUnit) => AssertName("metric", unit, PrometheusType.Gauge, false, $"metric_{expectedUnit}");
 
     [Theory]
     [InlineData("m", "meters")]
@@ -312,26 +225,17 @@ public sealed class PrometheusMetricTests
     [InlineData("J", "joules")]
     [InlineData("W", "watts")]
     [InlineData("g", "grams")]
-    public void Name_SIUnits_MappedCorrectly(string unit, string expectedUnit)
-    {
-        AssertName("metric", unit, PrometheusType.Gauge, false, $"metric_{expectedUnit}");
-    }
+    public void Name_SIUnits_MappedCorrectly(string unit, string expectedUnit) => AssertName("metric", unit, PrometheusType.Gauge, false, $"metric_{expectedUnit}");
 
     [Theory]
     [InlineData("Cel", "celsius")]
     [InlineData("Hz", "hertz")]
     [InlineData("%", "percent")]
     [InlineData("$", "dollars")]
-    public void Name_MiscUnits_MappedCorrectly(string unit, string expectedUnit)
-    {
-        AssertName("metric", unit, PrometheusType.Gauge, false, $"metric_{expectedUnit}");
-    }
+    public void Name_MiscUnits_MappedCorrectly(string unit, string expectedUnit) => AssertName("metric", unit, PrometheusType.Gauge, false, $"metric_{expectedUnit}");
 
     [Fact]
-    public void Name_UnknownUnit_UsedAsIs()
-    {
-        AssertName("metric", "custom_unit", PrometheusType.Gauge, false, "metric_custom_unit");
-    }
+    public void Name_UnknownUnit_UsedAsIs() => AssertName("metric", "custom_unit", PrometheusType.Gauge, false, "metric_custom_unit");
 
     [Theory]
     [InlineData("requests/s", "requests_per_second")]
@@ -342,37 +246,22 @@ public sealed class PrometheusMetricTests
     [InlineData("tasks/w", "tasks_per_week")]
     [InlineData("jobs/mo", "jobs_per_month")]
     [InlineData("cycles/y", "cycles_per_year")]
-    public void Name_RateUnits_MappedCorrectly(string unit, string expectedUnit)
-    {
-        AssertName("metric", unit, PrometheusType.Gauge, false, $"metric_{expectedUnit}");
-    }
+    public void Name_RateUnits_MappedCorrectly(string unit, string expectedUnit) => AssertName("metric", unit, PrometheusType.Gauge, false, $"metric_{expectedUnit}");
 
     [Theory]
     [InlineData("By/s", "bytes_per_second")]
     [InlineData("ms/m", "milliseconds_per_minute")]
     [InlineData("%/h", "percent_per_hour")]
-    public void Name_RateUnitsWithMapping_MappedCorrectly(string unit, string expectedUnit)
-    {
-        AssertName("metric", unit, PrometheusType.Gauge, false, $"metric_{expectedUnit}");
-    }
+    public void Name_RateUnitsWithMapping_MappedCorrectly(string unit, string expectedUnit) => AssertName("metric", unit, PrometheusType.Gauge, false, $"metric_{expectedUnit}");
 
     [Fact]
-    public void Name_UnitWithAnnotations_AnnotationsRemoved()
-    {
-        AssertName("metric", "{packet}By", PrometheusType.Gauge, false, "metric_bytes");
-    }
+    public void Name_UnitWithAnnotations_AnnotationsRemoved() => AssertName("metric", "{packet}By", PrometheusType.Gauge, false, "metric_bytes");
 
     [Fact]
-    public void Name_ComplexUnitWithAnnotations_AnnotationsRemoved()
-    {
-        AssertName("metric", "{CPU}%{usage}", PrometheusType.Gauge, false, "metric_percent");
-    }
+    public void Name_ComplexUnitWithAnnotations_AnnotationsRemoved() => AssertName("metric", "{CPU}%{usage}", PrometheusType.Gauge, false, "metric_percent");
 
     [Fact]
-    public void Name_EmptyUnit_NoSuffixAdded()
-    {
-        AssertName("metric", string.Empty, PrometheusType.Gauge, false, "metric");
-    }
+    public void Name_EmptyUnit_NoSuffixAdded() => AssertName("metric", string.Empty, PrometheusType.Gauge, false, "metric");
 
     [Fact]
     public void Name_NullUnit_NoSuffixAdded()
@@ -398,20 +287,14 @@ public sealed class PrometheusMetricTests
     [InlineData("events/quarter", "events_per_quarter")]
     [InlineData("packets/tick", "packets_per_tick")]
     [InlineData("items/unknown_unit", "items_per_unknown_unit")]
-    public void Name_RateUnitsWithUnknownPerUnit_UsedAsIs(string unit, string expectedUnit)
-    {
-        // Per units not in the known list (s, m, h, d, w, mo, y) should be used as-is
-        AssertName("metric", unit, PrometheusType.Gauge, false, $"metric_{expectedUnit}");
-    }
+    public void Name_RateUnitsWithUnknownPerUnit_UsedAsIs(string unit, string expectedUnit) =>
+        AssertName("metric", unit, PrometheusType.Gauge, false, $"metric_{expectedUnit}"); // Per units not in the known list (s, m, h, d, w, mo, y) should be used as-is
 
     [Theory]
     [InlineData("By/custom", "bytes_per_custom")]
     [InlineData("%/unknown", "percent_per_unknown")]
-    public void Name_RateUnitsWithMappedNumeratorAndUnknownDenominator_MapsCorrectly(string unit, string expectedUnit)
-    {
-        // Numerator should be mapped, denominator used as-is if unknown
-        AssertName("metric", unit, PrometheusType.Gauge, false, $"metric_{expectedUnit}");
-    }
+    public void Name_RateUnitsWithMappedNumeratorAndUnknownDenominator_MapsCorrectly(string unit, string expectedUnit) =>
+        AssertName("metric", unit, PrometheusType.Gauge, false, $"metric_{expectedUnit}"); // Numerator should be mapped, denominator used as-is if unknown
 
     [Fact]
     public void Name_UntypedMetricType_WorksCorrectly()
@@ -431,12 +314,10 @@ public sealed class PrometheusMetricTests
         Assert.Equal(PrometheusType.Summary, metric.Type);
     }
 
+    // Summary metrics should not have _total appended even if not already present
     [Fact]
     public void Name_SummaryWithTotal_DoesNotAppendTotal()
-    {
-        // Summary metrics should not have _total appended even if not already present
-        AssertName("requests", "1", PrometheusType.Summary, false, "requests");
-    }
+        => AssertName("requests", "1", PrometheusType.Summary, false, "requests");
 
     [Fact]
     public void GetPrometheusType_Summary_ReturnsSummary()
@@ -450,7 +331,7 @@ public sealed class PrometheusMetricTests
     public void GetPrometheusType_Untyped_ReturnsUntyped()
     {
         // MetricType enum value that maps to Untyped (case 0 in switch)
-        var result = PrometheusMetric.GetPrometheusType((MetricType)0x00);
+        var result = PrometheusMetric.GetPrometheusType(0);
         Assert.Equal(PrometheusType.Untyped, result);
     }
 
@@ -480,10 +361,7 @@ public sealed class PrometheusMetricTests
 
     [Fact]
     public void Name_MultipleSlashesInUnit_FirstSlashProcessed()
-    {
-        // Multiple slashes
-        AssertName("metric", "req/s/extra", PrometheusType.Gauge, false, "metric_req_per_s/extra");
-    }
+        => AssertName("metric", "req/s/extra", PrometheusType.Gauge, false, "metric_req_per_s/extra"); // // Multiple slashes
 
     [Theory]
     [InlineData(PrometheusType.Counter)]


### PR DESCRIPTION
## Changes

Cherry-pick fixes for new code analysis warnings identified by the .NET 11 preview 2 SDK in #6899.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
