### PR TITLE
[OTLP] Fix TODO in PersistentStorageHelper

### DIFF
--- a/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/PersistentStorage/PersistentStorageHelper.cs
+++ b/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/PersistentStorage/PersistentStorageHelper.cs
@@ -3,6 +3,9 @@
 
 using System.Globalization;
 using System.Runtime.CompilerServices;
+#if !NETFRAMEWORK
+using System.Runtime.InteropServices;
+#endif
 
 namespace OpenTelemetry.PersistentStorage.FileSystem;
 
@@ -106,9 +109,7 @@ internal static class PersistentStorageHelper
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void WriteAllBytes(string path, byte[] buffer)
-    {
-        File.WriteAllBytes(path, buffer);
-    }
+        => File.WriteAllBytes(path, buffer);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void RemoveFile(string fileName, out long fileSize)
@@ -120,9 +121,7 @@ internal static class PersistentStorageHelper
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static string GetUniqueFileName(string extension)
-    {
-        return string.Format(CultureInfo.InvariantCulture, $"{DateTime.UtcNow:yyyy-MM-ddTHHmmss.fffffffZ}-{Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture)}{extension}");
-    }
+        => string.Format(CultureInfo.InvariantCulture, $"{DateTime.UtcNow:yyyy-MM-ddTHHmmss.fffffffZ}-{Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture)}{extension}");
 
     internal static string CreateSubdirectory(string path)
     {
@@ -132,25 +131,44 @@ internal static class PersistentStorageHelper
 
     internal static DateTime GetDateTimeFromBlobName(string filePath)
     {
-        var fileName = Path.GetFileNameWithoutExtension(filePath);
-        var time = fileName.Substring(0, fileName.LastIndexOf('-'));
+        var fileName = GetFileNameWithoutExtension(filePath);
+        var timestamp = fileName.Substring(0, fileName.LastIndexOf('-'));
 
-        if (!DateTime.TryParseExact(time, "yyyy-MM-ddTHHmmss.fffffffZ", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var dateTime))
-        {
-            // In case of failure, return DateTime.MinValue so that the blob file can be removed as expired
-            dateTime = DateTime.MinValue;
-        }
-
-        return dateTime.ToUniversalTime();
+        return Parse(timestamp);
     }
 
     internal static DateTime GetDateTimeFromLeaseName(string filePath)
     {
-        var fileName = Path.GetFileNameWithoutExtension(filePath);
+        var fileName = GetFileNameWithoutExtension(filePath);
         var startIndex = fileName.LastIndexOf('@') + 1;
-        var time = fileName.Substring(startIndex);
+        var timestamp = fileName.Substring(startIndex);
 
-        if (!DateTime.TryParseExact(time, "yyyy-MM-ddTHHmmss.fffffffZ", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var dateTime))
+        return Parse(timestamp);
+    }
+
+    private static string GetFileNameWithoutExtension(string filePath)
+    {
+        var fileName = Path.GetFileNameWithoutExtension(filePath);
+
+#if !NETFRAMEWORK
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            // Non-Windows platforms will treat the entire path as the file name if it contains Windows
+            // path separators, so we need to extract the file name manually from after the last \ character.
+            var startIndex = fileName.LastIndexOf('\\');
+            if (startIndex > -1)
+            {
+                fileName = fileName.Substring(startIndex + 1);
+            }
+        }
+#endif
+
+        return fileName;
+    }
+
+    private static DateTime Parse(string timestamp)
+    {
+        if (!DateTime.TryParseExact(timestamp, "yyyy-MM-ddTHHmmss.fffffffZ", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var dateTime))
         {
             // In case of failure, return DateTime.MinValue so that the lease file can be removed as expired
             dateTime = DateTime.MinValue;

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/PersistentStorage/PersistentStorageHelperTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/PersistentStorage/PersistentStorageHelperTests.cs
@@ -28,13 +28,13 @@ public class PersistentStorageHelperTests
     }
 
     [Theory]
-    [InlineData("2024-01-15T143025.1234567Z-abc123.tmp")]
-    [InlineData("/path/to/2024-01-15T143025.1234567Z-abc123.blob")]
-    [InlineData("C:\\temp\\2024-01-15T143025.1234567Z-abc123.blob")]
+    [InlineData("2024-06-15T143025.1234567Z-abc123.tmp")]
+    [InlineData("/path/to/2024-06-15T143025.1234567Z-abc123.blob")]
+    [InlineData("C:\\temp\\2024-06-15T143025.1234567Z-abc123.blob")]
     public void GetDateTimeFromBlobName_WithDifferentPathFormats_ReturnsCorrectDateTime(string filePath)
     {
         var expectedDateTime = DateTime.ParseExact(
-            "2024-01-15T14:30:25.1234567Z",
+            "2024-06-15T14:30:25.1234567Z",
             "yyyy-MM-ddTHH:mm:ss.fffffffZ",
             CultureInfo.InvariantCulture,
             DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);


### PR DESCRIPTION
## Changes

Fix TODO by treating `DateTime` parse failures explicitly.

The net result is the same as the current behaviour, but it's explicitly documented.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] ~~Unit tests added/updated~~
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
