### PR TITLE
Add Exception to LogRecordData

### DIFF
--- a/src/OpenTelemetry.Api/.publicApi/Experimental/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/Experimental/PublicAPI.Unshipped.txt
@@ -26,6 +26,8 @@
 [OTEL1001]OpenTelemetry.Logs.LogRecordData
 [OTEL1001]OpenTelemetry.Logs.LogRecordData.Body.get -> string?
 [OTEL1001]OpenTelemetry.Logs.LogRecordData.Body.set -> void
+[OTEL1001]OpenTelemetry.Logs.LogRecordData.Exception.get -> System.Exception?
+[OTEL1001]OpenTelemetry.Logs.LogRecordData.Exception.set -> void
 [OTEL1001]OpenTelemetry.Logs.LogRecordData.LogRecordData() -> void
 [OTEL1001]OpenTelemetry.Logs.LogRecordData.LogRecordData(in System.Diagnostics.ActivityContext activityContext) -> void
 [OTEL1001]OpenTelemetry.Logs.LogRecordData.LogRecordData(System.Diagnostics.Activity? activity) -> void
@@ -73,5 +75,3 @@
 [OTEL1001]static OpenTelemetry.Logs.LogRecordAttributeList.CreateFromEnumerable(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, object?>>! attributes) -> OpenTelemetry.Logs.LogRecordAttributeList
 [OTEL1001]static OpenTelemetry.Logs.LogRecordSeverityExtensions.ToShortName(this OpenTelemetry.Logs.LogRecordSeverity logRecordSeverity) -> string!
 [OTEL1001]virtual OpenTelemetry.Logs.LoggerProvider.TryCreateLogger(string? name, out OpenTelemetry.Logs.Logger? logger) -> bool
-[OTEL1001]OpenTelemetry.Logs.LogRecordData.Exception.get -> System.Exception?
-[OTEL1001]OpenTelemetry.Logs.LogRecordData.Exception.set -> void

--- a/src/OpenTelemetry.Api/.publicApi/Experimental/PublicAPI.Unshipped.txt
+++ b/src/OpenTelemetry.Api/.publicApi/Experimental/PublicAPI.Unshipped.txt
@@ -73,3 +73,5 @@
 [OTEL1001]static OpenTelemetry.Logs.LogRecordAttributeList.CreateFromEnumerable(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, object?>>! attributes) -> OpenTelemetry.Logs.LogRecordAttributeList
 [OTEL1001]static OpenTelemetry.Logs.LogRecordSeverityExtensions.ToShortName(this OpenTelemetry.Logs.LogRecordSeverity logRecordSeverity) -> string!
 [OTEL1001]virtual OpenTelemetry.Logs.LoggerProvider.TryCreateLogger(string? name, out OpenTelemetry.Logs.Logger? logger) -> bool
+[OTEL1001]OpenTelemetry.Logs.LogRecordData.Exception.get -> System.Exception?
+[OTEL1001]OpenTelemetry.Logs.LogRecordData.Exception.set -> void

--- a/src/OpenTelemetry.Api/CHANGELOG.md
+++ b/src/OpenTelemetry.Api/CHANGELOG.md
@@ -6,6 +6,9 @@ Notes](../../RELEASENOTES.md).
 
 ## Unreleased
 
+* Added `Exception` property to `LogRecordData`.
+  ([#6980](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6980))
+
 * **Breaking change:** The Baggage API implements the latest [Baggage API
   specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.36.0/specification/baggage/api.md),
   which disallows empty baggage names and treats baggage names and values as case

--- a/src/OpenTelemetry.Api/Logs/LogRecordAttributeList.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordAttributeList.cs
@@ -191,6 +191,7 @@ internal
     /// Adds attributes representing an <see cref="Exception"/> to the list.
     /// </summary>
     /// <param name="exception"><see cref="Exception"/>.</param>
+    [Obsolete("Use LogRecordData.Exception instead. RecordException will be removed in a future version.")]
     public void RecordException(Exception exception)
     {
         Guard.ThrowIfNull(exception);

--- a/src/OpenTelemetry.Api/Logs/LogRecordData.cs
+++ b/src/OpenTelemetry.Api/Logs/LogRecordData.cs
@@ -128,6 +128,11 @@ internal
     /// </summary>
     public string? EventName { get; set; } = null;
 
+    /// <summary>
+    /// Gets or sets the exception associated with the log.
+    /// </summary>
+    public Exception? Exception { get; set; } = null;
+
     internal static void SetActivityContext(ref LogRecordData data, Activity? activity)
     {
         if (activity != null)

--- a/src/OpenTelemetry/Logs/LoggerSdk.cs
+++ b/src/OpenTelemetry/Logs/LoggerSdk.cs
@@ -37,6 +37,7 @@ internal sealed class LoggerSdk : Logger
             logRecord.Data = data;
             logRecord.ILoggerData = default;
             logRecord.ILoggerData.EventId = new EventId(default, data.EventName);
+            logRecord.ILoggerData.Exception = data.Exception;
 
             logRecord.Logger = this;
 

--- a/test/OpenTelemetry.Api.Tests/Logs/LogRecordDataTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Logs/LogRecordDataTests.cs
@@ -103,6 +103,23 @@ public sealed class LogRecordDataTests
     }
 
     [Fact]
+    public void ExceptionTest()
+    {
+        var record = new LogRecordData();
+        Assert.Null(record.Exception);
+
+        record = default;
+        Assert.Null(record.Exception);
+
+        var exception = new InvalidOperationException("test message");
+        record.Exception = exception;
+        Assert.Equal(exception, record.Exception);
+
+        record.Exception = null;
+        Assert.Null(record.Exception);
+    }
+
+    [Fact]
     public void SetActivityContextTest()
     {
         LogRecordData record = default;

--- a/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
+++ b/test/OpenTelemetry.Exporter.OpenTelemetryProtocol.Tests/OtlpLogExporterTests.cs
@@ -1526,6 +1526,42 @@ public class OtlpLogExporterTests
     }
 
     [Fact]
+    public void ExceptionIsRecordedWhenUsingTheBridgeApi()
+    {
+        var logRecords = new List<LogRecord>();
+
+        var exception = new InvalidOperationException("Some exception message");
+
+        using (var loggerProvider = Sdk.CreateLoggerProviderBuilder()
+                   .AddInMemoryExporter(logRecords)
+                   .Build())
+        {
+            var logger = loggerProvider.GetLogger();
+
+            logger.EmitLog(new LogRecordData
+            {
+                Body = "test body",
+                Exception = exception,
+            });
+        }
+
+        Assert.Single(logRecords);
+        var logRecord = logRecords[0];
+        Assert.Equal(exception, logRecord.Exception);
+
+        OtlpLogs.LogRecord? otlpLogRecord = ToOtlpLogs(DefaultSdkLimitOptions, new ExperimentalOptions(), logRecord);
+
+        Assert.NotNull(otlpLogRecord);
+        Assert.Equal("test body", otlpLogRecord.Body.StringValue);
+
+        Assert.Equal(3, otlpLogRecord.Attributes.Count);
+
+        Assert.Equal(exception.GetType().Name, TryGetAttribute(otlpLogRecord, SemanticConventions.AttributeExceptionType)?.Value.StringValue);
+        Assert.Equal(exception.Message, TryGetAttribute(otlpLogRecord, SemanticConventions.AttributeExceptionMessage)?.Value.StringValue);
+        Assert.Equal(exception.ToInvariantString(), TryGetAttribute(otlpLogRecord, SemanticConventions.AttributeExceptionStacktrace)?.Value.StringValue);
+    }
+
+    [Fact]
     public void LogSerialization_ExpandsBufferForLogsAndSerializes()
     {
         LogRecordAttributeList attributes = default;


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-dotnet/issues/4433

## Changes

Added `Exception` property to `LogRecordData` struct.

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [ ] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
