### PR TITLE
[Api] Fix new code analysis warnings

### DIFF
--- a/src/OpenTelemetry.Api/Baggage.cs
+++ b/src/OpenTelemetry.Api/Baggage.cs
@@ -318,14 +318,14 @@ public readonly struct Baggage : IEquatable<Baggage>
         return new Baggage(baggage);
     }
 
+#pragma warning disable CA1822 // Mark members as static
     /// <summary>
     /// Returns a new <see cref="Baggage"/> with all the key/value pairs removed.
     /// </summary>
     /// <returns>New <see cref="Baggage"/> with all the key/value pairs removed.</returns>
-#pragma warning disable CA1822 // Mark members as static
     public Baggage ClearBaggage()
-#pragma warning restore CA1822 // Mark members as static
         => default;
+#pragma warning restore CA1822 // Mark members as static
 
     /// <summary>
     /// Returns an enumerator that iterates through the <see cref="Baggage"/>.

--- a/src/OpenTelemetry.Api/Context/RuntimeContextSlot.cs
+++ b/src/OpenTelemetry.Api/Context/RuntimeContextSlot.cs
@@ -27,19 +27,19 @@ public abstract class RuntimeContextSlot<T> : IDisposable
     /// </summary>
     public string Name { get; private set; }
 
+#pragma warning disable CA1716 // Identifiers should not match keywords
     /// <summary>
     /// Get the value from the context slot.
     /// </summary>
     /// <returns>The value retrieved from the context slot.</returns>
-#pragma warning disable CA1716 // Identifiers should not match keywords
     public abstract T? Get();
 #pragma warning restore CA1716 // Identifiers should not match keywords
 
+#pragma warning disable CA1716 // Identifiers should not match keywords
     /// <summary>
     /// Set the value to the context slot.
     /// </summary>
     /// <param name="value">The value to be set.</param>
-#pragma warning disable CA1716 // Identifiers should not match keywords
     public abstract void Set(T value);
 #pragma warning restore CA1716 // Identifiers should not match keywords
 

--- a/src/OpenTelemetry.Api/Trace/SpanContext.cs
+++ b/src/OpenTelemetry.Api/Trace/SpanContext.cs
@@ -101,14 +101,14 @@ public readonly struct SpanContext : IEquatable<SpanContext>
         }
     }
 
+#pragma warning disable CA2225 // Operator overloads have named alternates
     /// <summary>
     /// Converts a <see cref="SpanContext"/> into an <see cref="ActivityContext"/>.
     /// </summary>
     /// <param name="spanContext"><see cref="SpanContext"/> source.</param>
-#pragma warning disable CA2225 // Operator overloads have named alternates
     public static implicit operator ActivityContext(SpanContext spanContext)
-#pragma warning restore CA2225 // Operator overloads have named alternates
         => spanContext.ActivityContext;
+#pragma warning restore CA2225 // Operator overloads have named alternates
 
     /// <summary>
     /// Compare two <see cref="SpanContext"/> for equality.

--- a/src/OpenTelemetry.Api/Trace/Tracer.cs
+++ b/src/OpenTelemetry.Api/Trace/Tracer.cs
@@ -52,10 +52,10 @@ public class Tracer
     /// </summary>
     /// <param name="span">The span to be made current.</param>
     /// <returns>The supplied span for call chaining.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #if NET
     [return: NotNullIfNotNull(nameof(span))]
 #endif
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static TelemetrySpan? WithSpan(TelemetrySpan? span)
     {
         span?.Activate();


### PR DESCRIPTION
## Changes

Cherry-pick fixes for new code analysis warnings identified by the .NET 11 preview 2 SDK in #6899 missed from #6956.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
