### PR TITLE
[Exporter.Console] Fix new code analysis warnings

### DIFF
--- a/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleLogRecordExporter.cs
@@ -84,7 +84,7 @@ public class ConsoleLogRecordExporter : ConsoleExporter<LogRecord>
             if (logRecord.Attributes != null)
             {
                 this.WriteLine("LogRecord.Attributes (Key:Value):");
-                for (int i = 0; i < logRecord.Attributes.Count; i++)
+                for (var i = 0; i < logRecord.Attributes.Count; i++)
                 {
                     // Special casing {OriginalFormat}
                     // See https://github.com/open-telemetry/opentelemetry-dotnet/pull/3182
@@ -114,7 +114,7 @@ public class ConsoleLogRecordExporter : ConsoleExporter<LogRecord>
                 this.WriteLine($"{"LogRecord.Exception:",-RightPaddingLength}{logRecord.Exception.ToInvariantString()}");
             }
 
-            int scopeDepth = -1;
+            var scopeDepth = -1;
 
             logRecord.ForEachScope(ProcessScope, this);
 
@@ -125,7 +125,7 @@ public class ConsoleLogRecordExporter : ConsoleExporter<LogRecord>
                     exporter.WriteLine("LogRecord.ScopeValues (Key:Value):");
                 }
 
-                foreach (KeyValuePair<string, object?> scopeItem in scope)
+                foreach (var scopeItem in scope)
                 {
                     if (this.TagWriter.TryTransformTag(scopeItem, out var result))
                     {

--- a/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.Console/ConsoleMetricExporter.cs
@@ -92,8 +92,8 @@ public class ConsoleMetricExporter : ConsoleExporter<Metric>
 
             foreach (ref readonly var metricPoint in metric.GetMetricPoints())
             {
-                string valueDisplay = string.Empty;
-                StringBuilder tagsBuilder = new StringBuilder();
+                var valueDisplay = string.Empty;
+                var tagsBuilder = new StringBuilder();
                 foreach (var tag in metricPoint.Tags)
                 {
                     if (this.TagWriter.TryTransformTag(tag, out var result))
@@ -111,7 +111,7 @@ public class ConsoleMetricExporter : ConsoleExporter<Metric>
 
                 var metricType = metric.MetricType;
 
-                if (metricType == MetricType.Histogram || metricType == MetricType.ExponentialHistogram)
+                if (metricType is MetricType.Histogram or MetricType.ExponentialHistogram)
                 {
                     var bucketsBuilder = new StringBuilder();
                     var sum = metricPoint.GetHistogramSum();
@@ -121,7 +121,7 @@ public class ConsoleMetricExporter : ConsoleExporter<Metric>
 #else
                     bucketsBuilder.Append($"Sum: {sum} Count: {count} ");
 #endif
-                    if (metricPoint.TryGetHistogramMinMaxValues(out double min, out double max))
+                    if (metricPoint.TryGetHistogramMinMaxValues(out var min, out var max))
                     {
 #if NET
                         bucketsBuilder.Append(CultureInfo.InvariantCulture, $"Min: {min} Max: {max} ");
@@ -134,7 +134,7 @@ public class ConsoleMetricExporter : ConsoleExporter<Metric>
 
                     if (metricType == MetricType.Histogram)
                     {
-                        bool isFirstIteration = true;
+                        var isFirstIteration = true;
                         double previousExplicitBound = default;
                         foreach (var histogramMeasurement in metricPoint.GetHistogramBuckets())
                         {
@@ -235,7 +235,7 @@ public class ConsoleMetricExporter : ConsoleExporter<Metric>
                             exemplarString.Append(exemplar.SpanId.ToHexString());
                         }
 
-                        bool appendedTagString = false;
+                        var appendedTagString = false;
                         foreach (var tag in exemplar.FilteredTags)
                         {
                             if (this.TagWriter.TryTransformTag(tag, out var result))

--- a/src/OpenTelemetry.Exporter.Console/Implementation/ConsoleTagWriter.cs
+++ b/src/OpenTelemetry.Exporter.Console/Implementation/ConsoleTagWriter.cs
@@ -16,13 +16,15 @@ internal sealed class ConsoleTagWriter : JsonStringArrayTagWriter<ConsoleTagWrit
     {
         Debug.Assert(onUnsupportedTagDropped != null, "onUnsupportedTagDropped was null");
 
+#if NET
+        this.onUnsupportedTagDropped = onUnsupportedTagDropped;
+#else
         this.onUnsupportedTagDropped = onUnsupportedTagDropped!;
+#endif
     }
 
     public bool TryTransformTag(KeyValuePair<string, object?> tag, out KeyValuePair<string, string> result)
-    {
-        return this.TryTransformTag(tag.Key, tag.Value, out result);
-    }
+        => this.TryTransformTag(tag.Key, tag.Value, out result);
 
     public bool TryTransformTag(string key, object? value, out KeyValuePair<string, string> result)
     {
@@ -64,15 +66,17 @@ internal sealed class ConsoleTagWriter : JsonStringArrayTagWriter<ConsoleTagWrit
     protected override void WriteArrayTag(ref ConsoleTag consoleTag, string key, ArraySegment<byte> arrayUtf8JsonBytes)
     {
         consoleTag.Key = key;
+#if NET
         consoleTag.Value = Encoding.UTF8.GetString(arrayUtf8JsonBytes.Array!, 0, arrayUtf8JsonBytes.Count);
+#else
+        consoleTag.Value = Encoding.UTF8.GetString(arrayUtf8JsonBytes.Array, 0, arrayUtf8JsonBytes.Count);
+#endif
     }
 
     protected override void OnUnsupportedTagDropped(
         string tagKey,
         string tagValueTypeFullName)
-    {
-        this.onUnsupportedTagDropped(tagKey, tagValueTypeFullName);
-    }
+        => this.onUnsupportedTagDropped(tagKey, tagValueTypeFullName);
 
     protected override bool TryWriteEmptyTag(ref ConsoleTag consoleTag, string key, object? value)
     {


### PR DESCRIPTION
## Changes

Cherry-pick fixes for new code analysis warnings identified by the .NET 11 preview 2 SDK in #6899.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
