### PR TITLE
[OpenTracing] Fix IDE0028 suppression

### DIFF
--- a/test/OpenTelemetry.Shims.OpenTracing.Tests/TestTextMap.cs
+++ b/test/OpenTelemetry.Shims.OpenTracing.Tests/TestTextMap.cs
@@ -12,9 +12,7 @@ internal sealed class TestTextMap : ITextMap
 
     public bool SetCalled { get; private set; }
 
-#pragma warning disable IDE0028 // Simplify collection initialization
-    public Dictionary<string, string> Items { get; } = new();
-#pragma warning restore IDE0028 // Simplify collection initialization
+    public Dictionary<string, string> Items { get; } = [];
 
     public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
     {


### PR DESCRIPTION
## Changes

Remove suppression for `IDE0028` and fix it, as this should now work with the .NET 10.0.2xx SDK.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
