### PR TITLE
[API.Tests] Fix IDE0200 warnings

### DIFF
--- a/test/OpenTelemetry.Api.Tests/Trace/TracerTests.cs
+++ b/test/OpenTelemetry.Api.Tests/Trace/TracerTests.cs
@@ -608,7 +608,7 @@ public sealed class TracerTests : IDisposable
         var previousActivity = Activity.Current;
         Assert.NotNull(previousActivity);
 
-        var thread = new Thread(() => previousActivity.Stop());
+        var thread = new Thread(previousActivity.Stop);
         thread.Start();
         thread.Join();
 
@@ -645,7 +645,7 @@ public sealed class TracerTests : IDisposable
         Assert.Same(grandparentActivity, parentActivity.Parent);
         Assert.Same(parentActivity, currentActivity.Parent);
 
-        var thread = new Thread(() => currentActivity.Stop());
+        var thread = new Thread(currentActivity.Stop);
         thread.Start();
         thread.Join();
 
@@ -713,7 +713,7 @@ public sealed class TracerTests : IDisposable
         var previousActivity = Activity.Current;
         Assert.NotNull(previousActivity);
 
-        var thread = new Thread(() => previousActivity.Stop());
+        var thread = new Thread(previousActivity.Stop);
         thread.Start();
         thread.Join();
 


### PR DESCRIPTION
## Changes

Fix IDE0200 warnings from the .NET 11 SDK surfaced by #6899.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (license requirements, nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] ~~Appropriate `CHANGELOG.md` files updated for non-trivial changes~~
* [ ] ~~Changes in public API reviewed (if applicable)~~
