### PR TITLE
[Exporters.InMemory] Fix new code analysis warnings

### DIFF
--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterLoggingExtensions.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterLoggingExtensions.cs
@@ -56,7 +56,7 @@ public static class InMemoryExporterLoggingExtensions
     private static InMemoryExporter<LogRecord> BuildExporter(ICollection<LogRecord> exportedItems)
     {
         return new InMemoryExporter<LogRecord>(
-            exportFunc: (in Batch<LogRecord> batch) => ExportLogRecord(in batch, exportedItems));
+            exportFunc: (in batch) => ExportLogRecord(in batch, exportedItems));
     }
 
     private static ExportResult ExportLogRecord(in Batch<LogRecord> batch, ICollection<LogRecord> exportedItems)

--- a/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterMetricsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.InMemory/InMemoryExporterMetricsExtensions.cs
@@ -168,7 +168,7 @@ public static class InMemoryExporterMetricsExtensions
     {
 #pragma warning disable CA2000 // Dispose objects before losing scope
         var metricExporter = new InMemoryExporter<Metric>(
-            exportFunc: (in Batch<Metric> metricBatch) => ExportMetricSnapshot(in metricBatch, exportedItems));
+            exportFunc: (in metricBatch) => ExportMetricSnapshot(in metricBatch, exportedItems));
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
         return PeriodicExportingMetricReaderHelper.CreatePeriodicExportingMetricReader(


### PR DESCRIPTION
## Changes

Cherry-pick fixes for new code analysis warnings identified by the .NET 11 preview 2 SDK in #6899.Please provide a brief description of the changes here.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
