### PR TITLE
[OTLP] Fix new code analysis warnings

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Builder/OtlpExporterBuilder.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Builder/OtlpExporterBuilder.cs
@@ -24,8 +24,6 @@ internal sealed class OtlpExporterBuilder
         string? name,
         IConfiguration? configuration)
     {
-        Debug.Assert(services != null, "services was null");
-
         if (configuration != null)
         {
             if (string.IsNullOrEmpty(name))
@@ -33,15 +31,17 @@ internal sealed class OtlpExporterBuilder
                 name = "otlp";
             }
 
-            BindConfigurationToOptions(services!, name!, configuration);
+#pragma warning disable IDE0370 // Suppression is unnecessary
+            BindConfigurationToOptions(services, name!, configuration);
+#pragma warning restore IDE0370 // Suppression is unnecessary
         }
 
         name ??= Options.DefaultName;
 
-        RegisterOtlpExporterServices(services!, name);
+        RegisterOtlpExporterServices(services, name);
 
         this.name = name;
-        this.Services = services!;
+        this.Services = services;
     }
 
     public IServiceCollection Services { get; }
@@ -119,9 +119,7 @@ internal sealed class OtlpExporterBuilder
 
     private static void BindConfigurationToOptions(IServiceCollection services, string name, IConfiguration configuration)
     {
-        Debug.Assert(services != null, "services was null");
         Debug.Assert(!string.IsNullOrEmpty(name), "name was null or empty");
-        Debug.Assert(configuration != null, "configuration was null");
 
         /* Config JSON structure is expected to be something like this:
             {
@@ -152,33 +150,30 @@ internal sealed class OtlpExporterBuilder
             }
         */
 
-        services!.Configure<OtlpExporterBuilderOptions>(name, configuration!);
+        services.Configure<OtlpExporterBuilderOptions>(name, configuration);
 
-        services!.Configure<LogRecordExportProcessorOptions>(
-            name, configuration!.GetSection(nameof(OtlpExporterBuilderOptions.LoggingOptions)));
+        services.Configure<LogRecordExportProcessorOptions>(
+            name, configuration.GetSection(nameof(OtlpExporterBuilderOptions.LoggingOptions)));
 
-        services!.Configure<MetricReaderOptions>(
+        services.Configure<MetricReaderOptions>(
             name, configuration.GetSection(nameof(OtlpExporterBuilderOptions.MetricsOptions)));
 
-        services!.Configure<ActivityExportProcessorOptions>(
+        services.Configure<ActivityExportProcessorOptions>(
             name, configuration.GetSection(nameof(OtlpExporterBuilderOptions.TracingOptions)));
     }
 
     private static void RegisterOtlpExporterServices(IServiceCollection services, string name)
     {
-        Debug.Assert(services != null, "services was null");
-        Debug.Assert(name != null, "name was null");
-
-        services!.AddOtlpExporterLoggingServices();
-        services!.AddOtlpExporterMetricsServices(name!);
-        services!.AddOtlpExporterTracingServices();
+        services.AddOtlpExporterLoggingServices();
+        services.AddOtlpExporterMetricsServices(name);
+        services.AddOtlpExporterTracingServices();
 
         // Note: UseOtlpExporterRegistration is added to the service collection
         // for each invocation to detect repeated calls to "UseOtlpExporter" and
         // to throw if "AddOtlpExporter" extensions are called
-        services!.AddSingleton(UseOtlpExporterRegistration.Instance);
+        services.AddSingleton(UseOtlpExporterRegistration.Instance);
 
-        services!.RegisterOptionsFactory((sp, configuration, name) => new OtlpExporterBuilderOptions(
+        services.RegisterOptionsFactory((sp, configuration, name) => new OtlpExporterBuilderOptions(
             configuration,
             /* Note: We don't use name for SdkLimitOptions. There should only be
             one provider for a given service collection so SdkLimitOptions is
@@ -195,10 +190,10 @@ internal sealed class OtlpExporterBuilder
             sp.GetService<IOptionsMonitor<MetricReaderOptions>>()?.Get(name),
             sp.GetService<IOptionsMonitor<ActivityExportProcessorOptions>>()?.Get(name)));
 
-        services!.ConfigureOpenTelemetryLoggerProvider(
+        services.ConfigureOpenTelemetryLoggerProvider(
             (sp, logging) =>
             {
-                var builderOptions = GetBuilderOptionsAndValidateRegistrations(sp, name!);
+                var builderOptions = GetBuilderOptionsAndValidateRegistrations(sp, name);
 
                 var processor = OtlpLogExporterHelperExtensions.BuildOtlpLogExporter(
                     sp,
@@ -213,10 +208,10 @@ internal sealed class OtlpExporterBuilder
                 logging.AddProcessor(processor);
             });
 
-        services!.ConfigureOpenTelemetryMeterProvider(
+        services.ConfigureOpenTelemetryMeterProvider(
             (sp, metrics) =>
             {
-                var builderOptions = GetBuilderOptionsAndValidateRegistrations(sp, name!);
+                var builderOptions = GetBuilderOptionsAndValidateRegistrations(sp, name);
 
                 metrics.AddReader(
                     OtlpMetricExporterExtensions.BuildOtlpExporterMetricReader(
@@ -227,10 +222,10 @@ internal sealed class OtlpExporterBuilder
                         skipUseOtlpExporterRegistrationCheck: true));
             });
 
-        services!.ConfigureOpenTelemetryTracerProvider(
+        services.ConfigureOpenTelemetryTracerProvider(
             (sp, tracing) =>
             {
-                var builderOptions = GetBuilderOptionsAndValidateRegistrations(sp, name!);
+                var builderOptions = GetBuilderOptionsAndValidateRegistrations(sp, name);
 
                 var processorOptions = builderOptions.ActivityExportProcessorOptions ?? throw new InvalidOperationException("ActivityExportProcessorOptions were missing with tracing enabled");
 

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcExportClient.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpGrpcExportClient.cs
@@ -51,7 +51,7 @@ internal sealed class OtlpGrpcExportClient : OtlpExportClient
             httpResponse.EnsureSuccessStatusCode();
 
             var trailingHeaders = httpResponse.TrailingHeaders();
-            Status status = GrpcProtocolHelpers.GetResponseStatus(httpResponse, trailingHeaders);
+            var status = GrpcProtocolHelpers.GetResponseStatus(httpResponse, trailingHeaders);
 
             if (status.Detail.Equals(Status.NoReplyDetailMessage, StringComparison.Ordinal))
             {
@@ -60,7 +60,7 @@ internal sealed class OtlpGrpcExportClient : OtlpExportClient
 #else
                 using var responseStream = httpResponse.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
 #endif
-                int firstByte = responseStream.ReadByte();
+                var firstByte = responseStream.ReadByte();
 
                 if (firstByte == -1)
                 {
@@ -95,7 +95,7 @@ internal sealed class OtlpGrpcExportClient : OtlpExportClient
             }
 
             string? grpcStatusDetailsHeader = null;
-            if (status.StatusCode == StatusCode.ResourceExhausted || status.StatusCode == StatusCode.Unavailable)
+            if (status.StatusCode is StatusCode.ResourceExhausted or StatusCode.Unavailable)
             {
                 grpcStatusDetailsHeader = GrpcProtocolHelpers.GetHeaderValue(trailingHeaders, GrpcStatusDetailsHeader);
             }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpRetry.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/ExportClient/OtlpRetry.cs
@@ -74,11 +74,9 @@ internal static class OtlpRetry
         }
     }
 
-    public static bool ShouldHandleHttpRequestException(Exception? exception)
-    {
-        // TODO: Handle specific exceptions.
-        return true;
-    }
+#pragma warning disable IDE0060 // Remove unused parameter
+    public static bool ShouldHandleHttpRequestException(Exception? exception) => true; // TODO: Handle specific exceptions.
+#pragma warning restore IDE0060 // Remove unused parameter
 
     public static bool TryGetGrpcRetryResult(ExportClientGrpcResponse response, int retryDelayMilliseconds, out RetryResult retryResult)
     {
@@ -183,11 +181,9 @@ internal static class OtlpRetry
         return true;
     }
 
+    // This implementation is internal, and it is guaranteed that deadline is UTC.
     private static bool IsDeadlineExceeded(DateTime? deadline)
-    {
-        // This implementation is internal, and it is guaranteed that deadline is UTC.
-        return deadline.HasValue && deadline <= DateTime.UtcNow;
-    }
+        => deadline.HasValue && deadline <= DateTime.UtcNow;
 
     private static int CalculateNextRetryDelay(int nextRetryDelayMilliseconds)
     {
@@ -199,49 +195,37 @@ internal static class OtlpRetry
     private static TimeSpan? TryGetHttpRetryDelay(HttpStatusCode statusCode, HttpResponseHeaders? responseHeaders)
     {
 #if NETSTANDARD2_1_OR_GREATER || NET
-        return statusCode == HttpStatusCode.TooManyRequests || statusCode == HttpStatusCode.ServiceUnavailable
+        return statusCode is HttpStatusCode.TooManyRequests or HttpStatusCode.ServiceUnavailable
 #else
-        return statusCode == (HttpStatusCode)429 || statusCode == HttpStatusCode.ServiceUnavailable
+        return statusCode is (HttpStatusCode)429 or HttpStatusCode.ServiceUnavailable
 #endif
             ? responseHeaders?.RetryAfter?.Delta
             : null;
     }
 
-    private static bool IsGrpcStatusCodeRetryable(StatusCode statusCode, bool hasRetryDelay)
+#pragma warning disable IDE0072 // Add missing cases
+    private static bool IsGrpcStatusCodeRetryable(StatusCode statusCode, bool hasRetryDelay) => statusCode switch
+#pragma warning restore IDE0072 // Add missing cases
     {
-        switch (statusCode)
-        {
-            case StatusCode.Cancelled:
-            case StatusCode.DeadlineExceeded:
-            case StatusCode.Aborted:
-            case StatusCode.OutOfRange:
-            case StatusCode.Unavailable:
-            case StatusCode.DataLoss:
-                return true;
-            case StatusCode.ResourceExhausted:
-                return hasRetryDelay;
-            default:
-                return false;
-        }
-    }
+        StatusCode.Cancelled or StatusCode.DeadlineExceeded or StatusCode.Aborted or StatusCode.OutOfRange or StatusCode.Unavailable or StatusCode.DataLoss => true,
+        StatusCode.ResourceExhausted => hasRetryDelay,
+        _ => false,
+    };
 
-    private static bool IsHttpStatusCodeRetryable(HttpStatusCode statusCode, bool hasRetryDelay)
+#pragma warning disable IDE0072 // Add missing cases
+    private static bool IsHttpStatusCodeRetryable(HttpStatusCode statusCode, bool hasRetryDelay) => statusCode switch
+#pragma warning restore IDE0072 // Add missing cases
     {
-        switch (statusCode)
-        {
 #if NETSTANDARD2_1_OR_GREATER || NET
-            case HttpStatusCode.TooManyRequests:
+        HttpStatusCode.TooManyRequests => true,
 #else
-            case (HttpStatusCode)429:
+        (HttpStatusCode)429 => true,
 #endif
-            case HttpStatusCode.BadGateway:
-            case HttpStatusCode.ServiceUnavailable:
-            case HttpStatusCode.GatewayTimeout:
-                return true;
-            default:
-                return false;
-        }
-    }
+        HttpStatusCode.BadGateway => true,
+        HttpStatusCode.ServiceUnavailable => true,
+        HttpStatusCode.GatewayTimeout => true,
+        _ => false,
+    };
 
     private static int GetRandomNumber(int min, int max)
     {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpCertificateManager.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpCertificateManager.cs
@@ -81,12 +81,12 @@ internal static class OtlpCertificateManager
                 try
                 {
 #if NET9_0_OR_GREATER
-                    clientCertificate = X509CertificateLoader.LoadPkcs12FromFile(clientCertificatePath, (string?)null);
+                    clientCertificate = X509CertificateLoader.LoadPkcs12FromFile(clientCertificatePath, null);
 #else
                     clientCertificate = new X509Certificate2(clientCertificatePath);
 #endif
                 }
-                catch (Exception ex) when (ex is CryptographicException || ex is InvalidDataException || ex is FormatException)
+                catch (Exception ex) when (ex is CryptographicException or InvalidDataException or FormatException)
                 {
                     // If PKCS#12 fails, try PEM format
                     clientCertificate = X509Certificate2.CreateFromPemFile(clientCertificatePath);
@@ -122,7 +122,7 @@ internal static class OtlpCertificateManager
 
         try
         {
-            X509Certificate2 clientCertificate = X509Certificate2.CreateFromPemFile(
+            var clientCertificate = X509Certificate2.CreateFromPemFile(
                 clientCertificatePath,
                 clientKeyPath);
 
@@ -169,7 +169,7 @@ internal static class OtlpCertificateManager
             chain.ChainPolicy.RevocationMode = X509RevocationMode.Online;
             chain.ChainPolicy.RevocationFlag = X509RevocationFlag.ExcludeRoot;
 
-            bool isValid = chain.Build(certificate);
+            var isValid = chain.Build(certificate);
 
             if (!isValid)
             {
@@ -184,18 +184,14 @@ internal static class OtlpCertificateManager
                     string.Join("; ", errors));
 
                 // Check if certificate is expired - this should throw an exception
-                bool isExpired = chain.ChainStatus.Any(status =>
-                    status.Status == X509ChainStatusFlags.NotTimeValid ||
-                    status.Status == X509ChainStatusFlags.NotTimeNested);
+                var isExpired = chain.ChainStatus.Any(status =>
+                    status.Status is X509ChainStatusFlags.NotTimeValid or X509ChainStatusFlags.NotTimeNested);
 
-                if (isExpired)
-                {
-                    throw new InvalidOperationException(
+                return isExpired
+                    ? throw new InvalidOperationException(
                         $"Certificate chain validation failed for {certificateType}: Certificate is expired. " +
-                        $"Errors: {string.Join("; ", errors)}");
-                }
-
-                return false;
+                        $"Errors: {string.Join("; ", errors)}")
+                    : false;
             }
 
             OpenTelemetryProtocolExporterEventSource.Log.MtlsCertificateChainValidated(
@@ -257,7 +253,7 @@ internal static class OtlpCertificateManager
             chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
             chain.ChainPolicy.RevocationFlag = X509RevocationFlag.ExcludeRoot;
 
-            bool isValid = chain.Build(serverCert);
+            var isValid = chain.Build(serverCert);
 
             if (isValid)
             {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpServiceCollectionExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
@@ -12,20 +11,13 @@ namespace OpenTelemetry.Exporter;
 internal static class OtlpServiceCollectionExtensions
 {
     public static void AddOtlpExporterLoggingServices(this IServiceCollection services)
-    {
-        Debug.Assert(services != null, "services was null");
-
-        AddOtlpExporterSharedServices(services!, registerSdkLimitOptions: true);
-    }
+        => AddOtlpExporterSharedServices(services, registerSdkLimitOptions: true);
 
     public static void AddOtlpExporterMetricsServices(this IServiceCollection services, string name)
     {
-        Debug.Assert(services != null, "services was null");
-        Debug.Assert(name != null, "name was null");
+        AddOtlpExporterSharedServices(services, registerSdkLimitOptions: false);
 
-        AddOtlpExporterSharedServices(services!, registerSdkLimitOptions: false);
-
-        services!.AddOptions<MetricReaderOptions>(name).Configure<IConfiguration>(
+        services.AddOptions<MetricReaderOptions>(name).Configure<IConfiguration>(
             (readerOptions, config) =>
             {
                 var otlpTemporalityPreference = config[OtlpSpecConfigDefinitions.MetricsTemporalityPreferenceEnvVarName];
@@ -53,11 +45,7 @@ internal static class OtlpServiceCollectionExtensions
     }
 
     public static void AddOtlpExporterTracingServices(this IServiceCollection services)
-    {
-        Debug.Assert(services != null, "services was null");
-
-        AddOtlpExporterSharedServices(services!, registerSdkLimitOptions: true);
-    }
+        => AddOtlpExporterSharedServices(services, registerSdkLimitOptions: true);
 
     private static void AddOtlpExporterSharedServices(
         IServiceCollection services,

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpLogSerializer.cs
@@ -58,12 +58,12 @@ internal static class ProtobufOtlpLogSerializer
     {
         while (true)
         {
-            int entryWritePosition = writePosition;
+            var entryWritePosition = writePosition;
 
             try
             {
                 writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpLogFieldNumberConstants.LogsData_Resource_Logs, ProtobufWireType.LEN);
-                int logsDataLengthPosition = writePosition;
+                var logsDataLengthPosition = writePosition;
                 writePosition += ReserveSizeForLength;
 
                 writePosition = WriteResourceLogs(buffer, writePosition, sdkLimitOptions, experimentalOptions, resource, scopeLogs);
@@ -73,7 +73,7 @@ internal static class ProtobufOtlpLogSerializer
                 // Serialization succeeded, return the final write position
                 return writePosition;
             }
-            catch (Exception ex) when (ex is IndexOutOfRangeException || ex is ArgumentException)
+            catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentException)
             {
                 // Reset write position and attempt to increase the buffer size
                 writePosition = entryWritePosition;
@@ -127,10 +127,10 @@ internal static class ProtobufOtlpLogSerializer
     {
         if (scopeLogs != null)
         {
-            foreach (KeyValuePair<string, List<LogRecord>> entry in scopeLogs)
+            foreach (var entry in scopeLogs)
             {
                 writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpLogFieldNumberConstants.ResourceLogs_Scope_Logs, ProtobufWireType.LEN);
-                int resourceLogsScopeLogsLengthPosition = writePosition;
+                var resourceLogsScopeLogsLengthPosition = writePosition;
                 writePosition += ReserveSizeForLength;
 
                 writePosition = WriteScopeLog(buffer, writePosition, sdkLimitOptions, experimentalOptions, entry.Value[0].Logger.Name, entry.Value);
@@ -151,7 +151,7 @@ internal static class ProtobufOtlpLogSerializer
         writePosition = ProtobufSerializer.WriteTagAndLength(buffer, writePosition, numberOfUtf8CharsInString + 1 + serializedLengthSize, ProtobufOtlpLogFieldNumberConstants.ScopeLogs_Scope, ProtobufWireType.LEN);
         writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Name, numberOfUtf8CharsInString, value);
 
-        for (int i = 0; i < logRecords.Count; i++)
+        for (var i = 0; i < logRecords.Count; i++)
         {
             writePosition = WriteLogRecord(buffer, writePosition, sdkLimitOptions, experimentalOptions, logRecords[i]);
         }
@@ -176,7 +176,7 @@ internal static class ProtobufOtlpLogSerializer
         ref var otlpTagWriterState = ref state.TagWriterState;
 
         otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpLogFieldNumberConstants.ScopeLogs_Log_Records, ProtobufWireType.LEN);
-        int logRecordLengthPosition = otlpTagWriterState.WritePosition;
+        var logRecordLengthPosition = otlpTagWriterState.WritePosition;
         otlpTagWriterState.WritePosition += ReserveSizeForLength;
 
         var timestamp = (ulong)logRecord.Timestamp.ToUnixTimeNanoseconds();
@@ -187,7 +187,9 @@ internal static class ProtobufOtlpLogSerializer
 
         if (!string.IsNullOrWhiteSpace(logRecord.SeverityText))
         {
+#pragma warning disable IDE0370 // Suppression is unnecessary
             otlpTagWriterState.WritePosition = ProtobufSerializer.WriteStringWithTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpLogFieldNumberConstants.LogRecord_Severity_Text, logRecord.SeverityText!);
+#pragma warning restore IDE0370 // Suppression is unnecessary
         }
         else if (logRecord.Severity.HasValue)
         {
@@ -209,8 +211,8 @@ internal static class ProtobufOtlpLogSerializer
             AddLogAttribute(state, SemanticConventions.AttributeExceptionStacktrace, logRecord.Exception.ToInvariantString());
         }
 
-        bool bodyPopulatedFromFormattedMessage = false;
-        bool isLogRecordBodySet = false;
+        var bodyPopulatedFromFormattedMessage = false;
+        var isLogRecordBodySet = false;
 
         if (logRecord.FormattedMessage != null)
         {
@@ -259,7 +261,7 @@ internal static class ProtobufOtlpLogSerializer
 
         if (logRecord.EventId.Name != null)
         {
-            otlpTagWriterState.WritePosition = ProtobufSerializer.WriteStringWithTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpLogFieldNumberConstants.LogRecord_Event_Name, logRecord.EventId.Name!);
+            otlpTagWriterState.WritePosition = ProtobufSerializer.WriteStringWithTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpLogFieldNumberConstants.LogRecord_Event_Name, logRecord.EventId.Name);
         }
 
         logRecord.ForEachScope(ProcessScope, state);
@@ -320,9 +322,7 @@ internal static class ProtobufOtlpLogSerializer
     }
 
     private static void AddLogAttribute(SerializationState state, KeyValuePair<string, object?> attribute)
-    {
-        AddLogAttribute(state, attribute.Key, attribute.Value);
-    }
+        => AddLogAttribute(state, attribute.Key, attribute.Value);
 
     private static void AddLogAttribute(SerializationState state, string key, object? value)
     {
@@ -333,7 +333,7 @@ internal static class ProtobufOtlpLogSerializer
         else
         {
             state.TagWriterState.WritePosition = ProtobufSerializer.WriteTag(state.TagWriterState.Buffer, state.TagWriterState.WritePosition, ProtobufOtlpLogFieldNumberConstants.LogRecord_Attributes, ProtobufWireType.LEN);
-            int logAttributesLengthPosition = state.TagWriterState.WritePosition;
+            var logAttributesLengthPosition = state.TagWriterState.WritePosition;
             state.TagWriterState.WritePosition += ReserveSizeForLength;
 
             ProtobufOtlpTagWriter.Instance.TryWriteTag(ref state.TagWriterState, key, value, state.AttributeValueLengthLimit);

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpMetricSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpMetricSerializer.cs
@@ -46,12 +46,12 @@ internal static class ProtobufOtlpMetricSerializer
     {
         while (true)
         {
-            int entryWritePosition = writePosition;
+            var entryWritePosition = writePosition;
 
             try
             {
                 writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.MetricsData_Resource_Metrics, ProtobufWireType.LEN);
-                int mericsDataLengthPosition = writePosition;
+                var mericsDataLengthPosition = writePosition;
                 writePosition += ReserveSizeForLength;
 
                 writePosition = WriteResourceMetrics(buffer, writePosition, resource, scopeMetrics);
@@ -61,7 +61,7 @@ internal static class ProtobufOtlpMetricSerializer
                 // Serialization succeeded, return the final write position
                 return writePosition;
             }
-            catch (Exception ex) when (ex is IndexOutOfRangeException || ex is ArgumentException)
+            catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentException)
             {
                 // Reset write position and attempt to increase the buffer size
                 writePosition = entryWritePosition;
@@ -100,10 +100,10 @@ internal static class ProtobufOtlpMetricSerializer
     {
         if (scopeMetrics != null)
         {
-            foreach (KeyValuePair<string, List<Metric>> entry in scopeMetrics)
+            foreach (var entry in scopeMetrics)
             {
                 writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ResourceMetrics_Scope_Metrics, ProtobufWireType.LEN);
-                int resourceMetricsScopeMetricsLengthPosition = writePosition;
+                var resourceMetricsScopeMetricsLengthPosition = writePosition;
                 writePosition += ReserveSizeForLength;
 
                 writePosition = WriteScopeMetric(buffer, writePosition, entry.Key, entry.Value);
@@ -118,7 +118,7 @@ internal static class ProtobufOtlpMetricSerializer
     private static int WriteScopeMetric(byte[] buffer, int writePosition, string meterName, List<Metric> metrics)
     {
         writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ScopeMetrics_Scope, ProtobufWireType.LEN);
-        int instrumentationScopeLengthPosition = writePosition;
+        var instrumentationScopeLengthPosition = writePosition;
         writePosition += ReserveSizeForLength;
 
         Debug.Assert(metrics.Count > 0, "Metrics collection is not expected to be empty.");
@@ -137,7 +137,7 @@ internal static class ProtobufOtlpMetricSerializer
         {
             if (meterTags is IReadOnlyList<KeyValuePair<string, object?>> readonlyMeterTags)
             {
-                for (int i = 0; i < readonlyMeterTags.Count; i++)
+                for (var i = 0; i < readonlyMeterTags.Count; i++)
                 {
                     writePosition = WriteTag(buffer, writePosition, readonlyMeterTags[i], ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Attributes);
                 }
@@ -153,7 +153,7 @@ internal static class ProtobufOtlpMetricSerializer
 
         ProtobufSerializer.WriteReservedLength(buffer, instrumentationScopeLengthPosition, writePosition - (instrumentationScopeLengthPosition + ReserveSizeForLength));
 
-        for (int i = 0; i < metrics.Count; i++)
+        for (var i = 0; i < metrics.Count; i++)
         {
             writePosition = WriteMetric(buffer, writePosition, metrics[i]);
         }
@@ -169,7 +169,7 @@ internal static class ProtobufOtlpMetricSerializer
     private static int WriteMetric(byte[] buffer, int writePosition, Metric metric)
     {
         writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ScopeMetrics_Metrics, ProtobufWireType.LEN);
-        int metricLengthPosition = writePosition;
+        var metricLengthPosition = writePosition;
         writePosition += ReserveSizeForLength;
 
         writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Metric_Name, metric.Name);
@@ -194,7 +194,7 @@ internal static class ProtobufOtlpMetricSerializer
             case MetricType.LongSumNonMonotonic:
                 {
                     writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Metric_Data_Sum, ProtobufWireType.LEN);
-                    int metricTypeLengthPosition = writePosition;
+                    var metricTypeLengthPosition = writePosition;
                     writePosition += ReserveSizeForLength;
 
                     writePosition = ProtobufSerializer.WriteBoolWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Sum_Is_Monotonic, metric.MetricType == MetricType.LongSum);
@@ -214,7 +214,7 @@ internal static class ProtobufOtlpMetricSerializer
             case MetricType.DoubleSumNonMonotonic:
                 {
                     writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Metric_Data_Sum, ProtobufWireType.LEN);
-                    int metricTypeLengthPosition = writePosition;
+                    var metricTypeLengthPosition = writePosition;
                     writePosition += ReserveSizeForLength;
 
                     writePosition = ProtobufSerializer.WriteBoolWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Sum_Is_Monotonic, metric.MetricType == MetricType.DoubleSum);
@@ -233,7 +233,7 @@ internal static class ProtobufOtlpMetricSerializer
             case MetricType.LongGauge:
                 {
                     writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Metric_Data_Gauge, ProtobufWireType.LEN);
-                    int metricTypeLengthPosition = writePosition;
+                    var metricTypeLengthPosition = writePosition;
                     writePosition += ReserveSizeForLength;
 
                     foreach (ref readonly var metricPoint in metric.GetMetricPoints())
@@ -249,7 +249,7 @@ internal static class ProtobufOtlpMetricSerializer
             case MetricType.DoubleGauge:
                 {
                     writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Metric_Data_Gauge, ProtobufWireType.LEN);
-                    int metricTypeLengthPosition = writePosition;
+                    var metricTypeLengthPosition = writePosition;
                     writePosition += ReserveSizeForLength;
 
                     foreach (ref readonly var metricPoint in metric.GetMetricPoints())
@@ -265,7 +265,7 @@ internal static class ProtobufOtlpMetricSerializer
             case MetricType.Histogram:
                 {
                     writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Metric_Data_Histogram, ProtobufWireType.LEN);
-                    int metricTypeLengthPosition = writePosition;
+                    var metricTypeLengthPosition = writePosition;
                     writePosition += ReserveSizeForLength;
 
                     writePosition = ProtobufSerializer.WriteEnumWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Histogram_Aggregation_Temporality, aggregationValue);
@@ -273,7 +273,7 @@ internal static class ProtobufOtlpMetricSerializer
                     foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                     {
                         writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Histogram_Data_Points, ProtobufWireType.LEN);
-                        int dataPointLengthPosition = writePosition;
+                        var dataPointLengthPosition = writePosition;
                         writePosition += ReserveSizeForLength;
 
                         var startTime = (ulong)metricPoint.StartTime.ToUnixTimeNanoseconds();
@@ -293,7 +293,7 @@ internal static class ProtobufOtlpMetricSerializer
                         var sum = metricPoint.GetHistogramSum();
                         writePosition = ProtobufSerializer.WriteDoubleWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.HistogramDataPoint_Sum, sum);
 
-                        if (metricPoint.TryGetHistogramMinMaxValues(out double min, out double max))
+                        if (metricPoint.TryGetHistogramMinMaxValues(out var min, out var max))
                         {
                             writePosition = ProtobufSerializer.WriteDoubleWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.HistogramDataPoint_Min, min);
                             writePosition = ProtobufSerializer.WriteDoubleWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.HistogramDataPoint_Max, max);
@@ -313,7 +313,7 @@ internal static class ProtobufOtlpMetricSerializer
             case MetricType.ExponentialHistogram:
                 {
                     writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.Metric_Data_Exponential_Histogram, ProtobufWireType.LEN);
-                    int metricTypeLengthPosition = writePosition;
+                    var metricTypeLengthPosition = writePosition;
                     writePosition += ReserveSizeForLength;
 
                     writePosition = ProtobufSerializer.WriteEnumWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogram_Aggregation_Temporality, aggregationValue);
@@ -321,7 +321,7 @@ internal static class ProtobufOtlpMetricSerializer
                     foreach (ref readonly var metricPoint in metric.GetMetricPoints())
                     {
                         writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogram_Data_Points, ProtobufWireType.LEN);
-                        int dataPointLengthPosition = writePosition;
+                        var dataPointLengthPosition = writePosition;
                         writePosition += ReserveSizeForLength;
 
                         var startTime = (ulong)metricPoint.StartTime.ToUnixTimeNanoseconds();
@@ -341,7 +341,7 @@ internal static class ProtobufOtlpMetricSerializer
                         var count = (ulong)metricPoint.GetHistogramCount();
                         writePosition = ProtobufSerializer.WriteFixed64WithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Count, count);
 
-                        if (metricPoint.TryGetHistogramMinMaxValues(out double min, out double max))
+                        if (metricPoint.TryGetHistogramMinMaxValues(out var min, out var max))
                         {
                             writePosition = ProtobufSerializer.WriteDoubleWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Min, min);
                             writePosition = ProtobufSerializer.WriteDoubleWithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Max, max);
@@ -353,7 +353,7 @@ internal static class ProtobufOtlpMetricSerializer
                         writePosition = ProtobufSerializer.WriteFixed64WithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Zero_Count, (ulong)exponentialHistogramData.ZeroCount);
 
                         writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Positive, ProtobufWireType.LEN);
-                        int positiveBucketsLengthPosition = writePosition;
+                        var positiveBucketsLengthPosition = writePosition;
                         writePosition += ReserveSizeForLength;
 
                         writePosition = ProtobufSerializer.WriteSInt32WithTag(buffer, writePosition, ProtobufOtlpMetricFieldNumberConstants.ExponentialHistogramDataPoint_Buckets_Offset, exponentialHistogramData.PositiveBuckets.Offset);
@@ -373,6 +373,9 @@ internal static class ProtobufOtlpMetricSerializer
                     ProtobufSerializer.WriteReservedLength(buffer, metricTypeLengthPosition, writePosition - (metricTypeLengthPosition + ReserveSizeForLength));
                     break;
                 }
+
+            default:
+                break;
         }
 
         ProtobufSerializer.WriteReservedLength(buffer, metricLengthPosition, writePosition - (metricLengthPosition + ReserveSizeForLength));
@@ -382,7 +385,7 @@ internal static class ProtobufOtlpMetricSerializer
     private static int WriteNumberDataPoint(byte[] buffer, int writePosition, int fieldNumber, in MetricPoint metricPoint, long value)
     {
         writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, fieldNumber, ProtobufWireType.LEN);
-        int dataPointLengthPosition = writePosition;
+        var dataPointLengthPosition = writePosition;
         writePosition += ReserveSizeForLength;
 
         // Casting to ulong is ok here as the bit representation for long versus ulong will be the same
@@ -420,7 +423,7 @@ internal static class ProtobufOtlpMetricSerializer
     private static int WriteNumberDataPoint(byte[] buffer, int writePosition, int fieldNumber, in MetricPoint metricPoint, double value)
     {
         writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, fieldNumber, ProtobufWireType.LEN);
-        int dataPointLengthPosition = writePosition;
+        var dataPointLengthPosition = writePosition;
         writePosition += ReserveSizeForLength;
 
         // Using a func here to avoid boxing/unboxing.
@@ -445,14 +448,14 @@ internal static class ProtobufOtlpMetricSerializer
 
     private static int WriteTag(byte[] buffer, int writePosition, KeyValuePair<string, object?> tag, int fieldNumber)
     {
-        ProtobufOtlpTagWriter.OtlpTagWriterState otlpTagWriterState = new ProtobufOtlpTagWriter.OtlpTagWriterState
+        var otlpTagWriterState = new ProtobufOtlpTagWriter.OtlpTagWriterState
         {
             Buffer = buffer,
             WritePosition = writePosition,
         };
 
         otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(buffer, otlpTagWriterState.WritePosition, fieldNumber, ProtobufWireType.LEN);
-        int fieldLengthPosition = otlpTagWriterState.WritePosition;
+        var fieldLengthPosition = otlpTagWriterState.WritePosition;
         otlpTagWriterState.WritePosition += ReserveSizeForLength;
 
         ProtobufOtlpTagWriter.Instance.TryWriteTag(ref otlpTagWriterState, tag.Key, tag.Value);
@@ -482,7 +485,7 @@ internal static class ProtobufOtlpMetricSerializer
     private static int WriteExemplar(byte[] buffer, int writePosition, in Exemplar exemplar, int fieldNumber, WriteExemplarFunc writeValueFunc)
     {
         writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, fieldNumber, ProtobufWireType.LEN);
-        int exemplarLengthPosition = writePosition;
+        var exemplarLengthPosition = writePosition;
         writePosition += ReserveSizeForLength;
 
         foreach (var tag in exemplar.FilteredTags)
@@ -525,7 +528,7 @@ internal static class ProtobufOtlpMetricSerializer
 
         static int WriteBucketCounts(byte[] buffer, int writePosition, HistogramBuckets.HistogramBucketValues[] values)
         {
-            int length = values.Length;
+            var length = values.Length;
 
             writePosition = WritePackedLength(
                 buffer,
@@ -533,7 +536,7 @@ internal static class ProtobufOtlpMetricSerializer
                 length,
                 ProtobufOtlpMetricFieldNumberConstants.HistogramDataPoint_Bucket_Counts);
 
-            for (int i = 0; i < length; i++)
+            for (var i = 0; i < length; i++)
             {
                 writePosition = ProtobufSerializer.WriteFixed64LittleEndianFormat(
                     buffer,
@@ -546,9 +549,9 @@ internal static class ProtobufOtlpMetricSerializer
 
         static int WriteExplicitBounds(byte[] buffer, int writePosition, double[] values)
         {
-            int length = 0;
+            var length = 0;
 
-            for (int i = 0; i < values.Length; i++)
+            for (var i = 0; i < values.Length; i++)
             {
                 if (values[i] != double.PositiveInfinity)
                 {
@@ -564,7 +567,7 @@ internal static class ProtobufOtlpMetricSerializer
                     length,
                     ProtobufOtlpMetricFieldNumberConstants.HistogramDataPoint_Explicit_Bounds);
 
-                for (int i = 0; i < values.Length; i++)
+                for (var i = 0; i < values.Length; i++)
                 {
                     var value = values[i];
                     if (value != double.PositiveInfinity)

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpResourceSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpResourceSerializer.cs
@@ -11,21 +11,21 @@ internal static class ProtobufOtlpResourceSerializer
 
     internal static int WriteResource(byte[] buffer, int writePosition, Resource? resource)
     {
-        ProtobufOtlpTagWriter.OtlpTagWriterState otlpTagWriterState = new ProtobufOtlpTagWriter.OtlpTagWriterState
+        var otlpTagWriterState = new ProtobufOtlpTagWriter.OtlpTagWriterState
         {
             Buffer = buffer,
             WritePosition = writePosition,
         };
 
         otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpTraceFieldNumberConstants.ResourceSpans_Resource, ProtobufWireType.LEN);
-        int resourceLengthPosition = otlpTagWriterState.WritePosition;
+        var resourceLengthPosition = otlpTagWriterState.WritePosition;
         otlpTagWriterState.WritePosition += ReserveSizeForLength;
 
         if (resource != null && resource != Resource.Empty)
         {
             if (resource.Attributes is IReadOnlyList<KeyValuePair<string, object>> resourceAttributesList)
             {
-                for (int i = 0; i < resourceAttributesList.Count; i++)
+                for (var i = 0; i < resourceAttributesList.Count; i++)
                 {
                     ProcessResourceAttribute(ref otlpTagWriterState, resourceAttributesList[i]);
                 }
@@ -48,7 +48,7 @@ internal static class ProtobufOtlpResourceSerializer
     private static void ProcessResourceAttribute(ref ProtobufOtlpTagWriter.OtlpTagWriterState otlpTagWriterState, KeyValuePair<string, object> attribute)
     {
         otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpTraceFieldNumberConstants.Resource_Attributes, ProtobufWireType.LEN);
-        int resourceAttributesLengthPosition = otlpTagWriterState.WritePosition;
+        var resourceAttributesLengthPosition = otlpTagWriterState.WritePosition;
         otlpTagWriterState.WritePosition += ReserveSizeForLength;
 
         ProtobufOtlpTagWriter.Instance.TryWriteTag(ref otlpTagWriterState, attribute.Key, attribute.Value);

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTagWriter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTagWriter.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Diagnostics;
 using OpenTelemetry.Internal;
 
 namespace OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer;
@@ -134,9 +133,7 @@ internal sealed class ProtobufOtlpTagWriter : TagWriter<ProtobufOtlpTagWriter.Ot
         }
 
         public override void WriteNullValue(ref OtlpTagWriterArrayState state)
-        {
-            state.WritePosition = ProtobufSerializer.WriteTagAndLength(state.Buffer, state.WritePosition, 0, ProtobufOtlpCommonFieldNumberConstants.ArrayValue_Value, ProtobufWireType.LEN);
-        }
+            => state.WritePosition = ProtobufSerializer.WriteTagAndLength(state.Buffer, state.WritePosition, 0, ProtobufOtlpCommonFieldNumberConstants.ArrayValue_Value, ProtobufWireType.LEN);
 
         public override void WriteIntegralValue(ref OtlpTagWriterArrayState state, long value)
         {
@@ -175,8 +172,6 @@ internal sealed class ProtobufOtlpTagWriter : TagWriter<ProtobufOtlpTagWriter.Ot
         public override bool TryResize()
         {
             var buffer = ThreadBuffer;
-
-            Debug.Assert(buffer != null, "buffer was null");
 
             if (buffer!.Length >= MaxBufferSize)
             {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTraceSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufOtlpTraceSerializer.cs
@@ -47,12 +47,12 @@ internal static class ProtobufOtlpTraceSerializer
     {
         while (true)
         {
-            int entryWritePosition = writePosition;
+            var entryWritePosition = writePosition;
 
             try
             {
                 writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.TracesData_Resource_Spans, ProtobufWireType.LEN);
-                int resourceSpansScopeSpansLengthPosition = writePosition;
+                var resourceSpansScopeSpansLengthPosition = writePosition;
                 writePosition += ReserveSizeForLength;
 
                 writePosition = WriteResourceSpans(buffer, writePosition, sdkLimitOptions, resource);
@@ -62,7 +62,7 @@ internal static class ProtobufOtlpTraceSerializer
                 // Serialization succeeded, return the final write position
                 return writePosition;
             }
-            catch (Exception ex) when (ex is IndexOutOfRangeException || ex is ArgumentException)
+            catch (Exception ex) when (ex is IndexOutOfRangeException or ArgumentException)
             {
                 // Reset write position and attempt to increase the buffer size
                 writePosition = entryWritePosition;
@@ -105,10 +105,10 @@ internal static class ProtobufOtlpTraceSerializer
     {
         if (scopeTracesList != null)
         {
-            foreach (KeyValuePair<string, List<Activity>> entry in scopeTracesList)
+            foreach (var entry in scopeTracesList)
             {
                 writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.ResourceSpans_Scope_Spans, ProtobufWireType.LEN);
-                int resourceSpansScopeSpansLengthPosition = writePosition;
+                var resourceSpansScopeSpansLengthPosition = writePosition;
                 writePosition += ReserveSizeForLength;
 
                 writePosition = WriteScopeSpan(buffer, writePosition, sdkLimitOptions, entry.Value[0].Source, entry.Value);
@@ -122,7 +122,7 @@ internal static class ProtobufOtlpTraceSerializer
     internal static int WriteScopeSpan(byte[] buffer, int writePosition, SdkLimitOptions sdkLimitOptions, ActivitySource activitySource, List<Activity> activities)
     {
         writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.ScopeSpans_Scope, ProtobufWireType.LEN);
-        int instrumentationScopeLengthPosition = writePosition;
+        var instrumentationScopeLengthPosition = writePosition;
         writePosition += ReserveSizeForLength;
 
         writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Name, activitySource.Name);
@@ -135,7 +135,7 @@ internal static class ProtobufOtlpTraceSerializer
         {
             var maxAttributeCount = sdkLimitOptions.SpanAttributeCountLimit ?? int.MaxValue;
             var maxAttributeValueLength = sdkLimitOptions.AttributeValueLengthLimit ?? int.MaxValue;
-            ProtobufOtlpTagWriter.OtlpTagWriterState otlpTagWriterState = new ProtobufOtlpTagWriter.OtlpTagWriterState
+            var otlpTagWriterState = new ProtobufOtlpTagWriter.OtlpTagWriterState
             {
                 Buffer = buffer,
                 WritePosition = writePosition,
@@ -145,12 +145,12 @@ internal static class ProtobufOtlpTraceSerializer
 
             if (activitySource.Tags is IReadOnlyList<KeyValuePair<string, object?>> activitySourceTagsList)
             {
-                for (int i = 0; i < activitySourceTagsList.Count; i++)
+                for (var i = 0; i < activitySourceTagsList.Count; i++)
                 {
                     if (otlpTagWriterState.TagCount < maxAttributeCount)
                     {
                         otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Attributes, ProtobufWireType.LEN);
-                        int instrumentationScopeAttributesLengthPosition = otlpTagWriterState.WritePosition;
+                        var instrumentationScopeAttributesLengthPosition = otlpTagWriterState.WritePosition;
                         otlpTagWriterState.WritePosition += ReserveSizeForLength;
 
                         ProtobufOtlpTagWriter.Instance.TryWriteTag(ref otlpTagWriterState, activitySourceTagsList[i].Key, activitySourceTagsList[i].Value, maxAttributeValueLength);
@@ -172,7 +172,7 @@ internal static class ProtobufOtlpTraceSerializer
                     if (otlpTagWriterState.TagCount < maxAttributeCount)
                     {
                         otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpCommonFieldNumberConstants.InstrumentationScope_Attributes, ProtobufWireType.LEN);
-                        int instrumentationScopeAttributesLengthPosition = otlpTagWriterState.WritePosition;
+                        var instrumentationScopeAttributesLengthPosition = otlpTagWriterState.WritePosition;
                         otlpTagWriterState.WritePosition += ReserveSizeForLength;
 
                         ProtobufOtlpTagWriter.Instance.TryWriteTag(ref otlpTagWriterState, tag.Key, tag.Value, maxAttributeValueLength);
@@ -199,14 +199,16 @@ internal static class ProtobufOtlpTraceSerializer
 
         ProtobufSerializer.WriteReservedLength(buffer, instrumentationScopeLengthPosition, writePosition - (instrumentationScopeLengthPosition + ReserveSizeForLength));
 
-        for (int i = 0; i < activities.Count; i++)
+        for (var i = 0; i < activities.Count; i++)
         {
             writePosition = WriteSpan(buffer, writePosition, sdkLimitOptions, activities[i]);
         }
 
         if (!string.IsNullOrEmpty(activitySource.TelemetrySchemaUrl))
         {
+#pragma warning disable IDE0370 // Suppression is unnecessary
             writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.ScopeSpans_Schema_Url, activitySource.TelemetrySchemaUrl!);
+#pragma warning restore IDE0370 // Suppression is unnecessary
         }
 
         return writePosition;
@@ -215,7 +217,7 @@ internal static class ProtobufOtlpTraceSerializer
     internal static int WriteSpan(byte[] buffer, int writePosition, SdkLimitOptions sdkLimitOptions, Activity activity)
     {
         writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.ScopeSpans_Span, ProtobufWireType.LEN);
-        int spanLengthPosition = writePosition;
+        var spanLengthPosition = writePosition;
         writePosition += ReserveSizeForLength;
 
         writePosition = ProtobufSerializer.WriteTagAndLength(buffer, writePosition, TraceIdSize, ProtobufOtlpTraceFieldNumberConstants.Span_Trace_Id, ProtobufWireType.LEN);
@@ -241,7 +243,7 @@ internal static class ProtobufOtlpTraceSerializer
         writePosition = ProtobufSerializer.WriteFixed64WithTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.Span_Start_Time_Unix_Nano, (ulong)activity.StartTimeUtc.ToUnixTimeNanoseconds());
         writePosition = ProtobufSerializer.WriteFixed64WithTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.Span_End_Time_Unix_Nano, (ulong)(activity.StartTimeUtc.ToUnixTimeNanoseconds() + activity.Duration.ToNanoseconds()));
 
-        (writePosition, StatusCode? statusCode, string? statusMessage) = WriteActivityTags(buffer, writePosition, sdkLimitOptions, activity);
+        (writePosition, var statusCode, var statusMessage) = WriteActivityTags(buffer, writePosition, sdkLimitOptions, activity);
         writePosition = WriteSpanEvents(buffer, writePosition, sdkLimitOptions, activity);
         writePosition = WriteSpanLinks(buffer, writePosition, sdkLimitOptions, activity);
         writePosition = WriteSpanStatus(buffer, writePosition, activity, statusCode, statusMessage);
@@ -266,7 +268,7 @@ internal static class ProtobufOtlpTraceSerializer
 
     internal static int WriteTraceFlags(byte[] buffer, int position, ActivityTraceFlags activityTraceFlags, bool hasRemoteParent, int fieldNumber)
     {
-        uint spanFlags = (uint)activityTraceFlags & (byte)0x000000FF;
+        var spanFlags = (uint)activityTraceFlags & 0x000000FF;
 
         spanFlags |= 0x00000100;
         if (hasRemoteParent)
@@ -283,9 +285,9 @@ internal static class ProtobufOtlpTraceSerializer
     {
         StatusCode? statusCode = null;
         string? statusMessage = null;
-        int maxAttributeCount = sdkLimitOptions.SpanAttributeCountLimit ?? int.MaxValue;
-        int maxAttributeValueLength = sdkLimitOptions.AttributeValueLengthLimit ?? int.MaxValue;
-        ProtobufOtlpTagWriter.OtlpTagWriterState otlpTagWriterState = new ProtobufOtlpTagWriter.OtlpTagWriterState
+        var maxAttributeCount = sdkLimitOptions.SpanAttributeCountLimit ?? int.MaxValue;
+        var maxAttributeValueLength = sdkLimitOptions.AttributeValueLengthLimit ?? int.MaxValue;
+        var otlpTagWriterState = new ProtobufOtlpTagWriter.OtlpTagWriterState
         {
             Buffer = buffer,
             WritePosition = writePosition,
@@ -315,12 +317,14 @@ internal static class ProtobufOtlpTraceSerializer
                 case "otel.status_description":
                     statusMessage = tag.Value as string;
                     continue;
+                default:
+                    break;
             }
 
             if (otlpTagWriterState.TagCount < maxAttributeCount)
             {
                 otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpTraceFieldNumberConstants.Span_Attributes, ProtobufWireType.LEN);
-                int spanAttributesLengthPosition = otlpTagWriterState.WritePosition;
+                var spanAttributesLengthPosition = otlpTagWriterState.WritePosition;
                 otlpTagWriterState.WritePosition += ReserveSizeForLength;
 
                 ProtobufOtlpTagWriter.Instance.TryWriteTag(ref otlpTagWriterState, tag.Key, tag.Value, maxAttributeValueLength);
@@ -345,15 +349,15 @@ internal static class ProtobufOtlpTraceSerializer
 
     internal static int WriteSpanEvents(byte[] buffer, int writePosition, SdkLimitOptions sdkLimitOptions, Activity activity)
     {
-        int maxEventCountLimit = sdkLimitOptions.SpanEventCountLimit ?? int.MaxValue;
-        int eventCount = 0;
-        int droppedEventCount = 0;
+        var maxEventCountLimit = sdkLimitOptions.SpanEventCountLimit ?? int.MaxValue;
+        var eventCount = 0;
+        var droppedEventCount = 0;
         foreach (ref readonly var evnt in activity.EnumerateEvents())
         {
             if (eventCount < maxEventCountLimit)
             {
                 writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.Span_Events, ProtobufWireType.LEN);
-                int spanEventsLengthPosition = writePosition;
+                var spanEventsLengthPosition = writePosition;
                 writePosition += ReserveSizeForLength; // Reserve 4 bytes for length
 
                 writePosition = ProtobufSerializer.WriteStringWithTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.Event_Name, evnt.Name);
@@ -380,10 +384,10 @@ internal static class ProtobufOtlpTraceSerializer
 
     internal static int WriteEventAttributes(ref byte[] buffer, int writePosition, SdkLimitOptions sdkLimitOptions, ActivityEvent evnt)
     {
-        int maxAttributeCount = sdkLimitOptions.SpanEventAttributeCountLimit ?? int.MaxValue;
-        int maxAttributeValueLength = sdkLimitOptions.AttributeValueLengthLimit ?? int.MaxValue;
+        var maxAttributeCount = sdkLimitOptions.SpanEventAttributeCountLimit ?? int.MaxValue;
+        var maxAttributeValueLength = sdkLimitOptions.AttributeValueLengthLimit ?? int.MaxValue;
 
-        ProtobufOtlpTagWriter.OtlpTagWriterState otlpTagWriterState = new ProtobufOtlpTagWriter.OtlpTagWriterState
+        var otlpTagWriterState = new ProtobufOtlpTagWriter.OtlpTagWriterState
         {
             Buffer = buffer,
             WritePosition = writePosition,
@@ -396,7 +400,7 @@ internal static class ProtobufOtlpTraceSerializer
             if (otlpTagWriterState.TagCount < maxAttributeCount)
             {
                 otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpTraceFieldNumberConstants.Event_Attributes, ProtobufWireType.LEN);
-                int eventAttributesLengthPosition = otlpTagWriterState.WritePosition;
+                var eventAttributesLengthPosition = otlpTagWriterState.WritePosition;
                 otlpTagWriterState.WritePosition += ReserveSizeForLength;
                 ProtobufOtlpTagWriter.Instance.TryWriteTag(ref otlpTagWriterState, tag.Key, tag.Value, maxAttributeValueLength);
                 ProtobufSerializer.WriteReservedLength(buffer, eventAttributesLengthPosition, otlpTagWriterState.WritePosition - (eventAttributesLengthPosition + ReserveSizeForLength));
@@ -419,16 +423,16 @@ internal static class ProtobufOtlpTraceSerializer
 
     internal static int WriteSpanLinks(byte[] buffer, int writePosition, SdkLimitOptions sdkLimitOptions, Activity activity)
     {
-        int maxLinksCount = sdkLimitOptions.SpanLinkCountLimit ?? int.MaxValue;
-        int linkCount = 0;
-        int droppedLinkCount = 0;
+        var maxLinksCount = sdkLimitOptions.SpanLinkCountLimit ?? int.MaxValue;
+        var linkCount = 0;
+        var droppedLinkCount = 0;
 
         foreach (ref readonly var link in activity.EnumerateLinks())
         {
             if (linkCount < maxLinksCount)
             {
                 writePosition = ProtobufSerializer.WriteTag(buffer, writePosition, ProtobufOtlpTraceFieldNumberConstants.Span_Links, ProtobufWireType.LEN);
-                int spanLinksLengthPosition = writePosition;
+                var spanLinksLengthPosition = writePosition;
                 writePosition += ReserveSizeForLength; // Reserve 4 bytes for length
 
                 writePosition = ProtobufSerializer.WriteTagAndLength(buffer, writePosition, TraceIdSize, ProtobufOtlpTraceFieldNumberConstants.Link_Trace_Id, ProtobufWireType.LEN);
@@ -463,9 +467,9 @@ internal static class ProtobufOtlpTraceSerializer
 
     internal static int WriteLinkAttributes(byte[] buffer, int writePosition, SdkLimitOptions sdkLimitOptions, ActivityLink link)
     {
-        int maxAttributeCount = sdkLimitOptions.SpanLinkAttributeCountLimit ?? int.MaxValue;
-        int maxAttributeValueLength = sdkLimitOptions.AttributeValueLengthLimit ?? int.MaxValue;
-        ProtobufOtlpTagWriter.OtlpTagWriterState otlpTagWriterState = new ProtobufOtlpTagWriter.OtlpTagWriterState
+        var maxAttributeCount = sdkLimitOptions.SpanLinkAttributeCountLimit ?? int.MaxValue;
+        var maxAttributeValueLength = sdkLimitOptions.AttributeValueLengthLimit ?? int.MaxValue;
+        var otlpTagWriterState = new ProtobufOtlpTagWriter.OtlpTagWriterState
         {
             Buffer = buffer,
             WritePosition = writePosition,
@@ -478,7 +482,7 @@ internal static class ProtobufOtlpTraceSerializer
             if (otlpTagWriterState.TagCount < maxAttributeCount)
             {
                 otlpTagWriterState.WritePosition = ProtobufSerializer.WriteTag(otlpTagWriterState.Buffer, otlpTagWriterState.WritePosition, ProtobufOtlpTraceFieldNumberConstants.Link_Attributes, ProtobufWireType.LEN);
-                int linkAttributesLengthPosition = otlpTagWriterState.WritePosition;
+                var linkAttributesLengthPosition = otlpTagWriterState.WritePosition;
                 otlpTagWriterState.WritePosition += ReserveSizeForLength;
                 ProtobufOtlpTagWriter.Instance.TryWriteTag(ref otlpTagWriterState, tag.Key, tag.Value, maxAttributeValueLength);
                 ProtobufSerializer.WriteReservedLength(buffer, linkAttributesLengthPosition, otlpTagWriterState.WritePosition - (linkAttributesLengthPosition + ReserveSizeForLength));
@@ -525,7 +529,7 @@ internal static class ProtobufOtlpTraceSerializer
             position = ProtobufSerializer.WriteTagAndLength(buffer, position, 2, ProtobufOtlpTraceFieldNumberConstants.Span_Status, ProtobufWireType.LEN);
         }
 
-        var finalStatusCode = useActivity ? (int)activity.Status : (statusCode != null && statusCode != StatusCode.Unset) ? (int)statusCode! : (int)StatusCode.Unset;
+        var finalStatusCode = useActivity ? (int)activity.Status : (statusCode is not null and not StatusCode.Unset) ? (int)statusCode : (int)StatusCode.Unset;
         position = ProtobufSerializer.WriteEnumWithTag(buffer, position, ProtobufOtlpTraceFieldNumberConstants.Status_Code, finalStatusCode);
 
         return position;

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufSerializer.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Serializer/ProtobufSerializer.cs
@@ -267,7 +267,7 @@ internal static class ProtobufSerializer
             }
         }
 #else
-        int numberOfUtf8CharsInString = Utf8Encoding.GetByteCount(value);
+        var numberOfUtf8CharsInString = Utf8Encoding.GetByteCount(value);
 #endif
         return numberOfUtf8CharsInString;
     }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/OtlpExporterPersistentStorageTransmissionHandler.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/Transmission/OtlpExporterPersistentStorageTransmissionHandler.cs
@@ -28,8 +28,7 @@ internal sealed class OtlpExporterPersistentStorageTransmissionHandler : OtlpExp
     internal OtlpExporterPersistentStorageTransmissionHandler(PersistentBlobProvider persistentBlobProvider, IExportClient exportClient, double timeoutMilliseconds)
         : base(exportClient, timeoutMilliseconds)
     {
-        Debug.Assert(persistentBlobProvider != null, "persistentBlobProvider was null");
-        this.persistentBlobProvider = persistentBlobProvider!;
+        this.persistentBlobProvider = persistentBlobProvider;
 
         this.thread = new Thread(this.RetryStoredRequests)
         {
@@ -49,10 +48,7 @@ internal sealed class OtlpExporterPersistentStorageTransmissionHandler : OtlpExp
     }
 
     protected override bool OnSubmitRequestFailure(byte[] request, int contentLength, ExportClientResponse response)
-    {
-        Debug.Assert(request != null, "request was null");
-        return RetryHelper.ShouldRetryRequest(response, OtlpRetry.InitialBackoffMilliseconds, out _) && this.persistentBlobProvider.TryCreateBlob(request!, out _);
-    }
+        => RetryHelper.ShouldRetryRequest(response, OtlpRetry.InitialBackoffMilliseconds, out _) && this.persistentBlobProvider.TryCreateBlob(request, out _);
 
     protected override void OnShutdown(int timeoutMilliseconds)
     {
@@ -113,7 +109,7 @@ internal sealed class OtlpExporterPersistentStorageTransmissionHandler : OtlpExp
                     break;
                 }
 
-                int fileCount = 0;
+                var fileCount = 0;
 
                 // TODO: Run maintenance job.
                 // Transmit 10 files at a time.

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptions.cs
@@ -66,8 +66,6 @@ public class OtlpExporterOptions : IOtlpExporterOptions
         OtlpExporterOptionsConfigurationType configurationType,
         BatchExportActivityProcessorOptions defaultBatchOptions)
     {
-        Debug.Assert(defaultBatchOptions != null, "defaultBatchOptions was null");
-
         this.ApplyConfiguration(configuration, configurationType);
 
         this.DefaultHttpClientFactory = () =>
@@ -90,7 +88,7 @@ public class OtlpExporterOptions : IOtlpExporterOptions
             };
         };
 
-        this.BatchExportProcessorOptions = defaultBatchOptions!;
+        this.BatchExportProcessorOptions = defaultBatchOptions;
     }
 
     /// <inheritdoc/>
@@ -256,8 +254,6 @@ public class OtlpExporterOptions : IOtlpExporterOptions
         IConfiguration configuration,
         OtlpExporterOptionsConfigurationType configurationType)
     {
-        Debug.Assert(configuration != null, "configuration was null");
-
         // Note: When using the "AddOtlpExporter" extensions configurationType
         // never has a value other than "Default" because OtlpExporterOptions is
         // shared by all signals and there is no way to differentiate which
@@ -265,7 +261,7 @@ public class OtlpExporterOptions : IOtlpExporterOptions
         if (configurationType == OtlpExporterOptionsConfigurationType.Default)
         {
             this.ApplyConfigurationUsingSpecificationEnvVars(
-                configuration!,
+                configuration,
                 OtlpSpecConfigDefinitions.DefaultEndpointEnvVarName,
                 appendSignalPathToEndpoint: true,
                 OtlpSpecConfigDefinitions.DefaultProtocolEnvVarName,
@@ -275,7 +271,7 @@ public class OtlpExporterOptions : IOtlpExporterOptions
         else if (configurationType == OtlpExporterOptionsConfigurationType.Logs)
         {
             this.ApplyConfigurationUsingSpecificationEnvVars(
-                configuration!,
+                configuration,
                 OtlpSpecConfigDefinitions.LogsEndpointEnvVarName,
                 appendSignalPathToEndpoint: false,
                 OtlpSpecConfigDefinitions.LogsProtocolEnvVarName,
@@ -285,7 +281,7 @@ public class OtlpExporterOptions : IOtlpExporterOptions
         else if (configurationType == OtlpExporterOptionsConfigurationType.Metrics)
         {
             this.ApplyConfigurationUsingSpecificationEnvVars(
-                configuration!,
+                configuration,
                 OtlpSpecConfigDefinitions.MetricsEndpointEnvVarName,
                 appendSignalPathToEndpoint: false,
                 OtlpSpecConfigDefinitions.MetricsProtocolEnvVarName,
@@ -295,7 +291,7 @@ public class OtlpExporterOptions : IOtlpExporterOptions
         else if (configurationType == OtlpExporterOptionsConfigurationType.Traces)
         {
             this.ApplyConfigurationUsingSpecificationEnvVars(
-                configuration!,
+                configuration,
                 OtlpSpecConfigDefinitions.TracesEndpointEnvVarName,
                 appendSignalPathToEndpoint: false,
                 OtlpSpecConfigDefinitions.TracesProtocolEnvVarName,

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpExporterOptionsExtensions.cs
@@ -31,11 +31,11 @@ internal static class OtlpExporterOptionsExtensions
         {
             // According to the specification, URL-encoded headers must be supported.
             optionHeaders = Uri.UnescapeDataString(optionHeaders);
-            ReadOnlySpan<char> headersSpan = optionHeaders.AsSpan();
+            var headersSpan = optionHeaders.AsSpan();
 
             while (!headersSpan.IsEmpty)
             {
-                int commaIndex = headersSpan.IndexOf(',');
+                var commaIndex = headersSpan.IndexOf(',');
                 ReadOnlySpan<char> pair;
                 if (commaIndex == -1)
                 {
@@ -48,7 +48,7 @@ internal static class OtlpExporterOptionsExtensions
                     headersSpan = headersSpan.Slice(commaIndex + 1);
                 }
 
-                int equalIndex = pair.IndexOf('=');
+                var equalIndex = pair.IndexOf('=');
                 if (equalIndex == -1)
                 {
                     throw new ArgumentException("Headers provided in an invalid format.");
@@ -75,7 +75,7 @@ internal static class OtlpExporterOptionsExtensions
         // `HttpClient.Timeout.TotalMilliseconds` would be populated with the correct timeout value for both the exporter configuration cases:
         // 1. User provides their own HttpClient. This case is straightforward as the user wants to use their `HttpClient` and thereby the same client's timeout value.
         // 2. If the user configures timeout via the exporter options, then the timeout set for the `HttpClient` initialized by the exporter will be set to user provided value.
-        double timeoutMilliseconds = exportClient is OtlpHttpExportClient httpTraceExportClient
+        var timeoutMilliseconds = exportClient is OtlpHttpExportClient httpTraceExportClient
             ? httpTraceExportClient.HttpClient.Timeout.TotalMilliseconds
             : options.TimeoutMilliseconds;
 
@@ -103,7 +103,7 @@ internal static class OtlpExporterOptionsExtensions
         var httpClient = options.HttpClientFactory?.Invoke() ?? throw new InvalidOperationException("OtlpExporterOptions was missing HttpClientFactory or it returned null.");
 
 #pragma warning disable CS0618 // Suppressing gRPC obsolete warning
-        if (options.Protocol != OtlpExportProtocol.Grpc && options.Protocol != OtlpExportProtocol.HttpProtobuf)
+        if (options.Protocol is not OtlpExportProtocol.Grpc and not OtlpExportProtocol.HttpProtobuf)
         {
             throw new NotSupportedException($"Protocol {options.Protocol} is not supported.");
         }
@@ -135,13 +135,13 @@ internal static class OtlpExporterOptionsExtensions
         {
             options.HttpClientFactory = () =>
             {
-                Type? httpClientFactoryType = Type.GetType("System.Net.Http.IHttpClientFactory, Microsoft.Extensions.Http", throwOnError: false);
+                var httpClientFactoryType = Type.GetType("System.Net.Http.IHttpClientFactory, Microsoft.Extensions.Http", throwOnError: false);
                 if (httpClientFactoryType != null)
                 {
-                    object? httpClientFactory = serviceProvider.GetService(httpClientFactoryType);
+                    var httpClientFactory = serviceProvider.GetService(httpClientFactoryType);
                     if (httpClientFactory != null)
                     {
-                        MethodInfo? createClientMethod = httpClientFactoryType.GetMethod(
+                        var createClientMethod = httpClientFactoryType.GetMethod(
                             "CreateClient",
                             BindingFlags.Public | BindingFlags.Instance,
                             binder: null,
@@ -149,7 +149,7 @@ internal static class OtlpExporterOptionsExtensions
                             modifiers: null);
                         if (createClientMethod != null)
                         {
-                            HttpClient? client = (HttpClient?)createClientMethod.Invoke(httpClientFactory, [httpClientName]);
+                            var client = (HttpClient?)createClientMethod.Invoke(httpClientFactory, [httpClientName]);
 
                             if (client != null)
                             {

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporter.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Buffers.Binary;
-using System.Diagnostics;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Transmission;
@@ -23,8 +22,6 @@ public sealed class OtlpLogExporter : BaseExporter<LogRecord>
     private readonly OtlpExporterTransmissionHandler transmissionHandler;
     private readonly int startWritePosition;
 
-    private Resource? resource;
-
     // Initial buffer size set to ~732KB.
     // This choice allows us to gradually grow the buffer while targeting a final capacity of around 100 MB,
     // by the 7th doubling to maintain efficient allocation without frequent resizing.
@@ -35,7 +32,7 @@ public sealed class OtlpLogExporter : BaseExporter<LogRecord>
     /// </summary>
     /// <param name="options">Configuration options for the exporter.</param>
     public OtlpLogExporter(OtlpExporterOptions options)
-        : this(options, sdkLimitOptions: new(), experimentalOptions: new(), transmissionHandler: null)
+        : this(options ?? throw new ArgumentNullException(nameof(options)), sdkLimitOptions: new(), experimentalOptions: new(), transmissionHandler: null)
     {
     }
 
@@ -52,19 +49,19 @@ public sealed class OtlpLogExporter : BaseExporter<LogRecord>
         ExperimentalOptions experimentalOptions,
         OtlpExporterTransmissionHandler? transmissionHandler = null)
     {
-        Debug.Assert(exporterOptions != null, "exporterOptions was null");
-        Debug.Assert(sdkLimitOptions != null, "sdkLimitOptions was null");
-        Debug.Assert(experimentalOptions != null, "experimentalOptions was null");
-
-        this.experimentalOptions = experimentalOptions!;
-        this.sdkLimitOptions = sdkLimitOptions!;
+        this.experimentalOptions = experimentalOptions;
+        this.sdkLimitOptions = sdkLimitOptions;
 #pragma warning disable CS0618 // Suppressing gRPC obsolete warning
-        this.startWritePosition = exporterOptions!.Protocol == OtlpExportProtocol.Grpc ? GrpcStartWritePosition : 0;
+        this.startWritePosition = exporterOptions.Protocol == OtlpExportProtocol.Grpc ? GrpcStartWritePosition : 0;
 #pragma warning restore CS0618 // Suppressing gRPC obsolete warning
-        this.transmissionHandler = transmissionHandler ?? exporterOptions!.GetExportTransmissionHandler(experimentalOptions!, OtlpSignalType.Logs);
+        this.transmissionHandler = transmissionHandler ?? exporterOptions.GetExportTransmissionHandler(experimentalOptions, OtlpSignalType.Logs);
     }
 
-    internal Resource Resource => this.resource ??= this.ParentProvider.GetResource();
+    internal Resource Resource
+    {
+        get => field ??= this.ParentProvider.GetResource();
+        private set;
+    }
 
     /// <inheritdoc/>
 #pragma warning disable CA1725 // Parameter names should match base declaration
@@ -76,7 +73,7 @@ public sealed class OtlpLogExporter : BaseExporter<LogRecord>
 
         try
         {
-            int writePosition = ProtobufOtlpLogSerializer.WriteLogsData(ref this.buffer, this.startWritePosition, this.sdkLimitOptions, this.experimentalOptions, this.Resource, logRecordBatch);
+            var writePosition = ProtobufOtlpLogSerializer.WriteLogsData(ref this.buffer, this.startWritePosition, this.sdkLimitOptions, this.experimentalOptions, this.Resource, logRecordBatch);
 
             if (this.startWritePosition == GrpcStartWritePosition)
             {
@@ -84,7 +81,7 @@ public sealed class OtlpLogExporter : BaseExporter<LogRecord>
                 // byte 0 - Specifying if the payload is compressed.
                 // 1-4 byte - Specifies the length of payload in big endian format.
                 // 5 and above -  Protobuf serialized data.
-                Span<byte> data = new Span<byte>(this.buffer, 1, 4);
+                var data = new Span<byte>(this.buffer, 1, 4);
                 var dataLength = writePosition - GrpcStartWritePosition;
                 BinaryPrimitives.WriteUInt32BigEndian(data, (uint)dataLength);
             }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpLogExporterHelperExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -282,15 +281,9 @@ public static class OtlpLogExporterHelperExtensions
         bool skipUseOtlpExporterRegistrationCheck = false,
         Func<BaseExporter<LogRecord>, BaseExporter<LogRecord>>? configureExporterInstance = null)
     {
-        Debug.Assert(serviceProvider != null, "serviceProvider was null");
-        Debug.Assert(exporterOptions != null, "exporterOptions was null");
-        Debug.Assert(processorOptions != null, "processorOptions was null");
-        Debug.Assert(sdkLimitOptions != null, "sdkLimitOptions was null");
-        Debug.Assert(experimentalOptions != null, "experimentalOptions was null");
-
 #if NETFRAMEWORK || NETSTANDARD2_0
 #pragma warning disable CS0618 // Suppressing gRPC obsolete warning
-        if (exporterOptions!.Protocol == OtlpExportProtocol.Grpc &&
+        if (exporterOptions.Protocol == OtlpExportProtocol.Grpc &&
             ReferenceEquals(exporterOptions.HttpClientFactory, exporterOptions.DefaultHttpClientFactory))
 #pragma warning restore CS0618 // Suppressing gRPC obsolete warning
         {
@@ -301,7 +294,7 @@ public static class OtlpLogExporterHelperExtensions
 
         if (!skipUseOtlpExporterRegistrationCheck)
         {
-            serviceProvider!.EnsureNoUseOtlpExporterRegistrations();
+            serviceProvider.EnsureNoUseOtlpExporterRegistrations();
         }
 
         /*
@@ -322,9 +315,9 @@ public static class OtlpLogExporterHelperExtensions
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
         BaseExporter<LogRecord> otlpExporter = new OtlpLogExporter(
-            exporterOptions!,
-            sdkLimitOptions!,
-            experimentalOptions!);
+            exporterOptions,
+            sdkLimitOptions,
+            experimentalOptions);
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
         try
@@ -334,7 +327,7 @@ public static class OtlpLogExporterHelperExtensions
                 otlpExporter = configureExporterInstance(otlpExporter);
             }
 
-            if (processorOptions!.ExportProcessorType == ExportProcessorType.Simple)
+            if (processorOptions.ExportProcessorType == ExportProcessorType.Simple)
             {
                 return new SimpleLogRecordExportProcessor(otlpExporter);
             }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporter.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 using System.Buffers.Binary;
-using System.Diagnostics;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Serializer;
 using OpenTelemetry.Exporter.OpenTelemetryProtocol.Implementation.Transmission;
@@ -21,8 +20,6 @@ public class OtlpMetricExporter : BaseExporter<Metric>
     private readonly OtlpExporterTransmissionHandler transmissionHandler;
     private readonly int startWritePosition;
 
-    private Resource? resource;
-
     // Initial buffer size set to ~732KB.
     // This choice allows us to gradually grow the buffer while targeting a final capacity of around 100 MB,
     // by the 7th doubling to maintain efficient allocation without frequent resizing.
@@ -33,7 +30,7 @@ public class OtlpMetricExporter : BaseExporter<Metric>
     /// </summary>
     /// <param name="options">Configuration options for the exporter.</param>
     public OtlpMetricExporter(OtlpExporterOptions options)
-        : this(options, experimentalOptions: new(), transmissionHandler: null)
+        : this(options ?? throw new ArgumentNullException(nameof(options)), experimentalOptions: new(), transmissionHandler: null)
     {
     }
 
@@ -48,16 +45,17 @@ public class OtlpMetricExporter : BaseExporter<Metric>
         ExperimentalOptions experimentalOptions,
         OtlpExporterTransmissionHandler? transmissionHandler = null)
     {
-        Debug.Assert(exporterOptions != null, "exporterOptions was null");
-        Debug.Assert(experimentalOptions != null, "experimentalOptions was null");
-
 #pragma warning disable CS0618 // Suppressing gRPC obsolete warning
-        this.startWritePosition = exporterOptions!.Protocol == OtlpExportProtocol.Grpc ? GrpcStartWritePosition : 0;
+        this.startWritePosition = exporterOptions.Protocol == OtlpExportProtocol.Grpc ? GrpcStartWritePosition : 0;
 #pragma warning restore CS0618 // Suppressing gRPC obsolete warning
-        this.transmissionHandler = transmissionHandler ?? exporterOptions!.GetExportTransmissionHandler(experimentalOptions!, OtlpSignalType.Metrics);
+        this.transmissionHandler = transmissionHandler ?? exporterOptions.GetExportTransmissionHandler(experimentalOptions, OtlpSignalType.Metrics);
     }
 
-    internal Resource Resource => this.resource ??= this.ParentProvider.GetResource();
+    internal Resource Resource
+    {
+        get => field ??= this.ParentProvider.GetResource();
+        private set;
+    }
 
     /// <inheritdoc />
 #pragma warning disable CA1725 // Parameter names should match base declaration
@@ -69,7 +67,7 @@ public class OtlpMetricExporter : BaseExporter<Metric>
 
         try
         {
-            int writePosition = ProtobufOtlpMetricSerializer.WriteMetricsData(ref this.buffer, this.startWritePosition, this.Resource, metrics);
+            var writePosition = ProtobufOtlpMetricSerializer.WriteMetricsData(ref this.buffer, this.startWritePosition, this.Resource, metrics);
 
             if (this.startWritePosition == GrpcStartWritePosition)
             {
@@ -77,7 +75,7 @@ public class OtlpMetricExporter : BaseExporter<Metric>
                 // byte 0 - Specifying if the payload is compressed.
                 // 1-4 byte - Specifies the length of payload in big endian format.
                 // 5 and above -  Protobuf serialized data.
-                Span<byte> data = new Span<byte>(this.buffer, 1, 4);
+                var data = new Span<byte>(this.buffer, 1, 4);
                 var dataLength = writePosition - GrpcStartWritePosition;
                 BinaryPrimitives.WriteUInt32BigEndian(data, (uint)dataLength);
             }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpMetricExporterExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Exporter;
@@ -163,14 +162,9 @@ public static class OtlpMetricExporterExtensions
         bool skipUseOtlpExporterRegistrationCheck = false,
         Func<BaseExporter<Metric>, BaseExporter<Metric>>? configureExporterInstance = null)
     {
-        Debug.Assert(serviceProvider != null, "serviceProvider was null");
-        Debug.Assert(exporterOptions != null, "exporterOptions was null");
-        Debug.Assert(metricReaderOptions != null, "metricReaderOptions was null");
-        Debug.Assert(experimentalOptions != null, "experimentalOptions was null");
-
 #if NETFRAMEWORK || NETSTANDARD2_0
 #pragma warning disable CS0618 // Suppressing gRPC obsolete warning
-        if (exporterOptions!.Protocol == OtlpExportProtocol.Grpc &&
+        if (exporterOptions.Protocol == OtlpExportProtocol.Grpc &&
             ReferenceEquals(exporterOptions.HttpClientFactory, exporterOptions.DefaultHttpClientFactory))
 #pragma warning restore CS0618 // Suppressing gRPC obsolete warning
         {
@@ -181,13 +175,13 @@ public static class OtlpMetricExporterExtensions
 
         if (!skipUseOtlpExporterRegistrationCheck)
         {
-            serviceProvider!.EnsureNoUseOtlpExporterRegistrations();
+            serviceProvider.EnsureNoUseOtlpExporterRegistrations();
         }
 
-        exporterOptions!.TryEnableIHttpClientFactoryIntegration(serviceProvider!, "OtlpMetricExporter");
+        exporterOptions.TryEnableIHttpClientFactoryIntegration(serviceProvider, "OtlpMetricExporter");
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
-        BaseExporter<Metric> metricExporter = new OtlpMetricExporter(exporterOptions!, experimentalOptions!);
+        BaseExporter<Metric> metricExporter = new OtlpMetricExporter(exporterOptions, experimentalOptions);
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
         if (configureExporterInstance != null)
@@ -197,6 +191,6 @@ public static class OtlpMetricExporterExtensions
 
         return PeriodicExportingMetricReaderHelper.CreatePeriodicExportingMetricReader(
             metricExporter,
-            metricReaderOptions!);
+            metricReaderOptions);
     }
 }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporter.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporter.cs
@@ -21,8 +21,6 @@ public class OtlpTraceExporter : BaseExporter<Activity>
     private readonly OtlpExporterTransmissionHandler transmissionHandler;
     private readonly int startWritePosition;
 
-    private Resource? resource;
-
     // Initial buffer size set to ~732KB.
     // This choice allows us to gradually grow the buffer while targeting a final capacity of around 100 MB,
     // by the 7th doubling to maintain efficient allocation without frequent resizing.
@@ -33,7 +31,7 @@ public class OtlpTraceExporter : BaseExporter<Activity>
     /// </summary>
     /// <param name="options">Configuration options for the export.</param>
     public OtlpTraceExporter(OtlpExporterOptions options)
-        : this(options, sdkLimitOptions: new(), experimentalOptions: new(), transmissionHandler: null)
+        : this(options ?? throw new ArgumentNullException(nameof(options)), sdkLimitOptions: new(), experimentalOptions: new(), transmissionHandler: null)
     {
     }
 
@@ -50,17 +48,18 @@ public class OtlpTraceExporter : BaseExporter<Activity>
         ExperimentalOptions experimentalOptions,
         OtlpExporterTransmissionHandler? transmissionHandler = null)
     {
-        Debug.Assert(exporterOptions != null, "exporterOptions was null");
-        Debug.Assert(sdkLimitOptions != null, "sdkLimitOptions was null");
-
-        this.sdkLimitOptions = sdkLimitOptions!;
+        this.sdkLimitOptions = sdkLimitOptions;
 #pragma warning disable CS0618 // Suppressing gRPC obsolete warning
-        this.startWritePosition = exporterOptions!.Protocol == OtlpExportProtocol.Grpc ? GrpcStartWritePosition : 0;
+        this.startWritePosition = exporterOptions.Protocol == OtlpExportProtocol.Grpc ? GrpcStartWritePosition : 0;
 #pragma warning restore CS0618 // Suppressing gRPC obsolete warning
-        this.transmissionHandler = transmissionHandler ?? exporterOptions!.GetExportTransmissionHandler(experimentalOptions, OtlpSignalType.Traces);
+        this.transmissionHandler = transmissionHandler ?? exporterOptions.GetExportTransmissionHandler(experimentalOptions, OtlpSignalType.Traces);
     }
 
-    internal Resource Resource => this.resource ??= this.ParentProvider.GetResource();
+    internal Resource Resource
+    {
+        get => field ??= this.ParentProvider.GetResource();
+        private set;
+    }
 
     /// <inheritdoc/>
 #pragma warning disable CA1725 // Parameter names should match base declaration
@@ -72,7 +71,7 @@ public class OtlpTraceExporter : BaseExporter<Activity>
 
         try
         {
-            int writePosition = ProtobufOtlpTraceSerializer.WriteTraceData(ref this.buffer, this.startWritePosition, this.sdkLimitOptions, this.Resource, activityBatch);
+            var writePosition = ProtobufOtlpTraceSerializer.WriteTraceData(ref this.buffer, this.startWritePosition, this.sdkLimitOptions, this.Resource, activityBatch);
 
             if (this.startWritePosition == GrpcStartWritePosition)
             {
@@ -80,7 +79,7 @@ public class OtlpTraceExporter : BaseExporter<Activity>
                 // byte 0 - Specifying if the payload is compressed.
                 // 1-4 byte - Specifies the length of payload in big endian format.
                 // 5 and above -  Protobuf serialized data.
-                Span<byte> data = new Span<byte>(this.buffer, 1, 4);
+                var data = new Span<byte>(this.buffer, 1, 4);
                 var dataLength = writePosition - GrpcStartWritePosition;
                 BinaryPrimitives.WriteUInt32BigEndian(data, (uint)dataLength);
             }

--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/OtlpTraceExporterHelperExtensions.cs
@@ -123,15 +123,9 @@ public static class OtlpTraceExporterHelperExtensions
         bool skipUseOtlpExporterRegistrationCheck = false,
         Func<BaseExporter<Activity>, BaseExporter<Activity>>? configureExporterInstance = null)
     {
-        Debug.Assert(serviceProvider != null, "serviceProvider was null");
-        Debug.Assert(exporterOptions != null, "exporterOptions was null");
-        Debug.Assert(sdkLimitOptions != null, "sdkLimitOptions was null");
-        Debug.Assert(experimentalOptions != null, "experimentalOptions was null");
-        Debug.Assert(batchExportProcessorOptions != null, "batchExportProcessorOptions was null");
-
 #if NETFRAMEWORK || NETSTANDARD2_0
 #pragma warning disable CS0618 // Suppressing gRPC obsolete warning
-        if (exporterOptions!.Protocol == OtlpExportProtocol.Grpc &&
+        if (exporterOptions.Protocol == OtlpExportProtocol.Grpc &&
             ReferenceEquals(exporterOptions.HttpClientFactory, exporterOptions.DefaultHttpClientFactory))
 #pragma warning restore CS0618 // Suppressing gRPC obsolete warning
         {
@@ -142,13 +136,13 @@ public static class OtlpTraceExporterHelperExtensions
 
         if (!skipUseOtlpExporterRegistrationCheck)
         {
-            serviceProvider!.EnsureNoUseOtlpExporterRegistrations();
+            serviceProvider.EnsureNoUseOtlpExporterRegistrations();
         }
 
-        exporterOptions!.TryEnableIHttpClientFactoryIntegration(serviceProvider!, "OtlpTraceExporter");
+        exporterOptions.TryEnableIHttpClientFactoryIntegration(serviceProvider, "OtlpTraceExporter");
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
-        BaseExporter<Activity> otlpExporter = new OtlpTraceExporter(exporterOptions!, sdkLimitOptions!, experimentalOptions!);
+        BaseExporter<Activity> otlpExporter = new OtlpTraceExporter(exporterOptions, sdkLimitOptions, experimentalOptions);
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
         try
@@ -158,19 +152,14 @@ public static class OtlpTraceExporterHelperExtensions
                 otlpExporter = configureExporterInstance(otlpExporter);
             }
 
-            if (exportProcessorType == ExportProcessorType.Simple)
-            {
-                return new SimpleActivityExportProcessor(otlpExporter);
-            }
-            else
-            {
-                return new BatchActivityExportProcessor(
+            return exportProcessorType == ExportProcessorType.Simple
+                ? new SimpleActivityExportProcessor(otlpExporter)
+                : new BatchActivityExportProcessor(
                     otlpExporter,
-                    batchExportProcessorOptions!.MaxQueueSize,
+                    batchExportProcessorOptions.MaxQueueSize,
                     batchExportProcessorOptions.ScheduledDelayMilliseconds,
                     batchExportProcessorOptions.ExporterTimeoutMilliseconds,
                     batchExportProcessorOptions.MaxExportBatchSize);
-            }
         }
         catch
         {

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/Generators.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/Generators.cs
@@ -69,14 +69,14 @@ internal static class Generators
 
             // Generate tags
             var tagCount = Math.Min(size, 50);
-            for (int i = 0; i < tagCount; i++)
+            for (var i = 0; i < tagCount; i++)
             {
                 activity.SetTag($"tag.{i}", $"value_{i}_{Guid.NewGuid():N}");
             }
 
             // Generate events
             var eventCount = Math.Min(size / 10, 10);
-            for (int i = 0; i < eventCount; i++)
+            for (var i = 0; i < eventCount; i++)
             {
                 var eventTags = new ActivityTagsCollection
                 {
@@ -87,7 +87,7 @@ internal static class Generators
 
             // Generate links
             var linkCount = Math.Min(size / 10, 10);
-            for (int i = 0; i < linkCount; i++)
+            for (var i = 0; i < linkCount; i++)
             {
                 var linkTags = new ActivityTagsCollection
                 {
@@ -117,7 +117,7 @@ internal static class Generators
             var count = Math.Min(size, 20);
             var attributes = new Dictionary<string, object>(count);
 
-            for (int i = 0; i < count; i++)
+            for (var i = 0; i < count; i++)
             {
                 attributes[$"resource.attr.{i}"] = $"value_{i}";
             }
@@ -144,7 +144,7 @@ internal static class Generators
             if (size % 7 == 0)
             {
                 var boundaries = new double[Math.Min(size % 10, 10)];
-                for (int i = 0; i < boundaries.Length; i++)
+                for (var i = 0; i < boundaries.Length; i++)
                 {
                     boundaries[i] = (i * 50.0) + (size % 50);
                 }
@@ -163,7 +163,7 @@ internal static class Generators
                 var counterSingle = meter.CreateCounter<float>("test.counter.single");
                 var counterDouble = meter.CreateCounter<double>("test.counter.double");
 
-                for (int i = 0; i < size; i++)
+                for (var i = 0; i < size; i++)
                 {
                     counterByte.Add((byte)(100 * i));
                     counterInt16.Add((short)(100 * i));
@@ -175,14 +175,14 @@ internal static class Generators
 
                 var gauge = meter.CreateGauge<double>("test.gauge");
 
-                for (int i = 0; i < size; i++)
+                for (var i = 0; i < size; i++)
                 {
                     gauge.Record(0.1 * i);
                 }
 
                 var histogram = meter.CreateHistogram<int>("test.histogram");
 
-                for (int i = 0; i < size; i++)
+                for (var i = 0; i < size; i++)
                 {
                     histogram.Record(300 * i);
                 }
@@ -213,7 +213,7 @@ internal static class Generators
             // Add attributes
             var count = Math.Min(size, 50);
             var attributes = new List<KeyValuePair<string, object?>>(count);
-            for (int i = 0; i < count; i++)
+            for (var i = 0; i < count; i++)
             {
                 attributes.Add(new KeyValuePair<string, object?>($"log.attribute.{i}", $"value_{i}"));
             }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/ProtobufOtlpTraceSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.FuzzTests/ProtobufOtlpTraceSerializerTests.cs
@@ -228,7 +228,7 @@ public class ProtobufOtlpTraceSerializerTests
                 }
 
                 // Content should match
-                for (int i = 0; i < writePos1; i++)
+                for (var i = 0; i < writePos1; i++)
                 {
                     if (buffer1[i] != buffer2[i])
                     {

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/GrpcRetryTestCase.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/GrpcRetryTestCase.cs
@@ -24,72 +24,67 @@ public class GrpcRetryTestCase
 
     internal GrpcRetryAttempt[] RetryAttempts { get; }
 
-    public static TheoryData<GrpcRetryTestCase> GetGrpcTestCases()
-    {
-        return
-        [
-            new("Cancelled", [new(StatusCode.Cancelled)]),
-            new("DeadlineExceeded", [new(StatusCode.DeadlineExceeded)]),
-            new("Aborted", [new(StatusCode.Aborted)]),
-            new("OutOfRange", [new(StatusCode.OutOfRange)]),
-            new("DataLoss", [new(StatusCode.DataLoss)]),
-            new("Unavailable", [new(StatusCode.Unavailable)]),
+    public static TheoryData<GrpcRetryTestCase> GetGrpcTestCases() =>
+    [
+        new("Cancelled", [new(StatusCode.Cancelled)]),
+        new("DeadlineExceeded", [new(StatusCode.DeadlineExceeded)]),
+        new("Aborted", [new(StatusCode.Aborted)]),
+        new("OutOfRange", [new(StatusCode.OutOfRange)]),
+        new("DataLoss", [new(StatusCode.DataLoss)]),
+        new("Unavailable", [new(StatusCode.Unavailable)]),
 
-            new("OK", [new(StatusCode.OK, expectedSuccess: false)]),
-            new("PermissionDenied", [new(StatusCode.PermissionDenied, expectedSuccess: false)]),
-            new("Unknown", [new(StatusCode.Unknown, expectedSuccess: false)]),
+        new("OK", [new(StatusCode.OK, expectedSuccess: false)]),
+        new("PermissionDenied", [new(StatusCode.PermissionDenied, expectedSuccess: false)]),
+        new("Unknown", [new(StatusCode.Unknown, expectedSuccess: false)]),
 
-            new("ResourceExhausted w/o RetryInfo", [new(StatusCode.ResourceExhausted, expectedSuccess: false)]),
-            new("ResourceExhausted w/ RetryInfo", [new(StatusCode.ResourceExhausted, throttleDelay: GetThrottleDelayString(new Duration { Seconds = 2 }), expectedNextRetryDelayMilliseconds: 3000)]),
+        new("ResourceExhausted w/o RetryInfo", [new(StatusCode.ResourceExhausted, expectedSuccess: false)]),
+        new("ResourceExhausted w/ RetryInfo", [new(StatusCode.ResourceExhausted, throttleDelay: GetThrottleDelayString(new Duration { Seconds = 2 }), expectedNextRetryDelayMilliseconds: 3000)]),
 
-            new("Unavailable w/ RetryInfo", [new(StatusCode.Unavailable, throttleDelay: GetThrottleDelayString(Duration.FromTimeSpan(TimeSpan.FromMilliseconds(2000))), expectedNextRetryDelayMilliseconds: 3000)]),
+        new("Unavailable w/ RetryInfo", [new(StatusCode.Unavailable, throttleDelay: GetThrottleDelayString(Duration.FromTimeSpan(TimeSpan.FromMilliseconds(2000))), expectedNextRetryDelayMilliseconds: 3000)]),
 
-            new("Expired deadline", [new(StatusCode.Unavailable, deadlineExceeded: true, expectedSuccess: false)]),
+        new("Expired deadline", [new(StatusCode.Unavailable, deadlineExceeded: true, expectedSuccess: false)]),
 
-            new(
-                "Exponential backoff",
-                [
-                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 1500),
-                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 2250),
-                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 3375),
-                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 5000),
-                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 5000)
-                ],
-                expectedRetryAttempts: 5),
+        new(
+            "Exponential backoff",
+            [
+                new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 1500),
+                new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 2250),
+                new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 3375),
+                new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 5000),
+                new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 5000)
+            ],
+            expectedRetryAttempts: 5),
 
-            new(
-                "Retry until non-retryable status code encountered",
-                [
-                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 1500),
-                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 2250),
-                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 3375),
-                    new(StatusCode.PermissionDenied, expectedSuccess: false),
-                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 5000)
-                ],
-                expectedRetryAttempts: 4),
+        new(
+            "Retry until non-retryable status code encountered",
+            [
+                new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 1500),
+                new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 2250),
+                new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 3375),
+                new(StatusCode.PermissionDenied, expectedSuccess: false),
+                new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 5000)
+            ],
+            expectedRetryAttempts: 4),
 
-            // Test throttling affects exponential backoff.
-            new(
-                "Exponential backoff after throttling",
-                [
-                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 1500),
-                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 2250),
-                    new(StatusCode.Unavailable, throttleDelay: GetThrottleDelayString(Duration.FromTimeSpan(TimeSpan.FromMilliseconds(500))), expectedNextRetryDelayMilliseconds: 750),
-                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 1125),
-                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 1688),
-                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 2532),
-                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 3798),
-                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 5000),
-                    new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 5000)
-                ],
-                expectedRetryAttempts: 9),
-        ];
-    }
+        // Test throttling affects exponential backoff.
+        new(
+            "Exponential backoff after throttling",
+            [
+                new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 1500),
+                new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 2250),
+                new(StatusCode.Unavailable, throttleDelay: GetThrottleDelayString(Duration.FromTimeSpan(TimeSpan.FromMilliseconds(500))), expectedNextRetryDelayMilliseconds: 750),
+                new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 1125),
+                new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 1688),
+                new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 2532),
+                new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 3798),
+                new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 5000),
+                new(StatusCode.Unavailable, expectedNextRetryDelayMilliseconds: 5000)
+            ],
+            expectedRetryAttempts: 9),
+    ];
 
     public override string ToString()
-    {
-        return this.testRunnerName;
-    }
+        => this.testRunnerName;
 
     private static string GetThrottleDelayString(Duration throttleDelay)
     {
@@ -109,7 +104,7 @@ public class GrpcRetryTestCase
         return Convert.ToBase64String(status.ToByteArray());
     }
 
-    internal struct GrpcRetryAttempt
+    internal readonly struct GrpcRetryAttempt
     {
         internal GrpcRetryAttempt(
             StatusCode statusCode,

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/ExportClient/GrpcStatusDeserializerTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/ExportClient/GrpcStatusDeserializerTests.cs
@@ -23,7 +23,7 @@ public class GrpcStatusDeserializerTests
         };
 
         // Serialize the Status message and encode to base64
-        string grpcStatusDetailsBin = Convert.ToBase64String(status.ToByteArray());
+        var grpcStatusDetailsBin = Convert.ToBase64String(status.ToByteArray());
 
         // Use the GrpcStatusDeserializer to deserialize from the base64 input
         var deserializedStatus = GrpcStatusDeserializer.DeserializeStatus(grpcStatusDetailsBin);
@@ -55,7 +55,7 @@ public class GrpcStatusDeserializerTests
                 },
         };
 
-        string grpcStatusDetailsBin = Convert.ToBase64String(status.ToByteArray());
+        var grpcStatusDetailsBin = Convert.ToBase64String(status.ToByteArray());
 
         // Act
         var retryInfo = GrpcStatusDeserializer.ExtractRetryInfo(grpcStatusDetailsBin);
@@ -70,7 +70,7 @@ public class GrpcStatusDeserializerTests
     {
         // Arrange
         var status = new Google.Rpc.Status();
-        string grpcStatusDetailsBin = Convert.ToBase64String(status.ToByteArray());
+        var grpcStatusDetailsBin = Convert.ToBase64String(status.ToByteArray());
 
         // Act
         var deserializedStatus = GrpcStatusDeserializer.DeserializeStatus(grpcStatusDetailsBin);
@@ -97,7 +97,7 @@ public class GrpcStatusDeserializerTests
                 },
         };
 
-        string grpcStatusDetailsBin = Convert.ToBase64String(status.ToByteArray());
+        var grpcStatusDetailsBin = Convert.ToBase64String(status.ToByteArray());
 
         // Act
         var deserializedStatus = GrpcStatusDeserializer.DeserializeStatus(grpcStatusDetailsBin);
@@ -141,10 +141,9 @@ public class GrpcStatusDeserializerTests
                 },
         };
 
-        string grpcStatusDetailsBin = Convert.ToBase64String(status.ToByteArray());
+        var grpcStatusDetailsBin = Convert.ToBase64String(status.ToByteArray());
 
         // Act
-        byte[] data = Convert.FromBase64String(grpcStatusDetailsBin);
         var retryInfo = GrpcStatusDeserializer.ExtractRetryInfo(grpcStatusDetailsBin);
 
         // Assert
@@ -164,7 +163,7 @@ public class GrpcStatusDeserializerTests
             Details = { Any.Pack(new Google.Rpc.Status { Code = 5 }) }, // A different type packed
         };
 
-        string grpcStatusDetailsBin = Convert.ToBase64String(status.ToByteArray());
+        var grpcStatusDetailsBin = Convert.ToBase64String(status.ToByteArray());
 
         // Act
         var retryInfo = GrpcStatusDeserializer.ExtractRetryInfo(grpcStatusDetailsBin);
@@ -183,7 +182,7 @@ public class GrpcStatusDeserializerTests
             Message = "Boundary code test",
         };
 
-        string grpcStatusDetailsBin = Convert.ToBase64String(status.ToByteArray());
+        var grpcStatusDetailsBin = Convert.ToBase64String(status.ToByteArray());
 
         // Act
         var deserializedStatus = GrpcStatusDeserializer.DeserializeStatus(grpcStatusDetailsBin);
@@ -204,9 +203,7 @@ public class GrpcStatusDeserializerTests
 
     [Fact]
     public void TryGetGrpcRetryDelay_InvalidBase64Input_ReturnsNull()
-    {
-        Assert.Null(GrpcStatusDeserializer.TryGetGrpcRetryDelay("invalid-base64"));
-    }
+        => Assert.Null(GrpcStatusDeserializer.TryGetGrpcRetryDelay("invalid-base64"));
 
     [Fact]
     public void TryGetGrpcRetryDelay_NoRetryInfo_ReturnsNull()
@@ -219,7 +216,7 @@ public class GrpcStatusDeserializerTests
             Details = { Any.Pack(new Google.Rpc.Status { Code = 5 }) }, // Non-RetryInfo type
         };
 
-        string grpcStatusDetailsBin = Convert.ToBase64String(status.ToByteArray());
+        var grpcStatusDetailsBin = Convert.ToBase64String(status.ToByteArray());
 
         // Act
         var result = GrpcStatusDeserializer.TryGetGrpcRetryDelay(grpcStatusDetailsBin);
@@ -249,7 +246,7 @@ public class GrpcStatusDeserializerTests
         },
         };
 
-        string grpcStatusDetailsBin = Convert.ToBase64String(status.ToByteArray());
+        var grpcStatusDetailsBin = Convert.ToBase64String(status.ToByteArray());
 
         // Act
         var result = GrpcStatusDeserializer.TryGetGrpcRetryDelay(grpcStatusDetailsBin);
@@ -279,7 +276,7 @@ public class GrpcStatusDeserializerTests
         },
         };
 
-        string grpcStatusDetailsBin = Convert.ToBase64String(status.ToByteArray());
+        var grpcStatusDetailsBin = Convert.ToBase64String(status.ToByteArray());
 
         // Act
         var result = GrpcStatusDeserializer.TryGetGrpcRetryDelay(grpcStatusDetailsBin);
@@ -306,7 +303,7 @@ public class GrpcStatusDeserializerTests
         },
         };
 
-        string grpcStatusDetailsBin = Convert.ToBase64String(status.ToByteArray());
+        var grpcStatusDetailsBin = Convert.ToBase64String(status.ToByteArray());
 
         // Act
         var result = GrpcStatusDeserializer.TryGetGrpcRetryDelay(grpcStatusDetailsBin);
@@ -326,10 +323,10 @@ public class GrpcStatusDeserializerTests
             Message = "Truncated stream test",
         };
 
-        byte[] fullData = status.ToByteArray();
-        byte[] truncatedData = fullData.Take(fullData.Length / 2).ToArray(); // Truncate the data
+        var fullData = status.ToByteArray();
+        var truncatedData = fullData.Take(fullData.Length / 2).ToArray(); // Truncate the data
 
-        string grpcStatusDetailsBin = Convert.ToBase64String(truncatedData);
+        var grpcStatusDetailsBin = Convert.ToBase64String(truncatedData);
 
         // Act & Assert: Attempt to deserialize and expect an EndOfStreamException
         Assert.Throws<EndOfStreamException>(() =>

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/ExportClient/OtlpHttpTraceExportClientTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/ExportClient/OtlpHttpTraceExportClientTests.cs
@@ -31,7 +31,7 @@ public sealed class OtlpHttpTraceExportClientTests : IDisposable
         this.activityListener = new ActivityListener
         {
             ShouldListenTo = _ => true,
-            Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded,
+            Sample = (ref options) => ActivitySamplingResult.AllDataAndRecorded,
         };
 
         ActivitySource.AddActivityListener(this.activityListener);
@@ -61,7 +61,7 @@ public sealed class OtlpHttpTraceExportClientTests : IDisposable
         Assert.Contains(client.Headers, kvp => kvp.Key == header1.Name && kvp.Value == header1.Value);
         Assert.Contains(client.Headers, kvp => kvp.Key == header2.Name && kvp.Value == header2.Value);
 
-        for (int i = 0; i < options.StandardHeaders.Length; i++)
+        for (var i = 0; i < options.StandardHeaders.Length; i++)
         {
             Assert.Contains(client.Headers, entry => entry.Key == options.StandardHeaders[i].Key && entry.Value == options.StandardHeaders[i].Value);
         }
@@ -101,11 +101,10 @@ public sealed class OtlpHttpTraceExportClientTests : IDisposable
         if (includeServiceNameInResource)
         {
             resourceBuilder.AddAttributes(
-                new List<KeyValuePair<string, object>>
-                {
+                [
                     new(ResourceSemanticConventions.AttributeServiceName, "service_name"),
                     new(ResourceSemanticConventions.AttributeServiceNamespace, "ns_1"),
-                });
+                ]);
         }
 
         var builder = Sdk.CreateTracerProviderBuilder()
@@ -128,7 +127,7 @@ public sealed class OtlpHttpTraceExportClientTests : IDisposable
             var activityKind = isEven ? ActivityKind.Client : ActivityKind.Server;
             var activityTags = isEven ? evenTags : oddTags;
 
-            using Activity? activity = source.StartActivity($"span-{i}", activityKind, parentContext: default, activityTags);
+            using var activity = source.StartActivity($"span-{i}", activityKind, parentContext: default, activityTags);
             Assert.NotNull(activity);
             processor.OnEnd(activity);
         }
@@ -160,7 +159,7 @@ public sealed class OtlpHttpTraceExportClientTests : IDisposable
             Assert.Contains(httpRequest.Headers, h => h.Key == header1.Name && h.Value.First() == header1.Value);
             Assert.Contains(httpRequest.Headers, h => h.Key == header2.Name && h.Value.First() == header2.Value);
 
-            for (int i = 0; i < options.StandardHeaders.Length; i++)
+            for (var i = 0; i < options.StandardHeaders.Length; i++)
             {
                 Assert.Contains(httpRequest.Headers, entry => entry.Key == options.StandardHeaders[i].Key && entry.Value.First() == options.StandardHeaders[i].Value);
             }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/Serializer/OtlpArrayTagWriterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/Serializer/OtlpArrayTagWriterTests.cs
@@ -27,7 +27,7 @@ public sealed class OtlpArrayTagWriterTests : IDisposable
         this.activityListener = new ActivityListener
         {
             ShouldListenTo = _ => true,
-            Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded,
+            Sample = (ref options) => ActivitySamplingResult.AllDataAndRecorded,
         };
 
         ActivitySource.AddActivityListener(this.activityListener);
@@ -126,7 +126,7 @@ public sealed class OtlpArrayTagWriterTests : IDisposable
     {
         // Act
         this.arrayTagWriter.BeginWriteArray();
-        bool result = this.arrayTagWriter.TryResize();
+        var result = this.arrayTagWriter.TryResize();
 
         // Assert
         Assert.True(result);
@@ -136,8 +136,8 @@ public sealed class OtlpArrayTagWriterTests : IDisposable
     public void TryResize_RepeatedResizingStopsAtMaxBufferSize()
     {
         // Arrange
-        var arrayState = this.arrayTagWriter.BeginWriteArray();
-        bool resizeResult = true;
+        _ = this.arrayTagWriter.BeginWriteArray();
+        var resizeResult = true;
 
         // Act: Repeatedly attempt to resize until reaching maximum buffer size
         while (resizeResult)
@@ -154,13 +154,13 @@ public sealed class OtlpArrayTagWriterTests : IDisposable
     {
         // Create a large array exceeding 2 MB
         var largeArray = new string[512 * 1024];
-        for (int i = 0; i < largeArray.Length; i++)
+        for (var i = 0; i < largeArray.Length; i++)
         {
             largeArray[i] = "1234";
         }
 
         var lessthat1MBArray = new string[256 * 4];
-        for (int i = 0; i < lessthat1MBArray.Length; i++)
+        for (var i = 0; i < lessthat1MBArray.Length; i++)
         {
             lessthat1MBArray[i] = "1234";
         }
@@ -199,7 +199,7 @@ public sealed class OtlpArrayTagWriterTests : IDisposable
     public void LargeArray_WithSmallBaseBuffer_ThrowsExceptionOnWriteSpan()
     {
         var lessthat1MBArray = new string[256 * 256];
-        for (int i = 0; i < lessthat1MBArray.Length; i++)
+        for (var i = 0; i < lessthat1MBArray.Length; i++)
         {
             lessthat1MBArray[i] = "1234";
         }
@@ -220,7 +220,7 @@ public sealed class OtlpArrayTagWriterTests : IDisposable
     public void LargeArray_WithSmallBaseBuffer_ExpandsOnTraceData()
     {
         var lessthat1MBArray = new string[256 * 256];
-        for (int i = 0; i < lessthat1MBArray.Length; i++)
+        for (var i = 0; i < lessthat1MBArray.Length; i++)
         {
             lessthat1MBArray[i] = "1234";
         }
@@ -237,7 +237,7 @@ public sealed class OtlpArrayTagWriterTests : IDisposable
         var batch = new Batch<Activity>([activity], 1);
         RunTest(new(), batch);
 
-        void RunTest(SdkLimitOptions sdkOptions, Batch<Activity> batch)
+        static void RunTest(SdkLimitOptions sdkOptions, Batch<Activity> batch)
         {
             var buffer = new byte[4096];
             var writePosition = ProtobufOtlpTraceSerializer.WriteTraceData(ref buffer, 0, sdkOptions, ResourceBuilder.CreateEmpty().Build(), batch);

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/Serializer/ProtobufOtlpMetricSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/Serializer/ProtobufOtlpMetricSerializerTests.cs
@@ -159,13 +159,15 @@ public static class ProtobufOtlpMetricSerializerTests
         var type = typeof(AggregatorStore);
         var bindingAttributes = BindingFlags.NonPublic | BindingFlags.Instance;
 
-        var startTimeProperty = type.GetProperty(nameof(AggregatorStore.StartTimeExclusive), bindingAttributes)!;
-        var endTimeProperty = type.GetProperty(nameof(AggregatorStore.EndTimeInclusive), bindingAttributes)!;
+        var startTimeProperty = type.GetProperty(nameof(AggregatorStore.StartTimeExclusive), bindingAttributes);
+        var endTimeProperty = type.GetProperty(nameof(AggregatorStore.EndTimeInclusive), bindingAttributes);
 
         foreach (var metric in metrics)
         {
+#pragma warning disable CS8602 // Dereference of a possibly null reference.
             startTimeProperty.SetValue(metric.AggregatorStore, startTime);
             endTimeProperty.SetValue(metric.AggregatorStore, endTime);
+#pragma warning restore CS8602 // Dereference of a possibly null reference.
         }
 
         return metrics;

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/Serializer/ProtobufSerializerTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/Implementation/Serializer/ProtobufSerializerTests.cs
@@ -19,8 +19,8 @@ public class ProtobufSerializerTests
     [Fact]
     public void WriteTag_WritesCorrectly()
     {
-        byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteTag(buffer, 0, 1, ProtobufWireType.VARINT);
+        var buffer = new byte[10];
+        var position = ProtobufSerializer.WriteTag(buffer, 0, 1, ProtobufWireType.VARINT);
         Assert.Equal(1, position);
         Assert.Equal(8, buffer[0]);
     }
@@ -28,8 +28,8 @@ public class ProtobufSerializerTests
     [Fact]
     public void WriteLength_WritesCorrectly()
     {
-        byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteLength(buffer, 0, 300);
+        var buffer = new byte[10];
+        var position = ProtobufSerializer.WriteLength(buffer, 0, 300);
         Assert.Equal(2, position);
         Assert.Equal(0xAC, buffer[0]);
         Assert.Equal(0x02, buffer[1]);
@@ -38,8 +38,8 @@ public class ProtobufSerializerTests
     [Fact]
     public void WriteBoolWithTag_WritesCorrectly()
     {
-        byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteBoolWithTag(buffer, 0, 1, true);
+        var buffer = new byte[10];
+        var position = ProtobufSerializer.WriteBoolWithTag(buffer, 0, 1, true);
         Assert.Equal(2, position);
         Assert.Equal(8, buffer[0]);
         Assert.Equal(1, buffer[1]);
@@ -48,8 +48,8 @@ public class ProtobufSerializerTests
     [Fact]
     public void WriteFixed32WithTag_WritesCorrectly()
     {
-        byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteFixed32WithTag(buffer, 0, 1, 0x12345678);
+        var buffer = new byte[10];
+        var position = ProtobufSerializer.WriteFixed32WithTag(buffer, 0, 1, 0x12345678);
         Assert.Equal(5, position);
         Assert.Equal(13, buffer[0]);
         Assert.Equal(0x78, buffer[1]);
@@ -61,8 +61,8 @@ public class ProtobufSerializerTests
     [Fact]
     public void WriteFixed64WithTag_WritesCorrectly()
     {
-        byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteFixed64WithTag(buffer, 0, 1, 0x123456789ABCDEF0);
+        var buffer = new byte[10];
+        var position = ProtobufSerializer.WriteFixed64WithTag(buffer, 0, 1, 0x123456789ABCDEF0);
         Assert.Equal(9, position);
         Assert.Equal(9, buffer[0]); // Tag
         Assert.Equal(0xF0, buffer[1]);
@@ -78,8 +78,8 @@ public class ProtobufSerializerTests
     [Fact]
     public void WriteStringWithTag_WritesCorrectly()
     {
-        byte[] buffer = new byte[20];
-        int position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, "Hello");
+        var buffer = new byte[20];
+        var position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, "Hello");
         Assert.Equal(7, position);
         Assert.Equal(10, buffer[0]);
         Assert.Equal(5, buffer[1]);
@@ -109,10 +109,10 @@ public class ProtobufSerializerTests
             throw new ArgumentNullException(nameof(expectedBytes));
         }
 #endif
-        byte[] buffer = new byte[10];
+        var buffer = new byte[10];
         ProtobufSerializer.WriteReservedLength(buffer, 0, length);
 
-        for (int i = 0; i < expectedBytes.Length; i++)
+        for (var i = 0; i < expectedBytes.Length; i++)
         {
             Assert.Equal(expectedBytes[i], buffer[i]);
         }
@@ -121,8 +121,8 @@ public class ProtobufSerializerTests
     [Fact]
     public void WriteTagAndLength_WritesCorrectly()
     {
-        byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteTagAndLength(buffer, 0, 300, 1, ProtobufWireType.LEN);
+        var buffer = new byte[10];
+        var position = ProtobufSerializer.WriteTagAndLength(buffer, 0, 300, 1, ProtobufWireType.LEN);
         Assert.Equal(3, position);
         Assert.Equal(10, buffer[0]); // Tag
         Assert.Equal(0xAC, buffer[1]); // Length (300 in varint encoding)
@@ -132,8 +132,8 @@ public class ProtobufSerializerTests
     [Fact]
     public void WriteEnumWithTag_WritesCorrectly()
     {
-        byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteEnumWithTag(buffer, 0, 1, 5);
+        var buffer = new byte[10];
+        var position = ProtobufSerializer.WriteEnumWithTag(buffer, 0, 1, 5);
         Assert.Equal(2, position);
         Assert.Equal(8, buffer[0]); // Tag
         Assert.Equal(5, buffer[1]); // Enum value
@@ -142,8 +142,8 @@ public class ProtobufSerializerTests
     [Fact]
     public void WriteVarInt64_WritesCorrectly()
     {
-        byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteVarInt64(buffer, 0, 300);
+        var buffer = new byte[10];
+        var position = ProtobufSerializer.WriteVarInt64(buffer, 0, 300);
         Assert.Equal(2, position);
         Assert.Equal(0xAC, buffer[0]);
         Assert.Equal(0x02, buffer[1]);
@@ -152,8 +152,8 @@ public class ProtobufSerializerTests
     [Fact]
     public void WriteInt64WithTag_WritesCorrectly()
     {
-        byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteInt64WithTag(buffer, 0, 1, 300);
+        var buffer = new byte[10];
+        var position = ProtobufSerializer.WriteInt64WithTag(buffer, 0, 1, 300);
         Assert.Equal(3, position);
         Assert.Equal(8, buffer[0]); // Tag
         Assert.Equal(0xAC, buffer[1]);
@@ -163,8 +163,8 @@ public class ProtobufSerializerTests
     [Fact]
     public void WriteDoubleWithTag_WritesCorrectly()
     {
-        byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteDoubleWithTag(buffer, 0, 1, 123.456);
+        var buffer = new byte[10];
+        var position = ProtobufSerializer.WriteDoubleWithTag(buffer, 0, 1, 123.456);
         Assert.Equal(9, position);
         Assert.Equal(9, buffer[0]); // Tag
 
@@ -182,8 +182,8 @@ public class ProtobufSerializerTests
     [Fact]
     public void WriteSignedInt32_WritesCorrectly()
     {
-        byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteSInt32WithTag(buffer, 0, 1, 300);
+        var buffer = new byte[10];
+        var position = ProtobufSerializer.WriteSInt32WithTag(buffer, 0, 1, 300);
         Assert.Equal(3, position);
         Assert.Equal(8, buffer[0]); // Tag
         Assert.Equal(0xD8, buffer[1]);
@@ -200,8 +200,8 @@ public class ProtobufSerializerTests
     [Fact]
     public void WriteVarInt32_WritesCorrectly()
     {
-        byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteVarInt32(buffer, 0, 300);
+        var buffer = new byte[10];
+        var position = ProtobufSerializer.WriteVarInt32(buffer, 0, 300);
         Assert.Equal(2, position);
         Assert.Equal(0xAC, buffer[0]);
         Assert.Equal(0x02, buffer[1]);
@@ -210,8 +210,8 @@ public class ProtobufSerializerTests
     [Fact]
     public void WriteVarInt32_MaxValue_WritesCorrectly()
     {
-        byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteVarInt32(buffer, 0, uint.MaxValue);
+        var buffer = new byte[10];
+        var position = ProtobufSerializer.WriteVarInt32(buffer, 0, uint.MaxValue);
         Assert.Equal(5, position);
         Assert.Equal(0xFF, buffer[0]);
         Assert.Equal(0xFF, buffer[1]);
@@ -223,10 +223,10 @@ public class ProtobufSerializerTests
     [Fact]
     public void WriteVarInt64_MaxValue_WritesCorrectly()
     {
-        byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteVarInt64(buffer, 0, ulong.MaxValue);
+        var buffer = new byte[10];
+        var position = ProtobufSerializer.WriteVarInt64(buffer, 0, ulong.MaxValue);
         Assert.Equal(10, position);
-        for (int i = 0; i < 9; i++)
+        for (var i = 0; i < 9; i++)
         {
             Assert.Equal(0xFF, buffer[i]);
         }
@@ -237,8 +237,8 @@ public class ProtobufSerializerTests
     [Fact]
     public void WriteStringWithTag_EmptyString_WritesCorrectly()
     {
-        byte[] buffer = new byte[10];
-        int position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, string.Empty);
+        var buffer = new byte[10];
+        var position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, string.Empty);
         Assert.Equal(2, position);
         Assert.Equal(10, buffer[0]); // Tag
         Assert.Equal(0, buffer[1]); // Length
@@ -247,14 +247,14 @@ public class ProtobufSerializerTests
     [Fact]
     public void WriteStringWithTag_ASCIIString_WritesCorrectly()
     {
-        byte[] buffer = new byte[20];
-        int position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, "Hello");
+        var buffer = new byte[20];
+        var position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, "Hello");
         Assert.Equal(7, position);
         Assert.Equal(10, buffer[0]); // Tag
         Assert.Equal(5, buffer[1]); // Length
 
-        byte[] expectedContent = "Hello"u8.ToArray();
-        byte[] actualContent = new byte[5];
+        var expectedContent = "Hello"u8.ToArray();
+        var actualContent = new byte[5];
         Array.Copy(buffer, 2, actualContent, 0, 5);
         Assert.True(expectedContent.SequenceEqual(actualContent));
     }
@@ -262,15 +262,15 @@ public class ProtobufSerializerTests
     [Fact]
     public void WriteStringWithTag_UnicodeString_WritesCorrectly()
     {
-        byte[] buffer = new byte[20];
-        string unicodeString = "\u3053\u3093\u306b\u3061\u306f"; // "Hello" in Japanese
-        int position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, unicodeString);
+        var buffer = new byte[20];
+        var unicodeString = "\u3053\u3093\u306b\u3061\u306f"; // "Hello" in Japanese
+        var position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, unicodeString);
         Assert.Equal(17, position);
         Assert.Equal(10, buffer[0]); // Tag
         Assert.Equal(15, buffer[1]); // Length (3 bytes per character in UTF-8)
 
-        byte[] expectedContent = Encoding.UTF8.GetBytes(unicodeString);
-        byte[] actualContent = new byte[15];
+        var expectedContent = Encoding.UTF8.GetBytes(unicodeString);
+        var actualContent = new byte[15];
         Array.Copy(buffer, 2, actualContent, 0, 15);
         Assert.True(expectedContent.SequenceEqual(actualContent));
     }
@@ -278,16 +278,16 @@ public class ProtobufSerializerTests
     [Fact]
     public void WriteStringWithTag_LongString_WritesCorrectly()
     {
-        string longString = new string('a', 1000);
-        byte[] buffer = new byte[1100];
-        int position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, longString);
+        var longString = new string('a', 1000);
+        var buffer = new byte[1100];
+        var position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, longString);
         Assert.Equal(1003, position);
         Assert.Equal(10, buffer[0]); // Tag
         Assert.Equal(0xE8, buffer[1]); // Length (1000 in varint encoding)
         Assert.Equal(0x07, buffer[2]);
 
-        byte[] expectedContent = Encoding.UTF8.GetBytes(longString);
-        byte[] actualContent = new byte[1000];
+        var expectedContent = Encoding.UTF8.GetBytes(longString);
+        var actualContent = new byte[1000];
         Array.Copy(buffer, 3, actualContent, 0, 1000);
         Assert.True(expectedContent.SequenceEqual(actualContent));
     }
@@ -295,15 +295,15 @@ public class ProtobufSerializerTests
     [Fact]
     public void WriteStringWithTag_MixedEncodingString_WritesCorrectly()
     {
-        byte[] buffer = new byte[30];
-        string mixedString = "Hello\u4e16\u754c"; // "Hello World" with "World" in Chinese
-        int position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, mixedString);
+        var buffer = new byte[30];
+        var mixedString = "Hello\u4e16\u754c"; // "Hello World" with "World" in Chinese
+        var position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, mixedString);
         Assert.Equal(13, position);
         Assert.Equal(10, buffer[0]); // Tag
         Assert.Equal(11, buffer[1]); // Length (5 for "Hello" + 6 for Chinese "World" in UTF-8)
 
-        byte[] expectedContent = Encoding.UTF8.GetBytes(mixedString);
-        byte[] actualContent = new byte[11];
+        var expectedContent = Encoding.UTF8.GetBytes(mixedString);
+        var actualContent = new byte[11];
         Array.Copy(buffer, 2, actualContent, 0, 11);
         Assert.True(expectedContent.SequenceEqual(actualContent));
     }
@@ -311,15 +311,15 @@ public class ProtobufSerializerTests
     [Fact]
     public void WriteStringWithTag_StringWithSpecialCharacters_WritesCorrectly()
     {
-        byte[] buffer = new byte[30];
-        string specialString = "Hello\n\t\"World\"";
-        int position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, specialString);
+        var buffer = new byte[30];
+        var specialString = "Hello\n\t\"World\"";
+        var position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, specialString);
         Assert.Equal(16, position);
         Assert.Equal(10, buffer[0]); // Tag
         Assert.Equal(14, buffer[1]); // Length
 
-        byte[] expectedContent = Encoding.UTF8.GetBytes(specialString);
-        byte[] actualContent = new byte[14];
+        var expectedContent = Encoding.UTF8.GetBytes(specialString);
+        var actualContent = new byte[14];
         Array.Copy(buffer, 2, actualContent, 0, 14);
         Assert.True(expectedContent.SequenceEqual(actualContent));
     }
@@ -327,15 +327,15 @@ public class ProtobufSerializerTests
     [Fact]
     public void WriteStringWithTag_StringWithNullCharacters_WritesCorrectly()
     {
-        byte[] buffer = new byte[20];
-        string stringWithNull = "Hello\0World";
-        int position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, stringWithNull);
+        var buffer = new byte[20];
+        var stringWithNull = "Hello\0World";
+        var position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, stringWithNull);
         Assert.Equal(13, position);
         Assert.Equal(10, buffer[0]); // Tag
         Assert.Equal(11, buffer[1]); // Length
 
-        byte[] expectedContent = Encoding.UTF8.GetBytes(stringWithNull);
-        byte[] actualContent = new byte[11];
+        var expectedContent = Encoding.UTF8.GetBytes(stringWithNull);
+        var actualContent = new byte[11];
         Array.Copy(buffer, 2, actualContent, 0, 11);
         Assert.True(expectedContent.SequenceEqual(actualContent));
     }
@@ -343,15 +343,15 @@ public class ProtobufSerializerTests
     [Fact]
     public void WriteStringWithTag_SurrogatePairs_WritesCorrectly()
     {
-        byte[] buffer = new byte[20];
-        string surrogatePairString = "\uD83D\uDCD6"; // Books emoji
-        int position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, surrogatePairString);
+        var buffer = new byte[20];
+        var surrogatePairString = "\uD83D\uDCD6"; // Books emoji
+        var position = ProtobufSerializer.WriteStringWithTag(buffer, 0, 1, surrogatePairString);
         Assert.Equal(6, position);
         Assert.Equal(10, buffer[0]); // Tag
         Assert.Equal(4, buffer[1]); // Length (4 bytes for the surrogate pair in UTF-8)
 
-        byte[] expectedContent = Encoding.UTF8.GetBytes(surrogatePairString);
-        byte[] actualContent = new byte[4];
+        var expectedContent = Encoding.UTF8.GetBytes(surrogatePairString);
+        var actualContent = new byte[4];
         Array.Copy(buffer, 2, actualContent, 0, 4);
         Assert.True(expectedContent.SequenceEqual(actualContent));
     }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/MockCollectorIntegrationTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/MockCollectorIntegrationTests.cs
@@ -561,7 +561,7 @@ public sealed class MockCollectorIntegrationTests
         public void SetStatusCodes(int[] statusCodes)
         {
             this.statusCodeIndex = 0;
-            this.statusCodes = statusCodes.Select(x => (Grpc.Core.StatusCode)x).ToArray();
+            this.statusCodes = [.. statusCodes.Select(x => (Grpc.Core.StatusCode)x)];
         }
 
         public Grpc.Core.StatusCode NextStatus()
@@ -580,7 +580,7 @@ public sealed class MockCollectorIntegrationTests
         public void SetStatusCodes(int[] statusCodes)
         {
             this.statusCodeIndex = 0;
-            this.statusCodes = statusCodes.Select(x => (HttpStatusCode)x).ToArray();
+            this.statusCodes = [.. statusCodes.Select(x => (HttpStatusCode)x)];
         }
 
         public HttpStatusCode NextStatus()

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpAttributeTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpAttributeTests.cs
@@ -283,7 +283,7 @@ public class OtlpAttributeTests
 
     private static bool TryTransformTag(KeyValuePair<string, object?> tag, [NotNullWhen(true)] out OtlpCommon.KeyValue? attribute)
     {
-        ProtobufOtlpTagWriter.OtlpTagWriterState otlpTagWriterState = new ProtobufOtlpTagWriter.OtlpTagWriterState
+        var otlpTagWriterState = new ProtobufOtlpTagWriter.OtlpTagWriterState
         {
             Buffer = new byte[1024],
             WritePosition = 0,

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterHelperExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterHelperExtensionsTests.cs
@@ -23,12 +23,12 @@ public class OtlpExporterHelperExtensionsTests
 
         using var sp = services.BuildServiceProvider();
 
-        Assert.Throws<NotSupportedException>(() => sp.GetRequiredService<TracerProvider>());
+        Assert.Throws<NotSupportedException>(sp.GetRequiredService<TracerProvider>);
 
         var tracerProviderBuilder = Sdk.CreateTracerProviderBuilder()
                                         .AddOtlpExporter(o => o.Protocol = OtlpExportProtocol.Grpc);
 
-        Assert.Throws<NotSupportedException>(() => tracerProviderBuilder.Build());
+        Assert.Throws<NotSupportedException>(tracerProviderBuilder.Build);
     }
 
     [Fact]
@@ -41,12 +41,12 @@ public class OtlpExporterHelperExtensionsTests
 
         using var sp = services.BuildServiceProvider();
 
-        Assert.Throws<NotSupportedException>(() => sp.GetRequiredService<MeterProvider>());
+        Assert.Throws<NotSupportedException>(sp.GetRequiredService<MeterProvider>);
 
         var meterProviderBuilder = Sdk.CreateMeterProviderBuilder()
                                     .AddOtlpExporter(o => o.Protocol = OtlpExportProtocol.Grpc);
 
-        Assert.Throws<NotSupportedException>(() => meterProviderBuilder.Build());
+        Assert.Throws<NotSupportedException>(meterProviderBuilder.Build);
     }
 
     [Fact]
@@ -59,7 +59,7 @@ public class OtlpExporterHelperExtensionsTests
 
         using var sp = services.BuildServiceProvider();
 
-        Assert.Throws<NotSupportedException>(() => sp.GetRequiredService<ILoggerProvider>());
+        Assert.Throws<NotSupportedException>(sp.GetRequiredService<ILoggerProvider>);
 
         Assert.Throws<NotSupportedException>(() => LoggerFactory.Create(builder =>
         {

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpExporterOptionsExtensionsTests.cs
@@ -27,7 +27,7 @@ public class OtlpExporterOptionsExtensionsTests
 
         Assert.Equal(options.StandardHeaders.Length, headers.Count);
 
-        for (int i = 0; i < options.StandardHeaders.Length; i++)
+        for (var i = 0; i < options.StandardHeaders.Length; i++)
         {
             Assert.Contains(headers, entry => entry.Key == options.StandardHeaders[i].Key && entry.Value == options.StandardHeaders[i].Value);
         }
@@ -39,9 +39,7 @@ public class OtlpExporterOptionsExtensionsTests
     [InlineData(",,key1=value1,,key2=value2,,")]
     [InlineData("key1")]
     public void GetHeaders_InvalidOptionHeaders_ThrowsArgumentException(string inputOptionHeaders)
-    {
-        VerifyHeaders(inputOptionHeaders, string.Empty, true);
-    }
+        => VerifyHeaders(inputOptionHeaders, string.Empty, true);
 
     [Theory]
     [InlineData("", "")]
@@ -55,9 +53,7 @@ public class OtlpExporterOptionsExtensionsTests
     [InlineData("key1=value1%2Ckey2=value2", "key1=value1,key2=value2")]
     [InlineData("key1=value1%2Ckey2=value2%2Ckey3=value3", "key1=value1,key2=value2,key3=value3")]
     public void GetHeaders_ValidAndUrlEncodedHeaders_ReturnsCorrectHeaders(string inputOptionHeaders, string expectedNormalizedOptional)
-    {
-        VerifyHeaders(inputOptionHeaders, expectedNormalizedOptional);
-    }
+        => VerifyHeaders(inputOptionHeaders, expectedNormalizedOptional);
 
     [Theory]
 #pragma warning disable CS0618 // Suppressing gRPC obsolete warning
@@ -136,15 +132,15 @@ public class OtlpExporterOptionsExtensionsTests
     {
         if (retryStrategy == "in_memory")
         {
-            Assert.True(transmissionHandler is OtlpExporterRetryTransmissionHandler);
+            Assert.IsType<OtlpExporterRetryTransmissionHandler>(transmissionHandler);
         }
         else if (retryStrategy == "disk")
         {
-            Assert.True(transmissionHandler is OtlpExporterPersistentStorageTransmissionHandler);
+            Assert.IsType<OtlpExporterPersistentStorageTransmissionHandler>(transmissionHandler);
         }
         else
         {
-            Assert.True(transmissionHandler is OtlpExporterTransmissionHandler);
+            Assert.IsType<OtlpExporterTransmissionHandler>(transmissionHandler);
         }
 
         Assert.Equal(exportClientType, transmissionHandler.ExportClient.GetType());

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
@@ -31,11 +31,11 @@ public class OtlpLogExporterTests
     [Fact]
     public void AddOtlpExporterWithNamedOptions()
     {
-        int defaultConfigureExporterOptionsInvocations = 0;
-        int namedConfigureExporterOptionsInvocations = 0;
+        var defaultConfigureExporterOptionsInvocations = 0;
+        var namedConfigureExporterOptionsInvocations = 0;
 
-        int defaultConfigureSdkLimitsOptionsInvocations = 0;
-        int namedConfigureSdkLimitsOptionsInvocations = 0;
+        var defaultConfigureSdkLimitsOptionsInvocations = 0;
+        var namedConfigureSdkLimitsOptionsInvocations = 0;
 
         using var loggerProvider = Sdk.CreateLoggerProviderBuilder()
             .ConfigureServices(services =>
@@ -73,11 +73,11 @@ public class OtlpLogExporterTests
     [Fact]
     public void UserHttpFactoryCalledWhenUsingHttpProtobuf()
     {
-        OtlpExporterOptions options = new OtlpExporterOptions();
+        var options = new OtlpExporterOptions();
 
         var defaultFactory = options.HttpClientFactory;
 
-        int invocations = 0;
+        var invocations = 0;
         options.Protocol = OtlpExportProtocol.HttpProtobuf;
         options.HttpClientFactory = () =>
         {
@@ -131,7 +131,7 @@ public class OtlpLogExporterTests
     [InlineData(true)]
     public void AddOtlpLogExporterReceivesAttributesWithParseStateValueSetToFalse(bool callUseOpenTelemetry)
     {
-        bool optionsValidated = false;
+        var optionsValidated = false;
 
         var logRecords = new List<LogRecord>();
         using var loggerFactory = LoggerFactory.Create(builder =>
@@ -272,7 +272,7 @@ public class OtlpLogExporterTests
         Assert.Single(logRecords);
 
         var logRecord = logRecords[0];
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), logRecord);
+        var otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), logRecord);
 
         Assert.NotNull(otlpLogRecord);
         Assert.Equal("Hello from tomato 2.99.", otlpLogRecord.Body.StringValue);
@@ -319,7 +319,7 @@ public class OtlpLogExporterTests
           .Build();
 
         var logRecord = logRecords[0];
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new(configuration), logRecord);
+        var otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new(configuration), logRecord);
 
         Assert.NotNull(otlpLogRecord);
         Assert.Equal("Hello from tomato 2.99.", otlpLogRecord.Body.StringValue);
@@ -376,7 +376,7 @@ public class OtlpLogExporterTests
         logger.LogMessage();
 
         var logRecord = logRecords[0];
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), logRecord);
+        var otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), logRecord);
 
         Assert.NotNull(otlpLogRecord);
         Assert.True(otlpLogRecord.TimeUnixNano > 0);
@@ -396,7 +396,7 @@ public class OtlpLogExporterTests
         logger.LogWhenThereIsNoActivity();
 
         var logRecord = logRecords[0];
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), logRecord);
+        var otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), logRecord);
 
         Assert.Null(Activity.Current);
         Assert.NotNull(otlpLogRecord);
@@ -429,7 +429,7 @@ public class OtlpLogExporterTests
 
         var logRecord = logRecords[0];
 
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), logRecord);
+        var otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), logRecord);
 
         Assert.NotNull(otlpLogRecord);
         Assert.Equal(expectedTraceId.ToString(), ActivityTraceId.CreateFromBytes(otlpLogRecord.TraceId.ToByteArray()).ToString());
@@ -461,7 +461,7 @@ public class OtlpLogExporterTests
         Assert.Single(logRecords);
 
         var logRecord = logRecords[0];
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), logRecord);
+        var otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), logRecord);
 
         Assert.NotNull(otlpLogRecord);
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -488,6 +488,9 @@ public class OtlpLogExporterTests
                 break;
             case LogLevel.Critical:
                 Assert.Equal(OtlpLogs.SeverityNumber.Fatal, otlpLogRecord.SeverityNumber);
+                break;
+            case LogLevel.None:
+            default:
                 break;
         }
     }
@@ -516,7 +519,7 @@ public class OtlpLogExporterTests
         Assert.Single(logRecords);
 
         var logRecord = logRecords[0];
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), logRecord);
+        var otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), logRecord);
 
         Assert.NotNull(otlpLogRecord);
         if (includeFormattedMessage)
@@ -631,7 +634,7 @@ public class OtlpLogExporterTests
         var logRecord = logRecords[0];
         var loggedException = logRecord.Exception;
 
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), logRecord);
+        var otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), logRecord);
 
         Assert.NotNull(otlpLogRecord);
         var otlpLogRecordAttributes = otlpLogRecord.Attributes.ToString();
@@ -668,7 +671,7 @@ public class OtlpLogExporterTests
         logger.OpenTelemetryWithAttributes("I'm an attribute", "I too am an attribute", "I get dropped :(");
 
         var logRecord = logRecords[0];
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(sdkLimitOptions, new(), logRecord);
+        var otlpLogRecord = ToOtlpLogs(sdkLimitOptions, new(), logRecord);
 
         Assert.NotNull(otlpLogRecord);
         Assert.Equal(1u, otlpLogRecord.DroppedAttributesCount);
@@ -781,7 +784,7 @@ public class OtlpLogExporterTests
 
         // Assert.
         var logRecord = logRecords.Single();
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), logRecord);
+        var otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), logRecord);
 
         Assert.NotNull(otlpLogRecord);
         var actualScope = TryGetAttribute(otlpLogRecord, expectedScopeKey);
@@ -1367,11 +1370,11 @@ public class OtlpLogExporterTests
 
         Assert.Equal(2, logRecords.Count);
 
-        var batch = new Batch<LogRecord>(logRecords.ToArray(), logRecords.Count);
+        var batch = new Batch<LogRecord>([.. logRecords], logRecords.Count);
         var resourceBuilder = ResourceBuilder.CreateEmpty();
         var processResource = CreateResourceSpans(resourceBuilder.Build());
 
-        OtlpCollector.ExportLogsServiceRequest request = CreateLogsExportRequest(DefaultSdkLimitOptions, new ExperimentalOptions(), batch, resourceBuilder.Build());
+        var request = CreateLogsExportRequest(DefaultSdkLimitOptions, new ExperimentalOptions(), batch, resourceBuilder.Build());
 
         Assert.Single(request.ResourceLogs);
 
@@ -1401,8 +1404,7 @@ public class OtlpLogExporterTests
     [InlineData("logging", false)]
     [InlineData(null, true)]
     [InlineData("logging", true)]
-    public void VerifyEnvironmentVariablesTakenFromIConfigurationWhenUsingLoggerFactoryCreate(string? optionsName, bool callUseOpenTelemetry)
-    {
+    public void VerifyEnvironmentVariablesTakenFromIConfigurationWhenUsingLoggerFactoryCreate(string? optionsName, bool callUseOpenTelemetry) =>
         RunVerifyEnvironmentVariablesTakenFromIConfigurationTest(
             optionsName,
             configure =>
@@ -1419,15 +1421,13 @@ public class OtlpLogExporterTests
 
                 return (factory, factory);
             });
-    }
 
     [Theory]
     [InlineData(null, false)]
     [InlineData("logging", false)]
     [InlineData(null, true)]
     [InlineData("logging", true)]
-    public void VerifyEnvironmentVariablesTakenFromIConfigurationWhenUsingLoggingBuilder(string? optionsName, bool callUseOpenTelemetry)
-    {
+    public void VerifyEnvironmentVariablesTakenFromIConfigurationWhenUsingLoggingBuilder(string? optionsName, bool callUseOpenTelemetry) =>
         RunVerifyEnvironmentVariablesTakenFromIConfigurationTest(
             optionsName,
             configure =>
@@ -1448,7 +1448,6 @@ public class OtlpLogExporterTests
 
                 return (sp, factory);
             });
-    }
 
     [Theory]
     [InlineData("my_instrumentation_scope_name", "my_instrumentation_scope_name")]
@@ -1474,7 +1473,7 @@ public class OtlpLogExporterTests
         Assert.Single(logRecords);
 
         var batch = new Batch<LogRecord>([logRecords[0]], 1);
-        OtlpCollector.ExportLogsServiceRequest request = CreateLogsExportRequest(DefaultSdkLimitOptions, new ExperimentalOptions(), batch, ResourceBuilder.CreateEmpty().Build());
+        var request = CreateLogsExportRequest(DefaultSdkLimitOptions, new ExperimentalOptions(), batch, ResourceBuilder.CreateEmpty().Build());
 
         Assert.NotNull(request);
         Assert.Single(request.ResourceLogs);
@@ -1511,7 +1510,7 @@ public class OtlpLogExporterTests
         Assert.Single(logRecords);
         var logRecord = logRecords[0];
 
-        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), logRecord);
+        var otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), logRecord);
 
         Assert.NotNull(otlpLogRecord);
         Assert.Equal("test body", otlpLogRecord.Body.StringValue);
@@ -1639,9 +1638,7 @@ public class OtlpLogExporterTests
     }
 
     private static OtlpCommon.KeyValue? TryGetAttribute(OtlpLogs.LogRecord record, string key)
-    {
-        return record.Attributes.FirstOrDefault(att => att.Key == key);
-    }
+        => record.Attributes.FirstOrDefault(att => att.Key == key);
 
     private static void ConfigureOtlpExporter(
         ILoggingBuilder builder,
@@ -1723,7 +1720,7 @@ public class OtlpLogExporterTests
 
     private static ResourceSpans CreateResourceSpans(Resource resource)
     {
-        byte[] buffer = new byte[1024];
+        var buffer = new byte[1024];
         var writePosition = ProtobufOtlpResourceSerializer.WriteResource(buffer, 0, resource);
 
         ResourceSpans? resourceSpans;

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpMetricsExporterTests.cs
@@ -57,7 +57,7 @@ public sealed class OtlpMetricsExporterTests : IDisposable
             var metricReader = typeof(MetricReader)
                 .Assembly
                 .GetType("OpenTelemetry.Metrics.MeterProviderSdk")?
-                .GetField("reader", bindingFlags)?
+                .GetProperty("Reader", bindingFlags)?
                 .GetValue(meterProvider) as PeriodicExportingMetricReader;
 
             Assert.NotNull(metricReader);
@@ -73,8 +73,8 @@ public sealed class OtlpMetricsExporterTests : IDisposable
     [Fact]
     public void TestAddOtlpExporter_NamedOptions()
     {
-        int defaultExporterOptionsConfigureOptionsInvocations = 0;
-        int namedExporterOptionsConfigureOptionsInvocations = 0;
+        var defaultExporterOptionsConfigureOptionsInvocations = 0;
+        var namedExporterOptionsConfigureOptionsInvocations = 0;
 
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
             .ConfigureServices(services =>
@@ -100,11 +100,11 @@ public sealed class OtlpMetricsExporterTests : IDisposable
     [Fact]
     public void UserHttpFactoryCalled()
     {
-        OtlpExporterOptions options = new OtlpExporterOptions();
+        var options = new OtlpExporterOptions();
 
         var defaultFactory = options.HttpClientFactory;
 
-        int invocations = 0;
+        var invocations = 0;
         options.Protocol = OtlpExportProtocol.HttpProtobuf;
         options.HttpClientFactory = () =>
         {
@@ -142,7 +142,7 @@ public sealed class OtlpMetricsExporterTests : IDisposable
 
         services.AddHttpClient();
 
-        int invocations = 0;
+        var invocations = 0;
 
         services.AddHttpClient("OtlpMetricExporter", configureClient: (client) => invocations++);
 
@@ -167,11 +167,10 @@ public sealed class OtlpMetricsExporterTests : IDisposable
         if (includeServiceNameInResource)
         {
             resourceBuilder.AddAttributes(
-                new List<KeyValuePair<string, object>>
-                {
+                [
                     new KeyValuePair<string, object>(ResourceSemanticConventions.AttributeServiceName, "service-name"),
                     new KeyValuePair<string, object>(ResourceSemanticConventions.AttributeServiceNamespace, "ns1"),
-                });
+                ]);
         }
 
         var metrics = new List<Metric>();
@@ -201,7 +200,7 @@ public sealed class OtlpMetricsExporterTests : IDisposable
 
         provider.ForceFlush();
 
-        var batch = new Batch<Metric>(metrics.ToArray(), metrics.Count);
+        var batch = new Batch<Metric>([.. metrics], metrics.Count);
         var request = CreateMetricExportRequest(batch, resourceBuilder.Build());
 
         Assert.Single(request.ResourceMetrics);
@@ -257,7 +256,7 @@ public sealed class OtlpMetricsExporterTests : IDisposable
 
         provider.ForceFlush();
 
-        var batch = new Batch<Metric>(metrics.ToArray(), metrics.Count);
+        var batch = new Batch<Metric>([.. metrics], metrics.Count);
 
         var request = CreateMetricExportRequest(batch, ResourceBuilder.CreateEmpty().Build());
 
@@ -323,7 +322,7 @@ public sealed class OtlpMetricsExporterTests : IDisposable
             })
             .Build();
 
-        var attributes = enableKeyValues ? KeyValues : Array.Empty<KeyValuePair<string, object?>>();
+        var attributes = enableKeyValues ? KeyValues : [];
         if (longValue.HasValue)
         {
             var counter = meter.CreateCounter<long>(name, unit, description);
@@ -337,7 +336,7 @@ public sealed class OtlpMetricsExporterTests : IDisposable
 
         provider.ForceFlush();
 
-        var batch = new Batch<Metric>(metrics.ToArray(), metrics.Count);
+        var batch = new Batch<Metric>([.. metrics], metrics.Count);
         var request = CreateMetricExportRequest(batch, ResourceBuilder.CreateEmpty().Build());
 
         var resourceMetric = request.ResourceMetrics.Single();
@@ -418,7 +417,7 @@ public sealed class OtlpMetricsExporterTests : IDisposable
             })
             .Build();
 
-        var attributes = enableKeyValues ? KeyValues : Array.Empty<KeyValuePair<string, object?>>();
+        var attributes = enableKeyValues ? KeyValues : [];
         if (longValue.HasValue)
         {
             var counter = meter.CreateUpDownCounter<long>(name, unit, description);
@@ -432,7 +431,7 @@ public sealed class OtlpMetricsExporterTests : IDisposable
 
         provider.ForceFlush();
 
-        var batch = new Batch<Metric>(metrics.ToArray(), metrics.Count);
+        var batch = new Batch<Metric>([.. metrics], metrics.Count);
 
         var request = CreateMetricExportRequest(batch, ResourceBuilder.CreateEmpty().Build());
 
@@ -518,7 +517,7 @@ public sealed class OtlpMetricsExporterTests : IDisposable
             })
             .Build();
 
-        var attributes = enableKeyValues ? KeyValues : Array.Empty<KeyValuePair<string, object?>>();
+        var attributes = enableKeyValues ? KeyValues : [];
         if (longValue.HasValue)
         {
             var histogram = meter.CreateHistogram<long>(name, unit, description);
@@ -534,7 +533,7 @@ public sealed class OtlpMetricsExporterTests : IDisposable
 
         provider.ForceFlush();
 
-        var batch = new Batch<Metric>(metrics.ToArray(), metrics.Count);
+        var batch = new Batch<Metric>([.. metrics], metrics.Count);
         var request = CreateMetricExportRequest(batch, ResourceBuilder.CreateEmpty().Build());
 
         var resourceMetric = request.ResourceMetrics.Single();
@@ -652,7 +651,7 @@ public sealed class OtlpMetricsExporterTests : IDisposable
             })
             .Build();
 
-        var attributes = enableKeyValues ? KeyValues : Array.Empty<KeyValuePair<string, object?>>();
+        var attributes = enableKeyValues ? KeyValues : [];
         if (longValue.HasValue)
         {
             var histogram = meter.CreateHistogram<long>(name, unit, description);
@@ -666,7 +665,7 @@ public sealed class OtlpMetricsExporterTests : IDisposable
 
         provider.ForceFlush();
 
-        var batch = new Batch<Metric>(metrics.ToArray(), metrics.Count);
+        var batch = new Batch<Metric>([.. metrics], metrics.Count);
         var request = CreateMetricExportRequest(batch, ResourceBuilder.CreateEmpty().Build());
 
         var resourceMetric = request.ResourceMetrics.Single();
@@ -813,7 +812,7 @@ public sealed class OtlpMetricsExporterTests : IDisposable
                     ? null
                     : new MetricStreamConfiguration
                     {
-                        TagKeys = Array.Empty<string>(),
+                        TagKeys = [],
                     };
             })
             .AddInMemoryExporter(exportedItems)
@@ -838,7 +837,7 @@ public sealed class OtlpMetricsExporterTests : IDisposable
 
         meterProvider.ForceFlush();
 
-        var batch = new Batch<Metric>(exportedItems.ToArray(), exportedItems.Count);
+        var batch = new Batch<Metric>([.. exportedItems], exportedItems.Count);
         var request = CreateMetricExportRequest(batch, ResourceBuilder.CreateEmpty().Build());
 
         Assert.Single(request.ResourceMetrics);
@@ -875,11 +874,11 @@ public sealed class OtlpMetricsExporterTests : IDisposable
             }
             else
             {
-                byte[] traceIdBytes = new byte[16];
+                var traceIdBytes = new byte[16];
                 Assert.NotNull(activity);
                 activity.TraceId.CopyTo(traceIdBytes);
 
-                byte[] spanIdBytes = new byte[8];
+                var spanIdBytes = new byte[8];
                 activity.SpanId.CopyTo(spanIdBytes);
 
                 Assert.Equal(ByteString.CopyFrom(traceIdBytes), otlpExemplar.TraceId);
@@ -938,7 +937,7 @@ public sealed class OtlpMetricsExporterTests : IDisposable
 
         provider.ForceFlush();
 
-        var batch = new Batch<Metric>(metrics.ToArray(), metrics.Count);
+        var batch = new Batch<Metric>([.. metrics], metrics.Count);
 
         var buffer = new byte[50];
         var writePosition = ProtobufOtlpMetricSerializer.WriteMetricsData(ref buffer, 0, ResourceBuilder.CreateEmpty().Build(), in batch);

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpResourceTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpResourceTests.cs
@@ -25,7 +25,7 @@ public class OtlpResourceTests
         var resource = resourceBuilder.Build();
         Proto.Resource.V1.Resource otlpResource;
 
-        byte[] buffer = new byte[1024];
+        var buffer = new byte[1024];
         var writePosition = ProtobufOtlpResourceSerializer.WriteResource(buffer, 0, resource);
 
         // Deserialize the ResourceSpans and validate the attributes.

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpSecureHttpClientFactoryTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpSecureHttpClientFactoryTests.cs
@@ -72,8 +72,7 @@ public class OtlpSecureHttpClientFactoryTests
     }
 
     [Fact]
-    public void CreateHttpClient_ConfiguresServerCertificateValidation_WhenCaCertificatesProvided()
-    {
+    public void CreateHttpClient_ConfiguresServerCertificateValidation_WhenCaCertificatesProvided() =>
         SkipTestIfCryptoNotSupported(() =>
         {
             var tempTrustStoreFile = Path.GetTempFileName();
@@ -110,11 +109,9 @@ public class OtlpSecureHttpClientFactoryTests
                 }
             }
         });
-    }
 
     [Fact]
-    public void CreateHttpClient_ConfiguresServerValidation_WithCaOnly()
-    {
+    public void CreateHttpClient_ConfiguresServerValidation_WithCaOnly() =>
         SkipTestIfCryptoNotSupported(() =>
         {
             var tempTrustStoreFile = Path.GetTempFileName();
@@ -152,11 +149,9 @@ public class OtlpSecureHttpClientFactoryTests
                 }
             }
         });
-    }
 
     [Fact]
-    public void CreateHttpClient_InvokesServerValidationCallbackAfterFactoryReturns()
-    {
+    public void CreateHttpClient_InvokesServerValidationCallbackAfterFactoryReturns() =>
         SkipTestIfCryptoNotSupported(() =>
         {
             var tempTrustStoreFile = Path.GetTempFileName();
@@ -202,7 +197,6 @@ public class OtlpSecureHttpClientFactoryTests
                 }
             }
         });
-    }
 
     [Fact]
     public void ValidateServerCertificate_ReturnsTrue_WhenNoSslPolicyErrors()
@@ -326,7 +320,7 @@ public class OtlpSecureHttpClientFactoryTests
             DateTimeOffset.UtcNow.AddDays(-1),
             DateTimeOffset.UtcNow.AddDays(30));
 #if NET9_0_OR_GREATER
-        return X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx), (string?)null, X509KeyStorageFlags.Exportable);
+        return X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx), null, X509KeyStorageFlags.Exportable);
 #else
 #pragma warning disable SYSLIB0057
         return new X509Certificate2(cert.Export(X509ContentType.Pfx), (string?)null, X509KeyStorageFlags.Exportable);
@@ -354,7 +348,7 @@ public class OtlpSecureHttpClientFactoryTests
             DateTimeOffset.UtcNow.AddYears(1));
 
 #if NET9_0_OR_GREATER
-        return X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx), (string?)null, X509KeyStorageFlags.Exportable);
+        return X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx), null, X509KeyStorageFlags.Exportable);
 #else
 #pragma warning disable SYSLIB0057
         return new X509Certificate2(cert.Export(X509ContentType.Pfx), (string?)null, X509KeyStorageFlags.Exportable);
@@ -391,7 +385,7 @@ public class OtlpSecureHttpClientFactoryTests
             serialNumber);
 
 #if NET9_0_OR_GREATER
-        return X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx), (string?)null, X509KeyStorageFlags.Exportable);
+        return X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx), null, X509KeyStorageFlags.Exportable);
 #else
 #pragma warning disable SYSLIB0057
         return new X509Certificate2(cert.Export(X509ContentType.Pfx), (string?)null, X509KeyStorageFlags.Exportable);
@@ -415,7 +409,7 @@ public class OtlpSecureHttpClientFactoryTests
             DateTimeOffset.UtcNow.AddDays(-1));
 
 #if NET9_0_OR_GREATER
-        return X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx), (string?)null, X509KeyStorageFlags.Exportable);
+        return X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx), null, X509KeyStorageFlags.Exportable);
 #else
 #pragma warning disable SYSLIB0057
         return new X509Certificate2(cert.Export(X509ContentType.Pfx), (string?)null, X509KeyStorageFlags.Exportable);
@@ -428,7 +422,7 @@ public class OtlpSecureHttpClientFactoryTests
         var builder = new StringBuilder();
         builder.AppendLine(certificate.ExportCertificatePem().Trim());
 
-        using RSA? privateKey = certificate.GetRSAPrivateKey();
+        using var privateKey = certificate.GetRSAPrivateKey();
         if (privateKey != null)
         {
             var pkcs8Bytes = privateKey.ExportPkcs8PrivateKey();

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpSpecConfigDefinitionTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpSpecConfigDefinitionTests.cs
@@ -187,9 +187,7 @@ public class OtlpSpecConfigDefinitionTests : IEnumerable<object[]>
         public string ProtocolValue { get; }
 
         public IConfiguration ToConfiguration()
-        {
-            return this.AddToConfiguration(new ConfigurationBuilder()).Build();
-        }
+            => this.AddToConfiguration(new ConfigurationBuilder()).Build();
 
         public ConfigurationBuilder AddToConfiguration(ConfigurationBuilder configurationBuilder)
         {
@@ -311,12 +309,14 @@ public class OtlpSpecConfigDefinitionTests : IEnumerable<object[]>
 
             if (!string.IsNullOrWhiteSpace(this.HistogramAggregationValue))
             {
+#pragma warning disable IDE0370 // Remove unnecessary suppression
                 // Map spec-defined snake_case values to enum
                 var expectedValue = this.HistogramAggregationValue!.Equals("base2_exponential_bucket_histogram", StringComparison.OrdinalIgnoreCase)
                     ? MetricReaderHistogramAggregation.Base2ExponentialBucketHistogram
                     : this.HistogramAggregationValue.Equals("explicit_bucket_histogram", StringComparison.OrdinalIgnoreCase)
                         ? MetricReaderHistogramAggregation.ExplicitBucketHistogram
                         : (MetricReaderHistogramAggregation?)null;
+#pragma warning restore IDE0370 // Remove unnecessary suppression
 
                 Assert.Equal(expectedValue, metricReaderOptions.DefaultHistogramAggregation);
             }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTestHelpers.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTestHelpers.cs
@@ -14,8 +14,8 @@ internal static class OtlpTestHelpers
         RepeatedField<OtlpCommon.KeyValue> actual)
     {
         var expectedAttributes = expected.ToList();
-        int expectedSize = 0;
-        for (int i = 0; i < expectedAttributes.Count; i++)
+        var expectedSize = 0;
+        for (var i = 0; i < expectedAttributes.Count; i++)
         {
             var current = expectedAttributes[i].Value;
             Assert.Equal(expectedAttributes[i].Key, actual[i].Key);
@@ -70,7 +70,7 @@ internal static class OtlpTestHelpers
 
                     Assert.Equal(source.Length, actual[i].Value.ArrayValue.Values.Count);
 
-                    for (int j = 0; j < source.Length; j++)
+                    for (var j = 0; j < source.Length; j++)
                     {
                         var item = source.GetValue(j);
 

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTlsOptionsTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTlsOptionsTests.cs
@@ -53,8 +53,7 @@ public class OtlpTlsOptionsTests
     }
 
     [Fact]
-    public void OtlpSecureHttpClientFactory_CreatesClient_WithCaCertificateOnly()
-    {
+    public void OtlpSecureHttpClientFactory_CreatesClient_WithCaCertificateOnly() =>
         SkipTestIfCryptoNotSupported(() =>
         {
             var tempCertFile = Path.GetTempFileName();
@@ -81,11 +80,9 @@ public class OtlpTlsOptionsTests
                 }
             }
         });
-    }
 
     [Fact]
-    public void OtlpSecureHttpClientFactory_CreatesClient_WithMtlsClientCertificate()
-    {
+    public void OtlpSecureHttpClientFactory_CreatesClient_WithMtlsClientCertificate() =>
         SkipTestIfCryptoNotSupported(() =>
         {
             var tempCertFile = Path.GetTempFileName();
@@ -113,14 +110,11 @@ public class OtlpTlsOptionsTests
                 }
             }
         });
-    }
 
     [Fact]
-    public void OtlpSecureHttpClientFactory_ThrowsArgumentNullException_WhenOptionsIsNull()
-    {
+    public void OtlpSecureHttpClientFactory_ThrowsArgumentNullException_WhenOptionsIsNull() =>
         Assert.Throws<ArgumentNullException>(() =>
             OpenTelemetryProtocol.Implementation.OtlpSecureHttpClientFactory.CreateSecureHttpClient(null!));
-    }
 
     [Fact]
     public void OtlpSecureHttpClientFactory_ThrowsInvalidOperationException_WhenTlsNotEnabled()
@@ -131,11 +125,9 @@ public class OtlpTlsOptionsTests
     }
 
     [Fact]
-    public void OtlpCertificateManager_LoadCaCertificate_ThrowsFileNotFoundException()
-    {
+    public void OtlpCertificateManager_LoadCaCertificate_ThrowsFileNotFoundException() =>
         Assert.Throws<FileNotFoundException>(() =>
             OpenTelemetryProtocol.Implementation.OtlpCertificateManager.LoadCaCertificate("/nonexistent/cert.pem"));
-    }
 
     [Fact]
     public void OtlpCertificateManager_ValidateServerCertificate_ReturnsTrue_WhenNoSslPolicyErrors()
@@ -185,7 +177,7 @@ public class OtlpTlsOptionsTests
             DateTimeOffset.UtcNow.AddDays(-1),
             DateTimeOffset.UtcNow.AddDays(30));
 #if NET9_0_OR_GREATER
-        return X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx), (string?)null, X509KeyStorageFlags.Exportable);
+        return X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx), null, X509KeyStorageFlags.Exportable);
 #else
 #pragma warning disable SYSLIB0057
         return new X509Certificate2(cert.Export(X509ContentType.Pfx), (string?)null, X509KeyStorageFlags.Exportable);
@@ -213,7 +205,7 @@ public class OtlpTlsOptionsTests
             DateTimeOffset.UtcNow.AddYears(1));
 
 #if NET9_0_OR_GREATER
-        return X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx), (string?)null, X509KeyStorageFlags.Exportable);
+        return X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx), null, X509KeyStorageFlags.Exportable);
 #else
 #pragma warning disable SYSLIB0057
         return new X509Certificate2(cert.Export(X509ContentType.Pfx), (string?)null, X509KeyStorageFlags.Exportable);
@@ -250,7 +242,7 @@ public class OtlpTlsOptionsTests
             serialNumber);
 
 #if NET9_0_OR_GREATER
-        return X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx), (string?)null, X509KeyStorageFlags.Exportable);
+        return X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx), null, X509KeyStorageFlags.Exportable);
 #else
 #pragma warning disable SYSLIB0057
         return new X509Certificate2(cert.Export(X509ContentType.Pfx), (string?)null, X509KeyStorageFlags.Exportable);
@@ -263,7 +255,7 @@ public class OtlpTlsOptionsTests
         var builder = new StringBuilder();
         builder.AppendLine(certificate.ExportCertificatePem().Trim());
 
-        using RSA? privateKey = certificate.GetRSAPrivateKey();
+        using var privateKey = certificate.GetRSAPrivateKey();
         if (privateKey != null)
         {
             var pkcs8Bytes = privateKey.ExportPkcs8PrivateKey();

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpTraceExporterTests.cs
@@ -36,7 +36,7 @@ public sealed class OtlpTraceExporterTests : IDisposable
         this.activityListener = new ActivityListener
         {
             ShouldListenTo = _ => true,
-            Sample = (ref ActivityCreationOptions<ActivityContext> options) => options.Parent.TraceFlags.HasFlag(ActivityTraceFlags.Recorded)
+            Sample = (ref options) => options.Parent.TraceFlags.HasFlag(ActivityTraceFlags.Recorded)
                 ? ActivitySamplingResult.AllDataAndRecorded
                 : ActivitySamplingResult.AllData,
         };
@@ -45,15 +45,13 @@ public sealed class OtlpTraceExporterTests : IDisposable
     }
 
     public void Dispose()
-    {
-        this.activityListener.Dispose();
-    }
+        => this.activityListener.Dispose();
 
     [Fact]
     public void AddOtlpTraceExporterNamedOptionsSupported()
     {
-        int defaultExporterOptionsConfigureOptionsInvocations = 0;
-        int namedExporterOptionsConfigureOptionsInvocations = 0;
+        var defaultExporterOptionsConfigureOptionsInvocations = 0;
+        var namedExporterOptionsConfigureOptionsInvocations = 0;
 
         using var tracerProvider = Sdk.CreateTracerProviderBuilder()
             .ConfigureServices(services =>
@@ -80,11 +78,11 @@ public sealed class OtlpTraceExporterTests : IDisposable
     [Fact]
     public void UserHttpFactoryCalled()
     {
-        OtlpExporterOptions options = new OtlpExporterOptions();
+        var options = new OtlpExporterOptions();
 
         var defaultFactory = options.HttpClientFactory;
 
-        int invocations = 0;
+        var invocations = 0;
         options.Protocol = OtlpExportProtocol.HttpProtobuf;
         options.HttpClientFactory = () =>
         {
@@ -122,7 +120,7 @@ public sealed class OtlpTraceExporterTests : IDisposable
 
         services.AddHttpClient();
 
-        int invocations = 0;
+        var invocations = 0;
 
         services.AddHttpClient("OtlpTraceExporter", configureClient: (client) => invocations++);
 
@@ -175,11 +173,11 @@ public sealed class OtlpTraceExporterTests : IDisposable
             var activityKind = isEven ? ActivityKind.Client : ActivityKind.Server;
             var activityTags = isEven ? evenTags : oddTags;
 
-            using Activity? activity = source.StartActivity($"span-{i}", activityKind, parentContext: default, activityTags);
+            using var activity = source.StartActivity($"span-{i}", activityKind, parentContext: default, activityTags);
         }
 
         Assert.Equal(10, exportedItems.Count);
-        var batch = new Batch<Activity>(exportedItems.ToArray(), exportedItems.Count);
+        var batch = new Batch<Activity>([.. exportedItems], exportedItems.Count);
         RunTest(DefaultSdkLimitOptions, batch);
 
         void RunTest(SdkLimitOptions sdkOptions, Batch<Activity> batch)
@@ -261,7 +259,7 @@ public sealed class OtlpTraceExporterTests : IDisposable
         nestedChildActivity?.Dispose();
 
         Assert.Equal(2, exportedItems.Count);
-        var batch = new Batch<Activity>(exportedItems.ToArray(), exportedItems.Count);
+        var batch = new Batch<Activity>([.. exportedItems], exportedItems.Count);
         RunTest(DefaultSdkLimitOptions, batch, activitySourceWithTags);
 
         exportedItems.Clear();
@@ -270,7 +268,7 @@ public sealed class OtlpTraceExporterTests : IDisposable
         parentActivityNoTags?.Dispose();
 
         Assert.Single(exportedItems);
-        batch = new Batch<Activity>(exportedItems.ToArray(), exportedItems.Count);
+        batch = new Batch<Activity>([.. exportedItems], exportedItems.Count);
         RunTest(DefaultSdkLimitOptions, batch, activitySourceWithoutTags);
 
         void RunTest(SdkLimitOptions sdkOptions, Batch<Activity> batch, ActivitySource activitySource)
@@ -344,7 +342,7 @@ public sealed class OtlpTraceExporterTests : IDisposable
         activity?.Stop();
 
         Assert.Single(exportedItems);
-        var batch = new Batch<Activity>(exportedItems.ToArray(), exportedItems.Count);
+        var batch = new Batch<Activity>([.. exportedItems], exportedItems.Count);
 
         var request = CreateTraceExportRequest(DefaultSdkLimitOptions, batch, resourceBuilder.Build());
 
@@ -390,7 +388,7 @@ public sealed class OtlpTraceExporterTests : IDisposable
         activity?.Dispose();
 
         Assert.Single(exportedItems);
-        var batch = new Batch<Activity>(exportedItems.ToArray(), exportedItems.Count);
+        var batch = new Batch<Activity>([.. exportedItems], exportedItems.Count);
         RunTest(sdkOptions, batch);
 
         void RunTest(SdkLimitOptions sdkOptions, Batch<Activity> batch)
@@ -541,7 +539,7 @@ public sealed class OtlpTraceExporterTests : IDisposable
         var expectedEndTimeUnixNano = expectedStartTimeUnixNano + (duration.TotalMilliseconds * 1_000_000);
         Assert.Equal(expectedEndTimeUnixNano, otlpSpan.EndTimeUnixNano);
 
-        var childLinks = new List<ActivityLink> { new(rootActivity.Context, new ActivityTagsCollection(attributes)) };
+        var childLinks = new List<ActivityLink> { new(rootActivity.Context, [.. attributes]) };
         var childActivity = activitySource.StartActivity(
             "child",
             ActivityKind.Client,
@@ -552,7 +550,7 @@ public sealed class OtlpTraceExporterTests : IDisposable
 
         childActivity.SetStatus(ActivityStatusCode.Error, new string('a', 150));
 
-        var childEvents = new List<ActivityEvent> { new("e0"), new("e1", default, new ActivityTagsCollection(attributes)) };
+        var childEvents = new List<ActivityEvent> { new("e0"), new("e1", default, [.. attributes]) };
         childActivity.AddEvent(childEvents[0]);
         childActivity.AddEvent(childEvents[1]);
 
@@ -578,7 +576,7 @@ public sealed class OtlpTraceExporterTests : IDisposable
         for (var i = 0; i < childEvents.Count; i++)
         {
             Assert.Equal(childEvents[i].Name, otlpSpan.Events[i].Name);
-            OtlpTestHelpers.AssertOtlpAttributes(childEvents[i].Tags.ToList(), otlpSpan.Events[i].Attributes);
+            OtlpTestHelpers.AssertOtlpAttributes([.. childEvents[i].Tags], otlpSpan.Events[i].Attributes);
         }
 
         childLinks.Reverse();
@@ -667,7 +665,7 @@ public sealed class OtlpTraceExporterTests : IDisposable
         var batch = new Batch<Activity>([activity], 1);
         RunTest(new(), batch);
 
-        void RunTest(SdkLimitOptions sdkOptions, Batch<Activity> batch)
+        static void RunTest(SdkLimitOptions sdkOptions, Batch<Activity> batch)
         {
             var buffer = new byte[50];
             var writePosition = ProtobufOtlpTraceSerializer.WriteTraceData(ref buffer, 0, sdkOptions, ResourceBuilder.CreateEmpty().Build(), batch);
@@ -788,7 +786,7 @@ public sealed class OtlpTraceExporterTests : IDisposable
         using var activitySource = new ActivitySource(nameof(this.ToOtlpSpanTest));
         using var activity = activitySource.StartActivity("Name");
         Assert.NotNull(activity);
-        string tracestate = "a=b;c=d";
+        var tracestate = "a=b;c=d";
         if (traceStateWasSet)
         {
             activity.TraceStateString = tracestate;
@@ -813,11 +811,11 @@ public sealed class OtlpTraceExporterTests : IDisposable
     {
         const string ActivitySourceName = "otlp.test";
 #pragma warning disable CA2000 // Dispose objects before losing scope
-        TestActivityProcessor testActivityProcessor = new TestActivityProcessor();
+        var testActivityProcessor = new TestActivityProcessor();
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
-        bool startCalled = false;
-        bool endCalled = false;
+        var startCalled = false;
+        var endCalled = false;
 
         testActivityProcessor.StartAction =
             (a) =>
@@ -860,8 +858,7 @@ public sealed class OtlpTraceExporterTests : IDisposable
     }
 
     [Fact]
-    public void Null_BatchExportProcessorOptions_SupportedTest()
-    {
+    public void Null_BatchExportProcessorOptions_SupportedTest() =>
         Sdk.CreateTracerProviderBuilder()
             .AddOtlpExporter(
                 o =>
@@ -870,7 +867,6 @@ public sealed class OtlpTraceExporterTests : IDisposable
                     o.ExportProcessorType = ExportProcessorType.Batch;
                     o.BatchExportProcessorOptions = null!;
                 });
-    }
 
     [Fact]
     public void NonnamedOptionsMutateSharedInstanceTest()
@@ -973,7 +969,7 @@ public sealed class OtlpTraceExporterTests : IDisposable
     {
         using var activitySource = new ActivitySource(nameof(this.SpanFlagsTest));
 
-        ActivityContext ctx = new ActivityContext(
+        var ctx = new ActivityContext(
             ActivityTraceId.CreateRandom(),
             ActivitySpanId.CreateRandom(),
             isRecorded ? ActivityTraceFlags.Recorded : ActivityTraceFlags.None,
@@ -987,7 +983,7 @@ public sealed class OtlpTraceExporterTests : IDisposable
         Assert.NotNull(otlpSpan);
         var flags = (OtlpTrace.SpanFlags)otlpSpan.Flags;
 
-        ActivityTraceFlags traceFlags = (ActivityTraceFlags)(flags & OtlpTrace.SpanFlags.TraceFlagsMask);
+        var traceFlags = (ActivityTraceFlags)(flags & OtlpTrace.SpanFlags.TraceFlagsMask);
 
         if (isRecorded)
         {
@@ -1019,7 +1015,7 @@ public sealed class OtlpTraceExporterTests : IDisposable
     {
         using var activitySource = new ActivitySource(nameof(this.SpanLinkFlagsTest));
 
-        ActivityContext ctx = new ActivityContext(
+        var ctx = new ActivityContext(
             ActivityTraceId.CreateRandom(),
             ActivitySpanId.CreateRandom(),
             isRecorded ? ActivityTraceFlags.Recorded : ActivityTraceFlags.None,
@@ -1040,7 +1036,7 @@ public sealed class OtlpTraceExporterTests : IDisposable
 
         var flags = (OtlpTrace.SpanFlags)spanLink.Flags;
 
-        ActivityTraceFlags traceFlags = (ActivityTraceFlags)(flags & OtlpTrace.SpanFlags.TraceFlagsMask);
+        var traceFlags = (ActivityTraceFlags)(flags & OtlpTrace.SpanFlags.TraceFlagsMask);
 
         if (isRecorded)
         {

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/TestHttpMessageHandler.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/TestHttpMessageHandler.cs
@@ -19,20 +19,16 @@ internal sealed class TestHttpMessageHandler : HttpMessageHandler
 #if NET
         this.HttpRequestContent = request.Content!.ReadAsByteArrayAsync(cancellationToken).Result;
 #else
-        this.HttpRequestContent = request.Content!.ReadAsByteArrayAsync().Result;
+        this.HttpRequestContent = request.Content.ReadAsByteArrayAsync().Result;
 #endif
         return new HttpResponseMessage();
     }
 
 #if NET
     protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
-    {
-        return this.InternalSend(request, cancellationToken);
-    }
+        => this.InternalSend(request, cancellationToken);
 #endif
 
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-    {
-        return Task.FromResult(this.InternalSend(request, cancellationToken));
-    }
+        => Task.FromResult(this.InternalSend(request, cancellationToken));
 }

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/UseOtlpExporterExtensionTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/UseOtlpExporterExtensionTests.cs
@@ -21,9 +21,7 @@ public sealed class UseOtlpExporterExtensionTests : IDisposable
     }
 
     public void Dispose()
-    {
-        OtlpSpecConfigDefinitionTests.ClearEnvVars();
-    }
+        => OtlpSpecConfigDefinitionTests.ClearEnvVars();
 
     [Fact]
     public void UseOtlpExporterDefaultTest()
@@ -204,9 +202,9 @@ public sealed class UseOtlpExporterExtensionTests : IDisposable
 
         using var sp = services.BuildServiceProvider();
 
-        Assert.Throws<NotSupportedException>(() => sp.GetRequiredService<LoggerProvider>());
-        Assert.Throws<NotSupportedException>(() => sp.GetRequiredService<MeterProvider>());
-        Assert.Throws<NotSupportedException>(() => sp.GetRequiredService<TracerProvider>());
+        Assert.Throws<NotSupportedException>(sp.GetRequiredService<LoggerProvider>);
+        Assert.Throws<NotSupportedException>(sp.GetRequiredService<MeterProvider>);
+        Assert.Throws<NotSupportedException>(sp.GetRequiredService<TracerProvider>);
     }
 
     [Fact]
@@ -220,7 +218,7 @@ public sealed class UseOtlpExporterExtensionTests : IDisposable
 
         using var sp = services.BuildServiceProvider();
 
-        Assert.Throws<NotSupportedException>(() => sp.GetRequiredService<LoggerProvider>());
+        Assert.Throws<NotSupportedException>(sp.GetRequiredService<LoggerProvider>);
     }
 
     [Fact]
@@ -234,7 +232,7 @@ public sealed class UseOtlpExporterExtensionTests : IDisposable
 
         using var sp = services.BuildServiceProvider();
 
-        Assert.Throws<NotSupportedException>(() => sp.GetRequiredService<MeterProvider>());
+        Assert.Throws<NotSupportedException>(sp.GetRequiredService<MeterProvider>);
     }
 
     [Fact]
@@ -248,7 +246,7 @@ public sealed class UseOtlpExporterExtensionTests : IDisposable
 
         using var sp = services.BuildServiceProvider();
 
-        Assert.Throws<NotSupportedException>(() => sp.GetRequiredService<TracerProvider>());
+        Assert.Throws<NotSupportedException>(sp.GetRequiredService<TracerProvider>);
     }
 
     [Fact]


### PR DESCRIPTION
## Changes

Cherry-pick fixes for new code analysis warnings identified by the .NET 11 preview 2 SDK in #6899.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
